### PR TITLE
proxy: fix wrong forward auth request

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rs/zerolog"
 
 	"github.com/pomerium/pomerium/authorize/evaluator"
+	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/sessions"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
@@ -195,7 +196,7 @@ func (a *Authorize) handleForwardAuth(req *envoy_service_auth_v2.CheckRequest) b
 	req.Attributes.Request.Http.Host = verifyURL.Host
 	req.Attributes.Request.Http.Path = verifyURL.Path
 	if headers := req.GetAttributes().GetRequest().GetHttp().GetHeaders(); headers != nil {
-		if xfu := headers[http.CanonicalHeaderKey("x-forwarded-uri")]; xfu != "" {
+		if xfu := headers[http.CanonicalHeaderKey(httputil.HeaderForwardedURI)]; xfu != "" {
 			req.Attributes.Request.Http.Path += xfu
 		}
 	}

--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -118,8 +118,7 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 			return httputil.NewError(http.StatusBadRequest, err)
 		}
 
-		original := p.getOriginalRequest(r, uri)
-		authorized, err := p.isAuthorized(w, original)
+		authorized, err := p.isAuthorized(w, r)
 		if err != nil {
 			return httputil.NewError(http.StatusBadRequest, err)
 		}
@@ -151,11 +150,4 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 		httputil.Redirect(w, r, urlutil.NewSignedURL(p.SharedKey, &authN).String(), http.StatusFound)
 		return nil
 	})
-}
-
-func (p *Proxy) getOriginalRequest(r *http.Request, originalURL *url.URL) *http.Request {
-	originalRequest := r.Clone(r.Context())
-	originalRequest.Host = originalURL.Host
-	originalRequest.URL = originalURL
-	return originalRequest
 }

--- a/proxy/middleware.go
+++ b/proxy/middleware.go
@@ -55,16 +55,16 @@ func (p *Proxy) isAuthorized(w http.ResponseWriter, r *http.Request) (bool, erro
 		Method:   "GET",
 		Headers:  map[string]string{},
 		Path:     r.URL.Path,
-		Host:     r.URL.Host,
+		Host:     r.Host,
 		Scheme:   r.URL.Scheme,
 		Fragment: r.URL.Fragment,
 	}
 	for k := range r.Header {
 		httpAttrs.Headers[k] = r.Header.Get(k)
-		if r.URL.RawQuery != "" {
-			// envoy expects the query string in the path
-			httpAttrs.Path += "?" + r.URL.RawQuery
-		}
+	}
+	if r.URL.RawQuery != "" {
+		// envoy expects the query string in the path
+		httpAttrs.Path += "?" + r.URL.RawQuery
 	}
 
 	res, err := p.authzClient.Check(r.Context(), &envoy_service_auth_v2.CheckRequest{


### PR DESCRIPTION


## Summary
When proxy receives forward auth request, it should forward the request
as-is to authorize for verification. Currently, it composes the check
request with actual path, then send the request to authorize service.

It makes the request works accidently, because the composed check
request will satisfy the policy un-intentionally. Example, for forward
auth request:

	http://pomerium/?uri=https://httpbin.localhost.pomerium.io

the composed request will look like:

```
	&envoy_service_auth_v2.AttributeContext_HttpRequest{
		Method:   "GET",
		Headers:  map[string]string{},
		Path:     "",
		Host:     "httpbin.localhost.pomerium.io",
		Scheme:   "https",
	}
```

This check request has at least two problems.

First, it will make authorize.handleForwardAuth always returns false,
even though this is a real forward auth request. Because the "Host"
field in check request is not the forward auth host, which is "pomerium"
in this case.

Second, it will accidently matches rule like:

```
	policy:
	  - from: https://httpbin.localhost.pomerium.io
	    to: https://httpbin
	    allowed_domains:
	      - pomerium.io
```

If the rule contains other conditions, like "prefix", or "regex":

```
	policy:
	  - from: https://httpbin.localhost.pomerium.io
	    prefix: /headers
	    to: https://httpbin
	    allowed_domains:
	      - pomerium.io
```

Then the rule will never be triggered, because the "/headers" path can
be passed in request via "X-Forwarded-Uri" (traefik), instead of
directly from the path (nginx).

To fix this, we just pass the forward auth request as-is to authorize.


## Related issues
Fixes #873

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
