### PR TITLE
internal/controlplane: using envoy strip host port matching

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -10,6 +10,7 @@
 - authenticate: allow hot reloaded admin users config @cuonglm [GH-984]
 - authorize: include "kid" in JWT headers @cuonglm [GH-1046]
 - config: both base64 and file reference can be used for "certificates" @dmitrif [GH-1055]
+- envoy: enable strip host port matching @cuonglm [GH-1126]
 
 ### Changes
 

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -225,8 +225,9 @@ func buildMainHTTPConnectionManagerFilter(options *config.Options, domains []str
 			RandomSampling: &envoy_type_v3.Percent{Value: options.TracingSampleRate * 100},
 		},
 		// See https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for
-		UseRemoteAddress: &wrappers.BoolValue{Value: true},
-		SkipXffAppend:    false,
+		UseRemoteAddress:      &wrappers.BoolValue{Value: true},
+		SkipXffAppend:         false,
+		StripMatchingHostPort: true,
 	})
 
 	return &envoy_config_listener_v3.Filter{

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -308,6 +308,7 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 				"validateClusters": false
 			},
 			"statPrefix": "ingress",
+			"stripMatchingHostPort": true,
 			"tracing": {
 				"randomSampling": {
 					"value": 0.01


### PR DESCRIPTION
## Summary
With envoy 1.15.0 release, strip host port matching setting allows
incoming request with Host "example:443" will match again route with
domains match set to "example".

Not that this is not standard HTTP behavior, but it's more convenient
for users.

## Related issues

Fixes #959


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
