### PR TITLE
proxy: fix invalid session after logout in forward auth mode

### DIFF
--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -101,38 +101,31 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 			return httputil.NewError(http.StatusForbidden, errors.New(http.StatusText(http.StatusForbidden)))
 		}
 
-		// the route to validate will be pulled from the uri queryparam
-		// or inferred from forwarding headers
-		uriString := r.FormValue("uri")
-		if uriString == "" {
-			if r.Header.Get(httputil.HeaderForwardedProto) == "" || r.Header.Get(httputil.HeaderForwardedHost) == "" {
-				return httputil.NewError(http.StatusBadRequest, errors.New("no uri to validate"))
-			}
-			uriString = r.Header.Get(httputil.HeaderForwardedProto) + "://" +
-				r.Header.Get(httputil.HeaderForwardedHost) +
-				r.Header.Get(httputil.HeaderForwardedURI)
-		}
-
-		uri, err := urlutil.ParseAndValidateURL(uriString)
+		uri, err := getURIStringFromRequest(r)
 		if err != nil {
 			return httputil.NewError(http.StatusBadRequest, err)
 		}
 
-		authorized, err := p.isAuthorized(w, r)
+		ar, err := p.isAuthorized(w, r)
 		if err != nil {
 			return httputil.NewError(http.StatusBadRequest, err)
 		}
 
-		if authorized {
+		if ar.authorized {
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintf(w, "Access to %s is allowed.", uri.Host)
 			return nil
 		}
 
+		unAuthenticated := ar.statusCode == http.StatusUnauthorized
+		if unAuthenticated {
+			p.sessionStore.ClearSession(w, r)
+		}
+
 		_, err = sessions.FromContext(r.Context())
 		hasSession := err == nil
-		if hasSession {
+		if hasSession && !unAuthenticated {
 			return httputil.NewError(http.StatusForbidden, errors.New("access denied"))
 		}
 
@@ -140,19 +133,46 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 			return httputil.NewError(http.StatusUnauthorized, err)
 		}
 
-		// Traefik set the uri in the header, we must add it to redirect uri if present. Otherwise, request like
-		// https://example.com/foo will be redirected to https://example.com after authentication.
-		if xfu := r.Header.Get(httputil.HeaderForwardedURI); xfu != "" {
-			uri.Path += xfu
-		}
-		// redirect to authenticate
-		authN := *p.authenticateSigninURL
-		q := authN.Query()
-		q.Set(urlutil.QueryCallbackURI, uri.String())
-		q.Set(urlutil.QueryRedirectURI, uri.String())              // final destination
-		q.Set(urlutil.QueryForwardAuth, urlutil.StripPort(r.Host)) // add fwd auth to trusted audience
-		authN.RawQuery = q.Encode()
-		httputil.Redirect(w, r, urlutil.NewSignedURL(p.SharedKey, &authN).String(), http.StatusFound)
+		p.forwardAuthRedirectToSignInWithURI(w, r, uri)
 		return nil
 	})
+}
+
+// forwardAuthRedirectToSignInWithURI redirects request to authenticate signin url,
+// with all necessary information extracted from given input uri.
+func (p *Proxy) forwardAuthRedirectToSignInWithURI(w http.ResponseWriter, r *http.Request, uri *url.URL) {
+	// Traefik set the uri in the header, we must add it to redirect uri if present. Otherwise, request like
+	// https://example.com/foo will be redirected to https://example.com after authentication.
+	if xfu := r.Header.Get(httputil.HeaderForwardedURI); xfu != "" {
+		uri.Path += xfu
+	}
+
+	// redirect to authenticate
+	authN := *p.authenticateSigninURL
+	q := authN.Query()
+	q.Set(urlutil.QueryCallbackURI, uri.String())
+	q.Set(urlutil.QueryRedirectURI, uri.String())              // final destination
+	q.Set(urlutil.QueryForwardAuth, urlutil.StripPort(r.Host)) // add fwd auth to trusted audience
+	authN.RawQuery = q.Encode()
+	httputil.Redirect(w, r, urlutil.NewSignedURL(p.SharedKey, &authN).String(), http.StatusFound)
+}
+
+func getURIStringFromRequest(r *http.Request) (*url.URL, error) {
+	// the route to validate will be pulled from the uri queryparam
+	// or inferred from forwarding headers
+	uriString := r.FormValue("uri")
+	if uriString == "" {
+		if r.Header.Get(httputil.HeaderForwardedProto) == "" || r.Header.Get(httputil.HeaderForwardedHost) == "" {
+			return nil, errors.New("no uri to validate")
+		}
+		uriString = r.Header.Get(httputil.HeaderForwardedProto) + "://" +
+			r.Header.Get(httputil.HeaderForwardedHost) +
+			r.Header.Get(httputil.HeaderForwardedURI)
+	}
+
+	uri, err := urlutil.ParseAndValidateURL(uriString)
+	if err != nil {
+		return nil, err
+	}
+	return uri, nil
 }

--- a/proxy/forward_auth_test.go
+++ b/proxy/forward_auth_test.go
@@ -10,7 +10,9 @@ import (
 
 	envoy_service_auth_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
 	"github.com/google/go-cmp/cmp"
+	"google.golang.org/genproto/googleapis/rpc/status"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"gopkg.in/square/go-jose.v2/jwt"
 
 	"github.com/pomerium/pomerium/config"
@@ -37,6 +39,7 @@ func TestProxy_ForwardAuth(t *testing.T) {
 
 	allowClient := &mockCheckClient{
 		response: &envoy_service_auth_v2.CheckResponse{
+			Status:       &status.Status{Code: int32(codes.OK), Message: "OK"},
 			HttpResponse: &envoy_service_auth_v2.CheckResponse_OkResponse{},
 		},
 	}


### PR DESCRIPTION



## Summary
Currently, authorize service does handle unauthenticated request in
forward auth mode, and return status 401.

But proxy has not handled the response yet, and always returns 403 for
both unauthenticated and unauthorized request. That breaks session
handling in forward auth mode. That said, if user was signed out, or for
any reason, authorize service return 401 status, proxy does not redirect
user to re-signin, but always return 403.

To fix it, proxy is changed to handle envoy check response in more
details, to distinguish between 401 and 403 status.

Thanks to @simbaja for rasing the problem and come up with original fix.

## Related issues

Fixes #1014
Fixes #858


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
