### PR TITLE
pkg/storage/redis: move last version to redis

### DIFF
--- a/pkg/storage/redis/redis_test.go
+++ b/pkg/storage/redis/redis_test.go
@@ -38,6 +38,8 @@ func TestDB(t *testing.T) {
 	defer c.Close()
 
 	cleanup(c, db, t)
+	_, err = c.Do("DEL", db.lastVersionKey)
+	require.NoError(t, err)
 
 	t.Run("get missing record", func(t *testing.T) {
 		record, err := db.Get(ctx, id)


### PR DESCRIPTION


## Summary
So we can support multiple databroker servers, we can't do it if we
store last version inside Server struct.

## Related issues



**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
