### PR TITLE
expose all envoy cluster options in policy

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -1,13 +1,21 @@
 package config
 
-import "errors"
+import (
+	"errors"
+
+	"google.golang.org/protobuf/encoding/protojson"
+)
 
 const (
-	policyKey      = "policy"
-	toKey          = "to"
-	healthCheckKey = "health_check"
+	policyKey    = "policy"
+	toKey        = "to"
+	envoyOptsKey = "_envoy_opts"
 )
 
 var (
 	errKeysMustBeStrings = errors.New("cannot convert nested map: all keys must be strings")
+)
+
+var (
+	protoPartial = protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown: true}
 )

--- a/config/options.go
+++ b/config/options.go
@@ -332,7 +332,7 @@ func NewDefaultOptions() *Options {
 func newOptionsFromConfig(configFile string) (*Options, error) {
 	o, err := optionsFromViper(configFile)
 	if err != nil {
-		return nil, fmt.Errorf("config: options from config file %w", err)
+		return nil, fmt.Errorf("config: options from config file %q: %w", configFile, err)
 	}
 	serviceName := telemetry.ServiceName(o.Services)
 	metrics.AddPolicyCountCallback(serviceName, func() int64 {

--- a/docs/docs/topics/load_balancing.md
+++ b/docs/docs/topics/load_balancing.md
@@ -1,0 +1,60 @@
+---
+title: Upstream Load Balancing
+description: >-
+  This article covers Pomerium built-in load balancing capabilities in presence of multiple upstreams.
+---
+
+# Upstream Load Balancing
+
+This article covers Pomerium built-in load balancing capabilities in presence of multiple upstreams.
+
+## Multiple Upstreams
+
+You may specify multiple servers for your upstream application, and Pomerium would load balance user requests between them.
+
+```yaml
+policy:
+  - from: https://myapp.localhost.pomerium.io
+    to: 
+      - http://myapp-srv-1:8080
+      - http://myapp-srv-2:8080
+```
+
+::: tip
+    In presence of multiple upstreams, make sure to specify either an active or passive health check, or both, to avoid requests served to unhealthy backend.
+:::
+
+### Active Health Checks
+
+Active health checks issue periodic requests to each upstream to determine its health. 
+See [Health Checking](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a comprehensive overview.
+
+```yaml
+policy:
+  - from: https://myapp.localhost.pomerium.io
+    to: 
+      - http://myapp-srv-1:8080
+      - http://myapp-srv-2:8080
+    health_checks:
+      - timeout: 10s
+        interval: 60s
+        healthy_threshold: 1
+        unhealthy_threshold: 2
+        http_health_check:
+          path: "/"
+```
+### Passive Health Checks
+
+Passive health check tries to deduce upstream server health based on recent observed responses. 
+See [Outlier Detection](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier) for a comprehensive overview.
+
+## Load Balancing Method
+
+`lb_policy` should be set to one of the values:
+
+- [`ROUND_ROBIN`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-round-robin) (default)
+- [`LEAST_REQUEST`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-least-request) and may be further configured using [``](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-leastrequestlbconfig)
+- [`RING_HASH`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#ring-hash) and may be further configured using [`ring_hash_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-ringhashlbconfig) option
+- [`RANDOM`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#random)
+- [`MAGLEV`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#maglev) and may be further configured using [`maglev_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig) option
+

--- a/docs/docs/topics/load_balancing.md
+++ b/docs/docs/topics/load_balancing.md
@@ -15,7 +15,7 @@ You may specify multiple servers for your upstream application, and Pomerium wou
 ```yaml
 policy:
   - from: https://myapp.localhost.pomerium.io
-    to: 
+    to:
       - http://myapp-srv-1:8080
       - http://myapp-srv-2:8080
 ```
@@ -26,13 +26,13 @@ policy:
 
 ### Active Health Checks
 
-Active health checks issue periodic requests to each upstream to determine its health. 
+Active health checks issue periodic requests to each upstream to determine its health.
 See [Health Checking](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a comprehensive overview.
 
 ```yaml
 policy:
   - from: https://myapp.localhost.pomerium.io
-    to: 
+    to:
       - http://myapp-srv-1:8080
       - http://myapp-srv-2:8080
     health_checks:
@@ -45,7 +45,7 @@ policy:
 ```
 ### Passive Health Checks
 
-Passive health check tries to deduce upstream server health based on recent observed responses. 
+Passive health check tries to deduce upstream server health based on recent observed responses.
 See [Outlier Detection](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier) for a comprehensive overview.
 
 ## Load Balancing Method

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1390,7 +1390,7 @@ In presence of multiple upstreams, defines load balancing strategy between them.
 - Optional
 
 When defined, will issue periodic health check requests to upstream servers. When health checks are defined, unhealthy upstream servers would not serve traffic.
-See also `outlier_detection` for automatic upstream server health detection. 
+See also `outlier_detection` for automatic upstream server health detection.
 In presence of multiple upstream servers, it is recommended to set up either `health_checks` or `outlier_detection` or both.
 See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a list of supported parameters.
 

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1370,12 +1370,28 @@ When enabled, this option will pass identity headers to upstream applications. T
 If set, enables proxying of SPDY protocol upgrades.
 
 
-### Health Check
-- Config File Key: `health_check`
-- Type: `object`
+### Load Balancing
+- Config File Key: `lb_policy`
+- Type: `enum`
 - Optional
 
-When defined, will issue periodic health check requests to upstream servers.
+In presence of multiple upstreams, defines load balancing strategy between them.
+
+- [`ROUND_ROBIN`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-round-robin) (default)
+- [`LEAST_REQUEST`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-least-request) and may be further configured using [``](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-leastrequestlbconfig)
+- [`RING_HASH`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#ring-hash) and may be further configured using [`ring_hash_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-ringhashlbconfig) option
+- [`RANDOM`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#random)
+- [`MAGLEV`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#maglev) and may be further configured using [`maglev_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig) option
+
+
+### Health Checks
+- Config File Key: `health_checks`
+- Type: `array of objects`
+- Optional
+
+When defined, will issue periodic health check requests to upstream servers. When health checks are defined, unhealthy upstream servers would not serve traffic.
+See also `outlier_detection` for automatic upstream server health detection. 
+In presence of multiple upstream servers, it is recommended to set up either `health_checks` or `outlier_detection` or both.
 See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a list of supported parameters.
 
 

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -1516,7 +1516,6 @@ settings:
           - [`RING_HASH`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#ring-hash) and may be further configured using [`ring_hash_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-ringhashlbconfig) option
           - [`RANDOM`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#random)
           - [`MAGLEV`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#maglev) and may be further configured using [`maglev_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig) option
-        
       - name: "Health Checks"
         keys: ["health_checks"]
         attributes: |
@@ -1525,7 +1524,7 @@ settings:
           - Optional
         doc: |
           When defined, will issue periodic health check requests to upstream servers. When health checks are defined, unhealthy upstream servers would not serve traffic.
-          See also `outlier_detection` for automatic upstream server health detection. 
+          See also `outlier_detection` for automatic upstream server health detection.
           In presence of multiple upstream servers, it is recommended to set up either `health_checks` or `outlier_detection` or both.
           See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a list of supported parameters.
       - name: "Websocket Connections"

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -1502,14 +1502,31 @@ settings:
           - Default: `false`
         doc: |
           If set, enables proxying of SPDY protocol upgrades.
-      - name: "Health Check"
-        keys: ["health_check"]
+      - name: "Load Balancing"
+        keys: ["lb_policy"]
         attributes: |
-          - Config File Key: `health_check`
-          - Type: `object`
+          - Config File Key: `lb_policy`
+          - Type: `enum`
           - Optional
         doc: |
-          When defined, will issue periodic health check requests to upstream servers.
+          In presence of multiple upstreams, defines load balancing strategy between them.
+
+          - [`ROUND_ROBIN`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-round-robin) (default)
+          - [`LEAST_REQUEST`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-least-request) and may be further configured using [``](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-leastrequestlbconfig)
+          - [`RING_HASH`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#ring-hash) and may be further configured using [`ring_hash_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-ringhashlbconfig) option
+          - [`RANDOM`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#random)
+          - [`MAGLEV`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#maglev) and may be further configured using [`maglev_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig) option
+        
+      - name: "Health Checks"
+        keys: ["health_checks"]
+        attributes: |
+          - Config File Key: `health_checks`
+          - Type: `array of objects`
+          - Optional
+        doc: |
+          When defined, will issue periodic health check requests to upstream servers. When health checks are defined, unhealthy upstream servers would not serve traffic.
+          See also `outlier_detection` for automatic upstream server health detection. 
+          In presence of multiple upstream servers, it is recommended to set up either `health_checks` or `outlier_detection` or both.
           See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a list of supported parameters.
       - name: "Websocket Connections"
         keys: ["allow_websockets"]

--- a/internal/controlplane/constants.go
+++ b/internal/controlplane/constants.go
@@ -1,0 +1,23 @@
+package controlplane
+
+import (
+	"errors"
+	"time"
+
+	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"github.com/golang/protobuf/ptypes"
+)
+
+var (
+	errNoEndpoints           = errors.New("cluster must have endpoints")
+	defaultConnectionTimeout = ptypes.DurationProto(time.Second * 10)
+)
+
+// newDefaultEnvoyClusterConfig creates envoy cluster with certain default values
+func newDefaultEnvoyClusterConfig() *envoy_config_cluster_v3.Cluster {
+	return &envoy_config_cluster_v3.Cluster{
+		ConnectTimeout:  defaultConnectionTimeout,
+		RespectDnsTtl:   true,
+		DnsLookupFamily: envoy_config_cluster_v3.Cluster_AUTO,
+	}
+}


### PR DESCRIPTION
## Summary
all options from https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto should be available part of `policy` spec.

**Checklist**:
- [x] add related issues
- [x] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] ready for review

Pomerium `config.proto` will be handled as part of separate PR to import Envoy's proto specs explicitly. 