### PR TITLE
authenticate: remove CSP / referrer policy headers from other handlers

### DIFF
--- a/cmd/pomerium/options.go
+++ b/cmd/pomerium/options.go
@@ -68,8 +68,6 @@ var defaultOptions = &Options{
 		"X-Frame-Options":           "SAMEORIGIN",
 		"X-XSS-Protection":          "1; mode=block",
 		"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-		"Content-Security-Policy":   "default-src 'none'; style-src 'self' 'sha256-pSTVzZsFAqd2U3QYu+BoBDtuJWaPM/+qMy/dBRrhb5Y='; img-src 'self';",
-		"Referrer-Policy":           "Same-origin",
 	},
 }
 

--- a/docs/docs/certificates.md
+++ b/docs/docs/certificates.md
@@ -20,7 +20,7 @@ It should be noted that there are countless ways of building and managing [publi
 
 ::: warning
 
-LetsEncrypt certificates certificates must be renewed [every 90 days](https://letsencrypt.org/2015/11/09/why-90-days.html).
+LetsEncrypt certificates must be renewed [every 90 days](https://letsencrypt.org/2015/11/09/why-90-days.html).
 
 :::
 


### PR DESCRIPTION
These changes fixes a regression in #117 where content `Content-Security-Policy` and `Referrer-Policy` were incorrectly being applied to upstream routes in addition to authenticate handlers. These changes apply those headers **only** to authenticate's endpoints.


Closes #119 


Example

```bash
curl -I https://httpbin.corp.beyondperimeter.com/
HTTP/2 302
content-type: text/html; charset=utf-8
request-id: bb049b04-2718-9233-6e30-d0c1ac552580
set-cookie: _pomerium_proxy=; Path=/; Domain=httpbin.corp.beyondperimeter.com; Expires=Wed, 15 May 2019 04:14:14 GMT; HttpOnly; Secure
strict-transport-security: max-age=31536000; includeSubDomains; preload
x-content-type-options: nosniff
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
```

```bash
curl -I https://authenticate.corp.beyondperimeter.com/robots.txt
HTTP/2 200
content-security-policy: default-src 'none'; style-src 'self' 'sha256-pSTVzZsFAqd2U3QYu+BoBDtuJWaPM/+qMy/dBRrhb5Y='; img-src 'self';
referrer-policy: Same-origin
request-id: 84bf45af-5b70-9f21-4c21-ece1adadf887
strict-transport-security: max-age=31536000; includeSubDomains; preload
...
```


**Checklist**:
- [x] updated docs
- [x] ready for review
