### PR TITLE
Feature/remove request headers

### DIFF
--- a/config/policy.go
+++ b/config/policy.go
@@ -80,6 +80,11 @@ type Policy struct {
 	// value of any existing value of a given header key.
 	SetRequestHeaders map[string]string `mapstructure:"set_request_headers" yaml:"set_request_headers,omitempty"`
 
+	// RemoveRequestHeaders removes a collection of headers from a downstream request.
+	// Note that this has lower priority than `SetRequestHeaders`, if you specify `X-Custom-Header` in both
+	// `SetRequestHeaders` and `RemoveRequestHeaders`, then the header won't be removed.
+	RemoveRequestHeaders []string `mapstructure:"remove_request_headers" yaml:"remove_request_headers,omitempty"`
+
 	// PreserveHostHeader disables host header rewriting.
 	//
 	// https://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_set_header

--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -995,6 +995,24 @@ Set Request Headers allows you to set static values for given request headers. T
     X-Your-favorite-authenticating-Proxy: "Pomerium"
 ```
 
+### Remove Request Headers
+
+- Config File Key: `removet_request_headers`
+- Type: array of `strings`
+- Optional
+
+Remove Request Headers allows you to remove given request headers. This can be useful if you want to prevent privacy information from being passed to downstream applications. For example:
+
+```yaml
+- from: https://httpbin.corp.example.com
+  to: https://httpbin.org
+  allowed_users:
+    - bdd@pomerium.io
+  remove_request_headers:
+    - X-Email
+    - X-Username
+```
+
 ### To
 
 - `yaml`/`json` setting: `to`

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.10.0
+
+### New
+
+- config: add remove_request_headers @cuonglm [GH-702]
+
 ## v0.9.0
 
 ### New

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,6 @@ github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
-github.com/caddyserver/certmagic v0.10.13 h1:wfyYpXVXSSYMS1ZFpSr7HptwsC+j7elda5PUERrHtRc=
-github.com/caddyserver/certmagic v0.10.13/go.mod h1:Yz6cSRUdddGy6Ut5JfrvcqBwrm1BqXxJRqJq2TwjPnA=
 github.com/caddyserver/certmagic v0.11.0 h1:b7moj2Z/+iMa6x42V2L1AqbvHGti0aWGx2l7PkoERdQ=
 github.com/caddyserver/certmagic v0.11.0/go.mod h1:fqY1IZk5iqhsj5FU3Vw20Sjq66tEKaanTFYNZ74soMY=
 github.com/cenkalti/backoff/v4 v4.0.0 h1:6VeaLF9aI+MAUQ95106HwWzYZgJJpZ4stumjj6RFYAU=
@@ -355,8 +353,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/namedotcom/go v0.0.0-20180403034216-08470befbe04/go.mod h1:5sN+Lt1CaY4wsPvgQH/jsuJi4XO2ssZbdsIizr4CVC8=
-github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc h1:7xGrl4tTpBQu5Zjll08WupHyq+Sp0Z/adtyf1cfk3Q8=
-github.com/natefinch/atomic v0.0.0-20150920032501-a62ce929ffcc/go.mod h1:1rLVY/DWf3U6vSZgH16S7pymfrhK2lcUlXjgGglw/lY=
 github.com/natefinch/atomic v0.0.0-20200526193002-18c0533a5b09 h1:DXR0VtCesBD2ss3toN9OEeXszpQmW9dc3SvUbUfiBC0=
 github.com/natefinch/atomic v0.0.0-20200526193002-18c0533a5b09/go.mod h1:1rLVY/DWf3U6vSZgH16S7pymfrhK2lcUlXjgGglw/lY=
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
@@ -612,8 +608,6 @@ golang.org/x/net v0.0.0-20200222125558-5a598a2470a0/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2 h1:eDrdRpKgkcCqKZQwyZRyeFZgfqt37SL7Kv3tok06cKE=
-golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200528225125-3c3fba18258b h1:IYiJPiJfzktmDAO1HQiwjMjwjlYKHAL7KzeD544RJPs=
 golang.org/x/net v0.0.0-20200528225125-3c3fba18258b/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -771,8 +765,6 @@ google.golang.org/genproto v0.0.0-20200305110556-506484158171 h1:xes2Q2k+d/+YNXV
 google.golang.org/genproto v0.0.0-20200305110556-506484158171/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940 h1:MRHtG0U6SnaUb+s+LhNE1qt1FQ1wlhqr5E4usBKC0uA=
 google.golang.org/genproto v0.0.0-20200331122359-1ee6d9798940/go.mod h1:55QSHmfGQM9UVYDPBsyGGes0y52j32PQ3BqQfXhyH3c=
-google.golang.org/genproto v0.0.0-20200521103424-e9a78aa275b7 h1:JUs1uIDQ46c7iI0QuMPzAHqXaSmqKF0f9freFMk2ivs=
-google.golang.org/genproto v0.0.0-20200521103424-e9a78aa275b7/go.mod h1:YsZOwe1myG/8QRHRsmBRE1LrgQY60beZKjly0O1fX9U=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20200601130524-0f60399e6634 h1:yUEnIJPm1I2GGauN1xOkwj6gXw/3t1R+HA1r/cdnkHE=
 google.golang.org/genproto v0.0.0-20200601130524-0f60399e6634/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=

--- a/integration/manifests/lib/pomerium.libsonnet
+++ b/integration/manifests/lib/pomerium.libsonnet
@@ -119,6 +119,7 @@ local PomeriumPolicy = function() std.flattenArrays(
         set_request_headers: {
           'X-Custom-Request-Header': 'custom-request-header-value',
         },
+        remove_request_headers: ['X-Custom-Request-Header-To-Remove'],
       },
       {
         from: 'http://restricted-' + domain + '.localhost.pomerium.io',

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -182,7 +182,8 @@ func buildPolicyRoutes(options *config.Options, domain string) []*envoy_config_r
 					Timeout: routeTimeout,
 				},
 			},
-			RequestHeadersToAdd: requestHeadersToAdd,
+			RequestHeadersToAdd:    requestHeadersToAdd,
+			RequestHeadersToRemove: policy.RemoveRequestHeaders,
 		})
 	}
 	return routes

--- a/internal/controlplane/xds_routes_test.go
+++ b/internal/controlplane/xds_routes_test.go
@@ -221,8 +221,15 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				Source: &config.StringURL{URL: mustParseURL("https://example.com")},
 				Regex:  `^/[a]+$`,
 			},
+			{
+				Source:               &config.StringURL{URL: mustParseURL("https://example.com")},
+				Prefix:               "/some/prefix/",
+				RemoveRequestHeaders: []string{"HEADER-KEY"},
+				UpstreamTimeout:      time.Minute,
+			},
 		},
 	}, "example.com")
+
 	testutil.AssertProtoJSONEqual(t, `
 		[
 			{
@@ -240,7 +247,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				},
 				"route": {
 					"autoHostRewrite": true,
-					"cluster": "policy-d00072a199d7b614",
+					"cluster": "policy-4e2763e591b22dc8",
 					"timeout": "3s",
 					"upgradeConfigs": [{
 						"enabled": false,
@@ -263,7 +270,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				},
 				"route": {
 					"autoHostRewrite": false,
-					"cluster": "policy-907a31075a413547",
+					"cluster": "policy-e5d20435224ae9b",
 					"timeout": "0s",
 					"upgradeConfigs": [{
 						"enabled": true,
@@ -286,7 +293,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				},
 				"route": {
 					"autoHostRewrite": true,
-					"cluster": "policy-f05528f790686bc3",
+					"cluster": "policy-6e7239b3980df01f",
 					"timeout": "60s",
 					"upgradeConfigs": [{
 						"enabled": false,
@@ -319,13 +326,37 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				},
 				"route": {
 					"autoHostRewrite": true,
-					"cluster": "policy-e5d3a05ff1f97659",
+					"cluster": "policy-7bf4b11bf99ced85",
 					"timeout": "3s",
 					"upgradeConfigs": [{
 						"enabled": false,
 						"upgradeType": "websocket"
 					}]
 				}
+			},
+			{
+				"name": "policy-5",
+				"match": {
+					"prefix": "/some/prefix/"
+				},
+				"metadata": {
+					"filterMetadata": {
+						"envoy.filters.http.lua": {
+							"remove_pomerium_authorization": true,
+							"remove_pomerium_cookie": "pomerium"
+						}
+					}
+				},
+				"route": {
+					"autoHostRewrite": true,
+					"cluster": "policy-6b5e934ff586365d",
+					"timeout": "60s",
+					"upgradeConfigs": [{
+						"enabled": false,
+						"upgradeType": "websocket"
+					}]
+				},
+				"requestHeadersToRemove": ["HEADER-KEY"]
 			}
 		]
 	`, routes)


### PR DESCRIPTION
## Summary
Currently, we have "set_request_headers" config, which reflects envoy
route.Route.RequestHeadersToAdd. This commit add new config
"remove_request_headers", which reflects envoy RequestHeadersToRemove.

This is also a preparation for future PRs to implement disable user
identity in request headers feature.

## Related issues
Updates #702


**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
