### PR TITLE
ci: force docker driver

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -118,7 +118,7 @@ jobs:
           sudo install mkcert /usr/local/bin/
       - name: start minikube
         run: |
-          minikube start
+          minikube start --driver=docker
           kubectl cluster-info
 
       - name: install go


### PR DESCRIPTION
## Summary
We were seeing an occasional error on `minikube start`. Maybe this will fix it.

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
