### PR TITLE
envoy: bump envoy to 1.14.2

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 - config: add remove_request_headers @cuonglm [GH-702]
 
+## v0.9.1
+
+### Security
+
+- envoy: fixes CVE-2020-11080 by rejecting HTTP/2 SETTINGS frames with too many parameters  
+
 ## v0.9.0
 
 ### New

--- a/scripts/embed-envoy.bash
+++ b/scripts/embed-envoy.bash
@@ -3,7 +3,7 @@ set -euo pipefail
 
 BINARY=$1
 
-ENVOY_VERSION=1.14.1
+ENVOY_VERSION=1.14.2
 DIR=$(dirname "${BINARY}")
 GOOS=$(echo "${GOOS-}" | cut -d _ -f 1) # goreleaser is fine
 


### PR DESCRIPTION
Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>

## Summary

These changes increment the deployed version of envoy to 1.14.2.

## Related issues
- https://www.envoyproxy.io/docs/envoy/v1.14.2/intro/version_history#june-8-2020
- https://nvd.nist.gov/vuln/detail/CVE-2020-11080

**Checklist**:

- [x] add related issues
- [x] updated docs
- [x] ready for review
