### PR TITLE
authorize: reduce log noise for empty jwt

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -23,7 +23,6 @@ func (a *Authorize) okResponse(
 	rawSession []byte,
 	isNewSession bool,
 ) *envoy_service_auth_v2.CheckResponse {
-
 	requestHeaders, err := a.getEnvoyRequestHeaders(rawSession, isNewSession)
 	if err != nil {
 		log.Warn().Err(err).Msg("authorize: error generating new request headers")

--- a/authorize/session.go
+++ b/authorize/session.go
@@ -77,6 +77,10 @@ func getJWTSetCookieHeaders(cookieStore sessions.SessionStore, rawjwt []byte) (m
 }
 
 func getJWTClaimHeaders(options config.Options, encoder encoding.MarshalUnmarshaler, rawjwt []byte) (map[string]string, error) {
+	if len(rawjwt) == 0 {
+		return make(map[string]string), nil
+	}
+
 	var claims map[string]jwtClaim
 	err := encoder.Unmarshal(rawjwt, &claims)
 	if err != nil {


### PR DESCRIPTION
## Summary
Was seeing this log line:

```
11:40:59       pomerium | {"level":"warn","error":"square/go-jose: compact JWS format must have three parts","time":"2020-05-27T11:40:59-06:00","message":"authorize: error generating new request headers"}
```

That made it seem like something was wrong, but really there was no session at all because the user hadn't logged in yet. 

This change should prevent that log from happening by returning an empty header set for non-logged-in users.

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
