### PR TITLE
Don't force consent screen for every Azure AD login

### DIFF
--- a/internal/identity/microsoft.go
+++ b/internal/identity/microsoft.go
@@ -140,7 +140,7 @@ func (p *AzureProvider) Revoke(token string) error {
 
 // GetSignInURL returns the sign in url with typical oauth parameters
 func (p *AzureProvider) GetSignInURL(state string) string {
-	return p.oauth.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
+	return p.oauth.AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.SetAuthURLParam("prompt", "select_account"))
 }
 
 // Refresh renews a user's session using an oid refresh token without reprompting the user.


### PR DESCRIPTION
This change fixes an issue that for every login with the Azure AD identity provider the permission consent screen is shown.
With this change you still get a prompt for which account to use (like it is for the Google identity provider).
**Checklist**:
- [x] ready for review
