### PR TITLE
fix databroker restart versioning, handle missing sessions

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -58,9 +58,8 @@ type Authorize struct {
 
 	dataBrokerClient databroker.DataBrokerServiceClient
 
-	dataBrokerDataLock             sync.RWMutex
-	dataBrokerData                 evaluator.DataBrokerData
-	dataBrokerSessionServerVersion string
+	dataBrokerDataLock sync.RWMutex
+	dataBrokerData     evaluator.DataBrokerData
 }
 
 // New validates and creates a new Authorize service from a set of config options.

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -402,6 +402,11 @@ func getDenyVar(vars rego.Vars) []Result {
 // DataBrokerData stores the data broker data by type => id => record
 type DataBrokerData map[string]map[string]interface{}
 
+// Clear removes all the data for the given type URL from the databroekr data.
+func (dbd DataBrokerData) Clear(typeURL string) {
+	delete(dbd, typeURL)
+}
+
 // Get gets a record from the DataBrokerData.
 func (dbd DataBrokerData) Get(typeURL, id string) interface{} {
 	m, ok := dbd[typeURL]

--- a/authorize/evaluator/store.go
+++ b/authorize/evaluator/store.go
@@ -24,6 +24,12 @@ func NewStore() *Store {
 	}
 }
 
+// ClearRecords removes all the records from the store.
+func (s *Store) ClearRecords(typeURL string) {
+	rawPath := fmt.Sprintf("/databroker_data/%s", typeURL)
+	s.delete(rawPath)
+}
+
 // UpdateAdmins updates the admins in the store.
 func (s *Store) UpdateAdmins(admins []string) {
 	s.write("/admins", admins)

--- a/authorize/run.go
+++ b/authorize/run.go
@@ -138,6 +138,11 @@ func (a *Authorize) runDataTypeSyncer(ctx context.Context, typeURL string) error
 
 			backoff.Reset()
 			if res.GetServerVersion() != serverVersion {
+				log.Info().
+					Str("old_version", serverVersion).
+					Str("new_version", res.GetServerVersion()).
+					Str("type_url", typeURL).
+					Msg("detected new server version, clearing data")
 				serverVersion = res.GetServerVersion()
 				recordVersion = ""
 				a.clearRecords(typeURL)

--- a/authorize/run.go
+++ b/authorize/run.go
@@ -24,13 +24,8 @@ func (a *Authorize) Run(ctx context.Context) error {
 		return a.runTypesSyncer(ctx, updateTypes)
 	})
 
-	updateRecord := make(chan *databroker.Record)
 	eg.Go(func() error {
-		return a.runDataSyncer(ctx, updateTypes, updateRecord)
-	})
-
-	eg.Go(func() error {
-		return a.runDataUpdater(ctx, updateRecord)
+		return a.runDataSyncer(ctx, updateTypes)
 	})
 
 	return eg.Wait()
@@ -65,7 +60,7 @@ func (a *Authorize) runTypesSyncer(ctx context.Context, updateTypes chan<- []str
 	})
 }
 
-func (a *Authorize) runDataSyncer(ctx context.Context, updateTypes <-chan []string, updateRecord chan<- *databroker.Record) error {
+func (a *Authorize) runDataSyncer(ctx context.Context, updateTypes <-chan []string) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		seen := map[string]struct{}{}
@@ -78,7 +73,7 @@ func (a *Authorize) runDataSyncer(ctx context.Context, updateTypes <-chan []stri
 					dataType := dataType
 					if _, ok := seen[dataType]; !ok {
 						eg.Go(func() error {
-							return a.runDataTypeSyncer(ctx, dataType, updateRecord)
+							return a.runDataTypeSyncer(ctx, dataType)
 						})
 						seen[dataType] = struct{}{}
 					}
@@ -89,7 +84,7 @@ func (a *Authorize) runDataSyncer(ctx context.Context, updateTypes <-chan []stri
 	return eg.Wait()
 }
 
-func (a *Authorize) runDataTypeSyncer(ctx context.Context, typeURL string, updateRecord chan<- *databroker.Record) error {
+func (a *Authorize) runDataTypeSyncer(ctx context.Context, typeURL string) error {
 	var serverVersion, recordVersion string
 
 	log.Info().Str("type_url", typeURL).Msg("starting data initial load")
@@ -110,19 +105,10 @@ func (a *Authorize) runDataTypeSyncer(ctx context.Context, typeURL string, updat
 		}
 
 		serverVersion = res.GetServerVersion()
-		if typeURL == sessionTypeURL {
-			a.dataBrokerDataLock.Lock()
-			a.dataBrokerSessionServerVersion = serverVersion
-			a.dataBrokerDataLock.Unlock()
-		}
 		recordVersion = res.GetRecordVersion()
 
 		for _, record := range res.GetRecords() {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case updateRecord <- record:
-			}
+			a.updateRecord(record)
 		}
 
 		break
@@ -151,7 +137,11 @@ func (a *Authorize) runDataTypeSyncer(ctx context.Context, typeURL string, updat
 			}
 
 			backoff.Reset()
-			serverVersion = res.GetServerVersion()
+			if res.GetServerVersion() != serverVersion {
+				serverVersion = res.GetServerVersion()
+				recordVersion = ""
+				a.clearRecords(typeURL)
+			}
 			for _, record := range res.GetRecords() {
 				if record.GetVersion() > recordVersion {
 					recordVersion = record.GetVersion()
@@ -159,33 +149,24 @@ func (a *Authorize) runDataTypeSyncer(ctx context.Context, typeURL string, updat
 			}
 
 			for _, record := range res.GetRecords() {
-				select {
-				case <-stream.Context().Done():
-					return stream.Context().Err()
-				case updateRecord <- record:
-				}
+				a.updateRecord(record)
 			}
 		}
 	})
 }
 
-func (a *Authorize) runDataUpdater(ctx context.Context, updateRecord <-chan *databroker.Record) error {
-	log.Info().Msg("starting data updater")
-	for {
-		var record *databroker.Record
+func (a *Authorize) clearRecords(typeURL string) {
+	a.store.ClearRecords(typeURL)
+	a.dataBrokerDataLock.Lock()
+	a.dataBrokerData.Clear(typeURL)
+	a.dataBrokerDataLock.Unlock()
+}
 
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case record = <-updateRecord:
-		}
-
-		a.store.UpdateRecord(record)
-
-		a.dataBrokerDataLock.Lock()
-		a.dataBrokerData.Update(record)
-		a.dataBrokerDataLock.Unlock()
-	}
+func (a *Authorize) updateRecord(record *databroker.Record) {
+	a.store.UpdateRecord(record)
+	a.dataBrokerDataLock.Lock()
+	a.dataBrokerData.Update(record)
+	a.dataBrokerDataLock.Unlock()
 }
 
 func tryForever(ctx context.Context, callback func(onSuccess interface{ Reset() }) error) error {

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -178,10 +178,11 @@ func (src *ConfigSource) runUpdater(cfg *config.Config) {
 			}
 			onSuccess()
 
-			src.onSync(res.GetRecords())
-
-			for _, record := range res.GetRecords() {
-				recordVersion = record.GetVersion()
+			if len(res.GetRecords()) > 0 {
+				src.onSync(res.GetRecords())
+				for _, record := range res.GetRecords() {
+					recordVersion = record.GetVersion()
+				}
 			}
 
 			src.mu.Lock()

--- a/internal/databroker/server.go
+++ b/internal/databroker/server.go
@@ -230,6 +230,13 @@ func (srv *Server) Sync(req *databroker.SyncRequest, stream databroker.DataBroke
 	// reset record version if the server versions don't match
 	if req.GetServerVersion() != srv.version {
 		recordVersion = ""
+		// send the new server version to the client
+		err := stream.Send(&databroker.SyncResponse{
+			ServerVersion: srv.version,
+		})
+		if err != nil {
+			return err
+		}
 	}
 
 	db, err := srv.getDB(req.GetType())


### PR DESCRIPTION
## Summary
There were two issues in the code:

1. When the server version changed we properly updated the server version on the initial `GetAll` call, but we didn't update it in the `Sync` call, so we didn't detect the change. 
2. When we called `forceSync` we returned `nil` when no session was found, but this left the session state intact, and a user would see an error page instead of being redirected to the login page.

To fix these issues I made the following changes:

1. Data is now properly cleared from the databroker data map instead of relying on a lookup of the version to clear the state.
1. I removed the separate databroker data map update goroutine, and do it directly now.
1. In addition to updated the server version, we now reset the record version to the empty string. This should re-sync all the records, which is necessary if the server is restarted.
1. Rather than return nil for the error when looking up a session, we return a `not found` error. This way the session state is cleared and the user is treated as if they were logged out.

These changes could lead to a redirect loop and need to be more thoroughly tested.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
