### PR TITLE
deployment: cut separate archive for cli

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -1,6 +1,7 @@
 project_name: pomerium
 
 release:
+  prerelease: auto
   github:
     owner: pomerium
     name: pomerium

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -78,6 +78,7 @@ archives:
     id: pomerium
     builds:
       - pomerium
+      - pomerium-cli
     files:
       - none*
     format_overrides:

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -74,8 +74,17 @@ builds:
 
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    id: pomerium
     builds:
       - pomerium
+    files:
+      - none*
+    format_overrides:
+      - goos: windows
+        format: zip
+  - name_template: "{{ .ProjectName }}-cli-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
+    id: pomerium-cli
+    builds:
       - pomerium-cli
     files:
       - none*


### PR DESCRIPTION
# Summary

Creates a separate archive for `pomerium-cli`

```
136a310e3dec594b1a9347c0c99aa3695dae7e6bca084d426a1e5063d5e6a8bc  pomerium-linux-amd64.tar.gz
276dd322fab425b334b93ba14a62f058b8c446b1a6097af5e5f3b11123e0be90  pomerium-cli-linux-armv6.tar.gz
30bc8e948d55d03768439d75ffdbe3f6961b6d412bf3b815a01fc8a82d2fe82a  pomerium-darwin-amd64.tar.gz
86fe2bf382af35dc372b10352289aff74d7570aac6f94c5f331e0924a0c6b537  pomerium-cli-linux-arm64.tar.gz
91b87710f88566a9c0ac63cfac813eb249be429513335647bf4f7c5d21075b3d  pomerium-cli-windows-amd64.zip
9d35b9f156e908e76d8a1acb1bb080731fc54d9c9f9a4c7b50695fe770211057  pomerium-cli-freebsd-amd64.tar.gz
c4c83faca51b567a58b42221f34c968c94144ca80e67209b175cb7b3380d4670  pomerium-cli-darwin-amd64.tar.gz
e7cce543e628b9181c162c421b56bdddfe93aa5b5e4df39771bda0868b07a98e  pomerium-cli-linux-amd64.tar.gz
ebd8b59def297fcf46491077dd7d569c980eca1fed4749735054f2233f9140f8  pomerium-cli-linux-armv7.tar.gz
f973f536ce28de5a7d64406b1e61877655b1bcc26fa40c1b897e0c5c6cc22b48  pomerium-linux-arm64.tar.gz
```




**Checklist**:
- [x] ready for review
