### PR TITLE
internal/identity: fix azure group lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### FIXED
 
 - Fixed HEADERS environment variable parsing [GH-188]
+- Fixed Azure group lookups [GH-190]
 
 ## v0.0.5
 

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -304,7 +304,6 @@ func (a *Authenticate) ExchangeToken(w http.ResponseWriter, r *http.Request) {
 		httputil.ErrorResponse(w, r, &httputil.Error{Code: http.StatusInternalServerError, Message: "could not exchange identity for session"})
 		return
 	}
-	log.Info().Interface("session", session).Msg("Session")
 	if err := a.restStore.SaveSession(w, r, session); err != nil {
 		log.Error().Err(err).Msg("authenticate: failed returning new session")
 		httputil.ErrorResponse(w, r, &httputil.Error{Code: http.StatusInternalServerError, Message: "authenticate: failed returning new session"})

--- a/docs/docs/identity-providers.md
+++ b/docs/docs/identity-providers.md
@@ -75,7 +75,7 @@ Next you need to ensure that the Pomerium's Redirect URL is listed in allowed re
 
 Next, in order to retrieve group information from Active Directory, we need to enable the necessary permissions for the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/auth-v2-service#azure-ad-endpoint-considerations).
 
-On the **App registrations** page, click **API permissions**. Click the **Add a permission** button and select **Microsoft Graph API**, select **Delegated permissions**. Under the **Directory** row, select the checkbox for **Directory.Read.All**.
+On the **App registrations** page, click **API permissions**. Click the **Add a permission** button and select **Microsoft Graph API**, select **Delegated permissions**. Under the **Directory** row, select the checkbox for **Group.Read.All**.
 
 ![Azure add group membership claims](./microsoft/azure-api-settings.png)
 

--- a/internal/identity/microsoft.go
+++ b/internal/identity/microsoft.go
@@ -43,7 +43,7 @@ func NewAzureProvider(p *Provider) (*AzureProvider, error) {
 		return nil, err
 	}
 	if len(p.Scopes) == 0 {
-		p.Scopes = []string{oidc.ScopeOpenID, "profile", "email", "offline_access"}
+		p.Scopes = []string{oidc.ScopeOpenID, "profile", "email", "offline_access", "Group.Read.All"}
 	}
 	p.verifier = p.provider.Verifier(&oidc.Config{ClientID: p.ClientID})
 	p.oauth = &oauth2.Config{
@@ -91,8 +91,13 @@ func (p *AzureProvider) Authenticate(ctx context.Context, code string) (*session
 	if err != nil {
 		return nil, fmt.Errorf("identity/microsoft: could not verify id_token %v", err)
 	}
+
 	session.AccessToken = oauth2Token.AccessToken
 	session.RefreshToken = oauth2Token.RefreshToken
+	session.Groups, err = p.UserGroups(ctx, session.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("identity/microsoft: could not retrieve groups %v", err)
+	}
 	return session, nil
 }
 
@@ -112,17 +117,12 @@ func (p *AzureProvider) IDTokenToSession(ctx context.Context, rawIDToken string)
 	if err := idToken.Claims(&claims); err != nil {
 		return nil, fmt.Errorf("identity/microsoft: failed to parse id_token claims %v", err)
 	}
-	groups, err := p.UserGroups(ctx, claims.Email)
-	if err != nil {
-		return nil, fmt.Errorf("identity/microsoft: could not retrieve groups %v", err)
-	}
 
 	return &sessions.SessionState{
 		IDToken:         rawIDToken,
 		RefreshDeadline: idToken.Expiry.Truncate(time.Second),
 		Email:           claims.Email,
 		User:            idToken.Subject,
-		Groups:          groups,
 	}, nil
 }
 


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!
We generally follow Go coding and contributing conventions
https://golang.org/doc/contribute.html#commit_messages

Here's an example of a good PR/Commit:

    math: improve Sin, Cos and Tan precision for very large arguments

    The existing implementation has poor numerical properties for
    large arguments, so use the McGillicutty algorithm to improve
    accuracy above 1e10.

    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm

    Fixes #159
-->

Fixes #192 

@desimone I'm not seeing any place to insert some easy unit test fixes so maybe we should creat an issue for better testing around the identity providers in general.  

**Checklist**:
- [x] documentation updated
- [ ] unit tests added
- [x] related issues referenced
- [x] updated CHANGELOG.md
- [x] ready for review
