### PR TITLE
identity manager: fix directory sync timing

### DIFF
--- a/internal/identity/manager/manager.go
+++ b/internal/identity/manager/manager.go
@@ -161,15 +161,15 @@ func (mgr *Manager) refreshLoop(
 		}
 
 		now := time.Now()
-		nextTime := now.Add(maxWait)
+		nextTime = now.Add(maxWait)
 
 		// refresh groups
 		if mgr.directoryNextRefresh.Before(now) {
 			mgr.refreshDirectoryUserGroups(ctx)
 			mgr.directoryNextRefresh = now.Add(mgr.cfg.Load().groupRefreshInterval)
-			if mgr.directoryNextRefresh.Before(nextTime) {
-				nextTime = mgr.directoryNextRefresh
-			}
+		}
+		if mgr.directoryNextRefresh.Before(nextTime) {
+			nextTime = mgr.directoryNextRefresh
 		}
 
 		// refresh sessions


### PR DESCRIPTION
## Summary
I found this bug when working on the incremental azure directory sync. We were only resetting the next check time if we were due to refresh the directory users and groups.

In practice this meant if no one had logged in yet the 2nd (3rd, 4th, etc) directory sync wouldn't happen, because the `nextTime` would not have been changed.

We now always set the `nextTime` to the `directoryNextRefresh` if it's before `nextTime`.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
