### PR TITLE
k8s cmd: use authclient package

### DIFF
--- a/cmd/pomerium-cli/main.go
+++ b/cmd/pomerium-cli/main.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"crypto/tls"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
 var rootCmd = &cobra.Command{
@@ -21,4 +24,19 @@ func main() {
 func fatalf(msg string, args ...interface{}) {
 	fmt.Fprintf(os.Stderr, msg+"\n", args...)
 	os.Exit(1)
+}
+
+func getTLSConfig(insecureSkipVerify bool, caCert, alternateCAPath string) *tls.Config {
+	cfg := new(tls.Config)
+	if insecureSkipVerify {
+		cfg.InsecureSkipVerify = true
+	}
+	if caCert != "" {
+		var err error
+		cfg.RootCAs, err = cryptutil.GetCertPool(caCert, alternateCAPath)
+		if err != nil {
+			fatalf("%s", err)
+		}
+	}
+	return cfg
 }

--- a/cmd/pomerium-cli/tcp.go
+++ b/cmd/pomerium-cli/tcp.go
@@ -63,7 +63,7 @@ var tcpCmd = &cobra.Command{
 
 		var tlsConfig *tls.Config
 		if pomeriumURL.Scheme == "https" {
-			tlsConfig = new(tls.Config)
+			tlsConfig = getTLSConfig(false, "", "")
 		}
 
 		l := zerolog.New(zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {

--- a/go.sum
+++ b/go.sum
@@ -733,6 +733,7 @@ golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20201202161906-c7110b5ffcbb/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
+golang.org/x/net v0.0.0-20201224014010-6772e930b67b h1:iFwSg7t5GZmB/Q5TjiEAsdoLDrdJRC1RiF2WhuV29Qw=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
## Summary
As part of the TCP tunnel command we added a new `authclient` package. This PR refactors the existing `k8s` command to use that package instead of its own implementation.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
