### PR TITLE
internal/databroker: make Sync send data in smaller batches

### DIFF
--- a/cache/databroker_test.go
+++ b/cache/databroker_test.go
@@ -1,0 +1,71 @@
+package cache
+
+import (
+	"context"
+	"log"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/golang/protobuf/ptypes"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+
+	internal_databroker "github.com/pomerium/pomerium/internal/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+)
+
+const bufSize = 1024 * 1024
+
+var lis *bufconn.Listener
+
+func init() {
+	lis = bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+	internalSrv := internal_databroker.New()
+	srv := &DataBrokerServer{DataBrokerServiceServer: internalSrv}
+	databroker.RegisterDataBrokerServiceServer(s, srv)
+
+	go func() {
+		if err := s.Serve(lis); err != nil {
+			log.Fatalf("Server exited with error: %v", err)
+		}
+	}()
+}
+
+func bufDialer(context.Context, string) (net.Conn, error) {
+	return lis.Dial()
+}
+
+func BenchmarkSync(b *testing.B) {
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithInsecure())
+	if err != nil {
+		b.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	defer conn.Close()
+	c := databroker.NewDataBrokerServiceClient(conn)
+	any, _ := ptypes.MarshalAny(new(session.Session))
+
+	for i := 0; i < 10000; i++ {
+		c.Set(ctx, &databroker.SetRequest{Type: any.TypeUrl, Id: strconv.Itoa(i), Data: any})
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		client, _ := c.Sync(ctx, &databroker.SyncRequest{Type: any.GetTypeUrl()})
+		count := 0
+		for {
+			res, err := client.Recv()
+			if err != nil {
+				break
+			}
+			count += len(res.Records)
+			if count == 10000 {
+				break
+			}
+		}
+	}
+
+}

--- a/cache/databroker_test.go
+++ b/cache/databroker_test.go
@@ -2,18 +2,21 @@ package cache
 
 import (
 	"context"
-	"log"
 	"net"
 	"strconv"
 	"testing"
 
 	"github.com/golang/protobuf/ptypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/test/bufconn"
 
 	internal_databroker "github.com/pomerium/pomerium/internal/databroker"
+	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/grpc/user"
 )
 
 const bufSize = 1024 * 1024
@@ -29,13 +32,63 @@ func init() {
 
 	go func() {
 		if err := s.Serve(lis); err != nil {
-			log.Fatalf("Server exited with error: %v", err)
+			log.Fatal().Err(err).Msg("Server exited with error")
 		}
 	}()
 }
 
 func bufDialer(context.Context, string) (net.Conn, error) {
 	return lis.Dial()
+}
+
+func TestServerSync(t *testing.T) {
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(bufDialer), grpc.WithInsecure())
+	require.NoError(t, err)
+	defer conn.Close()
+	c := databroker.NewDataBrokerServiceClient(conn)
+	any, _ := ptypes.MarshalAny(new(user.User))
+	numRecords := 200
+
+	for i := 0; i < numRecords; i++ {
+		c.Set(ctx, &databroker.SetRequest{Type: any.TypeUrl, Id: strconv.Itoa(i), Data: any})
+	}
+
+	t.Run("Sync ok", func(t *testing.T) {
+		client, _ := c.Sync(ctx, &databroker.SyncRequest{Type: any.GetTypeUrl()})
+		count := 0
+		for {
+			res, err := client.Recv()
+			if err != nil {
+				break
+			}
+			count += len(res.Records)
+			if count == numRecords {
+				break
+			}
+		}
+	})
+	t.Run("Error occurred while syncing", func(t *testing.T) {
+		ctx, cancelFunc := context.WithCancel(ctx)
+		defer cancelFunc()
+
+		client, _ := c.Sync(ctx, &databroker.SyncRequest{Type: any.GetTypeUrl()})
+		count := 0
+		numRecordsWanted := 100
+		cancelFuncCalled := false
+		for {
+			res, err := client.Recv()
+			if err != nil {
+				assert.True(t, cancelFuncCalled)
+				break
+			}
+			count += len(res.Records)
+			if count == numRecordsWanted {
+				cancelFunc()
+				cancelFuncCalled = true
+			}
+		}
+	})
 }
 
 func BenchmarkSync(b *testing.B) {
@@ -47,8 +100,9 @@ func BenchmarkSync(b *testing.B) {
 	defer conn.Close()
 	c := databroker.NewDataBrokerServiceClient(conn)
 	any, _ := ptypes.MarshalAny(new(session.Session))
+	numRecords := 10000
 
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < numRecords; i++ {
 		c.Set(ctx, &databroker.SetRequest{Type: any.TypeUrl, Id: strconv.Itoa(i), Data: any})
 	}
 
@@ -62,10 +116,9 @@ func BenchmarkSync(b *testing.B) {
 				break
 			}
 			count += len(res.Records)
-			if count == 10000 {
+			if count == numRecords {
 				break
 			}
 		}
 	}
-
 }


### PR DESCRIPTION

## Summary
GRPC streaming is better at sending multiple smaller message instead of
a big one.

Benchmark result for sending 10k messages at once vs multiple batches,
each with 100 messages:

```
name     old time/op  new time/op  delta
Sync-12  14.5ms ± 3%  12.4ms ± 2%  -14.40%  (p=0.000 n=10+9)
```

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
