### PR TITLE
internal/directory: use both id and name for group

### DIFF
--- a/internal/directory/azure/azure_test.go
+++ b/internal/directory/azure/azure_test.go
@@ -45,8 +45,8 @@ func newMockAPI(t *testing.T, srv *httptest.Server) http.Handler {
 		r.Get("/groups", func(w http.ResponseWriter, r *http.Request) {
 			_ = json.NewEncoder(w).Encode(M{
 				"value": []M{
-					{"id": "admin"},
-					{"id": "test"},
+					{"id": "admin", "name": "Admin Group"},
+					{"id": "test", "name": "Test Group"},
 				},
 			})
 		})
@@ -90,15 +90,15 @@ func Test(t *testing.T) {
 	assert.Equal(t, []*directory.User{
 		{
 			Id:     "azure/user-1",
-			Groups: []string{"admin"},
+			Groups: []string{"Admin Group", "admin"},
 		},
 		{
 			Id:     "azure/user-2",
-			Groups: []string{"test"},
+			Groups: []string{"Test Group", "test"},
 		},
 		{
 			Id:     "azure/user-3",
-			Groups: []string{"test"},
+			Groups: []string{"Test Group", "test"},
 		},
 	}, users)
 }

--- a/internal/directory/github/github_test.go
+++ b/internal/directory/github/github_test.go
@@ -38,12 +38,12 @@ func newMockAPI(t *testing.T, srv *httptest.Server) http.Handler {
 	r.Get("/orgs/{org_id}/teams", func(w http.ResponseWriter, r *http.Request) {
 		teams := map[string][]M{
 			"org1": {
-				{"slug": "team1"},
-				{"slug": "team2"},
+				{"slug": "team1", "id": 1},
+				{"slug": "team2", "id": 2},
 			},
 			"org2": {
-				{"slug": "team3"},
-				{"slug": "team4"},
+				{"slug": "team3", "id": 3},
+				{"slug": "team4", "id": 4},
 			},
 		}
 		orgID := chi.URLParam(r, "org_id")
@@ -96,10 +96,10 @@ func Test(t *testing.T) {
 	users, err := p.UserGroups(context.Background())
 	assert.NoError(t, err)
 	testutil.AssertProtoJSONEqual(t, `[
-		{ "id": "github/user1", "groups": ["team1", "team2", "team3"] },
-		{ "id": "github/user2", "groups": ["team1", "team3"] },
-		{ "id": "github/user3", "groups": ["team3"] },
-		{ "id": "github/user4", "groups": ["team4"] }
+		{ "id": "github/user1", "groups": ["1", "2", "3", "team1", "team2", "team3"] },
+		{ "id": "github/user2", "groups": ["1", "3", "team1", "team3"] },
+		{ "id": "github/user3", "groups": ["3", "team3"] },
+		{ "id": "github/user4", "groups": ["4", "team4"] }
 	]`, users)
 }
 

--- a/internal/directory/gitlab/gitlab_test.go
+++ b/internal/directory/gitlab/gitlab_test.go
@@ -32,8 +32,8 @@ func newMockAPI(t *testing.T, srv *httptest.Server) http.Handler {
 		})
 		r.Get("/groups", func(w http.ResponseWriter, r *http.Request) {
 			_ = json.NewEncoder(w).Encode([]M{
-				{"id": 1},
-				{"id": 2},
+				{"id": 1, "name": "Group 1"},
+				{"id": 2, "name": "Group 2"},
 			})
 		})
 		r.Get("/groups/{group_name}/members", func(w http.ResponseWriter, r *http.Request) {
@@ -69,9 +69,9 @@ func Test(t *testing.T) {
 	users, err := p.UserGroups(context.Background())
 	assert.NoError(t, err)
 	testutil.AssertProtoJSONEqual(t, `[
-		{ "id": "gitlab/11", "groups": ["1"] },
-		{ "id": "gitlab/12", "groups": ["2"] },
-		{ "id": "gitlab/13", "groups": ["2"] }
+		{ "id": "gitlab/11", "groups": ["1", "Group 1"] },
+		{ "id": "gitlab/12", "groups": ["2", "Group 2"] },
+		{ "id": "gitlab/13", "groups": ["2", "Group 2"] }
 	]`, users)
 }
 

--- a/internal/directory/okta/okta.go
+++ b/internal/directory/okta/okta.go
@@ -108,7 +108,7 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.User, error) {
 			return nil, err
 		}
 		for _, id := range ids {
-			userIDToGroups[id] = append(userIDToGroups[id], groupName)
+			userIDToGroups[id] = append(userIDToGroups[id], groupID, groupName)
 		}
 	}
 

--- a/internal/directory/okta/okta_test.go
+++ b/internal/directory/okta/okta_test.go
@@ -53,7 +53,7 @@ func newMockOkta(srv *httptest.Server, userEmailToGroups map[string][]string) ht
 				result = append(result, M{
 					"id": groups[i],
 					"profile": M{
-						"name": groups[i],
+						"name": groups[i] + "-name",
 					},
 				})
 				break
@@ -120,15 +120,15 @@ func TestProvider_UserGroups(t *testing.T) {
 	assert.Equal(t, []*directory.User{
 		{
 			Id:     "okta/a@example.com",
-			Groups: []string{"admin", "user"},
+			Groups: []string{"admin", "admin-name", "user", "user-name"},
 		},
 		{
 			Id:     "okta/b@example.com",
-			Groups: []string{"test", "user"},
+			Groups: []string{"test", "test-name", "user", "user-name"},
 		},
 		{
 			Id:     "okta/c@example.com",
-			Groups: []string{"user"},
+			Groups: []string{"user", "user-name"},
 		},
 	}, users)
 }

--- a/internal/directory/onelogin/onelogin.go
+++ b/internal/directory/onelogin/onelogin.go
@@ -121,7 +121,7 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.User, error) {
 	for userID, groupIDs := range userIDToGroupIDs {
 		for _, groupID := range groupIDs {
 			if groupName, ok := groupIDToName[groupID]; ok {
-				userIDToGroupNames[userID] = append(userIDToGroupNames[userID], groupName)
+				userIDToGroupNames[userID] = append(userIDToGroupNames[userID], strconv.Itoa(groupID), groupName)
 			} else {
 				userIDToGroupNames[userID] = append(userIDToGroupNames[userID], "NOGROUP")
 			}

--- a/internal/directory/onelogin/onelogin_test.go
+++ b/internal/directory/onelogin/onelogin_test.go
@@ -152,15 +152,15 @@ func TestProvider_UserGroups(t *testing.T) {
 	assert.Equal(t, []*directory.User{
 		{
 			Id:     "onelogin/111",
-			Groups: []string{"admin"},
+			Groups: []string{"0", "admin"},
 		},
 		{
 			Id:     "onelogin/222",
-			Groups: []string{"test"},
+			Groups: []string{"1", "test"},
 		},
 		{
 			Id:     "onelogin/333",
-			Groups: []string{"user"},
+			Groups: []string{"2", "user"},
 		},
 	}, users)
 }


### PR DESCRIPTION

## Summary

This PR allow both group name and group id in user's groups directory.

## Related issues

Fixes #1085
Updates #573 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
