### PR TITLE
.github/workflows: upgrade to go1.15

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.x
+          go-version: 1.15.x
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Lint Dependencies
@@ -28,7 +28,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
         platform: [ubuntu-latest, macos-latest, ubuntu-16.04]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -48,7 +48,7 @@ jobs:
   cover:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -70,7 +70,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.14.x]
+        go-version: [1.15.x]
         platform: [ubuntu-latest, macos-latest, ubuntu-16.04]
     runs-on: ${{ matrix.platform }}
     steps:
@@ -114,7 +114,7 @@ jobs:
       - name: install go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.x
+          go-version: 1.15.x
 
       - name: checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
## Summary

Upgrade CI to use go1.15



**Checklist**:
- [x] ready for review
