### PR TITLE
pkg/storage: make Watch returns receive only channel

### DIFF
--- a/pkg/storage/inmemory/inmemory.go
+++ b/pkg/storage/inmemory/inmemory.go
@@ -137,7 +137,7 @@ func (db *DB) Put(_ context.Context, id string, data *anypb.Any) error {
 
 // Watch returns the underlying signal.Signal binding channel to the caller.
 // Then the caller can listen to the channel for detecting changes.
-func (db *DB) Watch(ctx context.Context) chan struct{} {
+func (db *DB) Watch(ctx context.Context) <-chan struct{} {
 	ch := db.onchange.Bind()
 	go func() {
 		<-ctx.Done()

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -304,7 +304,7 @@ func (db *DB) subscribeRedisChannel(psc *redis.PubSubConn) error {
 
 // Watch returns a channel to the caller, when there is a change to the version set,
 // sending message to the channel to notify the caller.
-func (db *DB) Watch(ctx context.Context) chan struct{} {
+func (db *DB) Watch(ctx context.Context) <-chan struct{} {
 	ch := make(chan struct{})
 	go func() {
 		c := db.pool.Get()

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -33,5 +33,5 @@ type Backend interface {
 	// Watch returns a channel to the caller. The channel is used to notify
 	// about changes that happen in storage. When ctx is finished, Watch will close
 	// the channel.
-	Watch(ctx context.Context) chan struct{}
+	Watch(ctx context.Context) <-chan struct{}
 }

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -15,7 +15,7 @@ type mockBackend struct {
 	list         func(ctx context.Context, sinceVersion string) ([]*databroker.Record, error)
 	delete       func(ctx context.Context, id string) error
 	clearDeleted func(ctx context.Context, cutoff time.Time)
-	watch        func(ctx context.Context) chan struct{}
+	watch        func(ctx context.Context) <-chan struct{}
 }
 
 func (m *mockBackend) Put(ctx context.Context, id string, data *anypb.Any) error {
@@ -42,6 +42,6 @@ func (m *mockBackend) ClearDeleted(ctx context.Context, cutoff time.Time) {
 	m.clearDeleted(ctx, cutoff)
 }
 
-func (m *mockBackend) Watch(ctx context.Context) chan struct{} {
+func (m *mockBackend) Watch(ctx context.Context) <-chan struct{} {
 	return m.watch(ctx)
 }


### PR DESCRIPTION


## Summary
So the caller can not write to the channel, and insist that the channel
is for notifying only.


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
