### PR TITLE
authenticate: protect /.pomerium/admin endpoint

### DIFF
--- a/integration/control_plane_test.go
+++ b/integration/control_plane_test.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/integration/internal/flows"
 )
 
 func TestDashboard(t *testing.T) {
@@ -15,6 +17,28 @@ func TestDashboard(t *testing.T) {
 	ctx, clearTimeout := context.WithTimeout(ctx, time.Second*30)
 	defer clearTimeout()
 
+	t.Run("admin impersonate", func(t *testing.T) {
+		client := testcluster.NewHTTPClient()
+
+		res, err := flows.Authenticate(ctx, client, mustParseURL("https://httpdetails.localhost.pomerium.io/by-user"),
+			flows.WithEmail("bob@dogs.test"), flows.WithGroups("user"))
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		req, err := http.NewRequestWithContext(ctx, "GET", "https://httpdetails.localhost.pomerium.io/.pomerium/admin/impersonate", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, err = client.Do(req)
+		if !assert.NoError(t, err, "unexpected http error") {
+			return
+		}
+		defer res.Body.Close()
+
+		assertDeniedAccess(t, res)
+	})
 	t.Run("user dashboard", func(t *testing.T) {
 		client := testcluster.NewHTTPClient()
 

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -94,7 +94,7 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 						"domains": ["example.com"],
 						"routes": [
 							{
-								"name": "pomerium-protected-path-/.pomerium/jwt",
+								"name": "pomerium-path-/.pomerium/jwt",
 								"match": {
 									"path": "/.pomerium/jwt"
 								},
@@ -130,6 +130,24 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 										"@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
 										"disabled": true
 									}
+								}
+							},
+							{
+								"name": "pomerium-path-/.pomerium/admin",
+								"match": {
+									"path": "/.pomerium/admin"
+								},
+								"route": {
+									"cluster": "pomerium-control-plane-http"
+								}
+							},
+							{
+								"name": "pomerium-prefix-/.pomerium/admin/",
+								"match": {
+									"prefix": "/.pomerium/admin/"
+								},
+								"route": {
+									"cluster": "pomerium-control-plane-http"
 								}
 							},
 							{
@@ -214,7 +232,7 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 						"domains": ["*"],
 						"routes": [
 							{
-								"name": "pomerium-protected-path-/.pomerium/jwt",
+								"name": "pomerium-path-/.pomerium/jwt",
 								"match": {
 									"path": "/.pomerium/jwt"
 								},
@@ -250,6 +268,24 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 										"@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute",
 										"disabled": true
 									}
+								}
+							},
+							{
+								"name": "pomerium-path-/.pomerium/admin",
+								"match": {
+									"path": "/.pomerium/admin"
+								},
+								"route": {
+									"cluster": "pomerium-control-plane-http"
+								}
+							},
+							{
+								"name": "pomerium-prefix-/.pomerium/admin/",
+								"match": {
+									"prefix": "/.pomerium/admin/"
+								},
+								"route": {
+									"cluster": "pomerium-control-plane-http"
 								}
 							},
 							{


### PR DESCRIPTION
## Summary
This puts the `/.pomerium/admin` endpoint behind authz so only admins have access.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
