### PR TITLE
internal/controlplane: add telemetry http handler

### DIFF
--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/middleware"
+	"github.com/pomerium/pomerium/internal/telemetry"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
 	"github.com/pomerium/pomerium/internal/version"
 )
@@ -35,6 +36,7 @@ func (srv *Server) addHTTPMiddleware() {
 	root.Use(log.UserAgentHandler("user_agent"))
 	root.Use(log.RefererHandler("referer"))
 	root.Use(log.RequestIDHandler("request-id"))
+	root.Use(telemetry.HTTPStatsHandler(srv.name))
 	root.Use(middleware.Healthcheck("/ping", version.UserAgent()))
 	root.HandleFunc("/healthz", httputil.HealthCheck)
 	root.HandleFunc("/ping", httputil.HealthCheck)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -44,6 +44,7 @@ type Server struct {
 
 	currentConfig atomicVersionedOptions
 	configUpdated chan struct{}
+	name          string
 }
 
 // NewServer creates a new Server. Listener ports are chosen by the OS.


### PR DESCRIPTION
## Summary
Ensure we're getting proper tracing with propagation on the control plane http endpoints.

This is arguably a bug fix, so marking it for v0.10.x.

## Related issues
closes #535 

**Checklist**:
- [x] add related issues
- [x] ready for review
