### PR TITLE
authorize/evaluator/opa: set client tls cert usage explicitly

### DIFF
--- a/authorize/evaluator/functions.go
+++ b/authorize/evaluator/functions.go
@@ -6,12 +6,11 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/pomerium/pomerium/internal/log"
-
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/rakyll/statik/fs"
 
 	_ "github.com/pomerium/pomerium/authorize/evaluator/opa/policy" // load static assets
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 var isValidClientCertificateCache, _ = lru.New2Q(100)

--- a/authorize/evaluator/functions.go
+++ b/authorize/evaluator/functions.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/pomerium/pomerium/internal/log"
+
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/rakyll/statik/fs"
 
@@ -46,9 +48,13 @@ func isValidClientCertificate(ca, cert string) (bool, error) {
 	})
 	valid := verifyErr == nil
 
+	if verifyErr != nil {
+		log.Debug().Err(verifyErr).Msg("client certificate failed verification: %w")
+	}
+
 	isValidClientCertificateCache.Add(cacheKey, valid)
 
-	return valid, verifyErr
+	return valid, nil
 }
 
 func parseCertificate(pemStr string) (*x509.Certificate, error) {

--- a/authorize/evaluator/functions.go
+++ b/authorize/evaluator/functions.go
@@ -41,13 +41,14 @@ func isValidClientCertificate(ca, cert string) (bool, error) {
 	}
 
 	_, verifyErr := xcert.Verify(x509.VerifyOptions{
-		Roots: roots,
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	})
 	valid := verifyErr == nil
 
 	isValidClientCertificateCache.Add(cacheKey, valid)
 
-	return valid, nil
+	return valid, verifyErr
 }
 
 func parseCertificate(pemStr string) (*x509.Certificate, error) {

--- a/authorize/evaluator/functions_test.go
+++ b/authorize/evaluator/functions_test.go
@@ -111,7 +111,7 @@ func Test_isValidClientCertificate(t *testing.T) {
 	})
 	t.Run("unsigned cert", func(t *testing.T) {
 		valid, err := isValidClientCertificate(testCA, testUnsignedCert)
-		assert.NoError(t, err, "should not return an error")
+		assert.Error(t, err, "should return an error")
 		assert.False(t, valid, "should return false")
 	})
 	t.Run("not a cert", func(t *testing.T) {

--- a/authorize/evaluator/functions_test.go
+++ b/authorize/evaluator/functions_test.go
@@ -111,7 +111,7 @@ func Test_isValidClientCertificate(t *testing.T) {
 	})
 	t.Run("unsigned cert", func(t *testing.T) {
 		valid, err := isValidClientCertificate(testCA, testUnsignedCert)
-		assert.Error(t, err, "should return an error")
+		assert.NoError(t, err, "should not return an error")
 		assert.False(t, valid, "should return false")
 	})
 	t.Run("not a cert", func(t *testing.T) {


### PR DESCRIPTION
## Summary
x509.Certificate.Verify() defaults to checking for Server usage rather than Client usage.  Set VerifyOptions to check for client usage explicitly.

**Checklist**:
- [x] ready for review
