### PR TITLE
authenticate: change signin/signout endpoints

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -69,8 +69,8 @@ func (a *Authenticate) Mount(r *mux.Router) {
 	v.Use(middleware.ValidateSignature(a.sharedKey))
 	v.Use(sessions.RetrieveSession(a.sessionLoaders...))
 	v.Use(a.VerifySession)
-	v.Path("/sign_in").Handler(httputil.HandlerFunc(a.SignIn))
-	v.Path("/sign_out").Handler(httputil.HandlerFunc(a.SignOut))
+	v.Path("/signin").Handler(httputil.HandlerFunc(a.SignIn))
+	v.Path("/signout").Handler(httputil.HandlerFunc(a.SignOut))
 	v.Path("/refresh").Handler(httputil.HandlerFunc(a.Refresh)).Methods(http.MethodGet)
 
 	wk := r.PathPrefix("/.well-known/pomerium").Subrouter()

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -83,7 +83,7 @@ func TestAuthenticate_Handler(t *testing.T) {
 	}
 
 	// cors preflight
-	req = httptest.NewRequest(http.MethodOptions, "/.pomerium/sign_in", nil)
+	req = httptest.NewRequest(http.MethodOptions, "/.pomerium/signin", nil)
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Access-Control-Request-Method", "GET")
 	req.Header.Set("Access-Control-Request-Headers", "X-Requested-With")

--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -126,7 +126,7 @@ func (a *Authorize) plainTextDeniedResponse(code int32, reason string, headers m
 func (a *Authorize) redirectResponse(in *envoy_service_auth_v2.CheckRequest) *envoy_service_auth_v2.CheckResponse {
 	opts := a.currentOptions.Load()
 
-	signinURL := opts.GetAuthenticateURL().ResolveReference(&url.URL{Path: "/.pomerium/sign_in"})
+	signinURL := opts.GetAuthenticateURL().ResolveReference(&url.URL{Path: "/.pomerium/signin"})
 	q := signinURL.Query()
 	q.Set(urlutil.QueryRedirectURI, getCheckRequestURL(in).String())
 	signinURL.RawQuery = q.Encode()

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -6,6 +6,14 @@
 
 - config: add remove_request_headers @cuonglm [GH-702]
 
+### Fixed
+
+- authenticate: fix "Sign Out" button does not work if render user's dashboard in authenticate service @cuonglm [GH-874]
+
+### Changes
+
+- authenticate: change signin/signout endpoints @cuonglm [GH-874]
+
 ## v0.9.0
 
 ### New

--- a/docs/docs/reference/programmatic-access.md
+++ b/docs/docs/reference/programmatic-access.md
@@ -20,7 +20,7 @@ For example:
 ```bash
 $ curl "https://httpbin.example.com/.pomerium/api/v1/login?redirect_uri=http://localhost:8000"
 
-https://authenticate.example.com/.pomerium/sign_in?redirect_uri=http%3A%2F%2Flocalhost%3Fpomerium_callback_uri%3Dhttps%253A%252F%252Fhttpbin.corp.example%252F.pomerium%252Fapi%252Fv1%252Flogin%253Fredirect_uri%253Dhttp%253A%252F%252Flocalhost&sig=hsLuzJctmgsN4kbMeQL16fe_FahjDBEcX0_kPYfg8bs%3D&ts=1573262981
+https://authenticate.example.com/.pomerium/signin?redirect_uri=http%3A%2F%2Flocalhost%3Fpomerium_callback_uri%3Dhttps%253A%252F%252Fhttpbin.corp.example%252F.pomerium%252Fapi%252Fv1%252Flogin%253Fredirect_uri%253Dhttp%253A%252F%252Flocalhost&sig=hsLuzJctmgsN4kbMeQL16fe_FahjDBEcX0_kPYfg8bs%3D&ts=1573262981
 ```
 
 ### Callback handler

--- a/proxy/middleware_test.go
+++ b/proxy/middleware_test.go
@@ -59,7 +59,7 @@ func TestProxy_AuthenticateSession(t *testing.T) {
 				SharedKey:              "80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ=",
 				cookieSecret:           []byte("80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ="),
 				authenticateURL:        uriParseHelper("https://authenticate.corp.example"),
-				authenticateSigninURL:  uriParseHelper("https://authenticate.corp.example/sign_in"),
+				authenticateSigninURL:  uriParseHelper("https://authenticate.corp.example/signin"),
 				authenticateRefreshURL: uriParseHelper(rURL),
 				sessionStore:           tt.session,
 				encoder:                tt.encoder,

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -36,8 +36,8 @@ import (
 const (
 	// authenticate urls
 	dashboardURL = "/.pomerium"
-	signinURL    = "/.pomerium/sign_in"
-	signoutURL   = "/.pomerium/sign_out"
+	signinURL    = "/.pomerium/signin"
+	signoutURL   = "/.pomerium/signout"
 	refreshURL   = "/.pomerium/refresh"
 )
 


### PR DESCRIPTION
## Summary
So it does not conflict with proxy endpoints, and make the "Sign Out"
button always works, regardless of where we render user's dashboard
page.

## Related issues
Fixes #857
Fixes #867


**Checklist**:
- [x] add related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
