### PR TITLE
authenticate: add tests to signing endpoints

### DIFF
--- a/authenticate/authenticate_test.go
+++ b/authenticate/authenticate_test.go
@@ -97,6 +97,15 @@ func TestNew(t *testing.T) {
 	emptyProviderURL.Provider = "oidc"
 	emptyProviderURL.ProviderURL = ""
 
+	goodSigningKey := newTestOptions(t)
+	goodSigningKey.SigningKey = "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUpCMFZkbko1VjEvbVlpYUlIWHhnd2Q0Yzd5YWRTeXMxb3Y0bzA1b0F3ekdvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFVUc1eENQMEpUVDFINklvbDhqS3VUSVBWTE0wNENnVzlQbEV5cE5SbVdsb29LRVhSOUhUMwpPYnp6aktZaWN6YjArMUt3VjJmTVRFMTh1dy82MXJVQ0JBPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
+
+	badSigningKey := newTestOptions(t)
+	badSigningKey.SigningKey = "%"
+
+	badSigninKeyPublic := newTestOptions(t)
+	badSigninKeyPublic.SigningKey = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJFakNCdWdJSkFNWUdtVzhpYWd1TU1Bb0dDQ3FHU000OUJBTUNNQkV4RHpBTkJnTlZCQU1NQm5WdWRYTmwKWkRBZ0Z3MHlNREExTWpJeU1EUTFNalJhR0E4ME56VTRNRFF4T1RJd05EVXlORm93RVRFUE1BMEdBMVVFQXd3RwpkVzUxYzJWa01Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRVVHNXhDUDBKVFQxSDZJb2w4akt1ClRJUFZMTTA0Q2dXOVBsRXlwTlJtV2xvb0tFWFI5SFQzT2J6empLWWljemIwKzFLd1YyZk1URTE4dXcvNjFyVUMKQkRBS0JnZ3Foa2pPUFFRREFnTkhBREJFQWlBSFFDUFh2WG5oeHlDTGNhZ3N3eWt4RUM1NFV5RmdyUVJVRmVCYwpPUzVCSFFJZ1Y3T2FXY2pMeHdsRlIrWDZTQ2daZDI5bXBtOVZKNnpXQURhWGdEN3FURW89Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
+
 	tests := []struct {
 		name string
 		opts *config.Options
@@ -110,6 +119,9 @@ func TestNew(t *testing.T) {
 		{"bad provider", badProvider, true},
 		{"bad cache url", badGRPCConn, true},
 		{"empty provider url", emptyProviderURL, true},
+		{"good signing key", goodSigningKey, false},
+		{"bad signing key", badSigningKey, true},
+		{"bad public signing key", badSigninKeyPublic, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#436  Summary
Adds tests related to the well known endpoint, jwks.json url, and signing. 



**Checklist**:
- [x] updated unit tests
- [x] ready for review
