### PR TITLE
fix error wrapping

### DIFF
--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -20,10 +20,7 @@ func Delete(ctx context.Context, client databroker.DataBrokerServiceClient, sess
 		Type: any.GetTypeUrl(),
 		Id:   sessionID,
 	})
-	if err != nil {
-		return fmt.Errorf("error deleting session: %w", err)
-	}
-	return nil
+	return err
 }
 
 // Get gets a session from the databroker.
@@ -35,7 +32,7 @@ func Get(ctx context.Context, client databroker.DataBrokerServiceClient, session
 		Id:   sessionID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error getting session from databroker: %w", err)
+		return nil, err
 	}
 
 	var s Session
@@ -54,10 +51,7 @@ func Set(ctx context.Context, client databroker.DataBrokerServiceClient, s *Sess
 		Id:   s.Id,
 		Data: any,
 	})
-	if err != nil {
-		return nil, fmt.Errorf("error setting session in databroker: %w", err)
-	}
-	return res, nil
+	return res, err
 }
 
 // AddClaims adds the flattened claims to the session.

--- a/pkg/grpc/user/user.go
+++ b/pkg/grpc/user/user.go
@@ -21,7 +21,7 @@ func Get(ctx context.Context, client databroker.DataBrokerServiceClient, userID 
 		Id:   userID,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error getting user from databroker: %w", err)
+		return nil, err
 	}
 
 	var u User
@@ -41,7 +41,7 @@ func Set(ctx context.Context, client databroker.DataBrokerServiceClient, u *User
 		Data: any,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error setting user in databroker: %w", err)
+		return nil, err
 	}
 	return res.GetRecord(), nil
 }
@@ -55,7 +55,7 @@ func SetServiceAccount(ctx context.Context, client databroker.DataBrokerServiceC
 		Data: any,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error setting service account in databroker: %w", err)
+		return nil, err
 	}
 	return res.GetRecord(), nil
 }


### PR DESCRIPTION
## Summary
When we wrap gRPC errors with `fmt.Errorf` the corresponding gRPC error code is lost. I believe the correct way to add info to a gRPC error is.

```go
status.Errorf(status.Code(err), "msg: %w", err)
```

In this case the added message wasn't very helpful anyway.

(we have code that ignores `NotFound` errors, but since those aren't preserved we're not handling errors properly from the databroker)

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
