### PR TITLE
internal/httputil: add HTTPStatsRoundTripper to DefaultClient

### DIFF
--- a/internal/httputil/client_test.go
+++ b/internal/httputil/client_test.go
@@ -1,0 +1,25 @@
+package httputil
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pomerium/pomerium/internal/telemetry/requestid"
+)
+
+func TestDefaultClient(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		for _, header := range []string{"X-B3-Sampled", "X-B3-Spanid", "X-B3-Traceid", "X-Request-Id"} {
+			if _, ok := r.Header[header]; !ok {
+				t.Errorf("header %s is not set", header)
+			}
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer ts.Close()
+	req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
+	req = req.WithContext(requestid.WithValue(context.Background(), "foo"))
+	_, _ = DefaultClient.Do(req)
+}


### PR DESCRIPTION
## Summary
Currently, our IdP HTTP client does not use the standard HTTPStatsRoundTripper
and uses a requestID tripper instead.

This commit introduces a wrapper for standard http.Client, which will
compose a tripper.Chain to use both requestID tripper and telemetry
tripper.

## Related issues
Fixes #808


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
