### PR TITLE
config: allow dynamic configuration of cookie settings

### DIFF
--- a/authenticate/authenticate_test.go
+++ b/authenticate/authenticate_test.go
@@ -86,9 +86,6 @@ func TestNew(t *testing.T) {
 	badRedirectURL.AuthenticateURL = nil
 	badRedirectURL.CookieName = "B"
 
-	badCookieName := newTestOptions(t)
-	badCookieName.CookieName = ""
-
 	badProvider := newTestOptions(t)
 	badProvider.Provider = ""
 	badProvider.CookieName = "C"
@@ -118,7 +115,6 @@ func TestNew(t *testing.T) {
 		{"good", good, false},
 		{"empty opts", &config.Options{}, true},
 		{"fails to validate", badRedirectURL, true},
-		{"bad cookie name", badCookieName, true},
 		{"bad provider", badProvider, true},
 		{"bad cache url", badGRPCConn, true},
 		{"empty provider url", emptyProviderURL, true},

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -23,18 +23,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
-type atomicOptions struct {
-	value atomic.Value
-}
-
-func (a *atomicOptions) Load() *config.Options {
-	return a.value.Load().(*config.Options)
-}
-
-func (a *atomicOptions) Store(options *config.Options) {
-	a.value.Store(options)
-}
-
 type atomicMarshalUnmarshaler struct {
 	value atomic.Value
 }
@@ -52,7 +40,7 @@ type Authorize struct {
 	pe    *evaluator.Evaluator
 	store *evaluator.Store
 
-	currentOptions atomicOptions
+	currentOptions *config.AtomicOptions
 	currentEncoder atomicMarshalUnmarshaler
 	templates      *template.Template
 
@@ -84,6 +72,7 @@ func New(opts *config.Options) (*Authorize, error) {
 	}
 
 	a := Authorize{
+		currentOptions:   config.NewAtomicOptions(),
 		store:            evaluator.NewStore(),
 		templates:        template.Must(frontend.NewTemplates()),
 		dataBrokerClient: databroker.NewDataBrokerServiceClient(dataBrokerConn),
@@ -99,7 +88,6 @@ func New(opts *config.Options) (*Authorize, error) {
 		return nil, err
 	}
 	a.currentEncoder.Store(encoder)
-	a.currentOptions.Store(new(config.Options))
 	return &a, nil
 }
 

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -35,7 +35,7 @@ func TestAuthorize_okResponse(t *testing.T) {
 		}},
 		JWTClaimsHeaders: []string{"email"},
 	}
-	a := new(Authorize)
+	a := &Authorize{currentOptions: config.NewAtomicOptions()}
 	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0}, "")
 	a.currentEncoder.Store(encoder)
 	a.currentOptions.Store(opt)
@@ -204,7 +204,7 @@ func TestAuthorize_okResponse(t *testing.T) {
 }
 
 func TestAuthorize_deniedResponse(t *testing.T) {
-	a := new(Authorize)
+	a := &Authorize{currentOptions: config.NewAtomicOptions()}
 	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0}, "")
 	a.currentEncoder.Store(encoder)
 	a.currentOptions.Store(&config.Options{

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -47,7 +47,7 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 -----END CERTIFICATE-----`
 
 func Test_getEvaluatorRequest(t *testing.T) {
-	a := new(Authorize)
+	a := &Authorize{currentOptions: config.NewAtomicOptions()}
 	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0}, "")
 	a.currentEncoder.Store(encoder)
 	a.currentOptions.Store(&config.Options{
@@ -273,7 +273,7 @@ func Test_handleForwardAuth(t *testing.T) {
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			a := new(Authorize)
+			a := &Authorize{currentOptions: config.NewAtomicOptions()}
 			var fau *url.URL
 			if tc.forwardAuthURL != "" {
 				fau = mustParseURL(tc.forwardAuthURL)
@@ -288,7 +288,7 @@ func Test_handleForwardAuth(t *testing.T) {
 }
 
 func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
-	a := new(Authorize)
+	a := &Authorize{currentOptions: config.NewAtomicOptions()}
 	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0}, "")
 	a.currentEncoder.Store(encoder)
 	a.currentOptions.Store(&config.Options{

--- a/authorize/session.go
+++ b/authorize/session.go
@@ -52,14 +52,15 @@ func loadSession(encoder encoding.MarshalUnmarshaler, rawJWT []byte) (*sessions.
 }
 
 func getCookieStore(options *config.Options, encoder encoding.MarshalUnmarshaler) (sessions.SessionStore, error) {
-	cookieOptions := &cookie.Options{
-		Name:     options.CookieName,
-		Domain:   options.CookieDomain,
-		Secure:   options.CookieSecure,
-		HTTPOnly: options.CookieHTTPOnly,
-		Expire:   options.CookieExpire,
-	}
-	cookieStore, err := cookie.NewStore(cookieOptions, encoder)
+	cookieStore, err := cookie.NewStore(func() cookie.Options {
+		return cookie.Options{
+			Name:     options.CookieName,
+			Domain:   options.CookieDomain,
+			Secure:   options.CookieSecure,
+			HTTPOnly: options.CookieHTTPOnly,
+			Expire:   options.CookieExpire,
+		}
+	}, encoder)
 	if err != nil {
 		return nil, err
 	}

--- a/authorize/session_test.go
+++ b/authorize/session_test.go
@@ -116,7 +116,7 @@ func TestAuthorize_getJWTClaimHeaders(t *testing.T) {
 			}},
 		}},
 	}
-	a := new(Authorize)
+	a := &Authorize{currentOptions: config.NewAtomicOptions()}
 	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0}, "")
 	a.currentEncoder.Store(encoder)
 	a.currentOptions.Store(opt)

--- a/config/options.go
+++ b/config/options.go
@@ -12,6 +12,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -985,4 +986,26 @@ func min(x, y int) int {
 		return x
 	}
 	return y
+}
+
+// AtomicOptions are Options that can be access atomically.
+type AtomicOptions struct {
+	value atomic.Value
+}
+
+// NewAtomicOptions creates a new AtomicOptions.
+func NewAtomicOptions() *AtomicOptions {
+	ao := new(AtomicOptions)
+	ao.Store(new(Options))
+	return ao
+}
+
+// Load loads the options.
+func (a *AtomicOptions) Load() *Options {
+	return a.value.Load().(*Options)
+}
+
+// Store stores the options.
+func (a *AtomicOptions) Store(options *Options) {
+	a.value.Store(options)
 }

--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -92,7 +92,7 @@ func Run(ctx context.Context, configFile string) error {
 			return err
 		}
 	}
-	if err := setupProxy(cfg.Options, controlPlane); err != nil {
+	if err := setupProxy(src, cfg, controlPlane); err != nil {
 		return err
 	}
 
@@ -174,15 +174,20 @@ func setupCache(opt *config.Options, controlPlane *controlplane.Server) (*cache.
 	return svc, nil
 }
 
-func setupProxy(opt *config.Options, controlPlane *controlplane.Server) error {
-	if !config.IsProxy(opt.Services) {
+func setupProxy(src config.Source, cfg *config.Config, controlPlane *controlplane.Server) error {
+	if !config.IsProxy(cfg.Options.Services) {
 		return nil
 	}
 
-	svc, err := proxy.New(*opt)
+	svc, err := proxy.New(cfg.Options)
 	if err != nil {
 		return fmt.Errorf("error creating proxy service: %w", err)
 	}
 	controlPlane.HTTPRouter.PathPrefix("/").Handler(svc)
+
+	log.Info().Msg("enabled proxy service")
+	src.OnConfigChange(svc.OnConfigChange)
+	svc.OnConfigChange(cfg)
+
 	return nil
 }

--- a/internal/sessions/cookie/cookie_store_test.go
+++ b/internal/sessions/cookie/cookie_store_test.go
@@ -32,13 +32,16 @@ func TestNewStore(t *testing.T) {
 		want    sessions.SessionStore
 		wantErr bool
 	}{
-		{"good", &Options{Name: "_cookie", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}, encoder, &Store{Name: "_cookie", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}, false},
-		{"missing name", &Options{Name: "", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}, encoder, nil, true},
+		{"good", &Options{Name: "_cookie", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}, encoder, &Store{getOptions: func() Options {
+			return Options{Name: "_cookie", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}
+		}}, false},
 		{"missing encoder", &Options{Name: "_cookie", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}, nil, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewStore(tt.opts, tt.encoder)
+			got, err := NewStore(func() Options {
+				return *tt.opts
+			}, tt.encoder)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewStore() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -66,13 +69,16 @@ func TestNewCookieLoader(t *testing.T) {
 		want    *Store
 		wantErr bool
 	}{
-		{"good", &Options{Name: "_cookie", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}, encoder, &Store{Name: "_cookie", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}, false},
-		{"missing name", &Options{Name: "", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}, encoder, nil, true},
+		{"good", &Options{Name: "_cookie", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}, encoder, &Store{getOptions: func() Options {
+			return Options{Name: "_cookie", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}
+		}}, false},
 		{"missing encoder", &Options{Name: "_cookie", Secure: true, HTTPOnly: true, Domain: "pomerium.io", Expire: 10 * time.Second}, nil, nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewCookieLoader(tt.opts, tt.encoder)
+			got, err := NewCookieLoader(func() Options {
+				return *tt.opts
+			}, tt.encoder)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("NewCookieLoader() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -117,13 +123,17 @@ func TestStore_SaveSession(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &Store{
-				Name:     "_pomerium",
-				Secure:   true,
-				HTTPOnly: true,
-				Domain:   "pomerium.io",
-				Expire:   10 * time.Second,
-				encoder:  tt.encoder,
-				decoder:  tt.decoder,
+				getOptions: func() Options {
+					return Options{
+						Name:     "_pomerium",
+						Secure:   true,
+						HTTPOnly: true,
+						Domain:   "pomerium.io",
+						Expire:   10 * time.Second,
+					}
+				},
+				encoder: tt.encoder,
+				decoder: tt.decoder,
 			}
 
 			r := httptest.NewRequest("GET", "/", nil)

--- a/internal/sessions/cookie/middleware_test.go
+++ b/internal/sessions/cookie/middleware_test.go
@@ -65,8 +65,10 @@ func TestVerifier(t *testing.T) {
 				encSession = append(encSession, cryptutil.NewKey()...)
 			}
 
-			cs, err := NewStore(&Options{
-				Name: "_pomerium",
+			cs, err := NewStore(func() Options {
+				return Options{
+					Name: "_pomerium",
+				}
 			}, encoder)
 			if err != nil {
 				t.Fatal(err)

--- a/proxy/forward_auth_test.go
+++ b/proxy/forward_auth_test.go
@@ -47,7 +47,7 @@ func TestProxy_ForwardAuth(t *testing.T) {
 	opts := testOptions(t)
 	tests := []struct {
 		name     string
-		options  config.Options
+		options  *config.Options
 		ctxError error
 		method   string
 
@@ -94,7 +94,7 @@ func TestProxy_ForwardAuth(t *testing.T) {
 				t.Fatal(err)
 			}
 			p.encoder = signer
-			p.UpdateOptions(tt.options)
+			p.OnConfigChange(&config.Config{Options: tt.options})
 			uri, err := url.Parse(tt.requestURI)
 			if err != nil {
 				t.Fatal(err)

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -118,7 +118,7 @@ func TestProxy_Callback(t *testing.T) {
 	opts := testOptions(t)
 	tests := []struct {
 		name    string
-		options config.Options
+		options *config.Options
 
 		method string
 
@@ -227,7 +227,7 @@ func TestProxy_Callback(t *testing.T) {
 			}
 			p.encoder = tt.cipher
 			p.sessionStore = tt.sessionStore
-			p.UpdateOptions(tt.options)
+			p.OnConfigChange(&config.Config{Options: tt.options})
 			redirectURI := &url.URL{Scheme: tt.scheme, Host: tt.host, Path: tt.path}
 			queryString := redirectURI.Query()
 			for k, v := range tt.qp {
@@ -276,7 +276,7 @@ func TestProxy_ProgrammaticLogin(t *testing.T) {
 	opts := testOptions(t)
 	tests := []struct {
 		name    string
-		options config.Options
+		options *config.Options
 
 		method string
 
@@ -337,7 +337,7 @@ func TestProxy_ProgrammaticCallback(t *testing.T) {
 	opts := testOptions(t)
 	tests := []struct {
 		name    string
-		options config.Options
+		options *config.Options
 
 		method string
 
@@ -434,7 +434,7 @@ func TestProxy_ProgrammaticCallback(t *testing.T) {
 			}
 			p.encoder = tt.cipher
 			p.sessionStore = tt.sessionStore
-			p.UpdateOptions(tt.options)
+			p.OnConfigChange(&config.Config{Options: tt.options})
 			redirectURI, _ := url.Parse(tt.redirectURI)
 			queryString := redirectURI.Query()
 			for k, v := range tt.qp {


### PR DESCRIPTION
## Summary
This PR makes the cookie options reloadable. I changed the cookie constructors so they take a getter function instead of the raw options. I also pulled out the `atomicOptions` struct into `config.AtomicOptions` and updated authenticate and proxy to use it.

## Related issues
- #1254 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
