### PR TITLE
Improve JWT header behavior

### DIFF
--- a/proxy/middleware.go
+++ b/proxy/middleware.go
@@ -9,8 +9,10 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
 
+	"github.com/pomerium/pomerium/internal/grpc/authorize"
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/sessions"
@@ -92,36 +94,42 @@ func (p *Proxy) AuthorizeSession(next http.Handler) http.Handler {
 	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		ctx, span := trace.StartSpan(r.Context(), "proxy.AuthorizeSession")
 		defer span.End()
-		if err := p.authorize(w, r); err != nil {
+		authz, err := p.authorize(w, r)
+		if err != nil {
 			return err
 		}
+
+		r.Header.Set(httputil.HeaderPomeriumJWTAssertion, authz.GetSignedJwt())
 		next.ServeHTTP(w, r.WithContext(ctx))
 		return nil
 	})
 }
 
-func (p *Proxy) authorize(w http.ResponseWriter, r *http.Request) error {
+func (p *Proxy) authorize(w http.ResponseWriter, r *http.Request) (*authorize.IsAuthorizedReply, error) {
 	ctx, span := trace.StartSpan(r.Context(), "proxy.authorize")
 	defer span.End()
+
 	jwt, _ := sessions.FromContext(ctx)
+
 	authz, err := p.AuthorizeClient.Authorize(ctx, jwt, r)
 	if err != nil {
-		return httputil.NewError(http.StatusInternalServerError, err)
+		return nil, httputil.NewError(http.StatusInternalServerError, err)
 	}
+
 	if authz.GetSessionExpired() {
 		newJwt, err := p.refresh(ctx, jwt)
 		if err != nil {
 			p.sessionStore.ClearSession(w, r)
 			log.FromRequest(r).Warn().Err(err).Msg("proxy: refresh failed")
-			return p.redirectToSignin(w, r)
+			return nil, p.redirectToSignin(w, r)
 		}
 		if err = p.sessionStore.SaveSession(w, r, newJwt); err != nil {
-			return httputil.NewError(http.StatusUnauthorized, err)
+			return nil, httputil.NewError(http.StatusUnauthorized, err)
 		}
 
 		authz, err = p.AuthorizeClient.Authorize(ctx, newJwt, r)
 		if err != nil {
-			return httputil.NewError(http.StatusUnauthorized, err)
+			return nil, httputil.NewError(http.StatusUnauthorized, err)
 		}
 	}
 	if !authz.GetAllow() {
@@ -130,12 +138,11 @@ func (p *Proxy) authorize(w http.ResponseWriter, r *http.Request) error {
 			Bool("allow", authz.GetAllow()).
 			Bool("expired", authz.GetSessionExpired()).
 			Msg("proxy/authorize: deny")
-		return httputil.NewError(http.StatusForbidden, errors.New("request denied"))
+		return nil, httputil.NewError(http.StatusForbidden, errors.New("request denied"))
 	}
 
-	r.Header.Set(httputil.HeaderPomeriumJWTAssertion, authz.GetSignedJwt())
-	w.Header().Set(httputil.HeaderPomeriumJWTAssertion, authz.GetSignedJwt())
-	return nil
+	return authz, nil
+
 }
 
 // SetResponseHeaders sets a map of response headers.
@@ -152,50 +159,78 @@ func SetResponseHeaders(headers map[string]string) func(next http.Handler) http.
 	}
 }
 
-func (p *Proxy) jwtClaimMiddleware(next http.Handler) http.Handler {
-	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		if jwt, err := sessions.FromContext(r.Context()); err == nil {
-			var jwtClaims map[string]interface{}
-			if err := p.encoder.Unmarshal([]byte(jwt), &jwtClaims); err == nil {
-				formattedJWTClaims := make(map[string]string)
+// jwtClaimMiddleware logs and propagates JWT claim information via request headers
+//
+// if returnJWTInfo is set to true, it will also return JWT claim information in the response
+func (p *Proxy) jwtClaimMiddleware(returnJWTInfo bool) mux.MiddlewareFunc {
 
-				// reformat claims into something resembling map[string]string
-				for claim, value := range jwtClaims {
-					var formattedClaim string
-					if cv, ok := value.([]interface{}); ok {
-						elements := make([]string, len(cv))
+	return func(next http.Handler) http.Handler {
 
-						for i, v := range cv {
-							elements[i] = fmt.Sprintf("%v", v)
-						}
-						formattedClaim = strings.Join(elements, ",")
-					} else {
-						formattedClaim = fmt.Sprintf("%v", value)
-					}
-					formattedJWTClaims[claim] = formattedClaim
-				}
+		return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+			defer next.ServeHTTP(w, r)
 
-				// log group, email, user claims
-				l := log.Ctx(r.Context())
-				for _, claimName := range []string{"groups", "email", "user"} {
+			jwt, err := sessions.FromContext(r.Context())
+			if err != nil {
+				log.Error().Err(err).Msg("proxy: could not locate session from context")
+				return nil // best effort decoding
+			}
 
-					l.UpdateContext(func(c zerolog.Context) zerolog.Context {
-						return c.Str(claimName, fmt.Sprintf("%v", formattedJWTClaims[claimName]))
-					})
+			formattedJWTClaims, err := p.getFormatedJWTClaims([]byte(jwt))
+			if err != nil {
+				log.Error().Err(err).Msg("proxy: failed to format jwt claims")
+				return nil // best effort formatting
+			}
 
-				}
+			// log group, email, user claims
+			l := log.Ctx(r.Context())
+			for _, claimName := range []string{"groups", "email", "user"} {
 
-				// set headers for any claims specified by config
-				for _, claimName := range p.jwtClaimHeaders {
-					if _, ok := formattedJWTClaims[claimName]; ok {
+				l.UpdateContext(func(c zerolog.Context) zerolog.Context {
+					return c.Str(claimName, fmt.Sprintf("%v", formattedJWTClaims[claimName]))
+				})
 
-						headerName := fmt.Sprintf("x-pomerium-claim-%s", claimName)
-						r.Header.Set(headerName, formattedJWTClaims[claimName])
+			}
+
+			// set headers for any claims specified by config
+			for _, claimName := range p.jwtClaimHeaders {
+				if _, ok := formattedJWTClaims[claimName]; ok {
+
+					headerName := fmt.Sprintf("x-pomerium-claim-%s", claimName)
+					r.Header.Set(headerName, formattedJWTClaims[claimName])
+					if returnJWTInfo {
+						w.Header().Add(headerName, formattedJWTClaims[claimName])
 					}
 				}
 			}
+
+			return nil
+		})
+	}
+}
+
+// getFormatJWTClaims reformats jwtClaims into something resembling map[string]string
+func (p *Proxy) getFormatedJWTClaims(jwt []byte) (map[string]string, error) {
+	formattedJWTClaims := make(map[string]string)
+
+	var jwtClaims map[string]interface{}
+	if err := p.encoder.Unmarshal(jwt, &jwtClaims); err != nil {
+		return formattedJWTClaims, err
+	}
+
+	for claim, value := range jwtClaims {
+		var formattedClaim string
+		if cv, ok := value.([]interface{}); ok {
+			elements := make([]string, len(cv))
+
+			for i, v := range cv {
+				elements[i] = fmt.Sprintf("%v", v)
+			}
+			formattedClaim = strings.Join(elements, ",")
+		} else {
+			formattedClaim = fmt.Sprintf("%v", value)
 		}
-		next.ServeHTTP(w, r)
-		return nil
-	})
+		formattedJWTClaims[claim] = formattedClaim
+	}
+
+	return formattedJWTClaims, nil
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -274,7 +274,7 @@ func (p *Proxy) reverseProxyHandler(r *mux.Router, policy config.Policy) *mux.Ro
 	// 7. Strip the user session cookie from the downstream request
 	rp.Use(middleware.StripCookie(p.cookieOptions.Name))
 	// 8 . Add claim details to the request logger context and headers
-	rp.Use(p.jwtClaimMiddleware)
+	rp.Use(p.jwtClaimMiddleware(false))
 
 	return r
 }


### PR DESCRIPTION
## Summary
- Stop returning signed JWT header to client during normal requests.  This reduces header size.
- Return signed JWT and any JWT claim headers on the forward auth endpoint.  This enables forward auth to be used in scenarios where downstream applications need access to JWT related information.

## Related issues
closes #631 
closes #532 


**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
