### PR TITLE
go.mod: bump required go version to 1.14

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pomerium/pomerium
 
-go 1.12
+go 1.14
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.0


### PR DESCRIPTION
Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>

## Summary
Renovate looks to be using go 1.12 which is my hunch based on the error

```
build github.com/pomerium/pomerium/cmd/pomerium: cannot load crypto/ed25519: cannot find module providing package crypto/ed25519
``` 



and looks to be validated by https://app.renovatebot.com/dashboard#github/pomerium/pomerium/187568370

```
"Command failed: docker run .... cache/others/go\":\"/tmp/renovate-cache/others/go\" -e GOPATH -e CGO_ENABLED -w \"/mnt/renovate/gh/pomerium/pomerium\" renovate/go:1.12.17
```

## Related issues
- https://docs.renovatebot.com/golang/
- https://blog.golang.org/using-go-modules
- https://github.com/renovatebot/renovate/issues/4475


**Checklist**:
- [ ] ready for review
