### PR TITLE
[Backport 0-9-0] Remove unnecessary viper.New() to 0-9-0

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -318,8 +318,7 @@ func NewOptionsFromConfig(configFile string) (*Options, error) {
 func optionsFromViper(configFile string) (*Options, error) {
 	// start a copy of the default options
 	o := NewDefaultOptions()
-	// New viper instance to save into Options later
-	v := viper.New()
+	v := o.viper
 	// Load up config
 	err := bindEnvs(o, v)
 	if err != nil {
@@ -337,6 +336,7 @@ func optionsFromViper(configFile string) (*Options, error) {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
+	// This is necessary because v.Unmarshal will overwrite .viper field.
 	o.viper = v
 
 	if err := o.Validate(); err != nil {


### PR DESCRIPTION
Backport b000930914769342880e35326254dbca9fdd2e93 from #849 