### PR TITLE
azure: support deriving credentials from client id, client secret and provider url

### DIFF
--- a/cache/cache.go
+++ b/cache/cache.go
@@ -129,6 +129,8 @@ func (c *Cache) update(cfg *config.Config) error {
 		Provider:       cfg.Options.Provider,
 		ProviderURL:    cfg.Options.ProviderURL,
 		QPS:            cfg.Options.QPS,
+		ClientID:       cfg.Options.ClientID,
+		ClientSecret:   cfg.Options.ClientSecret,
 	})
 
 	dataBrokerClient := databroker.NewDataBrokerServiceClient(c.localGRPCConnection)

--- a/config/options.go
+++ b/config/options.go
@@ -632,8 +632,9 @@ func (o *Options) Validate() error {
 	}
 
 	// if no service account was defined, there should not be any policies that
-	// assert group membership
-	if o.ServiceAccount == "" {
+	// assert group membership (except for azure which can be derived from the client
+	// id, secret and provider url)
+	if o.ServiceAccount == "" && o.Provider != "azure" {
 		for _, p := range o.Policies {
 			if len(p.AllowedGroups) != 0 {
 				return fmt.Errorf("config: `allowed_groups` requires `idp_service_account`")

--- a/internal/directory/provider.go
+++ b/internal/directory/provider.go
@@ -24,17 +24,12 @@ type Group = directory.Group
 // A User is a directory User.
 type User = directory.User
 
+// Options are the options specific to the provider.
+type Options = directory.Options
+
 // A Provider provides user group directory information.
 type Provider interface {
 	UserGroups(ctx context.Context) ([]*Group, []*User, error)
-}
-
-// Options are the options specific to the provider.
-type Options struct {
-	ServiceAccount string
-	Provider       string
-	ProviderURL    string
-	QPS            float64
 }
 
 var globalProvider = struct {
@@ -59,11 +54,10 @@ func GetProvider(options Options) (provider Provider) {
 
 	switch options.Provider {
 	case azure.Name:
-		serviceAccount, err := azure.ParseServiceAccount(options.ServiceAccount)
+		serviceAccount, err := azure.ParseServiceAccount(options)
 		if err == nil {
 			return azure.New(azure.WithServiceAccount(serviceAccount))
 		}
-
 		log.Warn().
 			Str("service", "directory").
 			Str("provider", options.Provider).

--- a/pkg/grpc/directory/directory.go
+++ b/pkg/grpc/directory/directory.go
@@ -48,3 +48,13 @@ func GetUser(ctx context.Context, client databroker.DataBrokerServiceClient, use
 	}
 	return &u, nil
 }
+
+// Options are directory provider options.
+type Options struct {
+	ServiceAccount string
+	Provider       string
+	ProviderURL    string
+	ClientID       string
+	ClientSecret   string
+	QPS            float64
+}


### PR DESCRIPTION
## Summary
This PR updates the Azure directory provider so that it supports deriving service account credentials from the existing configuration options. 

## Related issues
Fixes #1299 

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
