### PR TITLE
Changes related to forward auth invalid session handling

### DIFF
--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -119,21 +119,27 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 		}
 
 		original := p.getOriginalRequest(r, uri)
-		authorized, err := p.isAuthorized(w, original)
+		isAuthorized, needsAuthentication, err := p.isAuthorized(w, original)
 		if err != nil {
 			return httputil.NewError(http.StatusBadRequest, err)
 		}
 
-		if authorized {
+		if isAuthorized {
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintf(w, "Access to %s is allowed.", uri.Host)
 			return nil
 		}
 
+		//if unauthorized (for example, session is invalid), clear the session here too
+		if needsAuthentication {
+			p.sessionStore.ClearSession(w, r)
+		}
+
+		//if we have a session, and we didn't return unauthorized, return access denied
 		_, err = sessions.FromContext(r.Context())
 		hasSession := err == nil
-		if hasSession {
+		if hasSession && !needsAuthentication {
 			return httputil.NewError(http.StatusForbidden, errors.New("access denied"))
 		}
 


### PR DESCRIPTION
## Summary

If the session is invalid, don't return 403 in forward auth.  Instead, clear the session and allow it to flow through to the authenticate functionality.

## Related issues

Fixes #858 



**Checklist**:
- [X] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [X] ready for review
