### PR TITLE
internal/cmd/pomerium: fix data race in handling context

### DIFF
--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -90,7 +90,7 @@ func Run(ctx context.Context, configFile string) error {
 	go config.WatchChanges(configFile, opt, optionsUpdaters)
 
 	ctx, cancel := context.WithCancel(ctx)
-	go func() {
+	go func(ctx context.Context) {
 		ch := make(chan os.Signal, 2)
 		defer signal.Stop(ch)
 
@@ -102,7 +102,7 @@ func Run(ctx context.Context, configFile string) error {
 		case <-ctx.Done():
 		}
 		cancel()
-	}()
+	}(ctx)
 
 	// run everything
 	eg, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
## Summary
Caught by:

```
go test -race ./internal/cmd/pomerium
```

The ctx in Run is both read (in handle signal goroutine) and write
(when passing to errgroup context in Run), causes data race.

Fixing it, by passing the ctx to goroutine via argument instead of
accessing it directly.


**Checklist**:

- [x] ready for review
