### PR TITLE
enable ipv6 grpc routing

### DIFF
--- a/internal/controlplane/xds.go
+++ b/internal/controlplane/xds.go
@@ -86,12 +86,13 @@ func buildAddress(hostport string, defaultPort int) *envoy_config_core_v3.Addres
 		port = defaultPort
 	}
 	if host == "" {
-		host = "0.0.0.0"
+		host = "::"
 	}
 	return &envoy_config_core_v3.Address{
 		Address: &envoy_config_core_v3.Address_SocketAddress{SocketAddress: &envoy_config_core_v3.SocketAddress{
 			Address:       host,
 			PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{PortValue: uint32(port)},
+			Ipv4Compat:    true,
 		}},
 	}
 }


### PR DESCRIPTION
## Summary
Ensure we listen on ipv4 and ipv6 for gRPC routing to AuthZ service.  This should be broadly compatible with single and dual stack.

**Checklist**:
- [x] ready for review
