### PR TITLE
internal/sessions: handle claims "ver" field generally

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -571,7 +571,7 @@ func (a *Authenticate) saveSessionToDataBroker(ctx context.Context, sessionState
 	if err != nil {
 		return fmt.Errorf("authenticate: error saving session: %w", err)
 	}
-	sessionState.Version = res.GetServerVersion()
+	sessionState.Version = sessions.Version(res.GetServerVersion())
 
 	return nil
 }

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -48,10 +48,10 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v2.CheckRe
 	// only accept sessions whose databroker server versions match
 	if sessionState != nil {
 		a.dataBrokerDataLock.RLock()
-		if a.dataBrokerSessionServerVersion != sessionState.Version {
+		if a.dataBrokerSessionServerVersion != sessionState.Version.String() {
 			log.Warn().
 				Str("server_version", a.dataBrokerSessionServerVersion).
-				Str("session_version", sessionState.Version).
+				Str("session_version", sessionState.Version.String()).
 				Msg("clearing session due to invalid version")
 			sessionState = nil
 		}

--- a/internal/sessions/state_test.go
+++ b/internal/sessions/state_test.go
@@ -122,3 +122,30 @@ func TestState_UnmarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestVersion_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		jsonStr     string
+		wantVersion string
+		wantErr     bool
+	}{
+		{"Version is string", `"1"`, "1", false},
+		{"Version is integer", `1`, "1", false},
+		{"Version is float", `1.1`, "1.1", false},
+		{"Invalid version", `[1]`, "", true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			var v Version
+			if err := v.UnmarshalJSON([]byte(tc.jsonStr)); (err != nil) != tc.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tc.wantErr)
+			}
+			if !tc.wantErr && v.String() != tc.wantVersion {
+				t.Errorf("mismatch version, want: %s, got: %s", tc.wantVersion, v.String())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
"ver" field is not specified by RFC 7519, so in practice, most providers
return it as string, but okta returns it as number, which cause okta
authenticate broken.

To fix it, we handle "ver" field more generally, to allow both string and
number in json payload.

## Related issues


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
