### PR TITLE
docs: use .com sitemap hostname

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -8,8 +8,8 @@ module.exports = {
       pattern: "**/*.md",
     },
     sitemap: {
-      hostname: "https://www.pomerium.io",
-      outFile: "docs/sitemap.xml"
+      hostname: "https://www.pomerium.com",
+      outFile: "docs/sitemap.xml",
     },
     "@vuepress/google-analytics": {
       ga: "UA-129872447-2",


### PR DESCRIPTION
## Summary

Fixes the sitemap to use .com hostname values, not io. 

## Related issues

https://github.com/algolia/docsearch-configs/pull/2289#issuecomment-673323663


**Checklist**:
- [x] updated docs
- [x] ready for review
