### PR TITLE
cmd/pomerium: add version and options dump

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -37,7 +37,7 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("cmd/pomerium: options")
 	}
-
+	log.Info().Str("version", version.FullVersion()).Msg("cmd/pomerium")
 	grpcAuth := middleware.NewSharedSecretCred(opt.SharedKey)
 	grpcOpts := []grpc.ServerOption{grpc.UnaryInterceptor(grpcAuth.ValidateRequest)}
 	grpcServer := grpc.NewServer(grpcOpts...)
@@ -185,6 +185,7 @@ func parseOptions(configFile string) (*config.Options, error) {
 	}
 	if o.Debug {
 		log.SetDebugMode()
+		// log.Debug().Interface("options", o).Msg("cmd/pomerium")
 	}
 	if o.LogLevel != "" {
 		log.SetLevel(o.LogLevel)

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -71,6 +71,12 @@ head -c32 /dev/urandom | base64
 - Type: `bool`
 - Default: `false`
 
+::: danger
+
+Enabling the debug flag will result in sensitive information being logged!!! 
+
+:::
+
 By default, JSON encoded logs are produced. Debug enables colored, human-readable logs to be streamed to [standard out](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)). In production, it's recommended to be set to `false`.
 
 For example, if `true`


### PR DESCRIPTION
The following changes adds logging of pomerium's version on startup.

Fixes #161 

/cc @victornoel

**Checklist**:
- [x] updated docs
- [x] related issues referenced
- [x] ready for review
