### PR TITLE
envoy: Tracing config improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/lithammer/shortuuid/v3 v3.0.4
 	github.com/mitchellh/hashstructure v1.0.0
 	github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc
+	github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce
 	github.com/onsi/ginkgo v1.11.0 // indirect
 	github.com/onsi/gocleanup v0.0.0-20140331211545-c1a5478700b5
 	github.com/onsi/gomega v1.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -358,6 +358,8 @@ github.com/nrdcg/auroradns v1.0.1/go.mod h1:y4pc0i9QXYlFCWrhWrUSIETnZgrf4KuwjDIW
 github.com/nrdcg/dnspod-go v0.4.0/go.mod h1:vZSoFSFeQVm2gWLMkyX61LZ8HI3BaqtHZWgPTGKr6KQ=
 github.com/nrdcg/goinwx v0.6.1/go.mod h1:XPiut7enlbEdntAqalBIqcYcTEVhpv/dKWgDCX2SwKQ=
 github.com/nrdcg/namesilo v0.2.1/go.mod h1:lwMvfQTyYq+BbjJd30ylEG4GPSS6PII0Tia4rRpRiyw=
+github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce h1:RPclfga2SEJmgMmz2k+Mg7cowZ8yv4Trqw9UsJby758=
+github.com/nsf/jsondiff v0.0.0-20200515183724-f29ed568f4ce/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/internal/envoy/envoy_test.go
+++ b/internal/envoy/envoy_test.go
@@ -1,0 +1,69 @@
+package envoy
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	envoy_config_bootstrap_v3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
+	"github.com/golang/protobuf/proto"
+	"github.com/nsf/jsondiff"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/pomerium/pomerium/config"
+)
+
+func jsonDump(t *testing.T, m proto.GeneratedMessage) []byte {
+	t.Helper()
+
+	jsonBytes, err := protojson.Marshal(proto.MessageV2(m))
+	if err != nil {
+		t.Fatalf("failed to marshal json: %s", err)
+	}
+	return jsonBytes
+}
+
+func Test_addTraceConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		opts    *config.TracingOptions
+		want    string
+		wantErr bool
+	}{
+		{
+			"good zipkin",
+			&config.TracingOptions{Provider: config.ZipkinTracingProviderName, ZipkinEndpoint: &url.URL{Host: "localhost:9411"}},
+			`{"tracing":{"http":{"name":"envoy.tracers.opencensus","typedConfig":{"@type":"type.googleapis.com/envoy.config.trace.v3.OpenCensusConfig","zipkinExporterEnabled":true,"zipkinUrl":"//localhost:9411","incomingTraceContext":["B3","TRACE_CONTEXT","CLOUD_TRACE_CONTEXT","GRPC_TRACE_BIN"],"outgoingTraceContext":["B3","TRACE_CONTEXT","GRPC_TRACE_BIN"]}}}}`,
+			false,
+		},
+		{
+			"good jaeger",
+			&config.TracingOptions{Provider: config.JaegerTracingProviderName},
+			`{}`,
+			false,
+		},
+		{
+			"bad zipkin",
+			&config.TracingOptions{Provider: config.ZipkinTracingProviderName, ZipkinEndpoint: &url.URL{}},
+			`{}`,
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := &Server{}
+			baseCfg := &envoy_config_bootstrap_v3.Bootstrap{}
+
+			err := srv.addTraceConfig(tt.opts, baseCfg)
+
+			assert.Equal(t, tt.wantErr, err != nil, "unexpected error state")
+
+			diff, diffStr := jsondiff.Compare([]byte(tt.want), jsonDump(t, baseCfg), &jsondiff.Options{})
+			assert.Equal(t, jsondiff.FullMatch, diff, fmt.Sprintf("%s: differences: %s", diff.String(), diffStr))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Switch to OpenCensus tracer to utilize [trace propagation handling](https://www.envoyproxy.io/docs/envoy/v1.14.1/api-v3/config/trace/v3/trace.proto#envoy-v3-api-enum-config-trace-v3-opencensusconfig-tracecontext) (default to all now) 
- Add test around handling of traceConfig
- Ensure we don't panic when using Jaeger tracer

**Checklist**:
- [x] updated unit tests
- [x] ready for review
