### PR TITLE
Faster initial test runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 - go get -u golang.org/x/lint/golint
 - go get honnef.co/go/tools/cmd/staticcheck
 script:
-- env GO111MODULE=on make all
+- env GOPROXY=https://proxy.golang.org GO111MODULE=on make all
 - env GO111MODULE=on make cover
 - env GO111MODULE=on make release
 after_success:


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!
We generally follow Go coding and contributing conventions
https://golang.org/doc/contribute.html#commit_messages

Here's an example of a good PR/Commit:

    math: improve Sin, Cos and Tan precision for very large arguments

    The existing implementation has poor numerical properties for
    large arguments, so use the McGillicutty algorithm to improve
    accuracy above 1e10.

    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm

    Fixes #159
-->
Try to get first test runs to be faster

**Checklist**:

- [x] ready for review
