### PR TITLE
fix(examples): Use X-Pomerium-Claim headers

### DIFF
--- a/examples/traefik/config.yaml
+++ b/examples/traefik/config.yaml
@@ -12,6 +12,8 @@ idp_client_secret: REPLACEME
 insecure_server: true
 forward_auth_url: http://pomerium
 authenticate_service_url: https://authenticate.localhost.pomerium.io
+jwt_claims_headers: email,groups,user
+
 
 policy:
   - from: https://httpbin.localhost.pomerium.io

--- a/examples/traefik/docker-compose.yaml
+++ b/examples/traefik/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
   httpbin:
     image: kennethreitz/httpbin:latest
     labels:
-      - "traefik.http.middlewares.pomerium.forwardauth.authResponseHeaders=X-Pomerium-Authenticated-User-Email,x-pomerium-authenticated-user-id,x-pomerium-authenticated-user-groups,x-pomerium-jwt-assertion"
+      - "traefik.http.middlewares.pomerium.forwardauth.authResponseHeaders=X-Pomerium-Claim-Email,X-Pomerium-Claim-User,X-Pomerium-Claim-Groups,X-Pomerium-Jwt-Assertion"
       - "traefik.http.middlewares.pomerium.forwardauth.address=http://pomerium/"
       - "traefik.http.middlewares.pomerium.forwardauth.trustForwardHeader=true"
 


### PR DESCRIPTION

## Summary
Update traefik middleware to use X-Pomerium-Claim-* instead of X-Pomerium-Authenticated-*

## Related issues
fixes #1421



**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
