### PR TITLE
identity/gitlab: fix retrieve group error

### DIFF
--- a/docs/docs/identity-providers/gitlab.md
+++ b/docs/docs/identity-providers/gitlab.md
@@ -25,8 +25,9 @@ Field        | Description
 ------------ | --------------------------------------------
 Name         | The name of your web app
 Redirect URI | `https://${authenticate_service_url}/oauth2/callback`
-Scopes       | **Must** select **read_user** and **openid**
+Scopes       | **Must** select **openid**, **read_user** and **api**
 
+If no scopes are set, we will use the following scopes: `openid`, `api`, `read_user`, `profile`, `email`.
 
 Your `Client ID` and `Client Secret` will be displayed like below:
 

--- a/internal/identity/gitlab.go
+++ b/internal/identity/gitlab.go
@@ -19,8 +19,7 @@ import (
 
 const (
 	defaultGitLabProviderURL = "https://gitlab.com"
-	revokeURL                = "https://gitlab.com/oauth/revoke"
-	defaultGitLabGroupURL    = "https://gitlab.com/api/v4/groups"
+	groupPath                = "/api/v4/groups"
 )
 
 // GitLabProvider is an implementation of the OAuth Provider
@@ -57,8 +56,7 @@ func NewGitLabProvider(p *Provider) (*GitLabProvider, error) {
 		Scopes:       p.Scopes,
 	}
 	gp := &GitLabProvider{
-		Provider:  p,
-		RevokeURL: revokeURL,
+		Provider: p,
 	}
 
 	if err := p.provider.Claims(&gp); err != nil {
@@ -89,8 +87,9 @@ func (p *GitLabProvider) UserGroups(ctx context.Context, s *sessions.State) ([]s
 		FullName                       string      `json:"full_name,omitempty"`
 		FullPath                       string      `json:"full_path,omitempty"`
 	}
+	userGroupURL := p.ProviderURL + groupPath
 	headers := map[string]string{"Authorization": fmt.Sprintf("Bearer %s", s.AccessToken.AccessToken)}
-	err := httputil.Client(ctx, http.MethodGet, defaultGitLabGroupURL, version.UserAgent(), headers, nil, &response)
+	err := httputil.Client(ctx, http.MethodGet, userGroupURL, version.UserAgent(), headers, nil, &response)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->
 - remove hardcoded gitlab provider url.
 - update the gitlab identity provider documentation.
## Related issues
<!-- For example...
Fixes #159 
-->
Fixes #612 

**Checklist**:
- [X] add related issues
- [X] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [X] ready for review
