### PR TITLE
httputil: remove retry button

### DIFF
--- a/internal/frontend/assets/html/error.go.html
+++ b/internal/frontend/assets/html/error.go.html
@@ -28,12 +28,6 @@
               them with your
               <a href="/.pomerium/">request details</a>.
             </div>
-
-            {{end}} {{if.RetryURL}}
-            <div class="message">
-              If you believe the error is temporary, you can
-              <a href="{{.RetryURL}}">retry</a> the request.
-            </div>
             {{end}}
           </section>
           <div class="card-footer">
@@ -44,7 +38,6 @@
                 class="icon"
               />
             </a>
-
             <div class="text-right text-muted small">
               {{.RequestID}} <br />
               Pomerium {{.Version}}

--- a/internal/httputil/errors.go
+++ b/internal/httputil/errors.go
@@ -8,7 +8,6 @@ import (
 	"github.com/pomerium/pomerium/internal/frontend"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
-	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/internal/version"
 )
 
@@ -41,22 +40,6 @@ func (e *HTTPError) Debugable() bool {
 	return e.Status == http.StatusUnauthorized || e.Status == http.StatusForbidden
 }
 
-// RetryURL returns the requests intended destination, if any.
-func (e *HTTPError) RetryURL(r *http.Request) string {
-	return r.FormValue(urlutil.QueryRedirectURI)
-}
-
-type errResponse struct {
-	Status int
-	Error  string
-
-	StatusText string `json:"-"`
-	RequestID  string `json:",omitempty"`
-	CanDebug   bool   `json:"-"`
-	RetryURL   string `json:"-"`
-	Version    string `json:"-"`
-}
-
 // ErrorResponse replies to the request with the specified error message and HTTP code.
 // It does not otherwise end the request; the caller should ensure no further
 // writes are done to w.
@@ -67,24 +50,30 @@ func (e *HTTPError) ErrorResponse(w http.ResponseWriter, r *http.Request) {
 
 	log.FromRequest(r).Info().Err(e).Msg("httputil: ErrorResponse")
 	requestID := requestid.FromContext(r.Context())
-	response := errResponse{
+
+	response := struct {
+		Status     int
+		Error      string
+		StatusText string `json:"-"`
+		RequestID  string `json:",omitempty"`
+		CanDebug   bool   `json:"-"`
+		Version    string `json:"-"`
+	}{
 		Status:     e.Status,
 		StatusText: http.StatusText(e.Status),
 		Error:      e.Error(),
 		RequestID:  requestID,
 		CanDebug:   e.Debugable(),
-		RetryURL:   e.RetryURL(r),
 		Version:    fullVersion,
 	}
 
 	if r.Header.Get("Accept") == "application/json" {
 		w.Header().Set("Content-Type", "application/json")
-		err := json.NewEncoder(w).Encode(response)
-		if err != nil {
+		if err := json.NewEncoder(w).Encode(response); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 		}
-	} else {
-		w.Header().Set("Content-Type", "text/html; charset=UTF-8")
-		errorTemplate.ExecuteTemplate(w, "error.html", response)
+		return
 	}
+	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	errorTemplate.ExecuteTemplate(w, "error.html", response)
 }


### PR DESCRIPTION
## Summary

In previous versions of Pomerium (pre v0.9.0), a users were presented with an error page with a "retry url" link.  That link was populated from the value of the `pomerium_redirect_uri` query param. 

Under certain conditions, this queryparam could be misused to create a crafted retry URL link which in turn could then be used to trick a user to visiting a malicious site.

These changes remove the "retry url" functionality out of an abundance of caution. 

## Related issues

- https://github.com/pomerium/internal/issues/160


**Checklist**:

- [x] add related issues
- [x] ready for review
