### PR TITLE
authenticate: skip provider login screen

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -48,11 +48,12 @@ type Options struct {
 	SessionLifetimeTTL time.Duration `envconfig:"SESSION_LIFETIME_TTL"`
 
 	// Authentication provider configuration vars
-	ClientID     string   `envconfig:"IDP_CLIENT_ID"`     // IdP ClientID
-	ClientSecret string   `envconfig:"IDP_CLIENT_SECRET"` // IdP Secret
-	Provider     string   `envconfig:"IDP_PROVIDER"`      //Provider name e.g. "oidc","okta","google",etc
-	ProviderURL  string   `envconfig:"IDP_PROVIDER_URL"`
-	Scopes       []string `envconfig:"IDP_SCOPE" default:"openid,email,profile"`
+	ClientID           string   `envconfig:"IDP_CLIENT_ID"`     // IdP ClientID
+	ClientSecret       string   `envconfig:"IDP_CLIENT_SECRET"` // IdP Secret
+	Provider           string   `envconfig:"IDP_PROVIDER"`      //Provider name e.g. "oidc","okta","google",etc
+	ProviderURL        string   `envconfig:"IDP_PROVIDER_URL"`
+	Scopes             []string `envconfig:"IDP_SCOPE" default:"openid,email,profile"`
+	SkipProviderButton bool     `envconfig:"SKIP_PROVIDER_BUTTON"`
 }
 
 // OptionsFromEnvConfig builds the authentication service's configuration
@@ -122,6 +123,8 @@ type Authenticate struct {
 	sessionStore sessions.SessionStore
 	cipher       cryptutil.Cipher
 
+	skipProviderButton bool
+
 	provider providers.Provider
 }
 
@@ -160,15 +163,16 @@ func New(opts *Options, optionFuncs ...func(*Authenticate) error) (*Authenticate
 	}
 
 	p := &Authenticate{
-		SharedKey:        opts.SharedKey,
-		AllowedDomains:   opts.AllowedDomains,
-		ProxyRootDomains: dotPrependDomains(opts.ProxyRootDomains),
-		CookieSecure:     opts.CookieSecure,
-		RedirectURL:      opts.RedirectURL,
-		templates:        templates.New(),
-		csrfStore:        cookieStore,
-		sessionStore:     cookieStore,
-		cipher:           cipher,
+		SharedKey:          opts.SharedKey,
+		AllowedDomains:     opts.AllowedDomains,
+		ProxyRootDomains:   dotPrependDomains(opts.ProxyRootDomains),
+		CookieSecure:       opts.CookieSecure,
+		RedirectURL:        opts.RedirectURL,
+		templates:          templates.New(),
+		csrfStore:          cookieStore,
+		sessionStore:       cookieStore,
+		cipher:             cipher,
+		skipProviderButton: opts.SkipProviderButton,
 	}
 	// p.ServeMux = p.Handler()
 	p.provider, err = newProvider(opts)


### PR DESCRIPTION
This PR adds a SKIP_PROVIDER_BUTTON environment variable that skips the Pomerium sign-in page and redirects the user directly to the OAuth provider (Google, Okta, etc) if the user is not yet authenticated with that provider. It replicates the functionality of "-skip-provider-button" flag from https://github.com/bitly/oauth2_proxy. It also acts as an implementation of https://github.com/buzzfeed/sso/issues/132. My organization does use this feature in our current oauth2_proxy deployments, so it would be nice to have it here.

Internally, the implementation is hacky; if the flag is set while in SignIn(), it will call a separate helper whose only job is to extract the auth redirect URL from the authenticator instance, which proceeds to validate it as if it were user input. (The normal code path would extract the auth redirect URL from the URL query string that was provided on the sign in page, which we've also broken out into a helper function.) If there's a better way to do this, I'm open to it. It's also missing unit tests.
