### PR TITLE
authorize: strip port from host header if necessary

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -301,7 +301,7 @@ func getCheckRequestURL(req *envoy_service_auth_v2.CheckRequest) *url.URL {
 		Scheme: h.GetScheme(),
 		Host:   h.GetHost(),
 	}
-
+	u.Host = urlutil.GetDomainsForURL(u)[0]
 	// envoy sends the query string as part of the path
 	path := h.GetPath()
 	if idx := strings.Index(path, "?"); idx != -1 {


### PR DESCRIPTION




## Summary
After #1153, envoy can handle routes for `example.com` and `example.com:443`.
Authorize service should be updated to handle this case, too.

## Related issues
Fixes #959


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
