### PR TITLE
pkg/storage: introduce storage.Backend Watch method

### DIFF
--- a/internal/databroker/config_source_test.go
+++ b/internal/databroker/config_source_test.go
@@ -26,9 +26,9 @@ func TestConfigSource(t *testing.T) {
 	}
 	defer li.Close()
 
-	db := New()
+	dataBrokerServer := newTestServer()
 	srv := grpc.NewServer()
-	databroker.RegisterDataBrokerServiceServer(srv, db)
+	databroker.RegisterDataBrokerServiceServer(srv, dataBrokerServer)
 	go func() { _ = srv.Serve(li) }()
 
 	cfgs := make(chan *config.Config, 10)
@@ -52,7 +52,7 @@ func TestConfigSource(t *testing.T) {
 			},
 		},
 	})
-	_, _ = db.Set(ctx, &databroker.SetRequest{
+	_, _ = dataBrokerServer.Set(ctx, &databroker.SetRequest{
 		Type: configTypeURL,
 		Id:   "1",
 		Data: data,

--- a/internal/databroker/helper_no_redis.go
+++ b/internal/databroker/helper_no_redis.go
@@ -1,0 +1,7 @@
+// +build !redis
+
+package databroker
+
+func newTestServer() *Server {
+	return New()
+}

--- a/internal/databroker/helper_redis.go
+++ b/internal/databroker/helper_redis.go
@@ -1,0 +1,17 @@
+// +build redis
+
+package databroker
+
+import (
+	"os"
+
+	"github.com/pomerium/pomerium/pkg/storage/redis"
+)
+
+func newTestServer() *Server {
+	address := ":6379"
+	if redisURL := os.Getenv("REDIS_URL"); redisURL != "" {
+		address = redisURL
+	}
+	return New(WithStorageType(redis.Name), WithStorageConnectionString(address))
+}

--- a/internal/databroker/server.go
+++ b/internal/databroker/server.go
@@ -225,7 +225,7 @@ func (srv *Server) Sync(req *databroker.SyncRequest, stream databroker.DataBroke
 	for range ch {
 		updated, err := db.List(ctx, recordVersion)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		if len(updated) > 0 {
 			sort.Slice(updated, func(i, j int) bool {

--- a/internal/databroker/server.go
+++ b/internal/databroker/server.go
@@ -243,7 +243,7 @@ func (srv *Server) Sync(req *databroker.SyncRequest, stream databroker.DataBroke
 		return err
 	}
 
-	ch := db.Sync(ctx)
+	ch := db.Watch(ctx)
 
 	for range ch {
 		if err := srv.doSync(ctx, &recordVersion, db, stream); err != nil {

--- a/internal/databroker/server.go
+++ b/internal/databroker/server.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/signal"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/storage"
@@ -36,9 +37,9 @@ type Server struct {
 	cfg     *serverConfig
 	log     zerolog.Logger
 
-	mu       sync.RWMutex
-	byType   map[string]storage.Backend
-	onchange *Signal
+	mu           sync.RWMutex
+	byType       map[string]storage.Backend
+	onTypechange *signal.Signal
 }
 
 // New creates a new server.
@@ -49,8 +50,8 @@ func New(options ...ServerOption) *Server {
 		cfg:     cfg,
 		log:     log.With().Str("service", "databroker").Logger(),
 
-		byType:   make(map[string]storage.Backend),
-		onchange: NewSignal(),
+		byType:       make(map[string]storage.Backend),
+		onTypechange: signal.New(),
 	}
 	srv.initVersion()
 
@@ -109,8 +110,6 @@ func (srv *Server) Delete(ctx context.Context, req *databroker.DeleteRequest) (*
 		Str("type", req.GetType()).
 		Str("id", req.GetId()).
 		Msg("delete")
-
-	defer srv.onchange.Broadcast()
 
 	db, err := srv.getDB(req.GetType())
 	if err != nil {
@@ -182,8 +181,6 @@ func (srv *Server) Set(ctx context.Context, req *databroker.SetRequest) (*databr
 		Str("id", req.GetId()).
 		Msg("set")
 
-	defer srv.onchange.Broadcast()
-
 	db, err := srv.getDB(req.GetType())
 	if err != nil {
 		return nil, err
@@ -222,10 +219,14 @@ func (srv *Server) Sync(req *databroker.SyncRequest, stream databroker.DataBroke
 		return err
 	}
 
-	ch := srv.onchange.Bind()
-	defer srv.onchange.Unbind(ch)
-	for {
-		updated, _ := db.List(context.Background(), recordVersion)
+	ctx := stream.Context()
+	ch := db.Sync(ctx)
+
+	for range ch {
+		updated, err := db.List(ctx, recordVersion)
+		if err != nil {
+			panic(err)
+		}
 		if len(updated) > 0 {
 			sort.Slice(updated, func(i, j int) bool {
 				return updated[i].Version < updated[j].Version
@@ -239,13 +240,8 @@ func (srv *Server) Sync(req *databroker.SyncRequest, stream databroker.DataBroke
 				return err
 			}
 		}
-
-		select {
-		case <-stream.Context().Done():
-			return stream.Context().Err()
-		case <-ch:
-		}
 	}
+	return nil
 }
 
 // GetTypes returns all the known record types.
@@ -272,8 +268,8 @@ func (srv *Server) SyncTypes(req *emptypb.Empty, stream databroker.DataBrokerSer
 	srv.log.Info().
 		Msg("sync types")
 
-	ch := srv.onchange.Bind()
-	defer srv.onchange.Unbind(ch)
+	ch := srv.onTypechange.Bind()
+	defer srv.onTypechange.Unbind(ch)
 
 	var prev []string
 	for {

--- a/internal/databroker/server.go
+++ b/internal/databroker/server.go
@@ -238,12 +238,12 @@ func (srv *Server) Sync(req *databroker.SyncRequest, stream databroker.DataBroke
 	}
 
 	ctx := stream.Context()
+	ch := db.Watch(ctx)
+
 	// Do first sync, so we won't missed anything.
 	if err := srv.doSync(ctx, &recordVersion, db, stream); err != nil {
 		return err
 	}
-
-	ch := db.Watch(ctx)
 
 	for range ch {
 		if err := srv.doSync(ctx, &recordVersion, db, stream); err != nil {

--- a/internal/databroker/server_test.go
+++ b/internal/databroker/server_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/signal"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
@@ -20,8 +21,8 @@ func newServer(cfg *serverConfig) *Server {
 		cfg:     cfg,
 		log:     log.With().Str("service", "databroker").Logger(),
 
-		byType:   make(map[string]storage.Backend),
-		onchange: NewSignal(),
+		byType:       make(map[string]storage.Backend),
+		onTypechange: signal.New(),
 	}
 }
 

--- a/internal/signal/signal.go
+++ b/internal/signal/signal.go
@@ -1,6 +1,9 @@
-package databroker
+// Package signal provides mechanism for notifying multiple listeners when something happened.
+package signal
 
-import "sync"
+import (
+	"sync"
+)
 
 // A Signal is used to let multiple listeners know when something happened.
 type Signal struct {
@@ -8,8 +11,8 @@ type Signal struct {
 	chs map[chan struct{}]struct{}
 }
 
-// NewSignal creates a new Signal.
-func NewSignal() *Signal {
+// New creates a new Signal.
+func New() *Signal {
 	return &Signal{
 		chs: make(map[chan struct{}]struct{}),
 	}

--- a/pkg/storage/inmemory/inmemory.go
+++ b/pkg/storage/inmemory/inmemory.go
@@ -138,6 +138,11 @@ func (db *DB) Put(_ context.Context, id string, data *anypb.Any) error {
 // Then the caller can listen to the channel for detecting changes.
 func (db *DB) Sync(ctx context.Context) chan struct{} {
 	ch := db.onchange.Bind()
+	go func() {
+		<-ctx.Done()
+		close(ch)
+		db.onchange.Unbind(ch)
+	}()
 	return ch
 }
 

--- a/pkg/storage/inmemory/inmemory.go
+++ b/pkg/storage/inmemory/inmemory.go
@@ -134,9 +134,9 @@ func (db *DB) Put(_ context.Context, id string, data *anypb.Any) error {
 	return nil
 }
 
-// Sync returns the underlying signal.Signal binding channel to the caller.
+// Watch returns the underlying signal.Signal binding channel to the caller.
 // Then the caller can listen to the channel for detecting changes.
-func (db *DB) Sync(ctx context.Context) chan struct{} {
+func (db *DB) Watch(ctx context.Context) chan struct{} {
 	ch := db.onchange.Bind()
 	go func() {
 		<-ctx.Done()

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -228,9 +228,9 @@ func doNotify(ctx context.Context, psc *redis.PubSubConn, ch chan struct{}) {
 	}
 }
 
-// Sync returns a channel to the caller, when there is a change to the version set,
+// Watch returns a channel to the caller, when there is a change to the version set,
 // sending message to the channel to notify the caller.
-func (db *DB) Sync(ctx context.Context) chan struct{} {
+func (db *DB) Watch(ctx context.Context) chan struct{} {
 	ch := make(chan struct{})
 	go func() {
 		c := db.pool.Get()

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -256,7 +256,6 @@ func (db *DB) Watch(ctx context.Context) chan struct{} {
 		psConn := db.pool.Get()
 		defer psConn.Close()
 		psc := redis.PubSubConn{Conn: psConn}
-		defer psc.Conn.Close()
 		if err := psc.PSubscribe("__keyspace*__:" + db.versionSet); err != nil {
 			log.Error().Err(err).Msg("failed to subscribe to version set channel")
 			return

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -232,7 +232,8 @@ func doNotify(ctx context.Context, psc *redis.PubSubConn, ch chan struct{}) erro
 	return nil
 }
 
-func (db *DB) watchLoop(ctx context.Context, ch chan struct{}, eb *backoff.ExponentialBackOff) {
+func (db *DB) watchLoop(ctx context.Context, ch chan struct{}) {
+	eb := backoff.NewExponentialBackOff()
 top:
 	psConn := db.pool.Get()
 	defer psConn.Close()
@@ -275,10 +276,9 @@ func (db *DB) Watch(ctx context.Context) chan struct{} {
 			c.Close()
 			return
 		}
-
 		c.Close()
-		eb := backoff.NewExponentialBackOff()
-		db.watchLoop(ctx, ch, eb)
+
+		db.watchLoop(ctx, ch)
 	}()
 
 	return ch

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -215,7 +215,7 @@ func (db *DB) ClearDeleted(_ context.Context, cutoff time.Time) {
 func doNotify(ctx context.Context, psc *redis.PubSubConn, ch chan struct{}) error {
 	switch v := psc.ReceiveWithTimeout(time.Second).(type) {
 	case redis.Message:
-		log.Debug().Str("action", string(v.Data)).Msg("Got redis message")
+		log.Debug().Str("action", string(v.Data)).Msg("got redis message")
 		if string(v.Data) != watchAction {
 			return nil
 		}

--- a/pkg/storage/redis/redis_test.go
+++ b/pkg/storage/redis/redis_test.go
@@ -42,7 +42,7 @@ func TestDB(t *testing.T) {
 	_, err = c.Do("DEL", db.lastVersionKey)
 	require.NoError(t, err)
 
-	ch := db.Sync(ctx)
+	ch := db.Watch(ctx)
 
 	t.Run("get missing record", func(t *testing.T) {
 		record, err := db.Get(ctx, id)

--- a/pkg/storage/redis/redis_test.go
+++ b/pkg/storage/redis/redis_test.go
@@ -113,11 +113,11 @@ func TestDB(t *testing.T) {
 		assert.Len(t, records, 0)
 	})
 
-	expecetedNumEvents := 14
+	expectedNumEvents := 14
 	actualNumEvents := 0
 	for range ch {
 		actualNumEvents++
-		if actualNumEvents == expecetedNumEvents {
+		if actualNumEvents == expectedNumEvents {
 			cancelFunc()
 		}
 	}

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -31,7 +31,7 @@ type Backend interface {
 	ClearDeleted(ctx context.Context, cutoff time.Time)
 
 	// Watch returns a channel to the caller. The channel is used to notify
-	// about changes happen in storage. When ctx is finish, Watch will close
+	// about changes that happen in storage. When ctx is finished, Watch will close
 	// the channel.
 	Watch(ctx context.Context) chan struct{}
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -30,6 +30,8 @@ type Backend interface {
 	// ClearDeleted is used clear marked delete records.
 	ClearDeleted(ctx context.Context, cutoff time.Time)
 
-	// Sync is used to notify about changes happen in storage.
-	Sync(ctx context.Context) chan struct{}
+	// Watch returns a channel to the caller. The channel is used to notify
+	// about changes happen in storage. When ctx is finish, Watch will close
+	// the channel.
+	Watch(ctx context.Context) chan struct{}
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -29,4 +29,7 @@ type Backend interface {
 
 	// ClearDeleted is used clear marked delete records.
 	ClearDeleted(ctx context.Context, cutoff time.Time)
+
+	// Sync is used to notify about changes happen in storage.
+	Sync(ctx context.Context) chan struct{}
 }


### PR DESCRIPTION


## Summary
Currently, we're doing "sync" in databroker server. If we're going to
support multiple databroker servers instance, this mechanism won't work.

This commit moves the "sync" to storage backend, by adding new Sync
method. The Sync method will return a chanel for the caller. Everytime
something happens inside the storage, we notify the caller by sending a
message to the channel.


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
