### PR TITLE
internal/config: change internal-authenticate-addr to url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 - Add support for public, unauthenticated routes. [GH-129]
 
 ### CHANGED
-
+- Changed config `AUTHENTICATE_INTERNAL_URL`  to be a URL containing both a valid hostname and schema. [GH-153]
 - User state is now maintained and scoped at the domain level vs at the route level. [GH-128]
 - Error pages contain a link to sign out from the current user session. [GH-100]
 - Removed `LifetimeDeadline` from `sessions.SessionState`.

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -46,4 +46,6 @@ Usage of the POLICY_FILE envvar is no longer supported.  Support for file based 
       timeout: 30s
   ```
 
-### Z
+### Authenticate Internal Service Address
+
+The configuration variable [Authenticate Internal Service URL](https://www.pomerium.io/reference/#authenticate-internal-service-url) must now be a valid [URL](https://golang.org/pkg/net/url/#URL) type and contain both a hostname and valid `https` schema. 

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -323,9 +323,9 @@ Authenticate Service URL is the externally accessible URL for the authenticate s
 
 - Environmental Variable: `AUTHENTICATE_INTERNAL_URL`
 - Config File Key: `authenticate_internal_url`
-- Type: `string`
+- Type: `URL`
 - Optional
-- Example: `pomerium-authenticate-service.pomerium.svc.cluster.local`
+- Example: `https://pomerium-authenticate-service.pomerium.svc.cluster.local`
 
 Authenticate Internal Service URL is the internally routed dns name of the authenticate service. This setting is typically used with load balancers that do not gRPC, thus allowing you to specify an internally accessible name.
 
@@ -335,11 +335,11 @@ Authenticate Internal Service URL is the internally routed dns name of the authe
 - Config File Key: `authorize_service_url`
 - Type: `URL`
 - Required
-- Example: `https://access.corp.example.com` or `pomerium-authorize-service.pomerium.svc.cluster.local`
+- Example: `https://access.corp.example.com` or `https://pomerium-authorize-service.pomerium.svc.cluster.local`
 
 Authorize Service URL is the location of the internally accessible authorize service. NOTE: Unlike authenticate, authorize has no publicly accessible http handlers so this setting is purely for gRPC communication.
 
-If your load balancer does not support gRPC pass-through you'll need to set this value to an internally routable location (`pomerium-authorize-service.pomerium.svc.cluster.local`) instead of an externally routable one (`https://access.corp.example.com`).
+If your load balancer does not support gRPC pass-through you'll need to set this value to an internally routable location (`https://pomerium-authorize-service.pomerium.svc.cluster.local`) instead of an externally routable one (`https://access.corp.example.com`).
 
 ### Override Certificate Name
 

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.12
 require (
 	github.com/golang/mock v1.2.0
 	github.com/golang/protobuf v1.3.1
+	github.com/google/go-cmp v0.3.0
 	github.com/magiconair/properties v1.8.1 // indirect
 	github.com/pomerium/go-oidc v2.0.0+incompatible
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5y
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -161,7 +161,7 @@ func New(opts *config.Options) (*Proxy, error) {
 	p.AuthenticateClient, err = clients.NewAuthenticateClient("grpc",
 		&clients.Options{
 			Addr:                    opts.AuthenticateURL.Host,
-			InternalAddr:            opts.AuthenticateInternalAddr,
+			InternalAddr:            opts.AuthenticateInternalAddr.String(),
 			OverrideCertificateName: opts.OverrideCertificateName,
 			SharedSecret:            opts.SharedKey,
 			CA:                      opts.CA,


### PR DESCRIPTION
These changes standardize the way url config options are handled in pomerium. Namely:
- Standard lib's url.Parse is pretty lenient about what it accepts so I wrapped it to check for some basic attributes like host and scheme.
- I fixed what I think was a broken unit test. 
- Added a dependency called `go-cmp` which is an absolute delight to unit test with as comparing and checking deep structs. 

Fixes #153 

**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review

/cc @travisgroth @victornoel