### PR TITLE
authenticate: remove unused paths, generate cipher at startup, remove qp store

### DIFF
--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -150,8 +150,11 @@ func TestAuthenticate_SignIn(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
+			sharedCipher, _ := cryptutil.NewAEADCipherFromBase64(cryptutil.NewBase64Key())
+
 			a := &Authenticate{
 				state: newAtomicAuthenticateState(&authenticateState{
+					sharedCipher:     sharedCipher,
 					sessionStore:     tt.session,
 					redirectURL:      uriParseHelper("https://some.example"),
 					sharedEncoder:    tt.encoder,
@@ -566,7 +569,7 @@ func TestWellKnownEndpoint(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 	body := rr.Body.String()
-	expected := `{"jwks_uri":"https://auth.example.com/.well-known/pomerium/jwks.json","authentication_callback_endpoint":"https://auth.example.com/oauth2/callback"}`
+	expected := "{\"jwks_uri\":\"https://auth.example.com/.well-known/pomerium/jwks.json\",\"authentication_callback_endpoint\":\"https://auth.example.com/oauth2/callback\"}\n"
 	assert.Equal(t, body, expected)
 }
 
@@ -587,7 +590,7 @@ func TestJwksEndpoint(t *testing.T) {
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
 	body := rr.Body.String()
-	expected := `{"keys":[{"use":"sig","kty":"EC","kid":"5b419ade1895fec2d2def6cd33b1b9a018df60db231dc5ecb85cbed6d942813c","crv":"P-256","alg":"ES256","x":"UG5xCP0JTT1H6Iol8jKuTIPVLM04CgW9PlEypNRmWlo","y":"KChF0fR09zm884ymInM29PtSsFdnzExNfLsP-ta1AgQ"}]}`
+	expected := "{\"keys\":[{\"use\":\"sig\",\"kty\":\"EC\",\"kid\":\"5b419ade1895fec2d2def6cd33b1b9a018df60db231dc5ecb85cbed6d942813c\",\"crv\":\"P-256\",\"alg\":\"ES256\",\"x\":\"UG5xCP0JTT1H6Iol8jKuTIPVLM04CgW9PlEypNRmWlo\",\"y\":\"KChF0fR09zm884ymInM29PtSsFdnzExNfLsP-ta1AgQ\"}]}\n"
 	assert.Equal(t, expected, body)
 }
 func TestAuthenticate_Dashboard(t *testing.T) {

--- a/internal/httputil/errors.go
+++ b/internal/httputil/errors.go
@@ -1,7 +1,6 @@
 package httputil
 
 import (
-	"encoding/json"
 	"html/template"
 	"net/http"
 
@@ -68,10 +67,7 @@ func (e *HTTPError) ErrorResponse(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if r.Header.Get("Accept") == "application/json" {
-		w.Header().Set("Content-Type", "application/json")
-		if err := json.NewEncoder(w).Encode(response); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
+		RenderJSON(w, e.Status, response)
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")

--- a/internal/httputil/handlers.go
+++ b/internal/httputil/handlers.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -35,11 +36,14 @@ func Redirect(w http.ResponseWriter, r *http.Request, url string, code int) {
 func RenderJSON(w http.ResponseWriter, code int, v interface{}) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.WriteHeader(code)
-	if err := json.NewEncoder(w).Encode(v); err != nil {
+	b := new(bytes.Buffer)
+	if err := json.NewEncoder(b).Encode(v); err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
-		fmt.Fprintf(w, `{"error":"%s"}`, err)
+		fmt.Fprintf(b, `{"error":"%s"}`, err)
+	} else {
+		w.WriteHeader(code)
 	}
+	fmt.Fprint(w, b)
 }
 
 // The HandlerFunc type is an adapter to allow the use of

--- a/internal/httputil/handlers.go
+++ b/internal/httputil/handlers.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
@@ -25,6 +26,20 @@ func HealthCheck(w http.ResponseWriter, r *http.Request) {
 func Redirect(w http.ResponseWriter, r *http.Request, url string, code int) {
 	w.Header().Set(HeaderPomeriumResponse, "true")
 	http.Redirect(w, r, url, code)
+}
+
+// RenderJSON replies to the request with the specified struct as JSON and HTTP code.
+// It does not otherwise end the request; the caller should ensure no further
+// writes are done to w.
+// The error message should be application/json.
+func RenderJSON(w http.ResponseWriter, code int, v interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.WriteHeader(code)
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprintf(w, `{"error":"%s"}`, err)
+	}
 }
 
 // The HandlerFunc type is an adapter to allow the use of

--- a/internal/httputil/handlers_test.go
+++ b/internal/httputil/handlers_test.go
@@ -2,6 +2,7 @@ package httputil
 
 import (
 	"errors"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -88,6 +89,54 @@ func TestHandlerFunc_ServeHTTP(t *testing.T) {
 			tt.f.ServeHTTP(w, r)
 			if diff := cmp.Diff(tt.wantBody, w.Body.String()); diff != "" {
 				t.Errorf("ErrorResponse status:\n %s", diff)
+			}
+		})
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		code     int
+		v        interface{}
+		wantBody string
+	}{
+		{"simple",
+			http.StatusOK,
+			struct {
+				A string
+				B string
+				C int
+			}{
+				A: "A",
+				B: "B",
+				C: 1,
+			},
+			"{\"A\":\"A\",\"B\":\"B\",\"C\":1}\n"},
+		{"map",
+			http.StatusOK,
+			map[string]interface{}{
+				"C": 1, // notice order does not matter
+				"A": "A",
+				"B": "B",
+			},
+			// alphabetical
+			"{\"A\":\"A\",\"B\":\"B\",\"C\":1}\n"},
+		{"bad!",
+			http.StatusOK,
+			map[string]interface{}{
+				"BAD BOI": math.Inf(1),
+			},
+			`{"error":"json: unsupported value: +Inf"}`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := httptest.NewRecorder()
+
+			RenderJSON(w, tt.code, tt.v)
+			if diff := cmp.Diff(tt.wantBody, w.Body.String()); diff != "" {
+				t.Errorf("TestRenderJSON:\n %s", diff)
 			}
 		})
 	}

--- a/internal/urlutil/query_params.go
+++ b/internal/urlutil/query_params.go
@@ -14,7 +14,6 @@ const (
 	QuerySession           = "pomerium_session"
 	QuerySessionEncrypted  = "pomerium_session_encrypted"
 	QueryRedirectURI       = "pomerium_redirect_uri"
-	QueryProgrammaticToken = "pomerium_programmatic_token"
 	QueryForwardAuthURI    = "uri"
 )
 


### PR DESCRIPTION
## Summary

Small improvements to authenticate that I noticed while making unrelated changes. 

- Generate shared cipher on startup, not per request.
- Use a render json helper.
- Remove unused API path declarations.
- Remove unused queryparam store. 

## Related issues

- No specific issues but the cipher could be a performance (entropy exhaustion?) under stress.

**Checklist**:

- [x] updated unit tests
- [x] ready for review
