### PR TITLE
#1054 - Change  config key parsing to attempt Base64 decoding first.

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -558,9 +558,12 @@ func (o *Options) Validate() error {
 	}
 
 	for _, c := range o.CertificateFiles {
-		cert, err := cryptutil.CertificateFromFile(c.CertFile, c.KeyFile)
+		cert, err := cryptutil.CertificateFromBase64(c.CertFile, c.KeyFile)
 		if err != nil {
-			return fmt.Errorf("config: bad cert file %w", err)
+			cert, err = cryptutil.CertificateFromFile(c.CertFile, c.KeyFile)
+		}
+		if err != nil {
+			return fmt.Errorf("config: bad cert entry, base64 or file reference invalid. %w", err)
 		}
 		o.Certificates = append(o.Certificates, *cert)
 	}

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -505,6 +505,42 @@ func TestHTTPRedirectAddressStripQuotes(t *testing.T) {
 	assert.Equal(t, ":80", o.HTTPRedirectAddr)
 }
 
+func TestCertificatesArrayParsing(t *testing.T) {
+	t.Parallel()
+
+	testCertFileRef := "./testdata/example-cert.pem"
+	testKeyFileRef := "./testdata/example-key.pem"
+	testCertFile, _ := ioutil.ReadFile(testCertFileRef)
+	testKeyFile, _ := ioutil.ReadFile(testKeyFileRef)
+	testCertAsBase64 := base64.StdEncoding.EncodeToString(testCertFile)
+	testKeyAsBase64 := base64.StdEncoding.EncodeToString(testKeyFile)
+
+	tests := []struct {
+		name             string
+		certificateFiles []certificateFilePair
+		wantErr          bool
+	}{
+		{"Handles base64 string as params", []certificateFilePair{{KeyFile: testKeyAsBase64, CertFile: testCertAsBase64}}, false},
+		{"Handles file reference as params", []certificateFilePair{{KeyFile: testKeyFileRef, CertFile: testCertFileRef}}, false},
+		{"Returns an error otherwise", []certificateFilePair{{KeyFile: "abc", CertFile: "abc"}}, true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			o := NewDefaultOptions()
+			o.CertificateFiles = tt.certificateFiles
+			err := o.Validate()
+
+			if err != nil && tt.wantErr == false {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
 func TestCompareByteSliceSlice(t *testing.T) {
 	type Bytes = [][]byte
 


### PR DESCRIPTION
## Summary
My GO skills are non-existent but this is my stab to allow `certificates` to first try base64 decoding for the entries, and only then fallback to FS resolution.

## Related issues
Addresses #1054 

**Checklist**:
- [x] add related issues
- [x] updated docs (Bypassed as they are currently ambiguous)
- [x] updated unit tests (Bypassed due to lack of coverage)
- [x] updated UPGRADING.md (Bypassed due to not being a breaking change)
- [x] ready for review
