### PR TITLE
all: update outdated comments about OptionsUpdater interface

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -226,8 +226,7 @@ func (a *Authenticate) setAdminUsers(opts *config.Options) {
 	}
 }
 
-// OnConfigChange implements the OptionsUpdater interface and updates internal
-// structures based on config.Options
+// OnConfigChange updates internal structures based on config.Options
 func (a *Authenticate) OnConfigChange(cfg *config.Config) {
 	if a == nil {
 		return

--- a/config/options.go
+++ b/config/options.go
@@ -716,8 +716,8 @@ func (o *Options) Checksum() uint64 {
 }
 
 // handleConfigUpdate takes configuration file, an existing options struct, and
-// updates each service in the services slice OptionsUpdater with a new set of
-// options if any change is detected.
+// returns new options if any change is detected. If no change was detected, the
+// existing option will be returned.
 func handleConfigUpdate(configFile string, opt *Options) *Options {
 	serviceName := telemetry.ServiceName(opt.Services)
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -169,8 +169,7 @@ func New(opts config.Options) (*Proxy, error) {
 	return p, nil
 }
 
-// UpdateOptions implements the OptionsUpdater interface and updates internal
-// structures based on config.Options
+// UpdateOptions updates internal structures based on config.Options
 func (p *Proxy) UpdateOptions(o config.Options) error {
 	if p == nil {
 		return nil


### PR DESCRIPTION


## Summary
In #1088, OptionsUpdater was removed, but current code still mention it.
This commit updates all comments which still mention about that
interface (authorize is exlcuded, and will be updated in #1206).



**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
