### PR TITLE
[Backport 0-11-0] ci: fix pomerium-cli rpm name

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -285,4 +285,4 @@ nfpms:
         replacements:
           arm64: aarch64
           amd64: x86_64
-        file_name_template: '{{ .ProjectName }}-cli_{{ .Version }}-{{ .Release }}_{{ .Arch }}{{ if .Arm }}{{if eq .Arm "7"}}hf{{ end }}{{ end }}'
+        file_name_template: '{{ .ProjectName }}-cli-{{ .Version }}-{{ .Release }}_{{ .Arch }}{{ if .Arm }}{{if eq .Arm "7"}}hf{{ end }}{{ end }}'


### PR DESCRIPTION
Backport b831316 from #1661 