### PR TITLE
attach version to gRPC server metadata

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -723,6 +723,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/grpcutil/version.go
+++ b/pkg/grpcutil/version.go
@@ -1,0 +1,26 @@
+package grpcutil
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+// MetadataKeyPomeriumVersion is the gRPC metadata key used for the pomerium version.
+const MetadataKeyPomeriumVersion = "x-pomerium-version"
+
+// AttachMetadataInterceptors returns unary and server stream interceptors that attach metadata to the response.
+func AttachMetadataInterceptors(md metadata.MD) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
+	unary := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
+		grpc.SetHeader(ctx, md)
+		return handler(ctx, req)
+	}
+
+	stream := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
+		ss.SetHeader(md)
+		return handler(srv, ss)
+	}
+
+	return unary, stream
+}

--- a/pkg/grpcutil/version.go
+++ b/pkg/grpcutil/version.go
@@ -13,12 +13,12 @@ const MetadataKeyPomeriumVersion = "x-pomerium-version"
 // AttachMetadataInterceptors returns unary and server stream interceptors that attach metadata to the response.
 func AttachMetadataInterceptors(md metadata.MD) (grpc.UnaryServerInterceptor, grpc.StreamServerInterceptor) {
 	unary := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
-		grpc.SetHeader(ctx, md)
+		_ = grpc.SetHeader(ctx, md)
 		return handler(ctx, req)
 	}
 
 	stream := func(srv interface{}, ss grpc.ServerStream, info *grpc.StreamServerInfo, handler grpc.StreamHandler) error {
-		ss.SetHeader(md)
+		_ = ss.SetHeader(md)
 		return handler(srv, ss)
 	}
 


### PR DESCRIPTION
## Summary
This adds version information to the gRPC headers. Clients can retrieve these headers to know which version of Pomerium they're communicating with. (primarily useful for the databroker)

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
