### PR TITLE
proxy: disable tls 1.0 and 1.1

### DIFF
--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -351,6 +351,9 @@ func buildDownstreamTLSContext(options *config.Options, domain string) *envoy_ex
 	envoyCert := envoyTLSCertificateFromGoTLSCertificate(cert)
 	return &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
+			TlsParams: &envoy_extensions_transport_sockets_tls_v3.TlsParameters{
+				TlsMinimumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_2,
+			},
 			TlsCertificates: []*envoy_extensions_transport_sockets_tls_v3.TlsCertificate{envoyCert},
 			AlpnProtocols:   []string{"h2", "http/1.1"},
 			ValidationContextType: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -314,6 +314,9 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 					}
 				}
 			],
+			"tlsParams": {
+				"tlsMinimumProtocolVersion": "TLSv1_2"
+			},
 			"validationContext": {
 				"trustChainVerification": "ACCEPT_UNTRUSTED"
 			}


### PR DESCRIPTION
## Summary
To improve security we should disable support for TLS 1.0 and 1.1.

## Related issues
- #853 

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
