### PR TITLE
telemetry: Fix missing/incorrect grpc labels

### DIFF
--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -50,7 +50,7 @@ func Run(ctx context.Context, configFile string) error {
 	}
 
 	// setup the control plane
-	controlPlane, err := controlplane.NewServer()
+	controlPlane, err := controlplane.NewServer(opt.Services)
 	if err != nil {
 		return fmt.Errorf("error creating control plane: %w", err)
 	}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -47,7 +47,7 @@ type Server struct {
 }
 
 // NewServer creates a new Server. Listener ports are chosen by the OS.
-func NewServer() (*Server, error) {
+func NewServer(name string) (*Server, error) {
 	srv := &Server{
 		configUpdated: make(chan struct{}, 1),
 	}
@@ -61,7 +61,7 @@ func NewServer() (*Server, error) {
 		return nil, err
 	}
 	srv.GRPCServer = grpc.NewServer(
-		grpc.StatsHandler(telemetry.NewGRPCServerStatsHandler("control_plane")),
+		grpc.StatsHandler(telemetry.NewGRPCServerStatsHandler(name)),
 		grpc.UnaryInterceptor(requestid.UnaryServerInterceptor()),
 		grpc.StreamInterceptor(requestid.StreamServerInterceptor()),
 	)

--- a/internal/telemetry/grpc.go
+++ b/internal/telemetry/grpc.go
@@ -23,10 +23,10 @@ type GRPCServerStatsHandler struct {
 // TagRPC implements grpc.stats.Handler and adds metrics and tracing metadata to the context of a given RPC
 func (h *GRPCServerStatsHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.RPCTagInfo) context.Context {
 
-	metricCtx := h.metricsHandler.TagRPC(ctx, tagInfo)
-	handledCtx := h.Handler.TagRPC(metricCtx, tagInfo)
+	handledCtx := h.Handler.TagRPC(ctx, tagInfo)
+	metricCtx := h.metricsHandler.TagRPC(handledCtx, tagInfo)
 
-	return handledCtx
+	return metricCtx
 }
 
 // NewGRPCServerStatsHandler creates a new GRPCServerStatsHandler for a pomerium service


### PR DESCRIPTION
## Summary
Internal GRPC stats labels were missing / inconsistent.

**Checklist**:
- [x] ready for review
