### PR TITLE
deployment: Improve docker mutable tag publishing

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -93,7 +93,6 @@ snapshot:
 dockers:
   - image_templates:
       - "pomerium/pomerium:{{ .Tag }}"
-      - "pomerium/pomerium:latest"
     dockerfile: .github/Dockerfile-release
     binaries:
       - pomerium
@@ -111,7 +110,6 @@ dockers:
   - goarch: arm64
     image_templates:
       - "pomerium/pomerium:arm64v8-{{ .Tag }}"
-      - "pomerium/pomerium:arm64v8-latest"
     dockerfile: .github/Dockerfile-release.arm64v8
     binaries:
       - pomerium
@@ -130,7 +128,6 @@ dockers:
     goarm: 7
     image_templates:
       - "pomerium/pomerium:arm32v7-{{ .Tag }}"
-      - "pomerium/pomerium:arm32v7-latest"
     dockerfile: .github/Dockerfile-release.arm32v7
     binaries:
       - pomerium
@@ -150,7 +147,6 @@ dockers:
     goarm: 6
     image_templates:
       - "pomerium/pomerium:arm32v6-{{ .Tag }}"
-      - "pomerium/pomerium:arm32v6-latest"
     dockerfile: .github/Dockerfile-release.arm32v6
     binaries:
       - pomerium

--- a/.github/workflows/docker-master.yaml
+++ b/.github/workflows/docker-master.yaml
@@ -1,0 +1,19 @@
+name: Docker Tag - Master
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Docker Publish - Master
+        uses: zenato/docker-action@master
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: pomerium/pomerium
+          tag: master

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,3 +30,28 @@ jobs:
           args: release --config .github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get tag name
+        id: tagName
+        uses: olegtarasov/get-tag@v1
+
+      - name: Find latest tag
+        id: latestTag
+        run: |
+          LATEST_TAG=$(git tag | sort --version-sort | tail -1)
+          echo "::set-env name=LATEST_TAG::$LATEST_TAG"
+
+      - name: Publish latest tag
+        if: "env.LATEST_TAG == steps.tagName.outputs.tag"
+        run: |
+          docker tag pomerium/pomerium:${{ env.LATEST_TAG }} pomerium/pomerium:latest
+          docker push pomerium/pomerium:latest
+
+          docker tag pomerium/pomerium:arm32v7-${{ env.LATEST_TAG }} pomerium/pomerium:arm32v7-latest
+          docker push pomerium/pomerium:arm32v7-latest
+
+          docker tag pomerium/pomerium:arm32v6-${{ env.LATEST_TAG }} pomerium/pomerium:arm32v6-latest
+          docker push pomerium/pomerium:arm32v6-latest
+
+          docker tag pomerium/pomerium:arm64v8-${{ env.LATEST_TAG }} pomerium/pomerium:arm64v8-latest
+          docker push pomerium/pomerium:arm64v8-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 RUN make
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/base:debug
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml


### PR DESCRIPTION
## Summary
Update docker image publishing to:

- publish a `master` image on pushes to master
- use alpine for `master` image to allow for easier debugging
- publish `latest` images only on when the release tag is the latest version, to skip cherry picked releases to older versions

**Checklist**:
- [x] ready for review
