### PR TITLE
config: return errors on invalid URLs, fix linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,6 @@ linters:
     - stylecheck
     - typecheck
     - unconvert
-    - unparam
     - unused
     - varcheck
     # - asciicheck

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -280,7 +280,8 @@ func TestAuthorize_deniedResponse(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := a.deniedResponse(tc.in, tc.code, tc.reason, tc.headers)
+			got, err := a.deniedResponse(tc.in, tc.code, tc.reason, tc.headers)
+			require.NoError(t, err)
 			assert.Equal(t, tc.want.Status.Code, got.Status.Code)
 			assert.Equal(t, tc.want.Status.Message, got.Status.Message)
 			assert.Equal(t, tc.want.GetDeniedResponse().GetHeaders(), got.GetDeniedResponse().GetHeaders())

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -78,11 +78,11 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v2.CheckRe
 		return a.okResponse(reply), nil
 	case reply.Status == http.StatusUnauthorized:
 		if isForwardAuth && hreq.URL.Path == "/verify" {
-			return a.deniedResponse(in, http.StatusUnauthorized, "Unauthenticated", nil), nil
+			return a.deniedResponse(in, http.StatusUnauthorized, "Unauthenticated", nil)
 		}
-		return a.redirectResponse(in), nil
+		return a.redirectResponse(in)
 	}
-	return a.deniedResponse(in, int32(reply.Status), reply.Message, nil), nil
+	return a.deniedResponse(in, int32(reply.Status), reply.Message, nil)
 }
 
 func (a *Authorize) forceSync(ctx context.Context, ss *sessions.State) error {
@@ -212,9 +212,14 @@ func (a *Authorize) isForwardAuth(req *envoy_service_auth_v2.CheckRequest) bool 
 		return false
 	}
 
+	forwardAuthURL, err := opts.GetForwardAuthURL()
+	if err != nil {
+		return false
+	}
+
 	checkURL := getCheckRequestURL(req)
 
-	return urlutil.StripPort(checkURL.Host) == urlutil.StripPort(opts.GetForwardAuthURL().Host)
+	return urlutil.StripPort(checkURL.Host) == urlutil.StripPort(forwardAuthURL.Host)
 }
 
 func (a *Authorize) getEvaluatorRequestFromCheckRequest(in *envoy_service_auth_v2.CheckRequest, sessionState *sessions.State) *evaluator.Request {

--- a/config/options.go
+++ b/config/options.go
@@ -710,45 +710,46 @@ func (o *Options) Validate() error {
 }
 
 // GetAuthenticateURL returns the AuthenticateURL in the options or 127.0.0.1.
-func (o *Options) GetAuthenticateURL() *url.URL {
+func (o *Options) GetAuthenticateURL() (*url.URL, error) {
 	if o != nil && o.AuthenticateURL != nil {
-		return o.AuthenticateURL
+		return o.AuthenticateURL, nil
 	}
-	u, _ := url.Parse("https://127.0.0.1")
-	return u
+	return url.Parse("https://127.0.0.1")
 }
 
 // GetAuthorizeURL returns the AuthorizeURL in the options or 127.0.0.1:5443.
-func (o *Options) GetAuthorizeURL() *url.URL {
+func (o *Options) GetAuthorizeURL() (*url.URL, error) {
 	if o != nil && o.AuthorizeURL != nil {
-		return o.AuthorizeURL
+		return o.AuthorizeURL, nil
 	}
-	u, _ := url.Parse("http://127.0.0.1" + DefaultAlternativeAddr)
-	return u
+	return url.Parse("http://127.0.0.1" + DefaultAlternativeAddr)
 }
 
 // GetDataBrokerURL returns the DataBrokerURL in the options or 127.0.0.1:5443.
-func (o *Options) GetDataBrokerURL() *url.URL {
+func (o *Options) GetDataBrokerURL() (*url.URL, error) {
 	if o != nil && o.DataBrokerURL != nil {
-		return o.DataBrokerURL
+		return o.DataBrokerURL, nil
 	}
-	u, _ := url.Parse("http://127.0.0.1" + DefaultAlternativeAddr)
-	return u
+	return url.Parse("http://127.0.0.1" + DefaultAlternativeAddr)
 }
 
 // GetForwardAuthURL returns the ForwardAuthURL in the options or 127.0.0.1.
-func (o *Options) GetForwardAuthURL() *url.URL {
+func (o *Options) GetForwardAuthURL() (*url.URL, error) {
 	if o != nil && o.ForwardAuthURL != nil {
-		return o.ForwardAuthURL
+		return o.ForwardAuthURL, nil
 	}
-	u, _ := url.Parse("https://127.0.0.1")
-	return u
+	return url.Parse("https://127.0.0.1")
 }
 
 // GetOauthOptions gets the oauth.Options for the given config options.
-func (o *Options) GetOauthOptions() oauth.Options {
-	redirectURL := o.GetAuthenticateURL()
-	redirectURL.Path = o.AuthenticateCallbackPath
+func (o *Options) GetOauthOptions() (oauth.Options, error) {
+	redirectURL, err := o.GetAuthenticateURL()
+	if err != nil {
+		return oauth.Options{}, err
+	}
+	redirectURL = redirectURL.ResolveReference(&url.URL{
+		Path: o.AuthenticateCallbackPath,
+	})
 	return oauth.Options{
 		RedirectURL:    redirectURL,
 		ProviderName:   o.Provider,
@@ -757,7 +758,7 @@ func (o *Options) GetOauthOptions() oauth.Options {
 		ClientSecret:   o.ClientSecret,
 		Scopes:         o.Scopes,
 		ServiceAccount: o.ServiceAccount,
-	}
+	}, nil
 }
 
 // GetAllPolicies gets all the policies in the options.

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var cmpOptIgnoreUnexported = cmpopts.IgnoreUnexported(Options{})
@@ -498,7 +499,7 @@ func TestOptions_DefaultURL(t *testing.T) {
 	}
 	tests := []struct {
 		name           string
-		f              func() *url.URL
+		f              func() (*url.URL, error)
 		expectedURLStr string
 	}{
 		{"default authenticate url", defaultOptions.GetAuthenticateURL, "https://127.0.0.1"},
@@ -515,7 +516,9 @@ func TestOptions_DefaultURL(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			assert.Equal(t, tc.expectedURLStr, tc.f().String())
+			u, err := tc.f()
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedURLStr, u.String())
 		})
 	}
 }
@@ -530,7 +533,9 @@ func mustParseURL(str string) *url.URL {
 
 func TestOptions_GetOauthOptions(t *testing.T) {
 	opts := &Options{AuthenticateURL: mustParseURL("https://authenticate.example.com")}
+	oauthOptions, err := opts.GetOauthOptions()
+	require.NoError(t, err)
 
 	// Test that oauth redirect url hostname must point to authenticate url hostname.
-	assert.Equal(t, opts.AuthenticateURL.Hostname(), opts.GetOauthOptions().RedirectURL.Hostname())
+	assert.Equal(t, opts.AuthenticateURL.Hostname(), oauthOptions.RedirectURL.Hostname())
 }

--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -158,9 +158,15 @@ func setupAuthenticate(src config.Source, controlPlane *controlplane.Server) err
 	if err != nil {
 		return fmt.Errorf("error creating authenticate service: %w", err)
 	}
+
+	authenticateURL, err := src.GetConfig().Options.GetAuthenticateURL()
+	if err != nil {
+		return fmt.Errorf("error getting authenticate URL: %w", err)
+	}
+
 	src.OnConfigChange(svc.OnConfigChange)
 	svc.OnConfigChange(src.GetConfig())
-	host := urlutil.StripPort(src.GetConfig().Options.GetAuthenticateURL().Host)
+	host := urlutil.StripPort(authenticateURL.Host)
 	sr := controlPlane.HTTPRouter.Host(host).Subrouter()
 	svc.Mount(sr)
 	log.Info().Str("host", host).Msg("enabled authenticate service")

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -446,7 +446,8 @@ func Test_getAllDomains(t *testing.T) {
 	}
 	t.Run("routable", func(t *testing.T) {
 		t.Run("http", func(t *testing.T) {
-			actual := getAllRouteableDomains(options, "127.0.0.1:9000")
+			actual, err := getAllRouteableDomains(options, "127.0.0.1:9000")
+			require.NoError(t, err)
 			expect := []string{
 				"a.example.com",
 				"a.example.com:80",
@@ -460,7 +461,8 @@ func Test_getAllDomains(t *testing.T) {
 			assert.Equal(t, expect, actual)
 		})
 		t.Run("grpc", func(t *testing.T) {
-			actual := getAllRouteableDomains(options, "127.0.0.1:9001")
+			actual, err := getAllRouteableDomains(options, "127.0.0.1:9001")
+			require.NoError(t, err)
 			expect := []string{
 				"authorize.example.com:9001",
 				"cache.example.com:9001",
@@ -470,7 +472,8 @@ func Test_getAllDomains(t *testing.T) {
 	})
 	t.Run("tls", func(t *testing.T) {
 		t.Run("http", func(t *testing.T) {
-			actual := getAllTLSDomains(options, "127.0.0.1:9000")
+			actual, err := getAllTLSDomains(options, "127.0.0.1:9000")
+			require.NoError(t, err)
 			expect := []string{
 				"a.example.com",
 				"authenticate.example.com",
@@ -480,7 +483,8 @@ func Test_getAllDomains(t *testing.T) {
 			assert.Equal(t, expect, actual)
 		})
 		t.Run("grpc", func(t *testing.T) {
-			actual := getAllTLSDomains(options, "127.0.0.1:9001")
+			actual, err := getAllTLSDomains(options, "127.0.0.1:9001")
+			require.NoError(t, err)
 			expect := []string{
 				"authorize.example.com",
 				"cache.example.com",


### PR DESCRIPTION
## Summary
Update the config `Get...URL()` methods to return errors. This will be required when we support multiple endpoints.

Also fix a bunch of lint issues I inadvertently introduced. I didn't know the:

```
if x, err := ...; err != nil {
    return nil, err
} else {
    // do something with x
}
```

Pattern was disallowed by linting. Unfortunately this:

```
x, err := ...
if err != nil {
    return nil, err
}
// do something with x
```

Is not identical to the original code, it introduces a new variable at a different scope, which can cause issues when we re-use variable names.

## Related issues
#1718 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
