### PR TITLE
use the directory email when provided for the jwt

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -197,6 +197,9 @@ func (e *Evaluator) JWTPayload(req *Request) map[string]interface{} {
 			payload["email"] = u.GetEmail()
 		}
 		if du, ok := req.DataBrokerData.Get("type.googleapis.com/directory.User", s.GetUserId()).(*directory.User); ok {
+			if du.GetEmail() != "" {
+				payload["email"] = du.GetEmail()
+			}
 			var groupNames []string
 			for _, groupID := range du.GetGroupIds() {
 				if dg, ok := req.DataBrokerData.Get("type.googleapis.com/directory.Group", groupID).(*directory.Group); ok {


### PR DESCRIPTION
## Summary
Currently the Azure provider doesn't have email in the user object. However it does have it in the directory user object. This change makes it so that the JWT will contain the directory user email if it is provided.

We likely need to investigate Azure specifically to see if we can also get the email via the User object, but I think this change is helpful.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
