### PR TITLE
proxy: forward_auth honour uri query string when checking policy

### DIFF
--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -5,6 +5,14 @@ description: >-
   for Pomerium. Please read it carefully.
 ---
 
+# Since 0.10.0
+
+## Breaking
+
+### Policy checking for forward auth
+
+Forward auth now check the policy for URL given in the query string instead of the verify endpoint.
+
 # Since 0.9.0
 
 ## Breaking

--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -110,7 +110,11 @@ func (p *Proxy) Verify(verifyOnly bool) http.Handler {
 			return httputil.NewError(http.StatusBadRequest, err)
 		}
 
-		ar, err := p.isAuthorized(w, r)
+		authorizingRequest := r.Clone(r.Context())
+		authorizingRequest.URL = uri
+		authorizingRequest.Host = uri.Hostname()
+
+		ar, err := p.isAuthorized(w, authorizingRequest)
 		if err != nil {
 			return httputil.NewError(http.StatusBadRequest, err)
 		}

--- a/proxy/forward_auth_test.go
+++ b/proxy/forward_auth_test.go
@@ -2,12 +2,13 @@ package proxy
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	envoy_service_auth_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
 	"github.com/google/go-cmp/cmp"
@@ -39,8 +40,8 @@ type assertRequestClient struct {
 	envoy_service_auth_v2.AuthorizationClient
 
 	hostname string
-	path string
-	t *testing.T
+	path     string
+	t        *testing.T
 }
 
 func (v *assertRequestClient) Check(ctx context.Context, in *envoy_service_auth_v2.CheckRequest, opts ...grpc.CallOption) (*envoy_service_auth_v2.CheckResponse, error) {


### PR DESCRIPTION
## Summary
Currently forward proxy check the policy for the FORWARD_AUTH_HOST/validate endpoint. This PR changes it to the endpoint given by uri query string, allowing per-endpoint policy like non-forward auth setup.

**Checklist**:
- [ ] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] ready for review
