### PR TITLE
authenticate: move databroker connection to state

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -482,8 +482,7 @@ func (a *Authenticate) deleteSession(ctx context.Context, sessionID string) erro
 	if state.dataBrokerClient == nil {
 		return nil
 	}
-	err := session.Delete(ctx, state.dataBrokerClient, sessionID)
-	return err
+	return session.Delete(ctx, state.dataBrokerClient, sessionID)
 }
 
 func (a *Authenticate) isAdmin(user string) bool {

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -478,10 +478,6 @@ func (a *Authenticate) getSessionFromCtx(ctx context.Context) (*sessions.State, 
 
 func (a *Authenticate) deleteSession(ctx context.Context, sessionID string) error {
 	state := a.state.Load()
-
-	if state.dataBrokerClient == nil {
-		return nil
-	}
 	return session.Delete(ctx, state.dataBrokerClient, sessionID)
 }
 
@@ -563,11 +559,6 @@ func (a *Authenticate) Dashboard(w http.ResponseWriter, r *http.Request) error {
 
 func (a *Authenticate) saveSessionToDataBroker(ctx context.Context, sessionState *sessions.State, accessToken *oauth2.Token) error {
 	state := a.state.Load()
-
-	if state.dataBrokerClient == nil {
-		return nil
-	}
-
 	options := a.options.Load()
 
 	sessionExpiry, _ := ptypes.TimestampProto(time.Now().Add(options.CookieExpire))

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -348,6 +348,14 @@ func TestAuthenticate_OAuthCallback(t *testing.T) {
 			authURL, _ := url.Parse(tt.authenticateURL)
 			a := &Authenticate{
 				state: newAtomicAuthenticateState(&authenticateState{
+					dataBrokerClient: mockDataBrokerServiceClient{
+						get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
+							return nil, fmt.Errorf("not implemented")
+						},
+						set: func(ctx context.Context, in *databroker.SetRequest, opts ...grpc.CallOption) (*databroker.SetResponse, error) {
+							return &databroker.SetResponse{Record: &databroker.Record{Data: in.Data}}, nil
+						},
+					},
 					redirectURL:      authURL,
 					sessionStore:     tt.session,
 					cookieCipher:     aead,
@@ -647,6 +655,7 @@ type mockDataBrokerServiceClient struct {
 
 	delete func(ctx context.Context, in *databroker.DeleteRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	get    func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error)
+	set    func(ctx context.Context, in *databroker.SetRequest, opts ...grpc.CallOption) (*databroker.SetResponse, error)
 }
 
 func (m mockDataBrokerServiceClient) Delete(ctx context.Context, in *databroker.DeleteRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
@@ -655,4 +664,8 @@ func (m mockDataBrokerServiceClient) Delete(ctx context.Context, in *databroker.
 
 func (m mockDataBrokerServiceClient) Get(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
 	return m.get(ctx, in, opts...)
+}
+
+func (m mockDataBrokerServiceClient) Set(ctx context.Context, in *databroker.SetRequest, opts ...grpc.CallOption) (*databroker.SetResponse, error) {
+	return m.set(ctx, in, opts...)
 }

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -152,26 +152,27 @@ func TestAuthenticate_SignIn(t *testing.T) {
 					redirectURL:      uriParseHelper("https://some.example"),
 					sharedEncoder:    tt.encoder,
 					encryptedEncoder: tt.encoder,
-				}),
-				dataBrokerClient: mockDataBrokerServiceClient{
-					get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
-						data, err := ptypes.MarshalAny(&session.Session{
-							Id: "SESSION_ID",
-						})
-						if err != nil {
-							return nil, err
-						}
+					dataBrokerClient: mockDataBrokerServiceClient{
+						get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
+							data, err := ptypes.MarshalAny(&session.Session{
+								Id: "SESSION_ID",
+							})
+							if err != nil {
+								return nil, err
+							}
 
-						return &databroker.GetResponse{
-							Record: &databroker.Record{
-								Version: "0001",
-								Type:    data.GetTypeUrl(),
-								Id:      "SESSION_ID",
-								Data:    data,
-							},
-						}, nil
+							return &databroker.GetResponse{
+								Record: &databroker.Record{
+									Version: "0001",
+									Type:    data.GetTypeUrl(),
+									Id:      "SESSION_ID",
+									Data:    data,
+								},
+							}, nil
+						},
 					},
-				},
+				}),
+
 				options:  config.NewAtomicOptions(),
 				provider: identity.NewAtomicAuthenticator(),
 			}
@@ -237,32 +238,32 @@ func TestAuthenticate_SignOut(t *testing.T) {
 					sessionStore:     tt.sessionStore,
 					encryptedEncoder: mock.Encoder{},
 					sharedEncoder:    mock.Encoder{},
+					dataBrokerClient: mockDataBrokerServiceClient{
+						delete: func(ctx context.Context, in *databroker.DeleteRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+							return nil, nil
+						},
+						get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
+							data, err := ptypes.MarshalAny(&session.Session{
+								Id: "SESSION_ID",
+							})
+							if err != nil {
+								return nil, err
+							}
+
+							return &databroker.GetResponse{
+								Record: &databroker.Record{
+									Version: "0001",
+									Type:    data.GetTypeUrl(),
+									Id:      "SESSION_ID",
+									Data:    data,
+								},
+							}, nil
+						},
+					},
 				}),
 				templates: template.Must(frontend.NewTemplates()),
-				dataBrokerClient: mockDataBrokerServiceClient{
-					delete: func(ctx context.Context, in *databroker.DeleteRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
-						return nil, nil
-					},
-					get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
-						data, err := ptypes.MarshalAny(&session.Session{
-							Id: "SESSION_ID",
-						})
-						if err != nil {
-							return nil, err
-						}
-
-						return &databroker.GetResponse{
-							Record: &databroker.Record{
-								Version: "0001",
-								Type:    data.GetTypeUrl(),
-								Id:      "SESSION_ID",
-								Data:    data,
-							},
-						}, nil
-					},
-				},
-				options:  config.NewAtomicOptions(),
-				provider: identity.NewAtomicAuthenticator(),
+				options:   config.NewAtomicOptions(),
+				provider:  identity.NewAtomicAuthenticator(),
 			}
 			a.provider.Store(tt.provider)
 			u, _ := url.Parse("/sign_out")
@@ -477,26 +478,26 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 					cookieCipher:     aead,
 					encryptedEncoder: signer,
 					sharedEncoder:    signer,
-				}),
-				dataBrokerClient: mockDataBrokerServiceClient{
-					get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
-						data, err := ptypes.MarshalAny(&session.Session{
-							Id: "SESSION_ID",
-						})
-						if err != nil {
-							return nil, err
-						}
+					dataBrokerClient: mockDataBrokerServiceClient{
+						get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
+							data, err := ptypes.MarshalAny(&session.Session{
+								Id: "SESSION_ID",
+							})
+							if err != nil {
+								return nil, err
+							}
 
-						return &databroker.GetResponse{
-							Record: &databroker.Record{
-								Version: "0001",
-								Type:    data.GetTypeUrl(),
-								Id:      "SESSION_ID",
-								Data:    data,
-							},
-						}, nil
+							return &databroker.GetResponse{
+								Record: &databroker.Record{
+									Version: "0001",
+									Type:    data.GetTypeUrl(),
+									Id:      "SESSION_ID",
+									Data:    data,
+								},
+							}, nil
+						},
 					},
-				},
+				}),
 				options:  config.NewAtomicOptions(),
 				provider: identity.NewAtomicAuthenticator(),
 			}
@@ -593,29 +594,29 @@ func TestAuthenticate_Dashboard(t *testing.T) {
 					sessionStore:     tt.sessionStore,
 					encryptedEncoder: signer,
 					sharedEncoder:    signer,
+					dataBrokerClient: mockDataBrokerServiceClient{
+						get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
+							data, err := ptypes.MarshalAny(&session.Session{
+								Id:      "SESSION_ID",
+								UserId:  "USER_ID",
+								IdToken: &session.IDToken{IssuedAt: pbNow},
+							})
+							if err != nil {
+								return nil, err
+							}
+
+							return &databroker.GetResponse{
+								Record: &databroker.Record{
+									Version: "0001",
+									Type:    data.GetTypeUrl(),
+									Id:      "SESSION_ID",
+									Data:    data,
+								},
+							}, nil
+						},
+					},
 				}),
 				templates: template.Must(frontend.NewTemplates()),
-				dataBrokerClient: mockDataBrokerServiceClient{
-					get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
-						data, err := ptypes.MarshalAny(&session.Session{
-							Id:      "SESSION_ID",
-							UserId:  "USER_ID",
-							IdToken: &session.IDToken{IssuedAt: pbNow},
-						})
-						if err != nil {
-							return nil, err
-						}
-
-						return &databroker.GetResponse{
-							Record: &databroker.Record{
-								Version: "0001",
-								Type:    data.GetTypeUrl(),
-								Id:      "SESSION_ID",
-								Data:    data,
-							},
-						}, nil
-					},
-				},
 			}
 			u, _ := url.Parse("/")
 			r := httptest.NewRequest(tt.method, u.String(), nil)

--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -56,7 +56,8 @@ func newAuthenticateState() *authenticateState {
 }
 
 func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, error) {
-	if err := ValidateOptions(cfg.Options); err != nil {
+	err := ValidateOptions(cfg.Options)
+	if err != nil {
 		return nil, err
 	}
 
@@ -71,7 +72,6 @@ func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, err
 	}
 
 	// shared state encoder setup
-	var err error
 	state.sharedEncoder, err = jws.NewHS256Signer([]byte(cfg.Options.SharedKey), cfg.Options.GetAuthenticateURL().Host)
 	if err != nil {
 		return nil, err

--- a/go.sum
+++ b/go.sum
@@ -870,8 +870,6 @@ google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEY
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200808173500-a06252235341 h1:Kceb+1TNS2X7Cj/A+IUTljNerF/4wOFjlFJ0RGHYKKE=
-google.golang.org/genproto v0.0.0-20200808173500-a06252235341/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70 h1:wboULUXGF3c5qdUnKp+6gLAccE6PRpa/czkYvQ4UXv8=
 google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=


### PR DESCRIPTION
## Summary
This PR moves the databroker connection in authenticate to the state. This way if the connection changes it will pick up the new connection automatically.

I also added a call to `ValidateOptions` every time we rebuild the state.

## Related issues
- #1254 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
