### PR TITLE
proxy: fix wrong applied middleware

### DIFF
--- a/integration/control_plane_test.go
+++ b/integration/control_plane_test.go
@@ -15,6 +15,22 @@ func TestDashboard(t *testing.T) {
 	ctx, clearTimeout := context.WithTimeout(ctx, time.Second*30)
 	defer clearTimeout()
 
+	t.Run("user dashboard", func(t *testing.T) {
+		client := testcluster.NewHTTPClient()
+
+		req, err := http.NewRequestWithContext(ctx, "GET", "https://httpdetails.localhost.pomerium.io/.pomerium", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, err := client.Do(req)
+		if !assert.NoError(t, err, "unexpected http error") {
+			return
+		}
+		defer res.Body.Close()
+
+		assert.Equal(t, http.StatusFound, res.StatusCode, "unexpected status code")
+	})
 	t.Run("image asset", func(t *testing.T) {
 		client := testcluster.NewHTTPClient()
 

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -45,7 +45,7 @@ func (p *Proxy) registerDashboardHandlers(r *mux.Router) *mux.Router {
 	// callback used to set route-scoped session and redirect back to destination
 	// only accept signed requests (hmac) from other trusted pomerium services
 	c := r.PathPrefix(dashboardPath + "/callback").Subrouter()
-	h.Use(func(h http.Handler) http.Handler {
+	c.Use(func(h http.Handler) http.Handler {
 		return middleware.ValidateSignature(p.state.Load().sharedKey)(h)
 	})
 


### PR DESCRIPTION




## Summary
Validate signature middleware must be applied for the callback
sub-router, not the whole dashboard router.

## Related issues
Fixes #1297


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
