### PR TITLE
config: validate databroker settings

### DIFF
--- a/internal/databroker/config_source_test.go
+++ b/internal/databroker/config_source_test.go
@@ -33,11 +33,13 @@ func TestConfigSource(t *testing.T) {
 
 	cfgs := make(chan *config.Config, 10)
 
+	base := config.NewDefaultOptions()
+	base.DataBrokerURL = mustParse("http://" + li.Addr().String())
+	base.InsecureServer = true
+	base.GRPCInsecure = true
+
 	src := NewConfigSource(config.NewStaticSource(&config.Config{
-		Options: &config.Options{
-			DataBrokerURL: mustParse("http://" + li.Addr().String()),
-			GRPCInsecure:  true,
-		},
+		Options: base,
 	}), func(cfg *config.Config) {
 		cfgs <- cfg
 	})


### PR DESCRIPTION
## Summary
I forgot that we need to validate the options after updating them to populate some of the fields. With this change we'll validate the config after we update it in the databroker, and if validation fails we'll continue to use the existing config (and log the error).

Also I noticed we weren't skipping invalid policies like our error message said we were.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
