### PR TITLE
config: default to google idp credentials for serverless

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -614,6 +614,13 @@ func (o *Options) Validate() error {
 		}
 	}
 
+	// if we are using google provider, default to using ServiceAccount for
+	// GoogleCloudServerlessAuthenticationServiceAccount
+	if o.Provider == "google" && o.GoogleCloudServerlessAuthenticationServiceAccount == "" {
+		o.GoogleCloudServerlessAuthenticationServiceAccount = o.ServiceAccount
+		log.Info().Msg("defaulting to idp_service_account for google_cloud_serverless_authentication_service_account")
+	}
+
 	// strip quotes from redirect address (#811)
 	o.HTTPRedirectAddr = strings.Trim(o.HTTPRedirectAddr, `"'`)
 

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1126,7 +1126,10 @@ Authenticate Service URL is the externally accessible URL for the authenticate s
 
 Manually specify the service account credentials to support GCP's [Authorization Header](https://cloud.google.com/run/docs/authenticating/service-to-service) format.
 
-If unspecified, will default to ambient credentials in the default locations searched by the Google SDK.  This includes GCE metadata server tokens.
+If unspecified: 
+
+- If [Identity Provider Name](#identity-provider-name) is set to `google`, will default to [Identity Provider Service Account](#identity-provider-service-account) 
+- Otherwise, will default to ambient credentials in the default locations searched by the Google SDK.  This includes GCE metadata server tokens.
 
 ### Signing Key
 


### PR DESCRIPTION
## Summary
Allow users to use a single service account when using Google IDP with GCP Serverless Auth by defaulting to the `idp_service_account` credentials.

**Checklist**:
- [x] updated docs
- [x] ready for review
