### PR TITLE
internal/sessions: make user state domain scoped

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -68,7 +68,7 @@ func New(opts *config.Options) (*Authenticate, error) {
 	}
 	cookieStore, err := sessions.NewCookieStore(
 		&sessions.CookieStoreOptions{
-			Name:           opts.AuthenticateCookieName,
+			Name:           opts.CookieName,
 			CookieSecure:   opts.CookieSecure,
 			CookieHTTPOnly: opts.CookieHTTPOnly,
 			CookieExpire:   opts.CookieExpire,

--- a/authenticate/authenticate_test.go
+++ b/authenticate/authenticate_test.go
@@ -11,14 +11,14 @@ import (
 func testOptions() *config.Options {
 	redirectURL, _ := url.Parse("https://example.com/oauth2/callback")
 	return &config.Options{
-		AuthenticateURL:        redirectURL,
-		SharedKey:              "80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ=",
-		ClientID:               "test-client-id",
-		ClientSecret:           "OromP1gurwGWjQPYb1nNgSxtbVB5NnLzX6z5WOKr0Yw=",
-		CookieSecret:           "OromP1gurwGWjQPYb1nNgSxtbVB5NnLzX6z5WOKr0Yw=",
-		CookieRefresh:          time.Duration(1) * time.Hour,
-		CookieExpire:           time.Duration(168) * time.Hour,
-		AuthenticateCookieName: "pomerium",
+		AuthenticateURL: redirectURL,
+		SharedKey:       "80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ=",
+		ClientID:        "test-client-id",
+		ClientSecret:    "OromP1gurwGWjQPYb1nNgSxtbVB5NnLzX6z5WOKr0Yw=",
+		CookieSecret:    "OromP1gurwGWjQPYb1nNgSxtbVB5NnLzX6z5WOKr0Yw=",
+		CookieRefresh:   time.Duration(1) * time.Hour,
+		CookieExpire:    time.Duration(168) * time.Hour,
+		CookieName:      "pomerium",
 	}
 }
 

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -70,14 +70,13 @@ type Options struct {
 
 	// Session/Cookie management
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
-	AuthenticateCookieName string
-	ProxyCookieName        string
-	CookieSecret           string        `envconfig:"COOKIE_SECRET"`
-	CookieDomain           string        `envconfig:"COOKIE_DOMAIN"`
-	CookieSecure           bool          `envconfig:"COOKIE_SECURE"`
-	CookieHTTPOnly         bool          `envconfig:"COOKIE_HTTP_ONLY"`
-	CookieExpire           time.Duration `envconfig:"COOKIE_EXPIRE"`
-	CookieRefresh          time.Duration `envconfig:"COOKIE_REFRESH"`
+	CookieName     string        `envconfig:"COOKIE_NAME"`
+	CookieSecret   string        `envconfig:"COOKIE_SECRET"`
+	CookieDomain   string        `envconfig:"COOKIE_DOMAIN"`
+	CookieSecure   bool          `envconfig:"COOKIE_SECURE"`
+	CookieHTTPOnly bool          `envconfig:"COOKIE_HTTP_ONLY"`
+	CookieExpire   time.Duration `envconfig:"COOKIE_EXPIRE"`
+	CookieRefresh  time.Duration `envconfig:"COOKIE_REFRESH"`
 
 	// Identity provider configuration variables as specified by RFC6749
 	// https://openid.net/specs/openid-connect-basic-1_0.html#RFC6749
@@ -122,12 +121,11 @@ func NewOptions() *Options {
 		Debug:                  false,
 		LogLevel:               "debug",
 		Services:               "all",
-		AuthenticateCookieName: "_pomerium_authenticate",
 		CookieHTTPOnly:         true,
 		CookieSecure:           true,
 		CookieExpire:           time.Duration(14) * time.Hour,
 		CookieRefresh:          time.Duration(30) * time.Minute,
-		ProxyCookieName:        "_pomerium_proxy",
+		CookieName:             "_pomerium",
 		DefaultUpstreamTimeout: time.Duration(30) * time.Second,
 		Headers: map[string]string{
 			"X-Content-Type-Options":    "nosniff",

--- a/internal/httputil/errors.go
+++ b/internal/httputil/errors.go
@@ -2,17 +2,11 @@ package httputil // import "github.com/pomerium/pomerium/internal/httputil"
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 
 	"github.com/pomerium/pomerium/internal/templates"
-)
-
-var (
-	// ErrUserNotAuthorized is an error for unauthorized users.
-	ErrUserNotAuthorized = errors.New("user not authorized")
 )
 
 // HTTPError stores the status code and a message for a given HTTP error.

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -140,7 +140,7 @@ func New(opts *config.Options) (*Proxy, error) {
 
 	cookieStore, err := sessions.NewCookieStore(
 		&sessions.CookieStoreOptions{
-			Name:           opts.ProxyCookieName,
+			Name:           opts.CookieName,
 			CookieDomain:   opts.CookieDomain,
 			CookieSecure:   opts.CookieSecure,
 			CookieHTTPOnly: opts.CookieHTTPOnly,
@@ -267,7 +267,7 @@ func NewReverseProxyHandler(o *config.Options, proxy *httputil.ReverseProxy, rou
 	up := &UpstreamProxy{
 		name:       route.Destination.Host,
 		handler:    proxy,
-		cookieName: o.ProxyCookieName,
+		cookieName: o.CookieName,
 	}
 	if len(o.SigningKey) != 0 {
 		decodedSigningKey, _ := base64.StdEncoding.DecodeString(o.SigningKey)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -2,6 +2,7 @@ package proxy // import "github.com/pomerium/pomerium/proxy"
 
 import (
 	"encoding/base64"
+	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -82,7 +83,7 @@ func TestNewReverseProxyHandler(t *testing.T) {
 func testOptions() *config.Options {
 	authenticateService, _ := url.Parse("https://authenticate.corp.beyondperimeter.com")
 	authorizeService, _ := url.Parse("https://authorize.corp.beyondperimeter.com")
-	configBlob := `[{"from":"corp.example.notatld","to":"example.notatld"}]` //valid yaml
+	configBlob := `[{"from":"corp.example.notatld","to":"example.notatld"}]`
 	policy := base64.URLEncoding.EncodeToString([]byte(configBlob))
 
 	opts := config.NewOptions()
@@ -91,13 +92,30 @@ func testOptions() *config.Options {
 	opts.AuthorizeURL = authorizeService
 	opts.SharedKey = "80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ="
 	opts.CookieSecret = "OromP1gurwGWjQPYb1nNgSxtbVB5NnLzX6z5WOKr0Yw="
-	opts.ProxyCookieName = "pomerium"
+	opts.CookieName = "pomerium"
 	return opts
 }
 
-func testOptionsWithCORS() *config.Options {
-	configBlob := `[{"from":"corp.example.com","to":"example.com","cors_allow_preflight":true}]` //valid yaml
-	opts := testOptions()
+func testOptionsTestServer(uri string) *config.Options {
+	authenticateService, _ := url.Parse("https://authenticate.corp.beyondperimeter.com")
+	authorizeService, _ := url.Parse("https://authorize.corp.beyondperimeter.com")
+	// RFC 2606
+	configBlob := fmt.Sprintf(`[{"from":"httpbin.corp.example","to":"%s"}]`, uri)
+	policy := base64.URLEncoding.EncodeToString([]byte(configBlob))
+
+	opts := config.NewOptions()
+	opts.Policy = policy
+	opts.AuthenticateURL = authenticateService
+	opts.AuthorizeURL = authorizeService
+	opts.SharedKey = "80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ="
+	opts.CookieSecret = "OromP1gurwGWjQPYb1nNgSxtbVB5NnLzX6z5WOKr0Yw="
+	opts.CookieName = "pomerium"
+	return opts
+}
+
+func testOptionsWithCORS(uri string) *config.Options {
+	configBlob := fmt.Sprintf(`[{"from":"httpbin.corp.example","to":"%s","cors_allow_preflight":true}]`, uri)
+	opts := testOptionsTestServer(uri)
 	opts.Policy = base64.URLEncoding.EncodeToString([]byte(configBlob))
 	return opts
 }


### PR DESCRIPTION
- internal/sessions: session state is domain scoped
- internal/sessions: infer csrf cookie, route scoped
- proxy & authenticate: use shared cookie name
- proxy & authenticate: prevent resaving unchanged session
- proxy & authenticate: redirect instead of error for no session on login
- internal/config: merge cookies
- proxy: remove favicon specific route

tl;dr -- This fixes the annoying behavior of logging {in/out} from one route and not having that change be reflected in another route. 

Fixes #128 

**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review
