### PR TITLE
Allow setting the shared secret via an environment variable.

### DIFF
--- a/cmd/pomerium-cli/cli.go
+++ b/cmd/pomerium-cli/cli.go
@@ -82,6 +82,8 @@ var serviceAccountCmd = &cobra.Command{
 		var sharedKey string
 		if len(args) == 1 {
 			sharedKey = args[0]
+		} else if k := os.Getenv("POMERIUM_SHARED_KEY"); k != "" {
+			sharedKey = k
 		} else {
 			fmt.Print("Enter base64 encoded shared key >")
 			scanner := bufio.NewScanner(os.Stdin)

--- a/docs/docs/topics/impersonation.md
+++ b/docs/docs/topics/impersonation.md
@@ -100,6 +100,14 @@ The cli will then prompt you for your base64 encoded shared secret. As a reminde
 
 :::
 
+:::tip
+
+You can also pass the shared secret by setting the `POMERIUM_SHARED_KEY` environment variable.
+
+:::
+
+
+
 You should now see something like:
 
 ```jwt


### PR DESCRIPTION
This makes it easier to safely pass it in programmatically to a container
without cutting and pasting or putting it on the command line.

## Summary

Allows the shared secret to be passed in the  POMERIUM_SHARED_KEY environment variable, in addition to as the final command line argument or via an explicit prompt.


## Related issues
<!-- For example...
Fixes #159 
-->
None.

**Checklist**:
- [N/A] add related issues
- [X] updated docs
- [NA] updated unit tests
- [N/A] updated UPGRADING.md
- [X] ready for review
