### PR TITLE
internal/envoy: fix handleLogs causes envoy hang forever

### DIFF
--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -2,9 +2,8 @@
 package envoy
 
 import (
-	"bytes"
-
 	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -14,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	envoy_config_bootstrap_v3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -309,13 +309,20 @@ func (srv *Server) addTraceConfig(traceOpts *config.TracingOptions, bootCfg *env
 	return nil
 }
 
-func (srv *Server) handleLogs(stdout io.ReadCloser) {
+func (srv *Server) handleLogs(rc io.ReadCloser) {
+	defer rc.Close()
+
 	logFormatRE := regexp.MustCompile(`^[[]LOG_FORMAT[]](.*?)--(.*?)--(.*?)$`)
 	fileNameAndNumberRE := regexp.MustCompile(`^(\[[a-zA-Z0-9/-_.]+:[0-9]+])\s(.*)$`)
 
-	s := bufio.NewScanner(stdout)
-	for s.Scan() {
-		ln := s.Text()
+	s := bufio.NewReader(rc)
+	for {
+		ln, err := s.ReadString('\n')
+		if err != nil {
+			log.Error().Err(err).Msg("failed to read log")
+			continue
+		}
+		ln = strings.TrimRight(ln, "\r\n")
 
 		// format: [LOG_FORMAT]level--name--message
 		// message is c-escaped


### PR DESCRIPTION


## Summary
handleLogs uses bufio scanner to process log output from envoy. When in
debug mode, envoy produces very long log line, causing the scanner
fails, handleLogs stop processing log. But envoy continue writing to its
stdout, which is now not consumed by any process, envoy hangs there
forever.

Fixing this by switching to use bufio.Reader instead. This is also the
real fix for failed integration test, which is interpreted wrongly by
me in #910.

## Related issues
Updates #903 


**Checklist**:
- [x] add related issues
- [x] ready for review
