### PR TITLE
internal/directory/okta: fix wrong API query filter

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -138,3 +138,5 @@ jobs:
       - uses: pre-commit/action@release
         with:
           extra_args: --show-diff-on-failure --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
+        env:
+          SKIP: lint

--- a/go.sum
+++ b/go.sum
@@ -870,8 +870,6 @@ google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEY
 google.golang.org/genproto v0.0.0-20200618031413-b414f8b61790/go.mod h1:jDfRM7FcilCzHH/e9qn6dsT145K34l5v+OpcnNgKAAA=
 google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
-google.golang.org/genproto v0.0.0-20200808173500-a06252235341 h1:Kceb+1TNS2X7Cj/A+IUTljNerF/4wOFjlFJ0RGHYKKE=
-google.golang.org/genproto v0.0.0-20200808173500-a06252235341/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70 h1:wboULUXGF3c5qdUnKp+6gLAccE6PRpa/czkYvQ4UXv8=
 google.golang.org/genproto v0.0.0-20200815001618-f69a88009b70/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=

--- a/internal/directory/okta/okta_test.go
+++ b/internal/directory/okta/okta_test.go
@@ -40,7 +40,7 @@ func newMockOkta(srv *httptest.Server, userEmailToGroups map[string][]string) ht
 		})
 	})
 	r.Get("/api/v1/groups", func(w http.ResponseWriter, r *http.Request) {
-		lastUpdated := strings.Contains(r.URL.Query().Get("filter"), "lastUpdated")
+		lastUpdated := strings.Contains(r.URL.Query().Get("filter"), "lastUpdated ")
 		var groups []string
 		for group := range allGroups {
 			if lastUpdated && group != "user-updated" {


### PR DESCRIPTION

## Summary
Okta uses space " " instead of plus sign "+" in query filter.
See https://developer.okta.com/docs/reference/api-overview/#filtering


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
