### PR TITLE
ci: ensure systemd unit file is in packages

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -232,6 +232,9 @@ nfpms:
     config_files:
       "ospkg/conf/config.yaml": "/etc/pomerium/config.yaml"
 
+    files:
+      "ospkg/pomerium.service": "/usr/lib/systemd/system/pomerium.service"
+
     overrides:
       deb:
         dependencies:


### PR DESCRIPTION
## Summary
Fix systemd unit file missing from os packages

**Checklist**:
- [x] ready for review
