### PR TITLE
integration: set default headers

### DIFF
--- a/integration/manifests/lib/pomerium.libsonnet
+++ b/integration/manifests/lib/pomerium.libsonnet
@@ -184,6 +184,7 @@ local PomeriumConfigMap = function() {
     AUTHORIZE_SERVICE_URL: 'https://authorize.default.svc.cluster.local:5443',
     CACHE_SERVICE_URL: 'https://cache.default.svc.cluster.local:5443',
     FORWARD_AUTH_URL: 'https://forward-authenticate.localhost.pomerium.io',
+    HEADERS: 'X-Frame-Options:SAMEORIGIN',
 
     SHARED_SECRET: 'Wy+c0uSuIM0yGGXs82MBwTZwRiZ7Ki2T0LANnmzUtkI=',
     COOKIE_SECRET: 'eZ91a/j9fhgki9zPDU5zHdQWX4io89pJanChMVa5OoM=',


### PR DESCRIPTION

## Summary
After commit f62bb686d82820cc1313cfb79ec9364ccb5b368e, the default
headers, which include HSTS header will be set for response. It will
break integration test due to the interact with nginx ingress.

To fix it, set default headers without the HSTS header.
