### PR TITLE
proxy/forward_auth: don't reset forward auth path if X-Forwarded-Uri is not set

### DIFF
--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -149,7 +149,7 @@ func (p *Proxy) forwardAuthRedirectToSignInWithURI(w http.ResponseWriter, r *htt
 
 	// Traefik set the uri in the header, we must set it in redirect uri if present. Otherwise, request like
 	// https://example.com/foo will be redirected to https://example.com after authentication.
-	if xfu := r.Header.Get(httputil.HeaderForwardedURI); xfu != "/" {
+	if xfu := r.Header.Get(httputil.HeaderForwardedURI); xfu != "" && xfu != "/" {
 		uri.Path = xfu
 	}
 


### PR DESCRIPTION
## Summary
When using Pomerium forward auth with nginx, after authentication succeeded it will always redirect to domain root.

This is due to a codepath that is intended for reading Traefik original URL always hit when Traefik's header is missing.

**Checklist**:
- [ ] updated unit tests - I don't have test added - if you require one please suggest where should I add it
- [x] ready for review
