### PR TITLE
dev: add remote container debug configs

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,34 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go/.devcontainer/base.Dockerfile
+ARG VARIANT="1"
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+
+# [Optional] Install a version of Node.js using nvm for front end dev
+ARG INSTALL_NODE="true"
+ARG NODE_VERSION="lts/*"
+RUN if [ "${INSTALL_NODE}" = "true" ]; then su vscode -c "source /usr/local/share/nvm/nvm.sh && nvm install ${NODE_VERSION} 2>&1"; fi
+
+# install envoy
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+	&& apt-get -y install --no-install-recommends \
+	apt-transport-https \
+	ca-certificates \
+	curl \
+	gnupg-agent \
+	software-properties-common
+
+RUN curl -sL 'https://getenvoy.io/gpg' | sudo apt-key add -
+
+RUN add-apt-repository \
+	"deb [arch=amd64] https://dl.bintray.com/tetrate/getenvoy-deb \
+	$(lsb_release -cs) \
+	stable"
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+	&& apt-get -y install --no-install-recommends getenvoy-envoy
+
+
+# [Optional] Uncomment the next line to use go get to install anything else you need
+# RUN go get -x <your-dependency-or-tool>
+
+# [Optional] Uncomment this line to install global node packages.
+# RUN su vscode -c "source /usr/local/share/nvm/nvm.sh && npm install -g <your-package-here>" 2>&1

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,8 +13,8 @@
   // Add the IDs of extensions you want installed when the container is created.
   "extensions": ["golang.Go"],
   "postCreateCommand": "go version",
-
-  "dockerComposeFile": ["envs/traefik.yaml"],
+  "dockerComposeFile": ["envs/nginx.yaml"],
+  // "dockerComposeFile": ["envs/traefik.yaml"],
   "service": "pomerium",
   "shutdownAction": "none",
   "workspaceFolder": "/workspace"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 // For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go
 {
-  "name": "traefik",
+  "name": "pomerium-remote-containers",
   "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
   // Set *default* container specific settings.json values on container create.
   "settings": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go
+{
+  "name": "traefik",
+  "runArgs": ["--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"],
+  // Set *default* container specific settings.json values on container create.
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash",
+    "go.useGoProxyToCheckForToolUpdates": false,
+    "go.gopath": "/go",
+    "go.useLanguageServer": true
+  },
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": ["golang.Go"],
+  "postCreateCommand": "go version",
+
+  "dockerComposeFile": ["envs/traefik.yaml"],
+  "service": "pomerium",
+  "shutdownAction": "none",
+  "workspaceFolder": "/workspace"
+}

--- a/.devcontainer/envs/nginx.yaml
+++ b/.devcontainer/envs/nginx.yaml
@@ -1,0 +1,30 @@
+version: "3"
+services:
+  nginx:
+    image: nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ../../examples/nginx/httpbin.conf:/etc/nginx/conf.d/httpbin.conf
+      - ../../examples/nginx/pomerium.conf:/etc/nginx/conf.d/pomerium.conf
+      - ../../examples/nginx/_wildcard.localhost.pomerium.io.pem:/etc/nginx/nginx.pem
+      - ../../examples/nginx/_wildcard.localhost.pomerium.io-key.pem:/etc/nginx/nginx-key.pem
+
+  httpbin:
+    image: kennethreitz/httpbin:latest
+    expose:
+      - 80
+  pomerium:
+    build: ../.
+    volumes:
+      - ../../:/workspace:cached
+    command: /bin/sh -c "while sleep 1000; do :; done"
+    environment:
+      - INSECURE_SERVER=TRUE
+      - ADDRESS=:80
+      - FORWARD_AUTH_URL=http://fwdauth.localhost.pomerium.io
+      - JWT_CLAIMS_HEADERS="email,groups,user"
+    expose:
+      - 80

--- a/.devcontainer/envs/nginx.yaml
+++ b/.devcontainer/envs/nginx.yaml
@@ -9,6 +9,9 @@ services:
     volumes:
       - ../../examples/nginx/httpbin.conf:/etc/nginx/conf.d/httpbin.conf
       - ../../examples/nginx/pomerium.conf:/etc/nginx/conf.d/pomerium.conf
+      - ../../examples/nginx/proxy.conf:/etc/nginx/proxy.conf
+      - ../../examples/nginx/auth.conf:/etc/nginx/auth.conf
+      - ../../examples/nginx/ext_authz.conf:/etc/nginx/ext_authz.conf
       - ../../examples/nginx/_wildcard.localhost.pomerium.io.pem:/etc/nginx/nginx.pem
       - ../../examples/nginx/_wildcard.localhost.pomerium.io-key.pem:/etc/nginx/nginx-key.pem
 
@@ -16,6 +19,7 @@ services:
     image: kennethreitz/httpbin:latest
     expose:
       - 80
+
   pomerium:
     build: ../.
     volumes:
@@ -24,7 +28,7 @@ services:
     environment:
       - INSECURE_SERVER=TRUE
       - ADDRESS=:80
-      - FORWARD_AUTH_URL=http://fwdauth.localhost.pomerium.io
+      - FORWARD_AUTH_URL=https://fwdauth.localhost.pomerium.io
       - JWT_CLAIMS_HEADERS="email,groups,user"
     expose:
       - 80

--- a/.devcontainer/envs/traefik.yaml
+++ b/.devcontainer/envs/traefik.yaml
@@ -1,0 +1,50 @@
+version: "3"
+services:
+  traefik:
+    image: traefik:v2.3
+    command:
+      - "--accesslog=true"
+      - "--api.insecure=true"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.websecure.address=:443"
+      - "--entryPoints.websecure.forwardedHeaders.insecure"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker=true"
+
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
+  httpbin:
+    image: kennethreitz/httpbin:latest
+    labels:
+      - "traefik.http.middlewares.pomerium.forwardauth.authResponseHeaders=X-Pomerium-Claim-Email,X-Pomerium-Claim-User,X-Pomerium-Claim-Groups,X-Pomerium-Jwt-Assertion"
+      - "traefik.http.middlewares.pomerium.forwardauth.address=http://pomerium/"
+      - "traefik.http.middlewares.pomerium.forwardauth.trustForwardHeader=true"
+      - "traefik.http.routers.httpbin.middlewares=pomerium@docker"
+
+      - "traefik.enable=true"
+      - "traefik.http.routers.httpbin.rule=Host(`httpbin.localhost.pomerium.io`)"
+      - "traefik.http.routers.httpbin.entrypoints=websecure"
+      - "traefik.http.routers.httpbin.tls=true"
+
+  pomerium:
+    build: ../.
+    volumes:
+      - ../../:/workspace:cached
+    command: /bin/sh -c "while sleep 1000; do :; done"
+    environment:
+      - INSECURE_SERVER=TRUE
+      - ADDRESS=:80
+      - FORWARD_AUTH_URL=http://pomerium
+      - JWT_CLAIMS_HEADERS="email,groups,user"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.pomerium.rule=Host(`authenticate.localhost.pomerium.io`)"
+      - "traefik.http.routers.pomerium.entrypoints=websecure"
+      - "traefik.http.routers.pomerium.tls=true"
+    expose:
+      - 80

--- a/.devcontainer/readme.md
+++ b/.devcontainer/readme.md
@@ -1,0 +1,20 @@
+# Remote dev containers
+
+## What
+
+These are configurations for Visual Studio Code telling it how to create or access a development container with a well-defined tool and runtime stack.
+
+Basically, this allows us to run VS Code from within a container, remotely.
+
+## Why
+
+Integrating, testing, and debugging Pomerium behind other fronting proxies (nginx/traefik) in forward-auth configuration is a real pain. In particular, it is difficult to do step debugging inside a containerized environment where part of that environment lives outside the network stack of the other components.
+
+It turns out that bringing the debug environment to the containerized environment is easier than bringing the request flow.
+
+## How
+
+- Install [Remote-container](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+- run `Remote-Containers: Rebuild Container` from the Command Palette
+- ???
+- Debug, code, etc as your normally would.

--- a/.devcontainer/readme.md
+++ b/.devcontainer/readme.md
@@ -15,6 +15,7 @@ It turns out that bringing the debug environment to the containerized environmen
 ## How
 
 - Install [Remote-container](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+- Change `devcontainer.json` to use the docker compose file you want to test with
 - run `Remote-Containers: Rebuild Container` from the Command Palette
 - ???
 - Debug, code, etc as your normally would.

--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ _testmain.go
 
 .DS_Store
 .idea
-.vscode
 
 dist/*
 bin/*

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ _testmain.go
 
 .DS_Store
 .idea
+.vscode
 
 dist/*
 bin/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "debug pomerium",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceRoot}/cmd/pomerium",
+      "args": ["-config", "${workspaceRoot}/.config.yaml"]
+    }
+  ]
+}

--- a/examples/nginx/auth.conf
+++ b/examples/nginx/auth.conf
@@ -1,0 +1,11 @@
+# Send auth check to /authorize location.
+auth_request /authorize;
+
+auth_request_set $target_url $scheme://$http_host$request_uri;
+
+# Set cookies we get back from the auth check
+auth_request_set $saved_set_cookie $upstream_http_set_cookie;
+add_header Set-Cookie $saved_set_cookie;
+
+# If we get a 401, respond with a named location
+error_page 401 =302 https://fwdauth.localhost.pomerium.io/?uri=$target_url;

--- a/examples/nginx/docker-compose.yaml
+++ b/examples/nginx/docker-compose.yaml
@@ -11,6 +11,9 @@ services:
       - ./pomerium.conf:/etc/nginx/conf.d/pomerium.conf
       - ./_wildcard.localhost.pomerium.io.pem:/etc/nginx/nginx.pem
       - ./_wildcard.localhost.pomerium.io-key.pem:/etc/nginx/nginx-key.pem
+      - ./proxy.conf:/etc/nginx/proxy.conf
+      - ./auth.conf:/etc/nginx/auth.conf
+      - ./ext_authz.conf:/etc/nginx/ext_authz.conf
 
   httpbin:
     image: kennethreitz/httpbin:latest

--- a/examples/nginx/ext_authz.conf
+++ b/examples/nginx/ext_authz.conf
@@ -1,0 +1,16 @@
+location /authorize {
+	proxy_pass http://pomerium/verify?uri=$scheme://$http_host$request_uri;
+	proxy_set_header Host fwdauth.localhost.pomerium.io;
+	proxy_http_version 1.1;
+
+	proxy_set_header X-Original-URL $scheme://$http_host$request_uri;
+	proxy_set_header X-Real-IP $remote_addr;
+	proxy_set_header X-Forwarded-For $remote_addr;
+	proxy_set_header X-Forwarded-Proto $scheme;
+	proxy_set_header X-Forwarded-Host $http_host;
+	proxy_set_header X-Forwarded-Uri $request_uri;
+	proxy_cache_bypass $cookie_session;
+	proxy_no_cache $cookie_session;
+	proxy_buffers 4 32k;
+	proxy_pass_request_body off;
+}

--- a/examples/nginx/httpbin.conf
+++ b/examples/nginx/httpbin.conf
@@ -6,32 +6,11 @@ server {
     ssl_certificate /etc/nginx/nginx.pem;
     ssl_certificate_key /etc/nginx/nginx-key.pem;
 
+    include /etc/nginx/ext_authz.conf;
+
     location / {
       proxy_pass http://httpbin;
+      include /etc/nginx/auth.conf;
+      include /config/nginx/proxy.conf;
     }
-
-    ### External Authorization
-
-    # Send auth check to /authorize location.
-    auth_request /authorize;
-
-    # Set cookies we get back from the auth check
-    auth_request_set $saved_set_cookie $upstream_http_set_cookie;
-    add_header Set-Cookie $saved_set_cookie;
-
-    # If we get a 401, respond with a named location
-    error_page 401 = @error401;
-    # On 401, redirect the user to forward auth to start authentication flow
-    location @error401 {
-        return 302 https://fwdauth.localhost.pomerium.io/?uri=$scheme://$http_host$request_uri;
-    }
-
-    # The auth request must be a subpath of the server
-    location /authorize {
-      proxy_pass http://pomerium/verify?uri=$scheme://$http_host$request_uri;
-      proxy_set_header Host fwdauth.localhost.pomerium.io;
-      proxy_http_version 1.1;
-    }
-
-    ### End External Authorization
 }

--- a/examples/nginx/pomerium.conf
+++ b/examples/nginx/pomerium.conf
@@ -7,8 +7,7 @@ server {
 
     location / {
       proxy_pass http://pomerium;
-      proxy_set_header Host $http_host;
-      proxy_http_version 1.1;
+      include /config/nginx/proxy.conf;
     }
 }
 

--- a/examples/nginx/proxy.conf
+++ b/examples/nginx/proxy.conf
@@ -1,0 +1,32 @@
+client_body_buffer_size 128k
+
+#Timeout if the real server is dead
+proxy_next_upstream error timeout invalid_header http_500 http_502 http_503
+
+# Advanced Proxy Config
+send_timeout 5m
+proxy_read_timeout 360
+proxy_send_timeout 360
+proxy_connect_timeout 360
+
+# Basic Proxy Config
+proxy_set_header Host $host
+proxy_set_header X-Real-IP $remote_addr
+proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for
+proxy_set_header X-Forwarded-Proto $scheme
+proxy_set_header X-Forwarded-Host $http_host
+proxy_set_header X-Forwarded-Uri $request_uri
+proxy_set_header X-Forwarded-Ssl on
+proxy_http_version 1.1
+proxy_set_header Connection ""
+proxy_cache_bypass $cookie_session
+proxy_no_cache $cookie_session
+proxy_buffers 64 256k
+
+# If behind reverse proxy, forwards the correct IP
+set_real_ip_from 10.0.0.0/8
+set_real_ip_from 172.0.0.0/8
+set_real_ip_from 192.168.0.0/16
+set_real_ip_from fc00::/7
+real_ip_header X-Forwarded-For
+real_ip_recursive on


### PR DESCRIPTION
## Summary

Adds remote container development configurations for VS code. These are most useful for step-debugging / developing against other fronting proxies / forward-auth configurations. 

## Related issues

It's related to all my issues. All of them. 

- https://github.com/pomerium/pomerium/pull/1447
- https://github.com/pomerium/pomerium/pull/1415
- #1313 


**Checklist**:

- [x] ready for review
