### PR TITLE
Add helm charts

### DIFF
--- a/helm/.helmignore
+++ b/helm/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,0 +1,17 @@
+name: pomerium
+version: 0.0.1
+apiVersion: v1
+appVersion: 0.0.1
+home: http://www.pomerium.io/
+description: A reverse proxy that provides authentication with Google, Okta, Azure or other providers
+keywords:
+- kubernetes
+- oauth
+- oauth2
+- authentication
+- google
+- okta
+- azure
+sources:
+- https://github.com/pomerium/pomerium
+engine: gotpl

--- a/helm/README.md
+++ b/helm/README.md
@@ -1,0 +1,9 @@
+# Pomerium
+
+[Pomerium](https://github.com/pomerium/pomerium) is a tool for managing secure access to internal applications and resources.
+
+## TL;DR;
+
+```console
+$ helm install pomerium/pomerium
+```

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -1,0 +1,40 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pomerium.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pomerium.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pomerium.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "pomerium.routestring" -}}
+{{- $routes := dict "routes" (list) -}}
+{{- range $key, $val := .Values.proxy.routes -}}
+{{- $noop := printf "%s=%s" $key $val | append $routes.routes | set $routes "routes" -}}
+{{- end -}}
+{{- join "," $routes.routes | default "none=none" | quote -}}
+{{- end -}}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,0 +1,144 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ template "pomerium.name" . }}
+    chart: {{ template "pomerium.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "pomerium.fullname" . }}
+{{- if .Values.annotations }}
+  annotations:
+{{ toYaml .Values.annotations | indent 4 }}
+{{- end }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "pomerium.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
+      labels:
+        app: {{ template "pomerium.name" . }}
+        chart: {{ template "pomerium.chart" . }}
+        heritage: {{ .Release.Service }}
+        release: {{ .Release.Name }}
+{{- if .Values.podLabels }}
+{{ toYaml .Values.podLabels | indent 8 }}
+{{- end }}
+    spec:
+{{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}
+      containers:
+      - name: {{ .Chart.Name }}
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+{{- range $key, $value := .Values.extraArgs }}
+{{- if $value }}
+          - --{{ $key }}={{ $value }}
+{{- else }}
+          - --{{ $key }}
+{{- end }}
+{{- end }}
+        env:
+        - name: SERVICES
+          value: {{ .Values.config.services }}
+        - name: COOKIE_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "pomerium.fullname" . }}
+              key: cookie-secret
+        - name: SHARED_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "pomerium.fullname" . }}
+              key: shared-secret
+{{- if .Values.config.cert }}
+        - name: CERTIFICATE
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "pomerium.fullname" . }}
+              key: certificate
+{{- end }}
+{{- if .Values.config.key }}
+        - name: CERTIFICATE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "pomerium.fullname" . }}
+              key: certificate-key
+{{- end }}
+{{- if or (eq .Values.config.services "authenticate") (eq .Values.config.services "all") }}
+        - name: REDIRECT_URL
+          value: {{ .Values.authenticate.redirectUrl }}
+        - name: ALLOWED_DOMAINS
+          value: {{ .Values.authenticate.allowedDomains }}
+        - name: PROXY_ROOT_DOMAIN
+          value: {{ .Values.authenticate.proxyRootDomains }}
+        - name: IDP_PROVIDER
+          value: {{ .Values.authenticate.idp.provider }}
+        - name: IDP_PROVIDER_URL
+          value: {{ .Values.authenticate.idp.url }}
+        - name: IDP_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name:  {{ template "pomerium.fullname" . }}
+              key: idp-client-id
+        - name: IDP_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name:  {{ template "pomerium.fullname" . }}
+              key: idp-client-secret
+{{- end }}
+{{- if or (eq .Values.config.services "proxy") (eq .Values.config.services "all") }}
+        - name: AUTHENTICATE_SERVICE_URL
+          value: {{ .Values.proxy.authenticateServiceUrl }}
+        - name: ROUTES
+          value: {{ template "pomerium.routestring" . }}
+{{- end }}
+{{- range $name, $value := .Values.extraEnv }}
+        - name: {{ $name }}
+          value: {{ quote $value }}
+{{- end }}
+        ports:
+          - containerPort: 443
+            name: https
+            protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /ping
+            port: https
+            scheme: HTTPS
+        readinessProbe:
+          httpGet:
+            path: /ping
+            port: https
+            scheme: HTTPS
+        resources:
+{{ toYaml .Values.resources | indent 10 }}
+{{- if .Values.extraVolumes }}
+      volumes:
+{{- toYaml .Values.extraVolumes | indent 8 }}
+{{- end }}
+{{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+{{- end }}
+{{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
+{{- end }}
+{{- if .Values.affinity }}
+      affinity:
+{{ toYaml .Values.affinity | indent 8 }}
+{{- end }}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.ingress.enabled -}}
+{{- $serviceName := include "pomerium.fullname" . -}}
+{{- $servicePort := .Values.service.externalPort -}}
+{{- $paths := .Values.ingress.paths -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  labels:
+    app: {{ template "pomerium.name" . }}
+    chart: {{ template "pomerium.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
+  name: {{ template "pomerium.fullname" . }}
+{{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+  rules:
+{{- if .Values.ingress.extraRules }}
+{{ toYaml .Values.ingress.extraRules | indent 4 }}
+{{- end }}
+{{- if .Values.ingress.hosts }}
+{{- range $host := .Values.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+{{- range $p := $paths }}
+          - path: {{ $p }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+{{- end }}
+{{- end }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: {{ template "pomerium.name" . }}
+    chart: {{ template "pomerium.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "pomerium.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:
+{{- if or (eq .Values.config.services "authenticate") (eq .Values.config.services "all") }}
+  idp-client-id: {{ .Values.authenticate.idp.clientID | b64enc | quote }}
+  idp-client-secret: {{ .Values.authenticate.idp.clientSecret | b64enc | quote }}
+{{- end }}
+  cookie-secret: {{ .Values.config.cookieSecret | b64enc | quote }}
+  shared-secret: {{ .Values.config.sharedSecret | b64enc | quote }}
+{{- if .Values.config.cert }}
+  certificate: {{ .Values.config.cert | b64enc | quote }}
+{{- end }}
+{{- if .Values.config.key }}
+  certificate-key: {{ .Values.config.key | b64enc | quote }}
+{{- end }}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ template "pomerium.name" . }}
+    chart: {{ template "pomerium.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
+  name: {{ template "pomerium.fullname" . }}
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.externalPort }}
+      targetPort: https
+      protocol: TCP
+      name: http
+{{- if hasKey .Values.service "nodePort" }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
+  selector:
+    app: {{ template "pomerium.name" . }}
+    release: {{ .Release.Name }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -1,0 +1,85 @@
+# All config settings are required. sharedSecret must match between the authenticate
+# and proxy deployments.
+config:
+  sharedSecret: "XXXXXXXX"
+  cookieSecret: "XXXXXXXX"
+  services: all
+  cert:
+  key:
+# All below required if config.services is "authenticate" or "all"
+authenticate:
+  redirectUrl: http://example.com/oauth2/callback
+  allowedDomains: example.com
+  proxyRootDomains: example.com
+  idp:
+    provider: okta
+    url: https://example.oktapreview.com/oauth2/default
+    clientID: "XXXXXXXX"
+    clientSecret: "XXXXXXXX"
+# All below required if config.serviceModes is "proxy" or "all"
+proxy:
+  authenticateServiceUrl: https://example.com/oauth2/callback
+  routes:
+    "http.corp.example.com": "httpbin.org"
+
+# For any other settings that are optional
+# ADDRESS, POMERIUM_DEBUG, CERTIFICATE_FILE, CERTIFICATE_KEY_FILE
+# PROXY_ROOT_DOMAIN, COOKIE_DOMAIN, COOKIE_EXPIRE, COOKIE_REFRESH, COOKIE_SECURE, COOKIE_HTTP_ONLY, IDP_SCOPE
+# DEFAULT_UPSTREAM_TIMEOUT, PASS_ACCESS_TOKEN, SESSION_VALID_TTL, SESSION_LIFETIME_TTL, GRACE_PERIOD_TTL
+extraEnv: {}
+
+extraArgs: {}
+extraVolumes: {}
+
+image:
+  repository: "pomerium/pomerium"
+  tag: "0.0.1"
+  pullPolicy: "IfNotPresent"
+
+service:
+  type: ClusterIP
+  externalPort: 443
+  annotations: {}
+  # foo.io/bar: "true"
+  labels: {}
+
+ingress:
+  enabled: false
+  path: /
+  # Used to create an Ingress record.
+  # hosts:
+    # - chart-example.local
+  # annotations:
+  #   kubernetes.io/ingress.class: nginx
+  #   kubernetes.io/tls-acme: "true"
+  # tls:
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
+
+resources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 300Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 300Mi
+
+priorityClassName: ""
+
+# Affinity for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
+# affinity: {}
+
+# Tolerations for pod assignment
+# Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+# tolerations: []
+
+# Node labels for pod assignment
+# Ref: https://kubernetes.io/docs/user-guide/node-selection/
+# nodeSelector: {}
+
+podAnnotations: {}
+podLabels: {}
+replicaCount: 1


### PR DESCRIPTION
This PR adds Helm charts for deploying pomerium. This PR is paired with #9 for setting modes.

Open issues:
* Client secret, client ID, cookie secret, shared secret, and TLS cert/key are stored in K8s secrets, but the contents are still visible with helm get manifest. There should be an option to allow someone to provision the secrets outside of the chart.
* The README.md file is a stub, and needs proper documentation for both authenticator and proxy deployment.
* Maybe more sensible defaults in values.yaml should be provided.
* The default image location is dependent on #7. This is overridable in values.yaml.