### PR TITLE
authenticate: remove useless/duplicated code block

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -194,10 +194,7 @@ func (a *Authenticate) SignIn(w http.ResponseWriter, r *http.Request) error {
 		a.sessionStore.ClearSession(w, r)
 		return err
 	}
-	if err != nil {
-		a.sessionStore.ClearSession(w, r)
-		return err
-	}
+
 	// user impersonation
 	if impersonate := r.FormValue(urlutil.QueryImpersonateAction); impersonate != "" {
 		s.SetImpersonation(r.FormValue(urlutil.QueryImpersonateEmail), r.FormValue(urlutil.QueryImpersonateGroups))


### PR DESCRIPTION
## Summary

The second err handling block is useless, remove it.

## Related issues



**Checklist**:
- [x] ready for review
