### PR TITLE
chore(deps): envoy 1.15.1

### DIFF
--- a/scripts/embed-envoy.bash
+++ b/scripts/embed-envoy.bash
@@ -3,7 +3,7 @@ set -euo pipefail
 
 BINARY=$1
 
-ENVOY_VERSION=1.15.0
+ENVOY_VERSION=1.15.1
 DIR=$(dirname "${BINARY}")
 TARGET="${TARGET:-"$(go env GOOS)_$(go env GOARCH)"}"
 


### PR DESCRIPTION

## Summary

This addresses the following CVE(s):

* CVE-2020-25017 (CVSS score 6.5, Medium): Incorrect handling of duplicate HTTP headers

## Related issues

- https://groups.google.com/g/envoy-announce/c/fk0Qvgrln_s/m/w7kbfOHgCAAJ?pli=1


**Checklist**:

- [ ] ready for review
