### PR TITLE
telemetry: service label updates

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -99,7 +99,7 @@ func validateOptions(o config.Options) error {
 
 // newPolicyEvaluator returns an policy evaluator.
 func newPolicyEvaluator(opts *config.Options) (evaluator.Evaluator, error) {
-	metrics.AddPolicyCountCallback("authorize", func() int64 {
+	metrics.AddPolicyCountCallback("pomerium-authorize", func() int64 {
 		return int64(len(opts.Policies))
 	})
 	ctx := context.Background()

--- a/config/options.go
+++ b/config/options.go
@@ -14,6 +14,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pomerium/pomerium/internal/telemetry"
+
 	"github.com/pomerium/pomerium/internal/cryptutil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
@@ -304,11 +306,12 @@ func NewOptionsFromConfig(configFile string) (*Options, error) {
 	if o.LogLevel != "" {
 		log.SetLevel(o.LogLevel)
 	}
-	metrics.AddPolicyCountCallback(o.Services, func() int64 {
+	serviceName := telemetry.ServiceName(o.Services)
+	metrics.AddPolicyCountCallback(serviceName, func() int64 {
 		return int64(len(o.Policies))
 	})
 
-	metrics.SetConfigChecksum(o.Services, o.Checksum())
+	metrics.SetConfigChecksum(serviceName, o.Checksum())
 
 	return o, nil
 }
@@ -702,10 +705,12 @@ func WatchChanges(configFile string, opt *Options, services []OptionsUpdater) {
 // updates each service in the services slice OptionsUpdater with a new set of
 // options if any change is detected.
 func handleConfigUpdate(configFile string, opt *Options, services []OptionsUpdater) *Options {
+	serviceName := telemetry.ServiceName(opt.Services)
+
 	newOpt, err := NewOptionsFromConfig(configFile)
 	if err != nil {
 		log.Error().Err(err).Msg("config: could not reload configuration")
-		metrics.SetConfigInfo(opt.Services, false)
+		metrics.SetConfigInfo(serviceName, false)
 		return opt
 	}
 	optChecksum := opt.Checksum()
@@ -723,13 +728,13 @@ func handleConfigUpdate(configFile string, opt *Options, services []OptionsUpdat
 		if err := service.UpdateOptions(*newOpt); err != nil {
 			log.Error().Err(err).Msg("config: could not update options")
 			updateFailed = true
-			metrics.SetConfigInfo(opt.Services, false)
+			metrics.SetConfigInfo(serviceName, false)
 		}
 	}
 
 	if !updateFailed {
-		metrics.SetConfigInfo(newOpt.Services, true)
-		metrics.SetConfigChecksum(newOpt.Services, newOptChecksum)
+		metrics.SetConfigInfo(serviceName, true)
+		metrics.SetConfigChecksum(serviceName, newOptChecksum)
 	}
 	return newOpt
 }

--- a/config/options.go
+++ b/config/options.go
@@ -14,18 +14,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/pomerium/pomerium/internal/telemetry"
-
-	"github.com/pomerium/pomerium/internal/cryptutil"
-	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/internal/telemetry/metrics"
-	"github.com/pomerium/pomerium/internal/urlutil"
-
 	"github.com/cespare/xxhash/v2"
 	"github.com/fsnotify/fsnotify"
 	"github.com/mitchellh/hashstructure"
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
+
+	"github.com/pomerium/pomerium/internal/cryptutil"
+	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/telemetry"
+	"github.com/pomerium/pomerium/internal/telemetry/metrics"
+	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
 // DisableHeaderKey is the key used to check whether to disable setting header

--- a/config/trace.go
+++ b/config/trace.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/pomerium/pomerium/internal/telemetry"
+
 	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
@@ -44,7 +46,7 @@ type TracingOptions struct {
 func NewTracingOptions(o *Options) (*TracingOptions, error) {
 	tracingOpts := TracingOptions{
 		Provider:            o.TracingProvider,
-		Service:             o.Services,
+		Service:             telemetry.ServiceName(o.Services),
 		JaegerAgentEndpoint: o.TracingJaegerAgentEndpoint,
 		SampleRate:          o.TracingSampleRate,
 	}
@@ -66,6 +68,7 @@ func NewTracingOptions(o *Options) (*TracingOptions, error) {
 		}
 		tracingOpts.ZipkinEndpoint = zipkinEndpoint
 	case "":
+		return &TracingOptions{}, nil
 	default:
 		return nil, fmt.Errorf("config: provider %s unknown", o.TracingProvider)
 	}

--- a/config/trace.go
+++ b/config/trace.go
@@ -5,7 +5,6 @@ import (
 	"net/url"
 
 	"github.com/pomerium/pomerium/internal/telemetry"
-
 	"github.com/pomerium/pomerium/internal/urlutil"
 )
 

--- a/config/trace_test.go
+++ b/config/trace_test.go
@@ -17,8 +17,8 @@ func Test_NewTracingOptions(t *testing.T) {
 	}{
 		{
 			"jaeger_good",
-			&Options{TracingProvider: "jaeger", TracingJaegerAgentEndpoint: "foo", TracingJaegerCollectorEndpoint: "http://foo"},
-			&TracingOptions{Provider: "jaeger", JaegerAgentEndpoint: "foo", JaegerCollectorEndpoint: &url.URL{Scheme: "http", Host: "foo"}},
+			&Options{TracingProvider: "jaeger", TracingJaegerAgentEndpoint: "foo", TracingJaegerCollectorEndpoint: "http://foo", Services: ServiceAll},
+			&TracingOptions{Provider: "jaeger", JaegerAgentEndpoint: "foo", JaegerCollectorEndpoint: &url.URL{Scheme: "http", Host: "foo"}, Service: "pomerium"},
 			false,
 		},
 		{
@@ -29,8 +29,8 @@ func Test_NewTracingOptions(t *testing.T) {
 		},
 		{
 			"zipkin_good",
-			&Options{TracingProvider: "zipkin", ZipkinEndpoint: "https://foo/api/v1/spans"},
-			&TracingOptions{Provider: "zipkin", ZipkinEndpoint: &url.URL{Scheme: "https", Host: "foo", Path: "/api/v1/spans"}},
+			&Options{TracingProvider: "zipkin", ZipkinEndpoint: "https://foo/api/v1/spans", Services: ServiceAuthorize},
+			&TracingOptions{Provider: "zipkin", ZipkinEndpoint: &url.URL{Scheme: "https", Host: "foo", Path: "/api/v1/spans"}, Service: "pomerium-authorize"},
 			false,
 		},
 		{

--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -442,7 +442,7 @@ Expose a prometheus format HTTP endpoint on the specified port. Disabled by defa
 
 :::
 
-**Metrics tracked**
+#### Pomerium Metrics Tracked
 
 Name                                          | Type      | Description
 --------------------------------------------- | --------- | -----------------------------------------------------------------------
@@ -500,6 +500,14 @@ redis_idle_conns                              | Gauge     | Number of idle conne
 redis_misses_total                            | Counter   | Total number of times free connection was NOT found in the pool
 redis_stale_conns_total                       | Counter   | Total number of stale connections removed from the pool
 redis_timeouts_total                          | Counter   | Total number of times a wait timeout occurred
+
+#### Envoy Proxy Metrics
+
+As of `v0.9`, Pomerium uses [envoy Proxy]([https://](https://www.envoyproxy.io/) for the data plane. As such, proxy related metrics are sourced
+from envoy, and use envoy's internal [stats data model](https://www.envoyproxy.io/docs/envoy/latest/operations/stats_overview). Please see Envoy's documentation for information
+about specific metrics.
+
+All metrics coming from envoy will be labeled with `service="pomerium"` or `service="pomerium-proxy"`, depending if you're running all-in-one or distributed service mode.
 
 ### Proxy Log Level
 

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -13,10 +13,22 @@ description: >-
 
 - With this release we now use an embedded [envoy](https://www.envoyproxy.io/) binary as our proxy server. Due to this change we now only build and support Linux and MacOS binaries with the AMD64 architecture. We plan on supporting more platforms and architectures in future releases.
 
-### Tracing
+### Observability
+
+- The `service` label on metrics and tracing no longer reflects the `Services` configuration option directly.  `pomerium` will be used for all-in-one mode, and `pomerium-[service]` will
+  be used for distributed services
+
+#### Tracing
 
 - Jaeger tracing support is no longer end-to-end in the proxy service. We recommend updating to the Zipkin provider for proper tracing support.  Jaeger will continue to work but will not have coverage in the data plane.
 - Option `tracing_debug` is no longer supported. Use `tracing_sampling_rate` instead. [Details](https://www.pomerium.io/configuration/#shared-tracing-settings).
+
+#### Metrics
+
+With this release we now use an embedded [envoy](https://www.envoyproxy.io/) binary as our proxy server.  
+
+- Due to this change, data plane metric names and labels have changed to 
+  adopt envoy's internal data model.  [Details](https://www.pomerium.io/configuration/#envoy-proxy-metrics)
 
 # Since 0.7.0
 

--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"syscall"
 
+	"github.com/pomerium/pomerium/internal/telemetry"
+
 	envoy_service_auth_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
 	"golang.org/x/sync/errgroup"
 
@@ -166,12 +168,13 @@ func setupCache(opt *config.Options, controlPlane *controlplane.Server) error {
 }
 
 func setupMetrics(ctx context.Context, opt *config.Options) error {
+	serviceName := telemetry.ServiceName(opt.Services)
 	if opt.MetricsAddr != "" {
 		handler, err := metrics.PrometheusHandler(config.EnvoyAdminURL)
 		if err != nil {
 			return err
 		}
-		metrics.SetBuildInfo(opt.Services)
+		metrics.SetBuildInfo(serviceName)
 		metrics.RegisterInfoMetrics()
 		serverOpts := &httputil.ServerOptions{
 			Addr:     opt.MetricsAddr,

--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -4,10 +4,6 @@ package envoy
 import (
 	"bytes"
 
-	"github.com/pomerium/pomerium/internal/telemetry"
-
-	envoy_config_metrics_v3 "github.com/envoyproxy/go-control-plane/envoy/config/metrics/v3"
-
 	"bufio"
 	"context"
 	"errors"
@@ -23,7 +19,9 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	envoy_config_metrics_v3 "github.com/envoyproxy/go-control-plane/envoy/config/metrics/v3"
 	envoy_config_trace_v3 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/natefinch/atomic"
@@ -33,6 +31,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/telemetry"
 )
 
 const (

--- a/internal/envoy/envoy_test.go
+++ b/internal/envoy/envoy_test.go
@@ -5,8 +5,6 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/pomerium/pomerium/internal/testutil"
-
 	envoy_config_bootstrap_v3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	"github.com/golang/protobuf/proto"
 	"github.com/nsf/jsondiff"
@@ -14,6 +12,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testutil"
 )
 
 func jsonDump(t *testing.T, m proto.GeneratedMessage) []byte {

--- a/internal/telemetry/grpc.go
+++ b/internal/telemetry/grpc.go
@@ -32,8 +32,8 @@ func (h *GRPCServerStatsHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.
 // NewGRPCServerStatsHandler creates a new GRPCServerStatsHandler for a pomerium service
 func NewGRPCServerStatsHandler(service string) grpcstats.Handler {
 	return &GRPCServerStatsHandler{
-		service:        service,
+		service:        ServiceName(service),
 		Handler:        &ocgrpc.ServerHandler{},
-		metricsHandler: metrics.NewGRPCServerMetricsHandler(service),
+		metricsHandler: metrics.NewGRPCServerMetricsHandler(ServiceName(service)),
 	}
 }

--- a/internal/telemetry/util.go
+++ b/internal/telemetry/util.go
@@ -1,0 +1,15 @@
+package telemetry
+
+// ServiceName turns a pomerium service option into the appropriate external label for telemetry purposes
+//
+// Ex:
+// service 'all' -> 'pomerium'
+// service 'proxy' -> 'pomerium-proxy'
+func ServiceName(service string) string {
+	switch service {
+	case "all", "":
+		return "pomerium"
+	default:
+		return "pomerium-" + service
+	}
+}

--- a/internal/telemetry/util_test.go
+++ b/internal/telemetry/util_test.go
@@ -1,0 +1,27 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_ServiceName(t *testing.T) {
+
+	t.Parallel()
+	tests := []struct {
+		name        string
+		servicesOpt string
+		want        string
+	}{
+		{"all", "all", "pomerium"},
+		{"proxy", "proxy", "pomerium-proxy"},
+		{"missing", "", "pomerium"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, ServiceName(tt.servicesOpt))
+		})
+	}
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -157,7 +157,7 @@ func New(opts config.Options) (*Proxy, error) {
 	if err := p.UpdatePolicies(&opts); err != nil {
 		return nil, err
 	}
-	metrics.AddPolicyCountCallback("proxy", func() int64 {
+	metrics.AddPolicyCountCallback("pomerium-proxy", func() int64 {
 		return int64(len(opts.Policies))
 	})
 


### PR DESCRIPTION
## Summary
Update `service` label in telemetry to be more consistent and useful in the face of both envoy and internal metrics

- Map `services` option into something that always contains `pomerium` for easier discovery and tracking
- Ensure usage of this service name mapping across tracing, metrics and envoy stats config
- Document envoy related changes

**Checklist**:
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
