### PR TITLE
Add configurable JWT claim headers

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -135,6 +135,9 @@ type Options struct {
 	HeadersEnv string            `yaml:",omitempty"`
 	Headers    map[string]string `yaml:",omitempty"`
 
+	// List of JWT claims to insert as x-pomerium-claim-* headers on proxied requests
+	JWTClaimsHeaders []string `mapstructure:"jwt_claims_headers" yaml:"jwt_claims_headers,omitempty"`
+
 	// RefreshCooldown limits the rate a user can refresh her session
 	RefreshCooldown time.Duration `mapstructure:"refresh_cooldown" yaml:"refresh_cooldown,omitempty"`
 

--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -681,9 +681,9 @@ Default Upstream Timeout is the default timeout applied to a proxied route when 
 - Example: `email,groups`, `user`
 - Optional
   
-Set this option for the pomerium proxy to copy JWT claim information into request headers with the name `x-pomerium-claim-*`.  Any claim listed in the pomerium JWT can be placed into a header of the same name for downstream consumption.
+Set this option for the pomerium proxy to copy JWT claim information into request headers with the name `x-pomerium-claim-*`.  Any claim listed in the pomerium JWT can be placed into a header of the same name for downstream consumption.  This claim information sourced from your IDP and pomerium's own session metadata.
 
-Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}` for downstream authN/Z.
+Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}` for downstream authN/Z.  
 
 ## Cache Service
 

--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -674,6 +674,17 @@ Refresh cooldown is the minimum amount of time between allowed manually refreshe
 
 Default Upstream Timeout is the default timeout applied to a proxied route when no `timeout` key is specified by the policy.
 
+### JWT Claim Headers
+- Environmental Variable: `JWT_CLAIMS_HEADERS`
+- Config File Key: `jwt_claims_headers`
+- Type: `string list`
+- Example: `email,groups`, `user`
+- Optional
+  
+Set this option for the pomerium proxy to copy JWT claim information into request headers with the name `x-pomerium-claim-*`.  Any claim listed in the pomerium JWT can be placed into a header of the same name for downstream consumption.
+
+Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}` for downstream authN/Z.
+
 ## Cache Service
 
 The cache service is used for storing user session data.

--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -681,7 +681,7 @@ Default Upstream Timeout is the default timeout applied to a proxied route when 
 - Example: `email,groups`, `user`
 - Optional
   
-Set this option for the pomerium proxy to copy JWT claim information into request headers with the name `x-pomerium-claim-*`.  Any claim listed in the pomerium JWT can be placed into a header of the same name for downstream consumption.  This claim information sourced from your IDP and pomerium's own session metadata.
+Set this option for the pomerium proxy to copy JWT claim information into request headers with the name `x-pomerium-claim-*`.  Any claim listed in the pomerium JWT can be placed into a corresponding header for downstream consumption.  This claim information is sourced from your IDP and pomerium's own session metadata.
 
 Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}` for downstream authN/Z.  
 

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -13,6 +13,8 @@ description: >-
 
 User detail headers ( `x-pomerium-authenticated-user-id` / `x-pomerium-authenticated-user-email` / `x-pomerium-authenticated-user-groups`) have been removed in favor of using the more secure, more data rich attestation jwt header (`x-pomerium-jwt-assertion`).
 
+If you still rely on individual claim headers, please see the `jwt_claims_headers` option [here](https://www.pomerium.io/configuration/#jwt-claim-headers).
+
 ### Non-standard port users
 
 Non-standard port users (e.g. those not using `443`/`80` where the port _would_ be part of the client's request) will have to clear their user's session before upgrading. Starting with version v0.7.0, audience (`aud`) and issuer (`iss`) claims will be port specific.

--- a/proxy/middleware_test.go
+++ b/proxy/middleware_test.go
@@ -72,7 +72,7 @@ func TestProxy_AuthenticateSession(t *testing.T) {
 			r = r.WithContext(ctx)
 			r.Header.Set("Accept", "application/json")
 			w := httptest.NewRecorder()
-			got := a.userDetailsLoggerMiddleware(a.AuthenticateSession(fn))
+			got := a.jwtClaimMiddleware(a.AuthenticateSession(fn))
 			got.ServeHTTP(w, r)
 			if status := w.Code; status != tt.wantStatus {
 				t.Errorf("AuthenticateSession() error = %v, wantErr %v\n%v", w.Result().StatusCode, tt.wantStatus, w.Body.String())


### PR DESCRIPTION
## Summary
Introduce configuration to add arbitrary JWT claims as headers in proxied requests.

## Related issues
Closes #585 

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
