### PR TITLE
authenticate: ensure authorize url is set

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -55,6 +55,9 @@ func ValidateOptions(o config.Options) error {
 	if o.AuthenticateCallbackPath == "" {
 		return errors.New("authenticate: 'AUTHENTICATE_CALLBACK_PATH' is required")
 	}
+	if err := urlutil.ValidateURL(o.AuthorizeURL); err != nil {
+		return fmt.Errorf("authenticate: invalid 'AUTHORIZE_SERVICE_URL': %w", err)
+	}
 	return nil
 }
 

--- a/authenticate/authenticate_test.go
+++ b/authenticate/authenticate_test.go
@@ -106,6 +106,9 @@ func TestNew(t *testing.T) {
 	badSigninKeyPublic := newTestOptions(t)
 	badSigninKeyPublic.SigningKey = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUJFakNCdWdJSkFNWUdtVzhpYWd1TU1Bb0dDQ3FHU000OUJBTUNNQkV4RHpBTkJnTlZCQU1NQm5WdWRYTmwKWkRBZ0Z3MHlNREExTWpJeU1EUTFNalJhR0E4ME56VTRNRFF4T1RJd05EVXlORm93RVRFUE1BMEdBMVVFQXd3RwpkVzUxYzJWa01Ga3dFd1lIS29aSXpqMENBUVlJS29aSXpqMERBUWNEUWdBRVVHNXhDUDBKVFQxSDZJb2w4akt1ClRJUFZMTTA0Q2dXOVBsRXlwTlJtV2xvb0tFWFI5SFQzT2J6empLWWljemIwKzFLd1YyZk1URTE4dXcvNjFyVUMKQkRBS0JnZ3Foa2pPUFFRREFnTkhBREJFQWlBSFFDUFh2WG5oeHlDTGNhZ3N3eWt4RUM1NFV5RmdyUVJVRmVCYwpPUzVCSFFJZ1Y3T2FXY2pMeHdsRlIrWDZTQ2daZDI5bXBtOVZKNnpXQURhWGdEN3FURW89Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K"
 
+	badAuthZ := newTestOptions(t)
+	badAuthZ.AuthorizeURL = nil
+
 	tests := []struct {
 		name string
 		opts *config.Options
@@ -122,6 +125,7 @@ func TestNew(t *testing.T) {
 		{"good signing key", goodSigningKey, false},
 		{"bad signing key", badSigningKey, true},
 		{"bad public signing key", badSigninKeyPublic, true},
+		{"nil autz url", badAuthZ, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -548,6 +548,7 @@ func TestAuthenticate_Refresh(t *testing.T) {
 				CookieName:               "pomerium",
 				Addr:                     ":0",
 				CacheURL:                 uriParseHelper("https://authenticate.corp.beyondperimeter.com"),
+				AuthorizeURL:             uriParseHelper("https://authorize.corp.beyondperimeter.com"),
 			})
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
## Summary

Adds a check to make sure authorize URL is set if running in split service mode for AuthN. 


**Checklist**:
- [x] updated unit tests
- [x] ready for review
