### PR TITLE
Make IDP_PROVIDER env var mandatory

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -39,6 +39,9 @@ func ValidateOptions(o config.Options) error {
 	if err := urlutil.ValidateURL(o.AuthenticateURL); err != nil {
 		return fmt.Errorf("authenticate: invalid 'AUTHENTICATE_SERVICE_URL': %w", err)
 	}
+	if o.Provider == "" {
+		return errors.New("authenticate: 'IDP_PROVIDER' is required")
+	}
 	if o.ClientID == "" {
 		return errors.New("authenticate: 'IDP_CLIENT_ID' is required")
 	}


### PR DESCRIPTION
## Summary

Make sure the `IDP_PROVIDER` environment variable is populated and spew out a useful error message.

**Checklist**:
- [ ] add related issues - N/A
- [x] updated docs - Already OK
- [ ] updated unit tests - No coverage for mandatory env vars yet
- [ ] updated UPGRADING.md - N/A
- [x] ready for review
