### PR TITLE
Return an error regardless of envoy's exit status

### DIFF
--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -4,6 +4,7 @@ package envoy
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -83,7 +84,11 @@ func (srv *Server) Run(ctx context.Context) error {
 
 	// make sure envoy is killed if we're killed
 	srv.cmd.SysProcAttr = sysProcAttr
-	return srv.cmd.Run()
+	err = srv.cmd.Run()
+	if err == nil {
+		return errors.New("envoy exited without error")
+	}
+	return fmt.Errorf("envoy exited: %w", err)
 }
 
 func (srv *Server) writeConfig() error {


### PR DESCRIPTION
## Summary
Ensure we always return an error when envoy exits, so that we exit cleanly from CTRL+C, etc.

NB: I do not believe this will catch an out of band termination like sending SIGTERM to envoy.  Will follow up on that.

**Checklist**:
- [x] ready for review
