### PR TITLE
proxy: preserve path and query string for http->https redirect

### DIFF
--- a/internal/httputil/server.go
+++ b/internal/httputil/server.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
-	"fmt"
 	stdlog "log"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"sync"
@@ -69,9 +69,13 @@ func NewServer(opt *ServerOptions, h http.Handler, wg *sync.WaitGroup) (*http.Se
 // RedirectHandler takes an incoming request and redirects to its HTTPS counterpart
 func RedirectHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		newURL := new(url.URL)
+		*newURL = *r.URL
+		newURL.Scheme = "https"
+		newURL.Host = urlutil.StripPort(r.Host)
+
 		w.Header().Set("Connection", "close")
-		url := fmt.Sprintf("https://%s", urlutil.StripPort(r.Host))
-		http.Redirect(w, r, url, http.StatusMovedPermanently)
+		http.Redirect(w, r, newURL.String(), http.StatusMovedPermanently)
 	})
 }
 

--- a/internal/httputil/server_test.go
+++ b/internal/httputil/server_test.go
@@ -130,16 +130,17 @@ func waitSig(t *testing.T, c <-chan os.Signal, sig os.Signal) {
 
 func TestRedirectHandler(t *testing.T) {
 	tests := []struct {
-		name       string
+		url        string
 		wantStatus int
 		wantBody   string
 	}{
 		{"http://example", http.StatusMovedPermanently, "<a href=\"https://example\">Moved Permanently</a>.\n\n"},
 		{"http://example:8080", http.StatusMovedPermanently, "<a href=\"https://example\">Moved Permanently</a>.\n\n"},
+		{"http://example:8080/some/path?x=y", http.StatusMovedPermanently, "<a href=\"https://example/some/path?x=y\">Moved Permanently</a>.\n\n"},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(http.MethodGet, "http://example/", nil)
+		t.Run(tt.url, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
 			rr := httptest.NewRecorder()
 			RedirectHandler().ServeHTTP(rr, req)
 			if diff := cmp.Diff(tt.wantStatus, rr.Code); diff != "" {


### PR DESCRIPTION
## Summary
This PR changes our `HTTP -> HTTPS` redirect code to preserve the URL path and query string.

## Related issues
- Fixes #1449 

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
