### PR TITLE
Upgrade zipkin-go to v0.2.3

### DIFF
--- a/config/trace_test.go
+++ b/config/trace_test.go
@@ -117,8 +117,7 @@ func TestTraceManager(t *testing.T) {
 		TracingSampleRate: 1,
 	}})
 
-	mgr := NewTraceManager(src)
-	_ = mgr
+	_ = NewTraceManager(src)
 
 	_, span := trace.StartSpan(ctx, "Example")
 	span.End()
@@ -133,8 +132,8 @@ func TestTraceManager(t *testing.T) {
 	span.End()
 
 	expect := map[Request]struct{}{
-		{Name: "Example", URL: srv1.Listener.Addr().String()}: {},
-		{Name: "Example", URL: srv2.Listener.Addr().String()}: {},
+		{Name: "example", URL: srv1.Listener.Addr().String()}: {},
+		{Name: "example", URL: srv2.Listener.Addr().String()}: {},
 	}
 
 	for len(expect) > 0 {

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/onsi/gocleanup v0.0.0-20140331211545-c1a5478700b5
 	github.com/onsi/gomega v1.8.1 // indirect
 	github.com/open-policy-agent/opa v0.22.0
-	github.com/openzipkin/zipkin-go v0.2.2
+	github.com/openzipkin/zipkin-go v0.2.3
 	github.com/ory/dockertest/v3 v3.6.0
 	github.com/pelletier/go-toml v1.6.0 // indirect
 	github.com/pomerium/csrf v1.6.2-0.20190918035251-f3318380bad3

--- a/go.sum
+++ b/go.sum
@@ -431,6 +431,8 @@ github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rm
 github.com/openzipkin/zipkin-go v0.1.6/go.mod h1:QgAqvLzwWbR/WpD4A3cGpPtJrZXNIiJc5AZX7/PBEpw=
 github.com/openzipkin/zipkin-go v0.2.2 h1:nY8Hti+WKaP0cRsSeQ026wU03QsM762XBeCXBb9NAWI=
 github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnhQw8ySjnjRyN4=
+github.com/openzipkin/zipkin-go v0.2.3 h1:Ygv80onOuzQTaRs7aZGwPut9nkEXoNtluU1yuIGI67c=
+github.com/openzipkin/zipkin-go v0.2.3/go.mod h1:uEP5ksAmClUBnhP2JY/Km6gfQ5JCNS1WLrVYLnvDC0M=
 github.com/oracle/oci-go-sdk v7.0.0+incompatible/go.mod h1:VQb79nF8Z2cwLkLS35ukwStZIg5F66tcBccjip/j888=
 github.com/ory/dockertest/v3 v3.6.0 h1:I6KNJ6izxGduLACQii2SP/g7GN0JM9Xfaik6aAVaw6Y=
 github.com/ory/dockertest/v3 v3.6.0/go.mod h1:4ZOpj8qBUmh8fcBSVzkH2bws2s91JdGvHUqan4GHEuQ=


### PR DESCRIPTION


## Summary
Test needs to be changed to use lowercase name, as required by zipkin
JSON API v2 spec.

See: https://github.com/openzipkin/zipkin-go/pull/166



**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
