### PR TITLE
remove :443 or :80 from proxy URLs in authclient

### DIFF
--- a/internal/authclient/authclient.go
+++ b/internal/authclient/authclient.go
@@ -94,7 +94,17 @@ func (client *AuthClient) runHTTPServer(ctx context.Context, li net.Listener, in
 }
 
 func (client *AuthClient) runOpenBrowser(ctx context.Context, li net.Listener, serverURL *url.URL) error {
-	dst := serverURL.ResolveReference(&url.URL{
+	browserURL := new(url.URL)
+	*browserURL = *serverURL
+
+	// remove unnecessary ports to avoid HMAC error
+	if browserURL.Scheme == "http" && browserURL.Host == browserURL.Hostname()+":80" {
+		browserURL.Host = browserURL.Hostname()
+	} else if browserURL.Scheme == "https" && browserURL.Host == browserURL.Hostname()+":443" {
+		browserURL.Host = browserURL.Hostname()
+	}
+
+	dst := browserURL.ResolveReference(&url.URL{
 		Path: "/.pomerium/api/v1/login",
 		RawQuery: url.Values{
 			"pomerium_redirect_uri": {fmt.Sprintf("http://%s", li.Addr().String())},

--- a/internal/tcptunnel/tcptunnel_test.go
+++ b/internal/tcptunnel/tcptunnel_test.go
@@ -50,7 +50,7 @@ func TestTunnel(t *testing.T) {
 
 		w.WriteHeader(200)
 
-		in, _, err := w.(http.Hijacker).Hijack()
+		in, brw, err := w.(http.Hijacker).Hijack()
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -68,7 +68,7 @@ func TestTunnel(t *testing.T) {
 			errc <- err
 		}()
 		go func() {
-			_, err := io.Copy(out, in)
+			_, err := io.Copy(out, deBuffer(brw.Reader, in))
 			errc <- err
 		}()
 		<-errc


### PR DESCRIPTION
## Summary
When using `authclient` with a URL like `https://example.com:443`, the generated URL would contain the port in the redirect_uri. Somewhere along the redirect chain this port would be stripped, and you'd end up going to `https://example.com`, but the HMAC would be invalid because it was generated with the port in place.

This PR changes the code to strip `:443` and `:80` from the URL to open in the browser.

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
