### PR TITLE
grpc: use relative paths in codegen

### DIFF
--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -1,8 +1,8 @@
 package grpc
 
-//go:generate ../../scripts/protoc -I ./session/ --go_out=plugins=grpc:$GOPATH/src ./session/session.proto
-//go:generate ../../scripts/protoc -I ./user/ --go_out=plugins=grpc:$GOPATH/src ./user/user.proto
-//go:generate ../../scripts/protoc -I ./databroker/ --go_out=plugins=grpc:$GOPATH/src ./databroker/databroker.proto
-//go:generate ../../scripts/protoc -I ./directory/ --go_out=plugins=grpc:$GOPATH/src ./directory/directory.proto
-//go:generate ../../scripts/protoc -I ./audit/ --go_out=plugins=grpc:$GOPATH/src ./audit/audit.proto
-//go:generate ../../scripts/protoc -I ./config/ --go_out=plugins=grpc:$GOPATH/src ./config/config.proto
+//go:generate ../../scripts/protoc -I ./session/ --go_out=plugins=grpc,paths=source_relative:./session/. ./session/session.proto
+//go:generate ../../scripts/protoc -I ./user/ --go_out=plugins=grpc,paths=source_relative:./user/. ./user/user.proto
+//go:generate ../../scripts/protoc -I ./databroker/ --go_out=plugins=grpc,paths=source_relative:./databroker/. ./databroker/databroker.proto
+//go:generate ../../scripts/protoc -I ./directory/ --go_out=plugins=grpc,paths=source_relative:./directory/. ./directory/directory.proto
+//go:generate ../../scripts/protoc -I ./audit/ --go_out=plugins=grpc,paths=source_relative:./audit/. ./audit/audit.proto
+//go:generate ../../scripts/protoc -I ./config/ --go_out=plugins=grpc,paths=source_relative:./config/. ./config/config.proto


### PR DESCRIPTION
## Summary

Previously, `go generate` would put generated protobuf files assuming $GOPATH, this change uses relative imports instead.

## Related issues

- https://github.com/golang/protobuf/issues/872#issuecomment-509801539


**Checklist**:
- [x] add related issues
- [x] ready for review
