### PR TITLE
proxy: only set validation context if trusted_ca is used

### DIFF
--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -348,17 +348,22 @@ func buildDownstreamTLSContext(options *config.Options, domain string) *envoy_ex
 		trustedCA = inlineFilename(options.ClientCAFile)
 	}
 
+	var validationContext *envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext
+	if trustedCA != nil {
+		validationContext = &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{
+			ValidationContext: &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
+				TrustedCa:              trustedCA,
+				TrustChainVerification: envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext_ACCEPT_UNTRUSTED,
+			},
+		}
+	}
+
 	envoyCert := envoyTLSCertificateFromGoTLSCertificate(cert)
 	return &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
-			TlsCertificates: []*envoy_extensions_transport_sockets_tls_v3.TlsCertificate{envoyCert},
-			AlpnProtocols:   []string{"h2", "http/1.1"},
-			ValidationContextType: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{
-				ValidationContext: &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
-					TrustedCa:              trustedCA,
-					TrustChainVerification: envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext_ACCEPT_UNTRUSTED,
-				},
-			},
+			TlsCertificates:       []*envoy_extensions_transport_sockets_tls_v3.TlsCertificate{envoyCert},
+			AlpnProtocols:         []string{"h2", "http/1.1"},
+			ValidationContextType: validationContext,
 		},
 	}
 }

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -313,10 +313,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 						"filename": "`+keyFileName+`"
 					}
 				}
-			],
-			"validationContext": {
-				"trustChainVerification": "ACCEPT_UNTRUSTED"
-			}
+			]
 		}
 	}`, downstreamTLSContext)
 }


### PR DESCRIPTION
## Summary
This will only set the validation context in the XDS listeners if a `ClientCA` is used. I'm not sure how to reproduce the issue that was submitted, but maybe this will fix it.

## Related issues
- #852


**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
