### PR TITLE
memberlist: use bufio reader instead of scanner

### DIFF
--- a/cache/memberlist.go
+++ b/cache/memberlist.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	stdlog "log"
+	"strings"
 
 	"github.com/hashicorp/memberlist"
 	"github.com/rs/zerolog"
@@ -66,8 +67,12 @@ func (mh *memberlistHandler) NotifyUpdate(node *memberlist.Node) {
 }
 
 func (mh *memberlistHandler) runLogHandler(r io.Reader) {
-	s := bufio.NewScanner(r)
-	for s.Scan() {
-		mh.log.Debug().Msg(s.Text())
+	br := bufio.NewReader(r)
+	for {
+		str, err := br.ReadString('\n')
+		if err != nil {
+			break
+		}
+		mh.log.Debug().Msg(strings.TrimSpace(str))
 	}
 }


### PR DESCRIPTION
## Summary
`bufio.Scanner` will stop reading if a line is too long. This switches to using a `bufio.Reader` which won't do that.

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
