### PR TITLE
add cors_allow_preflight option to a route's policy

### DIFF
--- a/internal/middleware/middleware.go
+++ b/internal/middleware/middleware.go
@@ -117,10 +117,10 @@ func ValidateSignature(sharedSecret string) func(next http.Handler) http.Handler
 }
 
 // ValidateHost ensures that each request's host is valid
-func ValidateHost(mux map[string]http.Handler) func(next http.Handler) http.Handler {
+func ValidateHost(validHost func(host string) bool) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if _, ok := mux[r.Host]; !ok {
+			if !validHost(r.Host) {
 				httputil.ErrorResponse(w, r, "Unknown route", http.StatusNotFound)
 				return
 			}

--- a/internal/policy/policy.go
+++ b/internal/policy/policy.go
@@ -26,6 +26,10 @@ type Policy struct {
 
 	Source      *url.URL
 	Destination *url.URL
+
+	// Allow unauthenticated HTTP OPTIONS requests as per the CORS spec
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests
+	CORSAllowPreflight bool `yaml:"cors_allow_preflight"`
 }
 
 func (p *Policy) validate() (err error) {

--- a/policy.example.yaml
+++ b/policy.example.yaml
@@ -17,3 +17,8 @@
   to: http://hello:8080
   allowed_groups:
     - admins
+- from: cross-origin.corp.beyondperimeter.com 
+  to: httpbin.org
+  allowed_domains:
+      - gmail.com
+  cors_allow_preflight: true

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -127,6 +127,13 @@ func testOptions() *Options {
 	}
 }
 
+func testOptionsWithCORS() *Options {
+	configBlob := `[{"from":"corp.example.com","to":"example.com","cors_allow_preflight":true}]` //valid yaml
+	opts := testOptions()
+	opts.Policy = base64.URLEncoding.EncodeToString([]byte(configBlob))
+	return opts
+}
+
 func TestOptions_Validate(t *testing.T) {
 	good := testOptions()
 	badFromRoute := testOptions()
@@ -204,7 +211,7 @@ func TestNew(t *testing.T) {
 		opts      *Options
 		optFuncs  []func(*Proxy) error
 		wantProxy bool
-		numMuxes  int
+		numRoutes int
 		wantErr   bool
 	}{
 		{"good", good, nil, true, 1, false},
@@ -223,8 +230,8 @@ func TestNew(t *testing.T) {
 			if got == nil && tt.wantProxy == true {
 				t.Errorf("New() expected valid proxy struct")
 			}
-			if got != nil && len(got.mux) != tt.numMuxes {
-				t.Errorf("New() = num muxes \n%+v, want \n%+v", got, tt.numMuxes)
+			if got != nil && len(got.routeConfigs) != tt.numRoutes {
+				t.Errorf("New() = num routeConfigs \n%+v, want \n%+v", got, tt.numRoutes)
 			}
 		})
 	}


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!
We generally follow Go coding and contributing conventions
https://golang.org/doc/contribute.html#commit_messages

Here's an example of a good PR/Commit:

    math: improve Sin, Cos and Tan precision for very large arguments

    The existing implementation has poor numerical properties for
    large arguments, so use the McGillicutty algorithm to improve
    accuracy above 1e10.

    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm

    Fixes #159
-->
 Fixes  #78

Add a route-level setting (`false` by default) to allow unauthenticated OPTIONS requests for CORS. See #78 for more information.


**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] check for required headers in preflight requests
- [x] ready for review
