### PR TITLE
handle properly encoded nginx uris

### DIFF
--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -76,7 +76,7 @@ func Test_getEvaluatorRequest(t *testing.T) {
 							"accept":            "text/html",
 							"x-forwarded-proto": "https",
 						},
-						Path:   "/some/path?qs=1",
+						Path:   "/some/path%0A?qs=1",
 						Host:   "example.com",
 						Scheme: "http",
 						Body:   "BODY",
@@ -98,7 +98,7 @@ func Test_getEvaluatorRequest(t *testing.T) {
 		},
 		HTTP: evaluator.RequestHTTP{
 			Method: "GET",
-			URL:    "http://example.com/some/path?qs=1",
+			URL:    "http://example.com/some/path%0A?qs=1",
 			Headers: map[string]string{
 				"Accept":            "text/html",
 				"X-Forwarded-Proto": "https",
@@ -560,4 +560,19 @@ func TestAuthorize_Check(t *testing.T) {
 
 		})
 	}
+}
+
+func TestReplaceCheckRequestURL(t *testing.T) {
+	in := &envoy_service_auth_v2.CheckRequest{
+		Attributes: &envoy_service_auth_v2.AttributeContext{
+			Request: &envoy_service_auth_v2.AttributeContext_Request{
+				Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{},
+			},
+		},
+	}
+
+	newURL, _ := url.Parse("https://example.com/path%0A/example")
+	replaceCheckRequestURL(in, newURL)
+
+	assert.Equal(t, in.Attributes.Request.Http.Path, "/path%0A/example")
 }

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -72,8 +72,7 @@ func buildPomeriumHTTPRoutes(options *config.Options, domain string) []*envoy_co
 	if config.IsProxy(options.Services) && options.ForwardAuthURL != nil && hostMatchesDomain(options.GetForwardAuthURL(), domain) {
 		routes = append(routes,
 			// disable ext_authz and pass request to proxy handlers that enable authN flow
-			buildControlPlanePathAndQueryRoute("/verify", []string{urlutil.QueryForwardAuthURI, urlutil.QuerySessionEncrypted, urlutil.QueryRedirectURI}),
-			buildControlPlanePathAndQueryRoute("/", []string{urlutil.QueryForwardAuthURI, urlutil.QuerySessionEncrypted, urlutil.QueryRedirectURI}),
+			buildControlPlanePathAndQueryRoute("/verify", []string{urlutil.QueryForwardAuthURI}),
 			buildControlPlanePathAndQueryRoute("/", []string{urlutil.QueryForwardAuthURI}),
 			// otherwise, enforce ext_authz; pass all other requests through to an upstream
 			// handler that will simply respond with http status 200 / OK indicating that

--- a/internal/urlutil/url_test.go
+++ b/internal/urlutil/url_test.go
@@ -48,6 +48,7 @@ func TestParseAndValidateURL(t *testing.T) {
 		{"bad hostname", "https://", nil, true},
 		{"bad parse", "https://^", nil, true},
 		{"empty string error", "", nil, true},
+		{"%0A", "https://from.example.com/%0A/test", &url.URL{Scheme: "https", Host: "from.example.com", Path: "/\x0A/test"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
When setting up forward-auth with the nginx ingress controller we recommend urls like:

```
nginx.ingress.kubernetes.io/auth-url: "https://forwardauth.localhost.pomerium.io/verify?uri=$scheme://$host$request_uri"
```

However this causes problems when the request uri has special characters. Nginx also expose an `escaped_request_uri`, but when this option is used various parts of our forward-auth flow stop working.

This PR includes several changes:

1. When replacing the path on the envoy CheckRequest we re-escape it because the Go path is already decoded.
2. When converting the CheckRequest into an HTTP url we now parse the relative path via `u.Parse` to handle encoded paths.
3. The control plane routes for `/?uri=` and `/verify?uri=` no longer require the session and redirect URI query parameters, because these are embedded in the single `uri` query parameter.
4. The fallback `/?uri=` route now ends up handling both `/verify?uri=` and `/?uri=` when the final session passes through, so I added code to detect this and handle it appropriately.

I left much of the existing code paths in place, so I believe this should be backwards compatible. We should also update the documentation to recommend `escaped_request_uri`.

## Related issues
- #1559 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
