### PR TITLE
fix ordering of autocert config source

### DIFF
--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -39,12 +39,12 @@ func Run(ctx context.Context, configFile string) error {
 		return err
 	}
 
+	src = databroker.NewConfigSource(src)
+
 	src, err = autocert.New(src)
 	if err != nil {
 		return err
 	}
-
-	src = databroker.NewConfigSource(src)
 
 	// override the default http transport so we can use the custom CA in the TLS client config (#1570)
 	http.DefaultTransport = config.NewHTTPTransport(src)


### PR DESCRIPTION
## Summary
The ordering on the config source initialization made it so that any databroker config options would not be picked up by the autocert settings. Notably `http_redirect_addr` wasn't being changed. Changing the order so that the databroker is built first fixes the problem.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
