### PR TITLE
authorize/evaluator: fix wrong custom policies decision

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -163,7 +163,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, req *Request) (*Result, error)
 			if err != nil {
 				return nil, err
 			}
-			allow = allow && (!cres.Allowed || cres.Denied)
+			allow = allow && (cres.Allowed && !cres.Denied)
 			if cres.Reason != "" {
 				evalResult.Message = cres.Reason
 			}


### PR DESCRIPTION
## Summary

I discover this while working on #1198. Currently, if the main policy is allowed, but the custom policy return `&evaluator.CustomEvaluatorResponse{Allowed:false, Denied:true, Reason:""}`, then we still allow the request, while it should be forbidden.

Test will be added in #1198



**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
