### PR TITLE
depedency: update envoy to 1.16.2

### DIFF
--- a/scripts/embed-envoy.bash
+++ b/scripts/embed-envoy.bash
@@ -3,7 +3,7 @@ set -euo pipefail
 
 BINARY=$1
 
-ENVOY_VERSION=1.16.1
+ENVOY_VERSION=1.16.2
 DIR=$(dirname "${BINARY}")
 TARGET="${TARGET:-"$(go env GOOS)_$(go env GOARCH)"}"
 


### PR DESCRIPTION

## Summary

Bumps envoy to 1.16.2. 

## Related issues

- https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.16.2

**Checklist**:

- [x] ready for review
