### PR TITLE
authorize: use impersonate email/groups in JWT

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -231,6 +231,14 @@ func (e *Evaluator) JWTPayload(req *Request) map[string]interface{} {
 			payload["groups"] = groups
 		}
 	}
+
+	if req.Session.ImpersonateEmail != "" {
+		payload["email"] = req.Session.ImpersonateEmail
+	}
+	if len(req.Session.ImpersonateGroups) > 0 {
+		payload["groups"] = req.Session.ImpersonateGroups
+	}
+
 	return payload
 }
 

--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -247,6 +247,22 @@ func TestEvaluator_JWTPayload(t *testing.T) {
 				"groups": []string{"group1", "group2", "admin", "test"},
 			},
 		},
+		{
+			"with impersonate",
+			&Request{
+				HTTP: RequestHTTP{URL: "https://example.com"},
+				Session: RequestSession{
+					ImpersonateEmail:  "user@example.com",
+					ImpersonateGroups: []string{"admin", "test"},
+				},
+			},
+			map[string]interface{}{
+				"iss":    "authn.example.com",
+				"aud":    "example.com",
+				"email":  "user@example.com",
+				"groups": []string{"admin", "test"},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
This PR updates the JWT generation code in authorize to use the impersonate email and groups session options instead of the user email and groups. (if set)

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
