### PR TITLE
Backport fix for panic on reload to 0.7.x

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -88,10 +88,14 @@ func newPolicyEvaluator(opts *config.Options) (evaluator.Evaluator, error) {
 // UpdateOptions implements the OptionsUpdater interface and updates internal
 // structures based on config.Options
 func (a *Authorize) UpdateOptions(opts config.Options) error {
+	if a == nil {
+		return nil
+	}
 	log.Info().Str("checksum", fmt.Sprintf("%x", opts.Checksum())).Msg("authorize: updating options")
-	var err error
-	if a.pe, err = newPolicyEvaluator(&opts); err != nil {
+	pe, err := newPolicyEvaluator(&opts)
+	if err != nil {
 		return err
 	}
+	a.pe = pe
 	return nil
 }

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.7.6
+
+### Fixed
+
+- authorize: fix unexpected panic on reload @travisgroth [GH-652]
+
 ## v0.7.5
 
 ### Fixed


### PR DESCRIPTION
## Summary
Fix unexpected panic during config reload

## Related issues
#652 


**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] ready for review
