### PR TITLE
controplane: remove p-521 EC

### DIFF
--- a/internal/controlplane/xds_cluster_test.go
+++ b/internal/controlplane/xds_cluster_test.go
@@ -34,7 +34,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"X25519",
 								"P-256",
 								"P-384",
-								"P-512"
+								"P-521"
 							]
 						},
 						"validationContext": {
@@ -66,7 +66,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"X25519",
 								"P-256",
 								"P-384",
-								"P-512"
+								"P-521"
 							]
 						},
 						"validationContext": {
@@ -99,7 +99,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"X25519",
 								"P-256",
 								"P-384",
-								"P-512"
+								"P-521"
 							]
 						},
 						"validationContext": {
@@ -133,7 +133,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"X25519",
 								"P-256",
 								"P-384",
-								"P-512"
+								"P-521"
 							]
 						},
 						"validationContext": {
@@ -167,7 +167,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"X25519",
 								"P-256",
 								"P-384",
-								"P-512"
+								"P-521"
 							]
 						},
 						"tlsCertificates": [{
@@ -253,7 +253,7 @@ func Test_buildCluster(t *testing.T) {
 								"X25519",
 								"P-256",
 								"P-384",
-								"P-512"
+								"P-521"
 							]
 						},
 							"validationContext": {

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -123,6 +123,7 @@ func buildPolicyTransportSocket(policy *config.Policy) *envoy_config_core_v3.Tra
 					"X25519",
 					"P-256",
 					"P-384",
+					"P-521",
 				},
 			},
 			AlpnProtocols: []string{"http/1.1"},

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -123,7 +123,6 @@ func buildPolicyTransportSocket(policy *config.Policy) *envoy_config_core_v3.Tra
 					"X25519",
 					"P-256",
 					"P-384",
-					"P-512",
 				},
 			},
 			AlpnProtocols: []string{"http/1.1"},


### PR DESCRIPTION
## Summary

Fixes a typo in https://github.com/pomerium/pomerium/pull/1409. P-512 != P-521.

```json
{
  "level": "error",
  "error": "Error adding/updating cluster(s) policy-3816db18ba3f8895: Failed to initialize ECDH curves X25519:P-256:P-512",
  "code": 13,
  "details": null,
  "time": "2020-09-17T21:58:40-07:00",
  "message": "error applying configuration"
}
```

## Related issues

- https://github.com/pomerium/pomerium/pull/1409


**Checklist**:
- [x] add related issues
- [x] updated unit tests
- [x] ready for review
