### PR TITLE
authenticate: revoke current session oauth token before sign out

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -255,7 +255,7 @@ func (a *Authenticate) SignOut(w http.ResponseWriter, r *http.Request) error {
 
 	sessionState, err := a.getSessionFromCtx(ctx)
 	if err == nil {
-		if s, _ := session.Get(ctx, a.dataBrokerClient, sessionState.ID); s != nil {
+		if s, _ := session.Get(ctx, a.dataBrokerClient, sessionState.ID); s != nil && s.OauthToken != nil {
 			if err := a.provider.Revoke(ctx, manager.FromOAuthToken(s.OauthToken)); err != nil {
 				log.Warn().Err(err).Msg("failed to revoke access token")
 			}

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -236,6 +236,25 @@ func TestAuthenticate_SignOut(t *testing.T) {
 				encryptedEncoder: mock.Encoder{},
 				templates:        template.Must(frontend.NewTemplates()),
 				sharedEncoder:    mock.Encoder{},
+				dataBrokerClient: mockDataBrokerServiceClient{
+					get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
+						data, err := ptypes.MarshalAny(&session.Session{
+							Id: "SESSION_ID",
+						})
+						if err != nil {
+							return nil, err
+						}
+
+						return &databroker.GetResponse{
+							Record: &databroker.Record{
+								Version: "0001",
+								Type:    data.GetTypeUrl(),
+								Id:      "SESSION_ID",
+								Data:    data,
+							},
+						}, nil
+					},
+				},
 			}
 			u, _ := url.Parse("/sign_out")
 			params, _ := url.ParseQuery(u.RawQuery)

--- a/internal/identity/manager/manager.go
+++ b/internal/identity/manager/manager.go
@@ -275,7 +275,7 @@ func (mgr *Manager) refreshSession(ctx context.Context, userID, sessionID string
 		return
 	}
 
-	newToken, err := mgr.authenticator.Refresh(ctx, fromOAuthToken(s.OauthToken), &s)
+	newToken, err := mgr.authenticator.Refresh(ctx, FromOAuthToken(s.OauthToken), &s)
 	if isTemporaryError(err) {
 		mgr.log.Error().Err(err).
 			Str("user_id", s.GetUserId()).
@@ -290,7 +290,7 @@ func (mgr *Manager) refreshSession(ctx context.Context, userID, sessionID string
 		mgr.deleteSession(ctx, s.Session)
 		return
 	}
-	s.OauthToken = toOAuthToken(newToken)
+	s.OauthToken = ToOAuthToken(newToken)
 
 	_, err = mgr.sessionClient.Add(ctx, &session.AddRequest{Session: s.Session})
 	if err != nil {
@@ -327,7 +327,7 @@ func (mgr *Manager) refreshUser(ctx context.Context, userID string) {
 			continue
 		}
 
-		err := mgr.authenticator.UpdateUserInfo(ctx, fromOAuthToken(s.OauthToken), &u)
+		err := mgr.authenticator.UpdateUserInfo(ctx, FromOAuthToken(s.OauthToken), &u)
 		if isTemporaryError(err) {
 			mgr.log.Error().Err(err).
 				Str("user_id", s.GetUserId()).

--- a/internal/identity/manager/misc.go
+++ b/internal/identity/manager/misc.go
@@ -100,7 +100,8 @@ func fromSessionSchedulerKey(key string) (userID, sessionID string) {
 	return userID, sessionID
 }
 
-func fromOAuthToken(token *session.OAuthToken) *oauth2.Token {
+// FromOAuthToken converts a session oauth token to oauth2.Token.
+func FromOAuthToken(token *session.OAuthToken) *oauth2.Token {
 	expiry, _ := ptypes.Timestamp(token.GetExpiresAt())
 	return &oauth2.Token{
 		AccessToken:  token.GetAccessToken(),
@@ -110,7 +111,8 @@ func fromOAuthToken(token *session.OAuthToken) *oauth2.Token {
 	}
 }
 
-func toOAuthToken(token *oauth2.Token) *session.OAuthToken {
+// ToOAuthToken converts an oauth2.Token to a session oauth token.
+func ToOAuthToken(token *oauth2.Token) *session.OAuthToken {
 	expiry, _ := ptypes.TimestampProto(token.Expiry)
 	return &session.OAuthToken{
 		AccessToken:  token.AccessToken,


### PR DESCRIPTION


## Summary
After #926, we don't revoke access token before sign out anymore. It
causes sign out can not work anymore, because right after user click on
sign out button, we redirect user to idp provider authenticate page with
a valid access token, so user is logged in immediately again.

To fix it, just revoke the access token before sign out.

## Related issues



**Checklist**:

- [x] ready for review
