### PR TITLE
telemetry: Refactor GRPC Server Handler

### DIFF
--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -61,6 +61,9 @@ func Run(ctx context.Context, configFile string) error {
 	_, grpcPort, _ := net.SplitHostPort(controlPlane.GRPCListener.Addr().String())
 	_, httpPort, _ := net.SplitHostPort(controlPlane.HTTPListener.Addr().String())
 
+	log.Info().Str("port", grpcPort).Msg("gRPC server started")
+	log.Info().Str("port", httpPort).Msg("HTTP server started")
+
 	// create envoy server
 	envoyServer, err := envoy.NewServer(opt, grpcPort, httpPort)
 	if err != nil {

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/internal/telemetry/metrics"
+	"github.com/pomerium/pomerium/internal/telemetry"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
 )
 
@@ -61,7 +61,7 @@ func NewServer() (*Server, error) {
 		return nil, err
 	}
 	srv.GRPCServer = grpc.NewServer(
-		grpc.StatsHandler(metrics.NewGRPCServerStatsHandler("control_plane")),
+		grpc.StatsHandler(telemetry.NewGRPCServerStatsHandler("control_plane")),
 		grpc.UnaryInterceptor(requestid.UnaryServerInterceptor()),
 		grpc.StreamInterceptor(requestid.StreamServerInterceptor()),
 	)

--- a/internal/telemetry/doc.go
+++ b/internal/telemetry/doc.go
@@ -1,0 +1,2 @@
+// Package telemetry contains metrics and tracing constructs
+package telemetry

--- a/internal/telemetry/grpc.go
+++ b/internal/telemetry/grpc.go
@@ -17,15 +17,14 @@ type tagRPCHandler interface {
 type GRPCServerStatsHandler struct {
 	service        string
 	metricsHandler tagRPCHandler
-	traceHandler   tagRPCHandler
 	grpcstats.Handler
 }
 
 // TagRPC implements grpc.stats.Handler and adds metrics and tracing metadata to the context of a given RPC
 func (h *GRPCServerStatsHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.RPCTagInfo) context.Context {
 
-	traceCtx := h.traceHandler.TagRPC(ctx, tagInfo)
-	handledCtx := h.Handler.TagRPC(traceCtx, tagInfo)
+	metricCtx := h.metricsHandler.TagRPC(ctx, tagInfo)
+	handledCtx := h.Handler.TagRPC(metricCtx, tagInfo)
 
 	return handledCtx
 }

--- a/internal/telemetry/grpc.go
+++ b/internal/telemetry/grpc.go
@@ -1,0 +1,40 @@
+package telemetry
+
+import (
+	"context"
+
+	"go.opencensus.io/plugin/ocgrpc"
+	grpcstats "google.golang.org/grpc/stats"
+
+	"github.com/pomerium/pomerium/internal/telemetry/metrics"
+)
+
+type tagRPCHandler interface {
+	TagRPC(context.Context, *grpcstats.RPCTagInfo) context.Context
+}
+
+// GRPCServerStatsHandler provides a grpc stats.Handler for metrics and tracing for a pomerium service
+type GRPCServerStatsHandler struct {
+	service        string
+	metricsHandler tagRPCHandler
+	traceHandler   tagRPCHandler
+	grpcstats.Handler
+}
+
+// TagRPC implements grpc.stats.Handler and adds metrics and tracing metadata to the context of a given RPC
+func (h *GRPCServerStatsHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.RPCTagInfo) context.Context {
+
+	traceCtx := h.traceHandler.TagRPC(ctx, tagInfo)
+	handledCtx := h.Handler.TagRPC(traceCtx, tagInfo)
+
+	return handledCtx
+}
+
+// NewGRPCServerStatsHandler creates a new GRPCServerStatsHandler for a pomerium service
+func NewGRPCServerStatsHandler(service string) grpcstats.Handler {
+	return &GRPCServerStatsHandler{
+		service:        service,
+		Handler:        &ocgrpc.ServerHandler{},
+		metricsHandler: metrics.NewGRPCServerMetricsHandler(service),
+	}
+}

--- a/internal/telemetry/grpc_test.go
+++ b/internal/telemetry/grpc_test.go
@@ -23,10 +23,8 @@ func (m *mockTagHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.RPCTagIn
 func Test_GRPCServerStatsHandler(t *testing.T) {
 
 	metricsHandler := &mockTagHandler{}
-	traceHandler := &mockTagHandler{}
 	h := &GRPCServerStatsHandler{
 		metricsHandler: metricsHandler,
-		traceHandler:   traceHandler,
 		Handler:        &ocgrpc.ServerHandler{},
 	}
 
@@ -34,7 +32,6 @@ func Test_GRPCServerStatsHandler(t *testing.T) {
 	ctx = h.TagRPC(ctx, &grpcstats.RPCTagInfo{})
 
 	assert.True(t, metricsHandler.called)
-	assert.True(t, traceHandler.called)
 	assert.Equal(t, ctx.Value(mockCtxTag("added")), "true")
 	assert.Equal(t, ctx.Value(mockCtxTag("original")), "true")
 }

--- a/internal/telemetry/grpc_test.go
+++ b/internal/telemetry/grpc_test.go
@@ -1,0 +1,40 @@
+package telemetry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opencensus.io/plugin/ocgrpc"
+	grpcstats "google.golang.org/grpc/stats"
+)
+
+type mockTagHandler struct {
+	called bool
+}
+
+type mockCtxTag string
+
+func (m *mockTagHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.RPCTagInfo) context.Context {
+	m.called = true
+	return context.WithValue(ctx, mockCtxTag("added"), "true")
+}
+
+func Test_GRPCServerStatsHandler(t *testing.T) {
+
+	metricsHandler := &mockTagHandler{}
+	traceHandler := &mockTagHandler{}
+	h := &GRPCServerStatsHandler{
+		metricsHandler: metricsHandler,
+		traceHandler:   traceHandler,
+		Handler:        &ocgrpc.ServerHandler{},
+	}
+
+	ctx := context.WithValue(context.Background(), mockCtxTag("original"), "true")
+	ctx = h.TagRPC(ctx, &grpcstats.RPCTagInfo{})
+
+	assert.True(t, metricsHandler.called)
+	assert.True(t, traceHandler.called)
+	assert.Equal(t, ctx.Value(mockCtxTag("added")), "true")
+	assert.Equal(t, ctx.Value(mockCtxTag("original")), "true")
+}


### PR DESCRIPTION
## Summary
Small refactor that came about as part of other work.  The GRPC stats handlers in OpenCensus do implicit work for both metrics and tracing, so having them live in the metrics package doesn't make a lot fo sense.  

More work should be done to make similar changes for GRPC client and HTTP handlers in the future.

## Related issues
#752 


**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
