### PR TITLE
Use apt-get instead of apt to eliminate warning.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM golang:latest as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
-RUN apt update \
-    && apt -y install zip
+RUN apt-get update \
+    && apt-get -y install zip
 
 # cache depedency downloads
 COPY go.mod go.sum ./


### PR DESCRIPTION
WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Signed-off-by: Robert <rspier@pobox.com>

## Summary

Eliminates warning from apt when stdin is not a tty by using apt-get instead.

## Related issues



**Checklist**:
- [X] ready for review
