### PR TITLE
pkg/storage/redis: do not use timeout to signal redis conn to stop

### DIFF
--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -4,6 +4,7 @@ package redis
 import (
 	"context"
 	"fmt"
+	"net"
 	"strconv"
 	"time"
 
@@ -227,6 +228,9 @@ func (db *DB) doNotifyLoop(ctx context.Context, ch chan struct{}, psc *redis.Pub
 			}
 		case error:
 			log.Error().Err(v).Msg("failed to receive from redis channel")
+			if _, ok := v.(net.Error); ok {
+				return
+			}
 		}
 	}
 }


### PR DESCRIPTION




## Summary
Instead, we run the loop in goroutine, and when context was done,
closing the underlying connection of PubSubConn, so the Receive will
return.

## Related issues
Fixes #1154


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
