### PR TITLE
controlplane: use previous preferred cipher suite

### DIFF
--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -362,6 +362,14 @@ func buildDownstreamTLSContext(options *config.Options, domain string) *envoy_ex
 	return &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
 			TlsParams: &envoy_extensions_transport_sockets_tls_v3.TlsParameters{
+				CipherSuites: []string{
+					"ECDHE-ECDSA-AES256-GCM-SHA384",
+					"ECDHE-RSA-AES256-GCM-SHA384",
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+					"ECDHE-ECDSA-CHACHA20-POLY1305",
+					"ECDHE-RSA-CHACHA20-POLY1305",
+				},
 				TlsMinimumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_2,
 			},
 			TlsCertificates:       []*envoy_extensions_transport_sockets_tls_v3.TlsCertificate{envoyCert},

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -304,6 +304,14 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 	testutil.AssertProtoJSONEqual(t, `{
 		"commonTlsContext": {
 			"tlsParams": {
+				"cipherSuites": [
+					"ECDHE-ECDSA-AES256-GCM-SHA384",
+					"ECDHE-RSA-AES256-GCM-SHA384",
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+					"ECDHE-ECDSA-CHACHA20-POLY1305",
+					"ECDHE-RSA-CHACHA20-POLY1305"
+				],
 				"tlsMinimumProtocolVersion": "TLSv1_2"
 			},
 			"alpnProtocols": ["h2", "http/1.1"],


### PR DESCRIPTION
Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>

## Summary
Envoy defaults to its own preferred cipher suite which is [less opinionated than our previous cipher suite](https://github.com/pomerium/pomerium/blob/0-7-0/internal/httputil/server.go#L69-L76) and contains ciphers that are vulnerable to attacks like lucky13. 

## Related issues

- https://github.com/pomerium/pomerium/blob/0-7-0/internal/httputil/server.go#L69-L76
- https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/common.proto
- https://github.com/envoyproxy/envoy/issues/8848
- https://wiki.mozilla.org/Security/Server_Side_TLS

## Related issues

- https://github.com/pomerium/pomerium/issues/853


**Checklist**:
- [x] add related issues
- [x] ready for review
