### PR TITLE
ci: Add cloudrun build

### DIFF
--- a/.github/Dockerfile-cloudrun
+++ b/.github/Dockerfile-cloudrun
@@ -10,7 +10,7 @@ COPY pomerium* /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 COPY --from=entrypoint /bin/vals-entrypoint /bin/vals-entrypoint
 
-ENV ADDRESS ":80"
+ENV ADDRESS ":8080"
 ENV GRPC_INSECURE true
 ENV INSECURE_SERVER true
 

--- a/.github/Dockerfile-cloudrun
+++ b/.github/Dockerfile-cloudrun
@@ -1,0 +1,18 @@
+FROM pomerium/vals-entrypoint as entrypoint
+
+FROM busybox:latest as build
+RUN touch /config.yaml
+
+FROM gcr.io/distroless/base
+ENV AUTOCERT_DIR /data/autocert
+WORKDIR /pomerium
+COPY pomerium* /bin/
+COPY --from=build /config.yaml /pomerium/config.yaml
+COPY --from=entrypoint /bin/vals-entrypoint /bin/vals-entrypoint
+
+ENV ADDRESS ":80"
+ENV GRPC_INSECURE true
+ENV INSECURE_SERVER true
+
+ENTRYPOINT ["/bin/vals-entrypoint"]
+CMD ["exec","--","/bin/pomerium","-config","/pomerium/config.yaml"]

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -105,3 +105,18 @@ dockers:
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--label=repository=http://github.com/pomerium/pomerium"
       - "--label=homepage=http://www.pomerium.io"
+
+  - image_templates:
+      - "gcr.io/pomerium-io/pomerium:{{ .Tag }}-cloudrun"
+    dockerfile: .github/Dockerfile-cloudrun
+    binaries:
+      - pomerium
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=repository=http://github.com/pomerium/pomerium"
+      - "--label=homepage=http://www.pomerium.io"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,12 +17,24 @@ jobs:
         uses: actions/setup-go@v1
         with:
           go-version: 1.14.x
+
       - name: Set up Docker
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
       - uses: azure/docker-login@v1
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        with:
+          project_id: pomerium-io
+          service_account_key: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          export_default_credentials: true
+
+      - name: Gcloud login
+        run: gcloud auth configure-docker
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1
         with:


### PR DESCRIPTION
## Summary
Add image tailored for cloudrun deployment.

- Pushes image to public GCR
- Add GCP secrets friendly entrypoint
- Some requisite defaults set in ENV

## Using

This image will perform substitution of env vars via [vals](github.com/variantdev/vals) syntax.  For Cloud Run, the assumption is that GCP Secrets Manager will be used for sensitive parameters - `ref+gcpsecerets://myproject/mysecret[#/mykey]`

To source the config file from Secrets Manager, set `VALS_FILES=/pomerium/config.yaml:ref+gcpsecrets://myproject/pomerium-config`

### Example

Source main config from a secret called `pomerium-config` for shared secrets, source `IDP_SERVICE_ACCOUNT ` from a dedicated secret, and augment with a policy sourced locally at deploy time.

```shell
gcloud run deploy [SERVICE] \
--image gcr.io/pomerium-io/pomerium:[version]-cloudrun \
--set-env-vars VALS_FILES='/pomerium/config.yaml:ref+gcpsecrets://myproject/pomerium-config',IDP_SERVICE_ACCOUNT='ref+gcpsecrets://myproject/pomerium-idp-service-account',POLICY=$(cat policy.yaml | base64)
```

## Additional Info 

- At this time `--max-instances` should be set to 1 to minimize session loss.
- Custom domains are required to at least differentiate the `authenticate` endpoint from proxied endpoints.
- Docs update in follow up PR to go with GCP Serverless Authentication support

**Checklist**:
- [x] ready for review
