### PR TITLE
proxy: fix bug that would allow failed refresh session to continue

### DIFF
--- a/proxy/middleware.go
+++ b/proxy/middleware.go
@@ -85,7 +85,7 @@ func (p *Proxy) redirectToSignin(w http.ResponseWriter, r *http.Request) error {
 	log.FromRequest(r).Debug().Str("url", signinURL.String()).Msg("proxy: redirectToSignin")
 	httputil.Redirect(w, r, urlutil.NewSignedURL(p.SharedKey, &signinURL).String(), http.StatusFound)
 	p.sessionStore.ClearSession(w, r)
-	return nil
+	return httputil.ErrRedirectOnly
 }
 
 // AuthorizeSession is middleware to enforce a user is authorized for a request.


### PR DESCRIPTION
# Summary

Fixes a bug and potential security issue where a user with a valid but expired session could send a request to an upstream server despite their session being expired. 

Huge thank you to @selaux for reporting this issue. 

To be cherrypicked onto v0.8 release branches, and released as v0.8.2.

**Checklist**:

- [x] ready for review
