### PR TITLE
config: remove references to named ports

### DIFF
--- a/cmd/pomerium/main_test.go
+++ b/cmd/pomerium/main_test.go
@@ -201,7 +201,7 @@ func Test_configToServerOptions(t *testing.T) {
 		opt  *config.Options
 		want *httputil.ServerOptions
 	}{
-		{"simple convert", &config.Options{Addr: ":http"}, &httputil.ServerOptions{Addr: ":http"}},
+		{"simple convert", &config.Options{Addr: ":80"}, &httputil.ServerOptions{Addr: ":80"}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -4,18 +4,21 @@
 
 ### New
 
-- Add ability to set client certificates for downstream connections. [GH-259]
 - GRPC Improvements. [#261](https://github.com/pomerium/pomerium/pull/261) and [#69](https://github.com/pomerium/pomerium/issues/69)
+
   - Enable WaitForReady to allow background retries through transient failures
   - Expose a configurable timeout for backend requests to Authorize and Authenticate
   - Enable DNS round_robin load balancing to Authorize and Authenticate services by default
 
+- Add ability to set client certificates for downstream connections. [GH-259](https://github.com/pomerium/pomerium/pull/259)
 
 ### Fixed
 
 ### Changed
 
-- A policy's custom certificate authority can set as a file or a base64 encoded blob(`tls_custom_ca`/`tls_custom_ca_file`). [GH-259]
+- A policy's custom certificate authority can set as a file or a base64 encoded blob(`tls_custom_ca`/`tls_custom_ca_file`). [GH-259](https://github.com/pomerium/pomerium/pull/259)
+
+- Remove references to [service named ports](https://golang.org/src/net/lookup.go) and instead use their numeric equivalent. [GH-266](https://github.com/pomerium/pomerium/pull/266)
 
 ## v0.2.0
 
@@ -172,5 +175,5 @@
 
 - `http.Server` and `httputil.NewSingleHostReverseProxy` now uses pomerium's logging package instead of the standard library's built in one. [GH-58]
 
-[synology tutorial]: ./quick-start/synology.md
 [certificates documentation]: ../reference/certificates.md
+[synology tutorial]: ./quick-start/synology.md

--- a/docs/docs/reference/reference.md
+++ b/docs/docs/reference/reference.md
@@ -41,11 +41,11 @@ Service mode sets the pomerium service(s) to run. If testing, you may want to se
 - Environmental Variable: `ADDRESS`
 - Config File Key: `address`
 - Type: `string`
-- Example: `:https`, `:443`, `:8443`
-- Default: `:https`
+- Example: `:443`, `:8443`
+- Default: `:443`
 - Required
 
-Address specifies the host and port to serve HTTPS and gRPC requests from. If empty, `:https`/`:443` is used.
+Address specifies the host and port to serve HTTPS and gRPC requests from. If empty, `:443` is used.
 
 ## Administrators
 
@@ -174,7 +174,7 @@ Enable grpc DNS based round robin load balancing.  This method uses DNS to resol
 - Environmental Variable: `HTTP_REDIRECT_ADDR`
 - Config File Key: `http_redirect_addr`
 - Type: `string`
-- Example: `:80`, `:http`, `:8080`
+- Example: `:80`, `:8080`
 - Optional
 
 If set, the HTTP Redirect Address specifies the host and port to redirect http to https traffic on. If unset, no redirect server is started.

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -43,7 +43,7 @@ type Options struct {
 	Services string `mapstructure:"services"`
 
 	// Addr specifies the host and port on which the server should serve
-	// HTTPS requests. If empty, ":https" (localhost:443) is used.
+	// HTTPS requests. If empty, ":443" (localhost:443) is used.
 	Addr string `mapstructure:"address"`
 
 	// Cert and Key specifies the TLS certificates to use.
@@ -55,8 +55,7 @@ type Options struct {
 	KeyFile  string `mapstructure:"certificate_key_file"`
 
 	// HttpRedirectAddr, if set, specifies the host and port to run the HTTP
-	// to HTTPS redirect server on. For example, ":http" would start a server
-	// on port 80.  If empty, no redirect server is started.
+	// to HTTPS redirect server on. If empty, no redirect server is started.
 	HTTPRedirectAddr string `mapstructure:"http_redirect_addr"`
 
 	// Timeout settings : https://github.com/pomerium/pomerium/issues/40
@@ -167,7 +166,7 @@ var defaultOptions = Options{
 		"X-XSS-Protection":          "1; mode=block",
 		"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
 	},
-	Addr:                    ":https",
+	Addr:                    ":443",
 	CertFile:                filepath.Join(fileutil.Getwd(), "cert.pem"),
 	KeyFile:                 filepath.Join(fileutil.Getwd(), "privkey.pem"),
 	ReadHeaderTimeout:       10 * time.Second,

--- a/internal/httputil/options.go
+++ b/internal/httputil/options.go
@@ -10,7 +10,7 @@ import (
 // ServerOptions contains the configurations settings for a http server.
 type ServerOptions struct {
 	// Addr specifies the host and port on which the server should serve
-	// HTTPS requests. If empty, ":https" is used.
+	// HTTPS requests. If empty, ":443" is used.
 	Addr string
 
 	// TLS certificates to use.
@@ -27,7 +27,7 @@ type ServerOptions struct {
 }
 
 var defaultTLSServerOptions = &ServerOptions{
-	Addr:              ":https",
+	Addr:              ":443",
 	CertFile:          filepath.Join(fileutil.Getwd(), "cert.pem"),
 	KeyFile:           filepath.Join(fileutil.Getwd(), "privkey.pem"),
 	ReadHeaderTimeout: 10 * time.Second,
@@ -61,7 +61,7 @@ func (o *ServerOptions) applyTLSDefaults() {
 }
 
 var defaultHTTPServerOptions = &ServerOptions{
-	Addr:              ":http",
+	Addr:              ":80",
 	ReadHeaderTimeout: 10 * time.Second,
 	ReadTimeout:       5 * time.Second,
 	WriteTimeout:      5 * time.Second,


### PR DESCRIPTION
Go 1.12.8 changed the way url parse handles service named ports. To be on the safe side, these changes make ports explicit. 

See: 
- https://github.com/golang/go/commit/3226f2d492963d361af9dfc6714ef141ba606713#diff-6f43cc724ae52e4acba8855ce391e144
- https://golang.org/src/net/lookup.go

**Checklist**:
- [x] updated docs
- [x] related issues referenced
- [x] updated CHANGELOG.md
- [x] ready for review
