### PR TITLE
authorize: add evaluator store

### DIFF
--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -72,7 +72,7 @@ func TestJSONMarshal(t *testing.T) {
 func TestEvaluator_SignedJWT(t *testing.T) {
 	opt := config.NewDefaultOptions()
 	opt.AuthenticateURL = mustParseURL("https://authenticate.example.com")
-	e, err := New(opt)
+	e, err := New(opt, NewStore())
 	require.NoError(t, err)
 	req := &Request{
 		HTTP: RequestHTTP{
@@ -93,7 +93,7 @@ func TestEvaluator_JWTWithKID(t *testing.T) {
 	opt := config.NewDefaultOptions()
 	opt.AuthenticateURL = mustParseURL("https://authenticate.example.com")
 	opt.SigningKey = "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUpCMFZkbko1VjEvbVlpYUlIWHhnd2Q0Yzd5YWRTeXMxb3Y0bzA1b0F3ekdvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFVUc1eENQMEpUVDFINklvbDhqS3VUSVBWTE0wNENnVzlQbEV5cE5SbVdsb29LRVhSOUhUMwpPYnp6aktZaWN6YjArMUt3VjJmTVRFMTh1dy82MXJVQ0JBPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
-	e, err := New(opt)
+	e, err := New(opt, NewStore())
 	require.NoError(t, err)
 	req := &Request{
 		HTTP: RequestHTTP{
@@ -122,7 +122,7 @@ func mustParseURL(str string) *url.URL {
 func BenchmarkEvaluator_Evaluate(b *testing.B) {
 	e, err := New(&config.Options{
 		AuthenticateURL: mustParseURL("https://authn.example.com"),
-	})
+	}, NewStore())
 	if !assert.NoError(b, err) {
 		return
 	}

--- a/authorize/evaluator/store.go
+++ b/authorize/evaluator/store.go
@@ -1,0 +1,108 @@
+package evaluator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/open-policy-agent/opa/storage/inmem"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+// A Store stores data for the OPA rego policy evaluation.
+type Store struct {
+	opaStore storage.Store
+}
+
+// NewStore creates a new Store.
+func NewStore() *Store {
+	return &Store{
+		opaStore: inmem.New(),
+	}
+}
+
+// UpdateAdmins updates the admins in the store.
+func (s *Store) UpdateAdmins(admins []string) {
+	s.write("/admins", admins)
+}
+
+// UpdateRoutePolicies updates the route policies in the store.
+func (s *Store) UpdateRoutePolicies(routePolicies []config.Policy) {
+	s.write("/route_policies", routePolicies)
+}
+
+// UpdateRecord updates a record in the store.
+func (s *Store) UpdateRecord(record *databroker.Record) {
+	rawPath := fmt.Sprintf("/databroker_data/%s/%s", record.GetType(), record.GetId())
+
+	if record.GetDeletedAt() != nil {
+		s.delete(rawPath)
+		return
+	}
+
+	msg, err := record.GetData().UnmarshalNew()
+	if err != nil {
+		log.Error().Err(err).
+			Str("path", rawPath).
+			Msg("opa-store: error unmarshaling record data, ignoring")
+		return
+	}
+
+	s.write(rawPath, msg)
+}
+
+func (s *Store) delete(rawPath string) {
+	p, ok := storage.ParsePath(rawPath)
+	if !ok {
+		log.Error().
+			Str("path", rawPath).
+			Msg("opa-store: invalid path, ignoring data")
+		return
+	}
+
+	err := storage.Txn(context.Background(), s.opaStore, storage.WriteParams, func(txn storage.Transaction) error {
+		_, err := s.opaStore.Read(context.Background(), txn, p)
+		if storage.IsNotFound(err) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+
+		err = s.opaStore.Write(context.Background(), txn, storage.RemoveOp, p, nil)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("opa-store: error deleting data")
+		return
+	}
+}
+
+func (s *Store) write(rawPath string, value interface{}) {
+	p, ok := storage.ParsePath(rawPath)
+	if !ok {
+		log.Error().
+			Str("path", rawPath).
+			Msg("opa-store: invalid path, ignoring data")
+		return
+	}
+
+	err := storage.Txn(context.Background(), s.opaStore, storage.WriteParams, func(txn storage.Transaction) error {
+		err := storage.MakeDir(context.Background(), s.opaStore, txn, p)
+		if err != nil {
+			return err
+		}
+
+		return s.opaStore.Write(context.Background(), txn, storage.ReplaceOp, p, value)
+	})
+	if err != nil {
+		log.Error().Err(err).Msg("opa-store: error writing data")
+		return
+	}
+}

--- a/authorize/evaluator/store_test.go
+++ b/authorize/evaluator/store_test.go
@@ -19,38 +19,51 @@ func TestStore(t *testing.T) {
 
 	s := NewStore()
 
-	u := &user.User{
-		Version: "v1",
-		Id:      "u1",
-		Name:    "name",
-		Email:   "name@example.com",
-	}
-	any, _ := ptypes.MarshalAny(u)
-	s.UpdateRecord(&databroker.Record{
-		Version: "v1",
-		Type:    any.GetTypeUrl(),
-		Id:      u.GetId(),
-		Data:    any,
+	t.Run("admins", func(t *testing.T) {
+		s.UpdateAdmins([]string{"admin1", "admin2"})
+		v, err := storage.ReadOne(ctx, s.opaStore, storage.MustParsePath("/admins"))
+		assert.NoError(t, err)
+		assert.Equal(t, []interface{}{"admin1", "admin2"}, v)
+
+		s.UpdateAdmins([]string{"admin3"})
+		v, err = storage.ReadOne(ctx, s.opaStore, storage.MustParsePath("/admins"))
+		assert.NoError(t, err)
+		assert.Equal(t, []interface{}{"admin3"}, v)
 	})
+	t.Run("records", func(t *testing.T) {
+		u := &user.User{
+			Version: "v1",
+			Id:      "u1",
+			Name:    "name",
+			Email:   "name@example.com",
+		}
+		any, _ := ptypes.MarshalAny(u)
+		s.UpdateRecord(&databroker.Record{
+			Version: "v1",
+			Type:    any.GetTypeUrl(),
+			Id:      u.GetId(),
+			Data:    any,
+		})
 
-	v, err := storage.ReadOne(ctx, s.opaStore, storage.MustParsePath("/databroker_data/type.googleapis.com/user.User/u1"))
-	assert.NoError(t, err)
-	assert.Equal(t, map[string]interface{}{
-		"version": "v1",
-		"id":      "u1",
-		"name":    "name",
-		"email":   "name@example.com",
-	}, v)
+		v, err := storage.ReadOne(ctx, s.opaStore, storage.MustParsePath("/databroker_data/type.googleapis.com/user.User/u1"))
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]interface{}{
+			"version": "v1",
+			"id":      "u1",
+			"name":    "name",
+			"email":   "name@example.com",
+		}, v)
 
-	s.UpdateRecord(&databroker.Record{
-		Version:   "v2",
-		Type:      any.GetTypeUrl(),
-		Id:        u.GetId(),
-		Data:      any,
-		DeletedAt: ptypes.TimestampNow(),
+		s.UpdateRecord(&databroker.Record{
+			Version:   "v2",
+			Type:      any.GetTypeUrl(),
+			Id:        u.GetId(),
+			Data:      any,
+			DeletedAt: ptypes.TimestampNow(),
+		})
+
+		v, err = storage.ReadOne(ctx, s.opaStore, storage.MustParsePath("/databroker_data/type.googleapis.com/user.User/u1"))
+		assert.Error(t, err)
+		assert.Nil(t, v)
 	})
-
-	v, err = storage.ReadOne(ctx, s.opaStore, storage.MustParsePath("/databroker_data/type.googleapis.com/user.User/u1"))
-	assert.Error(t, err)
-	assert.Nil(t, v)
 }

--- a/authorize/evaluator/store_test.go
+++ b/authorize/evaluator/store_test.go
@@ -1,0 +1,56 @@
+package evaluator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/golang/protobuf/ptypes"
+	"github.com/open-policy-agent/opa/storage"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/user"
+)
+
+func TestStore(t *testing.T) {
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	defer clearTimeout()
+
+	s := NewStore()
+
+	u := &user.User{
+		Version: "v1",
+		Id:      "u1",
+		Name:    "name",
+		Email:   "name@example.com",
+	}
+	any, _ := ptypes.MarshalAny(u)
+	s.UpdateRecord(&databroker.Record{
+		Version: "v1",
+		Type:    any.GetTypeUrl(),
+		Id:      u.GetId(),
+		Data:    any,
+	})
+
+	v, err := storage.ReadOne(ctx, s.opaStore, storage.MustParsePath("/databroker_data/type.googleapis.com/user.User/u1"))
+	assert.NoError(t, err)
+	assert.Equal(t, map[string]interface{}{
+		"version": "v1",
+		"id":      "u1",
+		"name":    "name",
+		"email":   "name@example.com",
+	}, v)
+
+	s.UpdateRecord(&databroker.Record{
+		Version:   "v2",
+		Type:      any.GetTypeUrl(),
+		Id:        u.GetId(),
+		Data:      any,
+		DeletedAt: ptypes.TimestampNow(),
+	})
+
+	v, err = storage.ReadOne(ctx, s.opaStore, storage.MustParsePath("/databroker_data/type.googleapis.com/user.User/u1"))
+	assert.Error(t, err)
+	assert.Nil(t, v)
+}

--- a/authorize/run.go
+++ b/authorize/run.go
@@ -180,6 +180,8 @@ func (a *Authorize) runDataUpdater(ctx context.Context, updateRecord <-chan *dat
 		case record = <-updateRecord:
 		}
 
+		a.store.UpdateRecord(record)
+
 		a.dataBrokerDataLock.Lock()
 		a.dataBrokerData.Update(record)
 		a.dataBrokerDataLock.Unlock()


### PR DESCRIPTION
## Summary
This PR adds a new `Store` to the authorize evaluator.

This store holds the existing `admins` and `route_policies` data, but also stores the databroker data. This way the data will be available to custom rego policies.

Previously we passed this data on evaluation, but that has to go through a JSON marshal/unmarshal which is very slow. By using a Store we still go through the JSON marshal/unmarshal, but only when data is changed, not on every evaluation.

We still can't rely on this data for user/session/group evaluation, because it is eventually consistent, so we'd likely end up with an immediate rejection after a user logs in. So I didn't change that code.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
