### PR TITLE
cmd/pomerium-cli: do not require terminal with cached creds

### DIFF
--- a/cmd/pomerium-cli/kubernetes.go
+++ b/cmd/pomerium-cli/kubernetes.go
@@ -47,10 +47,6 @@ var kubernetesCmd = &cobra.Command{
 var kubernetesExecCredentialCmd = &cobra.Command{
 	Use: "exec-credential",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if !terminal.IsTerminal(int(os.Stdin.Fd())) {
-			return fmt.Errorf("only interactive sessions are supported")
-		}
-
 		if len(args) < 1 {
 			return fmt.Errorf("server url is required")
 		}
@@ -64,6 +60,11 @@ var kubernetesExecCredentialCmd = &cobra.Command{
 		if creds != nil {
 			printCreds(creds)
 			return nil
+		}
+
+		// require interactive session to handle login
+		if !terminal.IsTerminal(int(os.Stdin.Fd())) {
+			return fmt.Errorf("only interactive sessions are supported")
 		}
 
 		li, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
## Summary
Allow kubectl credentials provider to work in non-interactive sessions when we have credentials already.

**Checklist**:
- [x] ready for review
