### PR TITLE
internal/directory/google: return both group e-mail and id

### DIFF
--- a/internal/directory/google/google.go
+++ b/internal/directory/google/google.go
@@ -88,13 +88,15 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.User, error) {
 		return nil, fmt.Errorf("google: error getting API client: %w", err)
 	}
 
+	groupIDToEmails := map[string]string{}
 	var groups []string
 	err = apiClient.Groups.List().
 		Context(ctx).
 		Customer("my_customer").
 		Pages(ctx, func(res *admin.Groups) error {
 			for _, g := range res.Groups {
-				groups = append(groups, g.Id, g.Email)
+				groups = append(groups, g.Id)
+				groupIDToEmails[g.Id] = g.Email
 			}
 			return nil
 		})
@@ -109,7 +111,7 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.User, error) {
 			Context(ctx).
 			Pages(ctx, func(res *admin.Members) error {
 				for _, member := range res.Members {
-					userIDToGroups[member.Id] = append(userIDToGroups[member.Id], group)
+					userIDToGroups[member.Id] = append(userIDToGroups[member.Id], group, groupIDToEmails[group])
 				}
 				return nil
 			})

--- a/internal/directory/google/google.go
+++ b/internal/directory/google/google.go
@@ -94,7 +94,7 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.User, error) {
 		Customer("my_customer").
 		Pages(ctx, func(res *admin.Groups) error {
 			for _, g := range res.Groups {
-				groups = append(groups, g.Id)
+				groups = append(groups, g.Id, g.Email)
 			}
 			return nil
 		})


### PR DESCRIPTION
## Summary
For the Google directory provider, add both the immutable group ID and normal group e-mail to a user.  

Rationale - this allows the operator's discretion as to which type of group identifier to use, and restores the ability to use the previous (though imperfect) behavior.  

## Related issues
Closes #1079 


**Checklist**:
- [x] add related issues
- [x] ready for review
