### PR TITLE
use custom default http transport

### DIFF
--- a/config/http.go
+++ b/config/http.go
@@ -45,6 +45,6 @@ func (t *httpTransport) update(options *Options) {
 }
 
 // RoundTrip executes an HTTP request.
-func (t *httpTransport) RoundTrip(req *http.Request) (res *http.Response, err error) {
+func (t *httpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return t.transport.Load().(http.RoundTripper).RoundTrip(req)
 }

--- a/config/http.go
+++ b/config/http.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"crypto/tls"
+	"net/http"
+	"sync/atomic"
+
+	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+)
+
+type httpTransport struct {
+	underlying *http.Transport
+	transport  atomic.Value
+}
+
+// NewHTTPTransport creates a new http transport. If CA or CAFile is set, the transport will
+// add the CA to system cert pool.
+func NewHTTPTransport(src Source) http.RoundTripper {
+	t := new(httpTransport)
+	t.underlying, _ = http.DefaultTransport.(*http.Transport)
+	src.OnConfigChange(func(cfg *Config) {
+		t.update(cfg.Options)
+	})
+	t.update(src.GetConfig().Options)
+	return t
+}
+
+func (t *httpTransport) update(options *Options) {
+	nt := new(http.Transport)
+	if t.underlying != nil {
+		nt = t.underlying.Clone()
+	}
+	if options.CA != "" || options.CAFile != "" {
+		rootCAs, err := cryptutil.GetCertPool(options.CA, options.CAFile)
+		if err == nil {
+			nt.TLSClientConfig = &tls.Config{
+				RootCAs: rootCAs,
+			}
+		} else {
+			log.Error().Err(err).Msg("internal/config: error getting cert pool")
+		}
+	}
+	t.transport.Store(nt)
+}
+
+// RoundTrip executes an HTTP request.
+func (t *httpTransport) RoundTrip(req *http.Request) (res *http.Response, err error) {
+	return t.transport.Load().(http.RoundTripper).RoundTrip(req)
+}

--- a/config/http.go
+++ b/config/http.go
@@ -38,7 +38,7 @@ func (t *httpTransport) update(options *Options) {
 				RootCAs: rootCAs,
 			}
 		} else {
-			log.Error().Err(err).Msg("internal/config: error getting cert pool")
+			log.Error().Err(err).Msg("config: error getting cert pool")
 		}
 	}
 	t.transport.Store(nt)

--- a/config/http_test.go
+++ b/config/http_test.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"encoding/base64"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// this cert is the cert used by httptest when creating a TLS server
+var localCert = `
+-----BEGIN CERTIFICATE-----
+MIICEzCCAXygAwIBAgIQMIMChMLGrR+QvmQvpwAU6zANBgkqhkiG9w0BAQsFADAS
+MRAwDgYDVQQKEwdBY21lIENvMCAXDTcwMDEwMTAwMDAwMFoYDzIwODQwMTI5MTYw
+MDAwWjASMRAwDgYDVQQKEwdBY21lIENvMIGfMA0GCSqGSIb3DQEBAQUAA4GNADCB
+iQKBgQDuLnQAI3mDgey3VBzWnB2L39JUU4txjeVE6myuDqkM/uGlfjb9SjY1bIw4
+iA5sBBZzHi3z0h1YV8QPuxEbi4nW91IJm2gsvvZhIrCHS3l6afab4pZBl2+XsDul
+rKBxKKtD1rGxlG4LjncdabFn9gvLZad2bSysqz/qTAUStTvqJQIDAQABo2gwZjAO
+BgNVHQ8BAf8EBAMCAqQwEwYDVR0lBAwwCgYIKwYBBQUHAwEwDwYDVR0TAQH/BAUw
+AwEB/zAuBgNVHREEJzAlggtleGFtcGxlLmNvbYcEfwAAAYcQAAAAAAAAAAAAAAAA
+AAAAATANBgkqhkiG9w0BAQsFAAOBgQCEcetwO59EWk7WiJsG4x8SY+UIAA+flUI9
+tyC4lNhbcF2Idq9greZwbYCqTTTr2XiRNSMLCOjKyI7ukPoPjo16ocHj+P3vZGfs
+h1fIw3cSS2OolhloGw/XM6RWPWtPAlGykKLciQrBru5NAPvCMsb/I1DAceTiotQM
+fblo6RBxUQ==
+-----END CERTIFICATE-----
+`
+
+func TestHTTPTransport(t *testing.T) {
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s.Close()
+
+	src := NewStaticSource(&Config{
+		Options: &Options{
+			CA: base64.StdEncoding.EncodeToString([]byte(localCert)),
+		},
+	})
+	transport := NewHTTPTransport(src)
+	client := &http.Client{
+		Transport: transport,
+	}
+	_, err := client.Get(s.URL)
+	assert.NoError(t, err)
+}

--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -44,6 +45,9 @@ func Run(ctx context.Context, configFile string) error {
 	}
 
 	src = databroker.NewConfigSource(src)
+
+	// override the default http transport so we can use the custom CA in the TLS client config (#1570)
+	http.DefaultTransport = config.NewHTTPTransport(src)
 
 	logMgr := config.NewLogManager(src)
 	defer logMgr.Close()

--- a/pkg/cryptutil/tls.go
+++ b/pkg/cryptutil/tls.go
@@ -3,9 +3,43 @@ package cryptutil
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
 
 	"github.com/caddyserver/certmagic"
+
+	"github.com/pomerium/pomerium/internal/log"
 )
+
+// GetCertPool gets a cert pool for the given CA or CAFile.
+func GetCertPool(ca, caFile string) (*x509.CertPool, error) {
+	rootCAs, err := x509.SystemCertPool()
+	if err != nil {
+		log.Error().Msg("pkg/cryptutil: failed getting system cert pool making new one")
+		rootCAs = x509.NewCertPool()
+	}
+	if ca != "" || caFile != "" {
+		var data []byte
+		var err error
+		if ca != "" {
+			data, err = base64.StdEncoding.DecodeString(ca)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode certificate authority: %w", err)
+			}
+		} else {
+			data, err = ioutil.ReadFile(caFile)
+			if err != nil {
+				return nil, fmt.Errorf("certificate authority file %v not readable: %w", caFile, err)
+			}
+		}
+		if ok := rootCAs.AppendCertsFromPEM(data); !ok {
+			return nil, fmt.Errorf("failed to append CA cert to certPool")
+		}
+		log.Debug().Msg("pkg/cryptutil: added custom certificate authority")
+	}
+	return rootCAs, nil
+}
 
 // GetCertificateForDomain returns the tls Certificate which matches the given domain name.
 // It should handle both exact matches and wildcard matches. If none of those match, the first certificate will be used.

--- a/pkg/cryptutil/tls.go
+++ b/pkg/cryptutil/tls.go
@@ -19,25 +19,26 @@ func GetCertPool(ca, caFile string) (*x509.CertPool, error) {
 		log.Error().Msg("pkg/cryptutil: failed getting system cert pool making new one")
 		rootCAs = x509.NewCertPool()
 	}
-	if ca != "" || caFile != "" {
-		var data []byte
-		var err error
-		if ca != "" {
-			data, err = base64.StdEncoding.DecodeString(ca)
-			if err != nil {
-				return nil, fmt.Errorf("failed to decode certificate authority: %w", err)
-			}
-		} else {
-			data, err = ioutil.ReadFile(caFile)
-			if err != nil {
-				return nil, fmt.Errorf("certificate authority file %v not readable: %w", caFile, err)
-			}
-		}
-		if ok := rootCAs.AppendCertsFromPEM(data); !ok {
-			return nil, fmt.Errorf("failed to append CA cert to certPool")
-		}
-		log.Debug().Msg("pkg/cryptutil: added custom certificate authority")
+	if ca == "" && caFile == "" {
+		return rootCAs, nil
 	}
+
+	var data []byte
+	if ca != "" {
+		data, err = base64.StdEncoding.DecodeString(ca)
+		if err != nil {
+			return nil, fmt.Errorf("failed to decode certificate authority: %w", err)
+		}
+	} else {
+		data, err = ioutil.ReadFile(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("certificate authority file %v not readable: %w", caFile, err)
+		}
+	}
+	if ok := rootCAs.AppendCertsFromPEM(data); !ok {
+		return nil, fmt.Errorf("failed to append CA cert to certPool")
+	}
+	log.Debug().Msg("pkg/cryptutil: added custom certificate authority")
 	return rootCAs, nil
 }
 


### PR DESCRIPTION
## Summary
This sets the default HTTP transport to support the `CA` and `CAFile` defined in the config options. This should allow support for custom certs with any OIDC or directory provider.

## Related issues
Closes #1570 

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
