### PR TITLE
depedency: bump envoy to 1.15.0

### DIFF
--- a/scripts/embed-envoy.bash
+++ b/scripts/embed-envoy.bash
@@ -3,7 +3,7 @@ set -euo pipefail
 
 BINARY=$1
 
-ENVOY_VERSION=1.14.2
+ENVOY_VERSION=1.15.0
 DIR=$(dirname "${BINARY}")
 TARGET="${TARGET:-"$(go env GOOS)_$(go env GOARCH)"}"
 


### PR DESCRIPTION

## Summary

Bumps envoy to 1.15.0 for v0.10.0 release of Pomerium. 

## Related issues

- https://github.com/tetratelabs/getenvoy/issues/94
- https://github.com/pomerium/pomerium/pull/1076
- https://github.com/pomerium/pomerium/issues/959#issuecomment-647382565


\cc @cuonglm @yegle 

**Checklist**:

- [x] add related issues
- [x] ready for review
