### PR TITLE
{proxy/controlplane}: make health checks debug level

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -15,7 +15,7 @@ about: Let us know about a bug!
 
 ## What's your environment like?
 
-- Pomerium version (retrieve with `pomerium --version` or `/ping` endpoint):
+- Pomerium version (retrieve with `pomerium --version`):
 - Server Operating System/Architecture/Cloud:
 
 ## What's your config.yaml?

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -10,10 +10,8 @@ import (
 	"github.com/pomerium/pomerium/internal/frontend"
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/internal/middleware"
 	"github.com/pomerium/pomerium/internal/telemetry"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
-	"github.com/pomerium/pomerium/internal/version"
 )
 
 func (srv *Server) addHTTPMiddleware() {
@@ -37,7 +35,6 @@ func (srv *Server) addHTTPMiddleware() {
 	root.Use(log.RefererHandler("referer"))
 	root.Use(log.RequestIDHandler("request-id"))
 	root.Use(telemetry.HTTPStatsHandler(srv.name))
-	root.Use(middleware.Healthcheck("/ping", version.UserAgent()))
 	root.HandleFunc("/healthz", httputil.HealthCheck)
 	root.HandleFunc("/ping", httputil.HealthCheck)
 	root.PathPrefix("/.pomerium/assets/").Handler(http.StripPrefix("/.pomerium/assets/", frontend.MustAssetHandler()))

--- a/internal/middleware/middleware_test.go
+++ b/internal/middleware/middleware_test.go
@@ -42,42 +42,6 @@ func TestSetHeaders(t *testing.T) {
 	}
 }
 
-func TestHealthCheck(t *testing.T) {
-	t.Parallel()
-	testHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte("Hi"))
-	})
-	tests := []struct {
-		name       string
-		method     string
-		clientPath string
-		serverPath string
-
-		wantStatus int
-	}{
-		{"good - Get", http.MethodGet, "/ping", "/ping", http.StatusOK},
-		{"good - Head", http.MethodHead, "/ping", "/ping", http.StatusOK},
-		{"bad - Options", http.MethodOptions, "/ping", "/ping", http.StatusMethodNotAllowed},
-		{"bad - Put", http.MethodPut, "/ping", "/ping", http.StatusMethodNotAllowed},
-		{"bad - Post", http.MethodPost, "/ping", "/ping", http.StatusMethodNotAllowed},
-		{"bad - route miss", http.MethodGet, "/not-ping", "/ping", http.StatusOK},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-
-			r := httptest.NewRequest(tt.method, tt.clientPath, nil)
-			w := httptest.NewRecorder()
-
-			handler := Healthcheck(tt.serverPath, string("OK"))(testHandler)
-			handler.ServeHTTP(w, r)
-			if w.Code != tt.wantStatus {
-				t.Errorf("code differs. got %d want %d body: %s", w.Code, tt.wantStatus, w.Body.String())
-			}
-		})
-	}
-}
-
 func TestStripCookie(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
# Summary

These changes make health check endpoints default to `debug` log level. These changes also remove the pomerium version from the healthcheck endpoint `ping`. 

## Related issues

Fixes #776 
Fixes https://github.com/pomerium/internal/issues/147

**Checklist**:

- [x] add related issues
- [x] updated unit tests
- [x] ready for review
