### PR TITLE
Cuonglm/improve timeout error message

### DIFF
--- a/internal/identity/manager/config.go
+++ b/internal/identity/manager/config.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	defaultGroupRefreshInterval          = 10 * time.Minute
-	defaultGroupRefreshTimeout           = 1 * time.Minute
+	defaultGroupRefreshInterval          = 15 * time.Minute
+	defaultGroupRefreshTimeout           = 10 * time.Minute
 	defaultSessionRefreshGracePeriod     = 1 * time.Minute
 	defaultSessionRefreshCoolOffDuration = 10 * time.Second
 )

--- a/internal/identity/manager/manager.go
+++ b/internal/identity/manager/manager.go
@@ -213,7 +213,12 @@ func (mgr *Manager) refreshDirectoryUserGroups(ctx context.Context) {
 
 	directoryGroups, directoryUsers, err := mgr.cfg.Load().directory.UserGroups(ctx)
 	if err != nil {
-		mgr.log.Warn().Err(err).Msg("failed to refresh directory users and groups")
+		msg := "failed to refresh directory users and groups"
+		if ctx.Err() != nil {
+			msg += ". You may need to increase the identity provider directory timeout setting"
+			msg += "(https://www.pomerium.io/reference/#identity-provider-refresh-directory-settings)"
+		}
+		mgr.log.Warn().Err(err).Msg(msg)
 		return
 	}
 


### PR DESCRIPTION
## Summary

In case of timeout, showing what can be problem and lead user to documentation page. While at it, also increase the default refresh timeout/interval, so user with big groups can have better chance to be synced with default options.


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
