### PR TITLE
cmd/pomerium: wrap global mux with standard middleware

### DIFF
--- a/authorize/gprc.go
+++ b/authorize/gprc.go
@@ -5,14 +5,11 @@ import (
 	"context"
 
 	pb "github.com/pomerium/pomerium/proto/authorize"
-
-	"github.com/pomerium/pomerium/internal/log"
 )
 
 // Authorize validates the user identity, device, and context of a request for
 // a given route. Currently only checks identity.
 func (a *Authorize) Authorize(ctx context.Context, in *pb.AuthorizeRequest) (*pb.AuthorizeReply, error) {
 	ok := a.ValidIdentity(in.Route, &Identity{in.User, in.Email, in.Groups})
-	log.Debug().Str("route", in.Route).Strs("groups", in.Groups).Str("email", in.Email).Bool("Valid?", ok).Msg("authorize/grpc")
 	return &pb.AuthorizeReply{IsValid: ok}, nil
 }

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/pomerium/pomerium/internal/sessions"
-	"github.com/pomerium/pomerium/internal/version"
 	"github.com/pomerium/pomerium/proxy/clients"
 )
 
@@ -206,14 +205,11 @@ func TestProxy_Handler(t *testing.T) {
 	}
 	mux := http.NewServeMux()
 	mux.Handle("/", h)
-	req := httptest.NewRequest("GET", "/ping", nil)
-
+	req := httptest.NewRequest("GET", "/", nil)
 	rr := httptest.NewRecorder()
 	mux.ServeHTTP(rr, req)
-	expected := version.UserAgent()
-	body := rr.Body.String()
-	if body != expected {
-		t.Errorf("handler returned unexpected body: got %v want %v", body, expected)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404 route not found for empty route")
 	}
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -31,8 +31,6 @@ const (
 	HeaderEmail = "x-pomerium-authenticated-user-email"
 	// HeaderGroups is the header key containing the user's groups.
 	HeaderGroups = "x-pomerium-authenticated-user-groups"
-	// DisableHeaderKey is the key used to check whether to disable setting header
-	DisableHeaderKey = "disable"
 )
 
 // Options represents the configurations available for the proxy service.
@@ -72,9 +70,6 @@ type Options struct {
 	CookieExpire   time.Duration `envconfig:"COOKIE_EXPIRE"`
 	CookieRefresh  time.Duration `envconfig:"COOKIE_REFRESH"`
 
-	// Headers to set on all proxied requests. Add a 'disable' key map to turn off.
-	Headers map[string]string `envconfig:"HEADERS"`
-
 	// Sub-routes
 	Routes                 map[string]string `envconfig:"ROUTES"`
 	DefaultUpstreamTimeout time.Duration     `envconfig:"DEFAULT_UPSTREAM_TIMEOUT"`
@@ -88,12 +83,6 @@ var defaultOptions = &Options{
 	CookieExpire:           time.Duration(14) * time.Hour,
 	CookieRefresh:          time.Duration(30) * time.Minute,
 	DefaultUpstreamTimeout: time.Duration(30) * time.Second,
-	Headers: map[string]string{
-		"X-Content-Type-Options":    "nosniff",
-		"X-Frame-Options":           "SAMEORIGIN",
-		"X-XSS-Protection":          "1; mode=block",
-		"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-	},
 }
 
 // OptionsFromEnvConfig builds the identity provider service's configuration
@@ -189,7 +178,6 @@ type Proxy struct {
 	redirectURL  *url.URL
 	templates    *template.Template
 	routeConfigs map[string]*routeConfig
-	headers      map[string]string
 }
 
 type routeConfig struct {
@@ -227,12 +215,6 @@ func New(opts *Options) (*Proxy, error) {
 		return nil, err
 	}
 
-	// if the disable key is found in the security header map, clear the map
-	if _, disable := opts.Headers[DisableHeaderKey]; disable {
-		opts.Headers = make(map[string]string)
-	}
-	log.Debug().Interface("headers", opts.Headers).Msg("proxy: security headers")
-
 	p := &Proxy{
 		routeConfigs: make(map[string]*routeConfig),
 		// services
@@ -244,7 +226,6 @@ func New(opts *Options) (*Proxy, error) {
 		SharedKey:    opts.SharedKey,
 		redirectURL:  &url.URL{Path: "/.pomerium/callback"},
 		templates:    templates.New(),
-		headers:      opts.Headers,
 	}
 	var policies []policy.Policy
 	if opts.Policy != "" {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -124,7 +124,6 @@ func testOptions() *Options {
 		SharedKey:       "80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ=",
 		CookieSecret:    "OromP1gurwGWjQPYb1nNgSxtbVB5NnLzX6z5WOKr0Yw=",
 		CookieName:      "pomerium",
-		Headers:         defaultOptions.Headers,
 	}
 }
 
@@ -206,23 +205,18 @@ func TestNew(t *testing.T) {
 	shortCookieLength.CookieSecret = "gN3xnvfsAwfCXxnJorGLKUG4l2wC8sS8nfLMhcStPg=="
 	badRoutedProxy := testOptions()
 	badRoutedProxy.SigningKey = "YmFkIGtleQo="
-	disableHeaders := testOptions()
-	disableHeaders.Headers = map[string]string{"disable": "true"}
-
 	tests := []struct {
-		name       string
-		opts       *Options
-		wantProxy  bool
-		numRoutes  int
-		wantErr    bool
-		numHeaders int
+		name      string
+		opts      *Options
+		wantProxy bool
+		numRoutes int
+		wantErr   bool
 	}{
-		{"good", good, true, 1, false, len(defaultOptions.Headers)},
-		{"empty options", &Options{}, false, 0, true, 0},
-		{"nil options", nil, false, 0, true, 0},
-		{"short secret/validate sanity check", shortCookieLength, false, 0, true, 0},
-		{"invalid ec key, valid base64 though", badRoutedProxy, false, 0, true, 0},
-		{"test disabled headers", disableHeaders, false, 1, false, 0},
+		{"good", good, true, 1, false},
+		{"empty options", &Options{}, false, 0, true},
+		{"nil options", nil, false, 0, true},
+		{"short secret/validate sanity check", shortCookieLength, false, 0, true},
+		{"invalid ec key, valid base64 though", badRoutedProxy, false, 0, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -237,10 +231,6 @@ func TestNew(t *testing.T) {
 			if got != nil && len(got.routeConfigs) != tt.numRoutes {
 				t.Errorf("New() = num routeConfigs \n%+v, want \n%+v", got, tt.numRoutes)
 			}
-			if got != nil && len(got.headers) != tt.numHeaders {
-				t.Errorf("New() = num Headers \n%+v, want \n%+v", got.headers, tt.numHeaders)
-			}
-
 		})
 	}
 }


### PR DESCRIPTION
These changes abstract the shared middleware to the global serve mux. Headers, request id, loggers, and health checks (ping) middleware are now applied on all routes including 4xx and 5xx responses. 

See
- #116 

**Checklist**:
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review

/cc @yegle