### PR TITLE
internal/identity: google cannot have both approval_prompt and prompt

### DIFF
--- a/internal/identity/google.go
+++ b/internal/identity/google.go
@@ -119,14 +119,14 @@ func (p *GoogleProvider) Revoke(accessToken string) error {
 // Support for this scope differs between OpenID Connect providers. For instance
 // Google rejects it, favoring appending "access_type=offline" as part of the
 // authorization request instead.
-// Google only provide refresh_token on the first authorization from the user. If user clears 
+// Google only provide refresh_token on the first authorization from the user. If user clears
 // cookies, re-authorization will not bring back refresh_token. A work around to this is to add
 // prompt=consent to the OAuth redirect URL and will always return a refresh_token.
 // https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess
 // https://developers.google.com/identity/protocols/OAuth2WebServer#offline
 // https://stackoverflow.com/a/10857806/10592439
 func (p *GoogleProvider) GetSignInURL(state string) string {
-	return p.oauth.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce, oauth2.SetAuthURLParam("prompt", "consent"))
+	return p.oauth.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", "consent"))
 }
 
 // Authenticate creates an identity session with google from a authorization code, and follows up


### PR DESCRIPTION
Fixes a bug where caused by setting both `prompt=consent` and `approval_prompt=force`. Though approval_prompt seems to be legacy it is still in the [oauth2 source code](https://github.com/golang/oauth2/blob/9f3314589c9a9136388751d9adae6b0ed400978a/oauth2.go#L120). 

![Screen Shot 2019-04-08 at 5 13 21 PM](https://user-images.githubusercontent.com/1544881/55764725-a6c72380-5a21-11e9-81eb-ab57ddc47625.png)

See: 
- https://github.com/googleapis/oauth2client/issues/453
- #81 
- #80 



<!--  handy checklist ; not required--> 
**Checklist**:
- [ ] documentation updated
- [ ] unit tests added
- [x] related issues referenced
- [x] ready for review
