### PR TITLE
authenticate: session expiry now matches identity provider's

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"html/template"
 	"net/url"
-	"time"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/cryptutil"
@@ -21,10 +20,6 @@ import (
 )
 
 const callbackPath = "/oauth2/callback"
-
-// DefaultSessionDuration is the default time a managed route session is
-// valid for.
-var DefaultSessionDuration = time.Minute * 10
 
 // ValidateOptions checks that configuration are complete and valid.
 // Returns on first error found.

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -44,6 +44,9 @@ func (a *Authenticate) Handler() http.Handler {
 	c := cors.New(cors.Options{
 		AllowOriginRequestFunc: func(r *http.Request, _ string) bool {
 			err := middleware.ValidateRequestURL(r, a.sharedKey)
+			if err != nil {
+				log.FromRequest(r).Info().Err(err).Msg("authenticate: origin blocked")
+			}
 			return err == nil
 		},
 		AllowCredentials: true,
@@ -167,7 +170,7 @@ func (a *Authenticate) SignIn(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// sign the route session, as a JWT
-	signedJWT, err := a.sharedEncoder.Marshal(newSession.RouteSession(DefaultSessionDuration))
+	signedJWT, err := a.sharedEncoder.Marshal(newSession.RouteSession())
 	if err != nil {
 		httputil.ErrorResponse(w, r, httputil.Error(err.Error(), http.StatusBadRequest, err))
 		return
@@ -333,7 +336,7 @@ func (a *Authenticate) RefreshAPI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	signedJWT, err := a.sharedEncoder.Marshal(newSession.RouteSession(DefaultSessionDuration))
+	signedJWT, err := a.sharedEncoder.Marshal(newSession.RouteSession())
 	if err != nil {
 		httputil.ErrorResponse(w, r, httputil.Error("", http.StatusInternalServerError, err))
 		return

--- a/internal/sessions/state.go
+++ b/internal/sessions/state.go
@@ -108,10 +108,8 @@ func (s State) NewSession(issuer string, audience []string) *State {
 	return &s
 }
 
-// RouteSession creates a route session with access tokens stripped and a
-// custom validity period.
-func (s State) RouteSession(validity time.Duration) *State {
-	s.Expiry = jwt.NewNumericDate(timeNow().Add(validity))
+// RouteSession creates a route session with access tokens stripped.
+func (s State) RouteSession() *State {
 	s.AccessToken = nil
 	return &s
 }

--- a/internal/sessions/state_test.go
+++ b/internal/sessions/state_test.go
@@ -99,11 +99,10 @@ func TestState_RouteSession(t *testing.T) {
 		issuer string
 
 		audience []string
-		validity time.Duration
 
 		want *State
 	}{
-		{"good", "authenticate.x.y.z", []string{"http.x.y.z"}, jwt.NewNumericDate(timeNow()), nil, "authenticate.a.b.c", []string{"http.a.b.c"}, 20 * time.Second, &State{Issuer: "authenticate.a.b.c", Audience: []string{"http.a.b.c"}, NotBefore: jwt.NewNumericDate(timeNow()), IssuedAt: jwt.NewNumericDate(timeNow()), Expiry: jwt.NewNumericDate(timeNow().Add(20 * time.Second))}},
+		{"good", "authenticate.x.y.z", []string{"http.x.y.z"}, jwt.NewNumericDate(timeNow()), nil, "authenticate.a.b.c", []string{"http.a.b.c"}, &State{Issuer: "authenticate.a.b.c", Audience: []string{"http.a.b.c"}, NotBefore: jwt.NewNumericDate(timeNow()), IssuedAt: jwt.NewNumericDate(timeNow()), Expiry: jwt.NewNumericDate(timeNow())}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -117,7 +116,7 @@ func TestState_RouteSession(t *testing.T) {
 				cmpopts.IgnoreUnexported(State{}),
 			}
 			got := s.NewSession(tt.issuer, tt.audience)
-			got = got.RouteSession(tt.validity)
+			got = got.RouteSession()
 			if diff := cmp.Diff(got, tt.want, cmpOpts...); diff != "" {
 				t.Errorf("State.RouteSession() = %s", diff)
 			}

--- a/proxy/middleware.go
+++ b/proxy/middleware.go
@@ -3,7 +3,6 @@ package proxy // import "github.com/pomerium/pomerium/proxy"
 import (
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/pomerium/pomerium/internal/encoding"
 	"github.com/pomerium/pomerium/internal/httputil"
@@ -108,7 +107,7 @@ func (p *Proxy) SignRequest(signer encoding.Marshaler) func(next http.Handler) h
 				return
 			}
 			newSession := s.NewSession(r.Host, []string{r.Host})
-			jwt, err := signer.Marshal(newSession.RouteSession(time.Minute))
+			jwt, err := signer.Marshal(newSession.RouteSession())
 			if err != nil {
 				log.FromRequest(r).Error().Err(err).Msg("proxy: failed signing jwt")
 			} else {


### PR DESCRIPTION
`XHR` thy name is pain.

## Summary

These changes make pomerium tokens match the expiry of access token from the identity provider. 

## Related issues

Though not a solution to the following issues to ( #409, #390) , does alleviate some of the frequency. 


**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
