### PR TITLE
proxy: avoid second policy validation

### DIFF
--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -157,9 +157,6 @@ func New(opts config.Options) (*Proxy, error) {
 	}
 	p.authzClient = envoy_service_auth_v2.NewAuthorizationClient(authzConn)
 
-	if err := p.UpdatePolicies(&opts); err != nil {
-		return nil, err
-	}
 	metrics.AddPolicyCountCallback("pomerium-proxy", func() int64 {
 		return int64(len(opts.Policies))
 	})

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -90,11 +90,6 @@ func TestNew(t *testing.T) {
 	shortCookieLength.CookieSecret = "gN3xnvfsAwfCXxnJorGLKUG4l2wC8sS8nfLMhcStPg=="
 	badCookie := testOptions(t)
 	badCookie.CookieName = ""
-	badPolicyURL := config.Policy{To: "http://", From: "http://bar.example"}
-	badNewPolicy := testOptions(t)
-	badNewPolicy.Policies = []config.Policy{
-		badPolicyURL,
-	}
 
 	tests := []struct {
 		name      string
@@ -106,7 +101,6 @@ func TestNew(t *testing.T) {
 		{"empty options", config.Options{}, false, true},
 		{"short secret/validate sanity check", shortCookieLength, false, true},
 		{"invalid cookie name, empty", badCookie, false, true},
-		{"bad policy, bad policy url", badNewPolicy, false, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
We've refactored our config loading and proxy.New() is now handed pre-validated policies.  I also don't think the proxy is directly handling routes anymore.

This change avoids calling Validate() a second time, as it can break mutually exclusive option checks like [this](https://github.com/pomerium/pomerium/blob/7a53e6bb42167d86f4197c51da767796c46d3345/config/policy.go#L277).  

Overall, I believe we have some dead code in the pomerium services around config handling that could probably use some cleanup.

**Checklist**:
- [x] updated unit tests
- [x] ready for review
