### PR TITLE
envoy: forward claim and assertion headers

### DIFF
--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -117,7 +117,7 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 		}
 
 		original := p.getOriginalRequest(r, uri)
-		authorized, err := p.isAuthorized(original)
+		authorized, err := p.isAuthorized(w, original)
 		if err != nil {
 			return httputil.NewError(http.StatusBadRequest, err)
 		}

--- a/proxy/middleware.go
+++ b/proxy/middleware.go
@@ -45,7 +45,7 @@ func (p *Proxy) redirectToSignin(w http.ResponseWriter, r *http.Request) error {
 	return nil
 }
 
-func (p *Proxy) isAuthorized(r *http.Request) (bool, error) {
+func (p *Proxy) isAuthorized(w http.ResponseWriter, r *http.Request) (bool, error) {
 	tm, err := ptypes.TimestampProto(time.Now())
 	if err != nil {
 		return false, httputil.NewError(http.StatusInternalServerError, fmt.Errorf("error creating protobuf timestamp from current time: %w", err))
@@ -81,6 +81,9 @@ func (p *Proxy) isAuthorized(r *http.Request) (bool, error) {
 
 	switch res.HttpResponse.(type) {
 	case *envoy_service_auth_v2.CheckResponse_OkResponse:
+		for _, hdr := range res.GetOkResponse().GetHeaders() {
+			w.Header().Set(hdr.GetHeader().GetKey(), hdr.GetHeader().GetValue())
+		}
 		return true, nil
 	default:
 		return false, nil


### PR DESCRIPTION
## Summary
This change will copy any returned headers from the authorize check call to the response so that nginx will send them to the backend.

I tested this with an nginx configuration block like this (based on what I saw in the ingress-nginx template):

```
        location / {
            auth_request /auth;
            auth_request_set    $auth_cookie $upstream_http_set_cookie;

            auth_request_set $auth_header0 $upstream_http_x_pomerium_claim_email;
            proxy_set_header 'x-pomerium-claim-email' $auth_header0;
            auth_request_set $auth_header1 $upstream_http_x_pomerium_claim_user;
            proxy_set_header 'x-pomerium-claim-user' $auth_header1;
            auth_request_set $auth_header2 $upstream_http_x_pomerium_claim_groups;
            proxy_set_header 'x-pomerium-claim-groups' $auth_header2;
            auth_request_set $auth_header3 $upstream_http_x_pomerium_jwt_assertion;
            proxy_set_header 'x-pomerium-jwt-assertion' $auth_header3;

            proxy_pass http://127.0.0.1:5080;
            proxy_set_header Host            $host;
            proxy_set_header X-Forwarded-For $remote_addr;
        }
```

And saw them come through.

## Related issues

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
