### PR TITLE
[Backport 0-9-0] authorize/evaluator/opa: set client tls cert usage explicitly

### DIFF
--- a/authorize/evaluator/opa/functions.go
+++ b/authorize/evaluator/opa/functions.go
@@ -7,7 +7,6 @@ import (
 
 	lru "github.com/hashicorp/golang-lru"
 
-	_ "github.com/pomerium/pomerium/authorize/evaluator/opa/policy" // load static assets
 	"github.com/pomerium/pomerium/internal/log"
 )
 

--- a/authorize/evaluator/opa/functions.go
+++ b/authorize/evaluator/opa/functions.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 
 	lru "github.com/hashicorp/golang-lru"
+
+	_ "github.com/pomerium/pomerium/authorize/evaluator/opa/policy" // load static assets
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 var isValidClientCertificateCache, _ = lru.New2Q(100)
@@ -37,9 +40,14 @@ func isValidClientCertificate(ca, cert string) (bool, error) {
 	}
 
 	_, verifyErr := xcert.Verify(x509.VerifyOptions{
-		Roots: roots,
+		Roots:     roots,
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
 	})
 	valid := verifyErr == nil
+
+	if verifyErr != nil {
+		log.Debug().Err(verifyErr).Msg("client certificate failed verification: %w")
+	}
 
 	isValidClientCertificateCache.Add(cacheKey, valid)
 

--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.9.3
+
+### Fixed
+- authorize/evaluator/opa: set client tls cert usage explicitly @travisgroth GH-1026
+
 ## v0.9.2
 
 ### Fixed


### PR DESCRIPTION
Backport e27ee4dd32591b4932e2fbbf8cb3626fec4c037b from #1026 