### PR TITLE
lint: bump golangci-lint 1.21.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,10 @@
 # forked from istio
 service:
   # When updating this, also update bin/linters.sh accordingly
-  golangci-lint-version: 1.18.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.21.x # use the fixed version to not introduce new linters unexpectedly
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  deadline: 5m
+  deadline: 20m
 
   # which dirs to skip: they won't be analyzed;
   # can use regexp here: generated.*, regexp is applied on full path;
@@ -28,16 +28,20 @@ linters:
   disable:
     - depguard
     - dupl
+    - funlen
     - gochecknoglobals
     - gochecknoinits
+    - gocognit
     - goconst
     - gocyclo
+    - godox
+    - interfacer
+    - maligned
     - nakedret
     - prealloc
     - scopelint
-    - maligned
-    - interfacer
-    - funlen
+    - whitespace
+    - wsl
   fast: false
 
 linters-settings:

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ CTIMEVAR=-X $(PKG)/internal/version.GitCommit=$(GITCOMMIT) \
 	-X $(PKG)/internal/version.ProjectURL=$(PKG)
 GO_LDFLAGS=-ldflags "-s -w $(CTIMEVAR)"
 GOOSARCHES = linux/amd64 darwin/amd64 windows/amd64
-GOLANGCI_VERSION = v1.18.0 # .... for some reason v1.18.0 misses?
+GOLANGCI_VERSION = v1.21.0 # .... for some reason v1.18.0 misses?
  
 .PHONY: all
 all: clean build-deps test lint spellcheck build ## Runs a clean, build, fmt, lint, test, and vet.

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -151,7 +151,7 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		w.Header().Set("X-Content-Type-Options", "nosniff")
 		w.WriteHeader(http.StatusOK)
-		fmt.Fprintf(w, fmt.Sprintf("Access to %s is allowed.", uri.Host))
+		fmt.Fprintf(w, "Access to %s is allowed.", uri.Host)
 	})
 
 }


### PR DESCRIPTION
## Summary

Significant speed improvements in latest version of `golangci-lint`. Was hitting issues cutting local builds with deadlines.

## Related issues
- https://github.com/golangci/golangci-lint/issues/685#issuecomment-541886167


**Checklist**:
- [x] add related issues
- [x] ready for review
