### PR TITLE
add TLS flags for TCP tunnel

### DIFF
--- a/cmd/pomerium-cli/kubernetes.go
+++ b/cmd/pomerium-cli/kubernetes.go
@@ -15,20 +15,8 @@ import (
 	"github.com/pomerium/pomerium/internal/authclient"
 )
 
-var kubernetesExecCredentialOption struct {
-	disableTLSVerification bool
-	alternateCAPath        string
-	caCert                 string
-}
-
 func init() {
-	flags := kubernetesExecCredentialCmd.Flags()
-	flags.BoolVar(&kubernetesExecCredentialOption.disableTLSVerification, "disable-tls-verification", false,
-		"disables TLS verification")
-	flags.StringVar(&kubernetesExecCredentialOption.alternateCAPath, "alternate-ca-path", "",
-		"path to CA certificate to use for HTTP requests")
-	flags.StringVar(&kubernetesExecCredentialOption.caCert, "ca-cert", "",
-		"base64-encoded CA TLS certificate to use for HTTP requests")
+	addTLSFlags(kubernetesExecCredentialCmd)
 	kubernetesCmd.AddCommand(kubernetesExecCredentialCmd)
 	rootCmd.AddCommand(kubernetesCmd)
 }
@@ -57,11 +45,7 @@ var kubernetesExecCredentialCmd = &cobra.Command{
 
 		var tlsConfig *tls.Config
 		if serverURL.Scheme == "https" {
-			tlsConfig = getTLSConfig(
-				kubernetesExecCredentialOption.disableTLSVerification,
-				kubernetesExecCredentialOption.caCert,
-				kubernetesExecCredentialOption.alternateCAPath,
-			)
+			tlsConfig = getTLSConfig()
 		}
 
 		ac := authclient.New(authclient.WithTLSConfig(tlsConfig))

--- a/cmd/pomerium-cli/tcp.go
+++ b/cmd/pomerium-cli/tcp.go
@@ -25,6 +25,7 @@ var tcpCmdOptions struct {
 }
 
 func init() {
+	addTLSFlags(tcpCmd)
 	flags := tcpCmd.Flags()
 	flags.StringVar(&tcpCmdOptions.listen, "listen", "127.0.0.1:0",
 		"local address to start a listener on")
@@ -63,7 +64,7 @@ var tcpCmd = &cobra.Command{
 
 		var tlsConfig *tls.Config
 		if pomeriumURL.Scheme == "https" {
-			tlsConfig = getTLSConfig(false, "", "")
+			tlsConfig = getTLSConfig()
 		}
 
 		l := zerolog.New(zerolog.NewConsoleWriter(func(w *zerolog.ConsoleWriter) {


### PR DESCRIPTION
## Summary
Updates the TCP command to support the same TLS flags as the kubernetes command. Also refactors the kubernetes command so they use the same code path.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
