### PR TITLE
proxy: disable control-plane robots.txt for public unauthenticated routes

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -6,7 +6,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"regexp"
 	"strings"
 
 	"github.com/golang/protobuf/ptypes"
@@ -243,34 +242,9 @@ func (a *Authorize) getMatchingPolicy(requestURL *url.URL) *config.Policy {
 	options := a.currentOptions.Load()
 
 	for _, p := range options.Policies {
-		if p.Source == nil {
-			continue
+		if p.Matches(requestURL) {
+			return &p
 		}
-
-		if p.Source.Host != requestURL.Host {
-			continue
-		}
-
-		if p.Prefix != "" {
-			if !strings.HasPrefix(requestURL.Path, p.Prefix) {
-				continue
-			}
-		}
-
-		if p.Path != "" {
-			if requestURL.Path != p.Path {
-				continue
-			}
-		}
-
-		if p.Regex != "" {
-			re, err := regexp.Compile(p.Regex)
-			if err == nil && !re.MatchString(requestURL.String()) {
-				continue
-			}
-		}
-
-		return &p
 	}
 
 	return nil

--- a/config/policy.go
+++ b/config/policy.go
@@ -8,6 +8,8 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/cespare/xxhash/v2"
@@ -317,6 +319,39 @@ func (p *Policy) String() string {
 		return fmt.Sprintf("%s → %s", p.From, p.To)
 	}
 	return fmt.Sprintf("%s → %s", p.Source.String(), p.Destination.String())
+}
+
+// Matches returns true if the policy would match the given URL.
+func (p *Policy) Matches(requestURL *url.URL) bool {
+	// handle nils by always returning false
+	if p.Source == nil || requestURL == nil {
+		return false
+	}
+
+	if p.Source.Host != requestURL.Host {
+		return false
+	}
+
+	if p.Prefix != "" {
+		if !strings.HasPrefix(requestURL.Path, p.Prefix) {
+			return false
+		}
+	}
+
+	if p.Path != "" {
+		if requestURL.Path != p.Path {
+			return false
+		}
+	}
+
+	if p.Regex != "" {
+		re, err := regexp.Compile(p.Regex)
+		if err == nil && !re.MatchString(requestURL.String()) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // StringURL stores a URL as a string in json.

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -87,21 +87,6 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 						"domains": ["example.com"],
 						"routes": [
 							{
-								"name": "pomerium-path-/robots.txt",
-								"match": {
-									"path": "/robots.txt"
-								},
-								"route": {
-									"cluster": "pomerium-control-plane-http"
-								},
-								"typedPerFilterConfig": {
-									"envoy.filters.http.ext_authz": {
-										"@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-										"disabled": true
-									}
-								}
-							},
-							{
 								"name": "pomerium-path-/ping",
 								"match": {
 									"path": "/ping"
@@ -180,6 +165,21 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 								"name": "pomerium-prefix-/.well-known/pomerium/",
 								"match": {
 									"prefix": "/.well-known/pomerium/"
+								},
+								"route": {
+									"cluster": "pomerium-control-plane-http"
+								},
+								"typedPerFilterConfig": {
+									"envoy.filters.http.ext_authz": {
+										"@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+										"disabled": true
+									}
+								}
+							},
+							{
+								"name": "pomerium-path-/robots.txt",
+								"match": {
+									"path": "/robots.txt"
 								},
 								"route": {
 									"cluster": "pomerium-control-plane-http"
@@ -198,21 +198,6 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 						"domains": ["*"],
 						"routes": [
 							{
-								"name": "pomerium-path-/robots.txt",
-								"match": {
-									"path": "/robots.txt"
-								},
-								"route": {
-									"cluster": "pomerium-control-plane-http"
-								},
-								"typedPerFilterConfig": {
-									"envoy.filters.http.ext_authz": {
-										"@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
-										"disabled": true
-									}
-								}
-							},
-							{
 								"name": "pomerium-path-/ping",
 								"match": {
 									"path": "/ping"
@@ -291,6 +276,21 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 								"name": "pomerium-prefix-/.well-known/pomerium/",
 								"match": {
 									"prefix": "/.well-known/pomerium/"
+								},
+								"route": {
+									"cluster": "pomerium-control-plane-http"
+								},
+								"typedPerFilterConfig": {
+									"envoy.filters.http.ext_authz": {
+										"@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
+										"disabled": true
+									}
+								}
+							},
+							{
+								"name": "pomerium-path-/robots.txt",
+								"match": {
+									"path": "/robots.txt"
 								},
 								"route": {
 									"cluster": "pomerium-control-plane-http"

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -2,6 +2,7 @@ package controlplane
 
 import (
 	"fmt"
+	"net/url"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -41,13 +42,16 @@ func buildGRPCRoutes() []*envoy_config_route_v3.Route {
 
 func buildPomeriumHTTPRoutes(options *config.Options, domain string) []*envoy_config_route_v3.Route {
 	routes := []*envoy_config_route_v3.Route{
-		buildControlPlanePathRoute("/robots.txt"),
 		buildControlPlanePathRoute("/ping"),
 		buildControlPlanePathRoute("/healthz"),
 		buildControlPlanePathRoute("/.pomerium"),
 		buildControlPlanePrefixRoute("/.pomerium/"),
 		buildControlPlanePathRoute("/.well-known/pomerium"),
 		buildControlPlanePrefixRoute("/.well-known/pomerium/"),
+	}
+	// per #837, only add robots.txt if there are no unauthenticated routes
+	if !hasPublicPolicyMatchingURL(options, mustParseURL("https://"+domain+"/robots.txt")) {
+		routes = append(routes, buildControlPlanePathRoute("/robots.txt"))
 	}
 	// if we're handling authentication, add the oauth2 callback url
 	if config.IsAuthenticate(options.Services) && hostMatchesDomain(options.GetAuthenticateURL(), domain) {
@@ -241,4 +245,21 @@ func getPrefixRewrite(policy *config.Policy) string {
 		prefixRewrite = policy.Destination.Path
 	}
 	return prefixRewrite
+}
+
+func hasPublicPolicyMatchingURL(options *config.Options, requestURL *url.URL) bool {
+	for _, policy := range options.Policies {
+		if policy.AllowPublicUnauthenticatedAccess && policy.Matches(requestURL) {
+			return true
+		}
+	}
+	return false
+}
+
+func mustParseURL(str string) *url.URL {
+	u, err := url.Parse(str)
+	if err != nil {
+		panic(err)
+	}
+	return u
 }


### PR DESCRIPTION
## Summary
For public unauthenticated routes we want `robots.txt` to be forwarded to the backend. This PR implements that change.

## Related issues
Closes #837 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
