### PR TITLE
proxy: strip added params from verify callback

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Fixed an issue where requests handled by forward-auth would not be redirected back to the underlying route after successful authentication and authorization. [GH-363]
+- Fixed an issue where requests handled by forward-auth would add an extraneous query-param following sign-in causing issues in some configurations. [GH-366]
 
 ## v0.4.0
 

--- a/docs/docs/reference/reference.md
+++ b/docs/docs/reference/reference.md
@@ -303,7 +303,7 @@ Forward authentication creates an endpoint that can be used with third-party pro
 
 #### NGINX Ingress
 
-Some reverse-proxies, such as nginx split access control flow into two parts: verification and sign-in redirection. Notice the additional the additional `?no_redirect=true` query param in `auth-rul` which tells Pomerium to return a `401` instead of redirecting and starting the sign-in process.
+Some reverse-proxies, such as nginx split access control flow into two parts: verification and sign-in redirection. Notice the additional path `/verify` used for `auth-url` indicating to Pomerium that it should return a `401` instead of redirecting and starting the sign-in process.
 
 ```yaml
 apiVersion: extensions/v1beta1
@@ -313,8 +313,8 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     certmanager.k8s.io/issuer: "letsencrypt-prod"
-    nginx.ingress.kubernetes.io/auth-url: https://fwdauth.corp.example.com/.pomerium/verify?uri=$scheme://$host$request_uri&x-pomerium-no-auth-redirect=true
-    nginx.ingress.kubernetes.io/auth-signin: "https://fwdauth.corp.example.com/.pomerium/verify?uri=$scheme://$host$request_uri"
+    nginx.ingress.kubernetes.io/auth-url: https://fwdauth.corp.example.com?uri=$scheme://$host$request_uri
+    nginx.ingress.kubernetes.io/auth-signin: "https://fwdauth.corp.example.com/verify?uri=$scheme://$host$request_uri"
 spec:
   tls:
     - hosts:
@@ -356,7 +356,7 @@ services:
       - "traefik.http.routers.httpbin.rule=Host(`httpbin.corp.example.com`)"
       # Create a middleware named `foo-add-prefix`
       - "traefik.http.middlewares.test-auth.forwardauth.authResponseHeaders=X-Pomerium-Authenticated-User-Email,x-pomerium-authenticated-user-id,x-pomerium-authenticated-user-groups,x-pomerium-jwt-assertion"
-      - "traefik.http.middlewares.test-auth.forwardauth.address=http://fwdauth.corp.example.com/.pomerium/verify?uri=https://httpbin.corp.example.com"
+      - "traefik.http.middlewares.test-auth.forwardauth.address=http://fwdauth.corp.example.com/?uri=https://httpbin.corp.example.com"
       - "traefik.http.routers.httpbin.middlewares=test-auth@docker"
 ```
 

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -13,13 +13,15 @@ description: >-
 
 Previously, routes were verified by taking the downstream applications hostname in the form of a path `(e.g. ${fwdauth}/.pomerium/verify/httpbin.some.example`) variable. The new method for verifying a route using forward authentication is to pass the entire requested url in the form of a query string `(e.g. ${fwdauth}/.pomerium/verify?url=https://httpbin.some.example)` where the routed domain is the value of the `uri` key.
 
+Note that the verification URL is no longer nested under the `.pomerium` endpoint.
+
 For example, in nginx this would look like:
 
 ```diff
 -    nginx.ingress.kubernetes.io/auth-url: https://fwdauth.corp.example.com/.pomerium/verify/httpbin.corp.example.com?no_redirect=true
 -    nginx.ingress.kubernetes.io/auth-signin: https://fwdauth.corp.example.com/.pomerium/verify/httpbin.corp.example.com
-+    nginx.ingress.kubernetes.io/auth-url: https://fwdauth.corp.example.com/.pomerium/verify?uri=$scheme://$host$request_uri&x-pomerium-no-auth-redirect=true
-+    nginx.ingress.kubernetes.io/auth-signin: https://fwdauth.corp.example.com/.pomerium/verify?uri=$scheme://$host$request_uri
++    nginx.ingress.kubernetes.io/auth-url: https://fwdauth.corp.example.com/verify?uri=$scheme://$host$request_uri
++    nginx.ingress.kubernetes.io/auth-signin: https://fwdauth.corp.example.com?uri=$scheme://$host$request_uri
 
 ```
 


### PR DESCRIPTION
## Summary
This PR changes the way forward-authentication works in several respects: 

1) Forward-authentication handlers are not registered as part of the dashboard router registration process (this had the weird side effect of making it so that you could do forward-auth validation against _any_ proxied route at `${route}/.pomerium/verify`
1) Verification will now occur on at the _root_ of the forward authentication host handler. I think this is easier to read / work with. 
1) Verification and signing endpoints are now two distinct endpoints (more along the lines of what Nginx asks for). One handler that simply verifies (returns `200` or `401`) the request, and another which again verifies the request, but will return a `302` redirect to complete the authentication process. In practice, `sign-in` is a superset of verify.
    - The sign in and verify endpoint is `/`
    - The verify only endpoint is `/verify`
1. Additional query params (which are used to tell the proxy service when the authenticate service has completed authentication and can be redirected back to it's original domain) are now stripped from the redirect (Fixing #366).


This is a breaking change. But I would like to consider cherrypicking it as part of our patch release.  

\ cc @victornoel if you could give this a try that would be a big help. I've pushed a test image on docker hub with the tag `PR366v2`

```bash
docker run pomerium/pomerium:PR366v2 --version                                                                                          
v0.4.0-dirty+0e85b2b
```



## Related issues
Fixes #366 


**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated CHANGELOG.md
- [x] updated UPGRADING.md
- [x] ready for review
