### PR TITLE
envoy: Set ExtAuthz Cluster name to URL Host

### DIFF
--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -38,7 +38,7 @@ func (srv *Server) buildClusters(options *config.Options) []*envoy_config_cluste
 		buildInternalCluster(options, "pomerium-control-plane-http", httpURL, false),
 	}
 
-	clusters = append(clusters, buildInternalCluster(options, "pomerium-authz", authzURL, true))
+	clusters = append(clusters, buildInternalCluster(options, authzURL.Host, authzURL, true))
 
 	if config.IsProxy(options.Services) {
 		for _, policy := range options.Policies {

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -166,7 +166,7 @@ func buildMainHTTPConnectionManagerFilter(options *config.Options, domains []str
 				Timeout: grpcClientTimeout,
 				TargetSpecifier: &envoy_config_core_v3.GrpcService_EnvoyGrpc_{
 					EnvoyGrpc: &envoy_config_core_v3.GrpcService_EnvoyGrpc{
-						ClusterName: "pomerium-authz",
+						ClusterName: options.GetAuthorizeURL().Host,
 					},
 				},
 			},

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -50,7 +50,7 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 						"@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
 						"grpcService": {
 							"envoyGrpc": {
-								"clusterName": "pomerium-authz"
+								"clusterName": "127.0.0.1:5443"
 							},
 							"timeout": "10s"
 						},


### PR DESCRIPTION
## Summary
Force the envoy `ext_authz` call to use the pomerium `authorize` hostname in requests by naming the cluster accordingly.  A mismatch here can cause unintended routing issues with any upstream proxies present.

## Related issues
https://github.com/pomerium/pomerium/issues/983


**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
