### PR TITLE
docs: Add required in cookie_secret

### DIFF
--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -156,7 +156,7 @@ The name of the session cookie sent to clients.
 - Environmental Variable: `COOKIE_SECRET`
 - Config File Key: `cookie_secret`
 - Type: [base64 encoded] `string`
-- Required
+- Required for proxy service 
 
 Secret used to encrypt and sign session cookies. You can generate a random key with `head -c32 /dev/urandom | base64`.
 
@@ -1171,4 +1171,3 @@ If no certificate is specified, one will be generated and the base64'd public ke
 [signed headers]: ./signed-headers.md
 [toml]: https://en.wikipedia.org/wiki/TOML
 [yaml]: https://en.wikipedia.org/wiki/YAML
-

--- a/docs/configuration/readme.md
+++ b/docs/configuration/readme.md
@@ -156,6 +156,7 @@ The name of the session cookie sent to clients.
 - Environmental Variable: `COOKIE_SECRET`
 - Config File Key: `cookie_secret`
 - Type: [base64 encoded] `string`
+- Required
 
 Secret used to encrypt and sign session cookies. You can generate a random key with `head -c32 /dev/urandom | base64`.
 

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -212,7 +212,7 @@ func (db *DB) ClearDeleted(_ context.Context, cutoff time.Time) {
 	}
 }
 
-// doNotify receives event from redis and signal the channel that something happenned.
+// doNotify receives event from redis and signal the channel that something happened.
 func doNotify(ctx context.Context, psc *redis.PubSubConn, ch chan struct{}) error {
 	switch v := psc.ReceiveWithTimeout(time.Second).(type) {
 	case redis.Message:


### PR DESCRIPTION
## Summary
It appears that `cookie_secret` is required (from what I have tested locally, also read the code and it appears that it requires a base64 valid string). It just adds required tag to this field.
Feel free to close it if I understood the code wrong and if I am doing something wrong configuring it!

**Checklist**:
- [ ] add related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] ready for review
