### PR TITLE
envoy: b3 context propagation

### DIFF
--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -61,6 +61,9 @@ func Run(ctx context.Context, configFile string) error {
 	_, grpcPort, _ := net.SplitHostPort(controlPlane.GRPCListener.Addr().String())
 	_, httpPort, _ := net.SplitHostPort(controlPlane.HTTPListener.Addr().String())
 
+	log.Info().Str("port", grpcPort).Msg("gRPC server started")
+	log.Info().Str("port", httpPort).Msg("HTTP server started")
+
 	// create envoy server
 	envoyServer, err := envoy.NewServer(opt, grpcPort, httpPort)
 	if err != nil {

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/internal/telemetry/metrics"
+	"github.com/pomerium/pomerium/internal/telemetry"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
 )
 
@@ -61,7 +61,7 @@ func NewServer() (*Server, error) {
 		return nil, err
 	}
 	srv.GRPCServer = grpc.NewServer(
-		grpc.StatsHandler(metrics.NewGRPCServerStatsHandler("control_plane")),
+		grpc.StatsHandler(telemetry.NewGRPCServerStatsHandler("control_plane")),
 		grpc.UnaryInterceptor(requestid.UnaryServerInterceptor()),
 		grpc.StreamInterceptor(requestid.StreamServerInterceptor()),
 	)

--- a/internal/telemetry/doc.go
+++ b/internal/telemetry/doc.go
@@ -1,0 +1,2 @@
+// Package telemetry contains metrics and tracing constructs
+package telemetry

--- a/internal/telemetry/grpc.go
+++ b/internal/telemetry/grpc.go
@@ -1,0 +1,43 @@
+package telemetry
+
+import (
+	"context"
+
+	"go.opencensus.io/plugin/ocgrpc"
+	grpcstats "google.golang.org/grpc/stats"
+
+	"github.com/pomerium/pomerium/internal/telemetry/metrics"
+	"github.com/pomerium/pomerium/internal/telemetry/trace"
+)
+
+type tagRPCHandler interface {
+	TagRPC(context.Context, *grpcstats.RPCTagInfo) context.Context
+}
+
+// GRPCServerStatsHandler provides a grpc stats.Handler for metrics and tracing for a pomerium service
+type GRPCServerStatsHandler struct {
+	service        string
+	metricsHandler tagRPCHandler
+	traceHandler   tagRPCHandler
+	grpcstats.Handler
+}
+
+// TagRPC implements grpc.stats.Handler and adds tags to the context of a given RPC
+func (h *GRPCServerStatsHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.RPCTagInfo) context.Context {
+
+	traceCtx := h.traceHandler.TagRPC(ctx, tagInfo)
+	handledCtx := h.Handler.TagRPC(traceCtx, tagInfo)
+	taggedCtx := h.metricsHandler.TagRPC(handledCtx, tagInfo)
+
+	return taggedCtx
+}
+
+// NewGRPCServerStatsHandler creates a new GRPCServerStatsHandler for a pomerium service
+func NewGRPCServerStatsHandler(service string) grpcstats.Handler {
+	return &GRPCServerStatsHandler{
+		service:        service,
+		Handler:        &ocgrpc.ServerHandler{},
+		metricsHandler: metrics.NewGRPCServerMetricsHandler(service),
+		traceHandler:   trace.NewGRPCServerTracingHandler(service),
+	}
+}

--- a/internal/telemetry/grpc_test.go
+++ b/internal/telemetry/grpc_test.go
@@ -1,0 +1,34 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/plugin/ocgrpc"
+	grpcstats "google.golang.org/grpc/stats"
+)
+
+type mockTagHandler struct {
+	called bool
+}
+
+func (m *mockTagHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.RPCTagInfo) context.Context {
+	m.called = true
+	return ctx
+}
+
+func Test_GRPCServerStatsHandler(t *testing.T) {
+
+	metricsHandler := &mockTagHandler{}
+	traceHandler := &mockTagHandler{}
+	h := &GRPCServerStatsHandler{
+		metricsHandler: metricsHandler,
+		traceHandler:   traceHandler,
+		Handler:        &ocgrpc.ServerHandler{},
+	}
+	h.TagRPC(context.Background(), &grpcstats.RPCTagInfo{})
+
+	assert.True(t, metricsHandler.called)
+	assert.True(t, traceHandler.called)
+}

--- a/internal/telemetry/metrics/grpc.go
+++ b/internal/telemetry/metrics/grpc.go
@@ -111,6 +111,9 @@ var (
 
 // GRPCClientInterceptor creates a UnaryClientInterceptor which updates the RPC
 // context with metric tag metadata
+//
+// TODO: This handler will NOT currently propagate B3 headers to upstream servers.  See
+// GRPCServerStatsHandler for changes required
 func GRPCClientInterceptor(service string) grpc.UnaryClientInterceptor {
 	return func(
 		ctx context.Context,

--- a/internal/telemetry/metrics/grpc.go
+++ b/internal/telemetry/metrics/grpc.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"strings"
 
-	"github.com/pomerium/pomerium/internal/log"
 	"go.opencensus.io/plugin/ocgrpc"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
 	"google.golang.org/grpc"
 	grpcstats "google.golang.org/grpc/stats"
+
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 // GRPC Views
@@ -147,17 +148,18 @@ func GRPCClientInterceptor(service string) grpc.UnaryClientInterceptor {
 
 }
 
-// GRPCServerStatsHandler provides a grpc stats.Handler for a pomerium service to add tags and track
-// metrics to server side calls
-type GRPCServerStatsHandler struct {
+// GRPCServerMetricsHandler implements stats.Handler methods for metrics
+type GRPCServerMetricsHandler struct {
 	service string
-	grpcstats.Handler
 }
 
-// TagRPC implements grpc.stats.Handler and adds tags to the context of a given RPC
-func (h *GRPCServerStatsHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.RPCTagInfo) context.Context {
+// NewGRPCServerMetricsHandler creates a new GRPCServerStatsHandler for a pomerium service
+func NewGRPCServerMetricsHandler(service string) *GRPCServerMetricsHandler {
+	return &GRPCServerMetricsHandler{service: service}
+}
 
-	handledCtx := h.Handler.TagRPC(ctx, tagInfo)
+// TagRPC handles adding any metrics related values to the incoming context
+func (h *GRPCServerMetricsHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.RPCTagInfo) context.Context {
 
 	// Split the method into parts for better slicing
 	rpcInfo := strings.SplitN(tagInfo.FullMethodName, "/", 3)
@@ -169,21 +171,16 @@ func (h *GRPCServerStatsHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.
 	}
 
 	taggedCtx, tagErr := tag.New(
-		handledCtx,
+		ctx,
 		tag.Upsert(TagKeyService, h.service),
 		tag.Upsert(TagKeyGRPCMethod, rpcMethod),
 		tag.Upsert(TagKeyGRPCService, rpcService),
 	)
 	if tagErr != nil {
 		log.Warn().Err(tagErr).Str("context", "GRPCServerStatsHandler").Msg("telemetry/metrics: failed to create context")
-		return handledCtx
+		return ctx
 
 	}
 
 	return taggedCtx
-}
-
-// NewGRPCServerStatsHandler creates a new GRPCServerStatsHandler for a pomerium service
-func NewGRPCServerStatsHandler(service string) grpcstats.Handler {
-	return &GRPCServerStatsHandler{service: service, Handler: &ocgrpc.ServerHandler{}}
 }

--- a/internal/telemetry/trace/grpc.go
+++ b/internal/telemetry/trace/grpc.go
@@ -1,0 +1,66 @@
+package trace
+
+import (
+	"context"
+
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+	"go.opencensus.io/trace"
+	"google.golang.org/grpc/metadata"
+	grpcstats "google.golang.org/grpc/stats"
+)
+
+// GRPCServerTracingHandler implements stats.Handler methods for tracing
+type GRPCServerTracingHandler struct {
+	service string
+}
+
+// NewGRPCServerTracingHandler creates a new GRPCServerTracingHandler for a given service name
+func NewGRPCServerTracingHandler(service string) *GRPCServerTracingHandler {
+	return &GRPCServerTracingHandler{service: service}
+}
+
+// TagRPC handles adding any trace related values to the incoming context
+func (h *GRPCServerTracingHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.RPCTagInfo) context.Context {
+
+	b3SpanContext, _ := b3SpanContextFromRPC(ctx)
+	traceContext, _ := trace.StartSpanWithRemoteParent(ctx, h.service, b3SpanContext)
+
+	return traceContext
+}
+
+func b3SpanContextFromRPC(ctx context.Context) (trace.SpanContext, bool) {
+	m, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return trace.SpanContext{}, ok
+	}
+
+	traceIDHeaders := m.Get("x-b3-traceid")
+	if len(traceIDHeaders) == 0 {
+		return trace.SpanContext{}, ok
+	}
+
+	traceID, ok := b3.ParseTraceID(traceIDHeaders[0])
+	if !ok {
+		return trace.SpanContext{}, ok
+	}
+
+	spanIDHeaders := m.Get("x-b3-spanid")
+	if len(spanIDHeaders) == 0 {
+		return trace.SpanContext{}, ok
+	}
+
+	spanID, ok := b3.ParseSpanID(spanIDHeaders[0])
+	if !ok {
+		return trace.SpanContext{}, ok
+	}
+
+	sampled, _ := b3.ParseSampled(m.Get("x-b3-sampled")[0])
+
+	traceCtx := trace.SpanContext{
+		TraceID:      traceID,
+		SpanID:       spanID,
+		TraceOptions: sampled,
+	}
+
+	return traceCtx, ok
+}

--- a/internal/telemetry/trace/grpc_test.go
+++ b/internal/telemetry/trace/grpc_test.go
@@ -1,0 +1,52 @@
+package trace
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/plugin/ochttp/propagation/b3"
+	"go.opencensus.io/trace"
+	"google.golang.org/grpc/metadata"
+)
+
+func Test_GRPCServerTracingHandler(t *testing.T) {
+	h := NewGRPCServerTracingHandler("test_service")
+
+	t.Run("b3", func(t *testing.T) {
+
+		traceID := "742babd53873d170"
+		traceIDParsed, _ := b3.ParseTraceID(traceID)
+
+		spanID := "596a86e14ae535cb"
+		spanIDParsed, _ := b3.ParseSpanID(spanID)
+
+		sampled := "1"
+		sampledParsed, _ := b3.ParseSampled(sampled)
+
+		ctx := metadata.NewIncomingContext(context.Background(),
+			metadata.Pairs(
+				"x-b3-traceid", traceID,
+				"x-b3-spanid", spanID,
+				"x-b3-sampled", sampled,
+			),
+		)
+
+		spanContext := trace.FromContext(h.TagRPC(ctx, nil)).SpanContext()
+
+		assert.NotEqual(t, spanContext.SpanID, spanIDParsed)
+		assert.NotEmpty(t, spanContext.SpanID)
+		assert.Equal(t, traceIDParsed, spanContext.TraceID)
+		assert.Equal(t, spanContext.TraceOptions, sampledParsed)
+
+	})
+
+	t.Run("none", func(t *testing.T) {
+		ctx := metadata.NewIncomingContext(context.Background(), metadata.New(nil))
+
+		spanContext := trace.FromContext(h.TagRPC(ctx, nil)).SpanContext()
+		assert.NotEmpty(t, spanContext.SpanID)
+		assert.NotEmpty(t, spanContext.TraceID)
+	})
+
+}


### PR DESCRIPTION
## Summary
Ensure we are using the b3 headers from incoming RPC requests for tracing context internally.

**Checklist**:
- [x] updated unit tests
- [x] ready for review
