### PR TITLE
envoy: add duration and size to access log

### DIFF
--- a/internal/controlplane/grpc_accesslog.go
+++ b/internal/controlplane/grpc_accesslog.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	envoy_service_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
+	"github.com/golang/protobuf/ptypes"
 
 	"github.com/pomerium/pomerium/internal/log"
 )
@@ -32,6 +33,9 @@ func (srv *Server) StreamAccessLogs(stream envoy_service_accesslog_v2.AccessLogS
 			evt = evt.Str("forwarded-for", entry.GetRequest().GetForwardedFor())
 			evt = evt.Str("request-id", entry.GetRequest().GetRequestId())
 			// response properties
+			dur, _ := ptypes.Duration(entry.CommonProperties.TimeToLastDownstreamTxByte)
+			evt = evt.Dur("duration", dur)
+			evt = evt.Uint64("size", entry.Response.ResponseBodyBytes)
 			evt = evt.Uint32("response-code", entry.GetResponse().GetResponseCode().GetValue())
 			evt = evt.Str("response-code-details", entry.GetResponse().GetResponseCodeDetails())
 			evt.Msg("http-request")


### PR DESCRIPTION
## Summary
This adds `duration` and `size` to the envoy access log. These appeared to be the only two missing fields from the original proxy access logs.

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
