### PR TITLE
internal/sessions: separate query params, auth-header, and cookie stores

### DIFF
--- a/internal/sessions/cookie_store_test.go
+++ b/internal/sessions/cookie_store_test.go
@@ -38,33 +38,30 @@ func TestNewCookieStore(t *testing.T) {
 	}{
 		{"good",
 			&CookieStoreOptions{
-				Name:              "_cookie",
-				CookieSecure:      true,
-				CookieHTTPOnly:    true,
-				CookieDomain:      "pomerium.io",
-				CookieExpire:      10 * time.Second,
-				Encoder:           encoder,
-				BearerTokenHeader: "Authorization",
+				Name:           "_cookie",
+				CookieSecure:   true,
+				CookieHTTPOnly: true,
+				CookieDomain:   "pomerium.io",
+				CookieExpire:   10 * time.Second,
+				Encoder:        encoder,
 			},
 			&CookieStore{
-				Name:              "_cookie",
-				CookieSecure:      true,
-				CookieHTTPOnly:    true,
-				CookieDomain:      "pomerium.io",
-				CookieExpire:      10 * time.Second,
-				Encoder:           encoder,
-				BearerTokenHeader: "Authorization",
+				Name:           "_cookie",
+				CookieSecure:   true,
+				CookieHTTPOnly: true,
+				CookieDomain:   "pomerium.io",
+				CookieExpire:   10 * time.Second,
+				Encoder:        encoder,
 			},
 			false},
 		{"missing name",
 			&CookieStoreOptions{
-				Name:              "",
-				CookieSecure:      true,
-				CookieHTTPOnly:    true,
-				CookieDomain:      "pomerium.io",
-				CookieExpire:      10 * time.Second,
-				Encoder:           encoder,
-				BearerTokenHeader: "Authorization",
+				Name:           "",
+				CookieSecure:   true,
+				CookieHTTPOnly: true,
+				CookieDomain:   "pomerium.io",
+				CookieExpire:   10 * time.Second,
+				Encoder:        encoder,
 			},
 			nil,
 			true},
@@ -246,26 +243,6 @@ func TestMockSessionStore(t *testing.T) {
 			ms.ClearSession(nil, nil)
 			if ms.ResponseSession != "" {
 				t.Errorf("ResponseSession not empty! %s", ms.ResponseSession)
-			}
-		})
-	}
-}
-
-func Test_ParentSubdomain(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		s    string
-		want string
-	}{
-		{"httpbin.corp.example.com", "corp.example.com"},
-		{"some.httpbin.corp.example.com", "httpbin.corp.example.com"},
-		{"example.com", ""},
-		{"", ""},
-	}
-	for _, tt := range tests {
-		t.Run(tt.s, func(t *testing.T) {
-			if got := ParentSubdomain(tt.s); got != tt.want {
-				t.Errorf("ParentSubdomain() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/sessions/header_store.go
+++ b/internal/sessions/header_store.go
@@ -1,0 +1,61 @@
+package sessions // import "github.com/pomerium/pomerium/internal/sessions"
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/pomerium/pomerium/internal/cryptutil"
+)
+
+const (
+	// defaultAuthHeader and defaultAuthType are default header name for the
+	// authorization bearer  token header as defined in rfc2617
+	// https://tools.ietf.org/html/rfc6750#section-2.1
+	defaultAuthHeader = "Authorization"
+	defaultAuthType   = "Bearer"
+)
+
+// HeaderStore implements the load session store interface using http
+// authorization headers.
+type HeaderStore struct {
+	authHeader string
+	authType   string
+	encoder    cryptutil.SecureEncoder
+}
+
+// NewHeaderStore returns a new header store for loading sessions from
+// authorization headers.
+func NewHeaderStore(enc cryptutil.SecureEncoder) *HeaderStore {
+	return &HeaderStore{
+		authHeader: defaultAuthHeader,
+		authType:   defaultAuthType,
+		encoder:    enc,
+	}
+}
+
+// LoadSession tries to retrieve the token string from the Authorization header.
+//
+// NOTA BENE: While most servers do not log Authorization headers by default,
+// you should ensure no other services are logging or leaking your auth headers.
+func (as *HeaderStore) LoadSession(r *http.Request) (*State, error) {
+	cipherText := as.tokenFromHeader(r)
+	if cipherText == "" {
+		return nil, ErrNoSessionFound
+	}
+	session, err := UnmarshalSession(cipherText, as.encoder)
+	if err != nil {
+		return nil, ErrMalformed
+	}
+	return session, nil
+
+}
+
+// retrieve the value of the authorization header
+func (as *HeaderStore) tokenFromHeader(r *http.Request) string {
+	bearer := r.Header.Get(as.authHeader)
+	atSize := len(as.authType)
+	if len(bearer) > atSize && strings.EqualFold(bearer[0:atSize], as.authType) {
+		return bearer[atSize+1:]
+	}
+	return ""
+}

--- a/internal/sessions/query_store.go
+++ b/internal/sessions/query_store.go
@@ -1,0 +1,44 @@
+package sessions // import "github.com/pomerium/pomerium/internal/sessions"
+
+import (
+	"net/http"
+
+	"github.com/pomerium/pomerium/internal/cryptutil"
+)
+
+const (
+	defaultQueryParamKey = "pomerium_session"
+)
+
+// QueryParamStore implements the load session store interface using http
+// query strings / query parameters.
+type QueryParamStore struct {
+	queryParamKey string
+	encoder       cryptutil.SecureEncoder
+}
+
+// NewQueryParamStore returns a new query param store for loading sessions from
+// query strings / query parameters.
+func NewQueryParamStore(enc cryptutil.SecureEncoder) *QueryParamStore {
+	return &QueryParamStore{
+		queryParamKey: defaultQueryParamKey,
+		encoder:       enc,
+	}
+}
+
+// LoadSession tries to retrieve the token string from URL query parameters.
+//
+// NOTA BENE: By default, most servers _DO_ log query params, the leaking or
+// accidental logging of which should be considered a security issue.
+func (qp *QueryParamStore) LoadSession(r *http.Request) (*State, error) {
+	cipherText := r.URL.Query().Get(qp.queryParamKey)
+	if cipherText == "" {
+		return nil, ErrNoSessionFound
+	}
+	session, err := UnmarshalSession(cipherText, qp.encoder)
+	if err != nil {
+		return nil, ErrMalformed
+	}
+	return session, nil
+
+}

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -5,12 +5,24 @@ import (
 	"net/http"
 )
 
-// ErrEmptySession is an error for an empty sessions.
-var ErrEmptySession = errors.New("internal/sessions: empty session")
+var (
+	// ErrExpired is the error for an expired session.
+	ErrExpired = errors.New("internal/sessions: session is expired")
+	// ErrNoSessionFound is the error for when no session is found.
+	ErrNoSessionFound = errors.New("internal/sessions: session is not found")
+	// ErrMalformed is the error for when a session is found but is malformed.
+	ErrMalformed = errors.New("internal/sessions: session is malformed")
+)
 
 // SessionStore has the functions for setting, getting, and clearing the Session cookie
 type SessionStore interface {
 	ClearSession(http.ResponseWriter, *http.Request)
 	LoadSession(*http.Request) (*State, error)
 	SaveSession(http.ResponseWriter, *http.Request, *State) error
+}
+
+// SessionLoader is implemented by any struct that loads a pomerium session
+// given a request, and returns a user state.
+type SessionLoader interface {
+	LoadSession(*http.Request) (*State, error)
 }

--- a/internal/sessions/util.go
+++ b/internal/sessions/util.go
@@ -1,0 +1,12 @@
+package sessions // import "github.com/pomerium/pomerium/internal/sessions"
+
+import "strings"
+
+// ParentSubdomain returns the parent subdomain.
+func ParentSubdomain(s string) string {
+	if strings.Count(s, ".") < 2 {
+		return ""
+	}
+	split := strings.SplitN(s, ".", 2)
+	return split[1]
+}

--- a/internal/sessions/util_test.go
+++ b/internal/sessions/util_test.go
@@ -1,0 +1,23 @@
+package sessions
+
+import "testing"
+
+func Test_ParentSubdomain(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		s    string
+		want string
+	}{
+		{"httpbin.corp.example.com", "corp.example.com"},
+		{"some.httpbin.corp.example.com", "httpbin.corp.example.com"},
+		{"example.com", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.s, func(t *testing.T) {
+			if got := ParentSubdomain(tt.s); got != tt.want {
+				t.Errorf("ParentSubdomain() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -184,8 +184,8 @@ func (p *Proxy) Verify(w http.ResponseWriter, r *http.Request) {
 	}
 	// check the queryparams to see if this check immediately followed
 	// authentication. If so, redirect back to the originally requested hostname.
-	if isCallback := r.URL.Query().Get(disableCallback); isCallback == "true" {
-		http.Redirect(w, r, "http://"+hostname, http.StatusFound)
+	if isCallback := r.URL.Query().Get("pomerium-auth-callback"); isCallback == "true" {
+		http.Redirect(w, r, hostname, http.StatusFound)
 		return
 	}
 


### PR DESCRIPTION
## Summary
These changes standardize how session loading is done for session cookie, auth bearer token, and query params. Each implements a common interface that returns a user's session state. 

### Details
- Bearer token previously combined with session cookie.
- rearranged cookie-store to put exported methods above unexported
- added header store that implements session loader interface
- added query param store that implements session loader interface


## Related issues

- #281 (possibly solving a large portion of it)

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [x] ready for review
