### PR TITLE
deployment: set maintainer field in packages

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -218,7 +218,7 @@ nfpms:
     vendor: Pomerium, Inc.
     homepage: https://www.pomerium.com
     description: Identity Aware Proxy
-    maintainer:
+    maintainer: Pomerium <info@pomerium.com>
     license: Apache 2.0
     epoch: 1
     release: 1
@@ -264,7 +264,7 @@ nfpms:
     vendor: Pomerium, Inc.
     homepage: https://www.pomerium.com
     description: Identity Aware Proxy
-    maintainer:
+    maintainer: Pomerium <info@pomerium.com>
     license: Apache 2.0
     epoch: 1
     release: 1


### PR DESCRIPTION
## Summary

Set maintainer field to prevent errors on debian systems.

## Related issues

fixes #1838

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
