### PR TITLE
docs: update upgrading / changelog to v0.7.2

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,18 +1,18 @@
 // .vuepress/config.js
 module.exports = {
-  // title: "Pomerium",
+  title: "Pomerium",
   description:
     "Pomerium is a beyond-corp inspired, zero trust, open source identity-aware access proxy.",
   plugins: {
     sitemap: {
-      hostname: "https://www.pomerium.io",
+      hostname: "https://www.pomerium.io"
     },
     "@vuepress/google-analytics": {
-      ga: "UA-129872447-2",
-    },
+      ga: "UA-129872447-2"
+    }
   },
   markdown: {
-    externalLinkSymbol: false,
+    externalLinkSymbol: false
   },
   themeConfig: {
     logo: "/logo-long-civez.png",
@@ -38,13 +38,13 @@ module.exports = {
           { text: "v0.4.x", link: "https://0-4-0.docs.pomerium.io/docs" },
           { text: "v0.3.x", link: "https://0-3-0.docs.pomerium.io/docs" },
           { text: "v0.2.x", link: "https://0-2-0.docs.pomerium.io/docs" },
-          { text: "v0.1.x", link: "https://0-1-0.docs.pomerium.io/docs" },
-        ],
-      },
+          { text: "v0.1.x", link: "https://0-1-0.docs.pomerium.io/docs" }
+        ]
+      }
     ],
     algolia: {
       apiKey: "1653e881f3a6c17d3ad37f4d4c428e20",
-      indexName: "pomerium",
+      indexName: "pomerium"
     },
     sidebar: {
       "/docs/": [
@@ -59,8 +59,8 @@ module.exports = {
             "releases",
             "upgrading",
             "CHANGELOG",
-            "FAQ",
-          ],
+            "FAQ"
+          ]
         },
         {
           title: "Quick Start",
@@ -74,8 +74,8 @@ module.exports = {
             "quick-start/helm",
             "quick-start/kubernetes",
             "quick-start/synology",
-            "quick-start/from-source",
-          ],
+            "quick-start/from-source"
+          ]
         },
         {
           title: "Identity Providers",
@@ -90,8 +90,8 @@ module.exports = {
             "identity-providers/gitlab",
             "identity-providers/google",
             "identity-providers/okta",
-            "identity-providers/one-login",
-          ],
+            "identity-providers/one-login"
+          ]
         },
         {
           title: "Community",
@@ -103,8 +103,8 @@ module.exports = {
             "community/",
             "community/contributing",
             "community/code-of-conduct",
-            "community/security",
-          ],
+            "community/security"
+          ]
         },
         {
           title: "Reference",
@@ -118,9 +118,9 @@ module.exports = {
             "reference/impersonation",
             "reference/programmatic-access",
             "reference/getting-users-identity",
-            "reference/production-deployment",
-          ],
-        },
+            "reference/production-deployment"
+          ]
+        }
       ],
       "/recipes/": [
         {
@@ -129,8 +129,8 @@ module.exports = {
 
           collapsable: false,
           sidebarDepth: 1,
-          children: ["", "ad-guard", "vs-code-server", "kubernetes"],
-        },
+          children: ["", "ad-guard", "vs-code-server", "kubernetes"]
+        }
       ],
       "/enterprise/": [
         {
@@ -138,8 +138,8 @@ module.exports = {
           type: "group",
           collapsable: false,
           sidebarDepth: 1,
-          children: [""],
-        },
+          children: [""]
+        }
       ],
       "/configuration/": [
         {
@@ -147,9 +147,9 @@ module.exports = {
           type: "group",
           collapsable: false,
           sidebarDepth: 1,
-          children: ["", "examples"],
-        },
-      ],
-    },
-  },
+          children: ["", "examples"]
+        }
+      ]
+    }
+  }
 };

--- a/docs/.vuepress/styles/palette.styl
+++ b/docs/.vuepress/styles/palette.styl
@@ -48,6 +48,14 @@ $MQMobileNarrow = 419px
     &:hover, &.router-link-active
       color lighten($textColor, 8%) !important
 
+
+.dropdown-wrapper
+  .dropdown-title
+    color $navbar-text-color !important
+  .nav-dropdown
+    .dropdown-item
+      color $textColor !important
+
 @media (min-width: $MQMobile)
   .nav-links a
     &:hover, &.router-link-active
@@ -56,19 +64,6 @@ $MQMobileNarrow = 419px
     &:hover, &.router-link-active
       margin-bottom -2px
       border-bottom 2px solid lighten($navbar-text-color, 8%) !important
-
-
-
-.dropdown-wrapper
-  .dropdown-title
-    color $navbar-text-color !important
-    
-@media (max-width: $MQMobile)
-  .dropdown-wrapper
-    .dropdown-title
-      color $textColor !important
-
-@media (min-width: $MQMobile)
   .dropdown-wrapper
     .dropdown-title
       color $navbar-text-color !important

--- a/docs/.vuepress/styles/palette.styl
+++ b/docs/.vuepress/styles/palette.styl
@@ -42,6 +42,8 @@ $MQMobileNarrow = 419px
     background-color: $navbar-background !important
     color: $navbar-text-color !important
     padding-left 0rem
+  .site-name
+    display: none !important 
 
 .nav-links
   a
@@ -70,3 +72,8 @@ $MQMobileNarrow = 419px
     .nav-dropdown
       .dropdown-item
         color $textColor !important
+
+@media (max-width: $MQMobile)
+  .navbar
+    .site-name
+      display: none !important 

--- a/docs/.vuepress/styles/palette.styl
+++ b/docs/.vuepress/styles/palette.styl
@@ -51,7 +51,7 @@ $MQMobileNarrow = 419px
 
 .dropdown-wrapper
   .dropdown-title
-    color $navbar-text-color !important
+    color $textColor !important
   .nav-dropdown
     .dropdown-item
       color $textColor !important
@@ -67,3 +67,6 @@ $MQMobileNarrow = 419px
   .dropdown-wrapper
     .dropdown-title
       color $navbar-text-color !important
+    .nav-dropdown
+      .dropdown-item
+        color $textColor !important

--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -680,7 +680,7 @@ Default Upstream Timeout is the default timeout applied to a proxied route when 
 
 The JWT Claim Headers setting allows you to pass specific user session data down to downstream applications as HTTP request headers. Note, unlike the header `x-pomerium-jwt-assertion` these values are not signed by the authorization service.
 
-Any claim in the pomerium session JWT can be placed into a corresponding header for downstream consumption. This claim information is sourced from your IDP and pomerium's own session metadata.
+Any claim in the pomerium session JWT can be placed into a corresponding header for downstream consumption. This claim information is sourced from your Identity Provider (IdP) and Pomerium's own session metadata.
 
 Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}` for downstream authN/Z.
 

--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -80,7 +80,7 @@ Enabling the debug flag will result in sensitive information being logged!!!
 
 :::
 
-By default, JSON encoded logs are produced. Debug enables colored, human-readable logs to be streamed to [standard out](<https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)>). In production, it's recommended to be set to `false`.
+By default, JSON encoded logs are produced. Debug enables colored, human-readable logs to be streamed to [standard out](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)>). In production, it's recommended to be set to `false`.
 
 For example, if `true`
 
@@ -122,7 +122,9 @@ Turning on insecure server mode will result in pomerium starting, and operating 
 This setting can be useful in a situation where you have Pomerium behind a TLS terminating ingress or proxy. However, even in that case, it is highly recommended to use TLS to protect the confidentiality and integrity of service communication even behind the ingress using self-signed certificates or an internal CA. Please see our helm-chart for an example of just that.
 
 :::warning
+
 Pomerium should _never_ be exposed to the internet without TLS encryption.
+
 :::
 
 ### Certificate
@@ -202,7 +204,7 @@ Enable grpc DNS based round robin load balancing. This method uses DNS to resolv
 
 Set max connection age for GRPC servers. After this interval, servers ask clients to reconnect and perform any rediscovery for new/updated endpoints from DNS.
 
-See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for details
+See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> for details
 
 - Environmental Variable: `GRPC_SERVER_MAX_CONNECTION_AGE`
 - Config File Key: `grpc_server_max_connection_age`
@@ -213,7 +215,7 @@ See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for deta
 
 Additive period with `grpc_server_max_connection_age`, after which servers will force connections to close.
 
-See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for details
+See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> for details
 
 - Environmental Variable: `GRPC_SERVER_MAX_CONNECTION_AGE_GRACE`
 - Config File Key: `grpc_server_max_connection_age_grace`
@@ -222,8 +224,7 @@ See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters for deta
 
 ### Cookie options
 
-These settings control the Pomerium session cookies sent to users's
-browsers.
+These settings control the Pomerium session cookies sent to users's browsers.
 
 #### Cookie name
 
@@ -240,8 +241,7 @@ The name of the session cookie sent to clients.
 - Config File Key: `cookie_secret`
 - Type: [base64 encoded] `string`
 
-Secret used to encrypt and sign session cookies. You can generate a
-random key with `head -c32 /dev/urandom | base64`.
+Secret used to encrypt and sign session cookies. You can generate a random key with `head -c32 /dev/urandom | base64`.
 
 #### Cookie domain
 
@@ -251,8 +251,7 @@ random key with `head -c32 /dev/urandom | base64`.
 - Example: `corp.beyondperimeter.com`
 - Optional
 
-The scope of session cookies issued by Pomerium. Session cookies will
-be shared by all subdomains of the domain specified here.
+The scope of session cookies issued by Pomerium. Session cookies will be shared by all subdomains of the domain specified here.
 
 #### HTTPS only
 
@@ -261,12 +260,12 @@ be shared by all subdomains of the domain specified here.
 - Type: `bool`
 - Default: `true`
 
-If true, instructs browsers to only send user session cookies over
-HTTPS.
+If true, instructs browsers to only send user session cookies over HTTPS.
 
 :::warning
-Setting this to false may result in session cookies being sent in
-cleartext.
+
+Setting this to false may result in session cookies being sent in cleartext.
+
 :::
 
 #### Javascript security
@@ -276,12 +275,12 @@ cleartext.
 - Type: `bool`
 - Default: `true`
 
-If true, prevents javascript in browsers from reading user session
-cookies.
+If true, prevents javascript in browsers from reading user session cookies.
 
 :::warning
-Setting this to false enables hostile javascript to steal session
-cookies and impersonate users.
+
+Setting this to false enables hostile javascript to steal session cookies and impersonate users.
+
 :::
 
 #### Expiration
@@ -291,9 +290,7 @@ cookies and impersonate users.
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
 - Default: `14h`
 
-Sets the lifetime of session cookies. After this interval, users will
-be forced to go through the OAuth login flow again to get a new
-cookie.
+Sets the lifetime of session cookies. After this interval, users will be forced to go through the OAuth login flow again to get a new cookie.
 
 ### HTTP Redirect Address
 
@@ -324,63 +321,62 @@ Expose a prometheus format HTTP endpoint on the specified port. Disabled by defa
 
 **Metrics tracked**
 
-| Name                                          | Type      | Description                                                             |
-| --------------------------------------------- | --------- | ----------------------------------------------------------------------- |
-| boltdb_free_alloc_size_bytes                  | Gauge     | Bytes allocated in free pages                                           |
-| boltdb_free_page_n                            | Gauge     | Number of free pages on the freelist                                    |
-| boltdb_freelist_inuse_size_bytes              | Gauge     | Bytes used by the freelist                                              |
-| boltdb_open_txn                               | Gauge     | number of currently open read transactions                              |
-| boltdb_pending_page_n                         | Gauge     | Number of pending pages on the freelist                                 |
-| boltdb_txn                                    | Gauge     | total number of started read transactions                               |
-| boltdb_txn_cursor_total                       | Counter   | Total number of cursors created                                         |
-| boltdb_txn_node_deref_total                   | Counter   | Total number of node dereferences                                       |
-| boltdb_txn_node_total                         | Counter   | Total number of node allocations                                        |
-| boltdb_txn_page_alloc_size_bytes_total        | Counter   | Total bytes allocated                                                   |
-| boltdb_txn_page_total                         | Counter   | Total number of page allocations                                        |
-| boltdb_txn_rebalance_duration_ms_total        | Counter   | Total time spent rebalancing                                            |
-| boltdb_txn_rebalance_total                    | Counter   | Total number of node rebalances                                         |
-| boltdb_txn_spill_duration_ms_total            | Counter   | Total time spent spilling                                               |
-| boltdb_txn_spill_total                        | Counter   | Total number of nodes spilled                                           |
-| boltdb_txn_split_total                        | Counter   | Total number of nodes split                                             |
-| boltdb_txn_write_duration_ms_total            | Counter   | Total time spent writing to disk                                        |
-| boltdb_txn_write_total                        | Counter   | Total number of writes performed                                        |
-| groupcache_cache_hits_total                   | Counter   | Total cache hits in local or cluster cache                              |
-| groupcache_cache_hits_total                   | Counter   | Total cache hits in local or cluster cache                              |
-| groupcache_gets_total                         | Counter   | Total get request, including from peers                                 |
-| groupcache_loads_deduped_total                | Counter   | gets without cache hits after duplicate suppression                     |
-| groupcache_loads_total                        | Counter   | Total gets without cache hits                                           |
-| groupcache_local_load_errs_total              | Counter   | Total local load errors                                                 |
-| groupcache_local_loads_total                  | Counter   | Total good local loads                                                  |
-| groupcache_peer_errors_total                  | Counter   | Total errors from peers                                                 |
-| groupcache_peer_loads_total                   | Counter   | Total remote loads or cache hits without error                          |
-| groupcache_server_requests_total              | Counter   | Total gets from peers                                                   |
-| grpc_client_request_duration_ms               | Histogram | GRPC client request duration by service                                 |
-| grpc_client_request_size_bytes                | Histogram | GRPC client request size by service                                     |
-| grpc_client_requests_total                    | Counter   | Total GRPC client requests made by service                              |
-| grpc_client_response_size_bytes               | Histogram | GRPC client response size by service                                    |
-| grpc_server_request_duration_ms               | Histogram | GRPC server request duration by service                                 |
-| grpc_server_request_size_bytes                | Histogram | GRPC server request size by service                                     |
-| grpc_server_requests_total                    | Counter   | Total GRPC server requests made by service                              |
-| grpc_server_response_size_bytes               | Histogram | GRPC server response size by service                                    |
-| http_client_request_duration_ms               | Histogram | HTTP client request duration by service                                 |
-| http_client_request_size_bytes                | Histogram | HTTP client request size by service                                     |
-| http_client_requests_total                    | Counter   | Total HTTP client requests made by service                              |
-| http_client_response_size_bytes               | Histogram | HTTP client response size by service                                    |
-| http_server_request_duration_ms               | Histogram | HTTP server request duration by service                                 |
-| http_server_request_size_bytes                | Histogram | HTTP server request size by service                                     |
-| http_server_requests_total                    | Counter   | Total HTTP server requests handled by service                           |
-| http_server_response_size_bytes               | Histogram | HTTP server response size by service                                    |
-| pomerium_build_info                           | Gauge     | Pomerium build metadata by git revision, service, version and goversion |
-| pomerium_config_checksum_int64                | Gauge     | Currently loaded configuration checksum by service                      |
-| pomerium_config_last_reload_success           | Gauge     | Whether the last configuration reload succeeded by service              |
-| pomerium_config_last_reload_success_timestamp | Gauge     | The timestamp of the last successful configuration reload by service    |
-| redis_conns                                   | Gauge     | Number of total connections in the pool                                 |
-| redis_hits_total                              | Counter   | Total number of times free connection was found in the pool             |
-| redis_idle_conns                              | Gauge     | Number of idle connections in the pool                                  |
-| redis_misses_total                            | Counter   | Total number of times free connection was NOT found in the pool         |
-| redis_stale_conns_total                       | Counter   | Total number of stale connections removed from the pool                 |
-| redis_timeouts_total                          | Counter   | Total number of times a wait timeout occurred                           |
-
+Name                                          | Type      | Description
+--------------------------------------------- | --------- | -----------------------------------------------------------------------
+boltdb_free_alloc_size_bytes                  | Gauge     | Bytes allocated in free pages
+boltdb_free_page_n                            | Gauge     | Number of free pages on the freelist
+boltdb_freelist_inuse_size_bytes              | Gauge     | Bytes used by the freelist
+boltdb_open_txn                               | Gauge     | number of currently open read transactions
+boltdb_pending_page_n                         | Gauge     | Number of pending pages on the freelist
+boltdb_txn                                    | Gauge     | total number of started read transactions
+boltdb_txn_cursor_total                       | Counter   | Total number of cursors created
+boltdb_txn_node_deref_total                   | Counter   | Total number of node dereferences
+boltdb_txn_node_total                         | Counter   | Total number of node allocations
+boltdb_txn_page_alloc_size_bytes_total        | Counter   | Total bytes allocated
+boltdb_txn_page_total                         | Counter   | Total number of page allocations
+boltdb_txn_rebalance_duration_ms_total        | Counter   | Total time spent rebalancing
+boltdb_txn_rebalance_total                    | Counter   | Total number of node rebalances
+boltdb_txn_spill_duration_ms_total            | Counter   | Total time spent spilling
+boltdb_txn_spill_total                        | Counter   | Total number of nodes spilled
+boltdb_txn_split_total                        | Counter   | Total number of nodes split
+boltdb_txn_write_duration_ms_total            | Counter   | Total time spent writing to disk
+boltdb_txn_write_total                        | Counter   | Total number of writes performed
+groupcache_cache_hits_total                   | Counter   | Total cache hits in local or cluster cache
+groupcache_cache_hits_total                   | Counter   | Total cache hits in local or cluster cache
+groupcache_gets_total                         | Counter   | Total get request, including from peers
+groupcache_loads_deduped_total                | Counter   | gets without cache hits after duplicate suppression
+groupcache_loads_total                        | Counter   | Total gets without cache hits
+groupcache_local_load_errs_total              | Counter   | Total local load errors
+groupcache_local_loads_total                  | Counter   | Total good local loads
+groupcache_peer_errors_total                  | Counter   | Total errors from peers
+groupcache_peer_loads_total                   | Counter   | Total remote loads or cache hits without error
+groupcache_server_requests_total              | Counter   | Total gets from peers
+grpc_client_request_duration_ms               | Histogram | GRPC client request duration by service
+grpc_client_request_size_bytes                | Histogram | GRPC client request size by service
+grpc_client_requests_total                    | Counter   | Total GRPC client requests made by service
+grpc_client_response_size_bytes               | Histogram | GRPC client response size by service
+grpc_server_request_duration_ms               | Histogram | GRPC server request duration by service
+grpc_server_request_size_bytes                | Histogram | GRPC server request size by service
+grpc_server_requests_total                    | Counter   | Total GRPC server requests made by service
+grpc_server_response_size_bytes               | Histogram | GRPC server response size by service
+http_client_request_duration_ms               | Histogram | HTTP client request duration by service
+http_client_request_size_bytes                | Histogram | HTTP client request size by service
+http_client_requests_total                    | Counter   | Total HTTP client requests made by service
+http_client_response_size_bytes               | Histogram | HTTP client response size by service
+http_server_request_duration_ms               | Histogram | HTTP server request duration by service
+http_server_request_size_bytes                | Histogram | HTTP server request size by service
+http_server_requests_total                    | Counter   | Total HTTP server requests handled by service
+http_server_response_size_bytes               | Histogram | HTTP server response size by service
+pomerium_build_info                           | Gauge     | Pomerium build metadata by git revision, service, version and goversion
+pomerium_config_checksum_int64                | Gauge     | Currently loaded configuration checksum by service
+pomerium_config_last_reload_success           | Gauge     | Whether the last configuration reload succeeded by service
+pomerium_config_last_reload_success_timestamp | Gauge     | The timestamp of the last successful configuration reload by service
+redis_conns                                   | Gauge     | Number of total connections in the pool
+redis_hits_total                              | Counter   | Total number of times free connection was found in the pool
+redis_idle_conns                              | Gauge     | Number of idle connections in the pool
+redis_misses_total                            | Counter   | Total number of times free connection was NOT found in the pool
+redis_stale_conns_total                       | Counter   | Total number of stale connections removed from the pool
+redis_timeouts_total                          | Counter   | Total number of times a wait timeout occurred
 
 ### Tracing
 
@@ -390,10 +386,10 @@ Each unit work is called a Span in a trace. Spans include metadata about the wor
 
 #### Shared Tracing Settings
 
-| Config Key       | Description                                                       | Required |
-| :--------------- | :---------------------------------------------------------------- | -------- |
-| tracing_provider | The name of the tracing provider. (e.g. jaeger)                   | ✅        |
-| tracing_debug    | Will disable [sampling](https://opencensus.io/tracing/sampling/). | ❌        |
+Config Key       | Description                                                       | Required
+:--------------- | :---------------------------------------------------------------- | --------
+tracing_provider | The name of the tracing provider. (e.g. jaeger)                   | ✅
+tracing_debug    | Will disable [sampling](https://opencensus.io/tracing/sampling/). | ❌
 
 #### Jaeger
 
@@ -405,10 +401,10 @@ Each unit work is called a Span in a trace. Spans include metadata about the wor
 - Service dependency analysis
 - Performance / latency optimization
 
-| Config Key                        | Description                                 | Required |
-| :-------------------------------- | :------------------------------------------ | -------- |
-| tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅        |
-| tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅        |
+Config Key                        | Description                                 | Required
+:-------------------------------- | :------------------------------------------ | --------
+tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅
+tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅
 
 #### Example
 
@@ -570,12 +566,12 @@ Identity Provider Service Account is field used to configure any additional user
 
 The authenticate callback path is the path/url from the authenticate service that will receive the response from your identity provider. The value must exactly match one of the authorized redirect URIs for the OAuth 2.0 client.
 
-This value is referred to as the `redirect_url` in the [OpenIDConnect](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest) and OAuth2 specs.
+This value is referred to as the `redirect_url` in the [OpenIDConnect][oidc rfc] and OAuth2 specs.
 
 See also:
 
 - [OAuth2 RFC 6749](https://tools.ietf.org/html/rfc6749#section-3.1.2)
-- [OIDC Spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest)
+- [OIDC Spec][oidc rfc]
 - [Google - Setting Redirect URI](https://developers.google.com/identity/protocols/OpenIDConnect#setredirecturi)
 
 ## Proxy Service
@@ -675,15 +671,18 @@ Refresh cooldown is the minimum amount of time between allowed manually refreshe
 Default Upstream Timeout is the default timeout applied to a proxied route when no `timeout` key is specified by the policy.
 
 ### JWT Claim Headers
+
 - Environmental Variable: `JWT_CLAIMS_HEADERS`
 - Config File Key: `jwt_claims_headers`
-- Type: `string list`
-- Example: `email,groups`, `user`
+- Type: slice of `string`
+- Example: `email`,`groups`, `user`
 - Optional
-  
-Set this option for the pomerium proxy to copy JWT claim information into request headers with the name `x-pomerium-claim-*`.  Any claim listed in the pomerium JWT can be placed into a corresponding header for downstream consumption.  This claim information is sourced from your IDP and pomerium's own session metadata.
 
-Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}` for downstream authN/Z.  
+The JWT Claim Headers setting allows you to pass specific user session data down to downstream applications as HTTP request headers. Note, unlike the header `x-pomerium-jwt-assertion` these values are not signed by the authorization service.
+
+Any claim in the pomerium session JWT can be placed into a corresponding header for downstream consumption. This claim information is sourced from your IDP and pomerium's own session metadata.
+
+Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}` for downstream authN/Z.
 
 ## Cache Service
 

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -1,10 +1,34 @@
 # Changelog
 
+## v0.7.2
+
+## Changes
+
+- proxy: remove extra session unmarshalling @desimone (#592)
+- proxy: add configurable JWT claim headers @travisgroth (#596)
+- grpcutil: remove unused pkg @desimone (#593)
+
+## Fixed
+
+- site: fix site on mobile @desimone (#597)
+
+## Documentation
+
+- site: fix site on mobile @desimone (#597)
+
+## Dependency
+
+- chore(deps): update vuepress monorepo to v1.4.0 @renovate (#559)
+
+  ## v0.7.1
+
+There were no changes in the v0.7.1 release, but we updated the build process slightly.
+
 ## v0.7.0
 
 ### New
 
-- \*: remove import path comments @desimone (#545)
+- *: remove import path comments @desimone (#545)
 - authenticate: make callback path configurable @desimone (#493)
 - authenticate: return 401 for some specific error codes @cuonglm (#561)
 - authorization: log audience claim failure @desimone (#553)
@@ -390,20 +414,6 @@
 - `http.Server` and `httputil.NewSingleHostReverseProxy` now uses pomerium's logging package instead of the standard library's built in one. [GH-58]
 
 [certificates documentation]: ../reference/certificates.md
-[synology tutorial]: ./quick-start/synology.md
-[gh-35]: https://github.com/pomerium/pomerium/issues/35
-[gh-58]: https://github.com/pomerium/pomerium/issues/58
-[gh-69]: https://github.com/pomerium/pomerium/issues/69
-[gh-73]: https://github.com/pomerium/pomerium/issues/73
-[gh-74]: https://github.com/pomerium/pomerium/pull/74
-[gh-79]: https://github.com/pomerium/pomerium/pull/79
-[gh-81]: https://github.com/pomerium/pomerium/pull/81
-[gh-83]: https://github.com/pomerium/pomerium/pull/83
-[gh-92]: https://github.com/pomerium/pomerium/pull/92
-[gh-93]: https://github.com/pomerium/pomerium/pull/93
-[gh-95]: https://github.com/pomerium/pomerium/pull/95
-[gh-96]: https://github.com/pomerium/pomerium/pull/96
-[gh-97]: https://github.com/pomerium/pomerium/issues/97
 [gh-100]: https://github.com/pomerium/pomerium/issues/100
 [gh-101]: https://github.com/pomerium/pomerium/pull/101
 [gh-103]: https://github.com/pomerium/pomerium/issues/103
@@ -423,7 +433,6 @@
 [gh-153]: https://github.com/pomerium/pomerium/issues/153
 [gh-177]: https://github.com/pomerium/pomerium/pull/177
 [gh-179]: https://github.com/pomerium/pomerium/issues/179
-[gh-181]: https://github.com/pomerium/pomerium/issues/181
 [gh-181]: https://github.com/pomerium/pomerium/issues/188
 [gh-183]: https://github.com/pomerium/pomerium/pull/183
 [gh-190]: https://github.com/pomerium/pomerium/issues/190
@@ -436,10 +445,8 @@
 [gh-220]: https://github.com/pomerium/pomerium/pull/220
 [gh-227]: https://github.com/pomerium/pomerium/pull/227
 [gh-230]: https://github.com/pomerium/pomerium/pull/230
-[gh-230]: https://github.com/pomerium/pomerium/pull/230
 [gh-233]: https://github.com/pomerium/pomerium/issues/233
 [gh-240]: https://github.com/pomerium/pomerium/pull/240
-[gh-259]: https://github.com/pomerium/pomerium/pull/259
 [gh-259]: https://github.com/pomerium/pomerium/pull/259
 [gh-261]: https://github.com/pomerium/pomerium/pull/261
 [gh-262]: https://github.com/pomerium/pomerium/issues/262
@@ -458,5 +465,19 @@
 [gh-328]: https://github.com/pomerium/pomerium/issues/328
 [gh-332]: https://github.com/pomerium/pomerium/pull/332/
 [gh-338]: https://github.com/pomerium/pomerium/issues/338
+[gh-35]: https://github.com/pomerium/pomerium/issues/35
 [gh-363]: https://github.com/pomerium/pomerium/issues/363
 [gh-376]: https://github.com/pomerium/pomerium/pull/376/
+[gh-58]: https://github.com/pomerium/pomerium/issues/58
+[gh-69]: https://github.com/pomerium/pomerium/issues/69
+[gh-73]: https://github.com/pomerium/pomerium/issues/73
+[gh-74]: https://github.com/pomerium/pomerium/pull/74
+[gh-79]: https://github.com/pomerium/pomerium/pull/79
+[gh-81]: https://github.com/pomerium/pomerium/pull/81
+[gh-83]: https://github.com/pomerium/pomerium/pull/83
+[gh-92]: https://github.com/pomerium/pomerium/pull/92
+[gh-93]: https://github.com/pomerium/pomerium/pull/93
+[gh-95]: https://github.com/pomerium/pomerium/pull/95
+[gh-96]: https://github.com/pomerium/pomerium/pull/96
+[gh-97]: https://github.com/pomerium/pomerium/issues/97
+[synology tutorial]: ./quick-start/synology.md

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -13,7 +13,7 @@ description: >-
 
 :::warning
 
-This changed was reverted in v0.7.3, and the old headers can be safely used.
+This changed was partially reverted in v0.7.2\. Session details like `user`, `email`, and `groups` can still be explicitly extracted by setting the [jwt_claims_header](../configuration/readme.md#jwt-claim-headers) configuration option.
 
 :::
 

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -11,6 +11,12 @@ description: >-
 
 ### Getting user's identity
 
+:::warning
+
+This changed was reverted in v0.7.3, and the old headers can be safely used.
+
+:::
+
 User detail headers ( `x-pomerium-authenticated-user-id` / `x-pomerium-authenticated-user-email` / `x-pomerium-authenticated-user-groups`) have been removed in favor of using the more secure, more data rich attestation jwt header (`x-pomerium-jwt-assertion`).
 
 If you still rely on individual claim headers, please see the `jwt_claims_headers` option [here](https://www.pomerium.io/configuration/#jwt-claim-headers).


### PR DESCRIPTION
## Summary
Adds note about reverting the user/groups header. 

Fixes an style issue on the docs where the version dropdown is white text on a white background.

<img width="194" alt="Screen Shot 2020-04-11 at 8 41 56 PM" src="https://user-images.githubusercontent.com/1544881/79059987-e9bf6680-7c34-11ea-9be5-9ef704686c8a.png">


See preview : https://deploy-preview-601--pomerium-docs.netlify.com/

## Related issues

- https://github.com/pomerium/pomerium/pull/596
- https://github.com/pomerium/pomerium/pull/597

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] ready for review

## Related gif
![](https://i.imgur.com/Q3cUg29.gif)

