### PR TITLE
docs: add slack link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
-<span>
-  <img height="125" src="./docs/.vuepress/public/logo.svg" alt="logo" align="right">
-</span>
+<a href="https://pomerium.io" title="Pomerium is a zero trust, context and identity aware access proxy."><img src="./docs/.vuepress/public/logo-long.svg" height="70" alt="pomerium logo"></a>
 
-# Pomerium
-
+[![pomerium chat](https://img.shields.io/badge/chat-on%20slack-blue.svg?style=flat&logo=slack)](http://slack.pomerium.io)
 [![Travis CI](https://travis-ci.org/pomerium/pomerium.svg?branch=master)](https://travis-ci.org/pomerium/pomerium) [![Go Report Card](https://goreportcard.com/badge/github.com/pomerium/pomerium)](https://goreportcard.com/report/github.com/pomerium/pomerium) [![GoDoc](https://godoc.org/github.com/pomerium/pomerium?status.svg)][godocs] [![LICENSE](https://img.shields.io/github/license/pomerium/pomerium.svg)](https://github.com/pomerium/pomerium/blob/master/LICENSE) [![codecov](https://img.shields.io/codecov/c/github/pomerium/pomerium.svg?style=flat)](https://codecov.io/gh/pomerium/pomerium)
 
 Pomerium is a tool for managing secure access to internal applications and resources.


### PR DESCRIPTION
These changes adds a slack badge to the main repo's readme.
Also, changes the logo to be the long, wide version. 

See
- #155 

**Checklist**:
- [x] related issues referenced
- [x] ready for review
