### PR TITLE
internal/identity: use email for gsuite group identifier

### DIFF
--- a/internal/identity/google.go
+++ b/internal/identity/google.go
@@ -211,7 +211,7 @@ func (p *GoogleProvider) UserGroups(ctx context.Context, user string) ([]string,
 			return nil, fmt.Errorf("identity/google: group api request failed %v", err)
 		}
 		for _, group := range resp.Groups {
-			groups = append(groups, group.Name)
+			groups = append(groups, group.Email)
 		}
 	}
 	return groups, nil


### PR DESCRIPTION
Closes #67 

In the future, it makes sense to extend policy, group, and authorize to support  the more secure groupd_id and user_id.

<!--  handy checklist ; not required--> 
**Checklist**:
- [x] related issues referenced
- [x] ready for review

Thanks to @victornoel for reporting the issue. 