### PR TITLE
deployment: use distroless builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ CTIMEVAR=-X $(PKG)/internal/version.GitCommit=$(GITCOMMIT) \
 	-X $(PKG)/internal/version.BuildMeta=$(BUILDMETA) \
 	-X $(PKG)/internal/version.ProjectName=$(NAME) \
 	-X $(PKG)/internal/version.ProjectURL=$(PKG)
-GO_LDFLAGS=-ldflags "-w $(CTIMEVAR)"
+GO_LDFLAGS=-ldflags "-s -w $(CTIMEVAR)"
 GOOSARCHES = linux/amd64 darwin/amd64 windows/amd64
 
 


### PR DESCRIPTION
Replaces the current alpine based Dockerfile with [distroless](https://github.com/GoogleContainerTools/distroless). Improvements include:
- Minimal surface area, ideal for static builds like pomerium.
- Includes `ca-certificates`
- Includes`nsswitch`

Closes #97 .

**See also**

- [best practices for building containers](https://cloud.google.com/solutions/best-practices-for-building-containers#use_the_smallest_base_image_possible)
- [Life of a happy developer in a container world by David Gageot
 ](https://www.youtube.com/watch?v=lviLZFciDv4)
- [Distroless Docker: Containerizing Apps, not VMs](https://www.youtube.com/watch?v=lviLZFciDv4)

**Checklist**:
- [x] related issues referenced
- [x] ready for review

Test image is available on dockerhub as `pomerium/pomerium:distroless`

/cc @yegle @eriksw