### PR TITLE
cache: fix data race in NotifyJoin

### DIFF
--- a/cache/memberlist.go
+++ b/cache/memberlist.go
@@ -69,11 +69,11 @@ func (c *Cache) runMemberList(ctx context.Context) error {
 func (mh *memberlistHandler) NotifyJoin(node *memberlist.Node) {
 	mh.log.Debug().Interface("node", node).Msg("node joined")
 
-	go func() {
-		if mh.memberlist != nil && mh.memberlist.NumMembers() > 1 {
+	go func(memberListNotNil bool) {
+		if memberListNotNil && mh.memberlist.NumMembers() > 1 {
 			mh.log.Error().Msg("detected multiple cache servers, which is not supported")
 		}
-	}()
+	}(mh.memberlist != nil)
 }
 
 func (mh *memberlistHandler) NotifyLeave(node *memberlist.Node) {


### PR DESCRIPTION
## Summary
In 35af5c0b91e1f93313a6ca67ed62cd1a72b11c5b, the check for multiple
cache servers in NotifyJoin is made to be done in a goroutine. That can
lead to a data race, because the memberlist can be changed at the time
the goroutine was run. go warns about this race when test memberlist was
run with "-race".

## Related issues



**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
