### PR TITLE
internal/log: return full `X-Forwarded-For`

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 - The healthcheck endpoints (`/ping`) now returns the http status `405` StatusMethodNotAllowed for non-`GET` requests. [GH-319](https://github.com/pomerium/pomerium/issues/319)
 - Authenticate service no longer uses gRPC.
+- The global request logger now captures the full array of proxies from `X-Forwarded-For`, in addition to just the client IP.
 
 ### Removed
 


### PR DESCRIPTION
Previously, If a request went through multiple proxies, only the right-most IP address (the originating client) was logged as a forward address. In this implementation, each proxy and the originating IP are logged as an array. 

**Checklist**:
- [x] unit tests added
- [x] updated CHANGELOG.md
- [x] ready for review
