### PR TITLE
Gitlab auth provider

### DIFF
--- a/authenticate/providers/gitlab.go
+++ b/authenticate/providers/gitlab.go
@@ -1,0 +1,36 @@
+package providers // import "github.com/pomerium/pomerium/internal/providers"
+
+import (
+	"context"
+
+	oidc "github.com/pomerium/go-oidc"
+	"golang.org/x/oauth2"
+)
+
+const defaultGitlabProviderURL = "https://gitlab.com"
+
+// GitlabProvider is an implementation of the Provider interface
+type GitlabProvider struct {
+	*ProviderData
+}
+
+// NewGitlabProvider creates a new instance of a Gitlab provider.
+func NewGitlabProvider(p *ProviderData) (*GitlabProvider, error) {
+	ctx := context.Background()
+	if p.ProviderURL == "" {
+		p.ProviderURL = defaultGitlabProviderURL
+	}
+	provider, err := oidc.NewProvider(ctx, p.ProviderURL)
+	if err != nil {
+		return nil, err
+	}
+	p.verifier = provider.Verifier(&oidc.Config{ClientID: p.ClientID})
+	p.oauth = &oauth2.Config{
+		ClientID:     p.ClientID,
+		ClientSecret: p.ClientSecret,
+		Endpoint:     provider.Endpoint(),
+		RedirectURL:  p.RedirectURL.String(),
+		Scopes:       []string{oidc.ScopeOpenID, "read_user"},
+	}
+	return &GitlabProvider{ProviderData: p}, nil
+}

--- a/authenticate/providers/providers.go
+++ b/authenticate/providers/providers.go
@@ -17,6 +17,8 @@ import (
 const (
 	// AzureProviderName identifies the Azure provider
 	AzureProviderName = "azure"
+	// GitlabProviderName identifies the Gitlab provider
+	GitlabProviderName = "gitlab"
 	// GoogleProviderName identifies the Google provider
 	GoogleProviderName = "google"
 	// OIDCProviderName identifes a generic OpenID connect provider
@@ -55,6 +57,12 @@ func New(provider string, p *ProviderData) (Provider, error) {
 		return p, nil
 	case OktaProviderName:
 		p, err := NewOktaProvider(p)
+		if err != nil {
+			return nil, err
+		}
+		return p, nil
+	case GitlabProviderName:
+		p, err := NewGitlabProvider(p)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This adds a completely untested Gitlab provider. I don't have a Gitlab.com account or self hosted Gitlab deployment myself, so haven't tested. This closes #20.

Based off of documentation, examining the bit.ly implementation, and looking at https://gitlab.com/.well-known/openid-configuration, I believe Gitlab to be a normal OIDC provider, with the one quirk that it uses a scope called `read_user` instead of `profile` and `email`. The code here should provide that. For a self-hosted Gitlab, you should be able to set IDP_PROVIDER_URL to your own deployment's URL.

This would be configured using IDP_PROVIDER=gitlab in the environment, along with the standard IDP_CLIENT_ID and IDP_CLIENT_SECRET.

Can someone with Gitlab test?