### PR TITLE
wait for initial sync to complete before starting control plane

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -27,6 +27,8 @@ type Authorize struct {
 
 	dataBrokerDataLock sync.RWMutex
 	dataBrokerData     evaluator.DataBrokerData
+
+	dataBrokerInitialSync map[string]chan struct{}
 }
 
 // New validates and creates a new Authorize service from a set of config options.
@@ -36,6 +38,10 @@ func New(cfg *config.Config) (*Authorize, error) {
 		store:          evaluator.NewStore(),
 		templates:      template.Must(frontend.NewTemplates()),
 		dataBrokerData: make(evaluator.DataBrokerData),
+		dataBrokerInitialSync: map[string]chan struct{}{
+			"type.googleapis.com/directory.Group": make(chan struct{}, 1),
+			"type.googleapis.com/directory.User":  make(chan struct{}, 1),
+		},
 	}
 
 	state, err := newAuthorizeStateFromConfig(cfg, a.store)

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -420,6 +420,11 @@ func (dbd DataBrokerData) Clear(typeURL string) {
 	delete(dbd, typeURL)
 }
 
+// Count returns the number of entries for the given type URL.
+func (dbd DataBrokerData) Count(typeURL string) int {
+	return len(dbd[typeURL])
+}
+
 // Get gets a record from the DataBrokerData.
 func (dbd DataBrokerData) Get(typeURL, id string) interface{} {
 	m, ok := dbd[typeURL]


### PR DESCRIPTION
## Summary
This updates the authorize service so that we can wait until the initial sync is complete before starting the listener in the control plane. Assuming there's a health check on the service, and there's more than one authorize service, this should provide a more consistent experience when restarting the service.

## Related issues
Fixes #1620 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
