### PR TITLE
fix config race

### DIFF
--- a/pkg/storage/inmemory/inmemory.go
+++ b/pkg/storage/inmemory/inmemory.go
@@ -30,7 +30,8 @@ type byIDRecord struct {
 }
 
 func (k byIDRecord) Less(than btree.Item) bool {
-	return k.GetId() < than.(byIDRecord).GetId()
+	k2, _ := than.(byIDRecord)
+	return k.GetId() < k2.GetId()
 }
 
 type byVersionRecord struct {
@@ -38,7 +39,8 @@ type byVersionRecord struct {
 }
 
 func (k byVersionRecord) Less(than btree.Item) bool {
-	return k.GetVersion() < than.(byVersionRecord).GetVersion()
+	k2, _ := than.(byVersionRecord)
+	return k.GetVersion() < k2.GetVersion()
 }
 
 // DB is an in-memory database of records using b-trees.


### PR DESCRIPTION
## Summary
Because of the way we were building the config it was possible for the config to be updated before we had finished initializing the services. As a result we were using an older config and not detecting the change.

This PR makes it so that we always use the latest config in those places.

I think it may still be racy in a few places, so we should probably change the design slightly. A new design might be:

1. Remove the `OnConfigChange(li)` method on the `ConfigSource` interface, so that's no longer possible to add a listener after construction.
2. Update all the config sources so that they take in a list of listeners. (some already do) Add these immediately so we're guaranteed not to fire a change event before the listener is attached.
3. Update all the config source listeners (authenticate, authorize, etc) so their constructors don't take a current config, but instead rely entirely on the `ChangeListener` callback.
4. Update the method signature for `ChangeListener` so that it can return an error. Then, the first time we build the config, if there's an error return it, otherwise log it. I believe this will preserve the existing behavior.

The scope of this new design was quite large, so I decided to hold off on making those changes in this PR.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
