### PR TITLE
internal/identity: add github provider support [WIP]

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -75,12 +75,12 @@ func New(opts config.Options) (*Authenticate, error) {
 	if err != nil {
 		return nil, err
 	}
-	redirectURL := opts.AuthenticateURL
+	redirectURL := *opts.AuthenticateURL
 	redirectURL.Path = "/oauth2/callback"
 	provider, err := identity.New(
 		opts.Provider,
 		&identity.Provider{
-			RedirectURL:    redirectURL,
+			RedirectURL:    &redirectURL,
 			ProviderName:   opts.Provider,
 			ProviderURL:    opts.ProviderURL,
 			ClientID:       opts.ClientID,
@@ -97,7 +97,7 @@ func New(opts config.Options) (*Authenticate, error) {
 	}
 	return &Authenticate{
 		SharedKey:    opts.SharedKey,
-		RedirectURL:  redirectURL,
+		RedirectURL:  &redirectURL,
 		templates:    templates.New(),
 		csrfStore:    cookieStore,
 		sessionStore: cookieStore,

--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -80,7 +80,7 @@ func New(opts config.Options) (*Authenticate, error) {
 	provider, err := identity.New(
 		opts.Provider,
 		&identity.Provider{
-			RedirectURL:    &redirectURL,
+			RedirectURL:    redirectURL,
 			ProviderName:   opts.Provider,
 			ProviderURL:    opts.ProviderURL,
 			ClientID:       opts.ClientID,

--- a/go.sum
+++ b/go.sum
@@ -168,6 +168,7 @@ golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
+golang.org/x/lint v0.0.0-20190409202823-959b441ac422 h1:QzoH/1pFpZguR8NrRHLcO6jKqfv2zpuSqZLgdm7ZmjI=
 golang.org/x/lint v0.0.0-20190409202823-959b441ac422/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -225,6 +226,7 @@ golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBn
 golang.org/x/tools v0.0.0-20190425163242-31fd60d6bfdc/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b h1:mSUCVIwDx4hfXJfWsOPfdzEHxzb2Xjl6BQ8YgPnazQA=
 golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.6.0 h1:2tJEkRfnZL5g1GeBUlITh/rqT5HG3sFcoVCUUxmgJ2g=

--- a/internal/cryptutil/encrypt.go
+++ b/internal/cryptutil/encrypt.go
@@ -13,13 +13,14 @@ import (
 	"golang.org/x/crypto/chacha20poly1305"
 )
 
-const DefaultKeySize = 32
+// defaultKeySize is set to 256 bits / 32 bytes
+const defaultKeySize = 32
 
 // GenerateKey generates a random 32-byte key.
 //
 // Panics if source of randomness fails.
 func GenerateKey() []byte {
-	return randomBytes(DefaultKeySize)
+	return randomBytes(defaultKeySize)
 }
 
 // GenerateRandomString returns base64 encoded securely generated random string
@@ -32,7 +33,7 @@ func GenerateRandomString(c int) string {
 
 func randomBytes(c int) []byte {
 	if c < 0 {
-		c = DefaultKeySize
+		c = defaultKeySize
 	}
 	b := make([]byte, c)
 	if _, err := rand.Read(b); err != nil {

--- a/internal/identity/github.go
+++ b/internal/identity/github.go
@@ -1,0 +1,218 @@
+package identity // import "github.com/pomerium/pomerium/internal/identity"
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"golang.org/x/oauth2"
+
+	"github.com/pomerium/pomerium/internal/httputil"
+	"github.com/pomerium/pomerium/internal/sessions"
+	"github.com/pomerium/pomerium/internal/urlutil"
+	"github.com/pomerium/pomerium/internal/version"
+)
+
+const defaultGithubProviderURL = "https://github.com"
+const authAPI = "login/oauth/authorize"
+const tokenAPI = "login/oauth/access_token"
+const emailAPI = "user/emails"
+const orgsAPI = "user/orgs"
+const teamAPI = "user/teams"
+const userAPI = "user"
+
+var defaultGithubScopes = []string{"user:email", "read:org"}
+
+type GithubProvider struct {
+	*Provider
+
+	// baseURL would be different in the enterprise version
+	baseURL           *url.URL
+	authURL           *url.URL
+	tokenURL          *url.URL
+	userEmailEndpoint *url.URL
+	userOrgsEndpoint  *url.URL
+	userTeamsEndpoint *url.URL
+	userEndpoint      *url.URL
+}
+
+// Register a new oauth application: https://github.com/settings/applications/new
+// https://developer.github.com/apps/building-oauth-apps/authorizing-oauth-apps/
+// https://developer.github.com/v3/oauth_authorizations/#create-a-new-authorization
+func NewGithubProvider(p *Provider) (*GithubProvider, error) {
+	if p.ProviderURL == "" {
+		p.ProviderURL = defaultGithubProviderURL
+	}
+	if len(p.Scopes) == 0 {
+		p.Scopes = defaultGithubScopes
+	}
+	var err error
+	var gp GithubProvider
+	gp.baseURL, err = urlutil.ParseAndValidateURL(p.ProviderURL)
+	if err != nil {
+		return nil, fmt.Errorf("identity/github: couldn't parse provider url %v", err)
+	}
+	gp.authURL = &url.URL{Path: authAPI, Scheme: gp.baseURL.Scheme, Host: gp.baseURL.Host}
+	gp.tokenURL = &url.URL{Path: tokenAPI, Scheme: gp.baseURL.Scheme, Host: gp.baseURL.Host}
+	gp.userEmailEndpoint = &url.URL{Path: emailAPI, Scheme: gp.baseURL.Scheme, Host: "api." + gp.baseURL.Host}
+	gp.userOrgsEndpoint = &url.URL{Path: orgsAPI, Scheme: gp.baseURL.Scheme, Host: "api." + gp.baseURL.Host}
+	gp.userTeamsEndpoint = &url.URL{Path: teamAPI, Scheme: gp.baseURL.Scheme, Host: "api." + gp.baseURL.Host}
+	gp.userEndpoint = &url.URL{Path: userAPI, Scheme: gp.baseURL.Scheme, Host: "api." + gp.baseURL.Host}
+
+	p.oauth = &oauth2.Config{
+		ClientID:     p.ClientID,
+		ClientSecret: p.ClientSecret,
+		Endpoint: oauth2.Endpoint{
+			AuthURL:  gp.authURL.String(),
+			TokenURL: gp.tokenURL.String(),
+		},
+		RedirectURL: p.RedirectURL.String(),
+		Scopes:      p.Scopes,
+	}
+	gp.Provider = p
+	return &gp, nil
+}
+
+// Authenticate creates an identity session with google from a authorization code, and follows up
+// call to the admin/group api to check what groups the user is in.
+func (p *GithubProvider) Authenticate(ctx context.Context, code string) (*sessions.SessionState, error) {
+	resp, err := p.oauth.Exchange(ctx, code)
+	if err != nil {
+		return nil, fmt.Errorf("identity/google: token exchange failed %v", err)
+	}
+	var session sessions.SessionState
+	session.AccessToken = resp.AccessToken
+
+	// THIS IS ALL VERY VERY WEIRD; why doesn't github use OIDC?
+	// github doesn't have a refresh token!? AccessToken never expires
+	session.RefreshToken = resp.AccessToken
+	session.IDToken = resp.AccessToken
+	session.RefreshDeadline = resp.Expiry
+	if (session.RefreshDeadline == time.Time{}) {
+		session.RefreshDeadline = time.Now().Add(1 * time.Hour).Truncate(time.Second)
+	}
+	return p.fetchUserInfo(ctx, &session)
+}
+
+func (p *GithubProvider) Validate(ctx context.Context, idToken string) (bool, error) {
+	return true, nil
+}
+
+func (p *GithubProvider) fetchUserInfo(ctx context.Context, s *sessions.SessionState) (*sessions.SessionState, error) {
+	if s.AccessToken == "" {
+		return nil, fmt.Errorf("access token cannot be empty")
+	}
+	var err error
+	s.Email, err = p.userEmail(ctx, s.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get user's email %v", err)
+	}
+	s.User, err = p.userName(ctx, s.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get user's username %v", err)
+	}
+	orgs, err := p.userOrganizations(ctx, s.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get user's organization %v", err)
+	}
+	teams, err := p.userOrganizationTeams(ctx, s.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get user's teams %v", err)
+	}
+	s.Groups = append(orgs, teams...)
+	return s, nil
+}
+func (p *GithubProvider) Refresh(ctx context.Context, s *sessions.SessionState) (*sessions.SessionState, error) {
+
+	return p.fetchUserInfo(ctx, s)
+}
+
+// https://developer.github.com/v3/orgs/#list-your-organizations
+func (p *GithubProvider) userOrganizations(ctx context.Context, accessToken string) ([]string, error) {
+	var groups []string
+	var response []struct {
+		Description string `json:"description"`
+		ID          int    `json:"id"`
+		Login       string `json:"login"`
+		URL         string `json:"url"`
+	}
+	headers := map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", accessToken),
+		"Accept":        "application/vnd.github.v3+json",
+	}
+	err := httputil.Client(http.MethodGet, p.userOrgsEndpoint.String(), version.UserAgent(), headers, nil, &response)
+	if err != nil {
+		return groups, err
+	}
+	for _, org := range response {
+		groups = append(groups, org.Login)
+	}
+	return groups, nil
+}
+func (p *GithubProvider) userOrganizationTeams(ctx context.Context, accessToken string) ([]string, error) {
+	var groups []string
+	var response []struct {
+		CreatedAt    time.Time `json:"created_at"`
+		Description  string    `json:"description"`
+		ID           int       `json:"id"`
+		Name         string    `json:"name"`
+		Organization struct {
+			Login string `json:"login"`
+		} `json:"organization"`
+	}
+	headers := map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", accessToken),
+		"Accept":        "application/vnd.github.v3+json",
+	}
+	err := httputil.Client(http.MethodGet, p.userTeamsEndpoint.String(), version.UserAgent(), headers, nil, &response)
+	if err != nil {
+		return groups, err
+	}
+	for _, org := range response {
+		groups = append(groups, fmt.Sprintf("%s/%s", org.Organization.Login, org.Name))
+	}
+	return groups, nil
+}
+
+// userEmail gets all your email addresses, and specifies which one is visible to the public.
+// This endpoint is accessible with the user:email scope.
+func (p *GithubProvider) userEmail(ctx context.Context, accessToken string) (string, error) {
+	var response []struct {
+		Email      string `json:"email"`
+		Verified   bool   `json:"verified"`
+		Primary    bool   `json:"primary"`
+		Visibility string `json:"visibility"`
+	}
+	headers := map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", accessToken),
+		"Accept":        "application/vnd.github.v3+json",
+	}
+	err := httputil.Client(http.MethodGet, p.userEmailEndpoint.String(), version.UserAgent(), headers, nil, &response)
+	if err != nil {
+		return "", err
+	}
+	for _, email := range response {
+		if email.Verified && email.Primary {
+			return email.Email, nil
+		}
+	}
+	return "", fmt.Errorf("could not find a primary, verified email for user")
+}
+
+func (p *GithubProvider) userName(ctx context.Context, accessToken string) (string, error) {
+	var response struct {
+		ID    int    `json:"id"`
+		Login string `json:"login"`
+	}
+	headers := map[string]string{
+		"Authorization": fmt.Sprintf("Bearer %s", accessToken),
+		"Accept":        "application/vnd.github.v3+json",
+	}
+	err := httputil.Client(http.MethodGet, p.userEndpoint.String(), version.UserAgent(), headers, nil, &response)
+	if err != nil {
+		return "", err
+	}
+	return response.Login, nil
+}

--- a/internal/identity/providers.go
+++ b/internal/identity/providers.go
@@ -19,6 +19,8 @@ import (
 const (
 	// AzureProviderName identifies the Azure identity provider
 	AzureProviderName = "azure"
+	// GithubProviderName identifies the Github identity provider
+	GithubProviderName = "github"
 	// GitlabProviderName identifies the GitLab identity provider
 	GitlabProviderName = "gitlab"
 	// GoogleProviderName identifies the Google identity provider
@@ -58,6 +60,8 @@ func New(providerName string, p *Provider) (a Authenticator, err error) {
 	switch providerName {
 	case AzureProviderName:
 		a, err = NewAzureProvider(p)
+	case GithubProviderName:
+		a, err = NewGithubProvider(p)
 	case GitlabProviderName:
 		return nil, fmt.Errorf("identity: %s currently not supported", providerName)
 	case GoogleProviderName:

--- a/internal/identity/providers.go
+++ b/internal/identity/providers.go
@@ -87,7 +87,7 @@ func New(providerName string, p *Provider) (a Authenticator, err error) {
 type Provider struct {
 	ProviderName string
 
-	RedirectURL  *url.URL
+	RedirectURL  url.URL
 	ClientID     string
 	ClientSecret string
 	ProviderURL  string


### PR DESCRIPTION

<img width="606" alt="Screen Shot 2019-07-11 at 11 36 25 PM" src="https://user-images.githubusercontent.com/1544881/61107429-beed7b00-a434-11e9-876c-c078be5b7aaa.png">
PoC for a non-oidc provider.

<!--  
Thanks for sending a pull request!
We generally follow Go coding and contributing conventions
https://golang.org/doc/contribute.html#commit_messages

Here's an example of a good PR/Commit:

    math: improve Sin, Cos and Tan precision for very large arguments

    The existing implementation has poor numerical properties for
    large arguments, so use the McGillicutty algorithm to improve
    accuracy above 1e10.

    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm

    Fixes #159
-->

Closes #207 

**Checklist**:
- [ ] updated docs
- [ ] unit tests added
- [ ] related issues referenced
- [ ] updated CHANGELOG.md
- [ ] ready for review
