### PR TITLE
proxy: support for public unauthenticated routes

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -185,6 +185,18 @@ Allowed domains is a collection of whitelisted domains to authorize for a given 
 
 Allow unauthenticated HTTP OPTIONS requests as [per the CORS spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests).
 
+#### Public Access
+
+- `yaml`/`json` setting: `allow_public_unauthenticated_access`
+- Type: `bool`
+- Optional
+- Default: `false`
+
+**Use with caution:** Allow all requests for a given route, bypassing authentication and authorization. 
+Suitable for publicly exposed web services.
+
+If this setting is enabled, no whitelists (e.g. Allowed Users) should be provided in this route.
+
 #### Route Timeout
 
 - `yaml`/`json` setting: `timeout`

--- a/policy.example.yaml
+++ b/policy.example.yaml
@@ -19,3 +19,6 @@
   to: http://hello:8080
   allowed_groups:
     - admins
+- from: external-search.corp.beyondperimeter.com
+  to: google.com
+  allow_public_unauthenticated_access: true

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -180,8 +180,14 @@ func (p *Proxy) OAuthCallback(w http.ResponseWriter, r *http.Request) {
 // Conditions should be few in number and have strong justifications.
 func (p *Proxy) shouldSkipAuthentication(r *http.Request) bool {
 	pol, foundPolicy := p.policy(r)
+
 	if isCORSPreflight(r) && foundPolicy && pol.CORSAllowPreflight {
 		log.FromRequest(r).Debug().Msg("proxy: skipping authentication for valid CORS preflight request")
+		return true
+	}
+
+	if foundPolicy && pol.AllowPublicUnauthenticatedAccess {
+		log.FromRequest(r).Debug().Msg("proxy: skipping authentication for public route")
 		return true
 	}
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -120,6 +120,21 @@ func testOptionsWithCORS(uri string) *config.Options {
 	return opts
 }
 
+
+func testOptionsWithPublicAccess(uri string) *config.Options {
+	configBlob := fmt.Sprintf(`[{"from":"httpbin.corp.example","to":"%s","allow_public_unauthenticated_access":true}]`, uri)
+	opts := testOptions()
+	opts.Policy = base64.URLEncoding.EncodeToString([]byte(configBlob))
+	return opts
+}
+
+func testOptionsWithPublicAccessAndWhitelist(uri string) *config.Options {
+	configBlob := fmt.Sprintf(`[{"from":"httpbin.corp.example","to":"%s","allow_public_unauthenticated_access":true,"allowed_users":["test@gmail.com"]}]`, uri)
+	opts := testOptions()
+	opts.Policy = base64.URLEncoding.EncodeToString([]byte(configBlob))
+	return opts
+}
+
 func TestOptions_Validate(t *testing.T) {
 	good := testOptions()
 	badFromRoute := testOptions()
@@ -151,6 +166,9 @@ func TestOptions_Validate(t *testing.T) {
 	badPolicyToURL.Policy = "LSBmcm9tOiBodHRwYmluLmNvcnAuYmV5b25kcGVyaW1ldGVyLmNvbQogIHRvOiBodHRwOi8vaHR0cGJpbl4KICBhbGxvd2VkX2RvbWFpbnM6CiAgICAtIHBvbWVyaXVtLmlv"
 	badPolicyFromURL := testOptions()
 	badPolicyFromURL.Policy = "LSBmcm9tOiBodHRwYmluLmNvcnAuYmV5b25kcGVyaW1ldGVyLmNvbQogIHRvOiBodHRwOi8vaHR0cGJpbl4KICBhbGxvd2VkX2RvbWFpbnM6CiAgICAtIHBvbWVyaXVtLmlv"
+	corsPolicy := testOptionsWithCORS("example.notatld")
+	publicPolicy := testOptionsWithPublicAccess("example.notatld")
+	publicWithWhitelistPolicy := testOptionsWithPublicAccessAndWhitelist("example.notatld")
 
 	tests := []struct {
 		name    string
@@ -173,6 +191,9 @@ func TestOptions_Validate(t *testing.T) {
 		{"policy invalid base64", policyBadBase64, true},
 		{"policy bad to url", badPolicyFromURL, true},
 		{"policy bad from url", badPolicyFromURL, true},
+		{"CORS policy good", corsPolicy, false},
+		{"policy public good", publicPolicy, false},
+		{"policy public and whitelist bad", publicWithWhitelistPolicy, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #129

### Implementation Description

- Implemented a new access control option that allows public, unauthenticated access to specific targets.
- Added bypass check to `Proxy::shouldSkipAuthentication`

### Testing Done

- Ensured all unit tests pass in `proxy/`
- Ran the following manual integration test

#### Policy Configuration

```yaml
- from: hello1.homelab.tejunareddy.com
  to: http://localhost:8081
  allowed_users:
    - tejunareddy@gmail.com
- from: hello2.homelab.tejunareddy.com
  to: http://localhost:8082
  allowed_users:
    - not_a_user@yahoo.com
- from: hello3.homelab.tejunareddy.com
  to: http://localhost:8083
  allow_public_unauthenticated_access: true
```

#### Steps

1. Sign out of pomerium with `/.pomerium/signout`
2. Ensure 200 OK for hello3.homelab.tejunareddy.com, but 403 Forbidden for hello1 and hello2.
3. Sign into tejunareddy@gmail.com
4. Ensure 400 OK for hello3 and hello1, but 403 Forbidden for hello2.

### Other Notes

In order for this to work correctly, #132 must be fixed. I locally used the code in #133 to fix this issue, and tested this PR on top of that.

**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review
