### PR TITLE
authorize: add jti to JWT payload

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -206,6 +206,7 @@ func (e *Evaluator) JWTPayload(req *Request) map[string]interface{} {
 		payload["aud"] = u.Hostname()
 	}
 	if s, ok := req.DataBrokerData.Get("type.googleapis.com/session.Session", req.Session.ID).(*session.Session); ok {
+		payload["jti"] = s.GetId()
 		if tm, err := ptypes.Timestamp(s.GetIdToken().GetExpiresAt()); err == nil {
 			payload["exp"] = tm.Unix()
 		}

--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -153,6 +153,7 @@ func TestEvaluator_JWTPayload(t *testing.T) {
 				DataBrokerData: DataBrokerData{
 					"type.googleapis.com/session.Session": map[string]interface{}{
 						"SESSION_ID": &session.Session{
+							Id: "SESSION_ID",
 							IdToken: &session.IDToken{
 								ExpiresAt: nowPb,
 								IssuedAt:  nowPb,
@@ -167,6 +168,7 @@ func TestEvaluator_JWTPayload(t *testing.T) {
 			},
 			map[string]interface{}{
 				"iss": "authn.example.com",
+				"jti": "SESSION_ID",
 				"aud": "example.com",
 				"exp": now.Unix(),
 				"iat": now.Unix(),
@@ -178,6 +180,7 @@ func TestEvaluator_JWTPayload(t *testing.T) {
 				DataBrokerData: DataBrokerData{
 					"type.googleapis.com/session.Session": map[string]interface{}{
 						"SESSION_ID": &session.Session{
+							Id:     "SESSION_ID",
 							UserId: "USER_ID",
 						},
 					},
@@ -196,6 +199,7 @@ func TestEvaluator_JWTPayload(t *testing.T) {
 			},
 			map[string]interface{}{
 				"iss":   "authn.example.com",
+				"jti":   "SESSION_ID",
 				"aud":   "example.com",
 				"sub":   "USER_ID",
 				"user":  "USER_ID",
@@ -208,6 +212,7 @@ func TestEvaluator_JWTPayload(t *testing.T) {
 				DataBrokerData: DataBrokerData{
 					"type.googleapis.com/session.Session": map[string]interface{}{
 						"SESSION_ID": &session.Session{
+							Id:     "SESSION_ID",
 							UserId: "USER_ID",
 						},
 					},
@@ -237,6 +242,7 @@ func TestEvaluator_JWTPayload(t *testing.T) {
 			},
 			map[string]interface{}{
 				"iss":    "authn.example.com",
+				"jti":    "SESSION_ID",
 				"aud":    "example.com",
 				"groups": []string{"group1", "group2", "admin", "test"},
 			},


### PR DESCRIPTION
## Summary
This PR adds a `jti` to the JWT payload. `jti` is the unique identifier for the JWT and we use it to represent the session ID internally. It would be nice to also pass it through so that upstream applications can retrieve the currently logged-in user's session ID to query data from the databroker.

## Related issues


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
