### PR TITLE
envoy: implement various timeouts

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -97,10 +97,9 @@ type Options struct {
 	HTTPRedirectAddr string `mapstructure:"http_redirect_addr" yaml:"http_redirect_addr,omitempty"`
 
 	// Timeout settings : https://github.com/pomerium/pomerium/issues/40
-	ReadTimeout       time.Duration `mapstructure:"timeout_read" yaml:"timeout_read,omitempty"`
-	WriteTimeout      time.Duration `mapstructure:"timeout_write" yaml:"timeout_write,omitempty"`
-	ReadHeaderTimeout time.Duration `mapstructure:"timeout_read_header" yaml:"timeout_read_header,omitempty"`
-	IdleTimeout       time.Duration `mapstructure:"timeout_idle" yaml:"timeout_idle,omitempty"`
+	ReadTimeout  time.Duration `mapstructure:"timeout_read" yaml:"timeout_read,omitempty"`
+	WriteTimeout time.Duration `mapstructure:"timeout_write" yaml:"timeout_write,omitempty"`
+	IdleTimeout  time.Duration `mapstructure:"timeout_idle" yaml:"timeout_idle,omitempty"`
 
 	// Policies define per-route configuration and access control policies.
 	Policies   []Policy `yaml:"policy,omitempty"`
@@ -261,7 +260,6 @@ var defaultOptions = Options{
 		"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
 	},
 	Addr:                            ":443",
-	ReadHeaderTimeout:               10 * time.Second,
 	ReadTimeout:                     30 * time.Second,
 	WriteTimeout:                    0, // support streaming by default
 	IdleTimeout:                     5 * time.Minute,

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -206,7 +206,7 @@ func Test_Checksum(t *testing.T) {
 func TestOptionsFromViper(t *testing.T) {
 	t.Parallel()
 	opts := []cmp.Option{
-		cmpopts.IgnoreFields(Options{}, "CacheStore", "CookieSecret", "GRPCInsecure", "GRPCAddr", "CacheURLString", "CacheURL", "AuthorizeURL", "AuthorizeURLString", "DefaultUpstreamTimeout", "CookieExpire", "Services", "Addr", "RefreshCooldown", "LogLevel", "KeyFile", "CertFile", "SharedKey", "ReadTimeout", "ReadHeaderTimeout", "IdleTimeout", "GRPCClientTimeout", "GRPCClientDNSRoundRobin"),
+		cmpopts.IgnoreFields(Options{}, "CacheStore", "CookieSecret", "GRPCInsecure", "GRPCAddr", "CacheURLString", "CacheURL", "AuthorizeURL", "AuthorizeURLString", "DefaultUpstreamTimeout", "CookieExpire", "Services", "Addr", "RefreshCooldown", "LogLevel", "KeyFile", "CertFile", "SharedKey", "ReadTimeout", "IdleTimeout", "GRPCClientTimeout", "GRPCClientDNSRoundRobin"),
 		cmpopts.IgnoreFields(Policy{}, "Source", "Destination"),
 		cmpOptIgnoreUnexported,
 	}

--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -210,11 +210,11 @@ certificates:
 
 ### Global Timeouts
 
-- Environmental Variables: `TIMEOUT_READ` `TIMEOUT_WRITE` `TIMEOUT_READ_HEADER` `TIMEOUT_IDLE`
-- Config File Key: `timeout_read` `timeout_write` `timeout_read_header` `timeout_idle`
+- Environmental Variables: `TIMEOUT_READ` `TIMEOUT_WRITE` `TIMEOUT_IDLE`
+- Config File Key: `timeout_read` `timeout_write` `timeout_idle`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
 - Example: `TIMEOUT_READ=30s`
-- Defaults: `TIMEOUT_READ_HEADER=10s` `TIMEOUT_READ=30s` `TIMEOUT_WRITE=0` `TIMEOUT_IDLE=5m`
+- Defaults: `TIMEOUT_READ=30s` `TIMEOUT_WRITE=0` `TIMEOUT_IDLE=5m`
 
 Timeouts set the global server timeouts. For route-specific timeouts, see [policy](./#policy).
 
@@ -454,7 +454,7 @@ Each unit work is called a Span in a trace. Spans include metadata about the wor
 | tracing_provider | The name of the tracing provider. (e.g. jaeger, zipkin)           | ✅        |
 | tracing_debug    | Will disable [sampling](https://opencensus.io/tracing/sampling/). | ❌        |
 
-#### Jaeger (partial) 
+#### Jaeger (partial)
 
 **Warning** At this time, Jaeger protocol does not capture spans inside the proxy service.  Please
 use Zipkin protocol with Jaeger for full support.
@@ -474,9 +474,9 @@ use Zipkin protocol with Jaeger for full support.
 
 #### Zipkin
 
-Zipkin is an open source distributed tracing system and protocol.  
+Zipkin is an open source distributed tracing system and protocol.
 
-Many tracing backends support zipkin either directly or through intermediary agents, including Jaeger.  For full tracing support, we recommend using the Zipkin tracing protocol. 
+Many tracing backends support zipkin either directly or through intermediary agents, including Jaeger.  For full tracing support, we recommend using the Zipkin tracing protocol.
 
 | Config Key              | Description                      | Required |
 | :---------------------- | :------------------------------- | -------- |

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -144,13 +144,20 @@ func (srv *Server) buildMainHTTPConnectionManagerFilter(options *config.Options,
 		}
 	}
 
+	var grpcClientTimeout *durationpb.Duration
+	if options.GRPCClientTimeout != 0 {
+		grpcClientTimeout = ptypes.DurationProto(options.GRPCClientTimeout)
+	} else {
+		grpcClientTimeout = ptypes.DurationProto(30 * time.Second)
+	}
+
 	extAuthZ, _ := ptypes.MarshalAny(&envoy_extensions_filters_http_ext_authz_v3.ExtAuthz{
 		StatusOnError: &envoy_type_v3.HttpStatus{
 			Code: envoy_type_v3.StatusCode_InternalServerError,
 		},
 		Services: &envoy_extensions_filters_http_ext_authz_v3.ExtAuthz_GrpcService{
 			GrpcService: &envoy_config_core_v3.GrpcService{
-				Timeout: ptypes.DurationProto(time.Second * 30),
+				Timeout: grpcClientTimeout,
 				TargetSpecifier: &envoy_config_core_v3.GrpcService_EnvoyGrpc_{
 					EnvoyGrpc: &envoy_config_core_v3.GrpcService_EnvoyGrpc{
 						ClusterName: "pomerium-authz",


### PR DESCRIPTION
## Summary
This PR implements timeouts for envoy from the various configuration settings. The only one that doesn't appear supported was the `timeout_read_header`, so I removed it from the documentation.

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
