### PR TITLE
internal/telemetry/metrics: document concurrently using

### DIFF
--- a/internal/telemetry/metrics/kv_test.go
+++ b/internal/telemetry/metrics/kv_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func Test_AddGroupCacheMetrics(t *testing.T) {
-	t.Parallel()
-
 	gc := &groupcache.Group{}
 	AddGroupCacheMetrics(gc)
 
@@ -40,8 +38,6 @@ func Test_AddGroupCacheMetrics(t *testing.T) {
 }
 
 func Test_AddBoltDBMetrics(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name string
 		stat bbolt.Stats
@@ -68,8 +64,6 @@ func Test_AddBoltDBMetrics(t *testing.T) {
 }
 
 func Test_AddRedisMetrics(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name string
 		stat *redis.PoolStats

--- a/internal/telemetry/metrics/registry.go
+++ b/internal/telemetry/metrics/registry.go
@@ -18,6 +18,8 @@ var (
 // metricRegistry holds the non-view metrics and handles safe
 // initialization and updates.  Behavior without using newMetricRegistry()
 // is undefined.
+//
+// It is not safe to use metricRegistry concurrently.
 type metricRegistry struct {
 	registry       *metric.Registry
 	buildInfo      *metric.Int64Gauge


### PR DESCRIPTION
## Summary
Document that metricRegistry is not safe for concurrently use. While at
it, remove t.Parallel() in tests which use metricRegistry, which causes
data race, caught by:

	go test -race ./internal/telemetry/metrics

**Checklist**:

- [x] ready for review
