### PR TITLE
deployment: fix pomerium-cli release

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -44,7 +44,7 @@ builds:
             - TARGET={{ .Target }}
 
   - id: pomerium-cli
-    main: cmd/pomerium-cli/cli.go
+    main: cmd/pomerium-cli/main.go
     binary: pomerium-cli
     goarch:
       - amd64


### PR DESCRIPTION
## Summary

The go-releaser build definition needed to be update to point to the new location of `main` in `main.go`.

### Details

```
goreleaser release --rm-dist --snapshot -f .github/goreleaser.yaml

   • releasing...
   • loading config file       file=.github/goreleaser.yaml
   • running before hooks
      • running go mod download
      • running make build-deps
   • loading environment variables
   • getting and validating git state
      • releasing v0.10.0-rc1, commit ca6715d3c5c7187a260c5dead7f7e3a4112420f9
      • pipe skipped              error=disabled during snapshot mode
   • parsing tag
   • setting defaults
      • snapshotting
      • github/gitlab/gitea releases
      • project name
      • building binaries
      • creating source archive
      • archives
      • linux packages
      • snapcraft packages
      • calculating checksums
      • signing artifacts
      • docker images
      • artifactory
      • blobs
      • homebrew tap formula
      • scoop manifests
   • snapshotting
   • checking ./dist
   • writing effective config file
      • writing                   config=dist/config.yaml
   • generating changelog
      • pipe skipped              error=not available for snapshots
   • building binaries
      • building                  binary=/Users/bdd/pomerium/dist/pomerium_darwin_amd64/pomerium
      • building                  binary=/Users/bdd/pomerium/dist/pomerium_linux_arm64/pomerium
      • building                  binary=/Users/bdd/pomerium/dist/pomerium_linux_amd64/pomerium
      • running hook              hook=./scripts/embed-envoy.bash /Users/bdd/pomerium/dist/pomerium_darwin_amd64/pomerium
      • running hook              hook=./scripts/embed-envoy.bash /Users/bdd/pomerium/dist/pomerium_linux_arm64/pomerium
      • running hook              hook=./scripts/embed-envoy.bash /Users/bdd/pomerium/dist/pomerium_linux_amd64/pomerium
      • building                  binary=/Users/bdd/pomerium/dist/pomerium-cli_freebsd_amd64/pomerium-cli
      • building                  binary=/Users/bdd/pomerium/dist/pomerium-cli_linux_arm_7/pomerium-cli
      • building                  binary=/Users/bdd/pomerium/dist/pomerium-cli_linux_amd64/pomerium-cli
      • building                  binary=/Users/bdd/pomerium/dist/pomerium-cli_darwin_amd64/pomerium-cli
      • building                  binary=/Users/bdd/pomerium/dist/pomerium-cli_linux_arm64/pomerium-cli
      • building                  binary=/Users/bdd/pomerium/dist/pomerium-cli_windows_amd64/pomerium-cli.exe
      • building                  binary=/Users/bdd/pomerium/dist/pomerium-cli_linux_arm_6/pomerium-cli
```

**Checklist**:
- [x] ready for review
