### PR TITLE
move file change detection before autocert

### DIFF
--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -43,13 +43,13 @@ func Run(ctx context.Context, configFile string) error {
 	logMgr := config.NewLogManager(src)
 	defer logMgr.Close()
 
+	// trigger changes when underlying files are changed
+	src = config.NewFileWatcherSource(src)
+
 	src, err = autocert.New(src)
 	if err != nil {
 		return err
 	}
-
-	// trigger changes when underlying files are changed
-	src = config.NewFileWatcherSource(src)
 
 	// override the default http transport so we can use the custom CA in the TLS client config (#1570)
 	http.DefaultTransport = config.NewHTTPTransport(src)


### PR DESCRIPTION
## Summary
Autocert appends certificates to the options config. Those are erased before Validate is called again to avoid increasing the list every time.

## Related issues
Fixes #1792

**Checklist**:
- [x] add related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
