### PR TITLE
config: strip quotes from http redirect addr

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -581,6 +581,9 @@ func (o *Options) Validate() error {
 		}
 	}
 
+	// strip quotes from redirect address (#811)
+	o.HTTPRedirectAddr = strings.Trim(o.HTTPRedirectAddr, `"'`)
+
 	RedirectAndAutocertServer.update(o)
 
 	err = AutocertManager.update(o)

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/viper"
+	"github.com/stretchr/testify/assert"
 )
 
 var cmpOptIgnoreUnexported = cmpopts.IgnoreUnexported(Options{})
@@ -465,6 +466,14 @@ func TestOptions_sourceHostnames(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestHTTPRedirectAddressStripQuotes(t *testing.T) {
+	o := NewDefaultOptions()
+	o.InsecureServer = true
+	o.HTTPRedirectAddr = `":80"`
+	assert.NoError(t, o.Validate())
+	assert.Equal(t, ":80", o.HTTPRedirectAddr)
 }
 
 func TestCompareByteSliceSlice(t *testing.T) {


### PR DESCRIPTION
## Summary
It looks like we used to support quotes in the http redirect address. This change strips them from the options before updating the redirect server.

## Related issues
- #811 

**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
