### PR TITLE
fix panic when deleting a record twice from the inmemory data store

### DIFF
--- a/pkg/storage/inmemory/inmemory.go
+++ b/pkg/storage/inmemory/inmemory.go
@@ -30,7 +30,7 @@ type byIDRecord struct {
 }
 
 func (k byIDRecord) Less(than btree.Item) bool {
-	return k.Id < than.(byIDRecord).Id
+	return k.GetId() < than.(byIDRecord).GetId()
 }
 
 type byVersionRecord struct {
@@ -38,7 +38,7 @@ type byVersionRecord struct {
 }
 
 func (k byVersionRecord) Less(than btree.Item) bool {
-	return k.Version < than.(byVersionRecord).Version
+	return k.GetVersion() < than.(byVersionRecord).GetVersion()
 }
 
 // DB is an in-memory database of records using b-trees.
@@ -77,7 +77,7 @@ func (db *DB) ClearDeleted(_ context.Context, cutoff time.Time) {
 	var remaining []string
 	for _, id := range db.deletedIDs {
 		record, _ := db.byID.Get(byIDRecord{Record: &databroker.Record{Id: id}}).(byIDRecord)
-		ts, _ := ptypes.Timestamp(record.DeletedAt)
+		ts := record.GetDeletedAt().AsTime()
 		if ts.Before(cutoff) {
 			db.byID.Delete(record)
 			db.byVersion.Delete(byVersionRecord(record))

--- a/pkg/storage/inmemory/inmemory_test.go
+++ b/pkg/storage/inmemory/inmemory_test.go
@@ -74,4 +74,14 @@ func TestDB(t *testing.T) {
 		require.NoError(t, err)
 		assert.Len(t, records, 0)
 	})
+	t.Run("delete twice", func(t *testing.T) {
+		data := new(anypb.Any)
+		assert.NoError(t, db.Put(ctx, "abcd", data))
+		assert.NoError(t, db.Delete(ctx, "abcd"))
+		assert.NoError(t, db.Delete(ctx, "abcd"))
+		db.ClearDeleted(ctx, time.Now().Add(time.Second))
+		record, err := db.Get(ctx, "abcd")
+		require.Error(t, err)
+		assert.Nil(t, record)
+	})
 }


### PR DESCRIPTION
## Summary
If `Delete` was called twice for the same record id, and then `ClearDeleted` was called, it would result in a panic because the record would not be found during the second deletion. This PR fixes the issue by using protobuf get methods which are nil-safe. I also added a test which reproduced the original issue.

## Related issues
Fixes #1622 

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
