### PR TITLE
config: fix loading storage client cert from wrong location

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -597,7 +597,7 @@ func (o *Options) Validate() error {
 	}
 
 	if o.DataBrokerStorageCertFile != "" || o.DataBrokerStorageCertKeyFile != "" {
-		cert, err := cryptutil.CertificateFromFile(o.CertFile, o.KeyFile)
+		cert, err := cryptutil.CertificateFromFile(o.DataBrokerStorageCertFile, o.DataBrokerStorageCertKeyFile)
 		if err != nil {
 			return fmt.Errorf("config: bad databroker cert file %w", err)
 		}


### PR DESCRIPTION
## Summary
Storage certs are being loaded from the wrong options.

**Checklist**:
- [x] ready for review
