### PR TITLE
proxy: move set request headers before handle allow public access

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -259,6 +259,12 @@ func (p *Proxy) reverseProxyHandler(r *mux.Router, policy config.Policy) (*mux.R
 		rp.Use(middleware.CorsBypass(proxy))
 	}
 
+	// Optional: if additional headers are to be set for this url
+	if len(policy.SetRequestHeaders) != 0 {
+		log.Warn().Interface("headers", policy.SetRequestHeaders).Msg("proxy: set request headers")
+		rp.Use(SetResponseHeaders(policy.SetRequestHeaders))
+	}
+
 	// Optional: if a public route, skip access control middleware
 	if policy.AllowPublicUnauthenticatedAccess {
 		log.Warn().Str("route", policy.String()).Msg("proxy: all access control disabled")
@@ -281,11 +287,7 @@ func (p *Proxy) reverseProxyHandler(r *mux.Router, policy config.Policy) (*mux.R
 		}
 		rp.Use(p.SignRequest(signer))
 	}
-	// Optional: if additional headers are to be set for this url
-	if len(policy.SetRequestHeaders) != 0 {
-		log.Warn().Interface("headers", policy.SetRequestHeaders).Msg("proxy: set request headers")
-		rp.Use(SetResponseHeaders(policy.SetRequestHeaders))
-	}
+
 	return r, nil
 }
 


### PR DESCRIPTION
## Summary

Bring policy set_request_headers ahead of handling AllowPublicUnauthenticatedAccess to avoiding set_request_headers was bypassed when AllowPublicUnauthenticatedAccess enabled.

## Related issues

Fixes #477 

**Checklist**:
- [x] add related issues
- [x] ready for review
