### PR TITLE
internal/directory/okta: increase default batch size to 200

### DIFF
--- a/internal/directory/okta/okta.go
+++ b/internal/directory/okta/okta.go
@@ -61,7 +61,7 @@ func WithServiceAccount(serviceAccount *ServiceAccount) Option {
 
 func getConfig(options ...Option) *config {
 	cfg := new(config)
-	WithBatchSize(100)(cfg)
+	WithBatchSize(200)(cfg)
 	WithHTTPClient(http.DefaultClient)(cfg)
 	for _, option := range options {
 		option(cfg)


### PR DESCRIPTION




## Summary
See: https://developer.okta.com/docs/reference/api/groups/#list-groups-with-membership-updated-after-timestamp

## Related issues
Updates #1256


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
