### PR TITLE
ci: improve release snapshot name template

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -97,7 +97,7 @@ checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
 snapshot:
-  name_template: "{{ .Tag }}+next"
+  name_template: "{{ .Version }}+next+{{ .ShortCommit }}"
 
 dockers:
   - image_templates:


### PR DESCRIPTION
## Summary
Update snapshot name template to contain version and commit reference.  

- snapshot names can now be tied to commit history
- multiple snapshots can be made after a release and still be differentiated
- package filenames no longer contain leading `v`

Before:

```bash
   • linux packages
      • creating                  file=dist/pomerium_v0.11.0-rc1+next-1_amd64.deb
      • creating                  file=dist/pomerium-v0.11.0-rc1+next-1.x86_64.rpm
      • creating                  file=dist/pomerium_v0.11.0-rc1+next-1_arm64.deb
      • creating                  file=dist/pomerium-v0.11.0-rc1+next-1.aarch64.rpm
      • creating                  file=dist/pomerium-cli_v0.11.0-rc1+next-1_amd64.deb
      • creating                  file=dist/pomerium-cli_v0.11.0-rc1+next-1_x86_64.rpm
      • creating                  file=dist/pomerium-cli_v0.11.0-rc1+next-1_arm.rpm
      • creating                  file=dist/pomerium-cli_v0.11.0-rc1+next-1_armhf.deb
      • creating                  file=dist/pomerium-cli_v0.11.0-rc1+next-1_armhf.rpm
      • creating                  file=dist/pomerium-cli_v0.11.0-rc1+next-1_aarch64.rpm
      • creating                  file=dist/pomerium-cli_v0.11.0-rc1+next-1_arm64.deb
      • creating                  file=dist/pomerium-cli_v0.11.0-rc1+next-1_arm.deb
```

After:

```bash
   • linux packages
      • creating                  file=dist/pomerium-0.11.0-rc1+next+a41c37f9-1.x86_64.rpm
      • creating                  file=dist/pomerium_0.11.0-rc1+next+a41c37f9-1_arm64.deb
      • creating                  file=dist/pomerium-0.11.0-rc1+next+a41c37f9-1.aarch64.rpm
      • creating                  file=dist/pomerium_0.11.0-rc1+next+a41c37f9-1_amd64.deb
      • creating                  file=dist/pomerium-cli_0.11.0-rc1+next+a41c37f9-1_aarch64.rpm
      • creating                  file=dist/pomerium-cli_0.11.0-rc1+next+a41c37f9-1_x86_64.rpm
      • creating                  file=dist/pomerium-cli_0.11.0-rc1+next+a41c37f9-1_armhf.rpm
      • creating                  file=dist/pomerium-cli_0.11.0-rc1+next+a41c37f9-1_arm.deb
      • creating                  file=dist/pomerium-cli_0.11.0-rc1+next+a41c37f9-1_amd64.deb
      • creating                  file=dist/pomerium-cli_0.11.0-rc1+next+a41c37f9-1_armhf.deb
      • creating                  file=dist/pomerium-cli_0.11.0-rc1+next+a41c37f9-1_arm.rpm
      • creating                  file=dist/pomerium-cli_0.11.0-rc1+next+a41c37f9-1_arm64.deb
```

## Related issues
N/A


**Checklist**:
- [x] ready for review
