### PR TITLE
config: require shared key if using redis backed databroker

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -496,7 +496,7 @@ func (o *Options) Validate() error {
 
 	if IsAll(o.Services) {
 		// mutual auth between services on the same host can be generated at runtime
-		if o.SharedKey == "" {
+		if o.SharedKey == "" && o.DataBrokerStorageType == "memory" {
 			o.SharedKey = cryptutil.NewBase64Key()
 		}
 		// in all in one mode we are running just over the local socket

--- a/config/options.go
+++ b/config/options.go
@@ -496,7 +496,7 @@ func (o *Options) Validate() error {
 
 	if IsAll(o.Services) {
 		// mutual auth between services on the same host can be generated at runtime
-		if o.SharedKey == "" && o.DataBrokerStorageType == "memory" {
+		if o.SharedKey == "" && o.DataBrokerStorageType == StorageInMemoryName {
 			o.SharedKey = cryptutil.NewBase64Key()
 		}
 		// in all in one mode we are running just over the local socket

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -49,7 +49,7 @@ func Test_Validate(t *testing.T) {
 
 	missingSharedSecretWithPersistence := testOptions()
 	missingSharedSecretWithPersistence.SharedKey = ""
-	missingSharedSecretWithPersistence.DataBrokerStorageType = "redis"
+	missingSharedSecretWithPersistence.DataBrokerStorageType = StorageRedisName
 	missingSharedSecretWithPersistence.DataBrokerStorageConnectionString = "redis://somehost:6379"
 
 	tests := []struct {

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -47,6 +47,11 @@ func Test_Validate(t *testing.T) {
 	badSignoutRedirectURL := testOptions()
 	badSignoutRedirectURL.SignOutRedirectURLString = "--"
 
+	missingSharedSecretWithPersistence := testOptions()
+	missingSharedSecretWithPersistence.SharedKey = ""
+	missingSharedSecretWithPersistence.DataBrokerStorageType = "redis"
+	missingSharedSecretWithPersistence.DataBrokerStorageConnectionString = "redis://somehost:6379"
+
 	tests := []struct {
 		name     string
 		testOpts *Options
@@ -60,6 +65,7 @@ func Test_Validate(t *testing.T) {
 		{"invalid databroker storage type", invalidStorageType, true},
 		{"missing databroker storage dsn", missingStorageDSN, true},
 		{"invalid signout redirect url", badSignoutRedirectURL, true},
+		{"no shared key with databroker persistence", missingSharedSecretWithPersistence, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
When users configure a persistent databroker storage layer, we should ensure they have a shared key configured to prevent unexpected errors on restart.

## Related issues
fixes #1795


**Checklist**:
- [x] add related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] ready for review
