### PR TITLE
docs: use master for docs again

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -26,7 +26,7 @@ module.exports = {
       { text: "Recipes", link: "/recipes/" },
       { text: "Community", link: "/community/" },
       {
-        text: "v0.4.0", // current tagged version
+        text: "🚧Dev", // current tagged version
         ariaLabel: "Version menu",
         items: [
           { text: "🚧Dev", link: "https://master.docs.pomerium.io/docs" },

--- a/docs/docs/reference/examples/docker/basic.docker-compose.yml
+++ b/docs/docs/reference/examples/docker/basic.docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   pomerium:
-    image: pomerium/pomerium:v0.4.0
+    image: pomerium/pomerium:master
     environment:
       # Generate new secret keys. e.g. `head -c32 /dev/urandom | base64`
       - COOKIE_SECRET=V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=

--- a/docs/docs/reference/examples/docker/nginx.docker-compose.yml
+++ b/docs/docs/reference/examples/docker/nginx.docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - /var/run/docker.sock:/tmp/docker.sock:ro
 
   pomerium-authenticate:
-    image: pomerium/pomerium:v0.4.0 # or `build: .` to build from source
+    image: pomerium/pomerium:master # or `build: .` to build from source
     restart: always
     environment:
       - SERVICES=authenticate
@@ -38,7 +38,7 @@ services:
       - 443
 
   pomerium-proxy:
-    image: pomerium/pomerium:v0.4.0 # or `build: .` to build from source
+    image: pomerium/pomerium:master # or `build: .` to build from source
     restart: always
     environment:
       - SERVICES=proxy
@@ -60,7 +60,7 @@ services:
       - 443
 
   pomerium-authorize:
-    image: pomerium/pomerium:v0.4.0 # or `build: .` to build from source
+    image: pomerium/pomerium:master # or `build: .` to build from source
     restart: always
     environment:
       - SERVICES=authorize

--- a/docs/docs/reference/examples/kubernetes/pomerium-authenticate.yml
+++ b/docs/docs/reference/examples/kubernetes/pomerium-authenticate.yml
@@ -27,7 +27,7 @@ spec:
         app: pomerium-authenticate
     spec:
       containers:
-        - image: pomerium/pomerium:v0.4.0
+        - image: pomerium/pomerium:master
           name: pomerium-authenticate
           args:
             - --config=/etc/pomerium/config.yaml

--- a/docs/docs/reference/examples/kubernetes/pomerium-authorize.yml
+++ b/docs/docs/reference/examples/kubernetes/pomerium-authorize.yml
@@ -27,7 +27,7 @@ spec:
         app: pomerium-authorize
     spec:
       containers:
-        - image: pomerium/pomerium:v0.4.0
+        - image: pomerium/pomerium:master
           name: pomerium-authorize
           args:
             - --config=/etc/pomerium/config.yaml

--- a/docs/docs/reference/examples/kubernetes/pomerium-proxy.yml
+++ b/docs/docs/reference/examples/kubernetes/pomerium-proxy.yml
@@ -29,7 +29,7 @@ spec:
         app: pomerium-proxy
     spec:
       containers:
-        - image: pomerium/pomerium:v0.4.0
+        - image: pomerium/pomerium:master
           name: pomerium-proxy
           args:
             - --config=/etc/pomerium/config.yaml


### PR DESCRIPTION
## Summary

Kicks off a new release cycle. Resets docs to use master branch for docs and docker images. 

## Related issues
#350 

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] ready for review
