### PR TITLE
remove generated code from code coverage metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,10 +104,9 @@ spellcheck: # Spellcheck docs
 cover: ## Runs go test with coverage
 	@echo "==> $@"
 	$(GO) test -race -coverprofile=coverage.txt -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration)
-	@sed -i.bak '/.pb.go\:/d' coverage.txt
-	@sed -i.bak '/statik.go\:/d' coverage.txt
-	@sed -i.bak '/mock.go\:/d' coverage.txt
-
+	@sed -i.bak '/\.pb\.go\:/d' coverage.txt
+	@sed -i.bak '/\/statik\.go\:/d' coverage.txt
+	@sed -i.bak '/\/mock\.go\:/d' coverage.txt
 
 .PHONY: clean
 clean: ## Cleanup any build binaries or packages.

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,8 @@ spellcheck: # Spellcheck docs
 cover: ## Runs go test with coverage
 	@echo "==> $@"
 	$(GO) test -race -coverprofile=coverage.txt -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration)
+	@sed -i.bak '/.pb.go\:/d' coverage.txt
+	@sed -i.bak '/statik.go\:/d' coverage.txt
 
 .PHONY: clean
 clean: ## Cleanup any build binaries or packages.

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,8 @@ cover: ## Runs go test with coverage
 	$(GO) test -race -coverprofile=coverage.txt -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration)
 	@sed -i.bak '/.pb.go\:/d' coverage.txt
 	@sed -i.bak '/statik.go\:/d' coverage.txt
+	@sed -i.bak '/mock.go\:/d' coverage.txt
+
 
 .PHONY: clean
 clean: ## Cleanup any build binaries or packages.


### PR DESCRIPTION
## Summary

Try to remove some automatically generated code from the way codecov calculates metrics.

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
