### PR TITLE
envoy: support ports in hosts for routing

### DIFF
--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -336,20 +336,20 @@ func (srv *Server) buildDownstreamTLSContext(options *config.Options, domain str
 func (srv *Server) getAllRouteableDomains(options *config.Options, addr string) []string {
 	lookup := map[string]struct{}{}
 	if config.IsAuthenticate(options.Services) && addr == options.Addr {
-		lookup[urlutil.StripPort(options.AuthenticateURL.Host)] = struct{}{}
+		lookup[options.AuthenticateURL.Host] = struct{}{}
 	}
 	if config.IsAuthorize(options.Services) && addr == options.GRPCAddr {
-		lookup[urlutil.StripPort(options.AuthorizeURL.Host)] = struct{}{}
+		lookup[options.AuthorizeURL.Host] = struct{}{}
 	}
 	if config.IsCache(options.Services) && addr == options.GRPCAddr {
-		lookup[urlutil.StripPort(options.CacheURL.Host)] = struct{}{}
+		lookup[options.CacheURL.Host] = struct{}{}
 	}
 	if config.IsProxy(options.Services) && addr == options.Addr {
 		for _, policy := range options.Policies {
-			lookup[urlutil.StripPort(policy.Source.Host)] = struct{}{}
+			lookup[policy.Source.Host] = struct{}{}
 		}
 		if options.ForwardAuthURL != nil {
-			lookup[urlutil.StripPort(options.ForwardAuthURL.Host)] = struct{}{}
+			lookup[options.ForwardAuthURL.Host] = struct{}{}
 		}
 	}
 

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/cryptutil"
 	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
 var disableExtAuthz *any.Any
@@ -125,8 +124,8 @@ func (srv *Server) buildMainHTTPConnectionManagerFilter(options *config.Options,
 
 		if options.Addr == options.GRPCAddr {
 			// if this is a gRPC service domain and we're supposed to handle that, add those routes
-			if (config.IsAuthorize(options.Services) && domain == urlutil.StripPort(options.AuthorizeURL.Host)) ||
-				(config.IsCache(options.Services) && domain == urlutil.StripPort(options.CacheURL.Host)) {
+			if (config.IsAuthorize(options.Services) && domain == options.AuthorizeURL.Host) ||
+				(config.IsCache(options.Services) && domain == options.CacheURL.Host) {
 				vh.Routes = append(vh.Routes, srv.buildGRPCRoutes()...)
 			}
 		}

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -13,7 +13,6 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
 func (srv *Server) buildGRPCRoutes() []*envoy_config_route_v3.Route {
@@ -47,12 +46,12 @@ func (srv *Server) buildPomeriumHTTPRoutes(options *config.Options, domain strin
 		srv.buildControlPlanePrefixRoute("/.pomerium/"),
 	}
 	// if we're handling authentication, add the oauth2 callback url
-	if config.IsAuthenticate(options.Services) && domain == urlutil.StripPort(options.AuthenticateURL.Host) {
+	if config.IsAuthenticate(options.Services) && domain == options.AuthenticateURL.Host {
 		routes = append(routes,
 			srv.buildControlPlanePathRoute(options.AuthenticateCallbackPath))
 	}
 	// if we're the proxy and this is the forward-auth url
-	if config.IsProxy(options.Services) && options.ForwardAuthURL != nil && domain == urlutil.StripPort(options.ForwardAuthURL.Host) {
+	if config.IsProxy(options.Services) && options.ForwardAuthURL != nil && domain == options.ForwardAuthURL.Host {
 		routes = append(routes,
 			srv.buildControlPlanePrefixRoute("/"))
 	}

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -100,7 +100,7 @@ func (srv *Server) buildControlPlanePrefixRoute(prefix string) *envoy_config_rou
 func (srv *Server) buildPolicyRoutes(options *config.Options, domain string) []*envoy_config_route_v3.Route {
 	var routes []*envoy_config_route_v3.Route
 	for i, policy := range options.Policies {
-		if policy.Source.Hostname() != domain {
+		if policy.Source.Host != domain {
 			continue
 		}
 
@@ -122,7 +122,6 @@ func (srv *Server) buildPolicyRoutes(options *config.Options, domain string) []*
 		default:
 			match.PathSpecifier = &envoy_config_route_v3.RouteMatch_Prefix{Prefix: "/"}
 		}
-
 		clusterName := getPolicyName(&policy)
 
 		var requestHeadersToAdd []*envoy_config_core_v3.HeaderValueOption


### PR DESCRIPTION
## Summary
The virtual hosts and domains in envoy need to include port numbers in order to match urls like `http://httpdetails.localhost.pomerium.io:9000`. This should fix the configuration.

## Related issues
- Fixes #747 


**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
