### PR TITLE
cryptutil: more explicit decryption error

### DIFF
--- a/pkg/cryptutil/encrypt.go
+++ b/pkg/cryptutil/encrypt.go
@@ -44,7 +44,7 @@ func Decrypt(a cipher.AEAD, data, ad []byte) ([]byte, error) {
 	nonce := data[size:]
 	plaintext, err := a.Open(nil, nonce, ciphertext, ad)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("cryptutil: decryption failed (mismatched keys?): %w", err)
 	}
 	return plaintext, nil
 }

--- a/pkg/cryptutil/encrypt_test.go
+++ b/pkg/cryptutil/encrypt_test.go
@@ -23,11 +23,6 @@ func TestEncodeAndDecodeAccessToken(t *testing.T) {
 		t.Fatalf("plaintext is not encrypted plaintext:%v ciphertext:%x", plaintext, ciphertext)
 	}
 
-	got, err := Decrypt(c, ciphertext, nil)
-	if err != nil {
-		t.Fatalf("unexpected err decrypting: %v", err)
-	}
-
 	diffKey, err := NewAEADCipher(NewKey())
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)
@@ -40,11 +35,10 @@ func TestEncodeAndDecodeAccessToken(t *testing.T) {
 	_, err = Decrypt(c, []byte("oh"), nil)
 	assert.Error(t, err)
 
-	if !reflect.DeepEqual(got, plaintext) {
-		t.Logf(" got: %v", got)
-		t.Logf("want: %v", plaintext)
-		t.Fatal("got unexpected decrypted value")
-	}
+	// good
+	got, err := Decrypt(c, ciphertext, nil)
+	assert.NoError(t, err)
+	assert.Equal(t, got, plaintext)
 }
 
 func TestNewAEADCipher(t *testing.T) {

--- a/pkg/cryptutil/encrypt_test.go
+++ b/pkg/cryptutil/encrypt_test.go
@@ -28,11 +28,17 @@ func TestEncodeAndDecodeAccessToken(t *testing.T) {
 		t.Fatalf("unexpected err decrypting: %v", err)
 	}
 
-	// if less than 32 bytes, fail
-	_, err = Decrypt(c, []byte("oh"), nil)
-	if err == nil {
-		t.Fatalf("should fail if <32 bytes output: %v", err)
+	diffKey, err := NewAEADCipher(NewKey())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
 	}
+	// key mismatch
+	_, err = Decrypt(diffKey, ciphertext, nil)
+	assert.Error(t, err)
+
+	// bad data size
+	_, err = Decrypt(c, []byte("oh"), nil)
+	assert.Error(t, err)
 
 	if !reflect.DeepEqual(got, plaintext) {
 		t.Logf(" got: %v", got)


### PR DESCRIPTION

## Summary

We've had a few issues where folks running in all-in-one mode with persistent databroker backends would get an error 

```
{"level":"fatal","error":"failed to initialize directory groups: error getting all directory groups: rpc error: code = Unknown desc = chacha20poly1305: message authentication failed","time":"2020-11-22T02:52:09Z","message":"cmd/pomerium"}
```

Which could be a bit more clear. What's going on is that while we try to be helpful and auto-generate the `shared_secret` value in all-in-one mode which is used to encrypt data at rest in the databroker, if shared_secret is not explicitly set, you can end up with decryption errors because the shared key is getting rotated every restart. 

These changes should at least make the decryption error a bit more obvious as to what's going on. 

## Related issues

- https://pomerium-io.slack.com/archives/CK92MUAES/p1606013687231300

**Checklist**:

- [x] add related issues
- [x] ready for review
