### PR TITLE
policy: Add consistent route identifier

### DIFF
--- a/config/policy.go
+++ b/config/policy.go
@@ -157,6 +157,22 @@ func (p *Policy) Checksum() uint64 {
 	return cs
 }
 
+// RouteID returns a unique identifier for a route
+func (p *Policy) RouteID() uint64 {
+	id := routeID{
+		Source:      p.Source,
+		Destination: p.Destination,
+		Prefix:      p.Prefix,
+		Path:        p.Path,
+		Regex:       p.Regex,
+	}
+
+	cs, _ := hashstructure.Hash(id, &hashstructure.HashOptions{
+		Hasher: xxhash.New(),
+	})
+	return cs
+}
+
 func (p *Policy) String() string {
 	if p.Source == nil || p.Destination == nil {
 		return fmt.Sprintf("%s → %s", p.From, p.To)
@@ -172,4 +188,12 @@ type StringURL struct {
 // MarshalJSON returns the URLs host as json.
 func (u *StringURL) MarshalJSON() ([]byte, error) {
 	return json.Marshal(u.String())
+}
+
+type routeID struct {
+	Source      *StringURL
+	Destination *url.URL
+	Prefix      string
+	Path        string
+	Regex       string
 }

--- a/internal/controlplane/xds.go
+++ b/internal/controlplane/xds.go
@@ -172,7 +172,7 @@ func inlineFilename(name string) *envoy_config_core_v3.DataSource {
 }
 
 func getPolicyName(policy *config.Policy) string {
-	return fmt.Sprintf("policy-%x", policy.Checksum())
+	return fmt.Sprintf("policy-%x", policy.RouteID())
 }
 
 func envoyTLSCertificateFromGoTLSCertificate(cert *tls.Certificate) *envoy_extensions_transport_sockets_tls_v3.TlsCertificate {

--- a/internal/controlplane/xds_routes_test.go
+++ b/internal/controlplane/xds_routes_test.go
@@ -247,7 +247,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				},
 				"route": {
 					"autoHostRewrite": true,
-					"cluster": "policy-4e2763e591b22dc8",
+					"cluster": "policy-701142725541ce1f",
 					"timeout": "3s",
 					"upgradeConfigs": [{
 						"enabled": false,
@@ -270,7 +270,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				},
 				"route": {
 					"autoHostRewrite": false,
-					"cluster": "policy-e5d20435224ae9b",
+					"cluster": "policy-35b6cce9d52d36ed",
 					"timeout": "0s",
 					"upgradeConfigs": [{
 						"enabled": true,
@@ -293,7 +293,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				},
 				"route": {
 					"autoHostRewrite": true,
-					"cluster": "policy-6e7239b3980df01f",
+					"cluster": "policy-8935ca8067709cf7",
 					"timeout": "60s",
 					"upgradeConfigs": [{
 						"enabled": false,
@@ -326,7 +326,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				},
 				"route": {
 					"autoHostRewrite": true,
-					"cluster": "policy-7bf4b11bf99ced85",
+					"cluster": "policy-45c2908c3d6f0e52",
 					"timeout": "3s",
 					"upgradeConfigs": [{
 						"enabled": false,
@@ -349,7 +349,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				},
 				"route": {
 					"autoHostRewrite": true,
-					"cluster": "policy-6b5e934ff586365d",
+					"cluster": "policy-8935ca8067709cf7",
 					"timeout": "60s",
 					"upgradeConfigs": [{
 						"enabled": false,


### PR DESCRIPTION
## Summary
- adds a route identifier that is derived only from routing information (source/destination/path) on a policy
- update envoy to use this new identifier for cluster names

Prevents unnecessary cluster churn when policy related settings are changed (eg, `allowed_users`).  This was causing transient route failures after policy changes when using HTTP2.  

## Related issues
Closes #870 

**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
