### PR TITLE
cmd/pomerium : restore /ping without hostname

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -68,6 +68,11 @@ func main() {
 
 	topMux := http.NewServeMux()
 	if authenticateService != nil {
+		// Need to handle ping without host lookup for LB
+		topMux.HandleFunc("/ping", func(rw http.ResponseWriter, _ *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			fmt.Fprintf(rw, "OK")
+		})
 		topMux.Handle(authHost+"/", authenticateService.Handler())
 	}
 	if proxyService != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
We generally follow Go coding and contributing conventions 
which you can read about here https://golang.org/doc/contribute.html#commit_messages

Here's an example of a good PR/Commit:

    math: improve Sin, Cos and Tan precision for very large arguments

    The existing implementation has poor numerical properties for
    large arguments, so use the McGillicutty algorithm to improve
    accuracy above 1e10.

    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm

    Fixes #159
-->

Re-adding the hostless /ping for the authenticate service. Without these 4 lines, Pomerium fails to stay running when using the helm chart that's checked into the repo; the Kubernetes liveness/readiness probes don't see the pod as successfully running, and Kubernetes goes into an endless restart loop.

I have tried the following:
* Adding `httpHeaders: {name: "Host", value: "insert_redirect_uri_hostname_here"}` to both probes to try to force it to recognize. Pomerium fails to stay running.
* Removing the probes from the deployment definition. Pomerium successfully stays running and responds correctly. Thus it's certain that it's one of the probes failing.
* Modifying the code here to log the request.host golang reports. It reports "10.x.x.x:443". (Actual pod internal IP address for the 10.x.x.x). That won't match the authHost.

<!--  handy checklist ; not required--> 
**Checklist**:
- [ ] documentation updated
- [ ] unit tests added
- [ ] related issues referenced
- [ ] ready for review
