### PR TITLE
google: fix nil name

### DIFF
--- a/internal/directory/google/google.go
+++ b/internal/directory/google/google.go
@@ -168,11 +168,14 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.Group, []*direc
 		Customer(currentAccountCustomerID).
 		Pages(ctx, func(res *admin.Users) error {
 			for _, u := range res.Users {
-				userLookup[u.Id] = apiUserObject{
-					ID:          u.Id,
-					DisplayName: u.Name.FullName,
-					Email:       u.PrimaryEmail,
+				auo := apiUserObject{
+					ID:    u.Id,
+					Email: u.PrimaryEmail,
 				}
+				if u.Name != nil {
+					auo.DisplayName = u.Name.FullName
+				}
+				userLookup[u.Id] = auo
 			}
 			return nil
 		})


### PR DESCRIPTION
## Summary
Google users don't always have a name. This PR fixes a panic when this happens.

## Related issues
Fixes #1770 

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
