### PR TITLE
Fix pomerium cookie stripping

### DIFF
--- a/internal/middleware/reverse_proxy.go
+++ b/internal/middleware/reverse_proxy.go
@@ -32,12 +32,12 @@ func SignRequest(signer cryptutil.JWTSigner, id, email, groups, header string) f
 func StripPomeriumCookie(cookieName string) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			ctx, span := trace.StartSpan(r.Context(), "middleware.SignRequest")
+			ctx, span := trace.StartSpan(r.Context(), "middleware.StripPomeriumCookie")
 			defer span.End()
 
-			headers := make([]string, len(r.Cookies()))
+			headers := make([]string, 0, len(r.Cookies()))
 			for _, cookie := range r.Cookies() {
-				if cookie.Name != cookieName {
+				if !strings.HasPrefix(cookie.Name, cookieName) {
 					headers = append(headers, cookie.String())
 				}
 			}

--- a/internal/middleware/reverse_proxy_test.go
+++ b/internal/middleware/reverse_proxy_test.go
@@ -84,6 +84,11 @@ func TestStripPomeriumCookie(t *testing.T) {
 				Name:  tt.pomeriumCookie,
 				Value: "pomerium cookie!",
 			})
+
+			http.SetCookie(rr, &http.Cookie{
+				Name:  tt.pomeriumCookie + "_csrf",
+				Value: "pomerium csrf cookie!",
+			})
 			req := &http.Request{Header: http.Header{"Cookie": rr.Header()["Set-Cookie"]}}
 
 			handler := StripPomeriumCookie(tt.pomeriumCookie)(testHandler)


### PR DESCRIPTION
<!--  
Thanks for sending a pull request!
We generally follow Go coding and contributing conventions
https://golang.org/doc/contribute.html#commit_messages

Here's an example of a good PR/Commit:

    math: improve Sin, Cos and Tan precision for very large arguments

    The existing implementation has poor numerical properties for
    large arguments, so use the McGillicutty algorithm to improve
    accuracy above 1e10.

    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm

    Fixes #159
-->
This PR improves StripPomeriumCookie in two ways:
1. Strip cookies with `_pomerium` prefix (like `_pomerium_csrf`)
2. Do not generate cookie header with empty parts (like `Cookie: ;;;`)

Fixes #285 
**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [ ] updated CHANGELOG.md
- [x] ready for review
