### PR TITLE
deps: ensure renovate runs `go mod tidy`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "labels": [
     "dependency"
   ],
-  "postUpdateOptions": [{
-    "gomodTidy": true
-  }]
+  "postUpdateOptions": [
+    "gomodTidy"
+  ]
 }


### PR DESCRIPTION
## Summary
Fix renovate bot config for mod tidy.

https://docs.renovatebot.com/configuration-options/#postupdateoptions

https://docs.renovatebot.com/modules/manager/gomod/

**Checklist**:
- [x] ready for review
