### PR TITLE
upstream health check config

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -1,0 +1,13 @@
+package config
+
+import "errors"
+
+const (
+	policyKey      = "policy"
+	toKey          = "to"
+	healthCheckKey = "health_check"
+)
+
+var (
+	errKeysMustBeStrings = errors.New("cannot convert nested map: all keys must be strings")
+)

--- a/config/custom_test.go
+++ b/config/custom_test.go
@@ -45,7 +45,7 @@ func TestSerializable(t *testing.T) {
 
 	var mi map[interface{}]interface{}
 
-	err = yaml.Unmarshal([]byte(data), &mi)
+	err = yaml.Unmarshal(data, &mi)
 	require.NoError(t, err, "unmarshal")
 
 	ms, err := serializable(mi)

--- a/config/custom_test.go
+++ b/config/custom_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -36,4 +37,27 @@ func TestStringSlice_UnmarshalYAML(t *testing.T) {
 `), &slc)
 		assert.Equal(t, NewStringSlice("a", "b", "c"), slc)
 	})
+}
+
+func TestSerializable(t *testing.T) {
+	data := []byte(`
+health_check:
+  timeout: 5s
+  interval: 60s
+  healthyThreshold: 1
+  unhealthyThreshold: 2
+  http_health_check: 
+    host: "http://51.15.222.790:8080"
+    path: "/"
+`)
+	var mi map[interface{}]interface{}
+
+	err := yaml.Unmarshal(data, &mi)
+	require.NoError(t, err, "unmarshal")
+
+	ms, err := serializable(mi)
+	require.NoError(t, err, "serializable")
+
+	_, err = json.Marshal(ms)
+	require.NoError(t, err, "json marshal")
 }

--- a/config/custom_test.go
+++ b/config/custom_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -37,27 +36,4 @@ func TestStringSlice_UnmarshalYAML(t *testing.T) {
 `), &slc)
 		assert.Equal(t, NewStringSlice("a", "b", "c"), slc)
 	})
-}
-
-func TestSerializable(t *testing.T) {
-	data := []byte(`
-health_check:
-  timeout: 5s
-  interval: 60s
-  healthyThreshold: 1
-  unhealthyThreshold: 2
-  http_health_check: 
-    host: "http://51.15.222.790:8080"
-    path: "/"
-`)
-	var mi map[interface{}]interface{}
-
-	err := yaml.Unmarshal(data, &mi)
-	require.NoError(t, err, "unmarshal")
-
-	ms, err := serializable(mi)
-	require.NoError(t, err, "serializable")
-
-	_, err = json.Marshal(ms)
-	require.NoError(t, err, "json marshal")
 }

--- a/config/custom_test.go
+++ b/config/custom_test.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v2"
 )
 
@@ -36,4 +38,19 @@ func TestStringSlice_UnmarshalYAML(t *testing.T) {
 `), &slc)
 		assert.Equal(t, NewStringSlice("a", "b", "c"), slc)
 	})
+}
+func TestSerializable(t *testing.T) {
+	data, err := base64.StdEncoding.DecodeString("aGVhbHRoX2NoZWNrOgogIHRpbWVvdXQ6IDVzCiAgaW50ZXJ2YWw6IDYwcwogIGhlYWx0aHlUaHJlc2hvbGQ6IDEKICB1bmhlYWx0aHlUaHJlc2hvbGQ6IDIKICBodHRwX2hlYWx0aF9jaGVjazogCiAgICBob3N0OiAiaHR0cDovL2xvY2FsaG9zdDo4MDgwIgogICAgcGF0aDogIi8iCg==")
+	require.NoError(t, err, "decode")
+
+	var mi map[interface{}]interface{}
+
+	err = yaml.Unmarshal([]byte(data), &mi)
+	require.NoError(t, err, "unmarshal")
+
+	ms, err := serializable(mi)
+	require.NoError(t, err, "serializable")
+
+	_, err = json.Marshal(ms)
+	require.NoError(t, err, "json marshal")
 }

--- a/config/options.go
+++ b/config/options.go
@@ -399,7 +399,9 @@ func (o *Options) parsePolicy() error {
 	}
 	// Finish initializing policies
 	for i := range o.Policies {
-		if err := (&o.Policies[i]).Validate(); err != nil {
+		p := &o.Policies[i]
+		p.HealthCheck.embed()
+		if err := p.Validate(); err != nil {
 			return err
 		}
 	}

--- a/config/options.go
+++ b/config/options.go
@@ -361,7 +361,6 @@ func optionsFromViper(configFile string) (*Options, error) {
 		}
 	}
 
-	v.GetStringMap("policy")
 	if err := v.Unmarshal(o, viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),

--- a/config/options.go
+++ b/config/options.go
@@ -361,6 +361,7 @@ func optionsFromViper(configFile string) (*Options, error) {
 		}
 	}
 
+	v.GetStringMap("policy")
 	if err := v.Unmarshal(o, viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
@@ -400,7 +401,6 @@ func (o *Options) parsePolicy() error {
 	// Finish initializing policies
 	for i := range o.Policies {
 		p := &o.Policies[i]
-		p.HealthCheck.embed()
 		if err := p.Validate(); err != nil {
 			return err
 		}

--- a/config/policy.go
+++ b/config/policy.go
@@ -142,7 +142,8 @@ type Policy struct {
 	// OutlierDetection configures outlier detection for the upstream cluster.
 	OutlierDetection *PolicyOutlierDetection `mapstructure:"outlier_detection" yaml:"outlier_detection,omitempty" json:"outlier_detection,omitempty"`
 
-	HealthCheck *HealthCheck `mapstructure:"health_check" yaml:"health_check,omitempty" json:"health_check,omitempty"`
+	// HealthCheck defines active health checks. See https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto
+	HealthCheck *envoy_config_core_v3.HealthCheck `mapstructure:"health_check" yaml:"health_check,omitempty" json:"health_check,omitempty"`
 
 	SubPolicies []SubPolicy `mapstructure:"sub_policies" yaml:"sub_policies,omitempty" json:"sub_policies,omitempty"`
 }
@@ -171,27 +172,6 @@ type PolicyRedirect struct {
 }
 
 type PolicyOutlierDetection envoy_config_cluster_v3.OutlierDetection
-
-// HealthCheck allows to specify upstream health check rules.
-// see https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#config-core-v3-healthcheck for more details
-type HealthCheck struct {
-	envoy_config_core_v3.HealthCheck `mapstructure:",squash"`
-	HTTPHealthCheck                  envoy_config_core_v3.HealthCheck_HttpHealthCheck `mapstructure:"http_health_check" yaml:"http_health_check" json:"http_health_check"`
-}
-
-func (hc *HealthCheck) embed() {
-	if hc == nil {
-		return
-	}
-	hc.HealthCheck.HealthChecker = &envoy_config_core_v3.HealthCheck_HttpHealthCheck_{&hc.HTTPHealthCheck}
-}
-
-func (hc *HealthCheck) GetHealthCheck() *envoy_config_core_v3.HealthCheck {
-	if hc == nil {
-		return nil
-	}
-	return &hc.HealthCheck
-}
 
 // NewPolicyFromProto creates a new Policy from a protobuf policy config route.
 func NewPolicyFromProto(pb *configpb.Route) (*Policy, error) {
@@ -454,8 +434,8 @@ func (p *Policy) Validate() error {
 	}
 
 	if p.HealthCheck != nil {
-		if err := p.HealthCheck.GetHealthCheck().Validate(); err != nil {
-			return fmt.Errorf("health check: %+v, %+v: %w", p.HealthCheck.HealthCheck, p.HealthCheck.HTTPHealthCheck, err)
+		if err := p.HealthCheck.Validate(); err != nil {
+			return err
 		}
 	}
 

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1370,6 +1370,15 @@ When enabled, this option will pass identity headers to upstream applications. T
 If set, enables proxying of SPDY protocol upgrades.
 
 
+### Health Check
+- Config File Key: `health_check`
+- Type: `object`
+- Optional
+
+When defined, will issue periodic health check requests to upstream servers.
+See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a list of supported parameters.
+
+
 ### Websocket Connections
 - Config File Key: `allow_websockets`
 - Type: `bool`

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -1502,6 +1502,15 @@ settings:
           - Default: `false`
         doc: |
           If set, enables proxying of SPDY protocol upgrades.
+      - name: "Health Check"
+        keys: ["health_check"]
+        attributes: |
+          - Config File Key: `health_check`
+          - Type: `object`
+          - Optional
+        doc: |
+          When defined, will issue periodic health check requests to upstream servers.
+          See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a list of supported parameters.
       - name: "Websocket Connections"
         keys: ["allow_websockets"]
         attributes: |

--- a/internal/controlplane/xds_cluster_test.go
+++ b/internal/controlplane/xds_cluster_test.go
@@ -214,7 +214,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		cluster := buildCluster("example", endpoints, true,
 			config.GetEnvoyDNSLookupFamily(config.DNSLookupFamilyV4Only),
-			nil)
+			nil, nil)
 		testutil.AssertProtoJSONEqual(t, `
 			{
 				"name": "example",
@@ -253,7 +253,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		cluster := buildCluster("example", endpoints, true,
 			config.GetEnvoyDNSLookupFamily(config.DNSLookupFamilyAuto),
-			nil)
+			nil, nil)
 		testutil.AssertProtoJSONEqual(t, `
 			{
 				"name": "example",
@@ -344,7 +344,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		cluster := buildCluster("example", endpoints, true,
 			config.GetEnvoyDNSLookupFamily(config.DNSLookupFamilyAuto),
-			nil)
+			nil, nil)
 		testutil.AssertProtoJSONEqual(t, `
 			{
 				"name": "example",
@@ -379,7 +379,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		cluster := buildCluster("example", endpoints, true,
 			config.GetEnvoyDNSLookupFamily(config.DNSLookupFamilyAuto),
-			nil)
+			nil, nil)
 		testutil.AssertProtoJSONEqual(t, `
 			{
 				"name": "example",
@@ -417,7 +417,7 @@ func Test_buildCluster(t *testing.T) {
 			&envoy_config_cluster_v3.OutlierDetection{
 				EnforcingConsecutive_5Xx:       wrapperspb.UInt32(17),
 				SplitExternalLocalOriginErrors: true,
-			})
+			}, nil)
 		testutil.AssertProtoJSONEqual(t, `
 			{
 				"name": "example",

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -89,7 +89,7 @@ func (srv *Server) buildPolicyCluster(options *config.Options, policy *config.Po
 		dnsLookupFamily = envoy_config_cluster_v3.Cluster_V4_ONLY
 	}
 	outlierDetection := (*envoy_config_cluster_v3.OutlierDetection)(policy.OutlierDetection)
-	return buildCluster(name, endpoints, false, dnsLookupFamily, outlierDetection, policy.HealthCheck.GetHealthCheck())
+	return buildCluster(name, endpoints, false, dnsLookupFamily, outlierDetection, policy.HealthCheck)
 }
 
 func (srv *Server) buildPolicyEndpoints(policy *config.Policy) []Endpoint {

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -78,7 +78,7 @@ func (srv *Server) buildClusters(options *config.Options) []*envoy_config_cluste
 func (srv *Server) buildInternalCluster(options *config.Options, name string, dst *url.URL, forceHTTP2 bool) *envoy_config_cluster_v3.Cluster {
 	endpoints := []Endpoint{NewEndpoint(dst, srv.buildInternalTransportSocket(options, dst))}
 	dnsLookupFamily := config.GetEnvoyDNSLookupFamily(options.DNSLookupFamily)
-	return buildCluster(name, endpoints, forceHTTP2, dnsLookupFamily, nil)
+	return buildCluster(name, endpoints, forceHTTP2, dnsLookupFamily, nil, nil)
 }
 
 func (srv *Server) buildPolicyCluster(options *config.Options, policy *config.Policy) *envoy_config_cluster_v3.Cluster {
@@ -89,7 +89,7 @@ func (srv *Server) buildPolicyCluster(options *config.Options, policy *config.Po
 		dnsLookupFamily = envoy_config_cluster_v3.Cluster_V4_ONLY
 	}
 	outlierDetection := (*envoy_config_cluster_v3.OutlierDetection)(policy.OutlierDetection)
-	return buildCluster(name, endpoints, false, dnsLookupFamily, outlierDetection)
+	return buildCluster(name, endpoints, false, dnsLookupFamily, outlierDetection, policy.HealthCheck.GetHealthCheck())
 }
 
 func (srv *Server) buildPolicyEndpoints(policy *config.Policy) []Endpoint {
@@ -235,6 +235,7 @@ func buildCluster(
 	forceHTTP2 bool,
 	dnsLookupFamily envoy_config_cluster_v3.Cluster_DnsLookupFamily,
 	outlierDetection *envoy_config_cluster_v3.OutlierDetection,
+	healthCheck *envoy_config_core_v3.HealthCheck,
 ) *envoy_config_cluster_v3.Cluster {
 	if len(endpoints) == 0 {
 		return nil
@@ -254,6 +255,10 @@ func buildCluster(
 		TransportSocketMatches: buildTransportSocketMatches(endpoints),
 		DnsLookupFamily:        dnsLookupFamily,
 		OutlierDetection:       outlierDetection,
+	}
+
+	if healthCheck != nil {
+		cluster.HealthChecks = append(cluster.HealthChecks, healthCheck)
 	}
 
 	if forceHTTP2 {


### PR DESCRIPTION
## Summary
Envoy health check configuration option. 
Protobuf config support is ejected into a separate ticket to directly import all Envoy .proto structures. 

## Related issues
https://github.com/pomerium/internal/issues/246
https://github.com/pomerium/internal/issues/264

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review
