### PR TITLE
controlplane: add robots route

### DIFF
--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -87,6 +87,21 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 						"domains": ["example.com"],
 						"routes": [
 							{
+								"name": "pomerium-path-/robots.txt",
+								"match": {
+									"path": "/robots.txt"
+								},
+								"route": {
+									"cluster": "pomerium-control-plane-http"
+								},
+								"typedPerFilterConfig": {
+									"envoy.filters.http.ext_authz": {
+										"@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+										"disabled": true
+									}
+								}
+							},
+							{
 								"name": "pomerium-path-/ping",
 								"match": {
 									"path": "/ping"
@@ -182,6 +197,21 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 						"name": "catch-all",
 						"domains": ["*"],
 						"routes": [
+							{
+								"name": "pomerium-path-/robots.txt",
+								"match": {
+									"path": "/robots.txt"
+								},
+								"route": {
+									"cluster": "pomerium-control-plane-http"
+								},
+								"typedPerFilterConfig": {
+									"envoy.filters.http.ext_authz": {
+										"@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+										"disabled": true
+									}
+								}
+							},
 							{
 								"name": "pomerium-path-/ping",
 								"match": {

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -41,6 +41,7 @@ func buildGRPCRoutes() []*envoy_config_route_v3.Route {
 
 func buildPomeriumHTTPRoutes(options *config.Options, domain string) []*envoy_config_route_v3.Route {
 	routes := []*envoy_config_route_v3.Route{
+		buildControlPlanePathRoute("/robots.txt"),
 		buildControlPlanePathRoute("/ping"),
 		buildControlPlanePathRoute("/healthz"),
 		buildControlPlanePathRoute("/.pomerium"),

--- a/internal/controlplane/xds_routes_test.go
+++ b/internal/controlplane/xds_routes_test.go
@@ -44,6 +44,21 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 	testutil.AssertProtoJSONEqual(t, `
 		[
 			{
+				"name": "pomerium-path-/robots.txt",
+				"match": {
+					"path": "/robots.txt"
+				},
+				"route": {
+					"cluster": "pomerium-control-plane-http"
+				},
+				"typedPerFilterConfig": {
+					"envoy.filters.http.ext_authz": {
+						"@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+						"disabled": true
+					}
+				}
+			},
+			{
 				"name": "pomerium-path-/ping",
 				"match": {
 					"path": "/ping"


### PR DESCRIPTION

## Summary

Previously, we serve a custom robots.txt that returns even for unauthenticated requests (crawlers).

```
User-agent: *
Disallow: /
```

This changes reintroduces that behavior. 

## Related issues
- #837 


**Checklist**:
- [x] add related issues
- [x] ready for review
