### PR TITLE
docs: fix nginx config

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -181,7 +181,7 @@ Secret used to encrypt and sign session cookies. You can generate a random key w
 - Environmental Variable: `COOKIE_DOMAIN`
 - Config File Key: `cookie_domain`
 - Type: `string`
-- Example: `corp.beyondperimeter.com`
+- Example: `localhost.pomerium.io`
 - Optional
 
 The scope of session cookies issued by Pomerium.
@@ -244,18 +244,18 @@ For example, if `true`
 
 ```
 10:37AM INF cmd/pomerium version=v0.0.1-dirty+ede4124
-10:37AM INF proxy: new route from=httpbin.corp.beyondperimeter.com to=https://httpbin.org
-10:37AM INF proxy: new route from=ssl.corp.beyondperimeter.com to=http://neverssl.com
-10:37AM INF proxy/authenticator: grpc connection OverrideCertificateName= addr=auth.corp.beyondperimeter.com:443
+10:37AM INF proxy: new route from=httpbin.localhost.pomerium.io to=https://httpbin.org
+10:37AM INF proxy: new route from=ssl.localhost.pomerium.io to=http://neverssl.com
+10:37AM INF proxy/authenticator: grpc connection OverrideCertificateName= addr=auth.localhost.pomerium.io:443
 ```
 
 If `false`
 
 ```
 {"level":"info","version":"v0.0.1-dirty+ede4124","time":"2019-02-18T10:41:03-08:00","message":"cmd/pomerium"}
-{"level":"info","from":"httpbin.corp.beyondperimeter.com","to":"https://httpbin.org","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
-{"level":"info","from":"ssl.corp.beyondperimeter.com","to":"http://neverssl.com","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
-{"level":"info","OverrideCertificateName":"","addr":"auth.corp.beyondperimeter.com:443","time":"2019-02-18T10:41:03-08:00","message":"proxy/authenticator: grpc connection"}
+{"level":"info","from":"httpbin.localhost.pomerium.io","to":"https://httpbin.org","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
+{"level":"info","from":"ssl.localhost.pomerium.io","to":"http://neverssl.com","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
+{"level":"info","OverrideCertificateName":"","addr":"auth.localhost.pomerium.io:443","time":"2019-02-18T10:41:03-08:00","message":"proxy/authenticator: grpc connection"}
 ```
 
 

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -219,7 +219,7 @@ settings:
               - Environmental Variable: `COOKIE_DOMAIN`
               - Config File Key: `cookie_domain`
               - Type: `string`
-              - Example: `corp.beyondperimeter.com`
+              - Example: `localhost.pomerium.io`
               - Optional
             doc: |
               The scope of session cookies issued by Pomerium.
@@ -290,18 +290,18 @@ settings:
 
           ```
           10:37AM INF cmd/pomerium version=v0.0.1-dirty+ede4124
-          10:37AM INF proxy: new route from=httpbin.corp.beyondperimeter.com to=https://httpbin.org
-          10:37AM INF proxy: new route from=ssl.corp.beyondperimeter.com to=http://neverssl.com
-          10:37AM INF proxy/authenticator: grpc connection OverrideCertificateName= addr=auth.corp.beyondperimeter.com:443
+          10:37AM INF proxy: new route from=httpbin.localhost.pomerium.io to=https://httpbin.org
+          10:37AM INF proxy: new route from=ssl.localhost.pomerium.io to=http://neverssl.com
+          10:37AM INF proxy/authenticator: grpc connection OverrideCertificateName= addr=auth.localhost.pomerium.io:443
           ```
 
           If `false`
 
           ```
           {"level":"info","version":"v0.0.1-dirty+ede4124","time":"2019-02-18T10:41:03-08:00","message":"cmd/pomerium"}
-          {"level":"info","from":"httpbin.corp.beyondperimeter.com","to":"https://httpbin.org","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
-          {"level":"info","from":"ssl.corp.beyondperimeter.com","to":"http://neverssl.com","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
-          {"level":"info","OverrideCertificateName":"","addr":"auth.corp.beyondperimeter.com:443","time":"2019-02-18T10:41:03-08:00","message":"proxy/authenticator: grpc connection"}
+          {"level":"info","from":"httpbin.localhost.pomerium.io","to":"https://httpbin.org","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
+          {"level":"info","from":"ssl.localhost.pomerium.io","to":"http://neverssl.com","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
+          {"level":"info","OverrideCertificateName":"","addr":"auth.localhost.pomerium.io:443","time":"2019-02-18T10:41:03-08:00","message":"proxy/authenticator: grpc connection"}
           ```
         shortdoc: |
           Debug enables colored, human-readable logs to be streamed to standard out.

--- a/examples/config/config.example.yaml
+++ b/examples/config/config.example.yaml
@@ -5,7 +5,7 @@
 # service: "all" # optional, default is all
 # log_level: info # optional, default is debug
 
-authenticate_service_url: https://authenticate.corp.beyondperimeter.com
+authenticate_service_url: https://authenticate.localhost.pomerium.io
 # authorize service url will default to localhost in all-in-one mode, otherwise
 # it should be set to a "behind-the-ingress" routable url
 # authorize_service_url: https://pomerium-authorize-service.default.svc.cluster.local
@@ -75,17 +75,22 @@ authenticate_service_url: https://authenticate.corp.beyondperimeter.com
 
 # Proxied routes and per-route policies are defined in a policy block
 policy:
-  - from: https://httpbin.corp.beyondperimeter.com
+  - from: https://httpbin.localhost.pomerium.io
     to: http://httpbin
     allowed_domains:
       - pomerium.io
     cors_allow_preflight: true
     timeout: 30s
-  - from: https://external-httpbin.corp.beyondperimeter.com
+    pass_identity_headers: true
+
+  - from: https://external-httpbin.localhost.pomerium.io
     to: https://httpbin.org
     allowed_domains:
       - gmail.com
-  - from: https://hello.corp.beyondperimeter.com
+    pass_identity_headers: true
+
+  - from: https://hello.localhost.pomerium.io
     to: http://hello:8080
     allowed_groups:
       - admins@pomerium.io
+    pass_identity_headers: true

--- a/examples/config/config.minimal.yaml
+++ b/examples/config/config.minimal.yaml
@@ -23,3 +23,4 @@ policy:
     to: https://httpbin.org
     allowed_users:
       - bdd@pomerium.io
+    pass_identity_headers: true

--- a/examples/config/policy.example.yaml
+++ b/examples/config/policy.example.yaml
@@ -8,24 +8,24 @@
 # Proxied routes and per-route policies are defined in a policy block
 # NOTA BENE: You must uncomment the below 'policy' key if you are loading policy as a file.
 # policy:
-- from: https://httpbin.corp.beyondperimeter.com
+- from: https://httpbin.localhost.pomerium.io
   to: http://localhost:8000
   allowed_domains:
     - pomerium.io
   cors_allow_preflight: true
   timeout: 30s
-- from: https://external-httpbin.corp.beyondperimeter.com
+- from: https://external-httpbin.localhost.pomerium.io
   to: https://httpbin.org
   allowed_domains:
     - gmail.com
-- from: https://weirdlyssl.corp.beyondperimeter.com
+- from: https://weirdlyssl.localhost.pomerium.io
   to: http://neverssl.com
   allowed_users:
     - bdd@pomerium.io
   allowed_groups:
     - admins
     - developers
-- from: https://hello.corp.beyondperimeter.com
+- from: https://hello.localhost.pomerium.io
   to: http://localhost:8080
   allowed_groups:
     - admins@pomerium.io

--- a/examples/kubernetes/kubernetes-config.yaml
+++ b/examples/kubernetes/kubernetes-config.yaml
@@ -4,11 +4,11 @@ grpc_insecure: true
 address: ":80"
 grpc_address: ":80"
 
-authenticate_service_url: https://authenticate.corp.beyondperimeter.com
+authenticate_service_url: https://authenticate.localhost.pomerium.io
 authorize_service_url: http://pomerium-authorize-service.default.svc.cluster.local
 databroker_service_url: http://pomerium-cache-service.default.svc.cluster.local
 
-override_certificate_name: "*.corp.beyondperimeter.com"
+override_certificate_name: "*.localhost.pomerium.io"
 
 idp_provider: google
 idp_client_id: REPLACE_ME.apps.googleusercontent.com
@@ -18,7 +18,7 @@ idp_client_secret: "REPLACE_ME"
 idp_service_account: YOUR_SERVICE_ACCOUNT
 
 policy:
-  - from: https://httpbin.corp.beyondperimeter.com
+  - from: https://httpbin.localhost.pomerium.io
     to: http://httpbin.default.svc.cluster.local:8000
     allowed_domains:
       - gmail.com

--- a/examples/kubernetes/values.yaml
+++ b/examples/kubernetes/values.yaml
@@ -5,7 +5,7 @@ authenticate:
     clientSecret: YOUR_SECRET
     # Required for group data
     # https://www.pomerium.com/configuration/#identity-provider-service-account
-    serviceAccount: YOUR_SERVICE_ACCOUNT 
+    serviceAccount: YOUR_SERVICE_ACCOUNT
   service:
     annotations:
       cloud.google.com/app-protocols: '{"https":"HTTPS"}'
@@ -20,7 +20,7 @@ service:
 
 config:
   policy:
-    - from: https://hello.corp.beyondperimeter.com
+    - from: https://hello.localhost.pomerium.io
       to: http://nginx.default.svc.cluster.local:80
       allowed_domains:
         - gmail.com

--- a/examples/nginx/config.yaml
+++ b/examples/nginx/config.yaml
@@ -19,3 +19,4 @@ policy:
     allowed_domains:
       - pomerium.com
       - gmail.com
+    pass_identity_headers: true

--- a/examples/nginx/docker-compose.yaml
+++ b/examples/nginx/docker-compose.yaml
@@ -1,6 +1,10 @@
 version: "3"
 services:
   nginx:
+    # to emulate nginx-ingress behavior, use openresty which comes with 'escaped_request_uri'
+    # pre-compiled. Also uncomment lines marked `uncomment to emulate nginx-ingress behavior`
+    # in the nginx `.conf` configuration files.
+    # image: openresty/openresty
     image: nginx
     restart: unless-stopped
     ports:

--- a/examples/nginx/httpbin.conf
+++ b/examples/nginx/httpbin.conf
@@ -38,15 +38,22 @@ server {
 
     # Pass the extracted client certificate to the auth provider
 
-    set $target http://pomerium/verify?uri=$scheme://$http_host$request_uri&rd=$pass_access_scheme://$http_host$escaped_request_uri;
+    set $target http://pomerium/verify?uri=$scheme://$http_host$request_uri;
+
+    # uncomment to emulate nginx-ingress behavior
+    # set $target http://pomerium/verify?uri=$scheme://$http_host$request_uri&rd=$pass_access_scheme://$http_host$escaped_request_uri;
     proxy_pass $target;
   }
 
   location @authredirect {
     internal;
     add_header Set-Cookie $auth_cookie;
+
+    # uncomment to emulate nginx-ingress behavior
+    # return 302 https://fwdauth.localhost.pomerium.io/?uri=$scheme://$host$request_uri&rd=$pass_access_scheme://$http_host$escaped_request_uri;
+
     return 302
-      https://fwdauth.localhost.pomerium.io/?uri=$scheme://$host$request_uri&rd=$pass_access_scheme://$http_host$escaped_request_uri;
+      https://fwdauth.localhost.pomerium.io/?uri=$scheme://$host$request_uri;
   }
 
   location / {

--- a/examples/nginx/proxy.conf
+++ b/examples/nginx/proxy.conf
@@ -19,7 +19,8 @@ proxy_set_header Upgrade $http_upgrade;
 
 proxy_set_header Connection "";
 
-set_escape_uri $escaped_request_uri $request_uri;
+# uncomment to emulate nginx-ingress
+# set_escape_uri $escaped_request_uri $request_uri;
 
 # proxy_set_header X-Request-ID $req_id;
 proxy_set_header X-Real-IP $remote_addr;

--- a/examples/traefik/config.yaml
+++ b/examples/traefik/config.yaml
@@ -14,10 +14,10 @@ forward_auth_url: http://pomerium
 authenticate_service_url: https://authenticate.localhost.pomerium.io
 jwt_claims_headers: email,groups,user
 
-
 policy:
   - from: https://httpbin.localhost.pomerium.io
     to: https://httpbin
     allowed_domains:
       - pomerium.io
       - gmail.com
+    pass_identity_headers: true


### PR DESCRIPTION
Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>

## Summary

Fixes the nginx example which assumed support for a third party module. Also, renamed the example domains to use the `*.localhost.pomerium.io` which points back to localhost and is consistent with our other examples. 

## Related issues

Fixes #1690 


**Checklist**:

- [x] add related issues
- [x] updated docs
- [x] ready for review
