### PR TITLE
implement google cloud serverless authentication

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -2,6 +2,7 @@ package authorize
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/url"
 	"strings"
@@ -19,7 +20,7 @@ import (
 	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
-func (a *Authorize) okResponse(reply *evaluator.Result) *envoy_service_auth_v2.CheckResponse {
+func (a *Authorize) okResponse(ctx context.Context, reply *evaluator.Result) *envoy_service_auth_v2.CheckResponse {
 	requestHeaders, err := a.getEnvoyRequestHeaders(reply.SignedJWT)
 	if err != nil {
 		log.Warn().Err(err).Msg("authorize: error generating new request headers")
@@ -29,6 +30,12 @@ func (a *Authorize) okResponse(reply *evaluator.Result) *envoy_service_auth_v2.C
 		mkHeader(httputil.HeaderPomeriumJWTAssertion, reply.SignedJWT, false))
 
 	requestHeaders = append(requestHeaders, getKubernetesHeaders(reply)...)
+
+	if hdrs, err := a.getGoogleCloudServerlessAuthenticationHeaders(ctx, reply); err == nil {
+		requestHeaders = append(requestHeaders, hdrs...)
+	} else {
+		log.Warn().Err(err).Msg("error getting google cloud serverless authentication headers")
+	}
 
 	return &envoy_service_auth_v2.CheckResponse{
 		Status: &status.Status{Code: int32(codes.OK), Message: "OK"},

--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -2,7 +2,6 @@ package authorize
 
 import (
 	"bytes"
-	"context"
 	"net/http"
 	"net/url"
 	"strings"
@@ -20,7 +19,7 @@ import (
 	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
-func (a *Authorize) okResponse(ctx context.Context, reply *evaluator.Result) *envoy_service_auth_v2.CheckResponse {
+func (a *Authorize) okResponse(reply *evaluator.Result) *envoy_service_auth_v2.CheckResponse {
 	requestHeaders, err := a.getEnvoyRequestHeaders(reply.SignedJWT)
 	if err != nil {
 		log.Warn().Err(err).Msg("authorize: error generating new request headers")
@@ -31,7 +30,7 @@ func (a *Authorize) okResponse(ctx context.Context, reply *evaluator.Result) *en
 
 	requestHeaders = append(requestHeaders, getKubernetesHeaders(reply)...)
 
-	if hdrs, err := a.getGoogleCloudServerlessAuthenticationHeaders(ctx, reply); err == nil {
+	if hdrs, err := a.getGoogleCloudServerlessAuthenticationHeaders(reply); err == nil {
 		requestHeaders = append(requestHeaders, hdrs...)
 	} else {
 		log.Warn().Err(err).Msg("error getting google cloud serverless authentication headers")

--- a/authorize/google_cloud_serverless.go
+++ b/authorize/google_cloud_serverless.go
@@ -1,0 +1,120 @@
+package authorize
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/pomerium/pomerium/authorize/evaluator"
+)
+
+var (
+	gpcIdentityTokenExpiration  = time.Hour // tokens expire after one hour according to the GCP docs
+	gcpIdentityTokenGracePeriod = time.Minute * 10
+	gcpIdentityDocURL           = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity"
+	gcpIdentityTokenSource      = NewGCPIdentityTokenSource()
+)
+
+// A GCPIdentityToken is an identity token for a service account.
+type GCPIdentityToken struct {
+	Audience string
+	Token    string
+	Expires  time.Time
+}
+
+// The GCPIdentityTokenSource retrieves identity tokens for service accounts. It single-flights requests and caches
+// tokens.
+type GCPIdentityTokenSource struct {
+	singleflight.Group
+
+	mu     sync.Mutex
+	tokens map[string]GCPIdentityToken
+}
+
+// NewGCPIdentityTokenSource creates a new GCPIdentityTokenSource.
+func NewGCPIdentityTokenSource() *GCPIdentityTokenSource {
+	return &GCPIdentityTokenSource{
+		tokens: make(map[string]GCPIdentityToken),
+	}
+}
+
+// Get gets an identity token.
+func (src *GCPIdentityTokenSource) Get(ctx context.Context, audience string) (string, error) {
+	v, err, _ := src.Do(audience, func() (interface{}, error) {
+		src.mu.Lock()
+		tok, ok := src.tokens[audience]
+		src.mu.Unlock()
+
+		if ok && tok.Expires.Add(-gcpIdentityTokenGracePeriod).After(time.Now()) {
+			return tok, nil
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", gcpIdentityDocURL+"?"+url.Values{
+			"format":   {"full"},
+			"audience": {audience},
+		}.Encode(), nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Add("Metadata-Flavor", "Google")
+
+		res, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, err
+		}
+		defer res.Body.Close()
+
+		bs, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		tok = GCPIdentityToken{
+			Audience: audience,
+			Token:    strings.TrimSpace(string(bs)),
+			Expires:  time.Now().Add(gpcIdentityTokenExpiration),
+		}
+		src.mu.Lock()
+		src.tokens[audience] = tok
+		src.mu.Unlock()
+
+		return tok, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(GCPIdentityToken).Token, nil
+}
+
+func (a *Authorize) getGoogleCloudServerlessAuthenticationHeaders(
+	ctx context.Context,
+	reply *evaluator.Result,
+) ([]*envoy_api_v2_core.HeaderValueOption, error) {
+	if reply.MatchingPolicy == nil || !reply.MatchingPolicy.EnableGoogleCloudServerlessAuthentication {
+		return nil, nil
+	}
+
+	svcAccount := a.currentOptions.Load().GoogleCloudServerlessAuthenticationServiceAccount
+	if svcAccount != "" {
+		panic("custom service account not implemented")
+	}
+
+	audience := fmt.Sprintf("https://%s", reply.MatchingPolicy.Source.Hostname())
+
+	tok, err := gcpIdentityTokenSource.Get(ctx, audience)
+	if err != nil {
+		return nil, err
+	}
+
+	return []*envoy_api_v2_core.HeaderValueOption{
+		mkHeader("Authorization", "Bearer "+tok, false),
+	}, nil
+}

--- a/authorize/google_cloud_serverless.go
+++ b/authorize/google_cloud_serverless.go
@@ -21,6 +21,7 @@ var (
 	gcpIdentityTokenGracePeriod = time.Minute * 10
 	gcpIdentityDocURL           = "http://metadata/computeMetadata/v1/instance/service-accounts/default/identity"
 	gcpIdentityTokenSource      = NewGCPIdentityTokenSource()
+	gcpIdentityNow              = time.Now
 )
 
 // A GCPIdentityToken is an identity token for a service account.
@@ -53,7 +54,7 @@ func (src *GCPIdentityTokenSource) Get(ctx context.Context, audience string) (st
 		tok, ok := src.tokens[audience]
 		src.mu.Unlock()
 
-		if ok && tok.Expires.Add(-gcpIdentityTokenGracePeriod).After(time.Now()) {
+		if ok && tok.Expires.Add(-gcpIdentityTokenGracePeriod).After(gcpIdentityNow()) {
 			return tok, nil
 		}
 
@@ -80,7 +81,7 @@ func (src *GCPIdentityTokenSource) Get(ctx context.Context, audience string) (st
 		tok = GCPIdentityToken{
 			Audience: audience,
 			Token:    strings.TrimSpace(string(bs)),
-			Expires:  time.Now().Add(gpcIdentityTokenExpiration),
+			Expires:  gcpIdentityNow().Add(gpcIdentityTokenExpiration),
 		}
 		src.mu.Lock()
 		src.tokens[audience] = tok

--- a/authorize/google_cloud_serverless.go
+++ b/authorize/google_cloud_serverless.go
@@ -107,7 +107,7 @@ func (a *Authorize) getGoogleCloudServerlessAuthenticationHeaders(
 		panic("custom service account not implemented")
 	}
 
-	audience := fmt.Sprintf("https://%s", reply.MatchingPolicy.Source.Hostname())
+	audience := fmt.Sprintf("https://%s", reply.MatchingPolicy.Destination.Hostname())
 
 	tok, err := gcpIdentityTokenSource.Get(ctx, audience)
 	if err != nil {

--- a/authorize/google_cloud_serverless_test.go
+++ b/authorize/google_cloud_serverless_test.go
@@ -1,0 +1,48 @@
+package authorize
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGCPIdentityTokenSource(t *testing.T) {
+	originalGCPIdentityDocURL := gcpIdentityDocURL
+	defer func() {
+		gcpIdentityDocURL = originalGCPIdentityDocURL
+		gcpIdentityNow = time.Now
+	}()
+
+	now := time.Date(2020, 1, 1, 1, 0, 0, 0, time.Local)
+	gcpIdentityNow = func() time.Time {
+		return now
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Google", r.Header.Get("Metadata-Flavor"))
+		assert.Equal(t, "full", r.URL.Query().Get("format"))
+		assert.Equal(t, "example", r.URL.Query().Get("audience"))
+		_, _ = w.Write([]byte(now.Format(time.RFC3339)))
+	}))
+	defer srv.Close()
+
+	gcpIdentityDocURL = srv.URL
+
+	token, err := gcpIdentityTokenSource.Get(context.Background(), "example")
+	assert.NoError(t, err)
+	assert.Equal(t, "2020-01-01T01:00:00-07:00", token)
+
+	now = time.Date(2020, 1, 1, 1, 49, 0, 0, time.Local)
+	token, err = gcpIdentityTokenSource.Get(context.Background(), "example")
+	assert.NoError(t, err)
+	assert.Equal(t, "2020-01-01T01:00:00-07:00", token)
+
+	now = time.Date(2020, 1, 1, 1, 51, 0, 0, time.Local)
+	token, err = gcpIdentityTokenSource.Get(context.Background(), "example")
+	assert.NoError(t, err)
+	assert.Equal(t, "2020-01-01T01:51:00-07:00", token)
+}

--- a/authorize/google_cloud_serverless_test.go
+++ b/authorize/google_cloud_serverless_test.go
@@ -16,7 +16,7 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 		gcpIdentityNow = time.Now
 	}()
 
-	now := time.Date(2020, 1, 1, 1, 0, 0, 0, time.Local)
+	now := time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)
 	gcpIdentityNow = func() time.Time {
 		return now
 	}
@@ -36,5 +36,5 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 
 	token, err := src.Token()
 	assert.NoError(t, err)
-	assert.Equal(t, "2020-01-01T01:00:00-07:00", token.AccessToken)
+	assert.Equal(t, "2020-01-01T01:00:00Z", token.AccessToken)
 }

--- a/authorize/google_cloud_serverless_test.go
+++ b/authorize/google_cloud_serverless_test.go
@@ -1,7 +1,6 @@
 package authorize
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,17 +31,10 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 
 	gcpIdentityDocURL = srv.URL
 
-	token, err := gcpIdentityTokenSource.Get(context.Background(), "example")
+	src, err := getGoogleCloudServerlessTokenSource("", "example")
 	assert.NoError(t, err)
-	assert.Equal(t, "2020-01-01T01:00:00-07:00", token)
 
-	now = time.Date(2020, 1, 1, 1, 49, 0, 0, time.Local)
-	token, err = gcpIdentityTokenSource.Get(context.Background(), "example")
+	token, err := src.Token()
 	assert.NoError(t, err)
-	assert.Equal(t, "2020-01-01T01:00:00-07:00", token)
-
-	now = time.Date(2020, 1, 1, 1, 51, 0, 0, time.Local)
-	token, err = gcpIdentityTokenSource.Get(context.Background(), "example")
-	assert.NoError(t, err)
-	assert.Equal(t, "2020-01-01T01:51:00-07:00", token)
+	assert.Equal(t, "2020-01-01T01:00:00-07:00", token.AccessToken)
 }

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -78,7 +78,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v2.CheckRe
 
 	switch {
 	case reply.Status == http.StatusOK:
-		return a.okResponse(reply), nil
+		return a.okResponse(ctx, reply), nil
 	case reply.Status == http.StatusUnauthorized:
 		if isForwardAuth {
 			return a.deniedResponse(in, http.StatusUnauthorized, "Unauthenticated", nil), nil

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -78,7 +78,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v2.CheckRe
 
 	switch {
 	case reply.Status == http.StatusOK:
-		return a.okResponse(ctx, reply), nil
+		return a.okResponse(reply), nil
 	case reply.Status == http.StatusUnauthorized:
 		if isForwardAuth {
 			return a.deniedResponse(in, http.StatusUnauthorized, "Unauthenticated", nil), nil

--- a/config/options.go
+++ b/config/options.go
@@ -229,6 +229,10 @@ type Options struct {
 	// ClientCAFile points to a file that contains the certificate authority to validate client mTLS certificates against.
 	ClientCAFile string `mapstructure:"client_ca_file" yaml:"client_ca_file,omitempty"`
 
+	// GoogleCloudServerlessAuthenticationServiceAccount is the service account to use for GCP serverless authentication.
+	// If unset, the GCP metadata server will be used to query for identity tokens.
+	GoogleCloudServerlessAuthenticationServiceAccount string `mapstructure:"google_cloud_serverless_authentication_service_account" yaml:"google_cloud_serverless_authentication_service_account,omitempty"`
+
 	viper *viper.Viper
 
 	AutocertOptions `mapstructure:",squash" yaml:",inline"`

--- a/config/options.go
+++ b/config/options.go
@@ -231,7 +231,7 @@ type Options struct {
 
 	// GoogleCloudServerlessAuthenticationServiceAccount is the service account to use for GCP serverless authentication.
 	// If unset, the GCP metadata server will be used to query for identity tokens.
-	GoogleCloudServerlessAuthenticationServiceAccount string `mapstructure:"google_cloud_serverless_authentication_service_account" yaml:"google_cloud_serverless_authentication_service_account,omitempty"`
+	GoogleCloudServerlessAuthenticationServiceAccount string `mapstructure:"google_cloud_serverless_authentication_service_account" yaml:"google_cloud_serverless_authentication_service_account,omitempty"` //nolint
 
 	viper *viper.Viper
 

--- a/config/policy.go
+++ b/config/policy.go
@@ -103,6 +103,10 @@ type Policy struct {
 
 	// KubernetesServiceAccountToken is the kubernetes token to use for upstream requests.
 	KubernetesServiceAccountToken string `mapstructure:"kubernetes_service_account_token" yaml:"kubernetes_service_account_token,omitempty"`
+
+	// EnableGoogleCloudServerlessAuthentication adds "Authorization: Bearer ID_TOKEN" headers
+	// to upstream requests.
+	EnableGoogleCloudServerlessAuthentication bool `mapstructure:"enable_google_cloud_serverless_authentication" yaml:"enable_google_cloud_serverless_authentication,omitempty"`
 }
 
 // Validate checks the validity of a policy.

--- a/config/policy.go
+++ b/config/policy.go
@@ -106,7 +106,7 @@ type Policy struct {
 
 	// EnableGoogleCloudServerlessAuthentication adds "Authorization: Bearer ID_TOKEN" headers
 	// to upstream requests.
-	EnableGoogleCloudServerlessAuthentication bool `mapstructure:"enable_google_cloud_serverless_authentication" yaml:"enable_google_cloud_serverless_authentication,omitempty"`
+	EnableGoogleCloudServerlessAuthentication bool `mapstructure:"enable_google_cloud_serverless_authentication" yaml:"enable_google_cloud_serverless_authentication,omitempty"` //nolint
 }
 
 // Validate checks the validity of a policy.

--- a/go.sum
+++ b/go.sum
@@ -735,8 +735,6 @@ google.golang.org/api v0.15.0/go.mod h1:iLdEw5Ide6rF15KTC1Kkl0iskquN2gFfn9o9XIsb
 google.golang.org/api v0.17.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.18.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
 google.golang.org/api v0.20.0/go.mod h1:BwFmGc8tA3vsd7r/7kR8DY7iEEGSU04BFxCo5jP/sfE=
-google.golang.org/api v0.28.0 h1:jMF5hhVfMkTZwHW1SDpKq5CkgWLXOb31Foaca9Zr3oM=
-google.golang.org/api v0.28.0/go.mod h1:lIXQywCXRcnZPGlsd8NbLnOjtAoL6em04bJ9+z0MncE=
 google.golang.org/api v0.29.0 h1:BaiDisFir8O4IJxvAabCGGkQ6yCJegNQqSVoYUNAnbk=
 google.golang.org/api v0.29.0/go.mod h1:Lcubydp8VUV7KeIHD9z2Bys/sm/vGKnG1UHuDBSrHWM=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=

--- a/internal/controlplane/xds_cluster_test.go
+++ b/internal/controlplane/xds_cluster_test.go
@@ -160,7 +160,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 func Test_buildCluster(t *testing.T) {
 	rootCA, _ := getRootCertificateAuthority()
 	t.Run("insecure", func(t *testing.T) {
-		cluster := buildCluster("example", mustParseURL("http://example.com"), nil, true)
+		cluster := buildCluster("example", mustParseURL("http://example.com"), nil, true, true)
 		testutil.AssertProtoJSONEqual(t, `
 			{
 				"name": "example",
@@ -170,6 +170,7 @@ func Test_buildCluster(t *testing.T) {
 				"http2ProtocolOptions": {
 					"allowConnect": true
 				},
+				"dnsLookupFamily": "V4_ONLY",
 				"loadAssignment": {
 					"clusterName": "example",
 					"endpoints": [{
@@ -194,7 +195,7 @@ func Test_buildCluster(t *testing.T) {
 		transportSocket := buildPolicyTransportSocket(&config.Policy{
 			Destination: u,
 		})
-		cluster := buildCluster("example", u, transportSocket, true)
+		cluster := buildCluster("example", u, transportSocket, true, false)
 		testutil.AssertProtoJSONEqual(t, `
 			{
 				"name": "example",
@@ -242,7 +243,7 @@ func Test_buildCluster(t *testing.T) {
 		`, cluster)
 	})
 	t.Run("ip address", func(t *testing.T) {
-		cluster := buildCluster("example", mustParseURL("http://127.0.0.1"), nil, true)
+		cluster := buildCluster("example", mustParseURL("http://127.0.0.1"), nil, true, false)
 		testutil.AssertProtoJSONEqual(t, `
 			{
 				"name": "example",
@@ -272,7 +273,7 @@ func Test_buildCluster(t *testing.T) {
 		`, cluster)
 	})
 	t.Run("localhost", func(t *testing.T) {
-		cluster := buildCluster("example", mustParseURL("http://localhost"), nil, true)
+		cluster := buildCluster("example", mustParseURL("http://localhost"), nil, true, false)
 		testutil.AssertProtoJSONEqual(t, `
 			{
 				"name": "example",


### PR DESCRIPTION
## Summary
This PR adds google cloud serverless authentication support, primarily for cloud run. Changes:

* Two new config options: 
   * `google_cloud_serverless_authentication_service_account`: used to define the service account (not currently implemented because I don't know how to create the identity token using a service account)
   * `enable_google_cloud_serverless_authentication`: used to enable the authentication on a policy route
* Append the authorization header (when enabled) in the Authz OK response
* Add a GCP Identity Token Source which retrieves identity tokens using the compute metadata service and caches them
* Add an option to the xDS config to disable IPv6. During testing using IPv6 on a GCE instance to the cloudrun HTTP endpoint resulted in connection issues.

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
