### PR TITLE
config: Remove superfluous Options.Checksum type conversions

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -60,7 +60,7 @@ func newPolicyEvaluator(opts *config.Options) (evaluator.Evaluator, error) {
 // UpdateOptions implements the OptionsUpdater interface and updates internal
 // structures based on config.Options
 func (a *Authorize) UpdateOptions(opts config.Options) error {
-	log.Info().Str("checksum", opts.Checksum()).Msg("authorize: updating options")
+	log.Info().Str("checksum", fmt.Sprintf("%x", opts.Checksum())).Msg("authorize: updating options")
 	var err error
 	if a.pe, err = newPolicyEvaluator(&opts); err != nil {
 		return err

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -191,10 +191,10 @@ func Test_Checksum(t *testing.T) {
 	newChecksum := o.Checksum()
 
 	if newChecksum == oldChecksum {
-		t.Errorf("Checksum() failed to update old = %s, new = %s", oldChecksum, newChecksum)
+		t.Errorf("Checksum() failed to update old = %d, new = %d", oldChecksum, newChecksum)
 	}
 
-	if newChecksum == "" || oldChecksum == "" {
+	if newChecksum == 0 || oldChecksum == 0 {
 		t.Error("Checksum() not returning data")
 	}
 

--- a/internal/telemetry/metrics/info.go
+++ b/internal/telemetry/metrics/info.go
@@ -55,7 +55,7 @@ var (
 
 // SetConfigInfo records the status, checksum and timestamp of a configuration
 // reload. You must register InfoViews or the related config views before calling
-func SetConfigInfo(service string, success bool, checksum string) {
+func SetConfigInfo(service string, success bool) {
 
 	if success {
 		serviceTag := tag.Insert(TagKeyService, service)

--- a/internal/telemetry/metrics/info_test.go
+++ b/internal/telemetry/metrics/info_test.go
@@ -15,19 +15,18 @@ func Test_SetConfigInfo(t *testing.T) {
 	tests := []struct {
 		name                  string
 		success               bool
-		checksum              string
 		wantLastReload        string
 		wantLastReloadSuccess string
 	}{
-		{"success", true, "abcde", "{ { {service test_service} }&{1.", "{ { {service test_service} }&{1} }"},
-		{"failed", false, "abcde", "", "{ {  }&{0} }"},
+		{"success", true, "{ { {service test_service} }&{1.", "{ { {service test_service} }&{1} }"},
+		{"failed", false, "", "{ {  }&{0} }"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			view.Unregister(InfoViews...)
 			view.Register(InfoViews...)
-			SetConfigInfo("test_service", tt.success, tt.checksum)
+			SetConfigInfo("test_service", tt.success)
 
 			testDataRetrieval(ConfigLastReloadView, t, tt.wantLastReload)
 			testDataRetrieval(ConfigLastReloadSuccessView, t, tt.wantLastReloadSuccess)

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -182,7 +182,7 @@ func (p *Proxy) UpdateOptions(o config.Options) error {
 	if p == nil {
 		return nil
 	}
-	log.Info().Msg("proxy: updating options")
+	log.Info().Str("checksum", fmt.Sprintf("%x", o.Checksum())).Msg("proxy: updating options")
 	return p.UpdatePolicies(&o)
 }
 


### PR DESCRIPTION
## Summary
Return uint64 from Options.Checksum to reduce type conversions and other complexity.

config: Change Options.Checksum return signature
config: Ensure metrics are updated with correct checksum
authorize: Match new Checksum return type
telemetry/metrics: remove unused field in `SetConfigInfo`
proxy: log checksum changes

## Related issues
Fixes #449 


**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
