### PR TITLE
Relocate wrapped ResponseWriter to middleware

### DIFF
--- a/internal/log/middleware.go
+++ b/internal/log/middleware.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pomerium/pomerium/internal/middleware/responsewriter"
 	"github.com/rs/zerolog"
 )
 
@@ -164,7 +165,7 @@ func AccessHandler(f func(r *http.Request, status, size int, duration time.Durat
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
-			lw := NewWrapResponseWriter(w, r.ProtoMajor)
+			lw := responsewriter.NewWrapResponseWriter(w, r.ProtoMajor)
 			next.ServeHTTP(lw, r)
 			f(r, lw.Status(), lw.BytesWritten(), time.Since(start))
 		})

--- a/internal/middleware/responsewriter/wrap_writer.go
+++ b/internal/middleware/responsewriter/wrap_writer.go
@@ -1,4 +1,4 @@
-package log // import "github.com/pomerium/pomerium/internal/log"
+package responsewriter
 
 // The original work was derived from Goji's middleware, source:
 // https://github.com/zenazn/goji/tree/master/web/middleware

--- a/internal/middleware/responsewriter/wrap_writer_test.go
+++ b/internal/middleware/responsewriter/wrap_writer_test.go
@@ -1,4 +1,4 @@
-package log // import "github.com/pomerium/pomerium/internal/log"
+package responsewriter
 
 import (
 	"net/http/httptest"


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!
We generally follow Go coding and contributing conventions
https://golang.org/doc/contribute.html#commit_messages

Here's an example of a good PR/Commit:

    math: improve Sin, Cos and Tan precision for very large arguments

    The existing implementation has poor numerical properties for
    large arguments, so use the McGillicutty algorithm to improve
    accuracy above 1e10.

    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm

    Fixes #159
-->

Preliminary work for #35.

Move the wrapped ResponseWriter to middleware so we can leverage it elsewhere.

**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] ready for review
