### PR TITLE
config: ensure viper ignores `certificates` config field

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -94,7 +94,7 @@ type Options struct {
 	CertFile string `mapstructure:"certificate_file" yaml:"certificate_file,omitempty"`
 	KeyFile  string `mapstructure:"certificate_key_file" yaml:"certificate_key_file,omitempty"`
 
-	Certificates []tls.Certificate `yaml:"-"`
+	Certificates []tls.Certificate `mapstructure:"-" yaml:"-"`
 
 	// HttpRedirectAddr, if set, specifies the host and port to run the HTTP
 	// to HTTPS redirect server on. If empty, no redirect server is started.


### PR DESCRIPTION
## Summary
Viper is trying to parse the `certificates` field in our config into Options.Certificates and resulting in a nil element.  This causes a failure to start pomerium.

**Checklist**:
- [x] ready for review
