### PR TITLE
github: make issue templates less annoying

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,39 +3,35 @@ name: Bug report
 about: Let us know about a bug!
 ---
 
-<!-- Please reserve GitHub issues for bug reports and feature requests. -->
+## What happened?
 
- **Describe the bug** A clear and concise description of what the bug is.
+## What did you expect to happen?
 
-**To Reproduce** Steps to reproduce the behavior:
+## How'd it happen?
 
 1. Ran `x`
 2. Clicked `y`
 3. Saw error `z`
 
-**Expected behavior**
+## What's your environment like?
 
-A clear and concise description of what you expected to happen.
-
-**Environment:**
-
-- Pomerium version (retrieve with `pomerium --version`):
+- Pomerium version (retrieve with `pomerium --version` or `/ping` endpoint):
 - Server Operating System/Architecture/Cloud:
 
-Configuration file(s):
+## What's your config.yaml?
 
-```text
+```config.yaml
 # Paste your configs here
 # Be sure to scrub any sensitive values
 ```
 
-Logs(s):
+## What did you see in the logs?
 
-```text
-# Paste your configs here.
+```logs
+# Paste your logs here.
 # Be sure to scrub any sensitive values
 ```
 
-**Additional context**
+## Additional context
 
 Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,11 +9,7 @@ A clear and concise description of what the problem is. Ex. I'm always frustrate
 
 **Describe the solution you'd like**
 
-A clear and concise description of what you want to happen.
-
 **Describe alternatives you've considered**
-
-A clear and concise description of any alternative solutions or features you've considered.
 
 **Explain any additional use-cases**
 

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,25 +1,22 @@
-<!--  
-Thanks for sending a pull request!
-We generally follow Go coding and contributing conventions
-https://golang.org/doc/contribute.html#commit_messages
+## Summary
+<!--  For example...
+The existing implementation has poor numerical properties for
+large arguments, so use the McGillicutty algorithm to improve
+accuracy above 1e10.
 
-Here's an example of a good PR/Commit:
+The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
+-->
 
-    math: improve Sin, Cos and Tan precision for very large arguments
-
-    The existing implementation has poor numerical properties for
-    large arguments, so use the McGillicutty algorithm to improve
-    accuracy above 1e10.
-
-    The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-
-    Fixes #159
+## Related issues
+<!-- For example...
+Fixes #159 
 -->
 
 
 **Checklist**:
+- [ ] add related issues
 - [ ] updated docs
-- [ ] unit tests added
-- [ ] related issues referenced
+- [ ] updated unit tests
 - [ ] updated CHANGELOG.md
+- [ ] updated UPGRADING.md
 - [ ] ready for review


### PR DESCRIPTION
The current Issue templates are a little prickly. These might be a bit friendlier? 


**Checklist**:
- [x] ready for review
