### PR TITLE
 forward-auth: fix special character support for nginx 

### DIFF
--- a/.devcontainer/envs/nginx.yaml
+++ b/.devcontainer/envs/nginx.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   nginx:
-    image: nginx
+    image: openresty/openresty
     restart: unless-stopped
     ports:
       - "80:80"

--- a/examples/nginx/httpbin.conf
+++ b/examples/nginx/httpbin.conf
@@ -37,7 +37,8 @@ server {
     client_max_body_size 1m;
 
     # Pass the extracted client certificate to the auth provider
-    set $target http://pomerium/verify?uri=$scheme://$http_host$request_uri;
+
+    set $target http://pomerium/verify?uri=$scheme://$http_host$request_uri&rd=$pass_access_scheme://$http_host$escaped_request_uri;
     proxy_pass $target;
   }
 
@@ -45,7 +46,7 @@ server {
     internal;
     add_header Set-Cookie $auth_cookie;
     return 302
-      https://fwdauth.localhost.pomerium.io/?uri=$scheme://$host$request_uri;
+      https://fwdauth.localhost.pomerium.io/?uri=$scheme://$host$request_uri&rd=$pass_access_scheme://$http_host$escaped_request_uri;
   }
 
   location / {

--- a/examples/nginx/proxy.conf
+++ b/examples/nginx/proxy.conf
@@ -19,6 +19,8 @@ proxy_set_header Upgrade $http_upgrade;
 
 proxy_set_header Connection "";
 
+set_escape_uri $escaped_request_uri $request_uri;
+
 # proxy_set_header X-Request-ID $req_id;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $remote_addr;

--- a/proxy/forward_auth.go
+++ b/proxy/forward_auth.go
@@ -16,7 +16,6 @@ import (
 // see : https://www.pomerium.io/configuration/#forward-auth
 func (p *Proxy) registerFwdAuthHandlers() http.Handler {
 	r := httputil.NewRouter()
-
 	// NGNIX's forward-auth capabilities are split across two settings:
 	// `auth-url` and `auth-signin` which correspond to `verify` and `auth-url`
 	//
@@ -46,9 +45,9 @@ func (p *Proxy) registerFwdAuthHandlers() http.Handler {
 	r.Handle("/", httputil.HandlerFunc(p.startAuthN)).
 		Queries(urlutil.QueryForwardAuthURI, "{uri}")
 
-	// nginx 2 / traefik 1: verify and then start authenticate flow
-	r.Handle("/", httputil.HandlerFunc(p.allowUpstream))
-
+	// otherwise, send a 200 OK for any other route.
+	// these routes do _not_ enforce authZ, they are helper routes.
+	r.NotFoundHandler = httputil.HandlerFunc(p.allowUpstream)
 	return r
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where pomerium would not properly handle special characters. 

<img width="581" alt="Screen Shot 2020-11-09 at 6 35 09 PM" src="https://user-images.githubusercontent.com/1544881/98621985-5d098380-22bd-11eb-89db-a9c8359fe411.png">

<img width="795" alt="Screen Shot 2020-11-09 at 6 34 55 PM" src="https://user-images.githubusercontent.com/1544881/98621993-5ed34700-22bd-11eb-9a16-4ba75f6266d3.png">


## Related issues

- https://github.com/pomerium/pomerium/pull/1563
- Fixes https://github.com/pomerium/pomerium/issues/1559

**Checklist**:

- [x] add related issues
- [x] updated docs
- [x] ready for review
