### PR TITLE
autocert: fix  bootstrapped cache store path

### DIFF
--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -20,6 +20,7 @@ import (
 var (
 	errObtainCertFailed = errors.New("obtain cert failed")
 	errRenewCertFailed  = errors.New("renew cert failed")
+	defaultStorage      = &certmagic.FileStorage{Path: dataDir()}
 )
 
 // Manager manages TLS certificates.
@@ -37,6 +38,12 @@ type Manager struct {
 
 // New creates a new autocert manager.
 func New(src config.Source) (*Manager, error) {
+	// set certmagic default storage cache, otherwise cert renewal loop will be based off
+	// certmagic's own default location
+	certmagic.Default.Storage = &certmagic.FileStorage{
+		Path: src.GetConfig().Options.AutocertOptions.Folder,
+	}
+
 	mgr := &Manager{
 		src:       src,
 		certmagic: certmagic.NewDefault(),

--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -20,7 +20,6 @@ import (
 var (
 	errObtainCertFailed = errors.New("obtain cert failed")
 	errRenewCertFailed  = errors.New("renew cert failed")
-	defaultStorage      = &certmagic.FileStorage{Path: dataDir()}
 )
 
 // Manager manages TLS certificates.


### PR DESCRIPTION
## Summary

These changes ensure that autocert is being bootstrapped with the correct cache store location. Previously, we were using NewDefaults and inadvertently setting the cert renewal thread to look in the wrong  storage location. 


## Related issues

Fixes #1281 

## See also

https://github.com/caddyserver/certmagic/blob/10a8b5c72339665fa9fbdb180236cd64b13337b3/certmagic.go#L423-L442


**Checklist**:
- [x] add related issues
- [x] ready for review
