### PR TITLE
config: fix databroker policies

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -69,7 +69,7 @@ func validateOptions(o *config.Options) error {
 // newPolicyEvaluator returns an policy evaluator.
 func newPolicyEvaluator(opts *config.Options, store *evaluator.Store) (*evaluator.Evaluator, error) {
 	metrics.AddPolicyCountCallback("pomerium-authorize", func() int64 {
-		return int64(len(opts.Policies))
+		return int64(len(opts.GetAllPolicies()))
 	})
 	ctx := context.Background()
 	_, span := trace.StartSpan(ctx, "authorize.newPolicyEvaluator")

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -52,7 +52,7 @@ func New(options *config.Options, store *Store) (*Evaluator, error) {
 	e := &Evaluator{
 		custom:           NewCustomEvaluator(store.opaStore),
 		authenticateHost: options.AuthenticateURL.Host,
-		policies:         options.Policies,
+		policies:         options.GetAllPolicies(),
 	}
 	if options.ClientCA != "" {
 		e.clientCA = options.ClientCA
@@ -75,7 +75,7 @@ func New(options *config.Options, store *Store) (*Evaluator, error) {
 	}
 
 	store.UpdateAdmins(options.Administrators)
-	store.UpdateRoutePolicies(options.Policies)
+	store.UpdateRoutePolicies(options.GetAllPolicies())
 
 	e.rego = rego.New(
 		rego.Store(store.opaStore),

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -245,7 +245,7 @@ func (a *Authorize) getEvaluatorRequestFromCheckRequest(in *envoy_service_auth_v
 func (a *Authorize) getMatchingPolicy(requestURL *url.URL) *config.Policy {
 	options := a.currentOptions.Load()
 
-	for _, p := range options.Policies {
+	for _, p := range options.GetAllPolicies() {
 		if p.Matches(requestURL) {
 			return &p
 		}

--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -283,12 +283,14 @@ func (mgr *Manager) GetConfig() *config.Config {
 }
 
 func sourceHostnames(cfg *config.Config) []string {
-	if len(cfg.Options.Policies) == 0 {
+	policies := cfg.Options.GetAllPolicies()
+
+	if len(policies) == 0 {
 		return nil
 	}
 
 	dedupe := map[string]struct{}{}
-	for _, p := range cfg.Options.Policies {
+	for _, p := range policies {
 		dedupe[p.Source.Hostname()] = struct{}{}
 	}
 	if cfg.Options.AuthenticateURL != nil {

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -75,8 +75,8 @@ func (srv *Server) buildClusters(options *config.Options) ([]*envoy_config_clust
 	}
 
 	if config.IsProxy(options.Services) {
-		for i := range options.Policies {
-			policy := options.Policies[i]
+		for i, p := range options.GetAllPolicies() {
+			policy := p
 			if policy.EnvoyOpts == nil {
 				policy.EnvoyOpts = newDefaultEnvoyClusterConfig()
 			}

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -439,7 +439,7 @@ func getAllRouteableDomains(options *config.Options, addr string) []string {
 		}
 	}
 	if config.IsProxy(options.Services) && addr == options.Addr {
-		for _, policy := range options.Policies {
+		for _, policy := range options.GetAllPolicies() {
 			for _, h := range urlutil.GetDomainsForURL(policy.Source.URL) {
 				lookup[h] = struct{}{}
 			}

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -181,8 +181,8 @@ func buildPolicyRoutes(options *config.Options, domain string) []*envoy_config_r
 	var routes []*envoy_config_route_v3.Route
 	responseHeadersToAdd := toEnvoyHeaders(options.Headers)
 
-	for i := range options.Policies {
-		policy := options.Policies[i]
+	for i, p := range options.GetAllPolicies() {
+		policy := p
 		if !hostMatchesDomain(policy.Source.URL, domain) {
 			continue
 		}
@@ -445,7 +445,7 @@ func setHostRewriteOptions(policy *config.Policy, action *envoy_config_route_v3.
 }
 
 func hasPublicPolicyMatchingURL(options *config.Options, requestURL *url.URL) bool {
-	for _, policy := range options.Policies {
+	for _, policy := range options.GetAllPolicies() {
 		if policy.AllowPublicUnauthenticatedAccess && policy.Matches(requestURL) {
 			return true
 		}

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -82,7 +82,7 @@ func (src *ConfigSource) rebuild(firstTime bool) {
 	src.runUpdater(cfg)
 
 	seen := map[uint64]struct{}{}
-	for _, policy := range cfg.Options.Policies {
+	for _, policy := range cfg.Options.GetAllPolicies() {
 		seen[policy.RouteID()] = struct{}{}
 	}
 
@@ -128,7 +128,7 @@ func (src *ConfigSource) rebuild(firstTime bool) {
 	}
 
 	// add the additional policies here since calling `Validate` will reset them.
-	cfg.Options.Policies = append(cfg.Options.Policies, additionalPolicies...)
+	cfg.Options.AdditionalPolicies = append(cfg.Options.AdditionalPolicies, additionalPolicies...)
 
 	src.computedConfig = cfg
 	if !firstTime {

--- a/internal/databroker/config_source_test.go
+++ b/internal/databroker/config_source_test.go
@@ -65,7 +65,7 @@ func TestConfigSource(t *testing.T) {
 		assert.NoError(t, ctx.Err())
 		return
 	case cfg := <-cfgs:
-		assert.Len(t, cfg.Options.Policies, 0)
+		assert.Len(t, cfg.Options.AdditionalPolicies, 0)
 	}
 
 	select {
@@ -73,7 +73,7 @@ func TestConfigSource(t *testing.T) {
 		assert.NoError(t, ctx.Err())
 		return
 	case cfg := <-cfgs:
-		assert.Len(t, cfg.Options.Policies, 1)
+		assert.Len(t, cfg.Options.AdditionalPolicies, 1)
 	}
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -71,7 +71,7 @@ func New(cfg *config.Config) (*Proxy, error) {
 	p.currentRouter.Store(httputil.NewRouter())
 
 	metrics.AddPolicyCountCallback("pomerium-proxy", func() int64 {
-		return int64(len(p.currentOptions.Load().Policies))
+		return int64(len(p.currentOptions.Load().GetAllPolicies()))
 	})
 
 	return p, nil
@@ -94,7 +94,7 @@ func (p *Proxy) OnConfigChange(cfg *config.Config) {
 }
 
 func (p *Proxy) setHandlers(opts *config.Options) {
-	if len(opts.Policies) == 0 {
+	if len(opts.GetAllPolicies()) == 0 {
 		log.Warn().Msg("proxy: configuration has no policies")
 	}
 	r := httputil.NewRouter()


### PR DESCRIPTION
## Summary
The `Policies` slice is erased any time `Validate` is called. Because of this the policies added by the databroker were being inadvertently removed upstream.

This change adds another field called `AdditionalPolicies` to avoid this. I briefly looked into solving this by adding a new field to `config.Config` but it involved changing hundreds of files and I wasn't confident I could make those changes safely.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
