### PR TITLE
Fix command in Kubernetes Quick start docs

### DIFF
--- a/docs/docs/quick-start/kubernetes.md
+++ b/docs/docs/quick-start/kubernetes.md
@@ -24,7 +24,7 @@ Retrieve the latest copy of pomerium's source-code by cloning the repository.
 
 ```bash
 git clone https://github.com/pomerium/pomerium.git $HOME/pomerium
-cd $HOME/pomerium/docs/configuration/examples/kubernetes
+cd $HOME/pomerium/examples/kubernetes
 ```
 
 ## Configure


### PR DESCRIPTION
Fixed the 'cd' command which currently tries to change to a directory which doesn't exist.