### PR TITLE
internal/sessions: error if session too large

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@
 
 - Fixed HEADERS environment variable parsing [GH-188]
 - Fixed Azure group lookups [GH-190]
+- If a session is too large (over 4096 bytes) Pomerium will no longer fail silently. [GH-211]
 
-## v0.0.5
+  ## v0.0.5
 
 ### NEW
 

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -278,7 +278,7 @@ func (a *Authenticate) getOAuthCallback(w http.ResponseWriter, r *http.Request) 
 
 	if err := a.sessionStore.SaveSession(w, r, session); err != nil {
 		log.Error().Err(err).Msg("authenticate: failed saving new session")
-		return "", httputil.Error{Code: http.StatusInternalServerError, Message: "Internal Error"}
+		return "", httputil.Error{Code: http.StatusInternalServerError, Message: err.Error()}
 	}
 
 	return redirect, nil


### PR DESCRIPTION
If a session is too large to set (browser dictated), pomerium will no longer fail silently but instead raise both a log and error message. 

**Context**
- #211 



**Checklist**:
- [ ] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] updated CHANGELOG.md
- [x] ready for review

/cc @travisgroth 
