### PR TITLE
deployment: Generate deb and rpm packages

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -199,3 +199,44 @@ brews:
     folder: Formula
     install: |
       bin.install "pomerium"
+
+nfpms:
+  - id: pomerium
+
+    builds:
+      - pomerium
+
+    package_name: pomerium
+    vendor: Pomerium, Inc.
+    homepage: https://www.pomerium.com
+    description: Identity Aware Proxy
+    maintainer:
+    license: Apache 2.0
+    epoch: 1
+    release: 1
+    meta: false
+
+    formats:
+      - deb
+      - rpm
+
+    bindir: /usr/sbin
+
+    empty_folders:
+      - /etc/pomerium
+
+    scripts:
+      preinstall: ospkg/preinstall.sh
+      postinstall: ospkg/postinstall.sh
+
+    config_files:
+      "ospkg/conf/config.yaml": "/etc/pomerium/config.yaml"
+
+    overrides:
+      deb:
+        file_name_template: "{{ .ProjectName }}_{{ .Version }}-{{ .Release }}_{{ .Arch }}"
+      rpm:
+        replacements:
+          arm64: aarch64
+          amd64: x86_64
+        file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Release }}.{{ .Arch }}"

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -234,8 +234,12 @@ nfpms:
 
     overrides:
       deb:
+        dependencies:
+          - libsystemd0
         file_name_template: "{{ .ProjectName }}_{{ .Version }}-{{ .Release }}_{{ .Arch }}"
       rpm:
+        dependencies:
+          - systemd-libs
         replacements:
           arm64: aarch64
           amd64: x86_64
@@ -259,7 +263,7 @@ nfpms:
       - deb
       - rpm
 
-    bindir: /usr/bin
+    bindir: /usr/sbin
 
     overrides:
       deb:

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -240,3 +240,34 @@ nfpms:
           arm64: aarch64
           amd64: x86_64
         file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Release }}.{{ .Arch }}"
+  - id: pomerium-cli
+
+    builds:
+      - pomerium-cli
+
+    package_name: pomerium-cli
+    vendor: Pomerium, Inc.
+    homepage: https://www.pomerium.com
+    description: Identity Aware Proxy
+    maintainer:
+    license: Apache 2.0
+    epoch: 1
+    release: 1
+    meta: false
+
+    formats:
+      - deb
+      - rpm
+
+    bindir: /usr/bin
+
+    overrides:
+      deb:
+        replacements:
+          arm64: arm64
+        file_name_template: '{{ .ProjectName }}-cli_{{ .Version }}-{{ .Release }}_{{ .Arch }}{{ if .Arm }}{{if eq .Arm "7"}}hf{{ end }}{{ end }}'
+      rpm:
+        replacements:
+          arm64: aarch64
+          amd64: x86_64
+        file_name_template: '{{ .ProjectName }}-cli_{{ .Version }}-{{ .Release }}_{{ .Arch }}{{ if .Arm }}{{if eq .Arm "7"}}hf{{ end }}{{ end }}'

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -32,6 +32,13 @@ curl -L https://github.com/pomerium/pomerium/releases/download/${VERSION}/pomeri
     | tar -z -x
 ```
 
+### Packages
+
+- Supported formats: `rpm`, `deb`
+- Requires `systemd` support
+
+Official packages can be found on our [GitHub Releases](https://github.com/pomerium/pomerium/releases) page.
+
 ### Docker Image
 
 Pomerium utilizes a [minimal](https://github.com/GoogleContainerTools/distroless) [docker container](https://www.docker.com/resources/what-container). You can find Pomerium's images on [dockerhub](https://hub.docker.com/r/pomerium/pomerium). Pomerium can be pulled in several flavors and architectures.
@@ -97,6 +104,12 @@ VERSION=[desired version]
 curl -L https://github.com/pomerium/pomerium/releases/download/${VERSION}/pomerium-cli-${OS}-${ARCH}.tar.gz \
     | tar -z -x
 ```
+### Packages
+
+- Supported formats: `rpm`, `deb`
+- Requires `systemd` support
+
+Official packages can be found on our [GitHub Releases](https://github.com/pomerium/pomerium/releases) page.
 
 ### Homebrew
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -107,7 +107,6 @@ curl -L https://github.com/pomerium/pomerium/releases/download/${VERSION}/pomeri
 ### Packages
 
 - Supported formats: `rpm`, `deb`
-- Requires `systemd` support
 
 Official packages can be found on our [GitHub Releases](https://github.com/pomerium/pomerium/releases) page.
 

--- a/ospkg/conf/config.yaml
+++ b/ospkg/conf/config.yaml
@@ -1,3 +1,5 @@
+# Required settings below.  See complete documentation at https://www.pomerium.com/reference/
+
 # To run on :443 set AmbientCapabilities=CAP_NET_BIND_SERVICE
 # in a systemd override
 address: :8443

--- a/ospkg/conf/config.yaml
+++ b/ospkg/conf/config.yaml
@@ -1,0 +1,20 @@
+# To run on :443 set AmbientCapabilities=CAP_NET_BIND_SERVICE
+# in a systemd override
+address: :8443
+
+authenticate_service_url: https://authenticate.localhost.pomerium.io
+certificates:
+  - cert: /etc/pomerium/cert.pem
+    key: /etc/pomerium/key.pem
+shared_secret: XXXXXX
+cookie_secret: YYYYY
+idp_provider: "google"
+idp_client_id: XXXX
+idp_client_secret: YYYY
+idp_service_account: XXXXXX
+
+policy:
+  - from: https://httpbin.localhost.pomerium.io
+    to: https://httpbin.org
+    allowed_users:
+      - user@domain.com

--- a/ospkg/conf/config.yaml
+++ b/ospkg/conf/config.yaml
@@ -14,7 +14,7 @@ idp_client_secret: YYYY
 idp_service_account: XXXXXX
 
 policy:
-  - from: https://httpbin.localhost.pomerium.io
-    to: https://httpbin.org
+  - from: https://yoursite.localhost.pomerium.io
+    to: https://yoursite.local
     allowed_users:
       - user@domain.com

--- a/ospkg/pomerium.service
+++ b/ospkg/pomerium.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Pomerium
+
+[Service]
+ExecStart=/usr/sbin/pomerium -config /etc/pomerium/config.yaml
+User=pomerium
+Group=pomerium
+Environment=AUTOCERT_DIR=/etc/pomerium/
+
+[Install]
+WantedBy=multi-user.target

--- a/ospkg/postinstall.sh
+++ b/ospkg/postinstall.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+chown pomerium:pomerium -R /etc/pomerium
+chmod 750 /etc/pomerium

--- a/ospkg/preinstall.sh
+++ b/ospkg/preinstall.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+if ! getent passwd pomerium >/dev/null; then
+    useradd --system -d / -s /sbin/nologin pomerium
+fi


### PR DESCRIPTION
## Summary
Adds some basic packages.
- run as non-root / unprivileged port
- includes base config file
- pre-configures autocert directory default

Artifact list on snapshot:

```
pomerium-cli_v0.10.0+next-1_aarch64.rpm
pomerium-cli_v0.10.0+next-1_amd64.deb
pomerium-cli_v0.10.0+next-1_arm.deb
pomerium-cli_v0.10.0+next-1_arm.rpm
pomerium-cli_v0.10.0+next-1_arm64.deb
pomerium-cli_v0.10.0+next-1_armhf.deb
pomerium-cli_v0.10.0+next-1_armhf.rpm
pomerium-cli_v0.10.0+next-1_x86_64.rpm
pomerium-v0.10.0+next-1.aarch64.rpm
pomerium-v0.10.0+next-1.x86_64.rpm
pomerium_v0.10.0+next-1_amd64.deb
pomerium_v0.10.0+next-1_arm64.deb
```

The 'v' doesn't show up in formal releases.

**Checklist**:
- [x] updated docs
- [x] ready for review
