### PR TITLE
pkg/storage: change backend interface to return error

### DIFF
--- a/internal/databroker/server_test.go
+++ b/internal/databroker/server_test.go
@@ -40,13 +40,15 @@ func TestServer_initVersion(t *testing.T) {
 		ctx := context.Background()
 		db, err := srv.getDB(recordTypeServerVersion)
 		require.NoError(t, err)
-		r := db.Get(ctx, serverVersionKey)
+		r, err := db.Get(ctx, serverVersionKey)
+		assert.Error(t, err)
 		assert.Nil(t, r)
 		srvVersion := uuid.New().String()
 		srv.version = srvVersion
 		srv.initVersion()
 		assert.Equal(t, srvVersion, srv.version)
-		r = db.Get(ctx, serverVersionKey)
+		r, err = db.Get(ctx, serverVersionKey)
+		require.NoError(t, err)
 		assert.NotNil(t, r)
 		var sv databroker.ServerVersion
 		assert.NoError(t, ptypes.UnmarshalAny(r.GetData(), &sv))
@@ -57,13 +59,15 @@ func TestServer_initVersion(t *testing.T) {
 		ctx := context.Background()
 		db, err := srv.getDB(recordTypeServerVersion)
 		require.NoError(t, err)
-		r := db.Get(ctx, serverVersionKey)
+		r, err := db.Get(ctx, serverVersionKey)
+		assert.Error(t, err)
 		assert.Nil(t, r)
 
 		srv.initVersion()
 		srvVersion := srv.version
 
-		r = db.Get(ctx, serverVersionKey)
+		r, err = db.Get(ctx, serverVersionKey)
+		require.NoError(t, err)
 		assert.NotNil(t, r)
 		var sv databroker.ServerVersion
 		assert.NoError(t, ptypes.UnmarshalAny(r.GetData(), &sv))

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -16,13 +16,13 @@ type Backend interface {
 	Put(ctx context.Context, id string, data *anypb.Any) error
 
 	// Get is used to retrieve a record.
-	Get(ctx context.Context, id string) *databroker.Record
+	Get(ctx context.Context, id string) (*databroker.Record, error)
 
 	// GetAll is used to retrieve all the records.
-	GetAll(ctx context.Context) []*databroker.Record
+	GetAll(ctx context.Context) ([]*databroker.Record, error)
 
 	// List is used to retrieve all the records since a version.
-	List(ctx context.Context, sinceVersion string) []*databroker.Record
+	List(ctx context.Context, sinceVersion string) ([]*databroker.Record, error)
 
 	// Delete is used to mark a record as deleted.
 	Delete(ctx context.Context, id string) error


### PR DESCRIPTION


## Summary
Since when storage backend like redis can be fault in many cases, the
interface should return error for the caller to handle.

## Related issues



**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
