### PR TITLE
cmd/pomerium: fix close on nil proxy clients

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -61,8 +61,10 @@ func main() {
 	if err != nil {
 		log.Fatal().Err(err).Msg("cmd/pomerium: proxy")
 	}
-	defer proxy.AuthenticateClient.Close()
-	defer proxy.AuthorizeClient.Close()
+	if proxy != nil {
+		defer proxy.AuthenticateClient.Close()
+		defer proxy.AuthorizeClient.Close()
+	}
 
 	go viper.WatchConfig()
 


### PR DESCRIPTION
When running in authenticate or authorize mode, Pomerium would try to defer close a  nil- instance of proxy.  

Fixes #242 . Thank you @unsubtleguy

**Checklist**:
- [x] related issues referenced
- [x] ready for review
