### PR TITLE
config: Expose and set default GRPC Server Keepalive Parameters

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/fsnotify/fsnotify"
 	"github.com/gorilla/mux"
-	"google.golang.org/grpc"
-
 	"github.com/pomerium/pomerium/authenticate"
 	"github.com/pomerium/pomerium/authorize"
 	"github.com/pomerium/pomerium/cache"
@@ -27,6 +25,8 @@ import (
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/internal/version"
 	"github.com/pomerium/pomerium/proxy"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 var versionFlag = flag.Bool("version", false, "prints the version")
@@ -147,7 +147,13 @@ func newGRPCServer(opt config.Options, as *authorize.Authorize, cs *cache.Cache,
 
 		}
 	}
-	so := &pgrpc.ServerOptions{Addr: opt.GRPCAddr}
+	so := &pgrpc.ServerOptions{
+		Addr: opt.GRPCAddr,
+		KeepaliveParams: keepalive.ServerParameters{
+			MaxConnectionAge:      opt.GRPCServerMaxConnectionAge,
+			MaxConnectionAgeGrace: opt.GRPCServerMaxConnectionAgeGrace,
+		},
+	}
 	if !opt.GRPCInsecure {
 		so.TLSCertificate = opt.TLSCertificate
 	}

--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -7,8 +7,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/fsnotify/fsnotify"
-	"github.com/gorilla/mux"
 	"github.com/pomerium/pomerium/authenticate"
 	"github.com/pomerium/pomerium/authorize"
 	"github.com/pomerium/pomerium/cache"
@@ -25,6 +23,9 @@ import (
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/internal/version"
 	"github.com/pomerium/pomerium/proxy"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/gorilla/mux"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 )

--- a/config/options.go
+++ b/config/options.go
@@ -171,6 +171,11 @@ type Options struct {
 	GRPCClientTimeout       time.Duration `mapstructure:"grpc_client_timeout" yaml:"grpc_client_timeout,omitempty"`
 	GRPCClientDNSRoundRobin bool          `mapstructure:"grpc_client_dns_roundrobin" yaml:"grpc_client_dns_roundrobin,omitempty"`
 
+	//GRPCServerMaxConnectionAge sets MaxConnectionAge in the grpc ServerParameters used to create GRPC Services
+	GRPCServerMaxConnectionAge time.Duration `mapstructure:"grpc_server_max_connection_age" yaml:"grpc_server_max_connection_age,omitempty"`
+	//GRPCServerMaxConnectionAgeGrace sets MaxConnectionAgeGrace in the grpc ServerParameters used to create GRPC Services
+	GRPCServerMaxConnectionAgeGrace time.Duration `mapstructure:"grpc_server_max_connection_age_grace,omitempty" yaml:"grpc_server_max_connection_age_grace,omitempty"` //nolint: lll
+
 	// ForwardAuthEndpoint allows for a given route to be used as a forward-auth
 	// endpoint instead of a reverse proxy. Some third-party proxies that do not
 	// have rich access control capabilities (nginx, envoy, ambassador, traefik)
@@ -217,17 +222,19 @@ var defaultOptions = Options{
 		"X-XSS-Protection":          "1; mode=block",
 		"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
 	},
-	Addr:                     ":443",
-	ReadHeaderTimeout:        10 * time.Second,
-	ReadTimeout:              30 * time.Second,
-	WriteTimeout:             0, // support streaming by default
-	IdleTimeout:              5 * time.Minute,
-	RefreshCooldown:          5 * time.Minute,
-	GRPCAddr:                 ":443",
-	GRPCClientTimeout:        10 * time.Second, // Try to withstand transient service failures for a single request
-	GRPCClientDNSRoundRobin:  true,
-	CacheStore:               "autocache",
-	AuthenticateCallbackPath: "/oauth2/callback",
+	Addr:                            ":443",
+	ReadHeaderTimeout:               10 * time.Second,
+	ReadTimeout:                     30 * time.Second,
+	WriteTimeout:                    0, // support streaming by default
+	IdleTimeout:                     5 * time.Minute,
+	RefreshCooldown:                 5 * time.Minute,
+	GRPCAddr:                        ":443",
+	GRPCClientTimeout:               10 * time.Second, // Try to withstand transient service failures for a single request
+	GRPCClientDNSRoundRobin:         true,
+	GRPCServerMaxConnectionAge:      5 * time.Minute,
+	GRPCServerMaxConnectionAgeGrace: 5 * time.Minute,
+	CacheStore:                      "autocache",
+	AuthenticateCallbackPath:        "/oauth2/callback",
 }
 
 // NewDefaultOptions returns a copy the default options. It's the caller's

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -219,12 +220,14 @@ func TestOptionsFromViper(t *testing.T) {
 		{"good",
 			[]byte(`{"insecure_server":true,"policy":[{"from": "https://from.example","to":"https://to.example"}]}`),
 			&Options{
-				Policies:                 []Policy{{From: "https://from.example", To: "https://to.example"}},
-				CookieName:               "_pomerium",
-				CookieSecure:             true,
-				InsecureServer:           true,
-				CookieHTTPOnly:           true,
-				AuthenticateCallbackPath: "/oauth2/callback",
+				Policies:                        []Policy{{From: "https://from.example", To: "https://to.example"}},
+				CookieName:                      "_pomerium",
+				CookieSecure:                    true,
+				InsecureServer:                  true,
+				CookieHTTPOnly:                  true,
+				GRPCServerMaxConnectionAge:      5 * time.Minute,
+				GRPCServerMaxConnectionAgeGrace: 5 * time.Minute,
+				AuthenticateCallbackPath:        "/oauth2/callback",
 				Headers: map[string]string{
 					"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
 					"X-Frame-Options":           "SAMEORIGIN",
@@ -234,13 +237,15 @@ func TestOptionsFromViper(t *testing.T) {
 		{"good disable header",
 			[]byte(`{"insecure_server":true,"headers": {"disable":"true"},"policy":[{"from": "https://from.example","to":"https://to.example"}]}`),
 			&Options{
-				Policies:                 []Policy{{From: "https://from.example", To: "https://to.example"}},
-				CookieName:               "_pomerium",
-				AuthenticateCallbackPath: "/oauth2/callback",
-				CookieSecure:             true,
-				CookieHTTPOnly:           true,
-				InsecureServer:           true,
-				Headers:                  map[string]string{}},
+				Policies:                        []Policy{{From: "https://from.example", To: "https://to.example"}},
+				CookieName:                      "_pomerium",
+				AuthenticateCallbackPath:        "/oauth2/callback",
+				CookieSecure:                    true,
+				CookieHTTPOnly:                  true,
+				InsecureServer:                  true,
+				GRPCServerMaxConnectionAge:      5 * time.Minute,
+				GRPCServerMaxConnectionAgeGrace: 5 * time.Minute,
+				Headers:                         map[string]string{}},
 			false},
 		{"bad url", []byte(`{"policy":[{"from": "https://","to":"https://to.example"}]}`), nil, true},
 		{"bad policy", []byte(`{"policy":[{"allow_public_unauthenticated_access": "dog","to":"https://to.example"}]}`), nil, true},

--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -198,6 +198,30 @@ Enable grpc DNS based round robin load balancing. This method uses DNS to resolv
 - Type: `bool`
 - Default: `true`
 
+#### GRPC Server Max Connection Age
+
+Set max connection age for GRPC servers.  After this interval, servers ask clients to reconnect and perform any rediscovery for new/updated endpoints from DNS.  
+
+See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for details
+
+- Environmental Variable: `GRPC_SERVER_MAX_CONNECTION_AGE`
+- Config File Key: `grpc_server_max_connection_age`
+- Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
+- Default: `5m`
+
+
+#### GRPC Server Max Connection Age Grace
+
+Additive period with `grpc_server_max_connection_age`, after which servers will force connections to close.
+
+See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for details
+
+- Environmental Variable: `GRPC_SERVER_MAX_CONNECTION_AGE_GRACE`
+- Config File Key: `grpc_server_max_connection_age_grace`
+- Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
+- Default: `5m`
+
+
 ### Cookie options
 
 These settings control the Pomerium session cookies sent to users's
@@ -335,8 +359,8 @@ Each unit work is called a Span in a trace. Spans include metadata about the wor
 
 | Config Key       | Description                                                       | Required |
 | :--------------- | :---------------------------------------------------------------- | -------- |
-| tracing_provider | The name of the tracing provider. (e.g. jaeger)                   | ✅       |
-| tracing_debug    | Will disable [sampling](https://opencensus.io/tracing/sampling/). | ❌       |
+| tracing_provider | The name of the tracing provider. (e.g. jaeger)                   | ✅        |
+| tracing_debug    | Will disable [sampling](https://opencensus.io/tracing/sampling/). | ❌        |
 
 #### Jaeger
 
@@ -350,8 +374,8 @@ Each unit work is called a Span in a trace. Spans include metadata about the wor
 
 | Config Key                        | Description                                 | Required |
 | :-------------------------------- | :------------------------------------------ | -------- |
-| tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅       |
-| tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅       |
+| tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅        |
+| tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅        |
 
 #### Example
 

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/keepalive"

--- a/internal/grpc/server.go
+++ b/internal/grpc/server.go
@@ -10,9 +10,9 @@ import (
 
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
-
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/keepalive"
 )
 
 // NewServer creates a new gRPC serve.
@@ -27,7 +27,10 @@ func NewServer(opt *ServerOptions, registrationFn func(s *grpc.Server), wg *sync
 	if err != nil {
 		return nil, err
 	}
-	grpcOpts := []grpc.ServerOption{grpc.StatsHandler(metrics.NewGRPCServerStatsHandler(opt.Addr))}
+	grpcOpts := []grpc.ServerOption{
+		grpc.StatsHandler(metrics.NewGRPCServerStatsHandler(opt.Addr)),
+		grpc.KeepaliveParams(opt.KeepaliveParams),
+	}
 
 	if opt.TLSCertificate != nil {
 		log.Debug().Str("addr", opt.Addr).Msg("internal/grpc: serving over TLS")
@@ -65,6 +68,8 @@ type ServerOptions struct {
 	// In this mode, Pomerium is susceptible to man-in-the-middle attacks.
 	// This should be used only for testing.
 	InsecureServer bool
+
+	KeepaliveParams keepalive.ServerParameters
 }
 
 var defaultServerOptions = &ServerOptions{

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/pomerium/pomerium/internal/cryptutil"
+
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 )

--- a/internal/grpc/server_test.go
+++ b/internal/grpc/server_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pomerium/pomerium/internal/cryptutil"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
 )
 
 const privKey = `-----BEGIN EC PRIVATE KEY-----
@@ -46,6 +47,7 @@ func TestNewServer(t *testing.T) {
 		wantErr        bool
 	}{
 		{"simple", &ServerOptions{Addr: ":0"}, func(s *grpc.Server) {}, &sync.WaitGroup{}, false, false},
+		{"simple keepalive options", &ServerOptions{Addr: ":0", KeepaliveParams: keepalive.ServerParameters{MaxConnectionAge: 5 * time.Minute}}, func(s *grpc.Server) {}, &sync.WaitGroup{}, false, false},
 		{"bad tcp port", &ServerOptions{Addr: ":9999999"}, func(s *grpc.Server) {}, &sync.WaitGroup{}, true, true},
 		{"with certs", &ServerOptions{Addr: ":0", TLSCertificate: certb64}, func(s *grpc.Server) {}, &sync.WaitGroup{}, false, false},
 	}


### PR DESCRIPTION
## Summary
As of v0.26, go-grpc no longer polls DNS regularly for endpoint updates.  Discovery is only performed when a client detects a state change.  This is triggered during error conditions, but routine scaling operations in an otherwise functioning environment may leave endpoints underutilized.  To ensure we occasionally re-discover endpoints even when no connection errors have been encountered, the recommended pattern is to set server side options which gracefully terminate client connections at regular intervals.

This PR sets a reasonable default (5m) for this occasional termination and allows users to configure it further for their environments if needed.

Reference documentation - https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters

## Related issues
https://github.com/grpc/grpc-go/pull/3165
https://github.com/grpc/grpc-go/pull/3228
https://github.com/grpc/grpc-go/issues/3353#issuecomment-582040107

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] ready for review
