### PR TITLE
sessions/state: Add nickname claim

### DIFF
--- a/internal/sessions/state.go
+++ b/internal/sessions/state.go
@@ -39,6 +39,7 @@ type State struct {
 	FamilyName    string `json:"family_name,omitempty"`    // google
 	Picture       string `json:"picture,omitempty"`        // google
 	EmailVerified bool   `json:"email_verified,omitempty"` // google
+	Nickname      string `json:"nickname,omitempty"`       // gitlab
 
 	// Impersonate-able fields
 	ImpersonateEmail  string   `json:"impersonate_email,omitempty"`


### PR DESCRIPTION
## Summary

GitLab returns the user name in a `nickname` claim instead of `user`, so make
it available in `sessions.State`.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
