### PR TITLE
Add Helm chart fixes

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: pomerium
-version: 1.0.0
-appVersion: 0.0.3
+version: 1.1.0
+appVersion: 0.0.5
 home: http://www.pomerium.io/
 icon: https://www.pomerium.io/logo.svg
 description: Pomerium is an identity-aware access proxy.

--- a/helm/templates/authenticate-deployment.yaml
+++ b/helm/templates/authenticate-deployment.yaml
@@ -22,6 +22,7 @@ spec:
     metadata:
 {{- if .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
@@ -63,8 +64,8 @@ spec:
               key: shared-secret
         - name: REDIRECT_URL
           value: {{ default (printf "https://%s.%s/oauth2/callback" .Values.authenticate.name  .Values.config.rootDomain ) .Values.authenticate.redirectUrl }}
-        - name: PROXY_ROOT_DOMAIN
-          value: {{ .Values.config.rootDomain }}
+        - name: AUTHENTICATE_SERVICE_URL
+          value: {{ default (printf "https://%s.%s" .Values.authenticate.name .Values.config.rootDomain ) .Values.proxy.authenticateServiceUrl }}
         - name: IDP_PROVIDER
           value: {{ .Values.authenticate.idp.provider }}
         - name: IDP_CLIENT_ID

--- a/helm/templates/authorize-deployment.yaml
+++ b/helm/templates/authorize-deployment.yaml
@@ -23,6 +23,7 @@ spec:
     metadata:
 {{- if .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:

--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -9,5 +9,6 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
 data:
-  policy.yaml: {{toYaml .Values.config.policyFile | indent 4}}
-{{- end }}
+  policy.yaml: |-
+{{toYaml .Values.config.policyFile | indent 4}}
+{{- end}}

--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -16,17 +16,22 @@ spec:
   tls:
     - secretName: {{ default .Values.ingress.secretName .Values.ingress.secret.name}}
       hosts:
-        - '*.{{ .Values.config.rootDomain }}'
+        {{- range .Values.config.policyFile }}
+        - {{ .from }}
+        {{- end }}
         - {{ .Values.authorize.name }}.{{ .Values.config.rootDomain }}
         - {{ .Values.authenticate.name }}.{{ .Values.config.rootDomain }}
   rules:
-    - host: '*.{{ .Values.config.rootDomain }}'
+    {{- $proxyService := printf "%s-%s" (include "pomerium.fullname" .)  .Values.proxy.name }}
+    {{- range .Values.config.policyFile }}
+    - host: {{ .from }}
       http:
         paths:
           - paths:
             backend:
-              serviceName: {{ include "pomerium.fullname" .}}-{{ .Values.proxy.name }}
+              serviceName: {{ $proxyService }}
               servicePort: https
+    {{- end }}
     - host: {{ .Values.authorize.name }}.{{ .Values.config.rootDomain }}
       http:
         paths:

--- a/helm/templates/proxy-deployment.yaml
+++ b/helm/templates/proxy-deployment.yaml
@@ -23,6 +23,7 @@ spec:
     metadata:
 {{- if .Values.podAnnotations }}
       annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}
       labels:
@@ -64,12 +65,10 @@ spec:
               key: shared-secret
         - name: AUTHENTICATE_SERVICE_URL
           value: {{ default (printf "https://%s.%s" .Values.authenticate.name .Values.config.rootDomain ) .Values.proxy.authenticateServiceUrl }}
-        - name: AUTHORIZE_SERVICE_URL
-          value: {{ default (printf "https://%s.%s" .Values.authorize.name .Values.config.rootDomain ) .Values.proxy.authorizeServiceUrl }}
         - name: AUTHENTICATE_INTERNAL_URL
           value: {{ default (printf "%s-%s.%s.svc.cluster.local" (include "pomerium.fullname" .) .Values.authenticate.name .Release.Namespace ) .Values.proxy.authenticateInternalUrl}}
-        - name: AUTHORIZE_INTERNAL_URL
-          value: {{ default (printf "%s-%s.%s.svc.cluster.local" (include "pomerium.fullname" .) .Values.authorize.name .Release.Namespace ) .Values.proxy.authorizeInternalUrl}}
+        - name: AUTHORIZE_SERVICE_URL
+          value: {{ default (printf "https://%s-%s.%s.svc.cluster.local" (include "pomerium.fullname" .) .Values.authorize.name .Release.Namespace ) .Values.proxy.authorizeInternalUrl}}
 {{- if or .Values.config.existingConfig .Values.config.policyFile}}
         - name: POLICY_FILE
           value: /etc/pomerium/policy.yaml

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -10,11 +10,7 @@ config:
   sharedSecret: ""
   cookieSecret: ""
   generateTLS: true
-  policyFile: |-
-    - from: httpbin.corp.pomerium.io
-      to: http://httpbin
-      allowed_domains:
-      - pomerium.io
+  policyFile:
     - from: external-httpbin.corp.pomerium.io
       to: httpbin.org
       allowed_domains:


### PR DESCRIPTION
The Helm chart had several issues regarding these variable changes:

> - Removed extraneous AUTHORIZE_INTERNAL_URL config option since authorization has no publica http handlers, only a gRPC service endpoint. [GH-93]
> - Removed PROXY_ROOT_DOMAIN config option which is now inferred from AUTHENTICATE_SERVICE_URL. Only callback requests originating from a URL on the same sub-domain are permitted. [GH-83]

We removed the *.{{rootDomain}} ingress rule as Kubernetes does not support such configurations. The chart now uses the policy configuration as single source of ingress rules.

It works as intended however still lacks documentation of the `omnibusMode` which would be nice.

I would suggest updating the pending Helm repo request https://github.com/helm/charts/pull/12415 or use own chart repository. There is already a repo as a service if you don't want to bother setting it up here: https://charts.banzaicloud.io/

I would also suggest to use versioned images in the chart (not latest) as every configuration variable change will break the chart as well which is frustrating if you are debugging :)

**Checklist**:
- [x] updated docs
- [x] related issues referenced
- [x] ready for review
