### PR TITLE
authenticate: catch missing required setting

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -19,7 +19,7 @@ import (
 // The checks do not modify the internal state of the Option structure. Returns
 // on first error found.
 func ValidateOptions(o *config.Options) error {
-	if o.AuthenticateURL == nil {
+	if o.AuthenticateURL == nil || o.AuthenticateURL.Hostname() == "" {
 		return errors.New("authenticate: 'AUTHENTICATE_SERVICE_URL' missing")
 	}
 	if o.ClientID == "" {

--- a/authenticate/authenticate_test.go
+++ b/authenticate/authenticate_test.go
@@ -38,6 +38,8 @@ func TestOptions_Validate(t *testing.T) {
 	shortCookieLength.CookieSecret = "gN3xnvfsAwfCXxnJorGLKUG4l2wC8sS8nfLMhcStPg=="
 	badSharedKey := testOptions()
 	badSharedKey.SharedKey = ""
+	badAuthenticateURL := testOptions()
+	badAuthenticateURL.AuthenticateURL = new(url.URL)
 
 	tests := []struct {
 		name    string
@@ -53,6 +55,7 @@ func TestOptions_Validate(t *testing.T) {
 		{"no shared secret", badSharedKey, true},
 		{"no client id", emptyClientID, true},
 		{"no client secret", emptyClientSecret, true},
+		{"empty authenticate url", badAuthenticateURL, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes an issue where `AuthenticateURL` validation check would fail because the setting is empty, but not nil. 

Closes #148 

**Checklist**:
- [x] unit tests added
- [x] ready for review
