### PR TITLE
ci: fix arm docker image releases

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -120,3 +120,20 @@ dockers:
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--label=repository=http://github.com/pomerium/pomerium"
       - "--label=homepage=http://www.pomerium.io"
+
+  - goarch: arm64
+    image_templates:
+      - "pomerium/pomerium:arm64v8-{{ .Tag }}"
+    dockerfile: .github/Dockerfile-release.arm64v8
+    binaries:
+      - pomerium
+      - pomerium-cli
+    build_flag_templates:
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=repository=http://github.com/pomerium/pomerium"
+      - "--label=homepage=http://www.pomerium.io"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,11 +58,5 @@ jobs:
           docker tag pomerium/pomerium:${{ env.LATEST_TAG }} pomerium/pomerium:latest
           docker push pomerium/pomerium:latest
 
-          docker tag pomerium/pomerium:arm32v7-${{ env.LATEST_TAG }} pomerium/pomerium:arm32v7-latest
-          docker push pomerium/pomerium:arm32v7-latest
-
-          docker tag pomerium/pomerium:arm32v6-${{ env.LATEST_TAG }} pomerium/pomerium:arm32v6-latest
-          docker push pomerium/pomerium:arm32v6-latest
-
           docker tag pomerium/pomerium:arm64v8-${{ env.LATEST_TAG }} pomerium/pomerium:arm64v8-latest
           docker push pomerium/pomerium:arm64v8-latest


### PR DESCRIPTION
## Summary
- add linux arm64 docker images back to the release pipeline
- remove push command from images no longer being generated

**Checklist**:
- [x] ready for review
