### PR TITLE
ci: Only run testing on master branch pushes and pull requests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,9 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 name: Test
 jobs:
   lint:


### PR DESCRIPTION
## Summary
Stop running tests on all pushes.  The current configuration generates noise from forked branches in addition to the tests run in PRs.

**Checklist**:
- [x] ready for review
