### PR TITLE
internal/logs: make non error conditions less scary in logs

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -8,22 +8,22 @@ import (
 	"os"
 	"time"
 
-	"github.com/pomerium/pomerium/internal/metrics"
-
 	"github.com/fsnotify/fsnotify"
+	"github.com/spf13/viper"
+	"google.golang.org/grpc"
+
 	"github.com/pomerium/pomerium/authenticate"
 	"github.com/pomerium/pomerium/authorize"
 	"github.com/pomerium/pomerium/internal/config"
 	"github.com/pomerium/pomerium/internal/https"
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/metrics"
 	"github.com/pomerium/pomerium/internal/middleware"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/internal/version"
 	pbAuthenticate "github.com/pomerium/pomerium/proto/authenticate"
 	pbAuthorize "github.com/pomerium/pomerium/proto/authorize"
 	"github.com/pomerium/pomerium/proxy"
-	"github.com/spf13/viper"
-	"google.golang.org/grpc"
 )
 
 var versionFlag = flag.Bool("version", false, "prints the version")
@@ -90,7 +90,7 @@ func main() {
 	}
 
 	if srv, err := startRedirectServer(opt.HTTPRedirectAddr); err != nil {
-		log.Debug().Err(err).Msg("cmd/pomerium: http redirect server not started")
+		log.Debug().Str("cause", err.Error()).Msg("cmd/pomerium: http redirect server not started")
 	} else {
 		defer srv.Close()
 	}

--- a/internal/metrics/exporter.go
+++ b/internal/metrics/exporter.go
@@ -1,4 +1,4 @@
-package metrics
+package metrics // import "github.com/pomerium/pomerium/internal/metrics"
 
 import (
 	"net/http"

--- a/internal/metrics/exporter_test.go
+++ b/internal/metrics/exporter_test.go
@@ -1,4 +1,4 @@
-package metrics
+package metrics // import "github.com/pomerium/pomerium/internal/metrics"
 
 import (
 	"bytes"

--- a/internal/metrics/middleware.go
+++ b/internal/metrics/middleware.go
@@ -1,4 +1,4 @@
-package metrics
+package metrics // import "github.com/pomerium/pomerium/internal/metrics"
 
 import (
 	"context"
@@ -6,13 +6,11 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/pomerium/pomerium/internal/middleware/responsewriter"
-
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 
-	"go.opencensus.io/stats/view"
-
-	"go.opencensus.io/stats"
+	"github.com/pomerium/pomerium/internal/middleware/responsewriter"
 )
 
 var (
@@ -26,14 +24,14 @@ var (
 	httpRequestDuration = stats.Int64("http_server_request_duration_ms", "HTTP Request duration in ms", "ms")
 
 	views = []*view.View{
-		&view.View{
+		{
 			Name:        httpRequestCount.Name(),
 			Measure:     httpRequestCount,
 			Description: httpRequestCount.Description(),
 			TagKeys:     []tag.Key{keyService, keyHost, keyMethod, keyStatus},
 			Aggregation: view.Count(),
 		},
-		&view.View{
+		{
 			Name:        httpRequestDuration.Name(),
 			Measure:     httpRequestDuration,
 			Description: httpRequestDuration.Description(),
@@ -46,7 +44,7 @@ var (
 				100000,
 			),
 		},
-		&view.View{
+		{
 			Name:        httpResponseSize.Name(),
 			Measure:     httpResponseSize,
 			Description: httpResponseSize.Description(),

--- a/internal/metrics/middleware_test.go
+++ b/internal/metrics/middleware_test.go
@@ -1,4 +1,4 @@
-package metrics
+package metrics // import "github.com/pomerium/pomerium/internal/metrics"
 
 import (
 	"bytes"


### PR DESCRIPTION
internal/metrics: simplified struct definition with fmt -s.
internal/metrics: added full path to package name.

<!--  
Thanks for sending a pull request!
We generally follow Go coding and contributing conventions
https://golang.org/doc/contribute.html#commit_messages

Here's an example of a good PR/Commit:

    math: improve Sin, Cos and Tan precision for very large arguments

    The existing implementation has poor numerical properties for
    large arguments, so use the McGillicutty algorithm to improve
    accuracy above 1e10.

    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm

    Fixes #159
-->

See:
- #184 

**Checklist**:
- [x] related issues referenced
- [x] ready for review

/cc @travisgroth 
