### PR TITLE
integration: add dummy value for idp_service_account

### DIFF
--- a/integration/manifests/lib/pomerium.libsonnet
+++ b/integration/manifests/lib/pomerium.libsonnet
@@ -201,6 +201,7 @@ local PomeriumConfigMap = function() {
     IDP_PROVIDER_URL: 'https://openid.localhost.pomerium.io',
     IDP_CLIENT_ID: 'pomerium-authenticate',
     IDP_CLIENT_SECRET: 'pomerium-authenticate-secret',
+    IDP_SERVICE_ACCOUNT: 'pomerium-service-account',
 
     POLICY: std.base64(std.manifestYamlDoc(PomeriumPolicy())),
   },


### PR DESCRIPTION
## Summary
After 1d1311a2400256d42d22a16fc02606379901058b, policy with groups rule
requires idp_service_account set.

## Related issues



**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
