### PR TITLE
envoy: switch to STRICT_DNS

### DIFF
--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -207,10 +207,11 @@ func (srv *Server) buildCluster(
 		}
 	}
 
-	if net.ParseIP(urlutil.StripPort(endpoint.Host)) == nil {
-		cluster.ClusterDiscoveryType = &envoy_config_cluster_v3.Cluster_Type{Type: envoy_config_cluster_v3.Cluster_LOGICAL_DNS}
-	} else {
+	// for IPs we use a static discovery type, otherwise we use DNS
+	if net.ParseIP(urlutil.StripPort(endpoint.Host)) != nil {
 		cluster.ClusterDiscoveryType = &envoy_config_cluster_v3.Cluster_Type{Type: envoy_config_cluster_v3.Cluster_STATIC}
+	} else {
+		cluster.ClusterDiscoveryType = &envoy_config_cluster_v3.Cluster_Type{Type: envoy_config_cluster_v3.Cluster_STRICT_DNS}
 	}
 
 	return cluster


### PR DESCRIPTION
## Summary
Current we are using `LOGICAL_DNS` for the DNS discovery type in envoy. After reading the documentation, `LOGICAL_DNS` is only really needed for large-scale web servers. It's unlikely the typical use case for pomerium will need this capability, so it makes more sense to use `STRICT_DNS` as the default.

`STRICT_DNS` always trusts the response from DNS as the complete list of addresses for a cluster, whereas `LOGICAL_DNS` assumes the DNS server only returns a subset of the addresses.

If this capability is needed in the future, we should add an additional policy configuration option to enable `LOGICAL_DNS`.

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
