### PR TITLE
deployment: support multiple docker architectures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ COPY go.sum .
 RUN go mod download
 
 COPY . .
-
+# docker build --build-arg ARCH=arm --build-arg ARM=7 .
+ARG ARCH=amd64
+ARG ARM=7
+ENV GOARCH=${ARCH}
+ENV GOARM=${ARM}
 RUN make
 
 FROM scratch


### PR DESCRIPTION
Adds support for injecting GOARCH, GOARM, and GOOS at runtime to dockerfile. 

I believe we can support this without changing the base image but I don't have an arm device to test. 

@fightforlife can you confirm the tags `latest-arm32v7` and `latest-arm32v7` work as expected? 

**Checklist**:
- [x] arm32v6 pushed
- [x] arm32v7 pushed
- [x] ready for review
