### PR TITLE
config: warn if custom scopes set for builtin providers

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -19,6 +19,12 @@ import (
 	"github.com/spf13/viper"
 	"gopkg.in/yaml.v2"
 
+	"github.com/pomerium/pomerium/internal/directory/azure"
+	"github.com/pomerium/pomerium/internal/directory/github"
+	"github.com/pomerium/pomerium/internal/directory/gitlab"
+	"github.com/pomerium/pomerium/internal/directory/google"
+	"github.com/pomerium/pomerium/internal/directory/okta"
+	"github.com/pomerium/pomerium/internal/directory/onelogin"
 	"github.com/pomerium/pomerium/internal/identity/oauth"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry"
@@ -651,6 +657,16 @@ func (o *Options) Validate() error {
 		return fmt.Errorf("config: server must be run with `autocert`, " +
 			"`insecure_server` or manually provided certificates to start")
 	}
+
+	switch o.Provider {
+	case azure.Name, github.Name, gitlab.Name, google.Name, okta.Name, onelogin.Name:
+		if len(o.Scopes) > 0 {
+			docLink := "https://www.pomerium.io/reference/#identity-provider-scopes"
+			log.Warn().Msg("config: using custom scopes may result in undefined behavior, see: " + docLink)
+		}
+	default:
+	}
+
 	return nil
 }
 

--- a/config/options.go
+++ b/config/options.go
@@ -36,6 +36,11 @@ import (
 // DisableHeaderKey is the key used to check whether to disable setting header
 const DisableHeaderKey = "disable"
 
+const (
+	idpCustomScopesDocLink = "https://www.pomerium.io/reference/#identity-provider-scopes"
+	idpCustomScopesWarnMsg = "config: using custom scopes may result in undefined behavior, see: " + idpCustomScopesDocLink
+)
+
 // DefaultAlternativeAddr is the address used is two services are competing over
 // the same listener. Typically this is invisible to the end user (e.g. localhost)
 // gRPC server, or is used for healthchecks (authorize only service)
@@ -661,8 +666,7 @@ func (o *Options) Validate() error {
 	switch o.Provider {
 	case azure.Name, github.Name, gitlab.Name, google.Name, okta.Name, onelogin.Name:
 		if len(o.Scopes) > 0 {
-			docLink := "https://www.pomerium.io/reference/#identity-provider-scopes"
-			log.Warn().Msg("config: using custom scopes may result in undefined behavior, see: " + docLink)
+			log.Warn().Msg(idpCustomScopesWarnMsg)
 		}
 	default:
 	}


### PR DESCRIPTION


## Summary

Warn if custom scopes set for builtin providers.

## Related issues
Fixes #1144


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
