### PR TITLE
jws: remove issuer

### DIFF
--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -359,7 +359,7 @@ func TestAuthenticate_OAuthCallback(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			signer, err := jws.NewHS256Signer(nil, "mock")
+			signer, err := jws.NewHS256Signer(nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -493,7 +493,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			signer, err := jws.NewHS256Signer(nil, "mock")
+			signer, err := jws.NewHS256Signer(nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -614,7 +614,7 @@ func TestAuthenticate_Dashboard(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 
-			signer, err := jws.NewHS256Signer(nil, "mock")
+			signer, err := jws.NewHS256Signer(nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -77,7 +77,7 @@ func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, err
 	}
 
 	// shared state encoder setup
-	state.sharedEncoder, err = jws.NewHS256Signer([]byte(cfg.Options.SharedKey), cfg.Options.GetAuthenticateURL().Host)
+	state.sharedEncoder, err = jws.NewHS256Signer([]byte(cfg.Options.SharedKey))
 	if err != nil {
 		return nil, err
 	}

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -36,7 +36,7 @@ func TestAuthorize_okResponse(t *testing.T) {
 		JWTClaimsHeaders: []string{"email"},
 	}
 	a := &Authorize{currentOptions: config.NewAtomicOptions(), state: newAtomicAuthorizeState(new(authorizeState))}
-	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0}, "")
+	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0})
 	a.state.Load().encoder = encoder
 	a.currentOptions.Store(opt)
 	a.store = evaluator.NewStore()
@@ -205,7 +205,7 @@ func TestAuthorize_okResponse(t *testing.T) {
 
 func TestAuthorize_deniedResponse(t *testing.T) {
 	a := &Authorize{currentOptions: config.NewAtomicOptions(), state: newAtomicAuthorizeState(new(authorizeState))}
-	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0}, "")
+	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0})
 	a.state.Load().encoder = encoder
 	a.currentOptions.Store(&config.Options{
 		Policies: []config.Policy{{

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -51,7 +51,7 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 
 func Test_getEvaluatorRequest(t *testing.T) {
 	a := &Authorize{currentOptions: config.NewAtomicOptions(), state: newAtomicAuthorizeState(new(authorizeState))}
-	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0}, "")
+	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0})
 	a.state.Load().encoder = encoder
 	a.currentOptions.Store(&config.Options{
 		Policies: []config.Policy{{
@@ -271,7 +271,7 @@ func Test_handleForwardAuth(t *testing.T) {
 
 func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 	a := &Authorize{currentOptions: config.NewAtomicOptions(), state: newAtomicAuthorizeState(new(authorizeState))}
-	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0}, "")
+	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0})
 	a.state.Load().encoder = encoder
 	a.currentOptions.Store(&config.Options{
 		Policies: []config.Policy{{

--- a/authorize/session_test.go
+++ b/authorize/session_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestLoadSession(t *testing.T) {
 	opts := config.NewDefaultOptions()
-	encoder, err := jws.NewHS256Signer(nil, "example.com")
+	encoder, err := jws.NewHS256Signer(nil)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -117,7 +117,7 @@ func TestAuthorize_getJWTClaimHeaders(t *testing.T) {
 		}},
 	}
 	a := &Authorize{currentOptions: config.NewAtomicOptions(), state: newAtomicAuthorizeState(new(authorizeState))}
-	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0}, "")
+	encoder, _ := jws.NewHS256Signer([]byte{0, 0, 0, 0})
 	a.state.Load().encoder = encoder
 	a.currentOptions.Store(opt)
 	a.store = evaluator.NewStore()

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -33,11 +33,7 @@ func newAuthorizeStateFromConfig(cfg *config.Config, store *evaluator.Store) (*a
 		return nil, fmt.Errorf("authorize: failed to update policy with options: %w", err)
 	}
 
-	var host string
-	if cfg.Options.AuthenticateURL != nil {
-		host = cfg.Options.AuthenticateURL.Host
-	}
-	state.encoder, err = jws.NewHS256Signer([]byte(cfg.Options.SharedKey), host)
+	state.encoder, err = jws.NewHS256Signer([]byte(cfg.Options.SharedKey))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/pomerium-cli/cli.go
+++ b/cmd/pomerium-cli/cli.go
@@ -160,7 +160,7 @@ var serviceAccountCmd = &cobra.Command{
 		}
 		serviceAccountOptions.serviceAccount.ID = sa.GetId()
 
-		encoder, err := jws.NewHS256Signer([]byte(sharedKey), serviceAccountOptions.serviceAccount.Issuer)
+		encoder, err := jws.NewHS256Signer([]byte(sharedKey))
 		if err != nil {
 			return fmt.Errorf("bad shared key: %w", err)
 		}

--- a/internal/encoding/jws/jws.go
+++ b/internal/encoding/jws/jws.go
@@ -13,19 +13,18 @@ import (
 // https://tools.ietf.org/html/rfc7519
 type JSONWebSigner struct {
 	Signer jose.Signer
-	Issuer string
 
 	key interface{}
 }
 
 // NewHS256Signer creates a SHA256 JWT signer from a 32 byte key.
-func NewHS256Signer(key []byte, issuer string) (encoding.MarshalUnmarshaler, error) {
+func NewHS256Signer(key []byte) (encoding.MarshalUnmarshaler, error) {
 	sig, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.HS256, Key: key},
 		(&jose.SignerOptions{}).WithType("JWT"))
 	if err != nil {
 		return nil, err
 	}
-	return &JSONWebSigner{Signer: sig, key: key, Issuer: issuer}, nil
+	return &JSONWebSigner{Signer: sig, key: key}, nil
 }
 
 // Marshal signs, and serializes a JWT.

--- a/internal/sessions/middleware_test.go
+++ b/internal/sessions/middleware_test.go
@@ -30,7 +30,7 @@ func TestNewContext(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			signer, err := jws.NewHS256Signer(cryptutil.NewKey(), "issuer")
+			signer, err := jws.NewHS256Signer(cryptutil.NewKey())
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/sessions/mock/mock_store.go
+++ b/internal/sessions/mock/mock_store.go
@@ -32,7 +32,7 @@ func (ms *Store) ClearSession(http.ResponseWriter, *http.Request) {
 // LoadSession returns the session and a error
 func (ms Store) LoadSession(*http.Request) (string, error) {
 	var signer encoding.MarshalUnmarshaler
-	signer, _ = jws.NewHS256Signer(ms.Secret, "mock")
+	signer, _ = jws.NewHS256Signer(ms.Secret)
 	jwt, _ := signer.Marshal(ms.Session)
 	return string(jwt), ms.LoadError
 }

--- a/proxy/forward_auth_test.go
+++ b/proxy/forward_auth_test.go
@@ -88,7 +88,7 @@ func TestProxy_ForwardAuth(t *testing.T) {
 			p.OnConfigChange(&config.Config{Options: tt.options})
 			state := p.state.Load()
 			state.sessionStore = tt.sessionStore
-			signer, err := jws.NewHS256Signer(nil, "mock")
+			signer, err := jws.NewHS256Signer(nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -49,7 +49,7 @@ func newProxyStateFromConfig(cfg *config.Config) (*proxyState, error) {
 	state.cookieSecret, _ = base64.StdEncoding.DecodeString(cfg.Options.CookieSecret)
 
 	// used to load and verify JWT tokens signed by the authenticate service
-	state.encoder, err = jws.NewHS256Signer([]byte(cfg.Options.SharedKey), cfg.Options.GetAuthenticateURL().Host)
+	state.encoder, err = jws.NewHS256Signer([]byte(cfg.Options.SharedKey))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Currently to create a new signer we pass in an issuer. Turns out we don't use the issuer for signing.

**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
