### PR TITLE
cryptutil: fix potential race with signer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@
 - Pomerium and its services will gracefully shutdown on [interrupt signal](http://man7.org/linux/man-pages/man7/signal.7.html). [GH-230]
 - [Google](https://developers.google.com/identity/protocols/OpenIDConnect) now prompts the user to select a user account (by adding `select_account` to the sign in url). This allows a user who has multiple accounts at the authorization server to select amongst the multiple accounts that they may have current sessions for.
 
+### FIXED
+
+- Fixed potential race condition when signing requests. [GH-240]
+
 ## v0.1.0
 
 ### NEW

--- a/internal/cryptutil/encrypt.go
+++ b/internal/cryptutil/encrypt.go
@@ -77,7 +77,7 @@ func (c *XChaCha20Cipher) GenerateNonce() []byte {
 func (c *XChaCha20Cipher) Encrypt(plaintext []byte) (joined []byte, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = fmt.Errorf("internal/aead: error encrypting bytes: %v", r)
+			err = fmt.Errorf("cryptutil: error encrypting bytes: %v", r)
 		}
 	}()
 	nonce := c.GenerateNonce()
@@ -92,7 +92,7 @@ func (c *XChaCha20Cipher) Encrypt(plaintext []byte) (joined []byte, err error) {
 // Decrypt a value using XChaCha20-Poly1305
 func (c *XChaCha20Cipher) Decrypt(joined []byte) ([]byte, error) {
 	if len(joined) <= c.aead.NonceSize() {
-		return nil, fmt.Errorf("internal/aead: invalid input size: %d", len(joined))
+		return nil, fmt.Errorf("cryptutil: invalid input size: %d", len(joined))
 	}
 	// grab out the nonce
 	pivot := len(joined) - c.aead.NonceSize()
@@ -161,13 +161,13 @@ func compress(data []byte) ([]byte, error) {
 	var buf bytes.Buffer
 	writer, err := gzip.NewWriterLevel(&buf, gzip.DefaultCompression)
 	if err != nil {
-		return nil, fmt.Errorf("internal/aead: failed to create a gzip writer: %q", err)
+		return nil, fmt.Errorf("cryptutil: failed to create a gzip writer: %q", err)
 	}
 	if writer == nil {
-		return nil, fmt.Errorf("internal/aead: failed to create a gzip writer")
+		return nil, fmt.Errorf("cryptutil: failed to create a gzip writer")
 	}
 	if _, err = writer.Write(data); err != nil {
-		return nil, fmt.Errorf("internal/aead: failed to compress data with err: %q", err)
+		return nil, fmt.Errorf("cryptutil: failed to compress data with err: %q", err)
 	}
 	if err = writer.Close(); err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func compress(data []byte) ([]byte, error) {
 func decompress(data []byte) ([]byte, error) {
 	reader, err := gzip.NewReader(bytes.NewReader(data))
 	if err != nil {
-		return nil, fmt.Errorf("internal/aead: failed to create a gzip reader: %q", err)
+		return nil, fmt.Errorf("cryptutil: failed to create a gzip reader: %q", err)
 	}
 	defer reader.Close()
 	var buf bytes.Buffer

--- a/internal/cryptutil/marshal.go
+++ b/internal/cryptutil/marshal.go
@@ -14,7 +14,7 @@ import (
 func DecodePublicKey(encodedKey []byte) (*ecdsa.PublicKey, error) {
 	block, _ := pem.Decode(encodedKey)
 	if block == nil {
-		return nil, fmt.Errorf("marshal: decoded nil PEM block")
+		return nil, fmt.Errorf("cryptutil: decoded nil PEM block")
 	}
 	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
 	if err != nil {
@@ -23,7 +23,7 @@ func DecodePublicKey(encodedKey []byte) (*ecdsa.PublicKey, error) {
 
 	ecdsaPub, ok := pub.(*ecdsa.PublicKey)
 	if !ok {
-		return nil, errors.New("marshal: data was not an ECDSA public key")
+		return nil, errors.New("cryptutil: data was not an ECDSA public key")
 	}
 
 	return ecdsaPub, nil
@@ -53,7 +53,7 @@ func DecodePrivateKey(encodedKey []byte) (*ecdsa.PrivateKey, error) {
 		block, encodedKey = pem.Decode(encodedKey)
 
 		if block == nil {
-			return nil, fmt.Errorf("failed to find EC PRIVATE KEY in PEM data after skipping types %v", skippedTypes)
+			return nil, fmt.Errorf("cryptutil: failed to find EC PRIVATE KEY in PEM data after skipping types %v", skippedTypes)
 		}
 
 		if block.Type == "EC PRIVATE KEY" {

--- a/internal/cryptutil/mock_cipher_test.go
+++ b/internal/cryptutil/mock_cipher_test.go
@@ -1,0 +1,44 @@
+package cryptutil // import "github.com/pomerium/pomerium/internal/cryptutil"
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMockCipher_Unmarshal(t *testing.T) {
+	e := errors.New("err")
+	mc := MockCipher{
+		EncryptResponse: []byte("EncryptResponse"),
+		EncryptError:    e,
+		DecryptResponse: []byte("DecryptResponse"),
+		DecryptError:    e,
+		MarshalResponse: "MarshalResponse",
+		MarshalError:    e,
+		UnmarshalError:  e,
+	}
+	b, err := mc.Encrypt([]byte("test"))
+	if string(b) != "EncryptResponse" {
+		t.Error("unexpected encrypt response")
+	}
+	if err != e {
+		t.Error("unexpected encrypt error")
+	}
+	b, err = mc.Decrypt([]byte("test"))
+	if string(b) != "DecryptResponse" {
+		t.Error("unexpected Decrypt response")
+	}
+	if err != e {
+		t.Error("unexpected Decrypt error")
+	}
+	s, err := mc.Marshal("test")
+	if err != e {
+		t.Error("unexpected Marshal error")
+	}
+	if s != "MarshalResponse" {
+		t.Error("unexpected MarshalResponse error")
+	}
+	err = mc.Unmarshal("s", "s")
+	if err != e {
+		t.Error("unexpected Unmarshal error")
+	}
+}


### PR DESCRIPTION
- Fixed a potential race condition where a signer could concurrently mutate a request signer. 
- Add unit tests for mock cipher 🙄 
- Fix up package messages for cryptutil package. 

```
==================
WARNING: DATA RACE
Write at 0x00c000382480 by goroutine 48:
  github.com/pomerium/pomerium/internal/cryptutil.(*ES256Signer).SignJWT()
      /Users/bdd/pomerium/internal/cryptutil/sign.go:80 +0x52
  github.com/pomerium/pomerium/internal/middleware.SignRequest.func1.1()
      /Users/bdd/pomerium/internal/middleware/reverse_proxy.go:17 +0x30b
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/middleware.StripPomeriumCookie.func1.1()
      /Users/bdd/pomerium/internal/middleware/reverse_proxy.go:45 +0x6d9
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/proxy.(*Proxy).Proxy()
      /Users/bdd/pomerium/proxy/handlers.go:281 +0x168
  github.com/pomerium/pomerium/proxy.(*Proxy).Proxy-fm()
      /Users/bdd/pomerium/proxy/handlers.go:227 +0x5f
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/middleware.ValidateHost.func1.1()
      /Users/bdd/pomerium/internal/middleware/middleware.go:151 +0x2c2
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:2375 +0x28a
  net/http.(*ServeMux).ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:2375 +0x28a
  github.com/pomerium/pomerium/internal/middleware.Healthcheck.func1.1()
      /Users/bdd/pomerium/internal/middleware/middleware.go:172 +0x2ee
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/log.RequestIDHandler.func1.1()
      /Users/bdd/pomerium/internal/log/middleware.go:158 +0x194
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/log.RefererHandler.func1.1()
      /Users/bdd/pomerium/internal/log/middleware.go:114 +0xf9
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/log.UserAgentHandler.func1.1()
      /Users/bdd/pomerium/internal/log/middleware.go:98 +0xf9
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/log.RemoteAddrHandler.func1.1()
      /Users/bdd/pomerium/internal/log/middleware.go:82 +0xf8
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/log.ForwardedAddrHandler.func1.1()
      /Users/bdd/pomerium/internal/log/middleware.go:193 +0x135
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/middleware.SetHeaders.func1.1()
      /Users/bdd/pomerium/internal/middleware/middleware.go:29 +0x4af
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/log.AccessHandler.func1.1()
      /Users/bdd/pomerium/internal/log/middleware.go:169 +0x2b7
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/log.NewHandler.func1.1()
      /Users/bdd/pomerium/internal/log/middleware.go:24 +0x4c3
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  go.opencensus.io/plugin/ochttp.(*Handler).ServeHTTP()
      /Users/bdd/go/pkg/mod/go.opencensus.io@v0.22.0/plugin/ochttp/server.go:86 +0x368
  github.com/pomerium/pomerium/internal/telemetry/metrics.HTTPMetricsHandler.func1.1()
      /Users/bdd/pomerium/internal/telemetry/metrics/http.go:132 +0x4ec
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  github.com/pomerium/pomerium/internal/httputil.grpcHandlerFunc.func1()
      /Users/bdd/pomerium/internal/httputil/tls.go:142 +0x145
  net/http.HandlerFunc.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:1995 +0x51
  net/http.serverHandler.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:2774 +0xce
  net/http.initNPNRequest.ServeHTTP()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:3323 +0xfc
  net/http.(*initNPNRequest).ServeHTTP()
      <autogenerated>:1 +0x94
  net/http.Handler.ServeHTTP-fm()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/server.go:86 +0x64
  net/http.(*http2serverConn).runHandler()
      /usr/local/Cellar/go/1.12.7/libexec/src/net/http/h2_bundle.go:5658 +0x96

```


**Checklist**:
- [x] unit tests added
- [x] updated CHANGELOG.md
- [x] ready for review
