### PR TITLE
integration-tests: add CORS test

### DIFF
--- a/integration/cors_test.go
+++ b/integration/cors_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCORS(t *testing.T) {
+	ctx := mainCtx
+	ctx, clearTimeout := context.WithTimeout(ctx, time.Second*30)
+	defer clearTimeout()
+
+	t.Run("enabled", func(t *testing.T) {
+		client := testcluster.NewHTTPClient()
+
+		req, err := http.NewRequestWithContext(ctx, "OPTIONS", "https://httpdetails.localhost.pomerium.io/cors-enabled", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		req.Header.Set("Origin", "https://httpdetails.localhost.pomerium.io")
+
+		res, err := client.Do(req)
+		if !assert.NoError(t, err, "unexpected http error") {
+			return
+		}
+		defer res.Body.Close()
+
+		assert.Equal(t, http.StatusOK, res.StatusCode, "unexpected status code")
+	})
+	t.Run("disabled", func(t *testing.T) {
+		client := testcluster.NewHTTPClient()
+
+		req, err := http.NewRequestWithContext(ctx, "OPTIONS", "https://httpdetails.localhost.pomerium.io/cors-disabled", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Access-Control-Request-Method", "GET")
+		req.Header.Set("Origin", "https://httpdetails.localhost.pomerium.io")
+
+		res, err := client.Do(req)
+		if !assert.NoError(t, err, "unexpected http error") {
+			return
+		}
+		defer res.Body.Close()
+
+		assert.NotEqual(t, http.StatusOK, res.StatusCode, "unexpected status code")
+	})
+}

--- a/integration/manifests/lib/pomerium.libsonnet
+++ b/integration/manifests/lib/pomerium.libsonnet
@@ -23,6 +23,18 @@ local PomeriumPolicy = function() std.flattenArrays([
     {
       from: 'http://' + domain + '.localhost.pomerium.io',
       to: 'http://' + domain + '.default.svc.cluster.local',
+      prefix: '/cors-enabled',
+      cors_allow_preflight: true,
+    },
+    {
+      from: 'http://' + domain + '.localhost.pomerium.io',
+      to: 'http://' + domain + '.default.svc.cluster.local',
+      prefix: '/cors-disabled',
+      cors_allow_preflight: false,
+    },
+    {
+      from: 'http://' + domain + '.localhost.pomerium.io',
+      to: 'http://' + domain + '.default.svc.cluster.local',
       allow_public_unauthenticated_access: true,
     },
   ]


### PR DESCRIPTION
## Summary
This adds an integration test for the `cors_allow_preflight` option.

When enabled we expect a CORS request consisting of an `OPTIONS` method coupled with the `Origin` and `Access-Control-Request-Method` headers to succeed. Whereas when disabled, we expect pomerium to respond with a 302, because these routes require authentication.

**Checklist**:
- [x] ready for review
