### PR TITLE
authenticate: handle XHR redirect flow

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -53,15 +53,9 @@ func (a *Authenticate) Handler() http.Handler {
 	// Proxy service endpoints
 	v := r.PathPrefix("/.pomerium").Subrouter()
 	c := cors.New(cors.Options{
-		AllowOriginRequestFunc: func(r *http.Request, _ string) bool {
-			return middleware.ValidSignature(
-				r.FormValue("redirect_uri"),
-				r.FormValue("sig"),
-				r.FormValue("ts"),
-				a.sharedKey)
-		},
-		AllowCredentials: true,
-		AllowedHeaders:   []string{"*"},
+		AllowOriginRequestFunc: middleware.ValidateRedirectURI,
+		AllowCredentials:       true,
+		AllowedHeaders:         []string{"*"},
 	})
 	v.Use(c.Handler)
 	v.Use(middleware.ValidateSignature(a.sharedKey))

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -69,6 +69,25 @@ func TestAuthenticate_Handler(t *testing.T) {
 	if body != expected {
 		t.Errorf("handler returned unexpected body: got %v want %v", body, expected)
 	}
+
+	// cors preflight
+	req = httptest.NewRequest(http.MethodOptions, "/.pomerium/sign_in", nil)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Access-Control-Request-Method", "GET")
+	req.Header.Set("Access-Control-Request-Headers", "X-Requested-With")
+	rr = httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+	expected = fmt.Sprintf("User-agent: *\nDisallow: /")
+	code := rr.Code
+	if code != http.StatusOK {
+		t.Errorf("bad preflight code")
+	}
+	resp := rr.Result()
+	body = resp.Header.Get("vary")
+	if body == "" {
+		t.Errorf("handler returned unexpected body: got %v want %v", body, expected)
+	}
+
 }
 
 func TestAuthenticate_SignIn(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,8 @@ require (
 	github.com/pomerium/go-oidc v2.0.0+incompatible
 	github.com/pquerna/cachecontrol v0.0.0-20180517163645-1555304b9b35 // indirect
 	github.com/prometheus/client_golang v0.9.3
-	github.com/rs/zerolog v1.14.3
+	github.com/rs/cors v1.7.0
+	github.com/rs/zerolog v1.16.0
 	github.com/spf13/afero v1.2.2 // indirect
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,9 +173,13 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
+github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.14.3 h1:4EGfSkR2hJDB0s3oFfrlPqjU1e4WLncergLil3nEKW0=
 github.com/rs/zerolog v1.14.3/go.mod h1:3WXPzbXEEliJ+a6UFE4vhIxV8qR1EML6ngzP9ug4eYg=
+github.com/rs/zerolog v1.16.0 h1:AaELmZdcJHT8m6oZ5py4213cdFK8XGXkB3dFdAQ+P7Q=
+github.com/rs/zerolog v1.16.0/go.mod h1:9nvC1axdVrAHcu/s9taAVfBuIdTZLVQmKQyvrUjF5+I=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
@@ -309,6 +313,7 @@ golang.org/x/tools v0.0.0-20190606124116-d0a3d012864b/go.mod h1:/rFqwRUd4F7ZHNgw
 golang.org/x/tools v0.0.0-20190621195816-6e04913cbbac/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190628153133-6cdbf07be9d0/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/tools v0.0.0-20190816200558-6889da9d5479/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20190828213141-aed303cbaa74/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190911174233-4f2ddba30aff/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20190927191325-030b2cf1153e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191010171213-8abd42400456/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=

--- a/internal/httputil/constants.go
+++ b/internal/httputil/constants.go
@@ -1,0 +1,9 @@
+package httputil // import "github.com/pomerium/pomerium/internal/httputil"
+
+const (
+	// HeaderPomeriumResponse is set when pomerium itself creates a response,
+	// as opposed to the downstream application and can be used to distinguish
+	// between an application error, and a pomerium related error when debugging.
+	// Especially useful when working with single page apps (SPA).
+	HeaderPomeriumResponse = "x-pomerium-intercepted-response"
+)

--- a/internal/httputil/handlers.go
+++ b/internal/httputil/handlers.go
@@ -17,3 +17,10 @@ func HealthCheck(w http.ResponseWriter, r *http.Request) {
 		w.Write([]byte(http.StatusText(http.StatusOK)))
 	}
 }
+
+// Redirect wraps the std libs's redirect method indicating that pomerium is
+// the origin of the response.
+func Redirect(w http.ResponseWriter, r *http.Request, url string, code int) {
+	w.Header().Set(HeaderPomeriumResponse, "true")
+	http.Redirect(w, r, url, code)
+}

--- a/internal/httputil/handlers_test.go
+++ b/internal/httputil/handlers_test.go
@@ -35,3 +35,34 @@ func TestHealthCheck(t *testing.T) {
 		})
 	}
 }
+
+func TestRedirect(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		method string
+
+		url  string
+		code int
+
+		wantStatus int
+	}{
+		{"good", http.MethodGet, "https://pomerium.io", http.StatusFound, http.StatusFound},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			r := httptest.NewRequest(tt.method, "/", nil)
+			w := httptest.NewRecorder()
+
+			Redirect(w, r, tt.url, tt.code)
+			if w.Code != tt.wantStatus {
+				t.Errorf("code differs. got %d want %d body: %s", w.Code, tt.wantStatus, w.Body.String())
+			}
+			if w.Result().Header.Get(HeaderPomeriumResponse) == "" {
+				t.Errorf("pomerium header not found")
+			}
+		})
+	}
+}

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -67,7 +67,7 @@ func (p *Proxy) SignOut(w http.ResponseWriter, r *http.Request) {
 	}
 	uri := urlutil.SignedRedirectURL(p.SharedKey, p.authenticateSignoutURL, redirectURL)
 	p.sessionStore.ClearSession(w, r)
-	http.Redirect(w, r, uri.String(), http.StatusFound)
+	httputil.Redirect(w, r, uri.String(), http.StatusFound)
 }
 
 // UserDashboard lets users investigate, and refresh their current session.
@@ -117,7 +117,7 @@ func (p *Proxy) Impersonate(w http.ResponseWriter, r *http.Request) {
 	q.Add("impersonate_group", r.FormValue("group"))
 	redirectURL.RawQuery = q.Encode()
 	uri := urlutil.SignedRedirectURL(p.SharedKey, p.authenticateSigninURL, redirectURL).String()
-	http.Redirect(w, r, uri, http.StatusFound)
+	httputil.Redirect(w, r, uri, http.StatusFound)
 }
 
 func (p *Proxy) registerFwdAuthHandlers() http.Handler {
@@ -198,7 +198,7 @@ func (p *Proxy) Callback(w http.ResponseWriter, r *http.Request) {
 	}
 	redirectURL.RawQuery = q.Encode()
 
-	http.Redirect(w, r, redirectURL.String(), http.StatusFound)
+	httputil.Redirect(w, r, redirectURL.String(), http.StatusFound)
 }
 
 // ProgrammaticLogin returns a signed url that can be used to login

--- a/proxy/middleware.go
+++ b/proxy/middleware.go
@@ -51,7 +51,7 @@ func (p *Proxy) authenticate(errOnFailure bool, w http.ResponseWriter, r *http.R
 			return err
 		}
 		uri := urlutil.SignedRedirectURL(p.SharedKey, p.authenticateSigninURL, urlutil.GetAbsoluteURL(r))
-		http.Redirect(w, r, uri.String(), http.StatusFound)
+		httputil.Redirect(w, r, uri.String(), http.StatusFound)
 		return err
 	}
 	// add pomerium's headers to the downstream request


### PR DESCRIPTION
## Summary

In the event of an authentication error, the proxy service now checks incoming requests to see if they contain the `X-Requested-With` header (which is typically, but not always, a XHR request) and will  return a direct error instead of redirecting to the identity provider. 

Also,  a request header `x-pomerium-intercepted-response: true` was added to indicate to any client application when a given response was created by pomerium itself, and not the downstream application. 

See the below links for why it's rather difficult to detect whether a request is a an ajax/xhr request. 

These changes also ensure that the authenticate service (in particular, the sign_in endpoint) properly handles preflight checks which are typically made when a `302` redirect is sent to reauthenticate a user. For example...
<img width="342" alt="Screen Shot 2019-11-14 at 10 20 12 AM" src="https://user-images.githubusercontent.com/1544881/68892230-5b6fa480-06d7-11ea-8758-11d60d0fcb7b.png">

### Limitations

If the managed app does not include credentials with their request (e.g. [XMLHttpRequest.withCredentials](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/withCredentials), pomerium won't be able to refresh a session resulting in a hard failure (either `302` or `401 depending if the `xhr` request uses the `X-Requested-With` header). 

## Related issues
- https://pomerium-io.slack.com/archives/CK6SVMPU0/p1573568647179000
- https://github.com/pomerium/pomerium/issues/281

## See also
- [What's the point of the X-Requested-With header?](https://stackoverflow.com/a/22533680)
- [x-request-with is important for security](https://markitzeroday.com/x-requested-with/cors/2017/06/29/csrf-mitigation-for-ajax-requests.html)
- [but angular doesn't add x-request-with by default](https://github.com/angular/angular.js/issues/11008)
- [this is complicated, but XMLHttpRequest is now lame and fetch is the new hot](https://developers.google.com/web/updates/2015/03/introduction-to-fetch)
- [and fetch doesn't add x-request-with by default](https://stackoverflow.com/questions/45591594/fetch-does-not-send-headers)
- [so basically, detecting an AJAX request is not always reliable](https://stackoverflow.com/a/28029666)

**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
