### PR TITLE
cache: fix closing too early

### DIFF
--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -160,7 +160,6 @@ func setupCache(opt *config.Options, controlPlane *controlplane.Server) error {
 	if err != nil {
 		return fmt.Errorf("error creating config service: %w", err)
 	}
-	defer svc.Close()
 	pbCache.RegisterCacheServer(controlPlane.GRPCServer, svc)
 	log.Info().Msg("enabled cache service")
 	return nil

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -274,7 +274,8 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 							}
 						]
 					}
-				]
+				],
+				"validateClusters": false
 			},
 			"statPrefix": "ingress",
 			"tracing": {


### PR DESCRIPTION
## Summary
We were closing the cache service immediately after starting it, resulting in autocache not working across machines.

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
