### PR TITLE
docs: add v0.11 link to version menu

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -37,10 +37,11 @@ module.exports = {
         rel: "",
       },
       {
-        text: "v0.10.x", // current tagged version
+        text: "v0.11.x", // current tagged version
         ariaLabel: "Version menu",
         items: [
           { text: "🚧Dev", link: "https://master.docs.pomerium.io/docs" },
+          { text: "v0.11.x", link: "https://0-11-0.docs.pomerium.io/docs" },
           { text: "v0.10.x", link: "https://0-10-0.docs.pomerium.io/docs" },
           { text: "v0.9.x", link: "https://0-9-0.docs.pomerium.io/docs" },
           { text: "v0.8.x", link: "https://0-8-0.docs.pomerium.io/docs" },


### PR DESCRIPTION
## Summary
Update docs to include v0.11 in the version menu

## Related issues
n/a


**Checklist**:
- [x] updated docs
- [x] ready for review
