### PR TITLE
proxy: use internal/httputil for error handling

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -47,16 +47,13 @@ type Options struct {
 
 	SessionLifetimeTTL time.Duration `envconfig:"SESSION_LIFETIME_TTL"`
 
-	// Authentication provider configuration vars
+	// Authentication provider configuration variables as specified by RFC6749
 	// See: https://openid.net/specs/openid-connect-basic-1_0.html#RFC6749
-	ClientID     string `envconfig:"IDP_CLIENT_ID"`
-	ClientSecret string `envconfig:"IDP_CLIENT_SECRET"`
-	Provider     string `envconfig:"IDP_PROVIDER"`
-	ProviderURL  string `envconfig:"IDP_PROVIDER_URL"`
-	// Scopes is an optional setting corresponding to OAuth 2.0 specification's access scopes
-	// issuing an Access Token. Named providers are already set with good defaults.
-	// Most likely only overrides if using the generic OIDC provider.
-	Scopes []string `envconfig:"IDP_SCOPE"`
+	ClientID     string   `envconfig:"IDP_CLIENT_ID"`
+	ClientSecret string   `envconfig:"IDP_CLIENT_SECRET"`
+	Provider     string   `envconfig:"IDP_PROVIDER"`
+	ProviderURL  string   `envconfig:"IDP_PROVIDER_URL"`
+	Scopes       []string `envconfig:"IDP_SCOPE"`
 }
 
 // OptionsFromEnvConfig builds the authentication service's configuration

--- a/internal/httputil/errors.go
+++ b/internal/httputil/errors.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 
 	"github.com/pomerium/pomerium/internal/templates"
-	"github.com/pomerium/pomerium/internal/version"
 )
 
 var (
@@ -51,12 +50,10 @@ func ErrorResponse(rw http.ResponseWriter, req *http.Request, message string, co
 			Code    int
 			Title   string
 			Message string
-			Version string
 		}{
 			Code:    code,
 			Title:   title,
 			Message: message,
-			Version: version.FullVersion(),
 		}
 		templates.New().ExecuteTemplate(rw, "error.html", t)
 	}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -1,12 +1,15 @@
 package templates // import "github.com/pomerium/pomerium/internal/templates"
 
 import (
+	"fmt"
 	"html/template"
+
+	"github.com/pomerium/pomerium/internal/version"
 )
 
 // New loads html and style resources directly. Panics on failure.
 func New() *template.Template {
-	t := template.New("authenticate-templates")
+	t := template.New("pomerium-templates")
 	template.Must(t.Parse(`
 {{define "header.html"}}
 <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
@@ -92,8 +95,7 @@ footer {
 }
 </style>
 {{end}}`))
-
-	t = template.Must(t.Parse(`{{define "footer.html"}}Secured by <b>pomerium</b> {{end}}`))
+	t = template.Must(t.Parse(fmt.Sprintf(`{{define "footer.html"}}Secured by <b>pomerium</b> %s {{end}}`, version.FullVersion())))
 
 	t = template.Must(t.Parse(`
 {{define "sign_in_message.html"}}
@@ -134,7 +136,7 @@ footer {
             </form>
         </div>
 
-        <footer>{{template "footer.html"}} </br> {{.Version}} </footer>
+        <footer>{{template "footer.html"}} </footer>
     </div>
 </body>
 </html>
@@ -159,7 +161,7 @@ footer {
           <span class="details">HTTP {{.Code}}</span>
         </p>
     </div>
-        <footer>{{template "footer.html"}} </br> {{.Version}} </footer>
+        <footer>{{template "footer.html"}} </footer>
     </div>
 </body>
 </html>{{end}}`))
@@ -190,7 +192,7 @@ footer {
               <button type="submit">Sign out</button>
             </form>
     	</div>
-    	<footer>{{template "footer.html"}} </br> {{.Version}}</footer>
+    	<footer>{{template "footer.html"}}</footer>
     </div>
 </body>
 </html>

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -8,13 +8,13 @@ import (
 )
 
 func TestProxy_RobotsTxt(t *testing.T) {
-	auth := Proxy{}
+	proxy := Proxy{}
 	req, err := http.NewRequest("GET", "/robots.txt", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	rr := httptest.NewRecorder()
-	handler := http.HandlerFunc(auth.RobotsTxt)
+	handler := http.HandlerFunc(proxy.RobotsTxt)
 	handler.ServeHTTP(rr, req)
 	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
@@ -22,6 +22,5 @@ func TestProxy_RobotsTxt(t *testing.T) {
 	expected := fmt.Sprintf("User-agent: *\nDisallow: /")
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned wrong body: got %v want %v", rr.Body.String(), expected)
-
 	}
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -301,7 +301,7 @@ func NewReverseProxyHandler(opts *Options, reverseProxy *httputil.ReverseProxy, 
 }
 
 // urlParse adds a scheme if none-exists, addressesing a quirk in how
-// one may expect url.Parse to function when a "naked" domain is sent.
+// one may expect url.Parse to function when given scheme-less domain is provided.
 //
 // see: https://github.com/golang/go/issues/12585
 // see: https://golang.org/pkg/net/url/#Parse


### PR DESCRIPTION
proxy: use internal/httputil for error handling

- General formatting and comment cleanup.
- Inject pomerium version at compile time via template package.