### PR TITLE
envoy: Switch to distroless/base for releases

### DIFF
--- a/.github/Dockerfile-release
+++ b/.github/Dockerfile-release
@@ -1,7 +1,7 @@
 FROM busybox:latest as build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/static
+FROM gcr.io/distroless/base
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY pomerium* /bin/


### PR DESCRIPTION
## Summary
Envoy is not a static binary, so we need to switch to `gcr.io/distroless/base` for the release image.

Thanks to @Vad1mo for reporting.

**Checklist**:
- [x] ready for review