### PR TITLE
ci: enable backporting from forks

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -1,6 +1,6 @@
 name: Backport
 on:
-  pull_request:
+  pull_request_target:
     types:
       - closed
       - labeled
@@ -14,3 +14,4 @@ jobs:
         uses: tibdex/backport@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          title_template: "{{originalTitle}}"


### PR DESCRIPTION
## Summary

- Allow backports from forks by using the new [`pull_request_target`](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) trigger.
- Update title template to look like original PR for a consistent changelog


## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
