### PR TITLE
envoy: enable TLS verification for internal services

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -609,8 +609,6 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200506145744-7e3656a0809f h1:QBjCr1Fz5kw158VqdE9JfI9cJnl/ymnJWAdMuinqL7Y=
-golang.org/x/net v0.0.0-20200506145744-7e3656a0809f/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120 h1:EZ3cVSzKOlJxAd8e8YAJ7no8nNypTxexh/YE/xW3ZEY=
 golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=

--- a/integration/manifests/lib/pomerium.libsonnet
+++ b/integration/manifests/lib/pomerium.libsonnet
@@ -174,15 +174,14 @@ local PomeriumConfigMap = function() {
   },
   data: {
     ADDRESS: ':443',
-    GRPC_ADDRESS: ':5080',
-    GRPC_INSECURE: 'true',
+    GRPC_ADDRESS: ':5443',
     DEBUG: 'true',
     LOG_LEVEL: 'debug',
 
     AUTHENTICATE_SERVICE_URL: 'https://authenticate.localhost.pomerium.io',
     AUTHENTICATE_CALLBACK_PATH: '/oauth2/callback',
-    AUTHORIZE_SERVICE_URL: 'http://authorize.default.svc.cluster.local:5080',
-    CACHE_SERVICE_URL: 'http://cache.default.svc.cluster.local:5080',
+    AUTHORIZE_SERVICE_URL: 'https://authorize.default.svc.cluster.local:5443',
+    CACHE_SERVICE_URL: 'https://cache.default.svc.cluster.local:5443',
     FORWARD_AUTH_URL: 'https://forward-authenticate.localhost.pomerium.io',
 
     SHARED_SECRET: 'Wy+c0uSuIM0yGGXs82MBwTZwRiZ7Ki2T0LANnmzUtkI=',
@@ -190,6 +189,8 @@ local PomeriumConfigMap = function() {
 
     CERTIFICATE: std.base64(tls.trusted.cert),
     CERTIFICATE_KEY: std.base64(tls.trusted.key),
+    CERTIFICATE_AUTHORITY: std.base64(tls.trusted.ca),
+    OVERRIDE_CERTIFICATE_NAME: 'pomerium.localhost.pomerium.io',
 
     IDP_PROVIDER: 'oidc',
     IDP_PROVIDER_URL: 'https://openid.localhost.pomerium.io',
@@ -286,7 +287,7 @@ local PomeriumDeployment = function(svc) {
           }],
           ports: [
             { name: 'https', containerPort: 443 },
-            { name: 'grpc', containerPort: 5080 },
+            { name: 'grpc', containerPort: 5443 },
           ],
           volumeMounts: [
             {
@@ -338,7 +339,7 @@ local PomeriumService = function(svc) {
       },
       {
         name: 'grpc',
-        port: 5080,
+        port: 5443,
         targetPort: 'grpc',
       },
     ],


### PR DESCRIPTION
## Summary
This enables behind-the-ingress internal TLS verification. I also updated the tests so that authorize and cache are now both reached over HTTPS.

Ideally we'd actually test both cases, but I think that's going to require some more test refactoring.

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
