### PR TITLE
deployment: add docker images for arm

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+docs
+scripts
+docker-compose.yml
+firebase.json
+*.example

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -2,12 +2,8 @@ FROM golang:latest as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
-# docker build --build-arg ARCH=arm --build-arg ARM=7 .
-# frustratingly not supported by dockerhub automated builds though
-ARG ARCH=amd64
-ARG ARM=7
-ENV GOARCH=${ARCH}
-ENV GOARM=${ARM}
+ENV GOARCH=arm
+ENV GOARM=6
 # cache depedency downloads
 COPY go.mod go.sum ./
 RUN go mod download

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -2,12 +2,8 @@ FROM golang:latest as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 ENV CGO_ENABLED=0
 ENV GO111MODULE=on
-# docker build --build-arg ARCH=arm --build-arg ARM=7 .
-# frustratingly not supported by dockerhub automated builds though
-ARG ARCH=amd64
-ARG ARM=7
-ENV GOARCH=${ARCH}
-ENV GOARM=${ARM}
+ENV GOARCH=arm
+ENV GOARM=7
 # cache depedency downloads
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
I was hoping to be able to do this without adding a bunch of dockerfiles per architecture but it looks like Docker hub does not currently support passing `ARG`s in with their automated builds. 

Closes #95.

See:
- https://github.com/docker/hub-feedback/issues/508


**Checklist**:
- [x] related issues referenced
- [x] ready for review

\cc @fightforlife
