### PR TITLE
envoy: add jwt-assertion

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -91,6 +91,14 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v2.CheckRe
 	evt = evt.Str("session", string(sess))
 	evt.Msg("authorize check")
 
+	requestHeaders = append(requestHeaders,
+		&envoy_api_v2_core.HeaderValueOption{
+			Header: &envoy_api_v2_core.HeaderValue{
+				Key:   "x-pomerium-jwt-assertion",
+				Value: reply.SignedJwt,
+			},
+		})
+
 	if reply.Allow {
 		return &envoy_service_auth_v2.CheckResponse{
 			Status: &status.Status{Code: int32(codes.OK), Message: "OK"},

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -384,3 +384,36 @@ func TestSNIMismatch(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, res.StatusCode)
 }
+
+func TestAttestationJWT(t *testing.T) {
+	ctx := mainCtx
+	ctx, clearTimeout := context.WithTimeout(ctx, time.Second*30)
+	defer clearTimeout()
+
+	client := testcluster.NewHTTPClient()
+
+	req, err := http.NewRequestWithContext(ctx, "GET", "https://httpdetails.localhost.pomerium.io/", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := client.Do(req)
+	if !assert.NoError(t, err, "unexpected http error") {
+		return
+	}
+	defer res.Body.Close()
+
+	var result struct {
+		Headers map[string]string `json:"headers"`
+	}
+	err = json.NewDecoder(res.Body).Decode(&result)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.NotEmpty(t,
+		"X-Pomerium-Jwt-Assertion-Value",
+		result.Headers["X-Pomerium-Jwt-Assertion"],
+		"Expected JWT assertion")
+
+}


### PR DESCRIPTION
Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>

## Summary
Adds `x-pomerium-jwt-assertion`. 

See : https://www.pomerium.io/docs/reference/getting-users-identity.html#verification



**Checklist**:
- [x] ready for review
