### PR TITLE
internal/directory/okta: remove rate limiter

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -703,19 +703,6 @@ Use it at your own risk, if you set a too low value, you may reach IDP API rate 
 
 :::
 
-### Identity Provider API Query Per Second
-
-- Environmental Variables: `IDP_QPS`
-- Config File Key: `idp_qps`
-- Type: `float64`
-- Example: `IDP_QPS=1.8`
-- Defaults: `IDP_QPS=1.0`
-
-Limit number of API requests per second to identity provider server. The lowest value is `1.0`, any value less than `1.0`
-has no effect.
-
-Currently, only applying for [okta].
-
 ## Proxy Service
 
 ### Authenticate Service URL

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	google.golang.org/api v0.30.0
 	google.golang.org/genproto v0.0.0-20200829155447-2bf3329a0021
 	google.golang.org/grpc v1.31.1

--- a/go.sum
+++ b/go.sum
@@ -672,8 +672,6 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
-golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20181030221726-6c7e314b6563/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
@@ -797,7 +795,6 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=
 google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc v1.31.0 h1:T7P4R73V3SSDPhH7WW7ATbfViLtmamH0DKrP3f9AuDI=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.1 h1:SfXqXS5hkufcdZ/mHtYCh53P2b+92WQq/DZcKLgsFRs=
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=

--- a/internal/directory/provider.go
+++ b/internal/directory/provider.go
@@ -99,9 +99,7 @@ func GetProvider(options Options) (provider Provider) {
 		if err == nil {
 			return okta.New(
 				okta.WithProviderURL(providerURL),
-				okta.WithServiceAccount(serviceAccount),
-				okta.WithQPS(options.QPS),
-			)
+				okta.WithServiceAccount(serviceAccount))
 		}
 		log.Warn().
 			Str("service", "directory").


### PR DESCRIPTION

## Summary
We did honor the rate limit header from okta, so don't bother to add our
rate limiter there.


## Related issues



**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
