### PR TITLE
proxy: implement preserve host headers for envoy

### DIFF
--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -133,6 +133,9 @@ func (srv *Server) buildPolicyRoutes(options config.Options, domain string) []*e
 						UpgradeType: "websocket",
 						Enabled:     &wrappers.BoolValue{Value: policy.AllowWebsockets},
 					}},
+					HostRewriteSpecifier: &envoy_config_route_v3.RouteAction_AutoHostRewrite{
+						AutoHostRewrite: &wrappers.BoolValue{Value: !policy.PreserveHostHeader},
+					},
 				},
 			},
 		})


### PR DESCRIPTION
## Summary
This implements the `preserve_host_header` option for policy routes.

## Related issues
Closes pomerium/internal#8


**Checklist**:
- [x] add related issues
- [x] ready for review
