### PR TITLE
docs: fix example policy name typo

### DIFF
--- a/docs/docs/examples/docker/basic.docker-compose.yml
+++ b/docs/docs/examples/docker/basic.docker-compose.yml
@@ -26,7 +26,7 @@ services:
     volumes:
       - ./cert.pem:/pomerium/cert.pem:ro
       - ./privkey.pem:/pomerium/privkey.pem:ro
-      - ./config-policy-only.yaml:/pomerium/config.yaml:ro
+      - ./config.example.policy.only.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
 

--- a/docs/docs/examples/docker/nginx.docker-compose.yml
+++ b/docs/docs/examples/docker/nginx.docker-compose.yml
@@ -42,7 +42,6 @@ services:
     environment:
       - POMERIUM_DEBUG=true
       - SERVICES=proxy
-      - POLICY_FILE=policy.yaml
       - AUTHENTICATE_SERVICE_URL=https://authenticate.corp.beyondperimeter.com
       # IMPORTANT! If you are running pomerium behind another ingress (loadbalancer/firewall/etc)
       # you must tell pomerium proxy how to communicate using an internal hostname for RPC
@@ -60,7 +59,7 @@ services:
     volumes:
       - ./cert.pem:/pomerium/cert.pem:ro
       - ./privkey.pem:/pomerium/privkey.pem:ro
-      - ./config-policy-only.yaml:/pomerium/config.yaml:ro
+      - ./config.example.policy.only.yaml:/pomerium/config.yaml:ro
     expose:
       - 443
 
@@ -70,7 +69,6 @@ services:
     environment:
       - POMERIUM_DEBUG=true
       - SERVICES=authorize
-      - POLICY_FILE=policy.yaml
       - SHARED_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=
       # nginx settings
       - VIRTUAL_PROTO=https
@@ -79,7 +77,7 @@ services:
     volumes:
       - ./cert.pem:/pomerium/cert.pem:ro
       - ./privkey.pem:/pomerium/privkey.pem:ro
-      - ./config-policy-only.yaml:/pomerium/config.yaml:ro
+      - ./config.example.policy.only.yaml:/pomerium/config.yaml:ro
     expose:
       - 443
 

--- a/docs/guide/readme.md
+++ b/docs/guide/readme.md
@@ -23,9 +23,9 @@ Edit the `docker-compose.yml` to match your specific [identity provider]'s setti
 
 ### Policy configuration
 
-Next, create a configuration file which will contain the routes you want to proxy, and their desired access-controls. For example, `config-policy-only.yaml`:
+Next, create a configuration file which will contain the routes you want to proxy, and their desired access-controls. For example, `config.example.policy.only.yaml`:
 
-<<< @/config-policy-only.yaml
+<<< @/config.example.policy.only.yaml
 
 ### Certificates
 

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -150,7 +150,7 @@ If set, the HTTP Redirect Address specifies the host and port to redirect http t
 
 Policy contains route specific settings, and access control details. If you are configuring via POLICY environment variable, just the contents of the policy needs to be passed. If you are configuring via file, the policy should be present under the policy key. For example,
 
-<<< @/config-policy-only.yaml
+<<< @/config.example.policy.only.yaml
 
 A list of policy configuration variables follows.
 

--- a/scripts/kubernetes_gke.sh
+++ b/scripts/kubernetes_gke.sh
@@ -23,8 +23,8 @@ kubectl create secret generic -n pomerium certificate-key --from-literal=certifi
 echo "=> load TLS to ingress"
 kubectl create secret tls -n pomerium pomerium-tls --key privkey.pem --cert cert.pem
 
-echo "=> initiliaze a configmap setting for POLICY from config-policy-only.yaml"
-kubectl create configmap -n pomerium policy --from-literal=policy=$(cat config-policy-only.yaml | base64)
+echo "=> initiliaze a configmap setting for POLICY from config.example.policy.only.yaml"
+kubectl create configmap -n pomerium policy --from-literal=policy=$(cat config.example.policy.only.yaml | base64)
 
 echo "=> settingidp-client-secret, you changed this right? :)"
 exit 1 # comment out or delete this line once you change the following two settings


### PR DESCRIPTION
- s/config-policy-only.yaml /config.example.policy.only/
- Removed `POLICY_FILE` references 

Closes #140 

**Checklist**:
- [x] updated docs
- [x] related issues referenced
