### PR TITLE
chore(deps): upgrade envoy to v0.16.0

### DIFF
--- a/scripts/embed-envoy.bash
+++ b/scripts/embed-envoy.bash
@@ -3,7 +3,7 @@ set -euo pipefail
 
 BINARY=$1
 
-ENVOY_VERSION=1.15.1
+ENVOY_VERSION=1.16.0
 DIR=$(dirname "${BINARY}")
 TARGET="${TARGET:-"$(go env GOOS)_$(go env GOARCH)"}"
 


### PR DESCRIPTION

## Summary

Updates envoy to [v0.16.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.16.0) .

I don't see any breaking changes in the changelog or in my light manual testing however please do double check :)

Notable enhancements for us...

- build: enable building envoy arm64 images by buildx tool in x86 CI platform
- ext_authz filter: added support for emitting dynamic metadata for both HTTP and network filters. The emitted dynamic metadata is set by dynamic metadata field in a returned CheckResponse.
- ext_authz filter: added stat_prefix as an optional additional prefix for the statistics emitted from ext_authz HTTP filter.
- ext_authz filter: added support for letting the authorization server instruct Envoy to remove headers from the original request by setting the new field headers_to_remove before forwarding it to the upstream.
- ext_authz filter: added support for sending raw bytes as request body of a gRPC check request by setting pack_as_bytes to true.
- tls: added OCSP stapling support through the ocsp_staple and ocsp_staple_policy configuration options. See OCSP Stapling for usage and runtime flags.





## Related issues
- Fixes https://github.com/pomerium/internal/issues/183
- Related to https://github.com/pomerium/pomerium/issues/268

**Checklist**:

- [x] add related issues
- [x] ready for review
