### PR TITLE
proxy: make http redirect server configurable

### DIFF
--- a/cmd/pomerium/options.go
+++ b/cmd/pomerium/options.go
@@ -38,6 +38,11 @@ type Options struct {
 	// CertFile and KeyFile specifies the TLS certificates to use.
 	CertFile string `envconfig:"CERTIFICATE_FILE"`
 	KeyFile  string `envconfig:"CERTIFICATE_KEY_FILE"`
+
+	// HttpRedirectAddr, if set, specifies the host and port to run the HTTP
+	// to HTTPS redirect server on. For example, ":http" would start a server
+	// on port 80.  If empty, no redirect server is started.
+	HTTPRedirectAddr string `envconfig:"HTTP_REDIRECT_ADDR"`
 }
 
 var defaultOptions = &Options{

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -31,6 +31,17 @@ Service mode sets the pomerium service(s) to run. If testing, you may want to se
 
 Address specifies the host and port to serve HTTPS and gRPC requests from. If empty, `:https`/`:443` is used.
 
+
+### HTTP Redirect Address
+
+- Environmental Variable: `HTTP_REDIRECT_ADDR`
+- Type: `string`
+- Default: `` (no serevr is started)
+- Example: `:80`
+- Optional
+
+If set, the HTTP Redirect Address specifies the host and port to redirect http to https traffic on. If not set, no redirect server is started. 
+
 ### Shared Secret
 
 - Environmental Variable: `SHARED_SECRET`

--- a/internal/urlutil/url.go
+++ b/internal/urlutil/url.go
@@ -2,6 +2,11 @@ package urlutil // import "github.com/pomerium/pomerium/internal/urlutil"
 
 import "strings"
 
+// StripPort returns a host, without any port number.
+//
+// If Host is an IPv6 literal with a port number, Hostname returns the
+// IPv6 literal without the square brackets. IPv6 literals may include
+// a zone identifier.
 func StripPort(hostport string) string {
 	colon := strings.IndexByte(hostport, ':')
 	if colon == -1 {


### PR DESCRIPTION
This would make the HTTP redirect server default to off and also allows for the port to be configured.

Closes #103.

```bash
#policy.yaml
export HTTP_REDIRECT_ADDR=":http"
```

`http http://external-httpbin.corp.beyondperimeter.com/ping`

```bash
HTTP/1.1 301 Moved Permanently
Connection: close
Content-Length: 89
Content-Type: text/html; charset=utf-8
Date: Fri, 03 May 2019 23:45:43 GMT
Location: https://external-httpbin.corp.beyondperimeter.com/ping

<a href="https://external-httpbin.corp.beyondperimeter.com/ping">Moved Permanently</a>.
```

See also:
- #92 

**Checklist**:
- [x] updated docs
- [ ] unit tests added
- [x] related issues referenced
- [x] ready for review

/cc @yegle @haozhou