### PR TITLE
directory: add service account struct and parsing method

### DIFF
--- a/internal/directory/provider.go
+++ b/internal/directory/provider.go
@@ -59,9 +59,15 @@ func GetProvider(options *config.Options) Provider {
 			Err(err).
 			Msg("invalid service account for gitlab directory provider")
 	case google.Name:
-		if options.ServiceAccount != "" {
-			return google.New(google.WithServiceAccount(options.ServiceAccount))
+		serviceAccount, err := google.ParseServiceAccount(options.ServiceAccount)
+		if err == nil {
+			return google.New(google.WithServiceAccount(serviceAccount))
 		}
+		log.Warn().
+			Str("service", "directory").
+			Str("provider", options.Provider).
+			Err(err).
+			Msg("invalid service account for google directory provider")
 	case okta.Name:
 		providerURL, _ := url.Parse(options.ProviderURL)
 		serviceAccount, err := okta.ParseServiceAccount(options.ServiceAccount)


### PR DESCRIPTION
## Summary
It looks like the docs for Google are already correct for configuring the service account. I went ahead and updated the code to use a ServiceAccount struct to match the other providers and give better error messages if `ImpersonateUser` is missing.

## Related issues
- #933


**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
