### PR TITLE
internal/httputil: prefer X25519 over P256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 
 - Add support for large cookie sessions by chunking. [GH-211]
 
+- Prefer [curve](https://wiki.mozilla.org/Security/Server_Side_TLS) X25519 to P256 for TLS connections. [GH-233]
+
 ## v0.1.0
 
 ### NEW

--- a/internal/httputil/https.go
+++ b/internal/httputil/https.go
@@ -178,8 +178,8 @@ func newDefaultTLSConfig(cert *tls.Certificate) *tls.Config {
 		PreferServerCipherSuites: true,
 		// Use curves which have assembly implementations
 		CurvePreferences: []tls.CurveID{
-			tls.CurveP256,
 			tls.X25519,
+			tls.CurveP256,
 		},
 		Certificates: []tls.Certificate{*cert},
 		// HTTP/2 must be enabled manually when using http.Serve


### PR DESCRIPTION
Prefer [curve](https://wiki.mozilla.org/Security/Server_Side_TLS) X25519 to P256 for TLS connections. 

Closes #233 

**Checklist**:
- [x] updated CHANGELOG.md
- [x] ready for review
