### PR TITLE
authenticate: fixes incorrect error check

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -20,6 +20,7 @@ import (
 var defaultOptions = &Options{
 	CookieName:         "_pomerium_authenticate",
 	CookieHTTPOnly:     true,
+	SkipProviderButton: true,
 	CookieExpire:       time.Duration(168) * time.Hour,
 	CookieRefresh:      time.Duration(1) * time.Hour,
 	SessionLifetimeTTL: time.Duration(720) * time.Hour,
@@ -52,7 +53,7 @@ type Options struct {
 	ClientSecret       string   `envconfig:"IDP_CLIENT_SECRET"` // IdP Secret
 	Provider           string   `envconfig:"IDP_PROVIDER"`      //Provider name e.g. "oidc","okta","google",etc
 	ProviderURL        string   `envconfig:"IDP_PROVIDER_URL"`
-	Scopes             []string `envconfig:"IDP_SCOPE" default:"openid,email,profile"`
+	Scopes             []string `envconfig:"IDP_SCOPE"`
 	SkipProviderButton bool     `envconfig:"SKIP_PROVIDER_BUTTON"`
 }
 

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -347,7 +347,7 @@ func (p *Authenticate) SignOutPage(rw http.ResponseWriter, req *http.Request, me
 // `redirectURI`, allowing the provider to redirect back to the sso proxy after authentication.
 func (p *Authenticate) OAuthStart(rw http.ResponseWriter, req *http.Request) {
 	authRedirectURL, err := url.Parse(req.URL.Query().Get("redirect_uri"))
-	if err == nil {
+	if err != nil {
 		httputil.ErrorResponse(rw, req, "Invalid redirect parameter", http.StatusBadRequest)
 		return
 	}


### PR DESCRIPTION
Fixes #24 , was a small typo in error check that always failed when redirect button was enabled.
