### PR TITLE
authorize: Force redirect scheme to https

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -129,7 +129,12 @@ func (a *Authorize) redirectResponse(in *envoy_service_auth_v2.CheckRequest) *en
 
 	signinURL := opts.GetAuthenticateURL().ResolveReference(&url.URL{Path: "/.pomerium/sign_in"})
 	q := signinURL.Query()
-	q.Set(urlutil.QueryRedirectURI, getCheckRequestURL(in).String())
+
+	// always assume https scheme
+	url := getCheckRequestURL(in)
+	url.Scheme = "https"
+
+	q.Set(urlutil.QueryRedirectURI, url.String())
 	signinURL.RawQuery = q.Encode()
 	redirectTo := urlutil.NewSignedURL(opts.SharedKey, signinURL).String()
 


### PR DESCRIPTION
## Summary
When building the redirect parameter, `authorize` currently attempts to use the `x-forwarded-proto` header from envoy.  Unfortunately this doesn't work correctly when in insecure mode, as it seems envoy sets `x-forwarded-proto` to the scheme it received the request on.

The result is a bad redirect and/or hmac error.  Given the nature of Pomerium, the easiest thing to do here is always set scheme to `https`.  

**Checklist**:
- [x] updated unit tests
- [x] ready for review
