### PR TITLE
github: fix retrieving team id with graphql API (#1554)

### DIFF
--- a/internal/directory/github/github_test.go
+++ b/internal/directory/github/github_test.go
@@ -42,13 +42,13 @@ func newMockAPI(t *testing.T, srv *httptest.Server) http.Handler {
 						"totalCount": 3,
 						"edges": []M{
 							{"node": M{
-								"id": 1,
+								"id": "MDQ6VGVhbTE=",
 							}},
 							{"node": M{
-								"id": 2,
+								"id": "MDQ6VGVhbTI=",
 							}},
 							{"node": M{
-								"id": 3,
+								"id": "MDQ6VGVhbTM=",
 							}},
 						},
 					},


### PR DESCRIPTION
## Summary

Current code expects gitHub graphql API returns int for id, but actually it is base64 string value.
This fixes the JSON definition and parsing team ID.

## Related issues

Fixes #1554

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
