### PR TITLE
deployment: throw away golanglint-ci defaults

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,7 +59,7 @@ linters-settings:
     check-shadowing: false
   golint:
     # minimal confidence for issues, default is 0.8
-    min-confidence: 0.0
+    min-confidence: 0.8
   gofmt:
     # simplify code: gofmt with `-s` option, true by default
     simplify: true
@@ -161,6 +161,29 @@ issues:
   # it can be disabled by `exclude-use-default: false`. To list all
   # excluded by default patterns execute `golangci-lint run --help`
   exclude:
+    ## Defaults we want from golangci-lint
+    # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+    - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+    # golint: False positive when tests are defined in package 'test'
+    - func name will be used as test\.Test.* by other packages, and that stutters; consider calling this
+    # govet: Common false positives
+    - (possible misuse of unsafe.Pointer|should have signature)
+    # staticcheck: Developers tend to write in C-style with an explicit 'break' in a 'switch', so it's ok to ignore
+    - ineffective break statement. Did you mean to break out of the outer loop
+    # gosec: Too many false-positives on 'unsafe' usage
+    - Use of unsafe calls should be audited
+    # gosec: Too many false-positives for parametrized shell calls
+    - Subprocess launch(ed with variable|ing should be audited)
+    # gosec: Duplicated errcheck checks
+    - G104
+    # gosec: Too many issues in popular repos
+    - (Expect directory permissions to be 0750 or less|Expect file permissions to be 0600 or less)
+    # gosec: False positive is triggered by 'src, err := ioutil.ReadFile(filename)'
+    - Potential file inclusion via variable
+
+    ##
+    ## Custom
+    ##
     # Mostly harmless buffer writes where we skip error checking
     # https://golang.org/pkg/bytes/#Buffer.Write
     - "Error return value of `w.Write` is not checked"
@@ -201,7 +224,7 @@ issues:
   # it can be disabled by this option. To list all
   # excluded by default patterns execute `golangci-lint run --help`.
   # Default value for this option is true.
-  exclude-use-default: true
+  exclude-use-default: false
 
   # Maximum issues count per one linter. Set to 0 to disable. Default is 50.
   max-per-linter: 0

--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -1,3 +1,5 @@
+// Package authenticate is a pomerium service that handles user authentication
+// and refersh (AuthN).
 package authenticate // import "github.com/pomerium/pomerium/authenticate"
 
 import (

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -1,3 +1,5 @@
+// Package authorize is a pomerium service that is responsible for determining
+// if a given request should be authorized (AuthZ).
 package authorize // import "github.com/pomerium/pomerium/authorize"
 
 import (

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,3 +1,6 @@
+// Package cache is a pomerium service that handles the storage of user
+// session state. It communicates over RPC with other pomerium services,
+// and can be configured to use a number of different backend cache stores.
 package cache // import "github.com/pomerium/pomerium/cache"
 
 import (

--- a/config/doc.go
+++ b/config/doc.go
@@ -1,0 +1,3 @@
+// Package config is a configuration abstraction that facilitates enabling
+// Pomerium settings  forvarious encoding types (JSON/YAML/ENVARS) and methods.
+package config // import "github.com/pomerium/pomerium/config"

--- a/config/options.go
+++ b/config/options.go
@@ -517,6 +517,9 @@ func (o *Options) Checksum() string {
 	return fmt.Sprintf("%x", hash)
 }
 
+// HandleConfigUpdate takes configuration file, an existing options struct, and
+// updates each service in the services slice OptionsUpdater with a new set of
+// options if any change is detected.
 func HandleConfigUpdate(configFile string, opt *Options, services []OptionsUpdater) *Options {
 	newOpt, err := NewOptionsFromConfig(configFile)
 	if err != nil {

--- a/internal/cryptutil/certificates.go
+++ b/internal/cryptutil/certificates.go
@@ -11,6 +11,7 @@ import (
 	"io/ioutil"
 )
 
+// CertifcateFromBase64 returns an X509 pair from a base64 encoded blob.
 func CertifcateFromBase64(cert, key string) (*tls.Certificate, error) {
 	decodedCert, err := base64.StdEncoding.DecodeString(cert)
 	if err != nil {
@@ -24,11 +25,15 @@ func CertifcateFromBase64(cert, key string) (*tls.Certificate, error) {
 	return &x509, err
 }
 
+// CertificateFromFile given a certificate, and key file path, returns a X509
+// keypair.
 func CertificateFromFile(certFile, keyFile string) (*tls.Certificate, error) {
 	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	return &cert, err
 }
 
+// CertPoolFromBase64 takes a base64 encoded string and returns a new
+// X509 certificate pool.
 func CertPoolFromBase64(encPemCerts string) (*x509.CertPool, error) {
 	b, err := base64.StdEncoding.DecodeString(encPemCerts)
 	if err != nil {
@@ -37,6 +42,7 @@ func CertPoolFromBase64(encPemCerts string) (*x509.CertPool, error) {
 	return bytesToCertPool(b)
 }
 
+// CertPoolFromFile reads a file and returns an X509 certificate pool.
 func CertPoolFromFile(pemFile string) (*x509.CertPool, error) {
 	b, err := ioutil.ReadFile(pemFile)
 	if err != nil {

--- a/internal/cryptutil/doc.go
+++ b/internal/cryptutil/doc.go
@@ -1,0 +1,3 @@
+// Package cryptutil provides cryptographic utility functions, complementing the
+// lower level abstractions found in the standard library.
+package cryptutil // import "github.com/pomerium/pomerium/internal/cryptutil"

--- a/internal/encoding/econding.go
+++ b/internal/encoding/econding.go
@@ -1,3 +1,5 @@
+// Package encoding defines interfaces shared by other packages that
+// convert data to and from byte-level and textual representations.
 package encoding // import "github.com/pomerium/pomerium/internal/encoding"
 
 // MarshalUnmarshaler can both Marshal and Unmarshal a struct into and from a set of bytes.

--- a/internal/encoding/mock/mock_encoder.go
+++ b/internal/encoding/mock/mock_encoder.go
@@ -1,3 +1,4 @@
+// Package mock implements a mock implementation of MarshalUnmarshaler.
 package mock // import "github.com/pomerium/pomerium/internal/encoding/mock"
 
 import (

--- a/internal/fileutil/fileutil.go
+++ b/internal/fileutil/fileutil.go
@@ -1,3 +1,5 @@
+// Package fileutil provides file utility functions, complementing the
+// lower level abstractions found in the standard library.
 package fileutil // import "github.com/pomerium/pomerium/internal/fileutil"
 
 import (

--- a/internal/frontend/templates.go
+++ b/internal/frontend/templates.go
@@ -1,5 +1,7 @@
 //go:generate statik -src=./assets -include=*.svg,*.html,*.css,*.js
 
+// Package frontend handles the generation, and instantiation of Pomerium's
+// html templates.
 package frontend // import "github.com/pomerium/pomerium/internal/frontend"
 
 import (

--- a/internal/grpc/authorize/client/authorize_client.go
+++ b/internal/grpc/authorize/client/authorize_client.go
@@ -1,3 +1,4 @@
+// Package client implements a gRPC client for the authorization service.
 package client
 
 import (

--- a/internal/grpc/cache/client/cache_client.go
+++ b/internal/grpc/cache/client/cache_client.go
@@ -1,3 +1,4 @@
+// Package client implements a gRPC client for the cache service.
 package client
 
 import (

--- a/internal/grpc/docs.go
+++ b/internal/grpc/docs.go
@@ -1,0 +1,3 @@
+// Package grpc provides gRPC utility functions, complementing the more
+// common ones in the github.com/grpc/grpc-go package
+package grpc // import "github.com/pomerium/pomerium/internal/grpc"

--- a/internal/grpcutil/doc.go
+++ b/internal/grpcutil/doc.go
@@ -1,0 +1,2 @@
+// Package grpcutil contains utility functions for working with gRPC.
+package grpcutil // import "github.com/pomerium/pomerium/internal/grpcutil"

--- a/internal/httputil/docs.go
+++ b/internal/httputil/docs.go
@@ -1,0 +1,3 @@
+// Package httputil provides HTTP utility functions, complementing the more
+// common ones in the net/http package
+package httputil // import "github.com/pomerium/pomerium/internal/httputil"

--- a/internal/kv/autocache/autocache.go
+++ b/internal/kv/autocache/autocache.go
@@ -1,3 +1,6 @@
+// Package autocache implements a key value store (kv.Store) using autocache
+// which combines functionality from groupcache, and memberlist libraries.
+// For more details, see https://github.com/pomerium/autocache
 package autocache
 
 import (

--- a/internal/kv/bolt/bolt.go
+++ b/internal/kv/bolt/bolt.go
@@ -1,3 +1,5 @@
+// Package bolt implements a key value store (kv.Store) using bbolt.
+// For more details, see https://github.com/etcd-io/bbolt
 package bolt
 
 import (

--- a/internal/kv/redis/redis.go
+++ b/internal/kv/redis/redis.go
@@ -1,3 +1,5 @@
+// Package redis implements a key value store (kv.Store) using redis.
+// For more details, see https://redis.io/
 package redis
 
 import (

--- a/internal/kv/store.go
+++ b/internal/kv/store.go
@@ -1,3 +1,5 @@
+// Package kv defines a Store interfaces that can be implemented by
+// datastores to provide key value storage capabilities.
 package kv
 
 import "context"

--- a/internal/middleware/responsewriter/wrap_writer.go
+++ b/internal/middleware/responsewriter/wrap_writer.go
@@ -1,3 +1,5 @@
+// Package responsewriter contains helper functions that useful for
+// hooking into various parts of a response.
 package responsewriter
 
 // The original work was derived from Goji's middleware, source:

--- a/internal/sessions/cache/cache_store.go
+++ b/internal/sessions/cache/cache_store.go
@@ -1,3 +1,5 @@
+// Package cache provides a remote cache based implementation of session store
+// and loader. See pomerium's cache service for more details.
 package cache // import "github.com/pomerium/pomerium/internal/sessions/cache"
 
 import (

--- a/internal/sessions/cookie/cookie_store.go
+++ b/internal/sessions/cookie/cookie_store.go
@@ -1,3 +1,4 @@
+// Package cookie provides a cookie based implementation of session store and loader.
 package cookie // import "github.com/pomerium/pomerium/internal/sessions/cookie"
 
 import (

--- a/internal/sessions/header/header_store.go
+++ b/internal/sessions/header/header_store.go
@@ -1,3 +1,5 @@
+// Package header provides a request header based implementation of a
+// session loader.
 package header // import "github.com/pomerium/pomerium/internal/sessions/header"
 
 import (

--- a/internal/sessions/mock/mock_store.go
+++ b/internal/sessions/mock/mock_store.go
@@ -1,3 +1,4 @@
+// Package mock provides a mock implementation of session store and loader.
 package mock // import "github.com/pomerium/pomerium/internal/sessions/mock"
 
 import (

--- a/internal/sessions/queryparam/query_store.go
+++ b/internal/sessions/queryparam/query_store.go
@@ -1,3 +1,5 @@
+// Package queryparam provides a query param based implementation of a both
+// as session store and loader.
 package queryparam // import "github.com/pomerium/pomerium/internal/sessions/queryparam"
 
 import (

--- a/internal/sessions/store.go
+++ b/internal/sessions/store.go
@@ -1,3 +1,5 @@
+// Package sessions handles the storage, management, and validation
+// of pomerium user sessions.
 package sessions // import "github.com/pomerium/pomerium/internal/sessions"
 
 import (

--- a/internal/telemetry/metrics/doc.go
+++ b/internal/telemetry/metrics/doc.go
@@ -1,0 +1,2 @@
+// Package metrics contains support for OpenCensus distributed metrics.
+package metrics // import "github.com/pomerium/pomerium/internal/telemetry/metrics"

--- a/internal/telemetry/metrics/info.go
+++ b/internal/telemetry/metrics/info.go
@@ -154,7 +154,7 @@ func SetBuildInfo(service string) {
 	registry.setBuildInfo(service)
 }
 
-// Register non-view based metrics registry globally for export
+// RegisterInfoMetrics registers non-view based metrics registry globally for export
 func RegisterInfoMetrics() {
 	metricproducer.GlobalManager().AddProducer(registry.registry)
 }

--- a/internal/telemetry/trace/doc.go
+++ b/internal/telemetry/trace/doc.go
@@ -1,0 +1,2 @@
+// Package trace contains support for OpenCensus distributed tracing.
+package trace // import "github.com/pomerium/pomerium/internal/telemetry/trace"

--- a/internal/telemetry/trace/trace.go
+++ b/internal/telemetry/trace/trace.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	// JaegerTracingProviderName is the name of the tracing provider Jaeger.
 	JaegerTracingProviderName = "jaeger"
 )
 
@@ -31,6 +32,7 @@ type TracingOptions struct {
 	JaegerAgentEndpoint string `mapstructure:"tracing_jaeger_agent_endpoint"`
 }
 
+// RegisterTracing creates a new trace exporter from TracingOptions.
 func RegisterTracing(opts *TracingOptions) error {
 	var err error
 	switch opts.Provider {

--- a/internal/tripper/roundtripper.go
+++ b/internal/tripper/roundtripper.go
@@ -1,3 +1,5 @@
+// Package tripper provides utility functions for working with the
+// http.RoundTripper interface.
 package tripper // import "github.com/pomerium/pomerium/internal/tripper"
 
 import (

--- a/internal/urlutil/url.go
+++ b/internal/urlutil/url.go
@@ -60,6 +60,7 @@ func ValidateURL(u *url.URL) error {
 	return nil
 }
 
+// DeepCopy creates a deep copy of a *url.URL
 func DeepCopy(u *url.URL) (*url.URL, error) {
 	if u == nil {
 		return nil, nil

--- a/internal/urlutil/url.go
+++ b/internal/urlutil/url.go
@@ -1,3 +1,4 @@
+// Package urlutil provides utility functions for working with go urls.
 package urlutil // import "github.com/pomerium/pomerium/internal/urlutil"
 
 import (

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,3 +1,4 @@
+// Package version enables setting build-time version using ldflags.
 package version // import "github.com/pomerium/pomerium/internal/version"
 
 import (

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -1,3 +1,7 @@
+// Package proxy is a pomerium service that provides reverse proxying of
+// internal routes. The proxy packages interoperates with other pomerium
+// services over RPC in order to make access control decisions about a
+// given incoming request.
 package proxy // import "github.com/pomerium/pomerium/proxy"
 
 import (


### PR DESCRIPTION
## Summary

TIL:  Asking programmers to comment their code is super duper "annoying" and only "the rare codebase has such comments". 

```
# golint: Annoying issue about not having a comment. The rare codebase has such comments
- (comment on exported (method|function|type|const)|should have( a package)? comment|comment should be of the form)
```

🙄 

## Related issues
- 
- https://github.com/pomerium/pomerium-operator/pull/5
- https://github.com/golang/lint/issues/186
- https://github.com/golangci/golangci-lint/issues/843
- https://github.com/golangci/golangci-lint/issues/464

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] ready for review
