### PR TITLE
internal/log: fix setting log level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - **WebSocket Support** : With [Go 1.12](https://golang.org/doc/go1.12#net/http/httputil) pomerium automatically proxies WebSocket requests.
 
 **CHANGED**:
-
+- Add `LOG_LEVEL` config setting that allows for setting the desired minimum log level for an event to be logged. 
+- Changed `POMERIUM_DEBUG` config setting to just do console-pretty printing. No longer sets log level.
 - Updated `generate_wildcard_cert.sh` to generate a elliptic curve 256 cert by default.
 - Updated `env.example` to include a `POLICY` setting example.
 - Added `IDP_SERVICE_ACCOUNT` to `env.example` .

--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -33,6 +33,9 @@ func main() {
 	if *debugFlag || mainOpts.Debug {
 		log.SetDebugMode()
 	}
+	if mainOpts.LogLevel != "" {
+		log.SetLevel(mainOpts.LogLevel)
+	}
 	if *versionFlag {
 		fmt.Printf("%s", version.FullVersion())
 		os.Exit(0)

--- a/cmd/pomerium/options.go
+++ b/cmd/pomerium/options.go
@@ -12,9 +12,12 @@ import (
 // or if a file location is not provided, the server will attempt to find a matching keypair
 // in the local directory as `./cert.pem` and `./privkey.pem` respectively.
 type Options struct {
-	// Debug enables more verbose logging, and outputs human-readable logs to Stdout.
-	// Set with POMERIUM_DEBUG
+	// Debug outputs human-readable logs to Stdout.
 	Debug bool `envconfig:"POMERIUM_DEBUG"`
+
+	// LogLevel sets the global override for log level. All Loggers will use at least this value.
+	// Possible options are "info","warn", and "error". Defaults to "debug".
+	LogLevel string `envconfig:"LOG_LEVEL"`
 
 	// SharedKey is the shared secret authorization key used to mutually authenticate
 	// requests between services.
@@ -39,6 +42,7 @@ type Options struct {
 
 var defaultOptions = &Options{
 	Debug:    false,
+	LogLevel: "debug",
 	Services: "all",
 }
 

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -60,7 +60,7 @@ Policy contains the routes, and their access policies. For example,
 - Type: `bool`
 - Default: `false`
 
-By default, JSON encoded logs are produced. Debug enables colored, human-readable, and more verbose logs to be streamed to [standard out](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)). In production, it's recommended to be set to `false`.
+By default, JSON encoded logs are produced. Debug enables colored, human-readable logs to be streamed to [standard out](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)). In production, it's recommended to be set to `false`.
 
 For example, if `true`
 
@@ -79,6 +79,15 @@ If `false`
 {"level":"info","from":"ssl.corp.beyondperimeter.com","to":"http://neverssl.com","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
 {"level":"info","OverrideCertificateName":"","addr":"auth.corp.beyondperimeter.com:443","time":"2019-02-18T10:41:03-08:00","message":"proxy/authenticator: grpc connection"}
 ```
+
+### Log Level
+
+- Environmental Variable: `LOG_LEVEL`
+- Type: `string`
+- Options: `debug` `info` `warn` `error`
+- Default: `debug`
+
+Log level sets the global logging level for pomerium. Only logs of the desired level and above will be logged. 
 
 ### Certificate
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -15,7 +15,21 @@ var Logger = zerolog.New(os.Stdout).With().Timestamp().Logger()
 // SetDebugMode tells the logger to use standard out and pretty print output.
 func SetDebugMode() {
 	Logger = Logger.Output(zerolog.ConsoleWriter{Out: os.Stdout})
-	// zerolog.SetGlobalLevel(zerolog.InfoLevel)
+}
+
+// SetLevel sets the minimum global log level. Options are 'debu' 'info' 'warn' and 'error'.
+// Defaults to 'debug'
+func SetLevel(level string) {
+	switch level {
+	case "info":
+		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+	case "warn":
+		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+	case "error":
+		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+	default:
+		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+	}
 }
 
 // With creates a child logger with the field added to its context.

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -131,3 +131,27 @@ func Example() {
 
 	// Output: {"level":"info","time":1199811905,"message":"This message appears when log level set to Debug or Info"}
 }
+
+func ExampleSetLevel() {
+	setup()
+	log.SetLevel("info")
+	log.Debug().Msg("Debug")
+	log.Info().Msg("Debug or Info")
+	log.SetLevel("warn")
+	log.Debug().Msg("Debug")
+	log.Info().Msg("Debug or Info")
+	log.Warn().Msg("Debug or Info or Warn")
+	log.SetLevel("error")
+	log.Debug().Msg("Debug")
+	log.Info().Msg("Debug or Info")
+	log.Warn().Msg("Debug or Info or Warn")
+	log.Error().Msg("Debug or Info or Warn or Error")
+	log.SetLevel("default-fall-through")
+	log.Debug().Msg("Debug")
+
+	// Output:
+	// {"level":"info","time":1199811905,"message":"Debug or Info"}
+	// {"level":"warn","time":1199811905,"message":"Debug or Info or Warn"}
+	// {"level":"error","time":1199811905,"message":"Debug or Info or Warn or Error"}
+	// {"level":"debug","time":1199811905,"message":"Debug"}
+}


### PR DESCRIPTION
- POMERIUM_DEBUG no longer sets log level.
- LOG_LEVEL now responsible for setting global log level.

Fixes #70 

Thank you @victornoel for reporting the issue.

<!--  handy checklist ; not required--> 
**Checklist**:
- [x] documentation updated
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review
