### PR TITLE
internal/httputil: use error structs for http errors

### DIFF
--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -164,7 +164,7 @@ func NewOptions() *Options {
 		AuthenticateInternalAddr: new(url.URL),
 		AuthorizeURL:             new(url.URL),
 		RefreshCooldown:          time.Duration(5 * time.Minute),
-		AllowWebsockets:   		  false,
+		AllowWebsockets:          false,
 	}
 	return o
 }

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -175,8 +175,8 @@ func TestValidateClientSecret(t *testing.T) {
 	}{
 		{"simple", "secret", "secret", "secret", http.StatusOK},
 		{"missing get param, valid header", "secret", "", "secret", http.StatusOK},
-		{"missing both", "secret", "", "", http.StatusUnauthorized},
-		{"simple bad", "bad-secret", "secret", "", http.StatusUnauthorized},
+		{"missing both", "secret", "", "", http.StatusInternalServerError},
+		{"simple bad", "bad-secret", "secret", "", http.StatusInternalServerError},
 		{"malformed, invalid hex digits", "secret", "%zzzzz", "", http.StatusBadRequest},
 	}
 

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -265,9 +265,11 @@ func New() *template.Template {
       <svg class="icon error" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="none" d="M0 0h24v24H0V0z"/><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zM4 12c0-4.42 3.58-8 8-8 1.85 0 3.55.63 4.9 1.69L5.69 16.9C4.63 15.55 4 13.85 4 12zm8 8c-1.85 0-3.55-.63-4.9-1.69L18.31 7.1C19.37 8.45 20 10.15 20 12c0 4.42-3.58 8-8 8z"/></svg>
         <h1 class="title">{{.Title}}</h1>
         <section>
-          <p class="message">{{.Message}}.</p>
-          <p class="message">Troubleshoot your <a href="/.pomerium">session</a>.</br>
-          {{if .RequestID}} Request {{.RequestID}} {{end}}
+          <p class="message">
+            {{if .Message}}{{.Message}}</br>{{end}}
+            {{if .CanDebug}}Troubleshoot your <a href="/.pomerium">session</a>.</br>{{end}}
+            {{if .RequestID}} Request {{.RequestID}}</br>{{end}}
+          
           </p>
         </section>
       </form>


### PR DESCRIPTION
The existing implementation used a ErrorResponse method to propogate
and create http error messages. Since we added functionality to
troubleshoot, signout, and do other tasks following an http error
it's useful to use Error struct in place of method arguments.

This fixes #157 where a troubleshooting links were appearing on pages
that it didn't make sense on (e.g. pages without valid sessions).

**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review
