### PR TITLE
integration: sleep for amount of time before running tests

### DIFF
--- a/integration/internal/cluster/setup.go
+++ b/integration/internal/cluster/setup.go
@@ -230,6 +230,7 @@ func applyManifests(ctx context.Context, jsonsrc string) error {
 		}
 		<-ticker.C
 	}
+	time.Sleep(time.Second * 10)
 	log.Info().Msg("all deployments are ready")
 
 	return nil


### PR DESCRIPTION

## Summary
Most of the flaky failure due to the fact that not all pods are ready
yet. We currently check the readiness by get all deployments and
heuristic parsing the output. So let wait for another 10 seconds before
running tests.


**Checklist**:
- [x] ready for review
