### PR TITLE
proxy: support websocket timeouts

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1216,7 +1216,7 @@ If set, enables proxying of websocket connections.
 
 :::warning
 
-**Use with caution:** websockets are long-lived connections, so [global timeouts](#global-timeouts) are not enforced. Allowing websocket connections to the proxy could result in abuse via [DOS attacks](https://www.cloudflare.com/learning/ddos/ddos-attack-tools/slowloris/).
+**Use with caution:** websockets are long-lived connections, so [global timeouts](#global-timeouts) are not enforced (though the policy-specific `timeout` is enforced). Allowing websocket connections to the proxy could result in abuse via [DOS attacks](https://www.cloudflare.com/learning/ddos/ddos-attack-tools/slowloris/).
 
 :::
 

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -223,8 +223,12 @@ func getRequestHeadersToRemove(options *config.Options, policy *config.Policy) [
 func getRouteTimeout(options *config.Options, policy *config.Policy) *durationpb.Duration {
 	var routeTimeout *durationpb.Duration
 	if policy.AllowWebsockets {
-		// disable the route timeout for websocket support
-		routeTimeout = ptypes.DurationProto(0)
+		if policy.UpstreamTimeout != 0 {
+			routeTimeout = ptypes.DurationProto(policy.UpstreamTimeout)
+		} else {
+			// disable the default route timeout for websocket support
+			routeTimeout = ptypes.DurationProto(0)
+		}
 	} else {
 		if policy.UpstreamTimeout != 0 {
 			routeTimeout = ptypes.DurationProto(policy.UpstreamTimeout)

--- a/internal/controlplane/xds_routes_test.go
+++ b/internal/controlplane/xds_routes_test.go
@@ -276,6 +276,14 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				PreserveHostHeader:  true,
 				PassIdentityHeaders: true,
 			},
+			{
+				Source:              &config.StringURL{URL: mustParseURL("https://example.com")},
+				Path:                "/websocket-timeout",
+				AllowWebsockets:     true,
+				PreserveHostHeader:  true,
+				PassIdentityHeaders: true,
+				UpstreamTimeout:     time.Second * 10,
+			},
 		},
 	}, "example.com")
 
@@ -429,7 +437,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						{ "enabled": true, "upgradeType": "spdy/3.1"}
 					]
 				}
-			},		
+			},
 			{
 				"name": "policy-7",
 				"match": {
@@ -450,6 +458,29 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					"upgradeConfigs": [
 						{ "enabled": true, "upgradeType": "websocket"},
 						{ "enabled": true, "upgradeType": "spdy/3.1"}
+					]
+				}
+			},
+			{
+				"name": "policy-8",
+				"match": {
+					"path": "/websocket-timeout"
+				},
+				"metadata": {
+					"filterMetadata": {
+						"envoy.filters.http.lua": {
+							"remove_pomerium_authorization": true,
+							"remove_pomerium_cookie": "pomerium"
+						}
+					}
+				},
+				"route": {
+					"autoHostRewrite": false,
+					"cluster": "policy-8",
+					"timeout": "10s",
+					"upgradeConfigs": [
+						{ "enabled": true, "upgradeType": "websocket"},
+						{ "enabled": false, "upgradeType": "spdy/3.1"}
 					]
 				}
 			}


### PR DESCRIPTION
## Summary
With this change we support using the `timeout` property on a policy with `allow_websockets`, though we still don't use the global timeout.

## Related issues
Closes #1327 


**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
