### PR TITLE
proxy: fix dashboard path prefix

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	// dashboardURL	is the path to authenticate's sign in endpoint
-	dashboardURL = "/.pomerium/"
+	dashboardURL = "/.pomerium"
 	// signinURL is the path to authenticate's sign in endpoint
 	signinURL = "/.pomerium/sign_in"
 	// signoutURL is the path to authenticate's sign out endpoint


### PR DESCRIPTION
Fixes an "off-by-one" route issue where the dashboard required a slash. Not adding a changelog item because this was caught before release. 

Fixes #344 

**Checklist**:
- [x] add related issues
- [x] ready for review
