### PR TITLE
github: fix nil pointer error

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -218,7 +218,7 @@ func (a *Authenticate) SignIn(w http.ResponseWriter, r *http.Request) error {
 // Handles both GET and POST.
 func (a *Authenticate) SignOut(w http.ResponseWriter, r *http.Request) error {
 	// no matter what happens, we want to clear the local session store
-	defer a.sessionStore.ClearSession(w, r)
+	a.sessionStore.ClearSession(w, r)
 
 	jwt, err := sessions.FromContext(r.Context())
 	if err != nil {


### PR DESCRIPTION
- fixes an issue where defer clear session would not be called

Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>

## Summary
Fixes an issue where the gitlab provider would panic on startup because of a nil pointer (to an embedded struct). 

## Related issues
Fixes #636 

Thank you @Vad1mo for reporting this issue. 


**Checklist**:
- [x] add related issues
- [x] ready for review
