### PR TITLE
proxy/forward_auth: copy response headers as request headers

### DIFF
--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -103,6 +103,13 @@ func (p *Proxy) allowUpstream(w http.ResponseWriter, r *http.Request) error {
 	if status := r.FormValue("auth_status"); status == fmt.Sprint(http.StatusForbidden) {
 		return httputil.NewError(http.StatusForbidden, errors.New(http.StatusText(http.StatusForbidden)))
 	}
+	// in forward-auth configuration we want to treat our request headers as response headers
+	// so that they can be forwarded by the fronting proxy, if desired
+	for k, vs := range r.Header {
+		for _, v := range vs {
+			w.Header().Set(k, v)
+		}
+	}
 	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
## Summary

When Pomerium is used in forward-auth configuration, fronting proxies rely on any forwarded headers to be set as response headers. These changes copy _all_ the request headers and writes them as response headers. 

Tested against traefik. 

```yaml
version: "3"
services:
  traefik:
    image: traefik:v2.3
    command:
      - "--accesslog=true"
      - "--api.insecure=true"
      - "--entrypoints.web.address=:80"
      - "--entrypoints.websecure.address=:443"
      - "--entryPoints.websecure.forwardedHeaders.insecure"
      - "--providers.docker.exposedbydefault=false"
      - "--providers.docker=true"

    ports:
      - "80:80"
      - "443:443"
      - "8080:8080"
    volumes:
      - /var/run/docker.sock:/var/run/docker.sock

  httpbin:
    image: kennethreitz/httpbin:latest
    labels:
      - "traefik.http.middlewares.pomerium.forwardauth.authResponseHeaders=X-Pomerium-Claim-Email,X-Pomerium-Claim-User,X-Pomerium-Claim-Groups,X-Pomerium-Jwt-Assertion"
      - "traefik.http.middlewares.pomerium.forwardauth.address=http://pomerium/"
      - "traefik.http.middlewares.pomerium.forwardauth.trustForwardHeader=true"
      - "traefik.http.routers.httpbin.middlewares=pomerium@docker"

      - "traefik.enable=true"
      - "traefik.http.routers.httpbin.rule=Host(`httpbin.localhost.pomerium.io`)"
      - "traefik.http.routers.httpbin.entrypoints=websecure"
      - "traefik.http.routers.httpbin.tls=true"

  pomerium:
    build: ../.
    volumes:
      - ../../:/workspace:cached
    command: /bin/sh -c "while sleep 1000; do :; done"
    environment:
      - INSECURE_SERVER=TRUE
      - ADDRESS=:80
      - FORWARD_AUTH_URL=http://pomerium
      - JWT_CLAIMS_HEADERS="email,groups,user"
    labels:
      - "traefik.enable=true"
      - "traefik.http.routers.pomerium.rule=Host(`authenticate.localhost.pomerium.io`)"
      - "traefik.http.routers.pomerium.entrypoints=websecure"
      - "traefik.http.routers.pomerium.tls=true"
    expose:
      - 80

```

## Related issues

- Regression caused by #1482
- Fixes #1564

**Checklist**:

- [x] add related issues
- [x] ready for review
