### PR TITLE
docs: update quickstart and examples

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -42,7 +42,7 @@ function guideSidebar(title) {
 		{
 			title,
 			collapsable: false,
-			children: ["", "helm", "kubernetes", "synology", "from-source"]
+			children: ["",  "binary","from-source","helm", "kubernetes", "synology"]
 		}
 	];
 }

--- a/docs/docs/examples.md
+++ b/docs/docs/examples.md
@@ -1,5 +1,5 @@
 ---
-sidebarDepth: 3
+sidebarDepth: 2
 ---
 
 # Example configs
@@ -24,7 +24,14 @@ Remember to set your identity provider settings and to generate new secret keys!
 
 Customize for your identity provider and run `./bin/pomerium -config config.yaml`
 
-<<< @/config.example.yaml
+#### Config file example
+
+<<< @/docs/docs/examples/config/config.example.yaml
+
+#### Environmental variable example
+
+<<< @/docs/docs/examples/config/config.example.env
+
 
 ## Docker
 
@@ -35,7 +42,7 @@ Uses the [latest pomerium build](https://hub.docker.com/r/pomerium/pomerium) fro
 - Minimal container-based configuration.
 - Docker and Docker-Compose based.
 - Runs a single container for all pomerium services
-- Routes default to on-premise [helloworld], [httpbin].
+- Routes default to on-premise [httpbin].
 
 Customize for your identity provider run `docker-compose up -f basic.docker-compose.yml`
 

--- a/docs/docs/examples/config/config.example.env
+++ b/docs/docs/examples/config/config.example.env
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Main configuration flags : https://www.pomerium.io/reference/
 
 # Main configuration flags
 # export ADDRESS=":8443"                      # optional, default is 443
@@ -11,14 +12,15 @@ export AUTHORIZE_SERVICE_URL=https://authorize.corp.beyondperimeter.com
 
 # Certificates can be loaded as files or base64 encoded bytes. If neither is set, a
 # pomerium will attempt to locate a pair in the root directory
-export CERTIFICATE_FILE="./cert.pem"        # optional, defaults to `./cert.pem`
-export CERTIFICATE_KEY_FILE="./privkey.pem" # optional, defaults to `./certprivkey.pem`
+# See : https://www.pomerium.io/docs/certificates.html
+export CERTIFICATE_FILE="$HOME/.acme.sh/*.corp.beyondperimeter.com_ecc/fullchain.cer"                      # optional, defaults to `./cert.pem`
+export CERTIFICATE_KEY_FILE="$HOME/.acme.sh/*.corp.beyondperimeter.com_ecc/*.corp.beyondperimeter.com.key" # optional, defaults to `./certprivkey.pem`
 # export CERTIFICATE="xxxxxx"                 # base64 encoded cert, eg. `base64 -i cert.pem`
 # export CERTIFICATE_KEY="xxxx"               # base64 encoded key, eg. `base64 -i privkey.pem`
 
 # Generate 256 bit random keys  e.g. `head -c32 /dev/urandom | base64`
-export SHARED_SECRET=9wiTZq4qvmS/plYQyvzGKWPlH/UBy0DMYMA2x/zngrM=
-export COOKIE_SECRET=uPGHo1ujND/k3B9V6yr52Gweq3RRYfFho98jxDG5Br8=
+export SHARED_SECRET="$(head -c32 /dev/urandom | base64)"
+export COOKIE_SECRET="$(head -c32 /dev/urandom | base64)"
 # If set, a JWT based signature is appended to each request header `x-pomerium-jwt-assertion`
 # export SIGNING_KEY="Replace with base64'd private key from ./scripts/self-signed-sign-key.sh"
 
@@ -39,8 +41,6 @@ export COOKIE_SECRET=uPGHo1ujND/k3B9V6yr52Gweq3RRYfFho98jxDG5Br8=
 ## GOOGLE
 export IDP_PROVIDER="google"
 export IDP_PROVIDER_URL="https://accounts.google.com" # optional for google
-export IDP_CLIENT_ID="REPLACE-ME.googleusercontent.com"
-export IDP_CLIENT_SECRET="REPLACEME"
 
 # IF GSUITE and you want to get user groups you will need to set a service account
 # see identity provider docs for gooogle for more info :
@@ -63,4 +63,4 @@ export IDP_CLIENT_SECRET="REPLACEME"
 # Proxied routes and per-route policies are defined in a policy provided either
 # directly as a base64 encoded yaml/json file, or as the policy key in the configuration
 # file
-export POLICY="$(base64 ./policy.yaml)"
+export POLICY="$(base64 ./docs/docs/examples/config/policy.example.yaml)"

--- a/docs/docs/examples/config/config.example.yaml
+++ b/docs/docs/examples/config/config.example.yaml
@@ -1,17 +1,18 @@
-# Main configuration flags
-address: ":8443" # optional, default is 443
+# Main configuration flags : https://www.pomerium.io/reference/
+#
+# address: ":8443" # optional, default is 443
 pomerium_debug: true # optional, default is false
-service: "all" # optional, default is all
-log_level: "info" # optional, default is debug
+# service: "all" # optional, default is all
+log_level: info # optional, default is debug
 
-authenticate_service_url: https://authenticate.corp.pomerium.io:8443
-authorize_service_url: https://authorize.corp.pomerium.io:8443
+authenticate_service_url: https://authenticate.corp.beyondperimeter.com
+authorize_service_url: https://authorize.corp.beyondperimeter.com
 
 # Certificates can be loaded as files or base64 encoded bytes. If neither is set, a
 # pomerium will attempt to locate a pair in the root directory
-certificate_file: "./cert.pem" # optional, defaults to `./cert.pem`
-certificate_key_file: "./privkey.pem" # optional, defaults to `./certprivkey.pem`
-certificate_authority_file: "./cert.pem"
+# certificate_file: "./cert.pem" # optional, defaults to `./cert.pem`
+# certificate_key_file: "./privkey.pem" # optional, defaults to `./certprivkey.pem`
+# certificate_authority_file: "./cert.pem"
 
 # base64 encoded cert, eg. `base64 -i cert.pem` / `base64 -i privkey.pem`
 # certificate: |
@@ -20,8 +21,8 @@ certificate_authority_file: "./cert.pem"
 #  "xxxx"
 
 # Generate 256 bit random keys  e.g. `head -c32 /dev/urandom | base64`
-shared_secret: hsJIQsx9KKx4qVlggg/T3AuLTmVu0uHhwTQgMPlVs7U=
-cookie_secret: WwMtDXWaRDMBQCylle8OJ+w4kLIDIGd8W3cB4/zFFtg=
+# shared_secret: hsJIQsx9KKx4qVlggg/T3AuLTmVu0uHhwTQgMPlVs7U=
+# cookie_secret: WwMtDXWaRDMBQCylle8OJ+w4kLIDIGd8W3cB4/zFFtg=
 # If set, a JWT based signature is appended to each request header `x-pomerium-jwt-assertion`
 # signing_key: "Replace with base64'd private key from ./scripts/self-signed-sign-key.sh"
 

--- a/docs/docs/examples/config/config.minimal.env
+++ b/docs/docs/examples/config/config.minimal.env
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# See : https://www.pomerium.io/docs/certificates.html
+export CERTIFICATE_FILE="$HOME/.acme.sh/*.corp.beyondperimeter.com_ecc/fullchain.cer"                      # optional, defaults to `./cert.pem`
+export CERTIFICATE_KEY_FILE="$HOME/.acme.sh/*.corp.beyondperimeter.com_ecc/*.corp.beyondperimeter.com.key" # optional, defaults to `./certprivkey.pem`
+
+# 256 bit random keys
+export SHARED_SECRET="$(head -c32 /dev/urandom | base64)"
+export COOKIE_SECRET="$(head -c32 /dev/urandom | base64)"

--- a/docs/docs/examples/config/config.minimal.yaml
+++ b/docs/docs/examples/config/config.minimal.yaml
@@ -1,0 +1,17 @@
+# See detailed configuration settings : https://www.pomerium.io/reference/
+authenticate_service_url: https://authenticate.corp.beyondperimeter.com
+authorize_service_url: https://authorize.corp.beyondperimeter.com
+
+# identity provider settings : https://www.pomerium.io/docs/identity-providers.html
+idp_provider: google
+idp_client_id: REPLACE_ME
+idp_client_secret: REPLACE_ME
+
+policy:
+  - from: httpbin.corp.beyondperimeter.com
+    to: http://httpbin
+    allowed_domains:
+      - pomerium.io
+  - from: external-httpbin.corp.beyondperimeter.com
+    to: https://httpbin.org
+    allow_public_unauthenticated_access: true

--- a/docs/docs/examples/config/policy.example.yaml
+++ b/docs/docs/examples/config/policy.example.yaml
@@ -1,7 +1,13 @@
-### Other keys configuration removed for clarity ###
+# This file contains only policy and route configuration details. Other
+# configuration settings required by pomerium are excluded for clarity.
+# See: https://www.pomerium.io/reference/
+#
+# For a complete self contained configuration see : config.example.yaml.
+# Or, mix and match a policy file (this) with env vars : config.example.env
 
 # Proxied routes and per-route policies are defined in a policy block
-policy: # Omit the 'policy' key if you are encoding it into an environment variable
+# NOTA BENE: You must uncomment the bellow 'policy' key if you are loading policy as a file.
+# policy: 
   - from: httpbin.corp.beyondperimeter.com
     to: http://localhost:8000
     allowed_domains:

--- a/docs/docs/examples/docker/basic.docker-compose.yml
+++ b/docs/docs/examples/docker/basic.docker-compose.yml
@@ -1,42 +1,23 @@
-# Example Pomerium configuration.
-#
-# NOTE! Change IDP_* settings to match your identity provider settings!
-# NOTE! Generate new SHARED_SECRET and COOKIE_SECRET keys! e.g. `head -c32 /dev/urandom | base64`
-# NOTE! Replace `corp.beyondperimeter.com` with whatever your domain is
-# NOTE! Make sure certificate files (cert.pem/privkey.pem) are in the same directory as this file
-# NOTE! Make sure your policy file (policy.example.yaml) is in the same directory as this file
-
 version: "3"
 services:
   pomerium:
-    image: pomerium/pomerium:latest # or `build: .` to build from source
+    image: pomerium/pomerium:v0.0.5
     environment:
-      - POMERIUM_DEBUG=true
       - SERVICES=all
-      - IDP_PROVIDER=google
-      - IDP_PROVIDER_URL=https://accounts.google.com
-      - IDP_CLIENT_ID=REPLACE_ME.apps.googleusercontent.com
-      - IDP_CLIENT_SECRET=REPLACE_ME
+      # Generate new secret keys. e.g. `head -c32 /dev/urandom | base64`
       - SHARED_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=
       - COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
-      - CERTIFICATE_FILE=cert.pem
-      - CERTIFICATE_KEY_FILE=privkey.pem
-      - AUTHENTICATE_SERVICE_URL=https://authenticate.corp.beyondperimeter.com
-      - AUTHORIZE_SERVICE_URL=https://authorize.corp.beyondperimeter.com
     volumes:
-      - ./cert.pem:/pomerium/cert.pem:ro
-      - ./privkey.pem:/pomerium/privkey.pem:ro
-      - ./config.example.policy.only.yaml:/pomerium/config.yaml:ro
+      # Mount your domain's certificates : https://www.pomerium.io/docs/certificates.html
+      - ~/.acme.sh/*.corp.beyondperimeter.com_ecc/fullchain.cer:/pomerium/cert.pem:ro
+      - ~/.acme.sh/*.corp.beyondperimeter.com_ecc/*.corp.beyondperimeter.com.key:/pomerium/privkey.pem:ro
+      # Mount your config file : https://www.pomerium.io/reference/
+      - ../config/config.minimal.yaml:/pomerium/config.yaml:ro
     ports:
       - 443:443
 
-  # https://httpbin.corp.beyondperimeter.com
+  # https://httpbin.corp.beyondperimeter.com --> Pomerium --> http://httpbin
   httpbin:
     image: kennethreitz/httpbin:latest
     expose:
       - 80
-  # https://hello.corp.beyondperimeter.com
-  hello:
-    image: gcr.io/google-samples/hello-app:1.0
-    expose:
-      - 8080

--- a/docs/docs/examples/docker/nginx.docker-compose.yml
+++ b/docs/docs/examples/docker/nginx.docker-compose.yml
@@ -5,34 +5,39 @@ services:
     ports:
       - "443:443"
     volumes:
-      # NOTE!!! : nginx must be supplied with your wildcard certificates. And it expects
-      # it in the format of whatever your wildcard domain name is in.
+      # NOTE!!! : nginx must be supplied with your wildcard certificates.
       # see : https://github.com/jwilder/nginx-proxy#wildcard-certificates
-      # So, if your subdomain is corp.beyondperimeter.com, you'd have the following :
-      - ./cert.pem:/etc/nginx/certs/corp.beyondperimeter.com.crt:ro
-      - ./privkey.pem:/etc/nginx/certs/corp.beyondperimeter.com.key:ro
+      - ~/.acme.sh/*.corp.beyondperimeter.com_ecc/fullchain.cer:/etc/nginx/certs/corp.beyondperimeter.com.crt:ro
+      - ~/.acme.sh/*.corp.beyondperimeter.com_ecc/*.corp.beyondperimeter.com.key:/etc/nginx/certs/corp.beyondperimeter.com.key:ro
       - /var/run/docker.sock:/tmp/docker.sock:ro
 
   pomerium-authenticate:
     image: pomerium/pomerium:latest # or `build: .` to build from source
     restart: always
     environment:
-      - POMERIUM_DEBUG=true
       - SERVICES=authenticate
-      # Identity Provider Settings (Must be changed!)
+      # NOTE!: Replace with your identity provider settings https://www.pomerium.io/docs/identity-providers.html
       - IDP_PROVIDER=google
       - IDP_PROVIDER_URL=https://accounts.google.com
       - IDP_CLIENT_ID=REPLACE_ME.apps.googleusercontent.com
       - IDP_CLIENT_SECRET=REPLACE_ME
+      # - IDP_CLIENT_SECRET=REPLACE_ME
+      # NOTE! Generate new secret keys! e.g. `head -c32 /dev/urandom | base64`
+      # Generated secret keys must match between services
+
       - SHARED_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=
       - COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
-      # nginx settings
+      # Tell nginx how to proxy pomerium's routes
       - VIRTUAL_PROTO=https
       - VIRTUAL_HOST=authenticate.corp.beyondperimeter.com
       - VIRTUAL_PORT=443
     volumes:
-      - ./cert.pem:/pomerium/cert.pem:ro
-      - ./privkey.pem:/pomerium/privkey.pem:ro
+      - ~/.acme.sh/*.corp.beyondperimeter.com_ecc/fullchain.cer:/pomerium/cert.pem:ro
+      - ~/.acme.sh/*.corp.beyondperimeter.com_ecc/*.corp.beyondperimeter.com.key:/pomerium/privkey.pem:ro
+      # Retrieve non-secret config keys from the config file : https://www.pomerium.io/reference/
+      # See `config.example.yaml` and modify to fit your needs.
+      - ../config/config.example.yaml:/pomerium/config.yaml:ro
+
     expose:
       - 443
 
@@ -40,26 +45,26 @@ services:
     image: pomerium/pomerium:latest # or `build: .` to build from source
     restart: always
     environment:
-      - POMERIUM_DEBUG=true
       - SERVICES=proxy
-      - AUTHENTICATE_SERVICE_URL=https://authenticate.corp.beyondperimeter.com
       # IMPORTANT! If you are running pomerium behind another ingress (loadbalancer/firewall/etc)
       # you must tell pomerium proxy how to communicate using an internal hostname for RPC
-      - AUTHENTICATE_INTERNAL_URL=pomerium-authenticate
+      - AUTHENTICATE_INTERNAL_URL=https://pomerium-authenticate
       - AUTHORIZE_SERVICE_URL=https://pomerium-authorize
       # When communicating internally, rPC is going to get a name conflict expecting an external
       # facing certificate name (i.e. authenticate-service.local vs *.corp.example.com).
       - OVERRIDE_CERTIFICATE_NAME=*.corp.beyondperimeter.com
       - SHARED_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=
       - COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=
-      # nginx settings
+      # Tell nginx how to proxy pomerium's routes
       - VIRTUAL_PROTO=https
       - VIRTUAL_HOST=*.corp.beyondperimeter.com
       - VIRTUAL_PORT=443
     volumes:
-      - ./cert.pem:/pomerium/cert.pem:ro
-      - ./privkey.pem:/pomerium/privkey.pem:ro
-      - ./config.example.policy.only.yaml:/pomerium/config.yaml:ro
+      - ~/.acme.sh/*.corp.beyondperimeter.com_ecc/fullchain.cer:/pomerium/cert.pem:ro
+      - ~/.acme.sh/*.corp.beyondperimeter.com_ecc/*.corp.beyondperimeter.com.key:/pomerium/privkey.pem:ro
+      # Retrieve non-secret config keys from the config file : https://www.pomerium.io/reference/
+      # See `config.example.yaml` and modify to fit your needs.
+      - ../config/config.example.yaml:/pomerium/config.yaml:ro
     expose:
       - 443
 
@@ -67,17 +72,18 @@ services:
     image: pomerium/pomerium:latest # or `build: .` to build from source
     restart: always
     environment:
-      - POMERIUM_DEBUG=true
       - SERVICES=authorize
       - SHARED_SECRET=aDducXQzK2tPY3R4TmdqTGhaYS80eGYxcTUvWWJDb2M=
-      # nginx settings
+      # Tell nginx how to proxy pomerium's routes
       - VIRTUAL_PROTO=https
       - VIRTUAL_HOST=authorize.corp.beyondperimeter.com
       - VIRTUAL_PORT=443
     volumes:
-      - ./cert.pem:/pomerium/cert.pem:ro
-      - ./privkey.pem:/pomerium/privkey.pem:ro
-      - ./config.example.policy.only.yaml:/pomerium/config.yaml:ro
+      - ~/.acme.sh/*.corp.beyondperimeter.com_ecc/fullchain.cer:/pomerium/cert.pem:ro
+      - ~/.acme.sh/*.corp.beyondperimeter.com_ecc/*.corp.beyondperimeter.com.key:/pomerium/privkey.pem:ro
+      # Retrieve non-secret config keys from the config file : https://www.pomerium.io/reference/
+      # See `config.example.yaml` and modify to fit your needs.
+      - ../config/config.example.yaml:/pomerium/config.yaml:ro
     expose:
       - 443
 

--- a/docs/docs/examples/kubernetes/authenticate.deploy.yml
+++ b/docs/docs/examples/kubernetes/authenticate.deploy.yml
@@ -25,6 +25,8 @@ spec:
           env:
             - name: SERVICES
               value: authenticate
+            - name: AUTHENTICATE_SERVICE_URL
+              value: https://authenticate.corp.beyondperimeter.com
             - name: IDP_PROVIDER
               value: google
             - name: IDP_PROVIDER_URL

--- a/docs/docs/identity-providers.md
+++ b/docs/docs/identity-providers.md
@@ -3,7 +3,7 @@ title: Identity Providers
 description: >-
   This article describes how to connect Pomerium to third-party identity
   providers / single-sign-on services. You will need to generate keys, copy
-  these into your promerium settings, and enable the connection.
+  these into your Pomerium settings, and enable the connection.
 ---
 
 # Identity Provider Configuration
@@ -129,11 +129,11 @@ Navigate to **User Settings** then **Applications** using the left-hand menu.
 
 On the **Applications** page, add a new application by setting the following parameters:
 
-Field        | Description
------------- | --------------------------------------------------------------------
-Name         | The name of your web app
-Redirect URI | Redirect URL (e.g.`https://authenticate.corp.example.com/oauth2/callback`)
-Scopes       | **Must** select **read_user** and **openid**
+| Field        | Description                                                                |
+| ------------ | -------------------------------------------------------------------------- |
+| Name         | The name of your web app                                                   |
+| Redirect URI | Redirect URL (e.g.`https://authenticate.corp.example.com/oauth2/callback`) |
+| Scopes       | **Must** select **read_user** and **openid**                               |
 
 ![Create New Credentials](./gitlab/gitlab-create-application.png)
 
@@ -170,10 +170,10 @@ On the **Credentials** page, click **Create credentials** and choose **OAuth [Cl
 
 On the **Create [Client ID]** page, select **Web application**. In the new fields that display, set the following parameters:
 
-Field                    | Description
------------------------- | --------------------------------------------------------------------
-Name                     | The name of your web app
-Authorized redirect URIs | Redirect URL (e.g.`https://authenticate.corp.example.com/oauth2/callback`)
+| Field                    | Description                                                                |
+| ------------------------ | -------------------------------------------------------------------------- |
+| Name                     | The name of your web app                                                   |
+| Authorized redirect URIs | Redirect URL (e.g.`https://authenticate.corp.example.com/oauth2/callback`) |
 
 ![Web App Credentials Configuration](./google/google-create-client-id-config.png)
 
@@ -246,13 +246,13 @@ On the **Create New Application** page, select the **Web** for your application.
 
 Next, provide the following information for your application settings:
 
-Field                        | Description
----------------------------- | ---------------------------------------------------------------------
-Name                         | The name of your application.
-Base URIs (optional)         | The domain(s) of your application.
-Login redirect URIs          | Redirect URL (e.g.`https://authenticate.corp.example.com/oauth2/callback`).
-Group assignments (optional) | The user groups that can sign in to this application.
-Grant type allowed           | **You must enable Refresh Token.**
+| Field                        | Description                                                                 |
+| ---------------------------- | --------------------------------------------------------------------------- |
+| Name                         | The name of your application.                                               |
+| Base URIs (optional)         | The domain(s) of your application.                                          |
+| Login redirect URIs          | Redirect URL (e.g.`https://authenticate.corp.example.com/oauth2/callback`). |
+| Group assignments (optional) | The user groups that can sign in to this application.                       |
+| Grant type allowed           | **You must enable Refresh Token.**                                          |
 
 ![Okta Create Application Settings](./okta/okta-create-app-settings.png)
 
@@ -270,23 +270,23 @@ Select your desired authorization server and navigate to the **claims tab**. Cli
 
 ![Okta configure group claim](./okta/okta-configure-groups-claim.png)
 
-Field                 | Value
---------------------- | ---------------------
-Name                  | groups
-Include in token type | **ID Token**, Always.
-Value Type            | Groups
-Filter                | Matches regex `.*`
-Include in            | Any scope
+| Field                 | Value                 |
+| --------------------- | --------------------- |
+| Name                  | groups                |
+| Include in token type | **ID Token**, Always. |
+| Value Type            | Groups                |
+| Filter                | Matches regex `.*`    |
+| Include in            | Any scope             |
 
 Add an another, almost identical, claim but this time for **Access Token**.
 
-Field                 | Value
---------------------- | -------------------------
-Name                  | groups
-Include in token type | **Access Token**, Always.
-Value Type            | Groups
-Filter                | Matches regex `.*`
-Include in            | Any scope
+| Field                 | Value                     |
+| --------------------- | ------------------------- |
+| Name                  | groups                    |
+| Include in token type | **Access Token**, Always. |
+| Value Type            | Groups                    |
+| Filter                | Matches regex `.*`        |
+| Include in            | Any scope                 |
 
 ![Okta list group claims](./okta/okta-list-groups-claim.png)
 

--- a/docs/docs/readme.md
+++ b/docs/docs/readme.md
@@ -1,3 +1,11 @@
+---
+title: Overview
+lang: en-US
+meta:
+  - name: keywords
+    content: pomerium identity-access-proxy beyondcorp zero-trust reverse-proxy ztn
+---
+
 # Overview
 
 ## What
@@ -28,7 +36,7 @@ Or for the visually inclined.
 
 ### Zero-trust
 
-Pomerium -- and zero-trust more broadly -- attempts to mitigate these shortcomings by adopting principles like:
+Pomerium attempts to mitigate these shortcomings by adopting principles like:
 
 - Trust flows from identity, device-state, and context; not network location.
 - Treat both internal and external networks as completely untrusted.
@@ -36,11 +44,12 @@ Pomerium -- and zero-trust more broadly -- attempts to mitigate these shortcomin
 - Every device, user, and application's communication should be authenticated, authorized, and encrypted.
 - Access policy should be dynamic, and built from multiple sources.
 
+This security model has typically been referred to as zero-trust or BeyondCorp-inspired. 
+
 ## Resources
 
-Pomerium was designed around the security model originally articulated by [John Kindervag](http://www.virtualstarmedia.com/downloads/Forrester_zero_trust_DNA.pdf) in 2010, and by Google in 2011 which as a result of the [Operation Aurora](https://en.wikipedia.org/wiki/Operation_Aurora) breach.
+Pomerium was inspired by the security model originally articulated by [John Kindervag](http://www.virtualstarmedia.com/downloads/Forrester_zero_trust_DNA.pdf) in 2010, and by Google in 2011 as a result of the [Operation Aurora](https://en.wikipedia.org/wiki/Operation_Aurora) breach.
 
-Typically this approach to security is called either zero-trust or BeyondCorp-inspired. Here's a curated list of resources covering th
 
 ### Books
 

--- a/docs/guide/binary.md
+++ b/docs/guide/binary.md
@@ -1,40 +1,23 @@
 ---
-title: From Source
+title: Binaries
 lang: en-US
 meta:
   - name: keywords
-    content: pomerium identity-access-proxy oidc git reverse-proxy
+    content: pomerium identity-access-proxy oidc reverse-proxy
 ---
 
-# Building Pomerium From Source
+# Pomerium with Prebuilt Binaries
 
-The following quick-start guide covers how to retrieve and build Pomerium directly from it's source as well as how to run Pomerium using a minimal but complete configuration.
+The following quick-start guide covers how to configure and run Pomerium using prebuilt binaries.
 
 ## Prerequisites
 
-- Install [git](https://git-scm.com/) version control system
-- Install the [go](https://golang.org/doc/install) programming language
 - A configured [identity provider]
 - A [wild-card TLS certificate]
 
 ## Download
 
-Retrieve the latest copy of pomerium's source code by cloning the repository.
-
-```bash
-git clone https://github.com/pomerium/pomerium.git $HOME/pomerium
-```
-
-## Make
-
-Build pomerium from source in a single step using make.
-
-```bash
-cd $HOME/pomerium
-make
-```
-
-[Make] will run all the tests, some code linters, then build the binary. If all is good, you should now have a freshly built pomerium binary in the `pomerium/bin` directory.
+[Download] the latest release of Pomerium for your machine's operating system and architecture.
 
 ## Configure
 
@@ -63,7 +46,7 @@ source ./env
 
 ## Navigate
 
-Browse to `external-httpbin.your.domain.example`. Connections between you and [httpbin] will now be proxied and managed by Pomerium. 
+Browse to `external-httpbin.your.domain.example`. Connections between you and [httpbin] will now be proxied and managed by Pomerium.
 
 [configuration variables]: ../reference/readme.md
 [download]: https://github.com/pomerium/pomerium/releases

--- a/docs/guide/helm.md
+++ b/docs/guide/helm.md
@@ -1,7 +1,16 @@
-# Helm
+---
+title: Helm
+lang: en-US
+meta:
+  - name: keywords
+    content: pomerium identity-access-proxy oidc kubernetes Helm reverse-proxy
+---
 
-This quickstart will show you how to deploy Pomerium with Kubernetes. Though there are [countless ways](https://kubernetes.io/docs/setup/pick-right-solution/) to work with Kubernetes, for the purpose of this guide, we will be using Google's [Kubernetes Engine](https://cloud.google.com/kubernetes-engine/). That said, most of the following steps should be very similar using any other provider with the biggest difference being in the configuration of your ingress. 
+# Pomerium using Helm
 
+This quickstart will show you how to deploy Pomerium with Kubernetes. Though there are [many ways](https://kubernetes.io/docs/setup/pick-right-solution/) to work with Kubernetes, for the purpose of this guide, we will be using Google's [Kubernetes Engine](https://cloud.google.com/kubernetes-engine/). That said, most of the following steps should be very similar using any other provider.
+
+In addition to sharing many of the same features as the Kubernetes quickstart guide, the default helm deployment script also includes a bootstrapped certificate authority enabling mutually authenticated and encrypted communication between services that does not depend on the external LetsEncrypt certificates. Having the external domain certificate decoupled makes it easier to renew external certificates. 
 
 ## Prerequisites
 
@@ -10,56 +19,33 @@ This quickstart will show you how to deploy Pomerium with Kubernetes. Though the
 - Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - Install the [Google Cloud SDK](https://cloud.google.com/kubernetes-engine/docs/quickstart)
 - Install [helm](https://helm.sh/docs/using_helm/)
-- A [wild-card TLS certificate](../docs/certificates.md)
-
-## Download
-
-Retrieve the latest copy of pomerium's source-code by cloning the repository.
-
-```bash
-git clone https://github.com/pomerium/pomerium.git $HOME/pomerium
-```
+- A [wild-card TLS certificate]
 
 ## Configure
 
-Edit the the install command in the [helm_gke.sh script ][./scripts/helm_gke.sh] to match your [identity provider] and access policy settings.
-
-
-Generate a wild-card TLS certificate. If you don't have one handy, the included [script] generates one from [LetsEncrypt].
+Download and modify the [helm_gke.sh script][./scripts/helm_gke.sh] to match your [identity provider] and [wild-card tls certificate] settings.
 
 ## Run
 
 Run [./scripts/helm_gke.sh] which will:
 
-1. Provision a new cluster
+1. Provision a new cluster.
 2. Create authenticate, authorize, and proxy [deployments](https://cloud.google.com/kubernetes-engine/docs/concepts/deployment).
 3. Provision and apply authenticate, authorize, and proxy [services](https://cloud.google.com/kubernetes-engine/docs/concepts/service).
 4. Configure an ingress, Google's default load balancer.
 
 ```bash
-sh ./scripts/helm_gke.sh
+./scripts/helm_gke.sh
 ```
-
-You should see roughly the following in your terminal. Note, provisioning does take a few minutes.
-
-[![helm pomerium screencast](https://asciinema.org/a/223821.svg)]([https://asciinema.org/a/223821](https://asciinema.org/a/YcYC4iZLZi5kCCU5lQIWzFnhV)
-
-And if you check out Google's Kubernetes Engine dashboard you'll see something like:
-
-![Google's Kubernetes Engine dashboard](./kubernetes-gke.png)
 
 ## Navigate
 
-Open a browser and navigate to `httpbin.corp.example.com`.
+Open a browser and navigate to `httpbin.your.domain.example`.
 
-You should see something like the following in your browser.
-
-![Getting started](./get-started.gif)
-
-[./scripts/helm_gke.sh]: ../docs/examples.html#google-kubernetes-engine
+[./scripts/helm_gke.sh]: ../docs/examples.html#helm
+[./scripts/kubernetes_gke.sh]: ../docs/examples.html#google-kubernetes-engine
 [example kubernetes files]: ../docs/examples.html#google-kubernetes-engine
-[helloworld]: https://hub.docker.com/r/tutum/hello-world
-[httpbin]: https://httpbin.org/
 [identity provider]: ../docs/identity-providers.md
 [letsencrypt]: https://letsencrypt.org/
 [script]: https://github.com/pomerium/pomerium/blob/master/scripts/generate_wildcard_cert.sh
+[wild-card tls certificate]: ../docs/certificates.md

--- a/docs/guide/kubernetes.md
+++ b/docs/guide/kubernetes.md
@@ -1,14 +1,22 @@
-# Kubernetes
+---
+title: Kubernetes
+lang: en-US
+meta:
+  - name: keywords
+    content: pomerium identity-access-proxy oidc kubernetes reverse-proxy
+---
 
-This quickstart will show you how to deploy Pomerium with Kubernetes. Though there are [countless ways](https://kubernetes.io/docs/setup/pick-right-solution/) to work with Kubernetes, for the purpose of this guide, we will be using Google's [Kubernetes Engine](https://cloud.google.com/kubernetes-engine/). That said, most of the following steps should be very similar using any other provider.
+# Pomerium using Kubernetes
+
+This quickstart will cover how to deploy Pomerium with Kubernetes. Though there are [many ways](https://kubernetes.io/docs/setup/pick-right-solution/) to work with Kubernetes, for the purpose of this guide, we will use Google's [Kubernetes Engine](https://cloud.google.com/kubernetes-engine/). That said, most of the following steps should be very similar using any other provider.
 
 ## Prerequisites
 
-- A [Google Cloud Account](https://console.cloud.google.com/)
 - A configured [identity provider]
-- Install [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
-- Install the [Google Cloud SDK](https://cloud.google.com/kubernetes-engine/docs/quickstart)
-- A [wild-card TLS certificate](../docs/certificates.md)
+- A [wild-card TLS certificate]
+- A [Google Cloud Account](https://console.cloud.google.com/)
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+- [Google Cloud SDK](https://cloud.google.com/kubernetes-engine/docs/quickstart)
 
 ## Download
 
@@ -20,15 +28,13 @@ git clone https://github.com/pomerium/pomerium.git $HOME/pomerium
 
 ## Configure
 
-Edit [./scripts/kubernetes_gke.sh] making sure to change the identity provider secret value to match your [identity provider] settings.
-
-Place your domain's wild-card TLS certificate (`privkey.pem` and `cert.pem`) in the root of the repository. If you don't have one handy, the included [script] generates one from [LetsEncrypt].
+Edit [./scripts/kubernetes_gke.sh] making sure to change the identity provider secret value to match your [identity provider] and [wild-card tls certificate] settings.
 
 ## Run
 
 Run [./scripts/kubernetes_gke.sh] which will:
 
-1. Provision a new cluster
+1. Provision a new cluster.
 2. Create authenticate, authorize, and proxy [deployments](https://cloud.google.com/kubernetes-engine/docs/concepts/deployment).
 3. Provision and apply authenticate, authorize, and proxy [services](https://cloud.google.com/kubernetes-engine/docs/concepts/service).
 4. Configure an ingress load balancer.
@@ -47,16 +53,12 @@ And if you check out Google's Kubernetes Engine dashboard you'll see something l
 
 ## Navigate
 
-Open a browser and navigate to `httpbin.your.domain.com`.
+Open a browser and navigate to `httpbin.your.domain.example`.
 
-You should see something like the following in your browser.
-
-![Getting started](./get-started.gif)
 
 [./scripts/kubernetes_gke.sh]: ../docs/examples.html#google-kubernetes-engine
 [example kubernetes files]: ../docs/examples.html#google-kubernetes-engine
-[helloworld]: https://hub.docker.com/r/tutum/hello-world
-[httpbin]: https://httpbin.org/
 [identity provider]: ../docs/identity-providers.md
 [letsencrypt]: https://letsencrypt.org/
 [script]: https://github.com/pomerium/pomerium/blob/master/scripts/generate_wildcard_cert.sh
+[wild-card tls certificate]: ../docs/certificates.md

--- a/docs/guide/readme.md
+++ b/docs/guide/readme.md
@@ -1,61 +1,57 @@
-# Docker
+---
+title: Docker
+lang: en-US
+meta:
+  - name: keywords
+    content: pomerium identity-access-proxy oidc docker reverse-proxy
+---
 
-Docker and docker-compose are tools for defining and running multi-container Docker applications. We've created an example docker-compose file that creates a minimal, but complete test environment for pomerium.
+# Pomerium using Docker
+
+[Docker] is a simple and easy way to start using Pomerium. In the following quick-start, we'll create a minimal but complete environment for running Pomerium with containers.
 
 ## Prerequisites
 
 - A configured [identity provider]
-- Install [docker]
-- Install [docker-compose]
-- A [wild-card TLS certificate](../docs/certificates.md)
-
-## Download
-
-Copy and paste the contents of the provided example [basic.docker-compose.yml].
+- [Docker] and [docker-compose]
+- A [wild-card TLS certificate]
 
 ## Configure
 
 ### Docker-compose
 
-Edit the `docker-compose.yml` to match your specific [identity provider]'s settings. For example, `basic.docker-compose.yml`:
+Download the following `docker-compose.yml` file and modify it to:
+
+- use newly generated secrets
+- mount your [wild-card TLS certificate]
+- mount Pomerium's `config.yaml` [configuration file]
 
 <<< @/docs/docs/examples/docker/basic.docker-compose.yml
 
-### Policy configuration
+### Configuration file
 
-Next, create a configuration file which will contain the routes you want to proxy, and their desired access-controls. For example, `config.example.policy.only.yaml`:
+Create a [configuration file] (`config.yaml`) for defining Pomerium's configuration settings, routes, and access-policies. Consider the following example:
 
-<<< @/config.example.policy.only.yaml
+<<< @/docs/docs/examples/config/config.minimal.yaml
 
-### Certificates
-
-Place your domain's wild-card TLS certificate next to the compose file. If you don't have one handy, the included [script] generates one from [LetsEncrypt].
+Ensure the `docker-compose.yml` contains the correct path to your `config.yaml`.
 
 ## Run
 
-Docker-compose will automatically download the latest pomerium release as well as two example containers.
+Finally, simply run docker compose.
 
 ```bash
 docker-compose up
 ```
 
-Pomerium is configured to delegate access to two test apps [helloworld] and [httpbin].
+Docker will automatically download the required [container images] for Pomerium and [httpbin]. Then, Pomerium will run with the configuration details set in the previous steps.
 
-## Navigate
+You should now be able access to the routes (e.g. `https://httpbin.corp.yourdomain.example`) as specified in your policy file.
 
-Open a browser and navigate to `hello.your.domain.com` or `httpbin.your.domain.com`. You should see something like the following in your browser.
-
-![Getting started](./get-started.gif)
-
-And in your terminal.
-
-[![asciicast](https://asciinema.org/a/tfbSWkUZgMRxHAQDqmcjjNwUg.svg)](https://asciinema.org/a/tfbSWkUZgMRxHAQDqmcjjNwUg)
-
-[basic.docker-compose.yml]: ../docs/examples.html#basic-docker-compose-yml
+[configuration file]: ../reference/readme.md
+[container images]: https://hub.docker.com/r/pomerium/pomerium
 [docker]: https://docs.docker.com/install/
 [docker-compose]: https://docs.docker.com/compose/install/
-[helloworld]: https://hub.docker.com/r/tutum/hello-world
 [httpbin]: https://httpbin.org/
 [identity provider]: ../docs/identity-providers.md
-[letsencrypt]: https://letsencrypt.org/
-[script]: https://github.com/pomerium/pomerium/blob/master/scripts/generate_wildcard_cert.sh
+[wild-card tls certificate]: ../docs/certificates.md

--- a/docs/guide/synology.md
+++ b/docs/guide/synology.md
@@ -165,18 +165,18 @@ Go to **Environment** tab.
 Field                     | Value
 ------------------------- | ---------------------------------------------------------------
 POLICY                    | output of `base64 -i policy.yaml`
-CERTIFICATE               | output of `base64 -i *.int.nas.example.com.cer`
-CERTIFICATE_KEY           | output of `base64 -i *.int.nas.example.com.key`
-CERTIFICATE_AUTHORITY     | output of `base64 -i ca.cer`
+CERTIFICATE               | output of `base64 -i "$HOME/.acme.sh/*.int.nas.bdd.io_ecc/fullchain.cer"`
+CERTIFICATE_KEY           | output of `base64 -i "$HOME/.acme.sh/*.int.nas.bdd.io_ecc/*.int.nas.bdd.io.key"`
+CERTIFICATE_AUTHORITY     | output of `base64 -i "$HOME/.acme.sh/*.int.nas.bdd.io_ecc/ca.cer"`
 OVERRIDE_CERTIFICATE_NAME | `*.int.nas.example.com`
 IDP_CLIENT_SECRET         | Values from setting up your [identity provider]
 IDP_CLIENT_ID             | Values from setting up your [identity provider]
 IDP_PROVIDER              | Values from setting up your [identity provider] (e.g. `google`)
-COOKIE_SECRET             | output of `head -c32 /dev/urandom                               | base64`
-SHARED_SECRET             | output of `head -c32 /dev/urandom                               | base64`
+COOKIE_SECRET             | output of `head -c32 /dev/urandom | base64`
+SHARED_SECRET             | output of `head -c32 /dev/urandom | base64`
 AUTHORIZE_SERVICE_URL     | `https://localhost`
 AUTHENTICATE_SERVICE_URL  | `https://authenticate.int.nas.example.com`
-AUTHENTICATE_INTERNAL_URL | `localhost`
+AUTHENTICATE_INTERNAL_URL | `https://localhost`
 
 For a detailed explanation, and additional options, please refer to the [configuration variable docs].
 
@@ -216,5 +216,4 @@ And just to be safe, try logging in from another google account to see what happ
 [identity provider]: ../docs/identity-providers.md#google
 [letsencrypt]: https://letsencrypt.org/
 [nginx]: https://www.nginx.com
-[script]: https://github.com/pomerium/pomerium/blob/master/scripts/generate_wildcard_cert.sh
 [self-hosted apps]: https://github.com/Kickball/awesome-selfhosted

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -4,7 +4,7 @@ sidebar: auto
 
 # Configuration
 
-Pomerium can use a combination of a YAML/JSON/TOML configuration file and [environmental variables] to set configuration settings.
+Pomerium can be configured using a either a configuration file ([YAML]/[JSON]/[TOML]) or [environmental variables]. In general, environmental variable keys are identical to config file keys but are in all uppercase.
 
 If you are coming from a kubernetes or docker background this should feel familiar. If not, check out the following primers.
 
@@ -13,7 +13,7 @@ If you are coming from a kubernetes or docker background this should feel famili
 - [Kubernetes: Config Maps](https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/)
 - [Docker: Environment variables](https://docs.docker.com/compose/environment-variables/)
 
-In general, any setting specified by environment variable can also be present in the optional config file as the same name but lower cased. Environment variables take precedence.
+Using both [environmental variables] and config file keys is allowed and encouraged (for instance, secret keys are probably best set as environmental variables). However, if duplicate configuration keys are found, environment variables take precedence.
 
 Pomerium will automatically reload the configuration file if it is changed.  At this time, only policy is re-configured when this reload occurs, but additional options may be added in the future.  It is suggested that your policy is stored in a configuration file so that you can take advantage of this feature.
 
@@ -165,7 +165,7 @@ Allowing websocket connections to the proxy could result in abuse via DOS attack
 
 Policy contains route specific settings, and access control details. If you are configuring via POLICY environment variable, just the contents of the policy needs to be passed. If you are configuring via file, the policy should be present under the policy key. For example,
 
-<<< @/config.example.policy.only.yaml
+<<< @/docs/docs/examples/config/policy.example.yaml
 
 A list of policy configuration variables follows.
 
@@ -407,9 +407,23 @@ By default, conservative [secure HTTP headers](https://www.owasp.org/index.php/O
 
 Refresh cooldown is the minimum amount of time between allowed manually refreshed sessions.
 
+### Default Upstream Timeout
+
+- Environmental Variable: `DEFAULT_UPSTREAM_TIMEOUT`
+- Config File Key: `default_upstream_timeout`
+- Type: [Duration](https://golang.org/pkg/time/#Duration) `string`
+- Example: `10m`, `1h45m`
+- Default: `30s`
+
+Default Upstream Timeout is the default timeout applied to a proxied route when no `timeout` key is specified by the policy.
+
+
 [base64 encoded]: https://en.wikipedia.org/wiki/Base64
 [environmental variables]: https://en.wikipedia.org/wiki/Environment_variable
 [identity provider]: ./identity-providers.md
+[json]: https://en.wikipedia.org/wiki/JSON
 [letsencrypt]: https://letsencrypt.org/
 [oidc rfc]: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest
 [script]: https://github.com/pomerium/pomerium/blob/master/scripts/generate_wildcard_cert.sh
+[toml]: https://en.wikipedia.org/wiki/TOML
+[yaml]: https://en.wikipedia.org/wiki/YAML

--- a/scripts/kubernetes_gke.sh
+++ b/scripts/kubernetes_gke.sh
@@ -17,14 +17,18 @@ kubectl create secret generic -n pomerium shared-secret --from-literal=shared-se
 kubectl create secret generic -n pomerium cookie-secret --from-literal=cookie-secret=$(head -c32 /dev/urandom | base64)
 
 echo "=> initiliaze secrets for TLS wild card certificatescertificate andcertificate-key"
-kubectl create secret generic -n pomerium certificate --from-literal=certificate=$(base64 -i cert.pem)
-kubectl create secret generic -n pomerium certificate-key --from-literal=certificate-key=$(base64 -i privkey.pem)
+kubectl create secret generic -n pomerium certificate \
+	--from-literal=certificate=$(base64 -i "$HOME/.acme.sh/*.corp.beyondperimeter.com_ecc/fullchain.cer")
+kubectl create secret generic -n pomerium certificate-key \
+	--from-literal=certificate-key=$(base64 -i "$HOME/.acme.sh/*.corp.beyondperimeter.com_ecc/*.corp.beyondperimeter.com.key")
 
 echo "=> load TLS to ingress"
-kubectl create secret tls -n pomerium pomerium-tls --key privkey.pem --cert cert.pem
+kubectl create secret tls -n pomerium pomerium-tls \
+	--key "$HOME/.acme.sh/*.corp.beyondperimeter.com_ecc/*.corp.beyondperimeter.com.key" \
+	--cert "$HOME/.acme.sh/*.corp.beyondperimeter.com_ecc/fullchain.cer"
 
-echo "=> initiliaze a configmap setting for POLICY from config.example.policy.only.yaml"
-kubectl create configmap -n pomerium policy --from-literal=policy=$(cat config.example.policy.only.yaml | base64)
+echo "=> initiliaze a configmap setting for POLICY from policy.example.yaml"
+kubectl create configmap -n pomerium policy --from-literal=policy=$(cat docs/docs/examples/config/policy.example.yaml | base64)
 
 echo "=> settingidp-client-secret, you changed this right? :)"
 exit 1 # comment out or delete this line once you change the following two settings


### PR DESCRIPTION
- Use wildcard certificate domain path from docs.
-  Generate secret keys on the fly for config.example.env
- Prefer as minimal (comment out) configuration as possible to get examples working. 
-  Change examples to show env-var best practices around secret. e.g. secrets should come from env vars, and other configurations can come from config file.

Part of #145 
Fixes #156 

**Checklist**:
- [x] update docker based examples
- [x] update kubernetes examples
- [x] update helm examples (addressed in follow up issue)
- [x] ADD a binary example instead of just source
- [x] tidy docs as you go 😄 
