### PR TITLE
databroker: require JWT for access

### DIFF
--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -116,6 +116,8 @@ func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, err
 		state.jwk.Keys = append(state.jwk.Keys, *jwk)
 	}
 
+	sharedKey, _ := base64.StdEncoding.DecodeString(cfg.Options.SharedKey)
+
 	dataBrokerConn, err := grpc.GetGRPCClientConn("databroker", &grpc.Options{
 		Addr:                    cfg.Options.DataBrokerURL,
 		OverrideCertificateName: cfg.Options.OverrideCertificateName,
@@ -125,6 +127,7 @@ func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, err
 		ClientDNSRoundRobin:     cfg.Options.GRPCClientDNSRoundRobin,
 		WithInsecure:            cfg.Options.GRPCInsecure,
 		ServiceName:             cfg.Options.Services,
+		SignedJWTKey:            sharedKey,
 	})
 	if err != nil {
 		return nil, err

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -1,6 +1,7 @@
 package authorize
 
 import (
+	"encoding/base64"
 	"fmt"
 	"sync/atomic"
 
@@ -41,6 +42,8 @@ func newAuthorizeStateFromConfig(cfg *config.Config, store *evaluator.Store) (*a
 		return nil, err
 	}
 
+	sharedKey, _ := base64.StdEncoding.DecodeString(cfg.Options.SharedKey)
+
 	cc, err := grpc.GetGRPCClientConn("databroker", &grpc.Options{
 		Addr:                    cfg.Options.DataBrokerURL,
 		OverrideCertificateName: cfg.Options.OverrideCertificateName,
@@ -50,6 +53,7 @@ func newAuthorizeStateFromConfig(cfg *config.Config, store *evaluator.Store) (*a
 		ClientDNSRoundRobin:     cfg.Options.GRPCClientDNSRoundRobin,
 		WithInsecure:            cfg.Options.GRPCInsecure,
 		ServiceName:             cfg.Options.Services,
+		SignedJWTKey:            sharedKey,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("authorize: error creating databroker connection: %w", err)

--- a/integration/control_plane_test.go
+++ b/integration/control_plane_test.go
@@ -20,7 +20,7 @@ func TestDashboard(t *testing.T) {
 	t.Run("admin impersonate", func(t *testing.T) {
 		client := testcluster.NewHTTPClient()
 
-		res, err := flows.Authenticate(ctx, client, mustParseURL("https://httpdetails.localhost.pomerium.io/by-user"),
+		_, err := flows.Authenticate(ctx, client, mustParseURL("https://httpdetails.localhost.pomerium.io/by-user"),
 			flows.WithEmail("bob@dogs.test"), flows.WithGroups("user"))
 		if !assert.NoError(t, err) {
 			return
@@ -31,7 +31,7 @@ func TestDashboard(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		res, err = client.Do(req)
+		res, err := client.Do(req)
 		if !assert.NoError(t, err, "unexpected http error") {
 			return
 		}

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -2,6 +2,7 @@ package databroker
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"sync"
 	"time"
@@ -138,6 +139,7 @@ func (src *ConfigSource) rebuild(firstTime bool) {
 }
 
 func (src *ConfigSource) runUpdater(cfg *config.Config) {
+	sharedKey, _ := base64.StdEncoding.DecodeString(cfg.Options.SharedKey)
 	connectionOptions := &grpc.Options{
 		Addr:                    cfg.Options.DataBrokerURL,
 		OverrideCertificateName: cfg.Options.OverrideCertificateName,
@@ -147,6 +149,7 @@ func (src *ConfigSource) runUpdater(cfg *config.Config) {
 		ClientDNSRoundRobin:     cfg.Options.GRPCClientDNSRoundRobin,
 		WithInsecure:            cfg.Options.GRPCInsecure,
 		ServiceName:             cfg.Options.Services,
+		SignedJWTKey:            sharedKey,
 	}
 	h, err := hashstructure.Hash(connectionOptions, nil)
 	if err != nil {

--- a/internal/telemetry/grpc.go
+++ b/internal/telemetry/grpc.go
@@ -55,13 +55,3 @@ func NewGRPCClientStatsHandler(service string) *GRPCClientStatsHandler {
 		UnaryInterceptor: metrics.GRPCClientInterceptor(ServiceName(service)),
 	}
 }
-
-// DialOptions returns telemetry related DialOptions appended to an optional existing list
-// of DialOptions
-func (h *GRPCClientStatsHandler) DialOptions(o ...grpc.DialOption) []grpc.DialOption {
-	o = append(o,
-		grpc.WithUnaryInterceptor(h.UnaryInterceptor),
-		grpc.WithStatsHandler(h.Handler),
-	)
-	return o
-}

--- a/internal/telemetry/grpc_test.go
+++ b/internal/telemetry/grpc_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opencensus.io/plugin/ocgrpc"
-	"google.golang.org/grpc"
 	grpcstats "google.golang.org/grpc/stats"
 )
 
@@ -35,28 +34,4 @@ func Test_GRPCServerStatsHandler(t *testing.T) {
 	assert.True(t, metricsHandler.called)
 	assert.Equal(t, ctx.Value(mockCtxTag("added")), "true")
 	assert.Equal(t, ctx.Value(mockCtxTag("original")), "true")
-}
-
-type mockDialOption struct {
-	name string
-	grpc.EmptyDialOption
-}
-
-func Test_NewGRPCClientStatsHandler(t *testing.T) {
-	t.Parallel()
-
-	h := NewGRPCClientStatsHandler("test")
-
-	origOpts := []grpc.DialOption{
-		mockDialOption{name: "one"},
-		mockDialOption{name: "two"},
-	}
-
-	newOpts := h.DialOptions(origOpts...)
-
-	for i := range origOpts {
-		assert.Contains(t, newOpts, origOpts[i])
-	}
-
-	assert.Greater(t, len(newOpts), len(origOpts))
 }

--- a/internal/telemetry/requestid/grpc_client.go
+++ b/internal/telemetry/requestid/grpc_client.go
@@ -14,7 +14,7 @@ func StreamClientInterceptor() grpc.StreamClientInterceptor {
 		desc *grpc.StreamDesc, cc *grpc.ClientConn,
 		method string, streamer grpc.Streamer, opts ...grpc.CallOption,
 	) (grpc.ClientStream, error) {
-		toMetadata(ctx)
+		ctx = toMetadata(ctx)
 		return streamer(ctx, desc, cc, method, opts...)
 	}
 }
@@ -26,21 +26,15 @@ func UnaryClientInterceptor() grpc.UnaryClientInterceptor {
 		method string, req, reply interface{},
 		cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption,
 	) error {
-		toMetadata(ctx)
+		ctx = toMetadata(ctx)
 		return invoker(ctx, method, req, reply, cc, opts...)
 	}
 }
 
-func toMetadata(ctx context.Context) {
+func toMetadata(ctx context.Context) context.Context {
 	requestID := FromContext(ctx)
 	if requestID == "" {
 		requestID = New()
 	}
-
-	md, ok := metadata.FromOutgoingContext(ctx)
-	if !ok {
-		return
-	}
-
-	md.Set(headerName, requestID)
+	return metadata.AppendToOutgoingContext(ctx, headerName, requestID)
 }

--- a/pkg/grpcutil/options.go
+++ b/pkg/grpcutil/options.go
@@ -1,0 +1,112 @@
+package grpcutil
+
+import (
+	"context"
+	"encoding/base64"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"gopkg.in/square/go-jose.v2"
+	"gopkg.in/square/go-jose.v2/jwt"
+)
+
+// WithStreamSignedJWT returns a StreamClientInterceptor that adds a JWT to requests.
+func WithStreamSignedJWT(key []byte) grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string, streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		ctx, err := withSignedJWT(ctx, key)
+		if err != nil {
+			return nil, err
+		}
+
+		return streamer(ctx, desc, cc, method, opts...)
+	}
+}
+
+// WithUnarySignedJWT returns a UnaryClientInterceptor that adds a JWT to requests.
+func WithUnarySignedJWT(key []byte) grpc.UnaryClientInterceptor {
+	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+		ctx, err := withSignedJWT(ctx, key)
+		if err != nil {
+			return err
+		}
+
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+func withSignedJWT(ctx context.Context, key []byte) (context.Context, error) {
+	if len(key) > 0 {
+		sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key},
+			(&jose.SignerOptions{}).WithType("JWT"))
+		if err != nil {
+			return ctx, err
+		}
+
+		rawjwt, err := jwt.Signed(sig).Claims(jwt.Claims{
+			Expiry: jwt.NewNumericDate(time.Now().Add(time.Hour)),
+		}).CompactSerialize()
+		if err != nil {
+			return ctx, err
+		}
+
+		ctx = WithOutgoingJWT(ctx, rawjwt)
+	}
+	return ctx, nil
+}
+
+// UnaryRequireSignedJWT requires a JWT in the gRPC metadata and that it be signed by the base64-encoded key.
+func UnaryRequireSignedJWT(key string) grpc.UnaryServerInterceptor {
+	keyBS, _ := base64.StdEncoding.DecodeString(key)
+	return func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		if err := requireSignedJWT(ctx, keyBS); err != nil {
+			return nil, err
+		}
+		return handler(ctx, req)
+	}
+}
+
+// StreamRequireSignedJWT requires a JWT in the gRPC metadata and that it be signed by the base64-encoded key.
+func StreamRequireSignedJWT(key string) grpc.StreamServerInterceptor {
+	keyBS, _ := base64.StdEncoding.DecodeString(key)
+	return func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		if err := requireSignedJWT(ss.Context(), keyBS); err != nil {
+			return err
+		}
+		return handler(srv, ss)
+	}
+}
+
+func requireSignedJWT(ctx context.Context, key []byte) error {
+	if len(key) > 0 {
+		rawjwt, ok := JWTFromGRPCRequest(ctx)
+		if !ok {
+			return status.Error(codes.Unauthenticated, "unauthenticated")
+		}
+
+		tok, err := jwt.ParseSigned(rawjwt)
+		if err != nil {
+			return status.Errorf(codes.Unauthenticated, "invalid JWT: %v", err)
+		}
+
+		var claims struct {
+			Expiry *jwt.NumericDate `json:"exp,omitempty"`
+		}
+		err = tok.Claims(key, &claims)
+		if err != nil {
+			return status.Errorf(codes.Unauthenticated, "invalid JWT: %v", err)
+		}
+
+		if claims.Expiry == nil || time.Now().After(claims.Expiry.Time()) {
+			return status.Errorf(codes.Unauthenticated, "expired JWT: %v", err)
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
This adds authentication to the databroker so that a JWT signed by the shared key is required to call methods.

## Related issues
- Fixes #1501 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
