### PR TITLE
docs: add upgrade guide

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -45,7 +45,7 @@ function docsSidebar(title) {
 		{
 			title,
 			collapsable: false,
-			children: ["", "identity-providers", "signed-headers", "certificates", "examples"]
+			children: ["", "identity-providers", "signed-headers", "certificates", "examples", "upgrading"]
 		}
 	];
 }

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -1,0 +1,18 @@
+---
+title: Upgrading
+description: >-
+  This page contains the list of deprecations and important or breaking changes
+  for Pomerium. Please read it carefully.
+---
+
+# Overview
+
+## Since 0.0.4
+
+This page contains the list of deprecations and important or breaking changes for pomerium `v0.0.4` compared to `v0.0.5`. Please read it carefully.
+
+### X
+
+### Y
+
+### Z


### PR DESCRIPTION
Just a simple upgrade guide roughly inspired after [HashiCorp's vault](https://github.com/hashicorp/vault/tree/master/website/source/docs/upgrading). WIP while I backfill changes but wanted to make format public. 

**Checklist**:
- [x] updated docs
- [x] related issues referenced
- [x] ready for review

\cc @travisgroth 