### PR TITLE
Fix dockerfile, add CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,5 @@ RUN make
 FROM scratch
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 WORKDIR /pomerium
-COPY --from=build /bin/* /bin/
+COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
+CMD ["/bin/pomerium"]


### PR DESCRIPTION
Change the Docker container to copy the pomerium binary instead of the base binaries from the Golang base container. Also makes the pomerium binary be run as the default command. This splits this functionality off from #9