### PR TITLE
Move docker image builds to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+env:
+  global:
+    secure: "IaW3NqPxMYTmIidY40pMC6rsrw9iWWZpIAbVST/NaFArI820zklyp7QdsBKITtYmvmne9XhHxYeOxqJFw5mSTZ9qT1oBpiYnwJL/m1ES+Xknx1MC1N6HV/LwSrsrRlSVbX/9Z/VDxawDq0WTH/omTBUooadcEMG8FSIIt1aDqIe7JnKGUL/EBAM1lkHYgpjT2ysVmB/PJpGGAcYUVrCRP67RR5WFFGsPBTZQHNpY1AUqrhjXneBpSyuHrz4uuj6Z4tl1EefFbBNftvgmkPiWbwhzahz5VLUboBwOEqEqb/K/VmJ7/hK16EFOwS71jGt7v18nocdQbtDFAlEhfeZjUggjJqH9oCoj0zYqhVoJ88xuptuWoBbrHew+R3DKIaCQ2jfg29hT6CEUTU0TqmAK9GLjqYfSGwNQ1h+3NmSUzbQNiNpCa53zVxy442EkVzoODnw6+8K9FkjTVCVykmi3D04btGMaZh58AelsQF8WXdKcSe8bEehVRAjwOeIO9PMsk4+0earQZKKrdXwxExByQudjTWIlvwL1THDlx8NGL3BcjzPubQAK4kcZFPVp3B5DxtBOEXicJC/EM3SYN09oX4qWqXYeJpPYJu+/opbMJJiNj2QC0G4ex0l37xLSnBndV1gwVQpBK6CGOVWK/qzPrfSNb+XaDbh3iS6usycUQFE="
+
 language: go
 go:
   - 1.x
@@ -42,3 +46,68 @@ deploy:
     - dist/pomerium-windows-amd64.md5
     - dist/pomerium-windows-amd64.sha256
   skip_cleanup: true
+
+docker_setup: &docker_setup
+  - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+  - sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
+  - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+  - echo ${DOCKER_PASSWORD} | docker login -u pomeriumci --password-stdin
+
+jobs:
+  include:
+    - name: "Test Build amd64"
+      stage: "Docker Build"
+      if: branch = bug/fix-build-arch-2
+      before_script: *docker_setup
+      script:
+        - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:${TRAVIS_COMMIT} Dockerfile.arm64v8
+
+    - name: "Build Master amd64"
+      if: branch = master
+      before_script: *docker_setup
+      script:
+        - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:master Dockerfile
+        - docker push ${TRAVIS_REPO_SLUG}
+
+    - name: "Build Master arm64v8"
+      if: branch = master
+      before_script: *docker_setup
+      script:
+        - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:arm64v8-master Dockerfile.arm64v8
+        - docker push ${TRAVIS_REPO_SLUG}
+
+    - name: "Build Tag amd64"
+      if: tag =~ /^v([0-9.]+)$/
+      before_script: *docker_setup
+      script:
+        - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:${TRAVIS_TAG} Dockerfile
+        - docker tag ${TRAVIS_REPO_SLUG}:${TRAVIS_TAG} ${TRAVIS_REPO_SLUG}:latest
+        - docker tag ${TRAVIS_REPO_SLUG}:${TRAVIS_TAG} ${TRAVIS_REPO_SLUG}:amd64-latest
+        - docker tag ${TRAVIS_REPO_SLUG}:${TRAVIS_TAG} ${TRAVIS_REPO_SLUG}:amd64-${TRAVIS_TAG}
+        - docker push ${TRAVIS_REPO_SLUG}
+
+    - name: "Build Tag arm64v8"
+      if: tag =~ /^v([0-9.]+)$/
+      before_script: *docker_setup
+      script:
+        - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:arm64v8-${TRAVIS_TAG} Dockerfile.arm64v8
+        - docker tag ${TRAVIS_REPO_SLUG}:arm64v8-${TRAVIS_TAG} ${TRAVIS_REPO_SLUG}:arm64v8-latest
+        - docker push ${TRAVIS_REPO_SLUG}
+
+    - name: "Build Tag arm32v7"
+      if: tag =~ /^v([0-9.]+)$/
+      before_script: *docker_setup
+      script:
+        - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:arm32v7-${TRAVIS_TAG} Dockerfile.arm32v7
+        - docker tag ${TRAVIS_REPO_SLUG}:arm32v7-${TRAVIS_TAG} ${TRAVIS_REPO_SLUG}:arm32v7-latest
+        - docker push ${TRAVIS_REPO_SLUG}
+
+    - name: "Build Tag arm32v6"
+      if: tag =~ /^v([0-9.]+)$/
+      before_script: *docker_setup
+      script:
+        - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:arm32v6-${TRAVIS_TAG} Dockerfile.arm32v6
+        - docker tag ${TRAVIS_REPO_SLUG}:arm32v6-${TRAVIS_TAG} ${TRAVIS_REPO_SLUG}:arm32v6-latest
+        - docker push ${TRAVIS_REPO_SLUG}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,12 @@ env:
   global:
     secure: "IaW3NqPxMYTmIidY40pMC6rsrw9iWWZpIAbVST/NaFArI820zklyp7QdsBKITtYmvmne9XhHxYeOxqJFw5mSTZ9qT1oBpiYnwJL/m1ES+Xknx1MC1N6HV/LwSrsrRlSVbX/9Z/VDxawDq0WTH/omTBUooadcEMG8FSIIt1aDqIe7JnKGUL/EBAM1lkHYgpjT2ysVmB/PJpGGAcYUVrCRP67RR5WFFGsPBTZQHNpY1AUqrhjXneBpSyuHrz4uuj6Z4tl1EefFbBNftvgmkPiWbwhzahz5VLUboBwOEqEqb/K/VmJ7/hK16EFOwS71jGt7v18nocdQbtDFAlEhfeZjUggjJqH9oCoj0zYqhVoJ88xuptuWoBbrHew+R3DKIaCQ2jfg29hT6CEUTU0TqmAK9GLjqYfSGwNQ1h+3NmSUzbQNiNpCa53zVxy442EkVzoODnw6+8K9FkjTVCVykmi3D04btGMaZh58AelsQF8WXdKcSe8bEehVRAjwOeIO9PMsk4+0earQZKKrdXwxExByQudjTWIlvwL1THDlx8NGL3BcjzPubQAK4kcZFPVp3B5DxtBOEXicJC/EM3SYN09oX4qWqXYeJpPYJu+/opbMJJiNj2QC0G4ex0l37xLSnBndV1gwVQpBK6CGOVWK/qzPrfSNb+XaDbh3iS6usycUQFE="
 
+stages:
+  - test
+  - "Docker Test Build"
+  - name: "Docker Build and Publish"
+    if: fork = false AND pull_request = false
+
 language: go
 go:
   - 1.x
@@ -53,34 +59,39 @@ docker_setup: &docker_setup
   - sudo apt-get update
   - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-ce
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+docker_login: &docker_login
   - echo ${DOCKER_PASSWORD} | docker login -u pomeriumci --password-stdin
 
 jobs:
   include:
     - name: "Test Build amd64"
-      stage: "Docker Build"
-      if: branch = bug/fix-build-arch-2
-      before_script: *docker_setup
+      stage: "Docker Test Build"
+      install: *docker_setup
       script:
-        - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:${TRAVIS_COMMIT} Dockerfile.arm64v8
+        - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:${TRAVIS_COMMIT} Dockerfile
 
     - name: "Build Master amd64"
+      stage: "Docker Build and Publish"
       if: branch = master
-      before_script: *docker_setup
+      install: *docker_setup
+      before_script: *docker_login
       script:
         - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:master Dockerfile
         - docker push ${TRAVIS_REPO_SLUG}
 
     - name: "Build Master arm64v8"
       if: branch = master
-      before_script: *docker_setup
+      install: *docker_setup
+      before_script: *docker_login
       script:
         - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:arm64v8-master Dockerfile.arm64v8
         - docker push ${TRAVIS_REPO_SLUG}
 
     - name: "Build Tag amd64"
       if: tag =~ /^v([0-9.]+)$/
-      before_script: *docker_setup
+      install: *docker_setup
+      before_script: *docker_login
       script:
         - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:${TRAVIS_TAG} Dockerfile
         - docker tag ${TRAVIS_REPO_SLUG}:${TRAVIS_TAG} ${TRAVIS_REPO_SLUG}:latest
@@ -90,7 +101,8 @@ jobs:
 
     - name: "Build Tag arm64v8"
       if: tag =~ /^v([0-9.]+)$/
-      before_script: *docker_setup
+      install: *docker_setup
+      before_script: *docker_login
       script:
         - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:arm64v8-${TRAVIS_TAG} Dockerfile.arm64v8
         - docker tag ${TRAVIS_REPO_SLUG}:arm64v8-${TRAVIS_TAG} ${TRAVIS_REPO_SLUG}:arm64v8-latest
@@ -98,7 +110,8 @@ jobs:
 
     - name: "Build Tag arm32v7"
       if: tag =~ /^v([0-9.]+)$/
-      before_script: *docker_setup
+      install: *docker_setup
+      before_script: *docker_login
       script:
         - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:arm32v7-${TRAVIS_TAG} Dockerfile.arm32v7
         - docker tag ${TRAVIS_REPO_SLUG}:arm32v7-${TRAVIS_TAG} ${TRAVIS_REPO_SLUG}:arm32v7-latest
@@ -106,7 +119,8 @@ jobs:
 
     - name: "Build Tag arm32v6"
       if: tag =~ /^v([0-9.]+)$/
-      before_script: *docker_setup
+      install: *docker_setup
+      before_script: *docker_login
       script:
         - .travis/docker_build.sh ${TRAVIS_REPO_SLUG}:arm32v6-${TRAVIS_TAG} Dockerfile.arm32v6
         - docker tag ${TRAVIS_REPO_SLUG}:arm32v6-${TRAVIS_TAG} ${TRAVIS_REPO_SLUG}:arm32v6-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,3 @@
-env:
-  global:
-    secure: "IaW3NqPxMYTmIidY40pMC6rsrw9iWWZpIAbVST/NaFArI820zklyp7QdsBKITtYmvmne9XhHxYeOxqJFw5mSTZ9qT1oBpiYnwJL/m1ES+Xknx1MC1N6HV/LwSrsrRlSVbX/9Z/VDxawDq0WTH/omTBUooadcEMG8FSIIt1aDqIe7JnKGUL/EBAM1lkHYgpjT2ysVmB/PJpGGAcYUVrCRP67RR5WFFGsPBTZQHNpY1AUqrhjXneBpSyuHrz4uuj6Z4tl1EefFbBNftvgmkPiWbwhzahz5VLUboBwOEqEqb/K/VmJ7/hK16EFOwS71jGt7v18nocdQbtDFAlEhfeZjUggjJqH9oCoj0zYqhVoJ88xuptuWoBbrHew+R3DKIaCQ2jfg29hT6CEUTU0TqmAK9GLjqYfSGwNQ1h+3NmSUzbQNiNpCa53zVxy442EkVzoODnw6+8K9FkjTVCVykmi3D04btGMaZh58AelsQF8WXdKcSe8bEehVRAjwOeIO9PMsk4+0earQZKKrdXwxExByQudjTWIlvwL1THDlx8NGL3BcjzPubQAK4kcZFPVp3B5DxtBOEXicJC/EM3SYN09oX4qWqXYeJpPYJu+/opbMJJiNj2QC0G4ex0l37xLSnBndV1gwVQpBK6CGOVWK/qzPrfSNb+XaDbh3iS6usycUQFE="
-
 stages:
   - test
   - "Docker Test Build"
@@ -61,7 +57,7 @@ docker_setup: &docker_setup
   - docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
 docker_login: &docker_login
-  - echo ${DOCKER_PASSWORD} | docker login -u pomeriumci --password-stdin
+  - echo ${DOCKER_PASSWORD} | docker login -u ${DOCKER_USERNAME} --password-stdin
 
 jobs:
   include:

--- a/.travis/docker_build.sh
+++ b/.travis/docker_build.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+FULL_IMAGE_NAME=${1:-pomerium/pomerium}
+DOCKERFILE=${2:-Dockerfile}
+
+docker build -t "${FULL_IMAGE_NAME}" -f "${DOCKERFILE}" .

--- a/hooks/post_checkout
+++ b/hooks/post_checkout
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-apt-get update
-apt-get install -y curl binfmt-support

--- a/hooks/pre_build
+++ b/hooks/pre_build
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker run --rm --privileged multiarch/qemu-user-static --reset


### PR DESCRIPTION
Related: #284 

It seems like Docker Hub automated builds really don't handle ARM builds correctly.  This PR moves image testing as well as publishing into Travis.  This should set the stage for moving to multi-arch as well.

**Checklist**:
- [x] related issues referenced
- [x] ready for review
