### PR TITLE
Enable websocket support

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -143,6 +143,19 @@ Timeouts set the global server timeouts. For route-specific timeouts, see [polic
 
 If set, the HTTP Redirect Address specifies the host and port to redirect http to https traffic on. If unset, no redirect server is started.
 
+### Websocket Connections
+
+- Environmental Variable: `ALLOW_WEBSOCKETS`
+- Config File Key: `allow_websockets`
+- Type: `bool`
+- Default: `false`
+
+If set, enables proxying of websocket connections. 
+Otherwise the proxy responds with `400 Bad Request` to all websocket connections.
+
+**Use with caution:** By definition, websockets are long-lived connections, so [global timeouts](#global-timeouts) are not enforced.
+Allowing websocket connections to the proxy could result in abuse via DOS attacks. 
+
 ### Policy
 
 - Environmental Variable: `POLICY`

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -129,6 +129,10 @@ type Options struct {
 	// Sub-routes
 	Routes                 map[string]string `mapstructure:"routes"`
 	DefaultUpstreamTimeout time.Duration     `mapstructure:"default_upstream_timeout"`
+
+	// Enable proxying of websocket connections. Defaults to "false".
+	// Caution: Enabling this feature could result in abuse via DOS attacks.
+	AllowWebsockets bool `mapstructure:"allow_websockets"`
 }
 
 // NewOptions returns a new options struct with default values
@@ -160,6 +164,7 @@ func NewOptions() *Options {
 		AuthenticateInternalAddr: new(url.URL),
 		AuthorizeURL:             new(url.URL),
 		RefreshCooldown:          time.Duration(5 * time.Minute),
+		AllowWebsockets:   		  false,
 	}
 	return o
 }

--- a/internal/log/middleware.go
+++ b/internal/log/middleware.go
@@ -164,7 +164,7 @@ func AccessHandler(f func(r *http.Request, status, size int, duration time.Durat
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
-			lw := NewWrapResponseWriter(w, 2)
+			lw := NewWrapResponseWriter(w, r.ProtoMajor)
 			next.ServeHTTP(lw, r)
 			f(r, lw.Status(), lw.BytesWritten(), time.Since(start))
 		})

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -273,7 +273,8 @@ func NewReverseProxyHandler(o *config.Options, proxy *httputil.ReverseProxy, rou
 		timeout = route.UpstreamTimeout
 	}
 	timeoutMsg := fmt.Sprintf("%s failed to respond within the %s timeout period", route.Destination.Host, timeout)
-	return http.TimeoutHandler(up, timeout, timeoutMsg), nil
+	timeoutHandler := http.TimeoutHandler(up, timeout, timeoutMsg)
+	return websocketHandlerFunc(up, timeoutHandler, o), nil
 }
 
 // urlParse wraps url.Parse to add a scheme if none-exists.


### PR DESCRIPTION
Fixes #77 

## Description

Allows proxy to handle websocket connections. 

### Major changes:

- Fix hardcoded HTTP protocol version. Hardcoded to HTTP2, which does not support websockets (at least not well)
- Prevent websocket connections from being proxied through a `timeoutHandler`, as websockets are long-lived connections and should not have timeouts enforced on them.
- Added configuration variable to opt-in to websocket support.

### Other Notes

This is an opt-in feature because it can be potentially abused (see discussion in this PR). By opting-in, the user acknowledges this risk.

**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review
