### PR TITLE
proxy: fix redirect url with traefik forward auth

### DIFF
--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -140,6 +140,11 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 			return httputil.NewError(http.StatusUnauthorized, err)
 		}
 
+		// Traefik set the uri in the header, we must add it to redirect uri if present. Otherwise, request like
+		// https://example.com/foo will be redirected to https://example.com after authentication.
+		if xfu := r.Header.Get(httputil.HeaderForwardedURI); xfu != "" {
+			uri.Path += xfu
+		}
 		// redirect to authenticate
 		authN := *p.authenticateSigninURL
 		q := authN.Query()


### PR DESCRIPTION


## Summary
With Traefik in forward auth mode, when accessing:

	https://example.com/foo

traefik will send a request like this to proxy:

	https://pomerium?uri=https://example.com

The path "/foo" is passed to proxy via "X-Forwarded-Uri" instead of via
query parameters. When proxy redirects request to authenticate, it only
set the "pomerirum_redirect_url" to the value of "uri".

So after authentication success, the user will be redirected to example.com
instead of example.com/foo. If "X-Forwarded-Uri" is present, we should
add it to redirect uri, so the user will be redirected to right place.



**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
