### PR TITLE
envoy: fix sni/hostname mismatched routing for http2 connection coalescing

### DIFF
--- a/integration/internal/cluster/cluster.go
+++ b/integration/internal/cluster/cluster.go
@@ -24,15 +24,20 @@ func New(workingDir string) *Cluster {
 	}
 }
 
-// NewHTTPClient creates a new *http.Client, with a cookie jar, and a LocalRoundTripper
-// which routes traffic to the nginx ingress controller.
+// NewHTTPClient calls NewHTTPClientWithTransport with the default cluster transport.
 func (cluster *Cluster) NewHTTPClient() *http.Client {
+	return cluster.NewHTTPClientWithTransport(cluster.Transport)
+}
+
+// NewHTTPClientWithTransport creates a new *http.Client, with a cookie jar, and a LocalRoundTripper
+// which routes traffic to the nginx ingress controller.
+func (cluster *Cluster) NewHTTPClientWithTransport(transport http.RoundTripper) *http.Client {
 	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 	if err != nil {
 		panic(err)
 	}
 	return &http.Client{
-		Transport: &loggingRoundTripper{cluster.Transport},
+		Transport: &loggingRoundTripper{transport},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			return http.ErrUseLastResponse
 		},

--- a/integration/internal/cluster/setup.go
+++ b/integration/internal/cluster/setup.go
@@ -51,7 +51,7 @@ func (cluster *Cluster) Setup(ctx context.Context) error {
 		return err
 	}
 
-	hostport, err := cluster.getNodeHTTPSAddr(ctx)
+	hostport, err := cluster.GetNodePortAddr(ctx, "ingress-nginx", "ingress-nginx-nodeport")
 	if err != nil {
 		return err
 	}
@@ -68,11 +68,12 @@ func (cluster *Cluster) Setup(ctx context.Context) error {
 	return nil
 }
 
-func (cluster *Cluster) getNodeHTTPSAddr(ctx context.Context) (hostport string, err error) {
+// GetNodePortAddr returns the node:port address for a NodePort kubernetes service.
+func (cluster *Cluster) GetNodePortAddr(ctx context.Context, namespace, svcName string) (hostport string, err error) {
 	var buf bytes.Buffer
 
-	args := []string{"get", "service", "--namespace", "ingress-nginx", "--output", "json",
-		"ingress-nginx-nodeport"}
+	args := []string{"get", "service", "--namespace", namespace, "--output", "json",
+		svcName}
 	err = run(ctx, "kubectl", withArgs(args...), withStdout(&buf))
 	if err != nil {
 		return "", fmt.Errorf("error getting service details with kubectl: %w", err)
@@ -94,7 +95,7 @@ func (cluster *Cluster) getNodeHTTPSAddr(ctx context.Context) (hostport string, 
 
 	buf.Reset()
 
-	args = []string{"get", "pods", "--namespace", "ingress-nginx", "--output", "json"}
+	args = []string{"get", "pods", "--namespace", namespace, "--output", "json"}
 	var sel []string
 	for k, v := range svcResult.Spec.Selector {
 		sel = append(sel, k+"="+v)

--- a/integration/manifests/lib/pomerium.libsonnet
+++ b/integration/manifests/lib/pomerium.libsonnet
@@ -178,7 +178,7 @@ local PomeriumDeployment = function(svc) {
           ip: '10.96.1.1',
           hostnames: [
             'openid.localhost.pomerium.io',
-            'authenticate.localhost.pomerium.io'
+            'authenticate.localhost.pomerium.io',
           ],
         }],
         initContainers: [{
@@ -265,6 +265,28 @@ local PomeriumService = function(svc) {
     ],
     selector: {
       app: 'pomerium-' + svc,
+    },
+  },
+};
+
+local PomeriumNodePortServce = function() {
+  apiVersion: 'v1',
+  kind: 'Service',
+  metadata: {
+    namespace: 'default',
+    name: 'pomerium-proxy-nodeport',
+    labels: {
+      app: 'pomerium-proxy',
+      'app.kubernetes.io/part-of': 'pomerium',
+    },
+  },
+  spec: {
+    type: 'NodePort',
+    ports: [
+      { name: 'https', port: 443, protocol: 'TCP', targetPort: 'https', nodePort: 31443 },
+    ],
+    selector: {
+      app: 'pomerium-proxy',
     },
   },
 };
@@ -392,6 +414,7 @@ local PomeriumForwardAuthIngress = function() {
     PomeriumDeployment('cache'),
     PomeriumService('proxy'),
     PomeriumDeployment('proxy'),
+    PomeriumNodePortServce(),
     PomeriumIngress(),
     PomeriumForwardAuthIngress(),
   ],

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -109,7 +109,7 @@ func (srv *Server) buildFilterChains(
 	var chains []*envoy_config_listener_v3.FilterChain
 	for _, domain := range allDomains {
 		// first we match on SNI
-		chains = append(chains, callback(domain, []string{domain}))
+		chains = append(chains, callback(domain, allDomains))
 	}
 	// if there are no SNI matches we match on HTTP host
 	chains = append(chains, callback("*", allDomains))


### PR DESCRIPTION
## Summary
During testing we discovered that browsers will coalesce http/2 connections if the IP address and TLS certificate are the same. This meant that when using a wildcard certificate with two domain names with the same IP address it was possible for requests for one to be routed to the routing table of the other. For example `a.example.com` would end up going to the Envoy filter chain for `b.example.com` because the TLS SNI handshake is only done at the beginning of the connection.

These changes add a test to ensure requests are handled properly even if the SNI and host headers are different. The fix was to add all domain routes for every virtual host.

**Checklist**:
- [x] updated unit tests
- [x] ready for review
