### PR TITLE
remove rootDomain from examples

### DIFF
--- a/docs/guides/argo.md
+++ b/docs/guides/argo.md
@@ -68,7 +68,6 @@ Like with Argo we will install Pomerium using the [Helm chart](https://github.co
 
 ```yaml
 config:
-  rootDomain: localhost.pomerium.io
   policy:
     - from: https://argo.localhost.pomerium.io
       to: http://argo-server.kube-system.svc.cluster.local:2746

--- a/docs/guides/kubernetes-dashboard.md
+++ b/docs/guides/kubernetes-dashboard.md
@@ -258,7 +258,6 @@ forwardAuth:
 config:
   sharedSecret: YOUR_SHARED_SECRET
   cookieSecret: YOUR_COOKIE_SECRET
-  rootDomain: domain.example
 
   policy:
     # this route is directly proxied by pomerium & injects the authorization header

--- a/examples/kubernetes/values.yaml
+++ b/examples/kubernetes/values.yaml
@@ -19,7 +19,6 @@ service:
   type: NodePort
 
 config:
-  rootDomain: corp.beyondperimeter.com
   policy:
     - from: https://hello.corp.beyondperimeter.com
       to: http://nginx.default.svc.cluster.local:80


### PR DESCRIPTION
The examples had rootDomain, which is not used anymore, as far as I can tell. It confused me for a long time.