### PR TITLE
autocert: support certificate renewal

### DIFF
--- a/internal/autocert/manager_test.go
+++ b/internal/autocert/manager_test.go
@@ -1,16 +1,193 @@
 package autocert
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
 	"fmt"
+	"io"
+	"math/big"
 	"net"
 	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/caddyserver/certmagic"
+	"github.com/go-chi/chi"
+	"github.com/go-chi/chi/middleware"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pomerium/pomerium/config"
 )
+
+type M = map[string]interface{}
+
+func newMockACME(srv *httptest.Server) http.Handler {
+	var certBuffer bytes.Buffer
+
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	r.Get("/acme/directory", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(M{
+			"keyChange":  srv.URL + "/acme/key-change",
+			"newAccount": srv.URL + "/acme/new-acct",
+			"newNonce":   srv.URL + "/acme/new-nonce",
+			"newOrder":   srv.URL + "/acme/new-order",
+			"revokeCert": srv.URL + "/acme/revoke-cert",
+		})
+	})
+	r.Head("/acme/new-nonce", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Replay-Nonce", "NONCE")
+		w.WriteHeader(http.StatusOK)
+	})
+	r.Post("/acme/new-acct", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Replay-Nonce", "NONCE")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(M{
+			"status": "valid",
+		})
+	})
+	r.Post("/acme/new-order", func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			Identifiers []struct {
+				Type  string `json:"type"`
+				Value string `json:"value"`
+			} `json:"identifiers"`
+		}
+		readJWSPayload(r.Body, &payload)
+		w.Header().Set("Replay-Nonce", "NONCE")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(M{
+			"status":   "pending",
+			"finalize": srv.URL + "/acme/finalize",
+		})
+	})
+	r.Post("/acme/finalize", func(w http.ResponseWriter, r *http.Request) {
+		var payload struct {
+			CSR string `json:"csr"`
+		}
+		readJWSPayload(r.Body, &payload)
+		bs, _ := base64.RawURLEncoding.DecodeString(payload.CSR)
+		csr, _ := x509.ParseCertificateRequest(bs)
+		caKey, _ := rsa.GenerateKey(rand.Reader, 2048)
+		tpl := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().Unix()),
+			DNSNames:     csr.DNSNames,
+			IPAddresses:  csr.IPAddresses,
+			Subject: pkix.Name{
+				CommonName: csr.DNSNames[0],
+			},
+			NotBefore: time.Now(),
+			NotAfter:  time.Now().Add(time.Second * 2),
+
+			KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+			ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+			BasicConstraintsValid: true,
+			IsCA:                  false,
+		}
+		der, _ := x509.CreateCertificate(rand.Reader, tpl, tpl, csr.PublicKey, caKey)
+		certBuffer.Reset()
+		_ = pem.Encode(&certBuffer, &pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+		w.Header().Set("Replay-Nonce", "NONCE")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(M{
+			"status":      "valid",
+			"finalize":    srv.URL + "/acme/finalize",
+			"certificate": srv.URL + "/acme/certificate",
+		})
+	})
+	r.Post("/acme/certificate", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Replay-Nonce", "NONCE")
+		w.Header().Set("Content-Type", "application/pem-certificate-chain")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(certBuffer.Bytes())
+	})
+	return r
+}
+
+func TestConfig(t *testing.T) {
+	var mockACME http.Handler
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mockACME.ServeHTTP(w, r)
+	}))
+	defer srv.Close()
+	mockACME = newMockACME(srv)
+
+	tmpdir := filepath.Join(os.TempDir(), uuid.New().String())
+	_ = os.MkdirAll(tmpdir, 0755)
+	defer os.RemoveAll(tmpdir)
+
+	li, err := net.Listen("tcp", "127.0.0.1:0")
+	if !assert.NoError(t, err) {
+		return
+	}
+	addr := li.Addr().String()
+	_ = li.Close()
+
+	oAcmeTemplate := acmeTemplate
+	defer func() { acmeTemplate = oAcmeTemplate }()
+	acmeTemplate = certmagic.ACMEManager{
+		CA:     srv.URL + "/acme/directory",
+		TestCA: srv.URL + "/acme/directory",
+	}
+
+	oCheckInterval := checkInterval
+	defer func() { checkInterval = oCheckInterval }()
+	checkInterval = time.Second
+
+	p1 := config.Policy{
+		From: "http://from.example.com", To: "http://to.example.com",
+	}
+	_ = p1.Validate()
+
+	mgr, err := New(config.NewStaticSource(&config.Config{
+		Options: &config.Options{
+			AutocertOptions: config.AutocertOptions{
+				Enable:     true,
+				UseStaging: true,
+				MustStaple: false,
+				Folder:     tmpdir,
+			},
+			HTTPRedirectAddr: addr,
+			Policies:         []config.Policy{p1},
+		},
+	}))
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	var certs []tls.Certificate
+	for i := 0; i < 10; i++ {
+		cfg := mgr.GetConfig()
+		assert.LessOrEqual(t, len(cfg.Options.Certificates), 1)
+		if len(cfg.Options.Certificates) == 1 && certs == nil {
+			certs = cfg.Options.Certificates
+		}
+
+		if !cmp.Equal(certs, cfg.Options.Certificates) {
+			return
+		}
+
+		time.Sleep(time.Second)
+	}
+	t.Fatalf("expected renewed certs, but certs never changed")
+}
 
 func TestRedirect(t *testing.T) {
 	li, err := net.Listen("tcp", "127.0.0.1:0")
@@ -70,4 +247,16 @@ func waitFor(addr string) error {
 		time.Sleep(time.Second)
 	}
 	return err
+}
+
+func readJWSPayload(r io.Reader, dst interface{}) {
+	var req struct {
+		Protected string `json:"protected"`
+		Payload   string `json:"payload"`
+		Signature string `json:"signature"`
+	}
+	_ = json.NewDecoder(r).Decode(&req)
+
+	bs, _ := base64.RawURLEncoding.DecodeString(req.Payload)
+	_ = json.Unmarshal(bs, dst)
 }


### PR DESCRIPTION
## Summary
This PR updates the autocert code to periodically check if certificates need to be renewed. Once renewed the XDS config will be updated and envoy should start serving new certificates.

I also added a test to this code by mocking out an ACME api. It doesn't remotely implement the actual protocol, but its enough to verify the certs are getting renewed.

## Related issues
- #1490 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
