### PR TITLE
Include pomerium-cli in the docker image by default.  Fixes #1343.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ COPY . .
 
 # build
 RUN make build-deps
-RUN make build
+RUN make build NAME=pomerium
+RUN make build NAME=pomerium-cli
 RUN touch /config.yaml
 
 FROM gcr.io/distroless/base:debug


### PR DESCRIPTION
Size increases by 22MB.  (144MB -> 167MB)

This normalizes with expectations (and instructions, see impersonation
docs) that it will be there.

## Summary

Adds a make build call to the Dockerfile to build the CLI.  
(Also makes the build call for the `pomerium` binary explicit.)

## Related issues
Fixes #1343 


**Checklist**:
- [x] add related issues
- [x ] ready for review
