### PR TITLE
controlplane: support P-384 / P-512 EC curves

### DIFF
--- a/internal/controlplane/xds_cluster_test.go
+++ b/internal/controlplane/xds_cluster_test.go
@@ -29,6 +29,14 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 					"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
 					"commonTlsContext": {
 						"alpnProtocols": ["http/1.1"],
+						"tlsParams": {
+							"ecdhCurves": [
+								"X25519",
+								"P-256",
+								"P-384",
+								"P-512"
+							]
+						},
 						"validationContext": {
 							"matchSubjectAltNames": [{
 								"exact": "example.com"
@@ -53,6 +61,14 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 					"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
 					"commonTlsContext": {
 						"alpnProtocols": ["http/1.1"],
+						"tlsParams": {
+							"ecdhCurves": [
+								"X25519",
+								"P-256",
+								"P-384",
+								"P-512"
+							]
+						},
 						"validationContext": {
 							"matchSubjectAltNames": [{
 								"exact": "use-this-name.example.com"
@@ -78,6 +94,14 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 					"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
 					"commonTlsContext": {
 						"alpnProtocols": ["http/1.1"],
+						"tlsParams": {
+							"ecdhCurves": [
+								"X25519",
+								"P-256",
+								"P-384",
+								"P-512"
+							]
+						},
 						"validationContext": {
 							"matchSubjectAltNames": [{
 								"exact": "example.com"
@@ -104,6 +128,14 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 					"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
 					"commonTlsContext": {
 						"alpnProtocols": ["http/1.1"],
+						"tlsParams": {
+							"ecdhCurves": [
+								"X25519",
+								"P-256",
+								"P-384",
+								"P-512"
+							]
+						},
 						"validationContext": {
 							"matchSubjectAltNames": [{
 								"exact": "example.com"
@@ -130,6 +162,14 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 					"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
 					"commonTlsContext": {
 						"alpnProtocols": ["http/1.1"],
+						"tlsParams": {
+							"ecdhCurves": [
+								"X25519",
+								"P-256",
+								"P-384",
+								"P-512"
+							]
+						},
 						"tlsCertificates": [{
 							"certificateChain":{
 								"filename": "`+filepath.Join(cacheDir, "pomerium", "envoy", "files", "tls-crt-921a8294d2e2ec54.pem")+`"
@@ -208,6 +248,14 @@ func Test_buildCluster(t *testing.T) {
 						"@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext",
 						"commonTlsContext": {
 							"alpnProtocols": ["http/1.1"],
+							"tlsParams": {
+							"ecdhCurves": [
+								"X25519",
+								"P-256",
+								"P-384",
+								"P-512"
+							]
+						},
 							"validationContext": {
 								"matchSubjectAltNames": [{
 									"exact": "example.com"

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -118,6 +118,14 @@ func buildPolicyTransportSocket(policy *config.Policy) *envoy_config_core_v3.Tra
 	}
 	tlsContext := &envoy_extensions_transport_sockets_tls_v3.UpstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
+			TlsParams: &envoy_extensions_transport_sockets_tls_v3.TlsParameters{
+				EcdhCurves: []string{
+					"X25519",
+					"P-256",
+					"P-384",
+					"P-512",
+				},
+			},
 			AlpnProtocols: []string{"http/1.1"},
 			ValidationContextType: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{
 				ValidationContext: buildPolicyValidationContext(policy),


### PR DESCRIPTION

## Summary

These changes add support for connecting to upstreams which use P-384 and P-512 EC curves. 

## Related issues

- https://github.com/envoyproxy/envoy/issues/10855

**Checklist**:

- [x] add related issues
- [x] updated unit tests
- [x] ready for review
