### PR TITLE
deployment: bump release go to v1.15.x

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,9 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
       - name: Set up Go
-        uses: actions/setup-go@v1
+        uses: setup-go@v2
         with:
-          go-version: 1.14.x
+          go-version: 1.15.x
 
       - name: Set up Docker
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
## Summary

Our release action is using an old version of go. 


**Checklist**:

- [x] ready for review
