### PR TITLE
proxy: fix authenticate internal service url

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -156,7 +156,7 @@ func New(opts *config.Options) (*Proxy, error) {
 	p.AuthenticateClient, err = clients.NewAuthenticateClient("grpc",
 		&clients.Options{
 			Addr:                    opts.AuthenticateURL.Host,
-			InternalAddr:            opts.AuthenticateInternalAddr.String(),
+			InternalAddr:            opts.AuthenticateInternalAddr.Host,
 			OverrideCertificateName: opts.OverrideCertificateName,
 			SharedSecret:            opts.SharedKey,
 			CA:                      opts.CA,


### PR DESCRIPTION
Previously, internal service url was being passed as it's full string representation, however
the grpc client expects a hostname:port pair. 

Thank you @victornoel for reporting the issue. 