### PR TITLE
authorize: log users and groups

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -351,6 +351,8 @@ func logAuthorizeCheck(
 		evt = evt.Bool("allow", reply.Status == http.StatusOK)
 		evt = evt.Int("status", reply.Status)
 		evt = evt.Str("message", reply.Message)
+		evt = evt.Str("user", reply.UserEmail)
+		evt = evt.Strs("groups", reply.UserGroups)
 	}
 
 	// potentially sensitive, only log if debug mode

--- a/go.sum
+++ b/go.sum
@@ -684,6 +684,7 @@ golang.org/x/net v0.0.0-20200520182314-0ba52f642ac2/go.mod h1:qpuaurCH72eLCgpAm/
 golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381 h1:VXak5I6aEWmAXeQjA+QSZzlgNrpq9mjcfDemuexIKsU=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc h1:zK/HqS5bZxDptfPJNq8v7vJfXtkU7r9TLIoSr1bXaP4=
 golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
## Summary

Fixes #1293 

Previously, authorization decisions were not logging user and groups. 

```
{"level":"info","service":"authorize","request-id":"02fd15f5-19a0-4e2b-b580-26960ec1a079","check-request-id":"fa7b7b10-657b-4532-a95e-4d67ad576671","method":"GET","path":"/spec.json","host":"httpbin.imac.bdd.io","query":"","allow":true,"status":200,"message":"OK","user":"snip@snip.com","groups":["ssnip"],"time":"2020-08-18T21:04:15-07:00","message":"authorize check"}
```


**Checklist**:
- [x] add related issues
- [x] ready for review
