### PR TITLE
proxy: use custom 404 handler

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -168,6 +168,9 @@ func (p *Proxy) UpdatePolicies(opts *config.Options) error {
 		log.Warn().Msg("proxy: configuration has no policies")
 	}
 	r := httputil.NewRouter()
+	r.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httputil.ErrorResponse(w, r, httputil.Error(fmt.Sprintf("%s route unknown", r.Host), http.StatusNotFound, nil))
+	})
 	r.SkipClean(true)
 	r.StrictSlash(true)
 	r.HandleFunc("/robots.txt", p.RobotsTxt).Methods(http.MethodGet)


### PR DESCRIPTION
Fixes a regression which came about as part of the gorilla mux switchover. Before this fix, 404's would just return the status code in text form. Now, they return a custom 404 page like before. 
<img width="859" alt="Screen Shot 2019-10-03 at 10 12 56 PM" src="https://user-images.githubusercontent.com/1544881/66182918-a653c200-e62b-11e9-82ae-c68723978ae7.png">

Fixes #345

Thanks again to @cmmichael  for reporting. 

**Checklist**:
- [x] add related issues
- [x] ready for review
