### PR TITLE
cache: attempt to join memberlist cluster for sanity check

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -31,9 +31,10 @@ type Cache struct {
 	userServer       *UserServer
 	manager          *manager.Manager
 
-	localListener       net.Listener
-	localGRPCServer     *grpc.Server
-	localGRPCConnection *grpc.ClientConn
+	localListener                net.Listener
+	localGRPCServer              *grpc.Server
+	localGRPCConnection          *grpc.ClientConn
+	deprecatedCacheClusterDomain string //TODO: remove in v0.11
 }
 
 // New creates a new cache service.
@@ -85,9 +86,10 @@ func New(opts config.Options) (*Cache, error) {
 		userServer:       userServer,
 		manager:          manager,
 
-		localListener:       localListener,
-		localGRPCServer:     localGRPCServer,
-		localGRPCConnection: localGRPCConnection,
+		localListener:                localListener,
+		localGRPCServer:              localGRPCServer,
+		localGRPCConnection:          localGRPCConnection,
+		deprecatedCacheClusterDomain: opts.GetDataBrokerURL().Hostname(),
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
Have cache attempt to join the legacy memberlist cluster to check for other nodes so that it can log error messages.

There's no particularly good way to safely keep the cluster to 1 node and support general rolling restarts.

**Checklist**:
- [x] ready for review
