### PR TITLE
idp: delete sessions on refresh error, handle zero times in oauth/id tokens for refresh

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pomerium/csrf"
 	"github.com/rs/cors"
 	"golang.org/x/oauth2"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/internal/cryptutil"
 	"github.com/pomerium/pomerium/internal/grpc/databroker"
@@ -491,7 +492,10 @@ func (a *Authenticate) saveSessionToDataBroker(ctx context.Context, sessionState
 	}
 
 	sessionExpiry, _ := ptypes.TimestampProto(time.Now().Add(time.Hour))
-	idTokenExpiry, _ := ptypes.TimestampProto(sessionState.Expiry.Time())
+	var idTokenExpiry *timestamppb.Timestamp
+	if sessionState.Expiry != nil {
+		idTokenExpiry, _ = ptypes.TimestampProto(sessionState.Expiry.Time())
+	}
 	idTokenIssuedAt, _ := ptypes.TimestampProto(sessionState.IssuedAt.Time())
 	oauthTokenExpiry, _ := ptypes.TimestampProto(accessToken.Expiry)
 

--- a/cache/session.go
+++ b/cache/session.go
@@ -51,14 +51,32 @@ func (srv *SessionServer) Add(ctx context.Context, req *session.AddRequest) (*se
 		Str("session_id", req.GetSession().GetId()).
 		Msg("add")
 
-	data, err := ptypes.MarshalAny(req.GetSession())
+	s := req.GetSession()
+
+	data, err := ptypes.MarshalAny(s)
 	if err != nil {
 		return nil, err
 	}
 
 	res, err := srv.dataBrokerClient.Set(ctx, &databroker.SetRequest{
 		Type: data.GetTypeUrl(),
-		Id:   req.GetSession().GetId(),
+		Id:   s.GetId(),
+		Data: data,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	s.Version = res.GetServerVersion()
+
+	data, err = ptypes.MarshalAny(s)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err = srv.dataBrokerClient.Set(ctx, &databroker.SetRequest{
+		Type: data.GetTypeUrl(),
+		Id:   s.GetId(),
 		Data: data,
 	})
 	if err != nil {

--- a/internal/identity/manager/data.go
+++ b/internal/identity/manager/data.go
@@ -74,26 +74,22 @@ type Session struct {
 func (s Session) NextRefresh() time.Time {
 	var tm time.Time
 
-	expiry, err := ptypes.Timestamp(s.GetOauthToken().GetExpiresAt())
-	if err == nil {
-		expiry = expiry.Add(-s.gracePeriod)
-		if tm.IsZero() || expiry.Before(tm) {
-			tm = expiry
+	if s.GetOauthToken().GetExpiresAt() != nil {
+		expiry, err := ptypes.Timestamp(s.GetOauthToken().GetExpiresAt())
+		if err == nil && !expiry.IsZero() {
+			expiry = expiry.Add(-s.gracePeriod)
+			if tm.IsZero() || expiry.Before(tm) {
+				tm = expiry
+			}
 		}
 	}
 
-	expiry, err = ptypes.Timestamp(s.GetIdToken().GetExpiresAt())
-	if err == nil {
-		expiry = expiry.Add(-s.gracePeriod)
-		if tm.IsZero() || expiry.Before(tm) {
-			tm = expiry
-		}
-	}
-
-	expiry, err = ptypes.Timestamp(s.GetExpiresAt())
-	if err == nil {
-		if tm.IsZero() || expiry.Before(tm) {
-			tm = expiry
+	if s.GetExpiresAt() != nil {
+		expiry, err := ptypes.Timestamp(s.GetExpiresAt())
+		if err == nil && !expiry.IsZero() {
+			if tm.IsZero() || expiry.Before(tm) {
+				tm = expiry
+			}
 		}
 	}
 

--- a/internal/identity/manager/data_test.go
+++ b/internal/identity/manager/data_test.go
@@ -48,17 +48,10 @@ func TestSession_NextRefresh(t *testing.T) {
 	}
 	assert.Equal(t, tm2.Add(-time.Second*10), s.NextRefresh())
 
-	tm3 := time.Date(2020, 6, 5, 12, 30, 0, 0, time.UTC)
+	tm3 := time.Date(2020, 6, 5, 12, 15, 0, 0, time.UTC)
 	pbtm3, _ := ptypes.TimestampProto(tm3)
-	s.IdToken = &session.IDToken{
-		ExpiresAt: pbtm3,
-	}
-	assert.Equal(t, tm3.Add(-time.Second*10), s.NextRefresh())
-
-	tm4 := time.Date(2020, 6, 5, 12, 15, 0, 0, time.UTC)
-	pbtm4, _ := ptypes.TimestampProto(tm4)
-	s.ExpiresAt = pbtm4
-	assert.Equal(t, tm4, s.NextRefresh())
+	s.ExpiresAt = pbtm3
+	assert.Equal(t, tm3, s.NextRefresh())
 }
 
 func TestSession_UnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
## Summary
If a session/user refresh fails we will now delete the session. This should handle revoked tokens. 

I made a couple other changes:
- handle zero timestamps better (apparently many providers have tokens which never expire)
- update the session with the server version on creation

## Related issues
- Fixes #935


**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
