### PR TITLE
all: fix misspelling of override

### DIFF
--- a/docs/docs/examples/docker/gitlab.docker-compose.yml
+++ b/docs/docs/examples/docker/gitlab.docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - AUTHENTICATE_INTERNAL_URL=pomerium-authenticate:443
       # When communicating internally, rPC is going to get a name conflict expecting an external
       # facing certificate name (i.e. authenticate-service.local vs *.corp.example.com).
-      - OVERIDE_CERTIFICATE_NAME=*.corp.beyondperimeter.com
+      - OVERRIDE_CERTIFICATE_NAME=*.corp.beyondperimeter.com
       - ROUTES=https://gitlab.corp.beyondperimeter.com=https://gitlab
       # Generate 256 bit random keys  e.g. `head -c32 /dev/urandom | base64`
       - SHARED_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=

--- a/docs/docs/examples/docker/nginx.docker-compose.yml
+++ b/docs/docs/examples/docker/nginx.docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - AUTHENTICATE_INTERNAL_URL=pomerium-authenticate:443
       # When communicating internally, rPC is going to get a name conflict expecting an external
       # facing certificate name (i.e. authenticate-service.local vs *.corp.example.com).
-      - OVERIDE_CERTIFICATE_NAME=*.corp.beyondperimeter.com
+      - OVERRIDE_CERTIFICATE_NAME=*.corp.beyondperimeter.com
       - ROUTES=https://httpbin.corp.beyondperimeter.com=http://httpbin,https://hello.corp.beyondperimeter.com=http://hello:8080/
       # Generate 256 bit random keys  e.g. `head -c32 /dev/urandom | base64`
       - SHARED_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=

--- a/docs/docs/examples/kubernetes/proxy.deploy.yml
+++ b/docs/docs/examples/kubernetes/proxy.deploy.yml
@@ -31,7 +31,7 @@ spec:
               value: https://auth.corp.beyondperimeter.com
             - name: AUTHENTICATE_INTERNAL_URL
               value: "pomerium-authenticate-service.pomerium.svc.cluster.local"
-            - name: OVERIDE_CERTIFICATE_NAME
+            - name: OVERRIDE_CERTIFICATE_NAME
               value: "*.corp.beyondperimeter.com"
             - name: SHARED_SECRET
               valueFrom:

--- a/proxy/authenticator/authenticator.go
+++ b/proxy/authenticator/authenticator.go
@@ -25,10 +25,10 @@ type Options struct {
 	// InternalAddr is the internal (behind the ingress) address to use when making an
 	// authentication connection. If empty, Addr is used.
 	InternalAddr string
-	// OverideCertificateName overrides the server name used to verify the hostname on the
+	// OverrideCertificateName overrides the server name used to verify the hostname on the
 	// returned certificates from the server.  gRPC internals also use it to override the virtual
 	// hosting name if it is set.
-	OverideCertificateName string
+	OverrideCertificateName string
 	// Shared secret is used to authenticate a authenticate-client with a authenticate-server.
 	SharedSecret string
 }

--- a/proxy/authenticator/grpc.go
+++ b/proxy/authenticator/grpc.go
@@ -45,13 +45,13 @@ func NewGRPC(opts *Options) (p Authenticator, err error) {
 	}
 
 	log.Info().
-		Str("OverideCertificateName", opts.OverideCertificateName).
+		Str("OverrideCertificateName", opts.OverrideCertificateName).
 		Str("addr", connAddr).Msgf("proxy/authenticator: grpc connection")
 	cert := credentials.NewTLS(&tls.Config{RootCAs: cp})
 
-	// overide allowed certificate name string, typically used when doing behind ingress connection
-	if opts.OverideCertificateName != "" {
-		err = cert.OverrideServerName(opts.OverideCertificateName)
+	// override allowed certificate name string, typically used when doing behind ingress connection
+	if opts.OverrideCertificateName != "" {
+		err = cert.OverrideServerName(opts.OverrideCertificateName)
 		if err != nil {
 			return nil, err
 		}

--- a/proxy/authenticator/grpc_test.go
+++ b/proxy/authenticator/grpc_test.go
@@ -193,7 +193,7 @@ func TestNewGRPC(t *testing.T) {
 		{"empty connection", &Options{Addr: "", SharedSecret: "shh"}, true, "proxy/authenticator: connection address required"},
 		{"empty connections", &Options{Addr: "", InternalAddr: "", SharedSecret: "shh"}, true, "proxy/authenticator: connection address required"},
 		{"internal addr", &Options{Addr: "", InternalAddr: "intranet.local", SharedSecret: "shh"}, false, ""},
-		{"cert overide", &Options{Addr: "", InternalAddr: "intranet.local", OverideCertificateName: "*.local", SharedSecret: "shh"}, false, ""},
+		{"cert override", &Options{Addr: "", InternalAddr: "intranet.local", OverrideCertificateName: "*.local", SharedSecret: "shh"}, false, ""},
 
 		// {"addr and internal ", &Options{Addr: "localhost", InternalAddr: "local.localhost", SharedSecret: "shh"}, nil, true, ""},
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -35,7 +35,7 @@ type Options struct {
 	// Authenticate service settings
 	AuthenticateURL          *url.URL `envconfig:"AUTHENTICATE_SERVICE_URL"`
 	AuthenticateInternalAddr string   `envconfig:"AUTHENTICATE_INTERNAL_URL"`
-	OverideCertificateName   string   `envconfig:"OVERIDE_CERTIFICATE_NAME"`
+	OverrideCertificateName  string   `envconfig:"OVERRIDE_CERTIFICATE_NAME"`
 	AuthenticatePort         int      `envconfig:"AUTHENTICATE_SERVICE_PORT"`
 
 	// SigningKey is a base64 encoded private key used to add a JWT-signature to proxied requests.
@@ -202,11 +202,11 @@ func New(opts *Options) (*Proxy, error) {
 	p.AuthenticateClient, err = authenticator.New(
 		"grpc",
 		&authenticator.Options{
-			Addr:                   opts.AuthenticateURL.Host,
-			InternalAddr:           opts.AuthenticateInternalAddr,
-			OverideCertificateName: opts.OverideCertificateName,
-			SharedSecret:           opts.SharedKey,
-			Port:                   opts.AuthenticatePort,
+			Addr:                    opts.AuthenticateURL.Host,
+			InternalAddr:            opts.AuthenticateInternalAddr,
+			OverrideCertificateName: opts.OverrideCertificateName,
+			SharedSecret:            opts.SharedKey,
+			Port:                    opts.AuthenticatePort,
 		})
 	return p, nil
 }


### PR DESCRIPTION
This PR fixes the misspelling of overide with a single "r" to override through the codebase, in variable names, comments, and docs.

**Checklist**:
- [x] documentation updated
- [x] unit tests added
- [ ] related issues referenced
- [x] ready for review
