### PR TITLE
Fix architecture on ARM images

### DIFF
--- a/Dockerfile.arm32v6
+++ b/Dockerfile.arm32v6
@@ -12,8 +12,10 @@ COPY . .
 RUN make build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/static
+FROM arm32v6/alpine
 WORKDIR /pomerium
+COPY --from=multiarch/qemu-user-static /usr/bin/qemu-arm-static /usr/bin/
+RUN apk --no-cache add ca-certificates
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 ENTRYPOINT [ "/bin/pomerium" ]

--- a/Dockerfile.arm32v7
+++ b/Dockerfile.arm32v7
@@ -12,8 +12,10 @@ COPY . .
 RUN make build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/static
+FROM arm32v7/alpine
 WORKDIR /pomerium
+COPY --from=multiarch/qemu-user-static /usr/bin/qemu-arm-static /usr/bin/
+RUN apk --no-cache add ca-certificates
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 ENTRYPOINT [ "/bin/pomerium" ]

--- a/Dockerfile.arm64v8
+++ b/Dockerfile.arm64v8
@@ -11,8 +11,10 @@ COPY . .
 RUN make build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/static
+FROM arm64v8/alpine
 WORKDIR /pomerium
+COPY --from=multiarch/qemu-user-static /usr/bin/qemu-aarch64-static /usr/bin/
+RUN apk --no-cache add ca-certificates
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 ENTRYPOINT [ "/bin/pomerium" ]

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+apt-get update
+apt-get install -y curl binfmt-support

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --rm --privileged multiarch/qemu-user-static --reset


### PR DESCRIPTION
Discovered as part of #268.  Doesn't fully resolve it, but is required to resolve it.

This PR changes our ARM Dockerfile builds to use alpine's ARM* base images (so that our architecture is correct) and uses qemu to do the final steps of the build, so that it can be built on any suitable AMD64 platform (such as Docker Hub's automated build system).

**Checklist**:
- [x] related issues referenced
- [x] ready for review
