### PR TITLE
envoy: Add GRPC stats handler to control plane service

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -7,8 +7,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/pomerium/pomerium/internal/telemetry/metrics"
-
 	"github.com/gorilla/mux"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -16,6 +14,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
 )
 

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -7,6 +7,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pomerium/pomerium/internal/telemetry/metrics"
+
 	"github.com/gorilla/mux"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -60,6 +62,7 @@ func NewServer() (*Server, error) {
 		return nil, err
 	}
 	srv.GRPCServer = grpc.NewServer(
+		grpc.StatsHandler(metrics.NewGRPCServerStatsHandler("control_plane")),
 		grpc.UnaryInterceptor(requestid.UnaryServerInterceptor()),
 		grpc.StreamInterceptor(requestid.StreamServerInterceptor()),
 	)


### PR DESCRIPTION
## Summary
Ensure we have the stats handler for metrics and tracing propagation on control plane.

**Checklist**:
- [x] ready for review
