### PR TITLE
move comma string slice util under x/xstrings

### DIFF
--- a/cmd/pomerium-cli/cli.go
+++ b/cmd/pomerium-cli/cli.go
@@ -16,22 +16,6 @@ import (
 	"gopkg.in/square/go-jose.v2/jwt"
 )
 
-type stringSlice []string
-
-func (i *stringSlice) String() string {
-	return fmt.Sprint(*i)
-}
-
-func (i *stringSlice) Set(value string) error {
-	if len(*i) > 0 {
-		return errors.New("already set")
-	}
-	for _, dt := range strings.Split(value, ",") {
-		*i = append(*i, dt)
-	}
-	return nil
-}
-
 type serviceAccount struct {
 	// Standard claims (as specified in RFC 7519).
 	jwt.Claims
@@ -60,9 +44,9 @@ func run() error {
 	// temporary variables we will use to hydrate our service account
 	// struct from basic types pulled in from our flags
 	var (
-		aud               stringSlice
-		groups            stringSlice
-		impersonateGroups stringSlice
+		aud               xstrings.CommaSlice
+		groups            xstrings.CommaSlice
+		impersonateGroups xstrings.CommaSlice
 		expiry            time.Duration
 	)
 

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/spf13/viper v1.6.2
+	github.com/stretchr/testify v1.5.1
 	github.com/uber/jaeger-client-go v2.20.1+incompatible // indirect
 	go.etcd.io/bbolt v1.3.4
 	go.opencensus.io v0.22.3

--- a/go.sum
+++ b/go.sum
@@ -344,6 +344,8 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/x/doc.go
+++ b/x/doc.go
@@ -1,0 +1,5 @@
+// Pacage x hosts packages that;
+// * starts with an `x` prefix where those can be considered extended versions of
+//   their original std or 3rd party package parents.
+// * or generic packages by their own that can be reused anywhere.
+package x

--- a/x/xstrings/slice.go
+++ b/x/xstrings/slice.go
@@ -1,0 +1,32 @@
+package xslice
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	// errAlreadySet returned if values set once.
+	errAlreadySet = errors.New("already set")
+)
+
+// CommaSlice is a slice that supports comma seperated strings
+// to be set to itself.
+type CommaSlice []string
+
+// String returns a string representation of slice.
+func (s *CommaSlice) String() string {
+	return fmt.Sprint(*s)
+}
+
+// Set sets comma seperated values to slice.
+func (s *CommaSlice) Set(value string) error {
+	if len(*s) > 0 {
+		return errAlreadySet
+	}
+	for _, dt := range strings.Split(value, ",") {
+		*s = append(*s, dt)
+	}
+	return nil
+}

--- a/x/xstrings/slice_test.go
+++ b/x/xstrings/slice_test.go
@@ -1,0 +1,19 @@
+package xslice
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommaSlice(t *testing.T) {
+	var (
+		s       CommaSlice
+		values  = []string{"a", "b"}
+		cvalues = strings.Join(values, ",")
+	)
+	require.Equal(t, nil, s.Set(cvalues), "should set once")
+	require.Equal(t, values, []string(s))
+	require.Equal(t, errAlreadySet, s.Set(cvalues), "should not set more than once")
+}


### PR DESCRIPTION
related to #564.

* initialized `x` packages.

## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues
<!-- For example...
Fixes #159 
-->


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
