### PR TITLE
tcp: prevent idle stream timeouts for TCP and Websocket routes

### DIFF
--- a/internal/controlplane/xds_routes_test.go
+++ b/internal/controlplane/xds_routes_test.go
@@ -300,6 +300,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				"route": {
 					"autoHostRewrite": false,
 					"cluster": "policy-2",
+					"idleTimeout": "0s",
 					"timeout": "0s",
 					"upgradeConfigs": [
 						{ "enabled": true, "upgradeType": "websocket"},
@@ -431,6 +432,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				"route": {
 					"autoHostRewrite": false,
 					"cluster": "policy-7",
+					"idleTimeout": "0s",
 					"timeout": "0s",
 					"upgradeConfigs": [
 						{ "enabled": true, "upgradeType": "websocket"},
@@ -455,6 +457,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				"route": {
 					"autoHostRewrite": false,
 					"cluster": "policy-8",
+					"idleTimeout": "0s",
 					"timeout": "10s",
 					"upgradeConfigs": [
 						{ "enabled": true, "upgradeType": "websocket"},
@@ -501,6 +504,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				"route": {
 					"autoHostRewrite": true,
 					"cluster": "policy-9",
+					"idleTimeout": "0s",
 					"timeout": "0s",
 					"upgradeConfigs": [
 						{ "enabled": false, "upgradeType": "websocket"},
@@ -526,6 +530,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				"route": {
 					"autoHostRewrite": true,
 					"cluster": "policy-10",
+					"idleTimeout": "0s",
 					"timeout": "10s",
 					"upgradeConfigs": [
 						{ "enabled": false, "upgradeType": "websocket"},


### PR DESCRIPTION
## Summary
Envoy has an idle stream timeout which defaults to 5 minutes if not set. This change sets it to 0 (thus disabling idle timeouts) for TCP or websocket routes.

The upstream timeout is an independent setting and still available via config options.

Before:

![before](https://user-images.githubusercontent.com/395272/103817215-76138400-5023-11eb-9906-9e0294a5040f.png)


After: (was open indefinitely, I manually closed it)

![after](https://user-images.githubusercontent.com/395272/103817217-77dd4780-5023-11eb-8a86-de52cb0359bc.png)

## Related issues
Fixes #1740 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
