### PR TITLE
docs: document un-supported HTTP 1.0 in 0.9.0 and higher

### DIFF
--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -13,6 +13,23 @@ description: >-
 
 With this release, default log level has been changed to INFO.
 
+### HTTP 1.0
+
+HTTP 1.0 is not supported anymore, if you relied on it, make sure to upgrade to HTTP 1.1 or higher.
+
+Example for HAProxy health check, in pre `0.9.0`:
+
+```shell script
+option httpchk GET /ping
+```
+
+In `0.9.0`:
+
+```shell script
+
+option httpchk GET /ping HTTP/1.1\r\nHost:pomerium
+```
+
 # Since 0.8.0
 
 ## Breaking

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -15,7 +15,7 @@ With this release, default log level has been changed to INFO.
 
 ### HTTP 1.0
 
-HTTP 1.0 is not supported anymore, if you relied on it, make sure to upgrade to HTTP 1.1 or higher.
+HTTP 1.0 is not supported anymore. If you relied on it make sure to upgrade to HTTP 1.1 or higher.
 
 Example for HAProxy health check, in pre `0.9.0`:
 


### PR DESCRIPTION
## Summary

Envoy does not support HTTP 1.0 by default, so document this breaking change in 0.9.0 and higher.

## Related issues
Fixes #915


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
