### PR TITLE
xds: force ipv4 for localhost to workaround ipv6 issue in docker compose

### DIFF
--- a/internal/controlplane/xds_cluster_test.go
+++ b/internal/controlplane/xds_cluster_test.go
@@ -271,4 +271,34 @@ func Test_buildCluster(t *testing.T) {
 			}
 		`, cluster)
 	})
+	t.Run("localhost", func(t *testing.T) {
+		cluster := buildCluster("example", mustParseURL("http://localhost"), nil, true)
+		testutil.AssertProtoJSONEqual(t, `
+			{
+				"name": "example",
+				"type": "STATIC",
+				"connectTimeout": "10s",
+				"respectDnsTtl": true,
+				"http2ProtocolOptions": {
+					"allowConnect": true
+				},
+				"loadAssignment": {
+					"clusterName": "example",
+					"endpoints": [{
+						"lbEndpoints": [{
+							"endpoint": {
+								"address": {
+									"socketAddress": {
+										"address": "127.0.0.1",
+										"ipv4Compat": true,
+										"portValue": 80
+									}
+								}
+							}
+						}]
+					}]
+				}
+			}
+		`, cluster)
+	})
 }

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"net"
 	"net/url"
+	"strings"
 	"time"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -183,6 +184,13 @@ func buildCluster(
 	defaultPort := 80
 	if transportSocket != nil && transportSocket.Name == "tls" {
 		defaultPort = 443
+	}
+
+	if endpoint.Hostname() == "localhost" {
+		u := new(url.URL)
+		*u = *endpoint
+		u.Host = strings.Replace(endpoint.Host, "localhost", "127.0.0.1", -1)
+		endpoint = u
 	}
 
 	cluster := &envoy_config_cluster_v3.Cluster{


### PR DESCRIPTION
## Summary
It looks like docker-compose returns an ipv6 ip address for DNS lookups to localhost, but doesn't actually support binding it. By manually resolving `localhost` to `127.0.0.1`, we can force ipv4 for localhost connections.

I believe this would break ipv6 only networks, but I imagine that's exceedingly rare, so this should preserve non-docker-compose use cases as well.

## Related issues
- Fixes #811 


**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
