### PR TITLE
deployment: expose config file interface in docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,11 @@ RUN go mod download
 COPY . .
 # build 
 RUN make
+RUN touch /config.yaml
 
 FROM gcr.io/distroless/static
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
-CMD ["/bin/pomerium"]
+COPY --from=build /config.yaml /pomerium/config.yaml
+ENTRYPOINT [ "/bin/pomerium" ]
+CMD ["-config","/pomerium/config.yaml"]

--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -10,8 +10,11 @@ RUN go mod download
 COPY . .
 # build 
 RUN make build
+RUN touch /config.yaml
 
 FROM gcr.io/distroless/static
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
-CMD ["/bin/pomerium"]
+COPY --from=build /config.yaml /pomerium/config.yaml
+ENTRYPOINT [ "/bin/pomerium" ]
+CMD ["-config","/pomerium/config.yaml"]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -10,8 +10,11 @@ RUN go mod download
 COPY . .
 # build 
 RUN make build
+RUN touch /config.yaml
 
 FROM gcr.io/distroless/static
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
-CMD ["/bin/pomerium"]
+COPY --from=build /config.yaml /pomerium/config.yaml
+ENTRYPOINT [ "/bin/pomerium" ]
+CMD ["-config","/pomerium/config.yaml"]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -9,8 +9,11 @@ RUN go mod download
 COPY . .
 # build 
 RUN make build
+RUN touch /config.yaml
 
 FROM gcr.io/distroless/static
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
-CMD ["/bin/pomerium"]
+COPY --from=build /config.yaml /pomerium/config.yaml
+ENTRYPOINT [ "/bin/pomerium" ]
+CMD ["-config","/pomerium/config.yaml"]

--- a/authorize/authorize_test.go
+++ b/authorize/authorize_test.go
@@ -26,7 +26,8 @@ func TestNew(t *testing.T) {
 		{"bad shared secret", "AZA85podM73CjLCjViDNz1EUvvejKpWp7Hysr0knXA==", policies, true},
 		{"really bad shared secret", "sup", policies, true},
 		{"validation error, short secret", "AZA85podM73CjLCjViDNz1EUvvejKpWp7Hysr0knXA==", policies, true},
-		{"nil options", "", []policy.Policy{}, true}, // special case
+		{"nil options", "", []policy.Policy{}, true},                                                  // special case
+		{"missing policies", "gXK6ggrlIW2HyKyUF9rUO4azrDgxhDPWqw9y+lJU7B8=", []policy.Policy{}, true}, // special case
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -22,9 +22,9 @@ Remember to set your identity provider settings and to generate new secret keys!
 - Great for testing Pomerium
 - Routes default to hosted version of httpbin.org
 
-Customize for your identity provider and run `source ./env && ./bin/pomerium`
+Customize for your identity provider and run `./bin/pomerium -config config.yaml`
 
-<<< @/env.example
+<<< @/config.example.yaml
 
 ## Docker
 

--- a/docs/docs/examples/docker/basic.docker-compose.yml
+++ b/docs/docs/examples/docker/basic.docker-compose.yml
@@ -23,11 +23,10 @@ services:
       - CERTIFICATE_KEY_FILE=privkey.pem
       - AUTHENTICATE_SERVICE_URL=https://authenticate.corp.beyondperimeter.com
       - AUTHORIZE_SERVICE_URL=https://authorize.corp.beyondperimeter.com
-      - POLICY_FILE=./policy.yaml
     volumes:
       - ./cert.pem:/pomerium/cert.pem:ro
       - ./privkey.pem:/pomerium/privkey.pem:ro
-      - ./policy.example.yaml:/pomerium/policy.yaml:ro
+      - ./config-policy-only.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
 

--- a/docs/docs/examples/docker/nginx.docker-compose.yml
+++ b/docs/docs/examples/docker/nginx.docker-compose.yml
@@ -60,7 +60,7 @@ services:
     volumes:
       - ./cert.pem:/pomerium/cert.pem:ro
       - ./privkey.pem:/pomerium/privkey.pem:ro
-      - ./policy.example.yaml:/pomerium/policy.yaml:ro
+      - ./config-policy-only.yaml:/pomerium/config.yaml:ro
     expose:
       - 443
 
@@ -79,7 +79,7 @@ services:
     volumes:
       - ./cert.pem:/pomerium/cert.pem:ro
       - ./privkey.pem:/pomerium/privkey.pem:ro
-      - ./policy.example.yaml:/pomerium/policy.yaml:ro
+      - ./config-policy-only.yaml:/pomerium/config.yaml:ro
     expose:
       - 443
 

--- a/docs/guide/readme.md
+++ b/docs/guide/readme.md
@@ -23,9 +23,9 @@ Edit the `docker-compose.yml` to match your specific [identity provider]'s setti
 
 ### Policy configuration
 
-Next, create a policy configuration file which will contain the routes you want to proxy, and their desired access-controls. For example, `policy.example.yaml`:
+Next, create a configuration file which will contain the routes you want to proxy, and their desired access-controls. For example, `config-policy-only.yaml`:
 
-<<< @/policy.example.yaml
+<<< @/config-policy-only.yaml
 
 ### Certificates
 

--- a/scripts/kubernetes_gke.sh
+++ b/scripts/kubernetes_gke.sh
@@ -23,8 +23,8 @@ kubectl create secret generic -n pomerium certificate-key --from-literal=certifi
 echo "=> load TLS to ingress"
 kubectl create secret tls -n pomerium pomerium-tls --key privkey.pem --cert cert.pem
 
-echo "=> initiliaze a configmap setting for POLICY frompolicy.example.yaml"
-kubectl create configmap -n pomerium policy --from-literal=policy=$(cat policy.example.yaml | base64)
+echo "=> initiliaze a configmap setting for POLICY from config-policy-only.yaml"
+kubectl create configmap -n pomerium policy --from-literal=policy=$(cat config-policy-only.yaml | base64)
 
 echo "=> settingidp-client-secret, you changed this right? :)"
 exit 1 # comment out or delete this line once you change the following two settings


### PR DESCRIPTION
<!--  
     #159
-->

Part of #115

- Existing env-only users should be unaffected.  
- Adds a default yaml location for users to mount a config over 
- Moves the config option to CMD so that pomerium args can be specified at runtime when desired 
  - Example use case is if someone wanted to pass their config as toml or json for some reason
  ```shell
  08:23 $ docker run -it pomerium -help
  Usage of /bin/pomerium:
    -config string
    	  Specify configuration file location
    -version
    	  prints the version
  ```

- I slurped in a test coverage fix that took my last PR down 0.1% and was annoying me 😄 

**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review