### PR TITLE
improvement: update gitlab api scope

### DIFF
--- a/docs/docs/identity-providers/gitlab.md
+++ b/docs/docs/identity-providers/gitlab.md
@@ -25,9 +25,9 @@ Field        | Description
 ------------ | --------------------------------------------
 Name         | The name of your web app
 Redirect URI | `https://${authenticate_service_url}/oauth2/callback`
-Scopes       | **Must** select **openid**, **read_user** and **api**
+Scopes       | **Must** select **openid**, **read_user** and **read_api**
 
-If no scopes are set, we will use the following scopes: `openid`, `api`, `read_user`, `profile`, `email`.
+If no scopes are set, we will use the following scopes: `openid`, `read_api`, `read_user`, `profile`, `email`.
 
 Your `Client ID` and `Client Secret` will be displayed like below:
 

--- a/internal/identity/oidc/gitlab/gitlab.go
+++ b/internal/identity/oidc/gitlab/gitlab.go
@@ -22,7 +22,7 @@ import (
 // Name identifies the GitLab identity provider
 const Name = "gitlab"
 
-var defaultScopes = []string{oidc.ScopeOpenID, "api", "read_user", "profile", "email"}
+var defaultScopes = []string{oidc.ScopeOpenID, "read_api", "read_user", "profile", "email"}
 
 const (
 	defaultProviderURL = "https://gitlab.com"


### PR DESCRIPTION
## Summary
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->
Changing the `api` scope which gives us too much than we need to `read_api`, the recent [GitLab 12.10 release](https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html#limiting-scopes-of-a-personal-access-token)

Reference: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/28944

## Related issues
<!-- For example...
Fixes #159 
-->
Fixes #612 

**Checklist**:
- [X] add related issues
- [X] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [X] ready for review
