### PR TITLE
deployment: fix 'dirty' build tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,9 @@ BUILDTAGS :=
 # Add to compile time flags
 VERSION := $(shell cat VERSION)
 GITCOMMIT := $(shell git rev-parse --short HEAD)
-GITUNTRACKEDCHANGES := $(shell git status --porcelain --untracked-files=no)
 BUILDMETA:=
-ifneq ($(GITUNTRACKEDCHANGES),"")
+GITUNTRACKEDCHANGES := $(shell git status --porcelain --untracked-files=no)
+ifneq ($(GITUNTRACKEDCHANGES),)
 	BUILDMETA := dirty
 endif
 CTIMEVAR=-X $(PKG)/internal/version.GitCommit=$(GITCOMMIT) \
@@ -40,6 +40,7 @@ tag: ## Create a new git tag to prepare to build a release
 .PHONY: build
 build: ## Builds dynamic executables and/or packages.
 	@echo "==> $@"
+	@echo Untracked changes? dirty? $(BUILDMETA) files? $(GITUNTRACKEDCHANGES)
 	@CGO_ENABLED=0 GO111MODULE=on go build -tags "$(BUILDTAGS)" ${GO_LDFLAGS} -o $(BINDIR)/$(NAME) ./cmd/"$(NAME)"
 
 .PHONY: lint


### PR DESCRIPTION
Until we have a better mechanism for determining if a build has unexpected files.

See:
- https://github.com/pomerium/pomerium/pull/172#issue-285418664
- https://github.com/pomerium/pomerium/issues/171
- https://github.com/pomerium/pomerium/issues/192#issuecomment-511651501

**Checklist**:
- [x] ready for review
