### PR TITLE
Update GitLab provider docs

### DIFF
--- a/docs/docs/identity-providers/gitlab.md
+++ b/docs/docs/identity-providers/gitlab.md
@@ -19,10 +19,10 @@ This document describes the use of GitLab as an identity provider with Pomerium.
 
 ![create an application](./img/gitlab/gitlab-create-applications.png)
 
-3. Add a new application by setting the following parameters:
+1. Add a new application by setting the following parameters:
 
 Field        | Description
------------- | --------------------------------------------
+------------ | ---------------------------------------------------------------------------------
 Name         | The name of your web app
 Redirect URI | `https://${authenticate_service_url}/oauth2/callback`
 Scopes       | `openid` required; `read_api`, `profile`, `email` as necessary for your policies.
@@ -31,14 +31,13 @@ Your `Client ID` and `Client Secret` will be displayed like below:
 
 ![Gitlab OAuth Client ID and Secret](./img/gitlab/gitlab-credentials.png)
 
-4. Set `Client ID` and `Client Secret` in Pomerium's settings.
+1. Set `Client ID` and `Client Secret` in Pomerium's settings.
 
 ## Service Account
 
 To use `allowed_groups` in a policy an `idp_service_account` needs to be set in the Pomerium configuration. The service account for Gitlab uses a personal access token generated at: [gitlab.com/profile/personal_access_tokens](https://gitlab.com/profile/personal_access_tokens) with `read_api` access:
 
 ![Gitlab Personal Access Token](./img/gitlab/gitlab-personal-access-token.png)
-
 
 The format of the `idp_service_account` for Gitlab is a base64-encoded JSON document:
 
@@ -56,9 +55,7 @@ When a user first uses pomerium to login, they will be presented with an authori
 
 Please be aware that [Group ID](https://docs.gitlab.com/ee/api/groups.html#details-of-a-group) will be used to affirm group(s) a user belongs to.
 
-[identity scopes]: ../../reference/readme.md#identity-provider-scopes
-
-#### GitLab.com
+### GitLab.com
 
 Your configuration should look like the following example:
 
@@ -70,7 +67,7 @@ idp_client_secret: "REDACTED"   // gitlab application secret
 idp_service_account: "REDACTED"   // gitlab service account, base64 json
 ```
 
-#### Self-Hosted GitLab
+### Self-Hosted GitLab
 
 Self-hosted CE/EE instances should be configured as a generic OpenID Connect provider:
 
@@ -78,7 +75,9 @@ Self-hosted CE/EE instances should be configured as a generic OpenID Connect pro
 idp_provider: oidc
 idp_client_id: "REACTED"
 idp_client_secret: "REDACTED"
-idp_scopes: openid,email // Intersects with scopes 
+idp_scopes: openid,email // Intersects with scopes
 idp_provider_url: https://gitlab.example.com // Base URL of GitLab instance
 idp_service_account: "REDACTED"   // gitlab service account, base64 json
 ```
+
+[identity scopes]: ../../reference/readme.md#identity-provider-scopes

--- a/docs/docs/identity-providers/gitlab.md
+++ b/docs/docs/identity-providers/gitlab.md
@@ -25,9 +25,7 @@ Field        | Description
 ------------ | --------------------------------------------
 Name         | The name of your web app
 Redirect URI | `https://${authenticate_service_url}/oauth2/callback`
-Scopes       | **Must** select the same as **[identity scopes]** option
-
-If no scopes are set, you **must** select **openid**, **api**, **profile** and **email**.
+Scopes       | `openid` required; `read_api`, `profile`, `email` as necessary for your policies.
 
 Your `Client ID` and `Client Secret` will be displayed like below:
 
@@ -52,16 +50,6 @@ The format of the `idp_service_account` for Gitlab is a base64-encoded JSON docu
 
 ## Pomerium Configuration
 
-Your configuration should look like the following example:
-
-```bash
-authenticate_service_url: https://authenticate.localhost.pomerium.io
-idp_provider: "gitlab"
-idp_client_id: "REDACTED"   // gitlab application ID
-idp_client_secret: "REDACTED"   // gitlab application secret
-idp_service_account: "REDACTED"   // gitlab service account
-```
-
 When a user first uses pomerium to login, they will be presented with an authorization screen similar to the following depending on the scope parameters setup:
 
 ![gitlab access authorization screen](./img/gitlab/gitlab-verify-access.png)
@@ -69,3 +57,28 @@ When a user first uses pomerium to login, they will be presented with an authori
 Please be aware that [Group ID](https://docs.gitlab.com/ee/api/groups.html#details-of-a-group) will be used to affirm group(s) a user belongs to.
 
 [identity scopes]: ../../reference/readme.md#identity-provider-scopes
+
+#### GitLab.com
+
+Your configuration should look like the following example:
+
+```
+authenticate_service_url: https://authenticate.localhost.pomerium.io
+idp_provider: "gitlab"
+idp_client_id: "REDACTED"   // gitlab application ID
+idp_client_secret: "REDACTED"   // gitlab application secret
+idp_service_account: "REDACTED"   // gitlab service account, base64 json
+```
+
+#### Self-Hosted GitLab
+
+Self-hosted CE/EE instances should be configured as a generic OpenID Connect provider:
+
+```
+idp_provider: oidc
+idp_client_id: "REACTED"
+idp_client_secret: "REDACTED"
+idp_scopes: openid,email // Intersects with scopes 
+idp_provider_url: https://gitlab.example.com // Base URL of GitLab instance
+idp_service_account: "REDACTED"   // gitlab service account, base64 json
+```


### PR DESCRIPTION
## Summary

Updates GitLab provider docs to reference self-hosted GitLab and provide additional clarity on required scopes.

**Checklist**:
- [ ] add related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
