### PR TITLE
cache: add client telemetry

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -150,6 +150,7 @@ func New(opts config.Options) (*Authenticate, error) {
 			RequestTimeout:          opts.GRPCClientTimeout,
 			ClientDNSRoundRobin:     opts.GRPCClientDNSRoundRobin,
 			WithInsecure:            opts.GRPCInsecure,
+			ServiceName:             opts.Services,
 		})
 	if err != nil {
 		return nil, err

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -79,6 +79,7 @@ func New(opts config.Options) (*Authorize, error) {
 			RequestTimeout:          opts.GRPCClientTimeout,
 			ClientDNSRoundRobin:     opts.GRPCClientDNSRoundRobin,
 			WithInsecure:            opts.GRPCInsecure,
+			ServiceName:             opts.Services,
 		})
 	if err != nil {
 		return nil, fmt.Errorf("authorize: error creating cache connection: %w", err)

--- a/internal/telemetry/grpc_test.go
+++ b/internal/telemetry/grpc_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opencensus.io/plugin/ocgrpc"
+	"google.golang.org/grpc"
 	grpcstats "google.golang.org/grpc/stats"
 )
 
@@ -34,4 +35,28 @@ func Test_GRPCServerStatsHandler(t *testing.T) {
 	assert.True(t, metricsHandler.called)
 	assert.Equal(t, ctx.Value(mockCtxTag("added")), "true")
 	assert.Equal(t, ctx.Value(mockCtxTag("original")), "true")
+}
+
+type mockDialOption struct {
+	name string
+	grpc.EmptyDialOption
+}
+
+func Test_NewGRPCClientStatsHandler(t *testing.T) {
+	t.Parallel()
+
+	h := NewGRPCClientStatsHandler("test")
+
+	origOpts := []grpc.DialOption{
+		mockDialOption{name: "one"},
+		mockDialOption{name: "two"},
+	}
+
+	newOpts := h.DialOptions(origOpts...)
+
+	for i := range origOpts {
+		assert.Contains(t, newOpts, origOpts[i])
+	}
+
+	assert.Greater(t, len(newOpts), len(origOpts))
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -150,6 +150,7 @@ func New(opts config.Options) (*Proxy, error) {
 		RequestTimeout:          opts.GRPCClientTimeout,
 		ClientDNSRoundRobin:     opts.GRPCClientDNSRoundRobin,
 		WithInsecure:            opts.GRPCInsecure,
+		ServiceName:             opts.Services,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- Refactor grpc client telemetry to be easier to consume consistently
- Update existing internal/grpc clients to pass service name correctly
- Update existing internal/grpc client to consume new telemetry DialOptions
- Update cache to consume new telemetry DialOptions

## Related Issues
Closes #976 

**Checklist**:
- [x] updated unit tests
- [x] ready for review
