### PR TITLE
docs: remove port from internal service url

### DIFF
--- a/docs/docs/examples/kubernetes/proxy.deploy.yml
+++ b/docs/docs/examples/kubernetes/proxy.deploy.yml
@@ -30,7 +30,7 @@ spec:
             - name: AUTHENTICATE_SERVICE_URL
               value: https://auth.corp.beyondperimeter.com
             - name: AUTHENTICATE_INTERNAL_URL
-              value: "pomerium-authenticate-service.pomerium.svc.cluster.local:443"
+              value: "pomerium-authenticate-service.pomerium.svc.cluster.local"
             - name: OVERIDE_CERTIFICATE_NAME
               value: "*.corp.beyondperimeter.com"
             - name: SHARED_SECRET


### PR DESCRIPTION
As you can see below an error occurs when you have the port. There is another option for port which screws it up.

```
189a15d0e56","error":"rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: Error while dialing dial tcp: address pomerium-authenticate-service.pomerium.svc.cluster.local:443:443: too many colons in address\"","time":"2019-02-14T16:27:07Z","message":"proxy: error redeeming authorization code"}
```

<!--  Thanks for sending a pull request!
We generally follow Go coding and contributing conventions 
which you can read about here https://golang.org/doc/contribute.html#commit_messages

Here's an example of a good PR/Commit:

    math: improve Sin, Cos and Tan precision for very large arguments

    The existing implementation has poor numerical properties for
    large arguments, so use the McGillicutty algorithm to improve
    accuracy above 1e10.

    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm

    Fixes #159
-->


<!--  handy checklist ; not required--> 
**Checklist**:
- [ ] documentation updated
- [ ] unit tests added
- [ ] related issues referenced
- [ ] ready for review
