### PR TITLE
proxy : add HTTP endpoint support

### DIFF
--- a/authenticate/circuit/breaker.go
+++ b/authenticate/circuit/breaker.go
@@ -157,7 +157,7 @@ type Breaker struct {
 	onStateChange StateChangeHook
 	onBackoff     BackoffHook
 
-	// used primarly for mocking tests
+	// used primarily for mocking tests
 	clock clock.Clock
 
 	mutex          sync.Mutex

--- a/authenticate/middleware_test.go
+++ b/authenticate/middleware_test.go
@@ -32,10 +32,10 @@ func Test_validRedirectURI(t *testing.T) {
 }
 
 func Test_validSignature(t *testing.T) {
-	goodUrl := "https://example.com/redirect"
+	goodURL := "https://example.com/redirect"
 	secretA := "41aOD7VNtQ1/KZDCGrkYpaHwB50JC1y6BDs2KPRVd2A="
 	now := fmt.Sprint(time.Now().Unix())
-	rawSig := redirectURLSignature(goodUrl, time.Now(), secretA)
+	rawSig := redirectURLSignature(goodURL, time.Now(), secretA)
 	sig := base64.URLEncoding.EncodeToString(rawSig)
 	staleTime := fmt.Sprint(time.Now().Add(-6 * time.Minute).Unix())
 
@@ -47,12 +47,12 @@ func Test_validSignature(t *testing.T) {
 		secret      string
 		want        bool
 	}{
-		{"good signature", goodUrl, string(sig), now, secretA, true},
+		{"good signature", goodURL, string(sig), now, secretA, true},
 		{"empty redirect url", "", string(sig), now, secretA, false},
 		{"bad redirect url", "https://google.com^", string(sig), now, secretA, false},
-		{"malformed signature", goodUrl, string(sig + "^"), now, "&*&@**($&#(", false},
-		{"malformed timestamp", goodUrl, string(sig), now + "^", secretA, false},
-		{"stale timestamp", goodUrl, string(sig), staleTime, secretA, false},
+		{"malformed signature", goodURL, string(sig + "^"), now, "&*&@**($&#(", false},
+		{"malformed timestamp", goodURL, string(sig), now + "^", secretA, false},
+		{"stale timestamp", goodURL, string(sig), staleTime, secretA, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/authenticate/providers/singleflight_middleware.go
+++ b/authenticate/providers/singleflight_middleware.go
@@ -19,7 +19,7 @@ var (
 )
 
 // SingleFlightProvider middleware provider that multiple requests for the same object
-// to be processed as a single request. This is often called request collpasing or coalesce.
+// to be processed as a single request. This is often called request collapsing or coalesce.
 // This middleware leverages the golang singlelflight provider, with modifications for metrics.
 //
 // It's common among HTTP reverse proxy cache servers such as nginx, Squid or Varnish - they all call it something else but works similarly.

--- a/docs/guide/readme.md
+++ b/docs/guide/readme.md
@@ -24,7 +24,7 @@
     export IDP_CLIENT_ID="YOU_GOT_THIS_FROM_STEP-3.apps.googleusercontent.com"
     export IDP_CLIENT_SECRET="YOU_GOT_THIS_FROM_STEP-3"
     # key/value list of simple routes.
-    export ROUTES='http.corp.example.com':'httpbin.org'
+    export ROUTES='http.corp.example.com=httpbin.org'
     ```
 
     You can also view the [env.example] configuration file for a more comprehensive list of options.

--- a/env.example
+++ b/env.example
@@ -26,9 +26,8 @@ export IDP_PROVIDER_URL="https://accounts.google.com" # optional for google
 export IDP_CLIENT_ID="REPLACE-ME.googleusercontent.com"
 export IDP_CLIENT_SECRET="REPLACEME"
 
-
 # export SCOPE="openid email" # generally, you want the default OIDC scopes
 
-# k/v seperated list of simple routes.
-export ROUTES='http.corp.example.com':'httpbin.org'
-
+# k/v seperated list of simple routes. If no scheme is set, HTTPS will be used.
+export ROUTES="example.corp.example.com=example.org"
+# export ROUTES="https://weirdlyssl.corp.example.com=http://neverssl.com" #https to http!

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/miscreant/miscreant-go v0.0.0-20181010193435-325cbd69228b
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/pomerium/envconfig v1.3.1-0.20180517194557-dd1402a4d99d
+	github.com/pomerium/envconfig v1.3.1-0.20190112072701-14cbcf832d31
 	github.com/pomerium/go-oidc v2.0.0+incompatible
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/rs/zerolog v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pomerium/envconfig v1.3.1-0.20180517194557-dd1402a4d99d h1:iAavGhspmmDa8LCcQLpHV/JBPWKL7EfvMN7YrGHBN3o=
 github.com/pomerium/envconfig v1.3.1-0.20180517194557-dd1402a4d99d/go.mod h1:1Kz8Ca8PhJDtLYqgvbDZGn6GsJCvrT52SxQ3sPNJkDc=
+github.com/pomerium/envconfig v1.3.1-0.20190112072701-14cbcf832d31 h1:bNqUesLWa+RUxQvSaV3//dEFviXdCSvMF9GKDOopFLU=
+github.com/pomerium/envconfig v1.3.1-0.20190112072701-14cbcf832d31/go.mod h1:1Kz8Ca8PhJDtLYqgvbDZGn6GsJCvrT52SxQ3sPNJkDc=
 github.com/pomerium/go-oidc v2.0.0+incompatible h1:gVvG/ExWsHQqatV+uceROnGmbVYF44mDNx5nayBhC0o=
 github.com/pomerium/go-oidc v2.0.0+incompatible/go.mod h1:DRsGVw6MOgxbfq4Y57jKOE8lbEfayxeiY0A8/4vxjBM=
 github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 h1:J9b7z+QKAmPf4YLrFg6oQUotqHQeUNWwkvo7jZp1GLU=

--- a/internal/aead/aead.go
+++ b/internal/aead/aead.go
@@ -113,7 +113,7 @@ func (c *MiscreantCipher) Marshal(s interface{}) (string, error) {
 }
 
 // Unmarshal takes the marshaled string, base64-decodes into a byte slice, decrypts the
-// byte slice the pased cipher, and unmarshals the resulting JSON into the struct pointer passed
+// byte slice the passed cipher, and unmarshals the resulting JSON into the struct pointer passed
 func (c *MiscreantCipher) Unmarshal(value string, s interface{}) error {
 	// convert base64 string value to bytes
 	ciphertext, err := base64.RawURLEncoding.DecodeString(value)

--- a/internal/sessions/cookie_store.go
+++ b/internal/sessions/cookie_store.go
@@ -69,11 +69,6 @@ func NewCookieStore(cookieName string, optFuncs ...func(*CookieStore) error) (*C
 		}
 	}
 
-	domain := c.CookieDomain
-	if domain == "" {
-		domain = "<default>"
-	}
-
 	return c, nil
 }
 

--- a/internal/sessions/session_state.go
+++ b/internal/sessions/session_state.go
@@ -53,7 +53,7 @@ func MarshalSession(s *SessionState, c aead.Cipher) (string, error) {
 }
 
 // UnmarshalSession takes the marshaled string, base64-decodes into a byte slice, decrypts the
-// byte slice using the pased cipher, and unmarshals the resulting JSON into a session state struct
+// byte slice using the passed cipher, and unmarshals the resulting JSON into a session state struct
 func UnmarshalSession(value string, c aead.Cipher) (*SessionState, error) {
 	s := &SessionState{}
 	err := c.Unmarshal(value, s)


### PR DESCRIPTION
Adds the ability to proxy HTTP endpoints. Would close #11 . Tested with the following route.

```bash
export ROUTES='https://nossl.corp.beyondperimeter.com=http://neverssl.com'
```
 
<img width="773" alt="neverssl" src="https://user-images.githubusercontent.com/1544881/51167312-1e3e4a00-185b-11e9-81f5-4d2bdd2a11c6.png">
