### PR TITLE
controlplane: only enable STATIC dns when all adresses are IP addresses

### DIFF
--- a/internal/controlplane/xds_cluster_test.go
+++ b/internal/controlplane/xds_cluster_test.go
@@ -211,7 +211,7 @@ func Test_buildCluster(t *testing.T) {
 	rootCA := srv.filemgr.FileDataSource(rootCAPath).GetFilename()
 	t.Run("insecure", func(t *testing.T) {
 		endpoints := srv.buildPolicyEndpoints(&config.Policy{
-			Destinations: mustParseURLs("http://example.com"),
+			Destinations: mustParseURLs("http://example.com", "http://1.2.3.4"),
 		})
 		cluster := newDefaultEnvoyClusterConfig()
 		cluster.DnsLookupFamily = envoy_config_cluster_v3.Cluster_V4_ONLY
@@ -235,6 +235,16 @@ func Test_buildCluster(t *testing.T) {
 								"address": {
 									"socketAddress": {
 										"address": "example.com",
+										"ipv4Compat": true,
+										"portValue": 80
+									}
+								}
+							}
+						}, {
+							"endpoint": {
+								"address": {
+									"socketAddress": {
+										"address": "1.2.3.4",
 										"ipv4Compat": true,
 										"portValue": 80
 									}
@@ -340,9 +350,9 @@ func Test_buildCluster(t *testing.T) {
 			}
 		`, cluster)
 	})
-	t.Run("ip address", func(t *testing.T) {
+	t.Run("ip addresses", func(t *testing.T) {
 		endpoints := srv.buildPolicyEndpoints(&config.Policy{
-			Destinations: mustParseURLs("http://127.0.0.1"),
+			Destinations: mustParseURLs("http://127.0.0.1", "http://127.0.0.2"),
 		})
 		cluster := newDefaultEnvoyClusterConfig()
 		err := buildCluster(cluster, "example", endpoints, true)
@@ -364,6 +374,16 @@ func Test_buildCluster(t *testing.T) {
 								"address": {
 									"socketAddress": {
 										"address": "127.0.0.1",
+										"ipv4Compat": true,
+										"portValue": 80
+									}
+								}
+							}
+						},{
+							"endpoint": {
+								"address": {
+									"socketAddress": {
+										"address": "127.0.0.2",
 										"ipv4Compat": true,
 										"portValue": 80
 									}

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -292,13 +292,13 @@ func buildCluster(
 	}
 
 	// for IPs we use a static discovery type, otherwise we use DNS
-	isIP := false
+	allIP := true
 	for _, lbe := range lbEndpoints {
-		if net.ParseIP(urlutil.StripPort(lbe.GetEndpoint().GetAddress().GetSocketAddress().GetAddress())) != nil {
-			isIP = true
+		if net.ParseIP(urlutil.StripPort(lbe.GetEndpoint().GetAddress().GetSocketAddress().GetAddress())) == nil {
+			allIP = false
 		}
 	}
-	if isIP {
+	if allIP {
 		cluster.ClusterDiscoveryType = &envoy_config_cluster_v3.Cluster_Type{Type: envoy_config_cluster_v3.Cluster_STATIC}
 	} else {
 		cluster.ClusterDiscoveryType = &envoy_config_cluster_v3.Cluster_Type{Type: envoy_config_cluster_v3.Cluster_STRICT_DNS}


### PR DESCRIPTION
## Summary
Currently we turn on the STATIC dns family if there is an IP address in the destination endpoint. This changes that behavior so we only enable STATIC dns when *all* endpoints are IP addresses.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
