### PR TITLE
internal/middleware: validate TLD plus one

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -162,14 +162,14 @@ func (a *Authenticate) OAuthStart(w http.ResponseWriter, r *http.Request) {
 	a.csrfStore.SetCSRF(w, r, nonce)
 
 	// verify redirect uri is from the root domain
-	if !middleware.SameSubdomain(authRedirectURL, a.RedirectURL) {
+	if !middleware.SameDomain(authRedirectURL, a.RedirectURL) {
 		httputil.ErrorResponse(w, r, "Invalid redirect parameter: redirect uri not from the root domain", http.StatusBadRequest)
 		return
 	}
 
 	// verify proxy url is from the root domain
 	proxyRedirectURL, err := url.Parse(authRedirectURL.Query().Get("redirect_uri"))
-	if err != nil || !middleware.SameSubdomain(proxyRedirectURL, a.RedirectURL) {
+	if err != nil || !middleware.SameDomain(proxyRedirectURL, a.RedirectURL) {
 		httputil.ErrorResponse(w, r, "Invalid redirect parameter: proxy url not from the root domain", http.StatusBadRequest)
 		return
 	}
@@ -261,7 +261,7 @@ func (a *Authenticate) getOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		return "", httputil.HTTPError{Code: http.StatusForbidden, Message: "Malformed redirect url"}
 	}
 	// sanity check, we are redirecting back to the same subdomain right?
-	if !middleware.SameSubdomain(redirectURL, a.RedirectURL) {
+	if !middleware.SameDomain(redirectURL, a.RedirectURL) {
 		return "", httputil.HTTPError{Code: http.StatusBadRequest, Message: "Invalid Redirect URI domain"}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/spf13/viper v1.3.2
 	github.com/stretchr/testify v1.3.0 // indirect
 	golang.org/x/crypto v0.0.0-20190513172903-22d7a77e9e5f
-	golang.org/x/net v0.0.0-20190522155817-f3200d17e092
+	golang.org/x/net v0.0.0-20190603091049-60506f45cf65
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 	golang.org/x/sys v0.0.0-20190524152521-dbbf3f1254d4 // indirect
 	golang.org/x/text v0.3.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092 h1:4QSRKanuywn15aTZvI/mIDEgPQpswuFndXpOj3rKEco=
 golang.org/x/net v0.0.0-20190522155817-f3200d17e092/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65 h1:+rhAzEzT3f4JtomfC371qB+0Ola2caSKcY69NUBZrRQ=
+golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181203162652-d668ce993890/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=


### PR DESCRIPTION
Refactor `ValidateRedirectURI` to check if two urls are coming from the same top level domain vs matching for exact subdomain and depth. 

Fixes #152 

See: 
- [Why it's trickier than it sounds](https://godoc.org/golang.org/x/net/publicsuffix#EffectiveTLDPlusOne)

**Checklist**:
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review
