### PR TITLE
proxy: support certificate authority to verify server

### DIFF
--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -74,6 +74,13 @@ spec:
               name: {{ template "pomerium.fullname" . }}
               key: certificate-key
 {{- end }}
+{{- if .Values.config.ca }}
+        - name: CERTIFICATE_AUTHORITY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "pomerium.fullname" . }}
+              key: certificate-authority
+{{- end }}
 {{- if or (eq .Values.config.services "authenticate") (eq .Values.config.services "all") }}
         - name: REDIRECT_URL
           value: {{ .Values.authenticate.redirectUrl }}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -22,3 +22,6 @@ data:
 {{- if .Values.config.key }}
   certificate-key: {{ .Values.config.key | b64enc | quote }}
 {{- end }}
+{{- if .Values.config.ca }}
+  certificate-authority: {{ .Values.config.ca | b64enc | quote }}
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -19,13 +19,14 @@ authenticate:
 # All below required if config.serviceModes is "proxy" or "all"
 proxy:
   authenticateServiceUrl: https://example.com/oauth2/callback
-  routes:
-    "http.corp.example.com": "httpbin.org"
+  routes: {}
+  # routes:
+  #   "http.corp.example.com": "httpbin.org"
 
 # For any other settings that are optional
-# ADDRESS, POMERIUM_DEBUG, CERTIFICATE_FILE, CERTIFICATE_KEY_FILE
+# ADDRESS, POMERIUM_DEBUG, CERTIFICATE_FILE, CERTIFICATE_KEY_FILE, CERTIFICATE_AUTHORITY_FILE,
 # PROXY_ROOT_DOMAIN, COOKIE_DOMAIN, COOKIE_EXPIRE, COOKIE_REFRESH, COOKIE_SECURE, COOKIE_HTTP_ONLY, IDP_SCOPES
-# DEFAULT_UPSTREAM_TIMEOUT, PASS_ACCESS_TOKEN, SESSION_VALID_TTL, SESSION_LIFETIME_TTL, GRACE_PERIOD_TTL
+# AUTHENTICATE_INTERNAL_URL, AUTHENTICATE_SERVICE_PORT, OVERRIDE_CERTIFICATE_NAME, DEFAULT_UPSTREAM_TIMEOUT, COOKIE_LIFETIME,
 extraEnv: {}
 
 extraArgs: {}

--- a/proxy/authenticator/authenticator.go
+++ b/proxy/authenticator/authenticator.go
@@ -31,6 +31,10 @@ type Options struct {
 	OverrideCertificateName string
 	// Shared secret is used to authenticate a authenticate-client with a authenticate-server.
 	SharedSecret string
+	// CA specifies the base64 encoded TLS certificate authority to use.
+	CA string
+	// CAFile specifies the TLS certificate authority file to use.
+	CAFile string
 }
 
 // New returns a new authenticate service client. Takes a client implementation name as an argument.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -37,6 +37,8 @@ type Options struct {
 	AuthenticateInternalAddr string   `envconfig:"AUTHENTICATE_INTERNAL_URL"`
 	OverrideCertificateName  string   `envconfig:"OVERRIDE_CERTIFICATE_NAME"`
 	AuthenticatePort         int      `envconfig:"AUTHENTICATE_SERVICE_PORT"`
+	CA                       string   `envconfig:"CERTIFICATE_AUTHORITY"`
+	CAFile                   string   `envconfig:"CERTIFICATE_AUTHORITY_FILE"`
 
 	// SigningKey is a base64 encoded private key used to add a JWT-signature to proxied requests.
 	// See : https://www.pomerium.io/guide/signed-headers.html
@@ -207,6 +209,8 @@ func New(opts *Options) (*Proxy, error) {
 			OverrideCertificateName: opts.OverrideCertificateName,
 			SharedSecret:            opts.SharedKey,
 			Port:                    opts.AuthenticatePort,
+			CA:                      opts.CA,
+			CAFile:                  opts.CAFile,
 		})
 	return p, nil
 }


### PR DESCRIPTION
This PR adds support for a certificate authority for the proxy to allow connections to the authenticate server when using your own certificate authority.

An unfortunate result of the conversion to using gRPC on the backend is that since AWS Application Load Balancer's [only talk HTTP/1.1](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html#listener-configuration]) from the LB to the application (they can terminate HTTP/2.0 from the client), gRPC is unable to traverse through the load balancer. This forces us to use an internal authenticator URL to talk from the proxy to the authenticator. However, this also means that we can no longer rely on the publicly signed certificates provided by AWS's certificate manager that the ALB uses. Since my organization doesn't have a central certificate authority set up, we were using some self signed certificates.

Assigning a self signed certificate to the authenticate server results in the following error in the proxy logs when the proxy tries to hit the authenticate gRPC endpoint:
```
{"level":"error","fwd_ip":"x.x.x.x","ip":"10.x.x.x","user_agent":"...","req_id":"...","error":"rpc error: code = Unavailable desc = all SubConns are in TransientFailure, latest connection error: connection error: desc = \"transport: authentication handshake failed: x509: certificate signed by unknown authority\"","time":"2019-02-17T02:19:34Z","message":"proxy: error redeeming authorization code"}
```

Thus we are forced to use a CA to sign the authenticator certificate. However for our purposes, we still don't want a central CA. Instead, we create a CA that itself is self-signed. But that then runs into the problem of the proxy trusting the self-signed CA.

This PR adds environment variables CERTIFICATE_AUTHORITY for base64 encoded contents or CERTIFICATE_AUTHORITY_FILE for a file located on the local disk. If present, it replaces the system certificate pool with one consisting of just the CA cert provided. Note that I'm open to renaming these environment variables if desired (maybe CA/CA_FILE?). It also updates the Helm charts to support passing certificate authority.

While we're here, we update the Helm chart with a more up to date list of possible environment variables, and remove the default routes; when someone overrides the proxy.routes, it actually merged the lists together, so anyone using the chart gets a useless route to httpbin.org in addition to the actual route they had; this removes that.

*bdd edit*
Additional context: 
- #4 
- #39 


**Checklist**:
- [ ] documentation updated
- [ ] unit tests added
- [ ] related issues referenced
- [x] ready for review
