### PR TITLE
fix go:generate for envoy config

### DIFF
--- a/pkg/grpc/grpc.go
+++ b/pkg/grpc/grpc.go
@@ -5,4 +5,4 @@ package grpc
 //go:generate ../../scripts/protoc -I ./databroker/ --go_out=plugins=grpc,paths=source_relative:./databroker/. ./databroker/databroker.proto
 //go:generate ../../scripts/protoc -I ./directory/ --go_out=plugins=grpc,paths=source_relative:./directory/. ./directory/directory.proto
 //go:generate ../../scripts/protoc -I ./audit/ --go_out=plugins=grpc,paths=source_relative:./audit/. ./audit/audit.proto
-//go:generate ../../scripts/protoc -I ./config/ --go_out=M"envoy/config/cluster/v3/cluster.proto"="github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3",plugins=grpc,paths=source_relative:./config/. ./config/config.proto
+//go:generate ../../scripts/protoc -I ./config/ --go_out=Menvoy/config/cluster/v3/cluster.proto=github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3,plugins=grpc,paths=source_relative:./config/. ./config/config.proto


### PR DESCRIPTION
## Summary
go:generate doesn't like using double quotes like this.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
