### PR TITLE
ci: fix deprecated command in latestTag step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,10 +79,10 @@ jobs:
         id: latestTag
         run: |
           LATEST_TAG=$(git tag | grep -vi 'rc' | sort --version-sort | tail -1)
-          echo "::set-env name=LATEST_TAG::$LATEST_TAG"
+          echo "::set-output name=tag::${LATEST_TAG}"
 
       - name: Publish latest tag
-        if: "env.LATEST_TAG == steps.tagName.outputs.tag"
+        if: "steps.latestTag.outputs.tag == steps.tagName.outputs.tag"
         run: |
           docker manifest create -a pomerium/pomerium:latest pomerium/pomerium:amd64-${{ env.LATEST_TAG }} pomerium/pomerium:arm64v8-${{ env.LATEST_TAG }}
           docker manifest push pomerium/pomerium:latest


### PR DESCRIPTION
## Summary
Remove deprecated `set-env` command from build process.

## Related issues
n/a


**Checklist**:
- [ ] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
