### PR TITLE
proxy: support external access control request handling (forward auth)

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -4,29 +4,31 @@
 
 ### New
 
-- Add ability to override HTTPS backend's TLS Server Name. [GH-297](https://github.com/pomerium/pomerium/pull/297)
-- Add ability to set pomerium's encrypted session in a auth bearer token, or query param.
-- Add host to the main request logger middleware. [GH-308](https://github.com/pomerium/pomerium/issues/308)
+- Add endpoint to support "forward-auth" integration with third-party ingresses and proxies. Supports [nginx]https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/, [nginx-ingress](https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/), and [Traefik](https://docs.traefik.io/middlewares/forwardauth/). [GH-324]
+- Add insecure transport support. [GH-328]
+- Add setting to override HTTPS backend's TLS Server Name. [GH-297]
+- Add setting to set pomerium's encrypted session in a auth bearer token, or query param.
+- Add host to the main request logger middleware. [GH-308]
 
 ### Security
 
-- The user's original intended location before completing the authentication process is now encrypted and kept confidential from the identity provider. [GH-316](https://github.com/pomerium/pomerium/pull/316)
+- The user's original intended location before completing the authentication process is now encrypted and kept confidential from the identity provider. [GH-316]
 - Under certain circumstances, where debug logging was enabled, pomerium's shared secret could be leaked to http access logs as a query param.
 
 ### Fixed
 
-- Fixed an issue where CSRF would fail if multiple tabs were open. [GH-306](https://github.com/pomerium/pomerium/issues/306)
-- Fixed an issue where pomerium would clean double slashes from paths.[GH-262](https://github.com/pomerium/pomerium/issues/262)
-- Fixed a bug where the impersonate form would persist an empty string for groups value if none set.[GH-303](https://github.com/pomerium/pomerium/issues/303)
+- Fixed an issue where CSRF would fail if multiple tabs were open. [GH-306]
+- Fixed an issue where pomerium would clean double slashes from paths. [GH-262]
+- Fixed a bug where the impersonate form would persist an empty string for groups value if none set. [GH-303]
 
 ### Changed
 
-- The healthcheck endpoints (`/ping`) now returns the http status `405` StatusMethodNotAllowed for non-`GET` requests. [GH-319](https://github.com/pomerium/pomerium/issues/319)
+- The healthcheck endpoints (`/ping`) now returns the http status `405` StatusMethodNotAllowed for non-`GET` requests.
 - Authenticate service no longer uses gRPC.
 - The global request logger now captures the full array of proxies from `X-Forwarded-For`, in addition to just the client IP.
-- Options code refactored to eliminate global Viper state. [GH-332](https://github.com/pomerium/pomerium/pull/332/files)
-- Pomerium will no longer default to looking for certificates in the root directory. [GH-328](https://github.com/pomerium/pomerium/issues/328)
-- Pomerium will validate that either `insecure_server`, or a valid certificate bundle is set. [GH-328](https://github.com/pomerium/pomerium/issues/328)
+- Options code refactored to eliminate global Viper state. [GH-332]
+- Pomerium will no longer default to looking for certificates in the root directory. [GH-328]
+- Pomerium will validate that either `insecure_server`, or a valid certificate bundle is set. [GH-328]
 
 ### Removed
 
@@ -52,7 +54,7 @@
 
 ### Changed
 
-- Pomerium will now strip `_csrf` cookies in addition to session cookies. [GG-285]
+- Pomerium will now strip `_csrf` cookies in addition to session cookies. [GH-285]
 - Disabled gRPC service config. [GH-280]
 - A policy's custom certificate authority can set as a file or a base64 encoded blob(`tls_custom_ca`/`tls_custom_ca_file`). [GH-259]
 
@@ -272,8 +274,17 @@
 [gh-259]: https://github.com/pomerium/pomerium/pull/259
 [gh-259]: https://github.com/pomerium/pomerium/pull/259
 [gh-261]: https://github.com/pomerium/pomerium/pull/261
+[gh-262]: https://github.com/pomerium/pomerium/issues/262
 [gh-266]: https://github.com/pomerium/pomerium/pull/266
 [gh-272]: https://github.com/pomerium/pomerium/pull/272
 [gh-280]: https://github.com/pomerium/pomerium/issues/280
 [gh-284]: https://github.com/pomerium/pomerium/pull/284
 [gh-285]: https://github.com/pomerium/pomerium/issues/285
+[gh-297]: https://github.com/pomerium/pomerium/pull/297
+[gh-303]: https://github.com/pomerium/pomerium/issues/303
+[gh-306]: https://github.com/pomerium/pomerium/issues/306
+[gh-308]: https://github.com/pomerium/pomerium/issues/308
+[gh-316]: https://github.com/pomerium/pomerium/pull/316
+[gh-319]: https://github.com/pomerium/pomerium/issues/319
+[gh-328]: https://github.com/pomerium/pomerium/issues/328
+[gh-332]: https://github.com/pomerium/pomerium/pull/332/

--- a/docs/docs/reference/img/auth-flow-diagram.svg
+++ b/docs/docs/reference/img/auth-flow-diagram.svg
@@ -1,0 +1,399 @@
+<svg id="mermaid-1570159603826" width="100%" xmlns="http://www.w3.org/2000/svg" height="100%" style="max-width:1450px;" viewBox="-50 -10 1450 981"><style>
+
+
+#mermaid-1570159603826 .label {
+  font-family: 'trebuchet ms', verdana, arial;
+  color: #333; }
+
+#mermaid-1570159603826 .label text {
+  fill: #333; }
+
+#mermaid-1570159603826 .node rect,
+#mermaid-1570159603826 .node circle,
+#mermaid-1570159603826 .node ellipse,
+#mermaid-1570159603826 .node polygon {
+  fill: #A176FF;
+  stroke: #999;
+  stroke-width: 1px; }
+
+#mermaid-1570159603826 .node.clickable {
+  cursor: pointer; }
+
+#mermaid-1570159603826 .arrowheadPath {
+  fill: #333333; }
+
+#mermaid-1570159603826 .edgePath .path {
+  stroke: #666;
+  stroke-width: 1.5px; }
+
+#mermaid-1570159603826 .edgeLabel {
+  background-color: white; }
+
+#mermaid-1570159603826 .cluster rect {
+  fill: #eaf2fb;
+  stroke: #26a;
+  stroke-width: 1px; }
+
+#mermaid-1570159603826 .cluster text {
+  fill: #333; }
+
+#mermaid-1570159603826 div.mermaidTooltip {
+  position: absolute;
+  text-align: center;
+  max-width: 200px;
+  padding: 2px;
+  font-family: 'trebuchet ms', verdana, arial;
+  font-size: 12px;
+  background: #eaf2fb;
+  border: 1px solid #26a;
+  border-radius: 2px;
+  pointer-events: none;
+  z-index: 100; }
+
+#mermaid-1570159603826 .actor {
+  stroke: #999;
+  fill: #A176FF; }
+
+#mermaid-1570159603826 text.actor {
+  fill: #333;
+  stroke: none; }
+
+#mermaid-1570159603826 .actor-line {
+  stroke: #666; }
+
+#mermaid-1570159603826 .messageLine0 {
+  stroke-width: 1.5;
+  stroke-dasharray: '2 2';
+  stroke: #333; }
+
+#mermaid-1570159603826 .messageLine1 {
+  stroke-width: 1.5;
+  stroke-dasharray: '2 2';
+  stroke: #333; }
+
+#mermaid-1570159603826 #arrowhead {
+  fill: #333; }
+
+#mermaid-1570159603826 .sequenceNumber {
+  fill: white; }
+
+#mermaid-1570159603826 #sequencenumber {
+  fill: #333; }
+
+#mermaid-1570159603826 #crosshead path {
+  fill: #333 !important;
+  stroke: #333 !important; }
+
+#mermaid-1570159603826 .messageText {
+  fill: #333;
+  stroke: none; }
+
+#mermaid-1570159603826 .labelBox {
+  stroke: #999;
+  fill: #A176FF; }
+
+#mermaid-1570159603826 .labelText {
+  fill: #333;
+  stroke: none; }
+
+#mermaid-1570159603826 .loopText {
+  fill: #333;
+  stroke: none; }
+
+#mermaid-1570159603826 .loopLine {
+  stroke-width: 2;
+  stroke-dasharray: '2 2';
+  stroke: #999; }
+
+#mermaid-1570159603826 .note {
+  stroke: #777700;
+  fill: #ffa; }
+
+#mermaid-1570159603826 .noteText {
+  fill: black;
+  stroke: none;
+  font-family: 'trebuchet ms', verdana, arial;
+  font-size: 14px; }
+
+#mermaid-1570159603826 .activation0 {
+  fill: #f4f4f4;
+  stroke: #666; }
+
+#mermaid-1570159603826 .activation1 {
+  fill: #f4f4f4;
+  stroke: #666; }
+
+#mermaid-1570159603826 .activation2 {
+  fill: #f4f4f4;
+  stroke: #666; }
+
+
+#mermaid-1570159603826 .section {
+  stroke: none;
+  opacity: 0.2; }
+
+#mermaid-1570159603826 .section0 {
+  fill: #80b3e6; }
+
+#mermaid-1570159603826 .section2 {
+  fill: #80b3e6; }
+
+#mermaid-1570159603826 .section1,
+#mermaid-1570159603826 .section3 {
+  fill: white;
+  opacity: 0.2; }
+
+#mermaid-1570159603826 .sectionTitle0 {
+  fill: #333; }
+
+#mermaid-1570159603826 .sectionTitle1 {
+  fill: #333; }
+
+#mermaid-1570159603826 .sectionTitle2 {
+  fill: #333; }
+
+#mermaid-1570159603826 .sectionTitle3 {
+  fill: #333; }
+
+#mermaid-1570159603826 .sectionTitle {
+  text-anchor: start;
+  font-size: 11px;
+  text-height: 14px; }
+
+
+#mermaid-1570159603826 .grid .tick {
+  stroke: #e6e6e6;
+  opacity: 0.3;
+  shape-rendering: crispEdges; }
+
+#mermaid-1570159603826 .grid path {
+  stroke-width: 0; }
+
+
+#mermaid-1570159603826 .today {
+  fill: none;
+  stroke: #d42;
+  stroke-width: 2px; }
+
+
+
+#mermaid-1570159603826 .task {
+  stroke-width: 2; }
+
+#mermaid-1570159603826 .taskText {
+  text-anchor: middle;
+  font-size: 11px; }
+
+#mermaid-1570159603826 .taskTextOutsideRight {
+  fill: #333;
+  text-anchor: start;
+  font-size: 11px; }
+
+#mermaid-1570159603826 .taskTextOutsideLeft {
+  fill: #333;
+  text-anchor: end;
+  font-size: 11px; }
+
+
+#mermaid-1570159603826 .task.clickable {
+  cursor: pointer; }
+
+#mermaid-1570159603826 .taskText.clickable {
+  cursor: pointer;
+  fill: #003163 !important;
+  font-weight: bold; }
+
+#mermaid-1570159603826 .taskTextOutsideLeft.clickable {
+  cursor: pointer;
+  fill: #003163 !important;
+  font-weight: bold; }
+
+#mermaid-1570159603826 .taskTextOutsideRight.clickable {
+  cursor: pointer;
+  fill: #003163 !important;
+  font-weight: bold; }
+
+
+#mermaid-1570159603826 .taskText0,
+#mermaid-1570159603826 .taskText1,
+#mermaid-1570159603826 .taskText2,
+#mermaid-1570159603826 .taskText3 {
+  fill: white; }
+
+#mermaid-1570159603826 .task0,
+#mermaid-1570159603826 .task1,
+#mermaid-1570159603826 .task2,
+#mermaid-1570159603826 .task3 {
+  fill: #26a;
+  stroke: #1a4d80; }
+
+#mermaid-1570159603826 .taskTextOutside0,
+#mermaid-1570159603826 .taskTextOutside2 {
+  fill: #333; }
+
+#mermaid-1570159603826 .taskTextOutside1,
+#mermaid-1570159603826 .taskTextOutside3 {
+  fill: #333; }
+
+
+#mermaid-1570159603826 .active0,
+#mermaid-1570159603826 .active1,
+#mermaid-1570159603826 .active2,
+#mermaid-1570159603826 .active3 {
+  fill: #A176FF;
+  stroke: #1a4d80; }
+
+#mermaid-1570159603826 .activeText0,
+#mermaid-1570159603826 .activeText1,
+#mermaid-1570159603826 .activeText2,
+#mermaid-1570159603826 .activeText3 {
+  fill: #333 !important; }
+
+
+#mermaid-1570159603826 .done0,
+#mermaid-1570159603826 .done1,
+#mermaid-1570159603826 .done2,
+#mermaid-1570159603826 .done3 {
+  stroke: #666;
+  fill: #bbb;
+  stroke-width: 2; }
+
+#mermaid-1570159603826 .doneText0,
+#mermaid-1570159603826 .doneText1,
+#mermaid-1570159603826 .doneText2,
+#mermaid-1570159603826 .doneText3 {
+  fill: #333 !important; }
+
+
+#mermaid-1570159603826 .crit0,
+#mermaid-1570159603826 .crit1,
+#mermaid-1570159603826 .crit2,
+#mermaid-1570159603826 .crit3 {
+  stroke: #b1361b;
+  fill: #d42;
+  stroke-width: 2; }
+
+#mermaid-1570159603826 .activeCrit0,
+#mermaid-1570159603826 .activeCrit1,
+#mermaid-1570159603826 .activeCrit2,
+#mermaid-1570159603826 .activeCrit3 {
+  stroke: #b1361b;
+  fill: #A176FF;
+  stroke-width: 2; }
+
+#mermaid-1570159603826 .doneCrit0,
+#mermaid-1570159603826 .doneCrit1,
+#mermaid-1570159603826 .doneCrit2,
+#mermaid-1570159603826 .doneCrit3 {
+  stroke: #b1361b;
+  fill: #bbb;
+  stroke-width: 2;
+  cursor: pointer;
+  shape-rendering: crispEdges; }
+
+#mermaid-1570159603826 .milestone {
+  transform: rotate(45deg) scale(0.8, 0.8); }
+
+#mermaid-1570159603826 .milestoneText {
+  font-style: italic; }
+
+#mermaid-1570159603826 .doneCritText0,
+#mermaid-1570159603826 .doneCritText1,
+#mermaid-1570159603826 .doneCritText2,
+#mermaid-1570159603826 .doneCritText3 {
+  fill: #333 !important; }
+
+#mermaid-1570159603826 .activeCritText0,
+#mermaid-1570159603826 .activeCritText1,
+#mermaid-1570159603826 .activeCritText2,
+#mermaid-1570159603826 .activeCritText3 {
+  fill: #333 !important; }
+
+#mermaid-1570159603826 .titleText {
+  text-anchor: middle;
+  font-size: 18px;
+  fill: #333; }
+
+#mermaid-1570159603826 g.classGroup text {
+  fill: #999;
+  stroke: none;
+  font-family: 'trebuchet ms', verdana, arial;
+  font-size: 10px; }
+
+#mermaid-1570159603826 g.classGroup rect {
+  fill: #A176FF;
+  stroke: #999; }
+
+#mermaid-1570159603826 g.classGroup line {
+  stroke: #999;
+  stroke-width: 1; }
+
+#mermaid-1570159603826 .classLabel .box {
+  stroke: none;
+  stroke-width: 0;
+  fill: #A176FF;
+  opacity: 0.5; }
+
+#mermaid-1570159603826 .classLabel .label {
+  fill: #999;
+  font-size: 10px; }
+
+#mermaid-1570159603826 .relation {
+  stroke: #999;
+  stroke-width: 1;
+  fill: none; }
+
+#mermaid-1570159603826 #compositionStart {
+  fill: #999;
+  stroke: #999;
+  stroke-width: 1; }
+
+#mermaid-1570159603826 #compositionEnd {
+  fill: #999;
+  stroke: #999;
+  stroke-width: 1; }
+
+#mermaid-1570159603826 #aggregationStart {
+  fill: #A176FF;
+  stroke: #999;
+  stroke-width: 1; }
+
+#mermaid-1570159603826 #aggregationEnd {
+  fill: #A176FF;
+  stroke: #999;
+  stroke-width: 1; }
+
+#mermaid-1570159603826 #dependencyStart {
+  fill: #999;
+  stroke: #999;
+  stroke-width: 1; }
+
+#mermaid-1570159603826 #dependencyEnd {
+  fill: #999;
+  stroke: #999;
+  stroke-width: 1; }
+
+#mermaid-1570159603826 #extensionStart {
+  fill: #999;
+  stroke: #999;
+  stroke-width: 1; }
+
+#mermaid-1570159603826 #extensionEnd {
+  fill: #999;
+  stroke: #999;
+  stroke-width: 1; }
+
+#mermaid-1570159603826 .commit-id,
+#mermaid-1570159603826 .commit-msg,
+#mermaid-1570159603826 .branch-label {
+  fill: lightgrey;
+  color: lightgrey; }
+
+#mermaid-1570159603826 .pieTitleText {
+  text-anchor: middle;
+  font-size: 25px;
+  fill: #333; }
+</style><style>#mermaid-1570159603826 {
+    color: rgba(0, 0, 0, 0.65098);
+    font: normal normal normal normal 14px/21px "trebuchet ms", verdana, arial;
+  }</style><g></g><g><line id="actor28" x1="75" y1="5" x2="75" y2="970" class="actor-line" stroke-width="0.5px" stroke="#999"></line><rect x="0" y="0" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="75" y="32.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="75" dy="0">Browser</tspan></text></g><g><line id="actor29" x1="275" y1="5" x2="275" y2="970" class="actor-line" stroke-width="0.5px" stroke="#999"></line><rect x="200" y="0" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="275" y="32.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="275" dy="0">Identity Provider</tspan></text></g><g><line id="actor30" x1="475" y1="5" x2="475" y2="970" class="actor-line" stroke-width="0.5px" stroke="#999"></line><rect x="400" y="0" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="475" y="32.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="475" dy="0">Ingress</tspan></text></g><g><line id="actor31" x1="675" y1="5" x2="675" y2="970" class="actor-line" stroke-width="0.5px" stroke="#999"></line><rect x="600" y="0" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="675" y="32.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="675" dy="0">Pomerium</tspan></text></g><g><line id="actor32" x1="875" y1="5" x2="875" y2="970" class="actor-line" stroke-width="0.5px" stroke="#999"></line><rect x="800" y="0" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="875" y="32.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="875" dy="0">Pomerium AuthN</tspan></text></g><g><line id="actor33" x1="1075" y1="5" x2="1075" y2="970" class="actor-line" stroke-width="0.5px" stroke="#999"></line><rect x="1000" y="0" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="1075" y="32.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="1075" dy="0">Pomerium AuthZ</tspan></text></g><g><line id="actor34" x1="1275" y1="5" x2="1275" y2="970" class="actor-line" stroke-width="0.5px" stroke="#999"></line><rect x="1200" y="0" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="1275" y="32.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="1275" dy="0">app</tspan></text></g><defs><marker id="arrowhead" refX="5" refY="2" markerWidth="6" markerHeight="4" orient="auto"><path d="M 0,0 V 4 L6,2 Z"></path></marker></defs><defs><marker id="crosshead" markerWidth="15" markerHeight="8" orient="auto" refX="16" refY="4"><path fill="black" stroke="#000000" style="stroke-dasharray: 0px, 0px;" stroke-width="1px" d="M 9,2 V 6 L16,4 Z"></path><path fill="none" stroke="#000000" style="stroke-dasharray: 0px, 0px;" stroke-width="1px" d="M 0,1 L 6,7 M 6,1 L 0,7"></path></marker></defs><defs><marker id="sequencenumber" refX="15" refY="15" markerWidth="60" markerHeight="40" orient="auto"><circle cx="15" cy="15" r="6"></circle></marker></defs><g><text x="275" y="93" style="text-anchor: middle;" class="messageText">GET /app</text><line x1="75" y1="100" x2="475" y2="100" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="575" y="128" style="text-anchor: middle;" class="messageText">/verify/app</text><line x1="475" y1="135" x2="675" y2="135" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="675" y="163" style="text-anchor: middle;" class="messageText">Authenticated?</text><path d="M 675,170 C 735,160 735,200 675,190" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></path></g><g><text x="675" y="228" style="text-anchor: middle;" class="messageText">No!</text><path d="M 675,235 C 735,225 735,265 675,255" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></path></g><g><text x="775" y="293" style="text-anchor: middle;" class="messageText"></text><line x1="675" y1="300" x2="875" y2="300" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="475" y="328" style="text-anchor: middle;" class="messageText">HTTP 301 sign in callback url</text><line x1="875" y1="335" x2="75" y2="335" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="175" y="363" style="text-anchor: middle;" class="messageText"></text><line x1="75" y1="370" x2="275" y2="370" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="175" y="398" style="text-anchor: middle;" class="messageText"></text><line x1="275" y1="405" x2="75" y2="405" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="475" y="433" style="text-anchor: middle;" class="messageText">HTTP 301: Oauth2 callback endpoint</text><line x1="75" y1="440" x2="875" y2="440" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="475" y="468" style="text-anchor: middle;" class="messageText">Save session</text><line x1="875" y1="475" x2="75" y2="475" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="275" y="503" style="text-anchor: middle;" class="messageText">HTTP 301 app</text><line x1="75" y1="510" x2="475" y2="510" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="575" y="538" style="text-anchor: middle;" class="messageText">/verify/app</text><line x1="475" y1="545" x2="675" y2="545" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="675" y="573" style="text-anchor: middle;" class="messageText">Authenticated?</text><path d="M 675,580 C 735,570 735,610 675,600" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></path></g><g><text x="675" y="638" style="text-anchor: middle;" class="messageText">Yes!</text><path d="M 675,645 C 735,635 735,675 675,665" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></path></g><g><text x="875" y="703" style="text-anchor: middle;" class="messageText">Authorized?</text><line x1="675" y1="710" x2="1075" y2="710" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="875" y="738" style="text-anchor: middle;" class="messageText">Yes?</text><line x1="1075" y1="745" x2="675" y2="745" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="575" y="773" style="text-anchor: middle;" class="messageText">HTTP 200</text><line x1="675" y1="780" x2="475" y2="780" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="875" y="808" style="text-anchor: middle;" class="messageText"></text><line x1="475" y1="815" x2="1275" y2="815" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="875" y="843" style="text-anchor: middle;" class="messageText"></text><line x1="1275" y1="850" x2="475" y2="850" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><text x="275" y="878" style="text-anchor: middle;" class="messageText">OK!</text><line x1="475" y1="885" x2="75" y2="885" class="messageLine0" stroke-width="2" stroke="black" style="fill: none;" marker-end="url(#arrowhead)"></line></g><g><rect x="0" y="905" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="75" y="937.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="75" dy="0">Browser</tspan></text></g><g><rect x="200" y="905" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="275" y="937.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="275" dy="0">Identity Provider</tspan></text></g><g><rect x="400" y="905" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="475" y="937.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="475" dy="0">Ingress</tspan></text></g><g><rect x="600" y="905" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="675" y="937.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="675" dy="0">Pomerium</tspan></text></g><g><rect x="800" y="905" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="875" y="937.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="875" dy="0">Pomerium AuthN</tspan></text></g><g><rect x="1000" y="905" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="1075" y="937.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="1075" dy="0">Pomerium AuthZ</tspan></text></g><g><rect x="1200" y="905" fill="#eaeaea" stroke="#666" width="150" height="65" rx="3" ry="3" class="actor"></rect><text x="1275" y="937.5" style="text-anchor: middle; font-size: 14px; font-family: Open-Sans, sans-serif;" dominant-baseline="central" alignment-baseline="central" class="actor"><tspan x="1275" dy="0">app</tspan></text></g></svg>

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -160,6 +160,17 @@ type Options struct {
 	GRPCClientTimeout       time.Duration `mapstructure:"grpc_client_timeout"`
 	GRPCClientDNSRoundRobin bool          `mapstructure:"grpc_client_dns_roundrobin"`
 
+	// ForwardAuthEndpoint allows for a given route to be used as a forward-auth
+	// endpoint instead of a reverse proxy. Some third-party proxies that do not
+	// have rich access control capabilities (nginx, envoy, ambassador, traefik)
+	// allow you to delegate and authenticate each request to your website
+	// with an external server or service. Pomerium can be configured to accept
+	// these requests with this switch
+	//
+	// todo(bdd): link to docs
+	ForwardAuthURLString string `mapstructure:"forward_auth_url"`
+	ForwardAuthURL       *url.URL
+
 	viper *viper.Viper
 }
 
@@ -405,6 +416,14 @@ func (o *Options) Validate() error {
 			return fmt.Errorf("internal/config: bad authorize-url %s : %w", o.AuthorizeURLString, err)
 		}
 		o.AuthorizeURL = u
+	}
+
+	if o.ForwardAuthURLString != "" {
+		u, err := urlutil.ParseAndValidateURL(o.ForwardAuthURLString)
+		if err != nil {
+			return fmt.Errorf("internal/config: bad forward-auth-url %s : %w", o.ForwardAuthURLString, err)
+		}
+		o.ForwardAuthURL = u
 	}
 
 	if o.PolicyFile != "" {

--- a/internal/config/policy.go
+++ b/internal/config/policy.go
@@ -65,6 +65,15 @@ type Policy struct {
 	TLSClientCertFile string `mapstructure:"tls_client_cert_file" yaml:"tls_client_cert_file"`
 	TLSClientKeyFile  string `mapstructure:"tls_client_key_file" yaml:"tls_client_key_file"`
 	ClientCertificate *tls.Certificate
+
+	// IsForwardAuthEndpoint allows for a given route to be used as a forward-auth
+	// endpoint instead of a reverse proxy. Some third-party proxies that do not
+	// have rich access control capabilities (nginx, envoy, ambassador, traefik)
+	// allow you to delegate and authenticate each request to your website
+	// with an external server or service. Pomerium can be configured to accept
+	// these requests with this switch
+	// todo(bdd): link to docs
+	IsForwardAuthEndpoint bool
 }
 
 // Validate checks the validity of a policy.

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -267,7 +267,7 @@ func New() *template.Template {
         <section>
           <p class="message">
             {{if .Message}}{{.Message}}</br>{{end}}
-            {{if .CanDebug}}Troubleshoot your <a href="/.pomerium">session</a>.</br>{{end}}
+            {{if .CanDebug}}Troubleshoot your <a href="/.pomerium/">session</a>.</br>{{end}}
             {{if .RequestID}} Request {{.RequestID}}</br>{{end}}
           
           </p>

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -19,8 +19,11 @@ import (
 // registerHelperHandlers returns the proxy service's ServeMux
 func (p *Proxy) registerHelperHandlers(r *mux.Router) *mux.Router {
 	h := r.PathPrefix(dashboardURL).Subrouter()
+	// 1. Retrieve the user session and add it to the request context
 	h.Use(sessions.RetrieveSession(p.sessionStore))
+	// 2. AuthN - Verify the user is authenticated. Set email, group, & id headers
 	h.Use(p.AuthenticateSession)
+	// 3. Enforce CSRF protections for any non-idempotent http method
 	h.Use(csrf.Protect(
 		p.cookieSecret,
 		csrf.Path("/"),
@@ -32,6 +35,7 @@ func (p *Proxy) registerHelperHandlers(r *mux.Router) *mux.Router {
 	h.HandleFunc("/impersonate", p.Impersonate).Methods(http.MethodPost)
 	h.HandleFunc("/sign_out", p.SignOut).Methods(http.MethodGet, http.MethodPost)
 	h.HandleFunc("/refresh", p.ForceRefresh).Methods(http.MethodPost)
+	h.HandleFunc("/verify/{hostname}", p.Verify).Methods(http.MethodGet)
 	return r
 }
 
@@ -146,4 +150,51 @@ func (p *Proxy) Impersonate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, dashboardURL, http.StatusFound)
+}
+
+// Verify checks a user's credentials for an arbitrary host. If the user is
+// properly authenticated and is authorized to access the supplied host,
+// a 200 http status code is returned. If the user is not authenticated, they
+// will be redirected to the authenticate service to sign in with their identity
+// provider. If the user is unauthorized, they will be given a 403 http status.
+func (p *Proxy) Verify(w http.ResponseWriter, r *http.Request) {
+	// retrieve the target destination hostname from the url path
+	hostname, ok := mux.Vars(r)["hostname"]
+	if !ok {
+		httputil.ErrorResponse(w, r, httputil.Error("no hostname set", http.StatusBadRequest, nil))
+		return
+	}
+	// attempt to retrieve the user session from the request context, validity
+	// of the identity session is asserted by the middleware chain
+	s, err := sessions.FromContext(r.Context())
+	if err != nil {
+		httputil.ErrorResponse(w, r, err)
+		return
+	}
+	// query the authorization service to see if the session's user has
+	// the appropriate authorization to access the given hostname
+	authorized, err := p.AuthorizeClient.Authorize(r.Context(), hostname, s)
+	if err != nil {
+		httputil.ErrorResponse(w, r, err)
+		return
+	} else if !authorized {
+		errMsg := fmt.Sprintf("%s is not authorized for this route", s.RequestEmail())
+		httputil.ErrorResponse(w, r, httputil.Error(errMsg, http.StatusForbidden, nil))
+		return
+	}
+	// check the queryparams to see if this check immediately followed
+	// authentication. If so, redirect back to the originally requested hostname.
+	if isCallback := r.URL.Query().Get(disableCallback); isCallback == "true" {
+		http.Redirect(w, r, "http://"+hostname, http.StatusFound)
+		return
+	}
+
+	// User is authenticated and authorized for the given host.
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set(HeaderUserID, s.User)
+	w.Header().Set(HeaderEmail, s.RequestEmail())
+	w.Header().Set(HeaderGroups, s.RequestGroups())
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprintf(w, "%s is authorized for %s.", s.Email, hostname)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -173,6 +173,11 @@ func (p *Proxy) UpdatePolicies(opts *config.Options) error {
 	r.HandleFunc("/robots.txt", p.RobotsTxt).Methods(http.MethodGet)
 	r = p.registerHelperHandlers(r)
 
+	if opts.ForwardAuthURL != nil {
+		// create a route to handle forward auth requests
+		r.Host(opts.ForwardAuthURL.Host).Subrouter().PathPrefix("/")
+	}
+
 	for _, policy := range opts.Policies {
 		if err := policy.Validate(); err != nil {
 			return fmt.Errorf("proxy: invalid policy %s", err)


### PR DESCRIPTION
## Flow

[diagram](https://mermaidjs.github.io/mermaid-live-editor/#/view/eyJjb2RlIjoic2VxdWVuY2VEaWFncmFtXG4gICAgcGFydGljaXBhbnQgQ2xpZW50IGFzIEJyb3dzZXJcbiAgICBwYXJ0aWNpcGFudCBJZFAgYXMgSWRlbnRpdHkgUHJvdmlkZXJcbiAgICBDbGllbnQtPj5JbmdyZXM6IEdFVCAvYXBwXG4gICAgSW5ncmVzLT4-UG9tZXJpdW06IC92ZXJpZnkvYXBwXG4gICAgUG9tZXJpdW0tPj5Qb21lcml1bTogQXV0aGVudGljYXRlZD9cbiAgICBQb21lcml1bS0-PiBQb21lcml1bTogTm8hXG4gICAgUG9tZXJpdW0tPj5Qb21lcml1bSBBdXRoTjogIFxuICAgIFBvbWVyaXVtIEF1dGhOLT4-Q2xpZW50OiBIVFRQIDMwMSBzaWduIGluIGNhbGxiYWNrIHVybFxuICAgIENsaWVudC0-PklkUDogIFxuICAgIElkUC0-PkNsaWVudDogIFxuICAgIENsaWVudC0-PlBvbWVyaXVtIEF1dGhOOiBIVFRQIDMwMTogT2F1dGgyIGNhbGxiYWNrIGVuZHBvaW50XG4gICAgUG9tZXJpdW0gQXV0aE4tPj4gQ2xpZW50OiBTYXZlIHNlc3Npb25cbiAgICBDbGllbnQtPj4gSW5ncmVzOiBIVFRQIDMwMSBhcHBcbiAgICBJbmdyZXMtPj4gUG9tZXJpdW06IC92ZXJpZnkvYXBwXG4gICAgUG9tZXJpdW0tPj5Qb21lcml1bTogQXV0aGVudGljYXRlZD9cbiAgICBQb21lcml1bS0-PiBQb21lcml1bTogWWVzIVxuICAgIFBvbWVyaXVtLT4-IFBvbWVyaXVtIEF1dGhaOiBBdXRob3JpemVkP1xuICAgIFBvbWVyaXVtIEF1dGhaLT4-IFBvbWVyaXVtOlllcz9cbiAgICBQb21lcml1bS0-PiBJbmdyZXM6IEhUVFAgMjAwXG4gICAgSW5ncmVzLT4-IGFwcDogIFxuICAgIGFwcC0-PiBJbmdyZXM6ICBcbiAgICBJbmdyZXMtPj4gQ2xpZW50OiAgT0shXG4iLCJtZXJtYWlkIjp7InRoZW1lIjoiZGVmYXVsdCJ9fQ)

## In action

Not that exciting, but I guess that's the point. Subsequent calls to any other routes will be transparent as well. 

https://www.youtube.com/watch?v=WXE79juX7zk&feature=youtu.be

## Example config

Using [Traefik forwardauth](https://docs.traefik.io/v2.0/middlewares/forwardauth/)

```yaml
version: "3"

services:
  reverse-proxy:
    # The official v2.0 Traefik docker image
    image: traefik:v2.0
    # Enables the web UI and tells Traefik to listen to docker
    command: --api.insecure=true --providers.docker
    ports:
      # The HTTP port
      - "80:80"
      # The Web UI (enabled by --api.insecure=true)
      - "8080:8080"
    volumes:
      # So that Traefik can listen to the Docker events
      - /var/run/docker.sock:/var/run/docker.sock
  whoami:
    # A container that exposes an API to show its IP address
    image: containous/whoami
    labels:
      - "traefik.http.routers.whoami.rule=Host(`whoami.corp.beyondperimeter.com`)"
      # Create a middleware named `foo-add-prefix`
      - "traefik.http.middlewares.test-auth.forwardauth.address=https://httpbin.corp.beyondperimeter.com/.pomerium/verify/http://whoami.corp.beyondperimeter.com"
      - "traefik.http.routers.whoami.middlewares=test-auth@docker"
  echo:
    # image: kennethreitz/httpbin
    image: mendhak/http-https-echo
    labels:
      - "traefik.http.routers.httpbin.rule=Host(`whoami.corp.beyondperimeter.com`)"

```


And using [nginx-ingress](https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md#external-authentication) . 
```yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: kuard
  annotations:
    kubernetes.io/ingress.class: "nginx"
    certmanager.k8s.io/issuer: "letsencrypt-prod"
    nginx.ingress.kubernetes.io/auth-url: https://httpbin.corp.beyondperimeter.com:8443/.pomerium/verify/kuard.k8s.corp.beyondperimeter.com?no_redirect=true
    nginx.ingress.kubernetes.io/auth-signin: https://httpbin.corp.beyondperimeter.com:8443/.pomerium/verify/kuard.k8s.corp.beyondperimeter.com

spec:
  tls:
    - hosts:
        - kuard.k8s.corp.beyondperimeter.com
      secretName: quickstart-example-tls
  rules:
    - host: kuard.k8s.corp.beyondperimeter.com
      http:
        paths:
          - path: /
            backend:
              serviceName: kuard
              servicePort: 80

```
**Checklist**:
- [x] updated docs
- [x] unit tests added
- [x] related issues referenced
- [x] updated CHANGELOG.md
- [x] ready for review
