### PR TITLE
proxy/forward-auth: block expired request  prior to 302

### DIFF
--- a/internal/httputil/errors.go
+++ b/internal/httputil/errors.go
@@ -12,9 +12,9 @@ import (
 	"github.com/pomerium/pomerium/internal/version"
 )
 
-// ErrRedirectOnly is the error case when a user's session failed to be refresh
-// and the user should be redirected to the authenticate service but ensuring
-// that the current request does not continue to go through.
+// ErrRedirectOnly is the error used when a user's session failed to be refreshed.
+// The user should be redirected to the authorization service, and the original
+// request should not be permitted to hit the upstream service.
 var ErrRedirectOnly = errors.New("httputil: redirecting to authenticate service")
 
 var errorTemplate = template.Must(frontend.NewTemplates())

--- a/internal/httputil/errors.go
+++ b/internal/httputil/errors.go
@@ -12,6 +12,9 @@ import (
 	"github.com/pomerium/pomerium/internal/version"
 )
 
+// ErrRedirectOnly is the error case when a user's session failed to be refresh
+// and the user should be redirected to the authenticate service but ensuring
+// that the current request does not continue to go through.
 var ErrRedirectOnly = errors.New("httputil: redirecting to authenticate service")
 
 var errorTemplate = template.Must(frontend.NewTemplates())

--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -132,7 +132,7 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 				q.Set(urlutil.QueryForwardAuth, urlutil.StripPort(r.Host)) // add fwd auth to trusted audience
 				authN.RawQuery = q.Encode()
 				httputil.Redirect(w, r, urlutil.NewSignedURL(p.SharedKey, &authN).String(), http.StatusFound)
-				return nil
+				return httputil.ErrRedirectOnly
 			}
 			return err
 		}


### PR DESCRIPTION
## Summary
See https://github.com/pomerium/pomerium/pull/762 but for forward auth as well. 

Thanks again to @selaux for reporting the original, and potential forward auth issue. 

## Related issues

-  https://github.com/pomerium/pomerium/pull/762

To be cherrypicked and released as v0.8.3

**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
