### PR TITLE
config: add getters for URLs to avoid nils

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -135,7 +135,7 @@ func New(opts config.Options) (*Authenticate, error) {
 
 	cacheConn, err := grpc.NewGRPCClientConn(
 		&grpc.Options{
-			Addr:                    opts.GetCacheURL(),
+			Addr:                    opts.CacheURL,
 			OverrideCertificateName: opts.OverrideCertificateName,
 			CA:                      opts.CA,
 			CAFile:                  opts.CAFile,

--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -110,7 +110,7 @@ func New(opts config.Options) (*Authenticate, error) {
 
 	// shared state encoder setup
 	sharedCipher, _ := cryptutil.NewAEADCipherFromBase64(opts.SharedKey)
-	sharedEncoder, err := jws.NewHS256Signer([]byte(opts.SharedKey), opts.AuthenticateURL.Host)
+	sharedEncoder, err := jws.NewHS256Signer([]byte(opts.SharedKey), opts.GetAuthenticateURL().Host)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +135,7 @@ func New(opts config.Options) (*Authenticate, error) {
 
 	cacheConn, err := grpc.NewGRPCClientConn(
 		&grpc.Options{
-			Addr:                    opts.CacheURL,
+			Addr:                    opts.GetCacheURL(),
 			OverrideCertificateName: opts.OverrideCertificateName,
 			CA:                      opts.CA,
 			CAFile:                  opts.CAFile,

--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -127,7 +127,7 @@ func (a *Authorize) plainTextDeniedResponse(code int32, reason string, headers m
 func (a *Authorize) redirectResponse(in *envoy_service_auth_v2.CheckRequest) *envoy_service_auth_v2.CheckResponse {
 	opts := a.currentOptions.Load()
 
-	signinURL := opts.AuthenticateURL.ResolveReference(&url.URL{Path: "/.pomerium/sign_in"})
+	signinURL := opts.GetAuthenticateURL().ResolveReference(&url.URL{Path: "/.pomerium/sign_in"})
 	q := signinURL.Query()
 	q.Set(urlutil.QueryRedirectURI, getCheckRequestURL(in).String())
 	signinURL.RawQuery = q.Encode()

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -125,7 +125,7 @@ func (a *Authorize) refreshSession(ctx context.Context, rawJWT []byte) (newSessi
 	options := a.currentOptions.Load()
 
 	// 1 - build a signed url to call refresh on authenticate service
-	refreshURI := options.AuthenticateURL.ResolveReference(&url.URL{Path: "/.pomerium/refresh"})
+	refreshURI := options.GetAuthenticateURL().ResolveReference(&url.URL{Path: "/.pomerium/refresh"})
 	signedRefreshURL := urlutil.NewSignedURL(options.SharedKey, refreshURI).String()
 
 	// 2 - http call to authenticate service
@@ -167,7 +167,7 @@ func (a *Authorize) handleForwardAuth(req *envoy_service_auth_v2.CheckRequest) b
 	}
 
 	checkURL := getCheckRequestURL(req)
-	if urlutil.StripPort(checkURL.Host) == urlutil.StripPort(opts.ForwardAuthURL.Host) {
+	if urlutil.StripPort(checkURL.Host) == urlutil.StripPort(opts.GetForwardAuthURL().Host) {
 		if (checkURL.Path == "/" || checkURL.Path == "/verify") && checkURL.Query().Get("uri") != "" {
 			verifyURL, err := url.Parse(checkURL.Query().Get("uri"))
 			if err != nil {

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -68,7 +68,7 @@ func newCacheStore(name string, o *config.Options) (s kv.Store, err error) {
 		s, err = autocache.New(&autocache.Options{
 			SharedKey:     o.SharedKey,
 			Log:           stdlog.New(acLog, "", 0),
-			ClusterDomain: o.CacheURL.Hostname(),
+			ClusterDomain: o.GetCacheURL().Hostname(),
 		})
 	default:
 		return nil, fmt.Errorf("cache: unknown store: %s", name)

--- a/config/options.go
+++ b/config/options.go
@@ -620,6 +620,42 @@ func (o *Options) sourceHostnames() []string {
 	return h
 }
 
+// GetAuthenticateURL returns the AuthenticateURL in the options or localhost.
+func (o *Options) GetAuthenticateURL() *url.URL {
+	if o != nil && o.AuthenticateURL != nil {
+		return o.AuthenticateURL
+	}
+	u, _ := url.Parse("https://localhost")
+	return u
+}
+
+// GetAuthorizeURL returns the AuthorizeURL in the options or localhost:5443.
+func (o *Options) GetAuthorizeURL() *url.URL {
+	if o != nil && o.AuthorizeURL != nil {
+		return o.AuthorizeURL
+	}
+	u, _ := url.Parse("http://localhost" + DefaultAlternativeAddr)
+	return u
+}
+
+// GetCacheURL returns the CacheURL in the options or localhost:5443.
+func (o *Options) GetCacheURL() *url.URL {
+	if o != nil && o.CacheURL != nil {
+		return o.CacheURL
+	}
+	u, _ := url.Parse("http://localhost" + DefaultAlternativeAddr)
+	return u
+}
+
+// GetForwardAuthURL returns the ForwardAuthURL in the options or localhost.
+func (o *Options) GetForwardAuthURL() *url.URL {
+	if o != nil && o.ForwardAuthURL != nil {
+		return o.ForwardAuthURL
+	}
+	u, _ := url.Parse("https://localhost")
+	return u
+}
+
 // OptionsUpdater updates local state based on an Options struct
 type OptionsUpdater interface {
 	UpdateOptions(Options) error

--- a/go.sum
+++ b/go.sum
@@ -605,8 +605,6 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200513185701-a91f0712d120 h1:EZ3cVSzKOlJxAd8e8YAJ7no8nNypTxexh/YE/xW3ZEY=
-golang.org/x/net v0.0.0-20200513185701-a91f0712d120/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 h1:eDrdRpKgkcCqKZQwyZRyeFZgfqt37SL7Kv3tok06cKE=
 golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -734,8 +732,6 @@ google.golang.org/api v0.15.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsb
 google.golang.org/api v0.17.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.18.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
-google.golang.org/api v0.24.0 h1:cG03eaksBzhfSIk7JRGctfp3lanklcOM/mTGvow7BbQ=
-google.golang.org/api v0.24.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.25.0 h1:LodzhlzZEUfhXzNUMIfVlf9Gr6Ua5MMtoFWh7+f47qA=
 google.golang.org/api v0.25.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
@@ -766,6 +762,7 @@ google.golang.org/genproto v0.0.0-20200305110556-506484158171 h1:xes2Q2k+d/+YNXV
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940 h1:MRHtG0U6SnaUb+s+LhNE1qt1FQ1wlhqr5E4usBKC0uA=
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
+google.golang.org/genproto v0.0.0-20200521103424-e9a78aa275b7 h1:JUs1uIDQ46c7iI0QuMPzAHqXaSmqKF0f9freFMk2ivs=
 google.golang.org/genproto v0.0.0-20200521103424-e9a78aa275b7/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -122,7 +122,7 @@ func setupAuthenticate(opt *config.Options, controlPlane *controlplane.Server) e
 	if err != nil {
 		return fmt.Errorf("error creating authenticate service: %w", err)
 	}
-	host := urlutil.StripPort(opt.AuthenticateURL.Host)
+	host := urlutil.StripPort(opt.GetAuthenticateURL().Host)
 	sr := controlPlane.HTTPRouter.Host(host).Subrouter()
 	svc.Mount(sr)
 	log.Info().Str("host", host).Msg("enabled authenticate service")

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -28,8 +28,8 @@ func (srv *Server) buildClusters(options *config.Options) []*envoy_config_cluste
 		Host:   srv.HTTPListener.Addr().String(),
 	}
 	authzURL := &url.URL{
-		Scheme: options.AuthorizeURL.Scheme,
-		Host:   options.AuthorizeURL.Host,
+		Scheme: options.GetAuthorizeURL().Scheme,
+		Host:   options.GetAuthorizeURL().Host,
 	}
 
 	clusters := []*envoy_config_cluster_v3.Cluster{

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -125,8 +125,8 @@ func buildMainHTTPConnectionManagerFilter(options *config.Options, domains []str
 
 		if options.Addr == options.GRPCAddr {
 			// if this is a gRPC service domain and we're supposed to handle that, add those routes
-			if (config.IsAuthorize(options.Services) && domain == options.AuthorizeURL.Host) ||
-				(config.IsCache(options.Services) && domain == options.CacheURL.Host) {
+			if (config.IsAuthorize(options.Services) && domain == options.GetAuthorizeURL().Host) ||
+				(config.IsCache(options.Services) && domain == options.GetCacheURL().Host) {
 				vh.Routes = append(vh.Routes, buildGRPCRoutes()...)
 			}
 		}
@@ -357,13 +357,13 @@ func buildDownstreamTLSContext(options *config.Options, domain string) *envoy_ex
 func getAllRouteableDomains(options *config.Options, addr string) []string {
 	lookup := map[string]struct{}{}
 	if config.IsAuthenticate(options.Services) && addr == options.Addr {
-		lookup[options.AuthenticateURL.Host] = struct{}{}
+		lookup[options.GetAuthenticateURL().Host] = struct{}{}
 	}
 	if config.IsAuthorize(options.Services) && addr == options.GRPCAddr {
-		lookup[options.AuthorizeURL.Host] = struct{}{}
+		lookup[options.GetAuthorizeURL().Host] = struct{}{}
 	}
 	if config.IsCache(options.Services) && addr == options.GRPCAddr {
-		lookup[options.CacheURL.Host] = struct{}{}
+		lookup[options.GetCacheURL().Host] = struct{}{}
 	}
 	if config.IsProxy(options.Services) && addr == options.Addr {
 		for _, policy := range options.Policies {

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -48,7 +48,7 @@ func buildPomeriumHTTPRoutes(options *config.Options, domain string) []*envoy_co
 		buildControlPlanePrefixRoute("/.well-known/pomerium/"),
 	}
 	// if we're handling authentication, add the oauth2 callback url
-	if config.IsAuthenticate(options.Services) && domain == options.AuthenticateURL.Host {
+	if config.IsAuthenticate(options.Services) && domain == options.GetAuthenticateURL().Host {
 		routes = append(routes, buildControlPlanePathRoute(options.AuthenticateCallbackPath))
 	}
 	// if we're the proxy and this is the forward-auth url

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -98,7 +98,7 @@ func New(opts config.Options) (*Proxy, error) {
 	decodedCookieSecret, _ := base64.StdEncoding.DecodeString(opts.CookieSecret)
 
 	// used to load and verify JWT tokens signed by the authenticate service
-	encoder, err := jws.NewHS256Signer([]byte(opts.SharedKey), opts.AuthenticateURL.Host)
+	encoder, err := jws.NewHS256Signer([]byte(opts.SharedKey), opts.GetAuthenticateURL().Host)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Add a few getters to the options struct to avoid returning nil URLs. This is to fix an issue that was reported in slack.

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
