### PR TITLE
pre-commit: add pre-commit configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,7 @@ _test
 # Architecture specific extensions/prefixes
 *.[568vq]
 [568vq].out
- 
+
 *.cgo1.go
 *.cgo2.c
 _cgo_defun.c
@@ -82,3 +82,5 @@ docs/.vuepress/dist/
 
 # autocert
 .pomerium/
+
+!.pre-commit-config.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/syntaqx/git-hooks
+    rev: v0.0.16
+    hooks:
+      - id: go-mod-tidy
+  - repo: local
+    hooks:
+      - id: lint
+        name: lint
+        language: system
+        entry: make
+        args: ["lint"]
+        types: ["go"]


### PR DESCRIPTION
## Summary
This adds a `pre-commit` configuration to automatically run `make lint` and `go mod tidy` before committing. It can be enabled by running `pip install pre-commit` and `pre-commit install`, so it is strictly optional.

**Checklist**:
- [x] ready for review
