### PR TITLE
authenticate: move properties to atomically updated state

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -69,10 +69,6 @@ type Authenticate struct {
 	// authentication flow
 	RedirectURL *url.URL
 
-	// values related to cross service communication
-	//
-	// sharedKey is used to encrypt and authenticate data between services
-	sharedKey string
 	// sharedCipher is used to encrypt data for use between services
 	sharedCipher cipher.AEAD
 	// sharedEncoder is the encoder to use to serialize data to be consumed
@@ -151,14 +147,9 @@ func New(cfg *config.Config) (*Authenticate, error) {
 	redirectURL, _ := urlutil.DeepCopy(cfg.Options.AuthenticateURL)
 	redirectURL.Path = cfg.Options.AuthenticateCallbackPath
 
-	if err != nil {
-		return nil, err
-	}
-
 	a := &Authenticate{
 		RedirectURL: redirectURL,
 		// shared state
-		sharedKey:     cfg.Options.SharedKey,
 		sharedCipher:  sharedCipher,
 		sharedEncoder: sharedEncoder,
 		// private state

--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -88,8 +88,7 @@ type Authenticate struct {
 	// encryptedEncoder is the encoder used to marshal and unmarshal session data
 	encryptedEncoder encoding.MarshalUnmarshaler
 	// sessionStore is the session store used to persist a user's session
-	sessionStore  sessions.SessionStore
-	cookieOptions *cookie.Options
+	sessionStore sessions.SessionStore
 
 	// sessionLoaders are a collection of session loaders to attempt to pull
 	// a user's session state from
@@ -129,14 +128,6 @@ func New(cfg *config.Config) (*Authenticate, error) {
 	cookieCipher, _ := cryptutil.NewAEADCipher(decodedCookieSecret)
 	encryptedEncoder := ecjson.New(cookieCipher)
 
-	cookieOptions := &cookie.Options{
-		Name:     cfg.Options.CookieName,
-		Domain:   cfg.Options.CookieDomain,
-		Secure:   cfg.Options.CookieSecure,
-		HTTPOnly: cfg.Options.CookieHTTPOnly,
-		Expire:   cfg.Options.CookieExpire,
-	}
-
 	dataBrokerConn, err := grpc.NewGRPCClientConn(
 		&grpc.Options{
 			Addr:                    cfg.Options.DataBrokerURL,
@@ -173,7 +164,6 @@ func New(cfg *config.Config) (*Authenticate, error) {
 		// private state
 		cookieSecret:     decodedCookieSecret,
 		cookieCipher:     cookieCipher,
-		cookieOptions:    cookieOptions,
 		encryptedEncoder: encryptedEncoder,
 		// grpc client for cache
 		dataBrokerClient: dataBrokerClient,

--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -3,29 +3,15 @@
 package authenticate
 
 import (
-	"crypto/cipher"
-	"encoding/base64"
 	"errors"
 	"fmt"
 	"html/template"
-	"net/url"
-	"sync"
-
-	"gopkg.in/square/go-jose.v2"
 
 	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/encoding"
-	"github.com/pomerium/pomerium/internal/encoding/ecjson"
-	"github.com/pomerium/pomerium/internal/encoding/jws"
 	"github.com/pomerium/pomerium/internal/frontend"
-	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/identity"
 	"github.com/pomerium/pomerium/internal/identity/oauth"
 	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/internal/sessions"
-	"github.com/pomerium/pomerium/internal/sessions/cookie"
-	"github.com/pomerium/pomerium/internal/sessions/header"
-	"github.com/pomerium/pomerium/internal/sessions/queryparam"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc"
@@ -64,44 +50,14 @@ func ValidateOptions(o *config.Options) error {
 
 // Authenticate contains data required to run the authenticate service.
 type Authenticate struct {
-	// RedirectURL is the authenticate service's externally accessible
-	// url that the identity provider (IdP) will callback to following
-	// authentication flow
-	RedirectURL *url.URL
-
-	// sharedEncoder is the encoder to use to serialize data to be consumed
-	// by other services
-	sharedEncoder encoding.MarshalUnmarshaler
-
-	// values related to user sessions
-	//
-	// cookieSecret is the secret to encrypt and authenticate session data
-	cookieSecret []byte
-	// cookieCipher is the cipher to use to encrypt/decrypt session data
-	cookieCipher cipher.AEAD
-	// encryptedEncoder is the encoder used to marshal and unmarshal session data
-	encryptedEncoder encoding.MarshalUnmarshaler
-	// sessionStore is the session store used to persist a user's session
-	sessionStore sessions.SessionStore
-
-	// sessionLoaders are a collection of session loaders to attempt to pull
-	// a user's session state from
-	sessionLoaders []sessions.SessionLoader
-
 	// dataBrokerClient is used to retrieve sessions
 	dataBrokerClient databroker.DataBrokerServiceClient
-
-	// guard administrator below.
-	administratorMu sync.Mutex
-	// administrators keeps track of administrator users.
-	administrator map[string]struct{}
-
-	jwk *jose.JSONWebKeySet
 
 	templates *template.Template
 
 	options  *config.AtomicOptions
 	provider *identity.AtomicAuthenticator
+	state    *atomicAuthenticateState
 }
 
 // New validates and creates a new authenticate service from a set of Options.
@@ -109,17 +65,6 @@ func New(cfg *config.Config) (*Authenticate, error) {
 	if err := ValidateOptions(cfg.Options); err != nil {
 		return nil, err
 	}
-
-	// shared state encoder setup
-	sharedEncoder, err := jws.NewHS256Signer([]byte(cfg.Options.SharedKey), cfg.Options.GetAuthenticateURL().Host)
-	if err != nil {
-		return nil, err
-	}
-
-	// private state encoder setup, used to encrypt oauth2 tokens
-	decodedCookieSecret, _ := base64.StdEncoding.DecodeString(cfg.Options.CookieSecret)
-	cookieCipher, _ := cryptutil.NewAEADCipher(decodedCookieSecret)
-	encryptedEncoder := ecjson.New(cookieCipher)
 
 	dataBrokerConn, err := grpc.NewGRPCClientConn(
 		&grpc.Options{
@@ -138,26 +83,13 @@ func New(cfg *config.Config) (*Authenticate, error) {
 
 	dataBrokerClient := databroker.NewDataBrokerServiceClient(dataBrokerConn)
 
-	qpStore := queryparam.NewStore(encryptedEncoder, urlutil.QueryProgrammaticToken)
-	headerStore := header.NewStore(encryptedEncoder, httputil.AuthorizationTypePomerium)
-
-	redirectURL, _ := urlutil.DeepCopy(cfg.Options.AuthenticateURL)
-	redirectURL.Path = cfg.Options.AuthenticateCallbackPath
-
 	a := &Authenticate{
-		RedirectURL: redirectURL,
-		// shared state
-		sharedEncoder: sharedEncoder,
-		// private state
-		cookieSecret:     decodedCookieSecret,
-		cookieCipher:     cookieCipher,
-		encryptedEncoder: encryptedEncoder,
 		// grpc client for cache
 		dataBrokerClient: dataBrokerClient,
-		jwk:              &jose.JSONWebKeySet{},
 		templates:        template.Must(frontend.NewTemplates()),
 		options:          config.NewAtomicOptions(),
 		provider:         identity.NewAtomicAuthenticator(),
+		state:            newAtomicAuthenticateState(newAuthenticateState()),
 	}
 
 	err = a.updateProvider(cfg)
@@ -165,46 +97,13 @@ func New(cfg *config.Config) (*Authenticate, error) {
 		return nil, err
 	}
 
-	cookieStore, err := cookie.NewStore(func() cookie.Options {
-		opts := a.options.Load()
-		return cookie.Options{
-			Name:     opts.CookieName,
-			Domain:   opts.CookieDomain,
-			Secure:   opts.CookieSecure,
-			HTTPOnly: opts.CookieHTTPOnly,
-			Expire:   opts.CookieExpire,
-		}
-	}, sharedEncoder)
+	state, err := newAuthenticateStateFromConfig(cfg)
 	if err != nil {
 		return nil, err
 	}
-
-	a.sessionStore = cookieStore
-	a.sessionLoaders = []sessions.SessionLoader{qpStore, headerStore, cookieStore}
-
-	if cfg.Options.SigningKey != "" {
-		decodedCert, err := base64.StdEncoding.DecodeString(cfg.Options.SigningKey)
-		if err != nil {
-			return nil, fmt.Errorf("authenticate: failed to decode signing key: %w", err)
-		}
-		jwk, err := cryptutil.PublicJWKFromBytes(decodedCert, jose.ES256)
-		if err != nil {
-			return nil, fmt.Errorf("authenticate: failed to convert jwks: %w", err)
-		}
-		a.jwk.Keys = append(a.jwk.Keys, *jwk)
-	}
+	a.state.Store(state)
 
 	return a, nil
-}
-
-func (a *Authenticate) setAdminUsers(opts *config.Options) {
-	a.administratorMu.Lock()
-	defer a.administratorMu.Unlock()
-
-	a.administrator = make(map[string]struct{}, len(opts.Administrators))
-	for _, admin := range opts.Administrators {
-		a.administrator[admin] = struct{}{}
-	}
 }
 
 // OnConfigChange updates internal structures based on config.Options
@@ -215,9 +114,13 @@ func (a *Authenticate) OnConfigChange(cfg *config.Config) {
 
 	log.Info().Str("checksum", fmt.Sprintf("%x", cfg.Options.Checksum())).Msg("authenticate: updating options")
 	a.options.Store(cfg.Options)
-	a.setAdminUsers(cfg.Options)
 	if err := a.updateProvider(cfg); err != nil {
 		log.Error().Err(err).Msg("authenticate: failed to update identity provider")
+	}
+	if state, err := newAuthenticateStateFromConfig(cfg); err != nil {
+		log.Error().Err(err).Msg("authenticate: failed to update state")
+	} else {
+		a.state.Store(state)
 	}
 }
 

--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -69,8 +69,6 @@ type Authenticate struct {
 	// authentication flow
 	RedirectURL *url.URL
 
-	// sharedCipher is used to encrypt data for use between services
-	sharedCipher cipher.AEAD
 	// sharedEncoder is the encoder to use to serialize data to be consumed
 	// by other services
 	sharedEncoder encoding.MarshalUnmarshaler
@@ -113,7 +111,6 @@ func New(cfg *config.Config) (*Authenticate, error) {
 	}
 
 	// shared state encoder setup
-	sharedCipher, _ := cryptutil.NewAEADCipherFromBase64(cfg.Options.SharedKey)
 	sharedEncoder, err := jws.NewHS256Signer([]byte(cfg.Options.SharedKey), cfg.Options.GetAuthenticateURL().Host)
 	if err != nil {
 		return nil, err
@@ -150,7 +147,6 @@ func New(cfg *config.Config) (*Authenticate, error) {
 	a := &Authenticate{
 		RedirectURL: redirectURL,
 		// shared state
-		sharedCipher:  sharedCipher,
 		sharedEncoder: sharedEncoder,
 		// private state
 		cookieSecret:     decodedCookieSecret,

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -168,6 +168,11 @@ func (a *Authenticate) SignIn(w http.ResponseWriter, r *http.Request) error {
 
 	options := a.options.Load()
 
+	sharedCipher, err := cryptutil.NewAEADCipherFromBase64(options.SharedKey)
+	if err != nil {
+		return httputil.NewError(http.StatusBadRequest, err)
+	}
+
 	redirectURL, err := urlutil.ParseAndValidateURL(r.FormValue(urlutil.QueryRedirectURI))
 	if err != nil {
 		return httputil.NewError(http.StatusBadRequest, err)
@@ -237,7 +242,7 @@ func (a *Authenticate) SignIn(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	// encrypt our route-based token JWT avoiding any accidental logging
-	encryptedJWT := cryptutil.Encrypt(a.sharedCipher, signedJWT, nil)
+	encryptedJWT := cryptutil.Encrypt(sharedCipher, signedJWT, nil)
 	// base64 our encrypted payload for URL-friendlyness
 	encodedJWT := base64.URLEncoding.EncodeToString(encryptedJWT)
 

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -111,10 +111,6 @@ func TestAuthenticate_Handler(t *testing.T) {
 
 func TestAuthenticate_SignIn(t *testing.T) {
 	t.Parallel()
-	aead, err := chacha20poly1305.NewX(cryptutil.NewKey())
-	if err != nil {
-		t.Fatal(err)
-	}
 	tests := []struct {
 		name string
 
@@ -152,7 +148,6 @@ func TestAuthenticate_SignIn(t *testing.T) {
 				RedirectURL:      uriParseHelper("https://some.example"),
 				sharedEncoder:    tt.encoder,
 				encryptedEncoder: tt.encoder,
-				sharedCipher:     aead,
 				dataBrokerClient: mockDataBrokerServiceClient{
 					get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
 						data, err := ptypes.MarshalAny(&session.Session{
@@ -175,6 +170,7 @@ func TestAuthenticate_SignIn(t *testing.T) {
 				options:  config.NewAtomicOptions(),
 				provider: identity.NewAtomicAuthenticator(),
 			}
+			a.options.Store(&config.Options{SharedKey: base64.StdEncoding.EncodeToString(cryptutil.NewKey())})
 			a.provider.Store(tt.provider)
 			uri := &url.URL{Scheme: tt.scheme, Host: tt.host}
 

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pomerium/pomerium/internal/identity"
 	"github.com/pomerium/pomerium/internal/identity/oidc"
 	"github.com/pomerium/pomerium/internal/sessions"
-	"github.com/pomerium/pomerium/internal/sessions/cookie"
 	mstore "github.com/pomerium/pomerium/internal/sessions/mock"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
@@ -46,8 +45,8 @@ func testAuthenticate() *Authenticate {
 	auth.RedirectURL, _ = url.Parse("https://auth.example.com/oauth/callback")
 	auth.sharedKey = cryptutil.NewBase64Key()
 	auth.cookieSecret = cryptutil.NewKey()
-	auth.cookieOptions = &cookie.Options{Name: "name"}
 	auth.templates = template.Must(frontend.NewTemplates())
+	auth.options = config.NewAtomicOptions()
 	return &auth
 }
 
@@ -153,10 +152,6 @@ func TestAuthenticate_SignIn(t *testing.T) {
 				sharedEncoder:    tt.encoder,
 				encryptedEncoder: tt.encoder,
 				sharedCipher:     aead,
-				cookieOptions: &cookie.Options{
-					Name:   "cookie",
-					Domain: "foo",
-				},
 				dataBrokerClient: mockDataBrokerServiceClient{
 					get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
 						data, err := ptypes.MarshalAny(&session.Session{

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -43,10 +43,12 @@ import (
 func testAuthenticate() *Authenticate {
 	var auth Authenticate
 	auth.RedirectURL, _ = url.Parse("https://auth.example.com/oauth/callback")
-	auth.sharedKey = cryptutil.NewBase64Key()
 	auth.cookieSecret = cryptutil.NewKey()
 	auth.templates = template.Must(frontend.NewTemplates())
 	auth.options = config.NewAtomicOptions()
+	auth.options.Store(&config.Options{
+		SharedKey: cryptutil.NewBase64Key(),
+	})
 	return &auth
 }
 
@@ -148,7 +150,6 @@ func TestAuthenticate_SignIn(t *testing.T) {
 			a := &Authenticate{
 				sessionStore:     tt.session,
 				RedirectURL:      uriParseHelper("https://some.example"),
-				sharedKey:        "secret",
 				sharedEncoder:    tt.encoder,
 				encryptedEncoder: tt.encoder,
 				sharedCipher:     aead,
@@ -171,6 +172,7 @@ func TestAuthenticate_SignIn(t *testing.T) {
 						}, nil
 					},
 				},
+				options:  config.NewAtomicOptions(),
 				provider: identity.NewAtomicAuthenticator(),
 			}
 			a.provider.Store(tt.provider)
@@ -256,6 +258,7 @@ func TestAuthenticate_SignOut(t *testing.T) {
 						}, nil
 					},
 				},
+				options:  config.NewAtomicOptions(),
 				provider: identity.NewAtomicAuthenticator(),
 			}
 			a.provider.Store(tt.provider)
@@ -344,6 +347,7 @@ func TestAuthenticate_OAuthCallback(t *testing.T) {
 				sessionStore:     tt.session,
 				cookieCipher:     aead,
 				encryptedEncoder: signer,
+				options:          config.NewAtomicOptions(),
 				provider:         identity.NewAtomicAuthenticator(),
 			}
 			a.provider.Store(tt.provider)
@@ -461,7 +465,6 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 				t.Fatal(err)
 			}
 			a := Authenticate{
-				sharedKey:        cryptutil.NewBase64Key(),
 				cookieSecret:     cryptutil.NewKey(),
 				RedirectURL:      uriParseHelper("https://authenticate.corp.beyondperimeter.com"),
 				sessionStore:     tt.session,
@@ -487,6 +490,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 						}, nil
 					},
 				},
+				options:  config.NewAtomicOptions(),
 				provider: identity.NewAtomicAuthenticator(),
 			}
 			a.provider.Store(tt.provider)

--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -1,0 +1,128 @@
+package authenticate
+
+import (
+	"crypto/cipher"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"sync/atomic"
+
+	"gopkg.in/square/go-jose.v2"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/encoding"
+	"github.com/pomerium/pomerium/internal/encoding/ecjson"
+	"github.com/pomerium/pomerium/internal/encoding/jws"
+	"github.com/pomerium/pomerium/internal/httputil"
+	"github.com/pomerium/pomerium/internal/sessions"
+	"github.com/pomerium/pomerium/internal/sessions/cookie"
+	"github.com/pomerium/pomerium/internal/sessions/header"
+	"github.com/pomerium/pomerium/internal/sessions/queryparam"
+	"github.com/pomerium/pomerium/internal/urlutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+)
+
+type authenticateState struct {
+	redirectURL *url.URL
+	// administrators keeps track of administrator users.
+	administrators map[string]struct{}
+	// sharedEncoder is the encoder to use to serialize data to be consumed
+	// by other services
+	sharedEncoder encoding.MarshalUnmarshaler
+	// cookieSecret is the secret to encrypt and authenticate session data
+	cookieSecret []byte
+	// cookieCipher is the cipher to use to encrypt/decrypt session data
+	cookieCipher cipher.AEAD
+	// encryptedEncoder is the encoder used to marshal and unmarshal session data
+	encryptedEncoder encoding.MarshalUnmarshaler
+	// sessionStore is the session store used to persist a user's session
+	sessionStore sessions.SessionStore
+	// sessionLoaders are a collection of session loaders to attempt to pull
+	// a user's session state from
+	sessionLoaders []sessions.SessionLoader
+
+	jwk *jose.JSONWebKeySet
+}
+
+func newAuthenticateState() *authenticateState {
+	return &authenticateState{
+		administrators: map[string]struct{}{},
+		jwk:            new(jose.JSONWebKeySet),
+	}
+}
+
+func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, error) {
+	state := &authenticateState{}
+
+	state.redirectURL, _ = urlutil.DeepCopy(cfg.Options.AuthenticateURL)
+	state.redirectURL.Path = cfg.Options.AuthenticateCallbackPath
+
+	state.administrators = make(map[string]struct{}, len(cfg.Options.Administrators))
+	for _, admin := range cfg.Options.Administrators {
+		state.administrators[admin] = struct{}{}
+	}
+
+	// shared state encoder setup
+	var err error
+	state.sharedEncoder, err = jws.NewHS256Signer([]byte(cfg.Options.SharedKey), cfg.Options.GetAuthenticateURL().Host)
+	if err != nil {
+		return nil, err
+	}
+
+	// private state encoder setup, used to encrypt oauth2 tokens
+	state.cookieSecret, _ = base64.StdEncoding.DecodeString(cfg.Options.CookieSecret)
+	state.cookieCipher, _ = cryptutil.NewAEADCipher(state.cookieSecret)
+	state.encryptedEncoder = ecjson.New(state.cookieCipher)
+
+	qpStore := queryparam.NewStore(state.encryptedEncoder, urlutil.QueryProgrammaticToken)
+	headerStore := header.NewStore(state.encryptedEncoder, httputil.AuthorizationTypePomerium)
+
+	cookieStore, err := cookie.NewStore(func() cookie.Options {
+		return cookie.Options{
+			Name:     cfg.Options.CookieName,
+			Domain:   cfg.Options.CookieDomain,
+			Secure:   cfg.Options.CookieSecure,
+			HTTPOnly: cfg.Options.CookieHTTPOnly,
+			Expire:   cfg.Options.CookieExpire,
+		}
+	}, state.sharedEncoder)
+	if err != nil {
+		return nil, err
+	}
+
+	state.sessionStore = cookieStore
+	state.sessionLoaders = []sessions.SessionLoader{qpStore, headerStore, cookieStore}
+
+	state.jwk = new(jose.JSONWebKeySet)
+	if cfg.Options.SigningKey != "" {
+		decodedCert, err := base64.StdEncoding.DecodeString(cfg.Options.SigningKey)
+		if err != nil {
+			return nil, fmt.Errorf("authenticate: failed to decode signing key: %w", err)
+		}
+		jwk, err := cryptutil.PublicJWKFromBytes(decodedCert, jose.ES256)
+		if err != nil {
+			return nil, fmt.Errorf("authenticate: failed to convert jwks: %w", err)
+		}
+		state.jwk.Keys = append(state.jwk.Keys, *jwk)
+	}
+
+	return state, nil
+}
+
+type atomicAuthenticateState struct {
+	atomic.Value
+}
+
+func newAtomicAuthenticateState(state *authenticateState) *atomicAuthenticateState {
+	aas := new(atomicAuthenticateState)
+	aas.Store(state)
+	return aas
+}
+
+func (aas *atomicAuthenticateState) Load() *authenticateState {
+	return aas.Value.Load().(*authenticateState)
+}
+
+func (aas *atomicAuthenticateState) Store(state *authenticateState) {
+	aas.Value.Store(state)
+}

--- a/pkg/cryptutil/encrypt.go
+++ b/pkg/cryptutil/encrypt.go
@@ -14,7 +14,6 @@ func NewAEADCipher(secret []byte) (cipher.AEAD, error) {
 		return nil, fmt.Errorf("cryptutil: got %d bytes but want 32", len(secret))
 	}
 	return chacha20poly1305.NewX(secret)
-
 }
 
 // NewAEADCipherFromBase64 takes a base64 encoded secret key and returns a new XChacha20poly1305 cipher.


### PR DESCRIPTION
## Summary
This change moves most of the properties on the Authenticate struct into a seperate authenticateState struct so they can be updated whenever configuration changes.

## Related issues
#1254 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
