### PR TITLE
debug: add pprof endpoints

### DIFF
--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -3,6 +3,7 @@ package controlplane
 
 import (
 	"net/http"
+	"net/http/pprof"
 	"time"
 
 	"github.com/gorilla/handlers"
@@ -38,4 +39,11 @@ func (srv *Server) addHTTPMiddleware() {
 	root.HandleFunc("/healthz", httputil.HealthCheck)
 	root.HandleFunc("/ping", httputil.HealthCheck)
 	root.PathPrefix("/.pomerium/assets/").Handler(http.StripPrefix("/.pomerium/assets/", frontend.MustAssetHandler()))
+
+	// pprof
+	root.Path("/debug/pprof/cmdline").HandlerFunc(pprof.Cmdline)
+	root.Path("/debug/pprof/profile").HandlerFunc(pprof.Profile)
+	root.Path("/debug/pprof/symbol").HandlerFunc(pprof.Symbol)
+	root.Path("/debug/pprof/trace").HandlerFunc(pprof.Trace)
+	root.PathPrefix("/debug/pprof/").HandlerFunc(pprof.Index)
 }


### PR DESCRIPTION
## Summary
These endpoints help to debug problems with memory leaks or performance. They will be exposed on the control plane HTTP server, which has a dynamic port. To use this with the pprof tool you'd execute something like:

```bash
go tool pprof 'http://localhost:33125/debug/pprof/heap?gc
```

The dynamic port can be found in the logs:

```json
{"level":"info","port":"33125","time":"2020-10-09T17:57:01Z","message":"HTTP server started"}
```

## Related issues
- #1496 

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
