### PR TITLE
forward-auth: support x-forwarded-uri

### DIFF
--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -108,7 +108,9 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 			if r.Header.Get(httputil.HeaderForwardedProto) == "" || r.Header.Get(httputil.HeaderForwardedHost) == "" {
 				return httputil.NewError(http.StatusBadRequest, errors.New("no uri to validate"))
 			}
-			uriString = r.Header.Get(httputil.HeaderForwardedProto) + "://" + r.Header.Get(httputil.HeaderForwardedHost)
+			uriString = r.Header.Get(httputil.HeaderForwardedProto) + "://" +
+				r.Header.Get(httputil.HeaderForwardedHost) +
+				r.Header.Get(httputil.HeaderForwardedURI)
 		}
 
 		uri, err := urlutil.ParseAndValidateURL(uriString)


### PR DESCRIPTION
## Summary
Traefik sends the URL path as an HTTP header named `x-forwarded-uri`. We weren't using it before, so only root-path route policies were working.

## Related issues
Fixes #763 

**Checklist**:
- [x] add related issues
- [x] updated docs
- [ ] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
