### PR TITLE
Fix reload panic in Authorize code

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -88,10 +88,14 @@ func newPolicyEvaluator(opts *config.Options) (evaluator.Evaluator, error) {
 // UpdateOptions implements the OptionsUpdater interface and updates internal
 // structures based on config.Options
 func (a *Authorize) UpdateOptions(opts config.Options) error {
+	if a == nil {
+		return nil
+	}
 	log.Info().Str("checksum", fmt.Sprintf("%x", opts.Checksum())).Msg("authorize: updating options")
-	var err error
-	if a.pe, err = newPolicyEvaluator(&opts); err != nil {
+	pe, err := newPolicyEvaluator(&opts)
+	if err != nil {
 		return err
 	}
+	a.pe = pe
 	return nil
 }


### PR DESCRIPTION
## Summary
prevent panic in `Authorize` code when running in proxy service mode and config is reloaded at runtime

## Related issues
Fixes #634 


**Checklist**:
- [x] add related issues
- [x] ready for review
