### PR TITLE
Make dockerfiles consistent between archs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Proxy's sign out handler `{}/.pomerium/sign_out` now accepts an optional `redirect_uri` parameter which can be used to specify a custom redirect page, so long as it is under the same top-level domain. [GH-183]
 - Policy configuration can now be empty at startup. [GH-190]
 - Websocket support is now set per-route instead of globally. [GH-204]
+- golint removed from amd64 container
 
 ### FIXED
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,19 @@
 FROM golang:latest as build
 WORKDIR /go/src/github.com/pomerium/pomerium
-ENV CGO_ENABLED=0
-ENV GO111MODULE=on
 # docker build --build-arg ARCH=arm --build-arg ARM=7 .
 # frustratingly not supported by dockerhub automated builds though
 ARG ARCH=amd64
-ARG ARM=7
+ARG ARM=7  
+
+ENV CGO_ENABLED=0
+ENV GO111MODULE=on
 ENV GOARCH=${ARCH}
 ENV GOARM=${ARM}
-RUN go get golang.org/x/lint/golint
 # cache depedency downloads
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-# build 
+# build
 RUN make
 RUN touch /config.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ fmt: ## Verifies all files have been `gofmt`ed.
 .PHONY: lint
 lint: ## Verifies `golint` passes.
 	@echo "==> $@"
+	@go get golang.org/x/lint/golint
 	@golint ./... | grep -v '.pb.go:' | grep -v vendor | tee /dev/stderr
 
 .PHONY: staticcheck


### PR DESCRIPTION
Working release checklist in #214 

I don't think the lint command belongs in the docker file for release; we aren't using it in the container.

I think the error reported in #121 should be fixed as part of the Makefile, if anywhere.  I can add that to this PR if that sounds right.

**Checklist**:
- [x] related issues referenced
- [x] updated CHANGELOG.md
- [x] ready for review
