### PR TITLE
state: infer user (`user`) from subject (`sub`)

### DIFF
--- a/internal/sessions/state.go
+++ b/internal/sessions/state.go
@@ -1,6 +1,7 @@
 package sessions
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -81,4 +82,23 @@ func (s *State) SetImpersonation(email, groups string) {
 	} else {
 		s.ImpersonateGroups = strings.Split(groups, ",")
 	}
+}
+
+// UnmarshalJSON returns a State struct from JSON. Additionally munges
+// a user's session by using by setting `user` claim to `sub` if empty.
+func (s *State) UnmarshalJSON(data []byte) error {
+	type StateAlias State
+	a := &struct {
+		*StateAlias
+	}{
+		StateAlias: (*StateAlias)(s),
+	}
+
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	if a.User == "" {
+		a.User = a.Subject
+	}
+	return nil
 }

--- a/internal/sessions/state_test.go
+++ b/internal/sessions/state_test.go
@@ -1,10 +1,12 @@
 package sessions
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"golang.org/x/oauth2"
 	"gopkg.in/square/go-jose.v2/jwt"
 )
@@ -66,6 +68,40 @@ func TestState_IsExpired(t *testing.T) {
 			}
 			if exp := s.IsExpired(); exp != tt.wantErr {
 				t.Errorf("State.IsExpired() error = %v, wantErr %v", exp, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestState_UnmarshalJSON(t *testing.T) {
+	fixedTime := time.Date(2009, 11, 17, 20, 34, 58, 651387237, time.UTC)
+	timeNow = func() time.Time {
+		return fixedTime
+	}
+	defer func() { timeNow = time.Now }()
+	tests := []struct {
+		name    string
+		in      *State
+		want    State
+		wantErr bool
+	}{
+		{"good", &State{}, State{NotBefore: jwt.NewNumericDate(fixedTime), IssuedAt: jwt.NewNumericDate(fixedTime), AccessTokenHash: "bbd82197d215198f"}, false},
+		{"with user", &State{User: "user"}, State{User: "user", NotBefore: jwt.NewNumericDate(fixedTime), IssuedAt: jwt.NewNumericDate(fixedTime), AccessTokenHash: "bbd82197d215198f"}, false},
+		{"without", &State{Subject: "user"}, State{User: "user", Subject: "user", NotBefore: jwt.NewNumericDate(fixedTime), IssuedAt: jwt.NewNumericDate(fixedTime), AccessTokenHash: "bbd82197d215198f"}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data, err := json.Marshal(tt.in)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			s := NewSession(&State{}, "", nil, &oauth2.Token{})
+			if err := s.UnmarshalJSON(data); (err != nil) != tt.wantErr {
+				t.Errorf("State.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if diff := cmp.Diff(s, tt.want); diff != "" {
+				t.Errorf("State.UnmarshalJSON() error = %v", diff)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Most identity providers do _not_ provide a user specific claim. However, `sub` is typically what is intended to be used for this field. These changes allow operators to write user (vs email) driven authorization policy based on the core oidc `sub` claim. 

> Subject Identifier
> Locally unique and never reassigned identifier within the Issuer for the End-User, which is intended to be consumed by the Client.

https://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes


To be cherrypicked onto `v0.8.x` branch. 


**Checklist**
- [x] updated unit tests
- [x] ready for review
