### PR TITLE
Docs: Update Istio VirtualService example

### DIFF
--- a/docs/configuration/examples/kubernetes/istio/virtual-services.yml
+++ b/docs/configuration/examples/kubernetes/istio/virtual-services.yml
@@ -12,6 +12,8 @@ spec:
     - route:
         - destination:
             host: pomerium-proxy
+            port:
+              number: 80
 ---
 apiVersion: networking.istio.io/v1beta1
 kind: VirtualService
@@ -27,4 +29,6 @@ spec:
     - route:
         - destination:
             host: pomerium-authenticate
+            port:
+              number: 80
 ---


### PR DESCRIPTION
It's necessary to specify the destination port for Pomerium services

## Summary

The current example configuration does not work as-is. After reaching out on Slack, @bjoernw indicated that the destination port must be specified:
"there was one change that i think travis made that you now need to make sure in your virtual service where you are routing to the proxy you need to route to port 80 explicitly"

## Related issues
None

**Checklist**:
- [ ] add related issues
- [X] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [X] ready for review
