### PR TITLE
ci: add stale issue automation

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -7,7 +7,6 @@ daysUntilClose: 7
 # Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
 onlyLabels:
   - WaitingForInfo
-  - ChangesRequested
 # Issues with these labels will never be considered stale
 exemptLabels:
   - thinking
@@ -28,6 +27,7 @@ pulls:
     This pull request has been automatically marked as stale because it has not had
     recent activity. It will be closed if no further activity occurs. Thank you
     for you
-
+  onlyLabels:
+    - ChangesRequested
 # Limit the number of actions per hour, from 1-30. Default is 30
 limitPerRun: 1

--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,33 @@
+# Documentation https://github.com/probot/stale
+
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels:
+  - WaitingForInfo
+  - ChangesRequested
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - thinking
+  - accepted
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: true
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: true
+
+pulls:
+  markComment: >
+    This pull request has been automatically marked as stale because it has not had
+    recent activity. It will be closed if no further activity occurs. Thank you
+    for you
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 1


### PR DESCRIPTION
 ## Summary
Add first pass at automated stale issue closure.  Intentionally very conservative.  Key aspects:

- 30 day count down with 7 day grace period
- Explicitly ignore labels that indicate activity on Pomerium's side (thinking, accepted)
- Explicitly ignore issues that are assigned
- Only evaluate `WaitingForInfo` / `ChangesRequested` labels
- Low rate limit to start, in case of any unexpected behavior

**Checklist**:
- [x] ready for review