### PR TITLE
internal/directory: improve google user groups list

### DIFF
--- a/internal/directory/google/google.go
+++ b/internal/directory/google/google.go
@@ -92,9 +92,14 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.User, error) {
 	var groups []string
 	err = apiClient.Groups.List().
 		Context(ctx).
+		Fields("id", "email", "directMembersCount").
 		Customer("my_customer").
 		Pages(ctx, func(res *admin.Groups) error {
 			for _, g := range res.Groups {
+				// Skip group without member.
+				if g.DirectMembersCount == 0 {
+					continue
+				}
 				groups = append(groups, g.Id)
 				groupIDToEmails[g.Id] = g.Email
 			}
@@ -109,6 +114,7 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.User, error) {
 		group := group
 		err = apiClient.Members.List(group).
 			Context(ctx).
+			Fields("id").
 			Pages(ctx, func(res *admin.Members) error {
 				for _, member := range res.Members {
 					userIDToGroups[member.Id] = append(userIDToGroups[member.Id], group, groupIDToEmails[group])


### PR DESCRIPTION
## Summary
Skip group without members, so it saves us time to handle group members,
and reduce the size of groups.

While at it, also querying API with the fields we need.

## Related issues
Fixes #567


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
