### PR TITLE
internal/envoy: start epoch from 0

### DIFF
--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -153,8 +153,8 @@ func (srv *Server) run() error {
 	}
 
 	if baseID, ok := readBaseID(); ok {
-		srv.restartEpoch++
 		args = append(args, "--base-id", strconv.Itoa(baseID), "--restart-epoch", strconv.Itoa(srv.restartEpoch))
+		srv.restartEpoch++ // start with epoch zero when we're a fresh pomerium process
 	} else {
 		args = append(args, "--use-dynamic-base-id", "--base-id-path", baseIDPath)
 	}


### PR DESCRIPTION
## Summary

Prevent two "cold" start issues by ensuring we always start from a `0` epoch.

After previous start:
`{"service":"envoy","name":"envoy","time":"2020-09-08T21:59:24Z","message":"previous envoy process is still initializing"}`

After a previous start, but the shared memory segment is missing:
`{"service":"envoy","name":"envoy","time":"2020-09-08T19:40:18Z","message":"[2020-09-08 19:40:18.453][1832][critical][assert] panic: cannot open shared memory region /envoy_shared_memory_356280060 check user permissions. Error: No such file or directory"}`

**Checklist**:
- [x] ready for review
