### PR TITLE
autocert: improve logging

### DIFF
--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -48,17 +48,21 @@ func newManager(ctx context.Context,
 	acmeTemplate certmagic.ACMEManager,
 	checkInterval time.Duration,
 ) (*Manager, error) {
+	certmagicConfig := certmagic.NewDefault()
 	// set certmagic default storage cache, otherwise cert renewal loop will be based off
 	// certmagic's own default location
-	certmagic.Default.Storage = &certmagic.FileStorage{
+	certmagicConfig.Storage = &certmagic.FileStorage{
 		Path: src.GetConfig().Options.AutocertOptions.Folder,
 	}
-	certmagic.Default.Logger = log.ZapLogger().With(zap.String("service", "autocert"))
+
+	logger := log.ZapLogger().With(zap.String("service", "autocert"))
+	certmagicConfig.Logger = logger
+	acmeTemplate.Logger = logger
 
 	mgr := &Manager{
 		src:          src,
 		acmeTemplate: acmeTemplate,
-		certmagic:    certmagic.NewDefault(),
+		certmagic:    certmagicConfig,
 	}
 	err := mgr.update(src.GetConfig())
 	if err != nil {

--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -40,6 +40,8 @@ func Run(ctx context.Context, configFile string) error {
 	}
 
 	src = databroker.NewConfigSource(src)
+	logMgr := config.NewLogManager(src)
+	defer logMgr.Close()
 
 	src, err = autocert.New(src)
 	if err != nil {
@@ -49,8 +51,6 @@ func Run(ctx context.Context, configFile string) error {
 	// override the default http transport so we can use the custom CA in the TLS client config (#1570)
 	http.DefaultTransport = config.NewHTTPTransport(src)
 
-	logMgr := config.NewLogManager(src)
-	defer logMgr.Close()
 	metricsMgr := config.NewMetricsManager(src)
 	defer metricsMgr.Close()
 	traceMgr := config.NewTraceManager(src)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -69,12 +69,16 @@ func SetLevel(level string) {
 	switch level {
 	case "info":
 		zerolog.SetGlobalLevel(zerolog.InfoLevel)
+		zapLevel.SetLevel(zapcore.InfoLevel)
 	case "warn":
 		zerolog.SetGlobalLevel(zerolog.WarnLevel)
+		zapLevel.SetLevel(zapcore.WarnLevel)
 	case "error":
 		zerolog.SetGlobalLevel(zerolog.ErrorLevel)
+		zapLevel.SetLevel(zapcore.ErrorLevel)
 	default:
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
+		zapLevel.SetLevel(zapcore.DebugLevel)
 	}
 }
 


### PR DESCRIPTION
## Summary
Ensure we're logging acme challenge errors.  Right now we log the failure but not the reason.  Here's an example with this PR:

```
{"level":"error","time":"2021-01-11T15:53:28-05:00","logger":"acme_client","msg":"challenge failed","service":"autocert","identifier":"authenticate.localhost.pomerium.io","challenge_type":"http-01","status_code":400,"problem_type":"urn:ietf:params:acme:error:dns","error":"No valid IP addresses found for authenticate.localhost.pomerium.io"}
```

- internal/autocert: configure logger for acme client
- internal/autocert: don't change certmagic package defaults
- cmd/pomerium: initialize logging before autocert starts
- internal/log: ensure zap logger level matches zerolog level

## Related issues
Closes #1749 


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
