### PR TITLE
internal/directory/okta: acceept non-json service account

### DIFF
--- a/internal/directory/okta/okta.go
+++ b/internal/directory/okta/okta.go
@@ -291,9 +291,8 @@ func ParseServiceAccount(rawServiceAccount string) (*ServiceAccount, error) {
 	}
 
 	var serviceAccount ServiceAccount
-	err = json.Unmarshal(bs, &serviceAccount)
-	if err != nil {
-		return nil, err
+	if err := json.Unmarshal(bs, &serviceAccount); err != nil {
+		serviceAccount.APIKey = string(bs)
 	}
 
 	if serviceAccount.APIKey == "" {

--- a/internal/directory/okta/okta_test.go
+++ b/internal/directory/okta/okta_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/go-chi/chi/middleware"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tomnomnom/linkheader"
 
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
@@ -206,4 +207,29 @@ func mustParseURL(rawurl string) *url.URL {
 		panic(err)
 	}
 	return u
+}
+
+func TestParseServiceAccount(t *testing.T) {
+	tests := []struct {
+		name              string
+		rawServiceAccount string
+		apiKey            string
+		wantErr           bool
+	}{
+		{"json", "ewogICAgImFwaV9rZXkiOiAiZm9vIgp9Cg==", "foo", false},
+		{"value", "Zm9v", "foo", false},
+		{"empty", "", "", true},
+		{"invalid", "Zm9v---", "", true},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := ParseServiceAccount(tc.rawServiceAccount)
+			require.True(t, (err != nil) == tc.wantErr)
+			if tc.apiKey != "" {
+				assert.Equal(t, tc.apiKey, got.APIKey)
+			}
+		})
+	}
 }


### PR DESCRIPTION

## Summary
Allow non-json encoded in okta service account value.

## Related issues
Fixes #1354



**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
