### PR TITLE
internal/sessions: support custom session domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fixed Azure group lookups [GH-190]
 - If a session is too large (over 4096 bytes) Pomerium will no longer fail silently. [GH-211]
 - Internal URLs like dashboard now start auth process to login a user if no session is found [GH-205].
+- When set,`CookieDomain` lets a user set the scope of the user session. CSRF cookies will still always be scoped at the individual route level. [GH-181]
 
   ## v0.0.5
 

--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -66,6 +66,7 @@ func New(opts config.Options) (*Authenticate, error) {
 	cookieStore, err := sessions.NewCookieStore(
 		&sessions.CookieStoreOptions{
 			Name:           opts.CookieName,
+			CookieDomain:   opts.CookieDomain,
 			CookieSecure:   opts.CookieSecure,
 			CookieHTTPOnly: opts.CookieHTTPOnly,
 			CookieExpire:   opts.CookieExpire,

--- a/internal/sessions/cookie_store.go
+++ b/internal/sessions/cookie_store.go
@@ -68,20 +68,19 @@ func NewCookieStore(opts *CookieStoreOptions) (*CookieStore, error) {
 }
 
 func (s *CookieStore) makeCookie(req *http.Request, name string, value string, expiration time.Duration, now time.Time) *http.Cookie {
-	// if csrf, scope cookie to the route or service specific domain
 	domain := req.Host
-	if h, _, err := net.SplitHostPort(domain); err == nil {
-		domain = h
-	}
-	if s.CookieDomain != "" {
-		domain = s.CookieDomain
-	}
 
-	// Non-CSRF sessions can shared, and set domain-wide
-	if !strings.Contains(name, "csrf") {
+	if name == s.csrfName() {
+		domain = req.Host
+	} else if s.CookieDomain != "" {
+		domain = s.CookieDomain
+	} else {
 		domain = splitDomain(domain)
 	}
 
+	if h, _, err := net.SplitHostPort(domain); err == nil {
+		domain = h
+	}
 	c := &http.Cookie{
 		Name:     name,
 		Value:    value,


### PR DESCRIPTION
These changes allow a users to manually set the scope of pomerium's session cookie via the setting `CookieDomain`. This setting is useful for users that must support pomerium services served from different subdomain, and thus need to scope sessions  at a higher level.

For example, if you had the following configuration.

```yaml
# extra fields removed for clarity
authenticate_service_url: https://authenticate.corp.beyondperimeter.com
authorize_service_url: https://authorize.corp.beyondperimeter.com

cookie_domain: "corp.beyondperimeter.com"

policy:
  - from: httpbin.aws.corp.beyondperimeter.com
    to: http://localhost:1111
  - from: httpbin.gke.corp.beyondperimeter.com
    to: http://localhost:2222
```

Fixes #181 
Fixes #197 

**Additional Context**
- https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
- https://godoc.org/github.com/pomerium/pomerium/internal/config#Options

**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] updated CHANGELOG.md
- [x] ready for review

/cc @victornoel
