### PR TITLE
gitlab/identity: change group unique identifier to ID

### DIFF
--- a/docs/docs/identity-providers/gitlab.md
+++ b/docs/docs/identity-providers/gitlab.md
@@ -23,11 +23,13 @@ Name         | The name of your web app
 Redirect URI | `https://${authenticate_service_url}/oauth2/callback`
 Scopes       | **Must** select **read_user** and **openid**
 
+[Group ID](https://docs.gitlab.com/ee/api/groups.html#details-of-a-group) will be used to affirm group(s) a user belongs to.
+
 Your `Client ID` and `Client Secret` will be displayed:
 
 ![Gitlab OAuth Client ID and Secret](./img/gitlab/gitlab-credentials.png)
 
-Set `Client ID` and `Client Secret` in Pomerium's settings. Your [environmental variables] should look something like this.
+Set `Client ID` and `Client Secret` in Pomerium's settings. Your environment variables should look something like this.
 
 ```bash
 authenticate_service_url: https://authenticate.localhost.pomerium.io


### PR DESCRIPTION
## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->
Based on our discussion in the [dev](https://pomerium-io.slack.com/archives/CUTRU68LA/p1584430862014100) slack channel, the unique identifier for a GitLab's group is changed from name to full_path.
## Related issues
<!-- For example...
Fixes #159 
-->
An improvement on this PR [#518](https://github.com/pomerium/pomerium/pull/518).

**Checklist**:
- [X] add related issues
- [X] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] ready for review
