### PR TITLE
cache: support databroker option changes

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pomerium/pomerium/internal/directory"
 	"github.com/pomerium/pomerium/internal/identity"
 	"github.com/pomerium/pomerium/internal/identity/manager"
+	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
@@ -35,18 +36,7 @@ type Cache struct {
 }
 
 // New creates a new cache service.
-func New(opts config.Options) (*Cache, error) {
-	if err := validate(opts); err != nil {
-		return nil, fmt.Errorf("cache: bad option: %w", err)
-	}
-
-	authenticator, err := identity.NewAuthenticator(opts.GetOauthOptions())
-	if err != nil {
-		return nil, fmt.Errorf("cache: failed to create authenticator: %w", err)
-	}
-
-	directoryProvider := directory.GetProvider(&opts)
-
+func New(cfg *config.Config) (*Cache, error) {
 	localListener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
@@ -56,7 +46,7 @@ func New(opts config.Options) (*Cache, error) {
 	// if we no longer register with that grpc Server
 	localGRPCServer := grpc.NewServer()
 
-	clientStatsHandler := telemetry.NewGRPCClientStatsHandler(opts.Services)
+	clientStatsHandler := telemetry.NewGRPCClientStatsHandler(cfg.Options.Services)
 	clientDialOptions := clientStatsHandler.DialOptions(grpc.WithInsecure())
 
 	localGRPCConnection, err := grpc.DialContext(
@@ -68,30 +58,33 @@ func New(opts config.Options) (*Cache, error) {
 		return nil, err
 	}
 
-	dataBrokerServer, err := NewDataBrokerServer(localGRPCServer, opts)
-	if err != nil {
-		return nil, err
-	}
-	dataBrokerClient := databroker.NewDataBrokerServiceClient(localGRPCConnection)
+	dataBrokerServer := NewDataBrokerServer(localGRPCServer, cfg)
 
-	manager := manager.New(
-		authenticator,
-		directoryProvider,
-		dataBrokerClient,
-		manager.WithGroupRefreshInterval(opts.RefreshDirectoryInterval),
-		manager.WithGroupRefreshTimeout(opts.RefreshDirectoryTimeout),
-	)
-
-	return &Cache{
-		dataBrokerServer: dataBrokerServer,
-		manager:          manager,
-
+	c := &Cache{
+		dataBrokerServer:             dataBrokerServer,
 		localListener:                localListener,
 		localGRPCServer:              localGRPCServer,
 		localGRPCConnection:          localGRPCConnection,
-		deprecatedCacheClusterDomain: opts.GetDataBrokerURL().Hostname(),
-		dataBrokerStorageType:        opts.DataBrokerStorageType,
-	}, nil
+		deprecatedCacheClusterDomain: cfg.Options.GetDataBrokerURL().Hostname(),
+		dataBrokerStorageType:        cfg.Options.DataBrokerStorageType,
+	}
+
+	err = c.update(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}
+
+// OnConfigChange is called whenever configuration is changed.
+func (c *Cache) OnConfigChange(cfg *config.Config) {
+	err := c.update(cfg)
+	if err != nil {
+		log.Error().Err(err).Msg("cache: error updating configuration")
+	}
+
+	c.dataBrokerServer.OnConfigChange(cfg)
 }
 
 // Register registers all the gRPC services with the given server.
@@ -121,9 +114,45 @@ func (c *Cache) Run(ctx context.Context) error {
 	return t.Wait()
 }
 
+func (c *Cache) update(cfg *config.Config) error {
+	if err := validate(cfg.Options); err != nil {
+		return fmt.Errorf("cache: bad option: %w", err)
+	}
+
+	authenticator, err := identity.NewAuthenticator(cfg.Options.GetOauthOptions())
+	if err != nil {
+		return fmt.Errorf("cache: failed to create authenticator: %w", err)
+	}
+
+	directoryProvider := directory.GetProvider(directory.Options{
+		ServiceAccount: cfg.Options.ServiceAccount,
+		Provider:       cfg.Options.Provider,
+		ProviderURL:    cfg.Options.ProviderURL,
+		QPS:            cfg.Options.QPS,
+	})
+
+	dataBrokerClient := databroker.NewDataBrokerServiceClient(c.localGRPCConnection)
+
+	options := []manager.Option{
+		manager.WithAuthenticator(authenticator),
+		manager.WithDirectoryProvider(directoryProvider),
+		manager.WithDataBrokerClient(dataBrokerClient),
+		manager.WithGroupRefreshInterval(cfg.Options.RefreshDirectoryInterval),
+		manager.WithGroupRefreshTimeout(cfg.Options.RefreshDirectoryTimeout),
+	}
+
+	if c.manager == nil {
+		c.manager = manager.New(options...)
+	} else {
+		c.manager.UpdateConfig(options...)
+	}
+
+	return nil
+}
+
 // validate checks that proper configuration settings are set to create
 // a cache instance
-func validate(o config.Options) error {
+func validate(o *config.Options) error {
 	if _, err := cryptutil.NewAEADCipherFromBase64(o.SharedKey); err != nil {
 		return fmt.Errorf("invalid 'SHARED_SECRET': %w", err)
 	}

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -30,7 +30,7 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.opts.Provider = "google"
-			_, err := New(tt.opts)
+			_, err := New(&config.Config{Options: &tt.opts})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cache/databroker.go
+++ b/cache/databroker.go
@@ -1,55 +1,38 @@
 package cache
 
 import (
-	"crypto/tls"
-	"crypto/x509"
-	"encoding/base64"
-	"fmt"
-	"io/ioutil"
-
 	"google.golang.org/grpc"
 
 	"github.com/pomerium/pomerium/config"
-	internal_databroker "github.com/pomerium/pomerium/internal/databroker"
-	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/pkg/cryptutil"
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/internal/databroker"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
 // A DataBrokerServer implements the data broker service interface.
 type DataBrokerServer struct {
-	databroker.DataBrokerServiceServer
+	*databroker.Server
 }
 
 // NewDataBrokerServer creates a new databroker service server.
-func NewDataBrokerServer(grpcServer *grpc.Server, opts config.Options) (*DataBrokerServer, error) {
-	key, err := base64.StdEncoding.DecodeString(opts.SharedKey)
-	if err != nil || len(key) != cryptutil.DefaultKeySize {
-		return nil, fmt.Errorf("shared key is required and must be %d bytes long", cryptutil.DefaultKeySize)
-	}
+func NewDataBrokerServer(grpcServer *grpc.Server, cfg *config.Config) *DataBrokerServer {
+	srv := &DataBrokerServer{}
+	srv.Server = databroker.New(srv.getOptions(cfg)...)
+	databrokerpb.RegisterDataBrokerServiceServer(grpcServer, srv)
+	return srv
+}
 
-	caCertPool := x509.NewCertPool()
-	if caCert, err := ioutil.ReadFile(opts.DataBrokerStorageCAFile); err == nil {
-		caCertPool.AppendCertsFromPEM(caCert)
-	} else {
-		log.Warn().Err(err).Msg("failed to read databroker CA file")
-	}
-	tlsConfig := &tls.Config{
-		RootCAs: caCertPool,
-		// nolint: gosec
-		InsecureSkipVerify: opts.DataBrokerStorageCertSkipVerify,
-	}
-	if opts.DataBrokerCertificate != nil {
-		tlsConfig.Certificates = []tls.Certificate{*opts.DataBrokerCertificate}
-	}
+// OnConfigChange updates the underlying databroker server whenever configuration is changed.
+func (srv *DataBrokerServer) OnConfigChange(cfg *config.Config) {
+	srv.UpdateConfig(srv.getOptions(cfg)...)
+}
 
-	internalSrv := internal_databroker.New(
-		internal_databroker.WithSecret(key),
-		internal_databroker.WithStorageType(opts.DataBrokerStorageType),
-		internal_databroker.WithStorageConnectionString(opts.DataBrokerStorageConnectionString),
-		internal_databroker.WithStorageTLSConfig(tlsConfig),
-	)
-	srv := &DataBrokerServer{DataBrokerServiceServer: internalSrv}
-	databroker.RegisterDataBrokerServiceServer(grpcServer, srv)
-	return srv, nil
+func (srv *DataBrokerServer) getOptions(cfg *config.Config) []databroker.ServerOption {
+	return []databroker.ServerOption{
+		databroker.WithSharedKey(cfg.Options.SharedKey),
+		databroker.WithStorageType(cfg.Options.DataBrokerStorageType),
+		databroker.WithStorageConnectionString(cfg.Options.DataBrokerStorageConnectionString),
+		databroker.WithStorageCAFile(cfg.Options.DataBrokerStorageCAFile),
+		databroker.WithStorageCertificate(cfg.Options.DataBrokerCertificate),
+		databroker.WithStorageCertSkipVerify(cfg.Options.DataBrokerStorageCertSkipVerify),
+	}
 }

--- a/cache/databroker_test.go
+++ b/cache/databroker_test.go
@@ -27,7 +27,7 @@ func init() {
 	lis = bufconn.Listen(bufSize)
 	s := grpc.NewServer()
 	internalSrv := internal_databroker.New()
-	srv := &DataBrokerServer{DataBrokerServiceServer: internalSrv}
+	srv := &DataBrokerServer{Server: internalSrv}
 	databroker.RegisterDataBrokerServiceServer(s, srv)
 
 	go func() {

--- a/cache/memberlist_test.go
+++ b/cache/memberlist_test.go
@@ -15,10 +15,12 @@ import (
 )
 
 func TestCache_runMemberList(t *testing.T) {
-	c, err := New(config.Options{
-		SharedKey:     cryptutil.NewBase64Key(),
-		DataBrokerURL: &url.URL{Scheme: "http", Host: "member1"},
-		Provider:      "google",
+	c, err := New(&config.Config{
+		Options: &config.Options{
+			SharedKey:     cryptutil.NewBase64Key(),
+			DataBrokerURL: &url.URL{Scheme: "http", Host: "member1"},
+			Provider:      "google",
+		},
 	})
 	require.NoError(t, err)
 

--- a/go.sum
+++ b/go.sum
@@ -870,8 +870,6 @@ google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEY
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200808173500-a06252235341 h1:Kceb+1TNS2X7Cj/A+IUTljNerF/4wOFjlFJ0RGHYKKE=
-google.golang.org/genproto v0.0.0-20200808173500-a06252235341/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70 h1:wboULUXGF3c5qdUnKp+6gLAccE6PRpa/czkYvQ4UXv8=
 google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=

--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -88,7 +88,7 @@ func Run(ctx context.Context, configFile string) error {
 	}
 	var cacheServer *cache.Cache
 	if config.IsCache(cfg.Options.Services) {
-		cacheServer, err = setupCache(cfg.Options, controlPlane)
+		cacheServer, err = setupCache(src, cfg, controlPlane)
 		if err != nil {
 			return err
 		}
@@ -162,13 +162,15 @@ func setupAuthorize(src config.Source, cfg *config.Config, controlPlane *control
 	return svc, nil
 }
 
-func setupCache(opt *config.Options, controlPlane *controlplane.Server) (*cache.Cache, error) {
-	svc, err := cache.New(*opt)
+func setupCache(src config.Source, cfg *config.Config, controlPlane *controlplane.Server) (*cache.Cache, error) {
+	svc, err := cache.New(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("error creating config service: %w", err)
 	}
 	svc.Register(controlPlane.GRPCServer)
 	log.Info().Msg("enabled cache service")
+	src.OnConfigChange(svc.OnConfigChange)
+	svc.OnConfigChange(cfg)
 	return svc, nil
 }
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -12,6 +12,9 @@ import (
 
 // Backend is the interface required for a storage backend.
 type Backend interface {
+	// Close closes the backend.
+	Close() error
+
 	// Put is used to insert or update a record.
 	Put(ctx context.Context, id string, data *anypb.Any) error
 

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"time"
 
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
 type mockBackend struct {
@@ -16,6 +17,10 @@ type mockBackend struct {
 	delete       func(ctx context.Context, id string) error
 	clearDeleted func(ctx context.Context, cutoff time.Time)
 	watch        func(ctx context.Context) <-chan struct{}
+}
+
+func (m *mockBackend) Close() error {
+	return nil
 }
 
 func (m *mockBackend) Put(ctx context.Context, id string, data *anypb.Any) error {


### PR DESCRIPTION
## Summary
This updates the cache (databroker) service to update the internal databroker server whenever configuration options change.

To implement this I added `Close` methods to `redis`/`inmemory` and re-create the databases if the options change such that a rebuild is necessary. In the case of `inmemory` this would cause all data to be erased, but for redis the switchover should be largely invisible.

Many of the databroker options aren't available in the dashboard currently but we will likely want to add them.

## Related issues
- #1254 

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
