### PR TITLE
internal/httputil: add request id to error page

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -143,9 +143,9 @@ func newProxyService(opt *config.Options, mux *http.ServeMux) (*proxy.Proxy, err
 
 func wrapMiddleware(o *config.Options, mux *http.ServeMux) http.Handler {
 	c := middleware.NewChain()
-	c = c.Append(middleware.NewHandler(log.Logger))
-	c = c.Append(middleware.AccessHandler(func(r *http.Request, status, size int, duration time.Duration) {
-		middleware.FromRequest(r).Debug().
+	c = c.Append(log.NewHandler(log.Logger))
+	c = c.Append(log.AccessHandler(func(r *http.Request, status, size int, duration time.Duration) {
+		log.FromRequest(r).Debug().
 			Dur("duration", duration).
 			Int("size", size).
 			Int("status", status).
@@ -159,11 +159,11 @@ func wrapMiddleware(o *config.Options, mux *http.ServeMux) http.Handler {
 	if o != nil && len(o.Headers) != 0 {
 		c = c.Append(middleware.SetHeaders(o.Headers))
 	}
-	c = c.Append(middleware.ForwardedAddrHandler("fwd_ip"))
-	c = c.Append(middleware.RemoteAddrHandler("ip"))
-	c = c.Append(middleware.UserAgentHandler("user_agent"))
-	c = c.Append(middleware.RefererHandler("referer"))
-	c = c.Append(middleware.RequestIDHandler("req_id", "Request-Id"))
+	c = c.Append(log.ForwardedAddrHandler("fwd_ip"))
+	c = c.Append(log.RemoteAddrHandler("ip"))
+	c = c.Append(log.UserAgentHandler("user_agent"))
+	c = c.Append(log.RefererHandler("referer"))
+	c = c.Append(log.RequestIDHandler("req_id", "Request-Id"))
 	c = c.Append(middleware.Healthcheck("/ping", version.UserAgent()))
 	return c.Then(mux)
 }

--- a/internal/log/middleware.go
+++ b/internal/log/middleware.go
@@ -1,4 +1,4 @@
-package middleware // import "github.com/pomerium/pomerium/internal/middleware"
+package log // import "github.com/pomerium/pomerium/internal/log"
 
 import (
 	"context"
@@ -9,15 +9,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pomerium/pomerium/internal/log"
 	"github.com/rs/zerolog"
 )
-
-// FromRequest gets the logger in the request's context.
-// This is a shortcut for log.Ctx(r.Context())
-func FromRequest(r *http.Request) *zerolog.Logger {
-	return log.Ctx(r.Context())
-}
 
 // NewHandler injects log into requests context.
 func NewHandler(log zerolog.Logger) func(http.Handler) http.Handler {

--- a/internal/log/middleware_test.go
+++ b/internal/log/middleware_test.go
@@ -1,4 +1,4 @@
-package middleware // import "github.com/pomerium/pomerium/internal/middleware"
+package log // import "github.com/pomerium/pomerium/internal/log"
 
 import (
 	"bytes"

--- a/internal/log/wrap_writer.go
+++ b/internal/log/wrap_writer.go
@@ -1,4 +1,4 @@
-package middleware // import "github.com/pomerium/pomerium/internal/middleware"
+package log // import "github.com/pomerium/pomerium/internal/log"
 
 // The original work was derived from Goji's middleware, source:
 // https://github.com/zenazn/goji/tree/master/web/middleware
@@ -175,7 +175,6 @@ type http2FancyWriter struct {
 
 func (f *http2FancyWriter) Flush() {
 	f.wroteHeader = true
-
 	fl := f.basicWriter.ResponseWriter.(http.Flusher)
 	fl.Flush()
 }

--- a/internal/log/wrap_writer_test.go
+++ b/internal/log/wrap_writer_test.go
@@ -1,4 +1,4 @@
-package middleware
+package log // import "github.com/pomerium/pomerium/internal/log"
 
 import (
 	"net/http/httptest"

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -266,7 +266,9 @@ func New() *template.Template {
         <h1 class="title">{{.Title}}</h1>
         <section>
           <p class="message">{{.Message}}.</p>
-          <p class="message">Troubleshoot your <a href="/.pomerium">session</a>.</p>
+          <p class="message">Troubleshoot your <a href="/.pomerium">session</a>.</br>
+          {{if .RequestID}} Request {{.RequestID}} {{end}}
+          </p>
         </section>
       </form>
       </div>


### PR DESCRIPTION
Adds request id to error pages. Rearranged some of the log-related middleware to be part of the more logically coherent package. 

Partially resolves #138 


**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review

/cc @yegle