### PR TITLE
docker: add missing golint command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ ARG ARCH=amd64
 ARG ARM=7
 ENV GOARCH=${ARCH}
 ENV GOARM=${ARM}
+RUN go get golang.org/x/lint/golint
 # cache depedency downloads
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!
We generally follow Go coding and contributing conventions
https://golang.org/doc/contribute.html#commit_messages

Here's an example of a good PR/Commit:

    math: improve Sin, Cos and Tan precision for very large arguments

    The existing implementation has poor numerical properties for
    large arguments, so use the McGillicutty algorithm to improve
    accuracy above 1e10.

    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm

    Fixes #159
-->
Fixes:
```
==> build
==> fmt
==> lint
/bin/sh: 1: golint: not found
```

**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review
