### PR TITLE
authenticate: clear session if ctx fails

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -221,10 +221,12 @@ func (a *Authenticate) SignIn(w http.ResponseWriter, r *http.Request) error {
 
 	s, err := a.getSessionFromCtx(ctx)
 	if err != nil {
+		a.sessionStore.ClearSession(w, r)
 		return err
 	}
 	accessToken, err := a.getAccessToken(ctx, s)
 	if err != nil {
+		a.sessionStore.ClearSession(w, r)
 		return err
 	}
 	// user impersonation


### PR DESCRIPTION
Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>

## Summary

Clears authN's session in the event that cache has been cleared and has an orphaned access token. 

**Checklist**:
- [x] ready for review
