### PR TITLE
databroker: add tracing for rego evaluation and databroker sync, fix bug in databroker config source

### DIFF
--- a/authorize/evaluator/custom.go
+++ b/authorize/evaluator/custom.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/storage"
+
+	"github.com/pomerium/pomerium/internal/telemetry/trace"
 )
 
 // A CustomEvaluatorRequest is the data needed to evaluate a custom rego policy.
@@ -42,6 +44,9 @@ func NewCustomEvaluator(store storage.Store) *CustomEvaluator {
 
 // Evaluate evaluates the custom rego policy.
 func (ce *CustomEvaluator) Evaluate(ctx context.Context, req *CustomEvaluatorRequest) (*CustomEvaluatorResponse, error) {
+	_, span := trace.StartSpan(ctx, "authorize.evaluator.custom.Evaluate")
+	defer span.End()
+
 	q, err := ce.getPreparedEvalQuery(ctx, req.RegoPolicy)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
This PR adds a couple additional traces for custom rego evaluation and the databroker config source. I also fixed a bug in the order of operations when loading options from the databroker. Calling `Validate` after adding the new policies would end up replacing them with the original environment variable, so I add them after calling validate instead.


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
