### PR TITLE
authenticate: infer settings from authenticate url

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,6 +1,7 @@
-<!--  Thanks for sending a pull request!
-We generally follow Go coding and contributing conventions 
-which you can read about here https://golang.org/doc/contribute.html#commit_messages
+<!--  
+Thanks for sending a pull request!
+We generally follow Go coding and contributing conventions
+https://golang.org/doc/contribute.html#commit_messages
 
 Here's an example of a good PR/Commit:
 
@@ -16,9 +17,8 @@ Here's an example of a good PR/Commit:
 -->
 
 
-<!--  handy checklist ; not required--> 
 **Checklist**:
-- [ ] documentation updated
+- [ ] updated docs
 - [ ] unit tests added
 - [ ] related issues referenced
 - [ ] ready for review

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Pomerium Changelog
 
+## vUNRELEASED
+
+### FEATURES
+
+### CHANGED
+
+- Removed `PROXY_ROOT_DOMAIN` config option which is now inferred from `AUTHENTICATE_SERVICE_URL`. Only callback requests originating from a URL on the same sub-domain are permitted. 
+- Removed `REDIRECT_URL` config option which is now inferred from `AUTHENTICATE_SERVICE_URL` (e.g. `https://$AUTHENTICATE_SERVICE_URL/oauth2/callback`).
+
+### FIXED
+
 ## v0.0.3
 
-**FEATURES:**
+### FEATURES
 
 - **Authorization** : The authorization module adds support for per-route access policy. In this release we support the most common forms of identity based access policy: `allowed_users`, `allowed_groups`, and `allowed_domains`. In future versions, the authorization module will also support context and device based authorization policy and decisions. See website documentation for more details.
 - **Group Support** : The authenticate service now retrieves a user's group membership information during authentication and refresh. This change may require additional identity provider configuration; all of which are described in the [updated docs](https://www.pomerium.io/docs/identity-providers.html). A brief summary of the requirements for each IdP are as follows:
@@ -14,13 +25,13 @@
 
 - **WebSocket Support** : With [Go 1.12](https://golang.org/doc/go1.12#net/http/httputil) pomerium automatically proxies WebSocket requests.
 
-**CHANGED**:
-- Add `LOG_LEVEL` config setting that allows for setting the desired minimum log level for an event to be logged. [GH-74] 
+### CHANGED
+
+- Add `LOG_LEVEL` config setting that allows for setting the desired minimum log level for an event to be logged. [GH-74]
 - Changed `POMERIUM_DEBUG` config setting to just do console-pretty printing. No longer sets log level. [GH-74]
 - Updated `generate_wildcard_cert.sh` to generate a elliptic curve 256 cert by default.
 - Updated `env.example` to include a `POLICY` setting example.
 - Added `IDP_SERVICE_ACCOUNT` to `env.example` .
-- Removed `PROXY_ROOT_DOMAIN` settings which has been replaced by `POLICY`.
 - Removed `ALLOWED_DOMAINS` settings which has been replaced by `POLICY`. Authorization is now handled by the authorization service and is defined in the policy configuration files.
 - Removed `ROUTES` settings which has been replaced by `POLICY`.
 - Add refresh endpoint `${url}/.pomerium/refresh` which forces a token refresh and responds with the json result.
@@ -32,6 +43,6 @@
 - **Removed gitlab provider**. We can't support groups until [this gitlab bug](https://gitlab.com/gitlab-org/gitlab-ce/issues/44435#note_88150387) is fixed.
 - Request context is now maintained throughout request-flow via the [context package](https://golang.org/pkg/context/) enabling timeouts, request tracing, and cancellation.
 
-**FIXED:**
+### FIXED
 
 - `http.Server` and `httputil.NewSingleHostReverseProxy` now uses pomerium's logging package instead of the standard library's built in one. [GH-58]

--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -40,7 +40,7 @@ func main() {
 		fmt.Printf("%s", version.FullVersion())
 		os.Exit(0)
 	}
-	log.Info().Str("version", version.FullVersion()).Str("service", mainOpts.Services).Msg("cmd/pomerium")
+	log.Info().Str("version", version.FullVersion()).Str("user-agent", version.UserAgent()).Str("service", mainOpts.Services).Msg("cmd/pomerium")
 
 	grpcAuth := middleware.NewSharedSecretCred(mainOpts.SharedKey)
 	grpcOpts := []grpc.ServerOption{grpc.UnaryInterceptor(grpcAuth.ValidateRequest)}
@@ -57,7 +57,7 @@ func main() {
 		if err != nil {
 			log.Fatal().Err(err).Msg("cmd/pomerium: new authenticate")
 		}
-		authHost = opts.RedirectURL.Host
+		authHost = opts.AuthenticateURL.Host
 		pbAuthenticate.RegisterAuthenticatorServer(grpcServer, authenticateService)
 	}
 

--- a/docs/docs/config-reference.md
+++ b/docs/docs/config-reference.md
@@ -87,7 +87,7 @@ If `false`
 - Options: `debug` `info` `warn` `error`
 - Default: `debug`
 
-Log level sets the global logging level for pomerium. Only logs of the desired level and above will be logged. 
+Log level sets the global logging level for pomerium. Only logs of the desired level and above will be logged.
 
 ### Certificate
 
@@ -107,22 +107,14 @@ Certificate key is the x509 _private-key_ used to establish secure HTTP and gRPC
 
 ## Authenticate Service
 
-### Redirect URL
+### Authenticate Service URL
 
-- Environmental Variable: `REDIRECT_URL`
+- Environmental Variable: `AUTHENTICATE_SERVICE_URL`
 - Type: `URL`
 - Required
-- Example: `https://auth.corp.example.com/oauth2/callback`
+- Example: `https://authenticate.corp.example.com`
 
-Redirect URL is the url the user will be redirected to following authentication with the third-party identity provider (IdP). Note the URL ends with `/oauth2/callback`. This setting will mirror the URL set when configuring your [identity provider]. Typically, on the provider side, this is called an _authorized callback url_.
-
-### Proxy Root Domains
-
-- Environmental Variable: `PROXY_ROOT_DOMAIN`
-- Type: `[]string` (e.g. comma separated list of strings)
-- Required
-
-Proxy Root Domains specifies the sub-domains that can proxy requests. For example, `httpbin.corp.example.com` would be a valid domain under the proxy root domain `corp.example.com`. If a proxy service attempts to authenticate a user from a non-whitelisted domain, an error will be returned.
+Authenticate Service URL is the externally accessible URL for the authenticate service.
 
 ### Identity Provider Name
 
@@ -191,7 +183,7 @@ Signing key is the base64 encoded key used to sign outbound requests. For more i
 - Environmental Variable: `AUTHENTICATE_SERVICE_URL`
 - Type: `URL`
 - Required
-- Example: `https://auth.corp.example.com`
+- Example: `https://authenticate.corp.example.com`
 
 Authenticate Service URL is the externally accessible URL for the authenticate service.
 
@@ -227,7 +219,7 @@ Authorize Internal Service URL is the internally routed dns name of the authoriz
 - Environmental Variable: `OVERRIDE_CERTIFICATE_NAME`
 - Type: `int`
 - Optional (but typically required if Authenticate Internal Service Address is set)
-- Example: `*.corp.example.com` if wild card or `authenticate.corp.example.com`
+- Example: `*.corp.example.com` if wild card or `authenticate.corp.example.com`/`authorize.corp.example.com`
 
 When Authenticate Internal Service Address is set, secure service communication can fail because the external certificate name will not match the internally routed service url. This setting allows you to override that check.
 

--- a/docs/docs/examples/docker/basic.docker-compose.yml
+++ b/docs/docs/examples/docker/basic.docker-compose.yml
@@ -13,18 +13,16 @@ services:
     environment:
       - POMERIUM_DEBUG=true
       - SERVICES=all
-      - REDIRECT_URL=https://auth.corp.beyondperimeter.com/oauth2/callback
       - IDP_PROVIDER=google
       - IDP_PROVIDER_URL=https://accounts.google.com
       - IDP_CLIENT_ID=REPLACE_ME.apps.googleusercontent.com
       - IDP_CLIENT_SECRET=REPLACE_ME
-      - PROXY_ROOT_DOMAIN=beyondperimeter.com
       - SHARED_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=
       - COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
       - CERTIFICATE_FILE=cert.pem
       - CERTIFICATE_KEY_FILE=privkey.pem
-      - AUTHENTICATE_SERVICE_URL=https://auth.corp.beyondperimeter.com
-      - AUTHORIZE_SERVICE_URL=https://access.corp.beyondperimeter.com
+      - AUTHENTICATE_SERVICE_URL=https://authenticate.corp.beyondperimeter.com
+      - AUTHORIZE_SERVICE_URL=https://authorize.corp.beyondperimeter.com
       - POLICY_FILE=./policy.yaml
     volumes:
       - ./cert.pem:/pomerium/cert.pem:ro

--- a/docs/docs/examples/docker/nginx.docker-compose.yml
+++ b/docs/docs/examples/docker/nginx.docker-compose.yml
@@ -19,18 +19,16 @@ services:
     environment:
       - POMERIUM_DEBUG=true
       - SERVICES=authenticate
-      - REDIRECT_URL=https://auth.corp.beyondperimeter.com/oauth2/callback
       # Identity Provider Settings (Must be changed!)
       - IDP_PROVIDER=google
       - IDP_PROVIDER_URL=https://accounts.google.com
       - IDP_CLIENT_ID=REPLACE_ME.apps.googleusercontent.com
       - IDP_CLIENT_SECRET=REPLACE_ME
-      - PROXY_ROOT_DOMAIN=corp.beyondperimeter.com
       - SHARED_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=
       - COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
       # nginx settings
       - VIRTUAL_PROTO=https
-      - VIRTUAL_HOST=auth.corp.beyondperimeter.com
+      - VIRTUAL_HOST=authenticate.corp.beyondperimeter.com
       - VIRTUAL_PORT=443
     volumes:
       - ./cert.pem:/pomerium/cert.pem:ro
@@ -45,8 +43,8 @@ services:
       - POMERIUM_DEBUG=true
       - SERVICES=proxy
       - POLICY_FILE=policy.yaml
-      - AUTHENTICATE_SERVICE_URL=https://auth.corp.beyondperimeter.com
-      - AUTHORIZE_SERVICE_URL=https://access.corp.beyondperimeter.com
+      - AUTHENTICATE_SERVICE_URL=https://authenticate.corp.beyondperimeter.com
+      - AUTHORIZE_SERVICE_URL=https://authorize.corp.beyondperimeter.com
       # IMPORTANT! If you are running pomerium behind another ingress (loadbalancer/firewall/etc)
       # you must tell pomerium proxy how to communicate using an internal hostname for RPC
       - AUTHENTICATE_INTERNAL_URL=pomerium-authenticate:443
@@ -77,7 +75,7 @@ services:
       - SHARED_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=
       # nginx settings
       - VIRTUAL_PROTO=https
-      - VIRTUAL_HOST=access.corp.beyondperimeter.com
+      - VIRTUAL_HOST=authorize.corp.beyondperimeter.com
       - VIRTUAL_PORT=443
     volumes:
       - ./cert.pem:/pomerium/cert.pem:ro

--- a/docs/docs/examples/kubernetes/authenticate.deploy.yml
+++ b/docs/docs/examples/kubernetes/authenticate.deploy.yml
@@ -25,16 +25,12 @@ spec:
           env:
             - name: SERVICES
               value: authenticate
-            - name: REDIRECT_URL
-              value: https://auth.corp.beyondperimeter.com/oauth2/callback
             - name: IDP_PROVIDER
               value: google
             - name: IDP_PROVIDER_URL
               value: https://accounts.google.com
             - name: IDP_CLIENT_ID
               value: 851877082059-bfgkpj09noog7as3gpc3t7r6n9sjbgs6.apps.googleusercontent.com 
-            - name: PROXY_ROOT_DOMAIN
-              value: beyondperimeter.com
             - name: SHARED_SECRET
               valueFrom:
                 secretKeyRef:

--- a/docs/docs/examples/kubernetes/ingress.nginx.yml
+++ b/docs/docs/examples/kubernetes/ingress.nginx.yml
@@ -16,8 +16,8 @@ spec:
     - secretName: pomerium-tls
       hosts:
         - "*.corp.beyondperimeter.com"
-        - "auth.corp.beyondperimeter.com"
-        - "access.corp.beyondperimeter.com"
+        - "authenticate.corp.beyondperimeter.com"
+        - "authorize.corp.beyondperimeter.com"
 
   rules:
     - host: "*.corp.beyondperimeter.com"
@@ -28,14 +28,14 @@ spec:
               serviceName: pomerium-proxy-service
               servicePort: https
 
-    - host: "auth.corp.beyondperimeter.com"
+    - host: "authenticate.corp.beyondperimeter.com"
       http:
         paths:
           - paths:
             backend:
               serviceName: pomerium-authenticate-service
               servicePort: https
-    - host: "access.corp.beyondperimeter.com"
+    - host: "authorize.corp.beyondperimeter.com"
       http:
         paths:
           - paths:

--- a/docs/docs/examples/kubernetes/ingress.yml
+++ b/docs/docs/examples/kubernetes/ingress.yml
@@ -12,8 +12,8 @@ spec:
     - secretName: pomerium-tls
       hosts:
         - "*.corp.beyondperimeter.com"
-        - "auth.corp.beyondperimeter.com"
-        - "access.corp.beyondperimeter.com"
+        - "authenticate.corp.beyondperimeter.com"
+        - "authorize.corp.beyondperimeter.com"
 
   rules:
     - host: "*.corp.beyondperimeter.com"
@@ -23,14 +23,14 @@ spec:
             backend:
               serviceName: pomerium-proxy-service
               servicePort: https
-    - host: "auth.corp.beyondperimeter.com"
+    - host: "authenticate.corp.beyondperimeter.com"
       http:
         paths:
           - paths:
             backend:
               serviceName: pomerium-authenticate-service
               servicePort: https
-    - host: "access.corp.beyondperimeter.com"
+    - host: "authorize.corp.beyondperimeter.com"
       http:
         paths:
           - paths:

--- a/docs/docs/examples/kubernetes/proxy.deploy.yml
+++ b/docs/docs/examples/kubernetes/proxy.deploy.yml
@@ -26,11 +26,11 @@ spec:
             - name: SERVICES
               value: proxy
             - name: AUTHORIZE_SERVICE_URL
-              value: https://access.corp.beyondperimeter.com
+              value: https://authorize.corp.beyondperimeter.com
             - name: AUTHORIZE_INTERNAL_URL
               value: "pomerium-authorize-service.pomerium.svc.cluster.local"
             - name: AUTHENTICATE_SERVICE_URL
-              value: https://auth.corp.beyondperimeter.com
+              value: https://authenticate.corp.beyondperimeter.com
             - name: AUTHENTICATE_INTERNAL_URL
               value: "pomerium-authenticate-service.pomerium.svc.cluster.local"
             - name: OVERRIDE_CERTIFICATE_NAME

--- a/docs/docs/identity-providers.md
+++ b/docs/docs/identity-providers.md
@@ -14,7 +14,7 @@ There are a few configuration steps required for identity provider integration. 
 
 In this guide we'll cover how to do the following for each identity provider:
 
-1. Set a **[Redirect URL]** pointing back to Pomerium.
+1. Set a **Redirect URL** pointing back to Pomerium. That is, `https://${AUTHENTICATE_SERVICE_URL}/oauth2/callback` 
 2. Generate a **[Client ID]** and **[Client Secret]**.
 3. Configure Pomerium to use the **[Client ID]** and **[Client Secret]** keys.
 
@@ -69,7 +69,7 @@ Click on **Save** and the key will be displayed. **Make sure to copy the value o
 
 ![Creating a Key](./microsoft/azure-create-key.png)
 
-Next you need to ensure that the Pomerium's Redirect URL is listed in allowed reply URLs for the created application. Navigate to **Azure Active Directory** -> **Apps registrations** and select your app. Then click **Settings** -> **Reply URLs** and add Pomerium's redirect URL. For example, `https://sso-auth.corp.beyondperimeter.com/oauth2/callback`.
+Next you need to ensure that the Pomerium's Redirect URL is listed in allowed reply URLs for the created application. Navigate to **Azure Active Directory** -> **Apps registrations** and select your app. Then click **Settings** -> **Reply URLs** and add Pomerium's redirect URL. For example, `https://authenticate.corp.beyondperimeter.com/oauth2/callback`.
 
 ![Add Reply URL](./microsoft/azure-redirect-url.png)
 
@@ -109,7 +109,6 @@ Finally, configure Pomerium with the identity provider settings retrieved in the
 
 ```bash
 # Azure
-REDIRECT_URL="https://sso-auth.corp.beyondperimeter.com/oauth2/callback"
 IDP_PROVIDER="azure"
 IDP_PROVIDER_URL="https://login.microsoftonline.com/{REPLACE-ME-SEE-ABOVE}/v2.0"
 IDP_CLIENT_ID="REPLACE-ME"
@@ -133,7 +132,7 @@ On the **Applications** page, add a new application by setting the following par
 Field        | Description
 ------------ | --------------------------------------------------------------------
 Name         | The name of your web app
-Redirect URI | [Redirect URL] (e.g.`https://auth.corp.example.com/oauth2/callback`)
+Redirect URI | Redirect URL (e.g.`https://authenticate.corp.example.com/oauth2/callback`)
 Scopes       | **Must** select **read_user** and **openid**
 
 ![Create New Credentials](./gitlab/gitlab-create-application.png)
@@ -147,7 +146,6 @@ Your [Client ID] and [Client Secret] will be displayed:
 Set [Client ID] and [Client Secret] in Pomerium's settings. Your [environmental variables] should look something like this.
 
 ```bash
-REDIRECT_URL="https://sso-auth.corp.beyondperimeter.com/oauth2/callback"
 IDP_PROVIDER="gitlab"
 # NOTE!!! Provider url is optional, but should be set if you are running an on-premise instance
 # defaults to : https://gitlab.com, a local copy would look something like `http://gitlab.corp.beyondperimeter.com`
@@ -175,7 +173,7 @@ On the **Create [Client ID]** page, select **Web application**. In the new field
 Field                    | Description
 ------------------------ | --------------------------------------------------------------------
 Name                     | The name of your web app
-Authorized redirect URIs | [Redirect URL] (e.g.`https://auth.corp.example.com/oauth2/callback`)
+Authorized redirect URIs | Redirect URL (e.g.`https://authenticate.corp.example.com/oauth2/callback`)
 
 ![Web App Credentials Configuration](./google/google-create-client-id-config.png)
 
@@ -229,7 +227,6 @@ Next we'll delegate G-suite group membership access to the service account we ju
 Your [environmental variables] should look something like this.
 
 ```bash
-REDIRECT_URL="https://sso-auth.corp.beyondperimeter.com/oauth2/callback"
 IDP_PROVIDER="google"
 IDP_PROVIDER_URL="https://accounts.google.com"
 IDP_CLIENT_ID="yyyy.apps.googleusercontent.com"
@@ -253,7 +250,7 @@ Field                        | Description
 ---------------------------- | ---------------------------------------------------------------------
 Name                         | The name of your application.
 Base URIs (optional)         | The domain(s) of your application.
-Login redirect URIs          | [Redirect URL] (e.g.`https://auth.corp.example.com/oauth2/callback`).
+Login redirect URIs          | Redirect URL (e.g.`https://authenticate.corp.example.com/oauth2/callback`).
 Group assignments (optional) | The user groups that can sign in to this application.
 Grant type allowed           | **You must enable Refresh Token.**
 
@@ -296,7 +293,6 @@ Include in            | Any scope
 Finally, configure Pomerium with the identity provider settings retrieved in the pervious steps. Your [environmental variables] should look something like this.
 
 ```bash
-REDIRECT_URL="https://sso-auth.corp.beyondperimeter.com/oauth2/callback"
 IDP_PROVIDER="okta"
 IDP_PROVIDER_URL="https://dev-108295-admin.oktapreview.com/"
 IDP_CLIENT_ID="0oairksnr0C0fEJ7l0h7"
@@ -319,7 +315,7 @@ On the App Configuration page, **name the app** and **select a logo**. Select **
 
 ![One Login select logo](./one-login/one-login-select-logo.png)
 
-Next, set set the **Redirect URI's** setting to be Pomerium's [redirect url].
+Next, set set the **Redirect URI's** setting to be Pomerium's redirect url `https://${AUTHENTICATE_SERVICE_URL}/oauth2/callback`.
 
 ![One Login set callback url](./one-login/one-login-callback-url.png)
 
@@ -345,7 +341,6 @@ To return the user's Active Directory field, configure the group to return `memb
 Finally, configure Pomerium with the identity provider settings retrieved in the pervious steps. Your [environmental variables] should look something like this.
 
 ```bash
-REDIRECT_URL="https://auth.corp.beyondperimeter.com/oauth2/callback"
 IDP_PROVIDER="onelogin"
 IDP_PROVIDER_URL="https://openid-connect.onelogin.com/oidc"
 IDP_CLIENT_ID="9e613ce0-1622-0137-452d-0a93c31f8392142934"
@@ -361,4 +356,3 @@ After reloading Pomerium, you should be able to see any login events from your O
 [environmental variables]: https://en.wikipedia.org/wiki/Environment_variable
 [oauth2]: https://oauth.net/2/
 [openid connect]: https://en.wikipedia.org/wiki/OpenID_Connect
-[redirect url]: ./config-reference.html#redirect-url

--- a/docs/guide/synology.md
+++ b/docs/guide/synology.md
@@ -173,10 +173,8 @@ OVERRIDE_CERTIFICATE_NAME | `*.int.nas.example.com`
 IDP_CLIENT_SECRET         | Values from setting up your [identity provider]
 IDP_CLIENT_ID             | Values from setting up your [identity provider]
 IDP_PROVIDER              | Values from setting up your [identity provider] (e.g. `google`)
-REDIRECT_URL              | `https://authenticate.int.nas.example.com/oauth2/callback`
 COOKIE_SECRET             | output of `head -c32 /dev/urandom | base64`
 SHARED_SECRET             | output of `head -c32 /dev/urandom | base64`
-PROXY_ROOT_DOMAIN         | `int.nas.example.com`
 AUTHORIZE_SERVICE_URL     | `https://authorize.int.nas.example.com`
 AUTHENTICATE_SERVICE_URL  | `https://authenticate.int.nas.example.com`
 AUTHORIZE_INTERNAL_URL    | `localhost:443`

--- a/env.example
+++ b/env.example
@@ -3,7 +3,11 @@
 # Main configuration flags
 # export ADDRESS=":8443"                      # optional, default is 443
 # export POMERIUM_DEBUG=true                  # optional, default is false
-# export SERVICE="all"                        # optional, default is all.
+# export SERVICE="all"                        # optional, default is all
+# export LOG_LEVEL="info"                     # optional, default is debug
+
+export AUTHENTICATE_SERVICE_URL=https://authenticate.corp.example.com
+export AUTHORIZE_SERVICE_URL=https://authorize.corp.example.com
 
 # Certificates can be loaded as files or base64 encoded bytes. If neither is set, a
 # pomerium will attempt to locate a pair in the root directory
@@ -12,8 +16,6 @@ export CERTIFICATE_KEY_FILE="./privkey.pem" # optional, defaults to `./certprivk
 # export CERTIFICATE="xxxxxx"                 # base64 encoded cert, eg. `base64 -i cert.pem`
 # export CERTIFICATE_KEY="xxxx"               # base64 encoded key, eg. `base64 -i privkey.pem`
 
-# The URL that the identity provider will call back after authenticating the user
-export REDIRECT_URL="https://sso-auth.corp.example.com/oauth2/callback"
 # Generate 256 bit random keys  e.g. `head -c32 /dev/urandom | base64`
 export SHARED_SECRET=9wiTZq4qvmS/plYQyvzGKWPlH/UBy0DMYMA2x/zngrM=
 export COOKIE_SECRET=uPGHo1ujND/k3B9V6yr52Gweq3RRYfFho98jxDG5Br8=

--- a/policy.example.yaml
+++ b/policy.example.yaml
@@ -1,19 +1,19 @@
 - from: httpbin.corp.beyondperimeter.com
   to: http://httpbin
   allowed_domains:
-  - pomerium.io
+    - pomerium.io
 - from: external-httpbin.corp.beyondperimeter.com
   to: httpbin.org
   allowed_domains:
-  - gmail.com
+    - gmail.com
 - from: weirdlyssl.corp.beyondperimeter.com
   to: http://neverssl.com
   allowed_users:
-  - bdd@pomerium.io
+    - bdd@pomerium.io
   allowed_groups:
-  - admins
-  - developers
+    - admins
+    - developers
 - from: hello.corp.beyondperimeter.com
   to: http://hello:8080
   allowed_groups:
-  - admins
+    - admins

--- a/scripts/helm_gke.sh
+++ b/scripts/helm_gke.sh
@@ -37,7 +37,6 @@ echo " replace configuration settings to meet your specific needs and identity p
 
 helm install ./helm/ \
 	--set service.type="NodePort" \
-	--set config.rootDomain="corp.pomerium.io" \
 	--set ingress.secret.name="pomerium-tls" \
 	--set ingress.secret.cert=$(base64 -i "$HOME/.acme.sh/*.corp.pomerium.io_ecc/*.corp.pomerium.io.cer") \
 	--set ingress.secret.key=$(base64 -i "$HOME/.acme.sh/*.corp.pomerium.io_ecc/*.corp.pomerium.io.key") \


### PR DESCRIPTION
- Removed `PROXY_ROOT_DOMAIN` config option which is now inferred from `AUTHENTICATE_SERVICE_URL`. Only callback requests originating from a URL on the same sub-domain are permitted. 
- Removed `REDIRECT_URL` config option which is now inferred from `AUTHENTICATE_SERVICE_URL` (e.g. `https://$AUTHENTICATE_SERVICE_URL/oauth2/callback`).

See:
- #71 

<!--  handy checklist ; not required--> 
**Checklist**:
- [x] documentation updated
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review
