### PR TITLE
pkg/storage/redis: Prevent connection churn

### DIFF
--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -77,6 +77,7 @@ func New(rawURL, recordType string, opts ...Option) (*DB, error) {
 			}
 			return nil
 		},
+		MaxIdle: 100,
 	}
 	metrics.AddRedisMetrics(db.pool.Stats)
 	return db, nil

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -77,7 +77,9 @@ func New(rawURL, recordType string, opts ...Option) (*DB, error) {
 			}
 			return nil
 		},
-		MaxIdle: 100,
+		MaxIdle:     64,
+		IdleTimeout: time.Minute,
+		MaxActive:   128,
 	}
 	metrics.AddRedisMetrics(db.pool.Stats)
 	return db, nil


### PR DESCRIPTION
## Summary
Set `MaxIdle` to a non-zero value, preventing aggressive connection termination.

## Related issues
Closes #1600 
https://github.com/gomodule/redigo/issues/534

**Checklist**:
- [x] add related issues
- [x] ready for review
