### PR TITLE
unique envoy cluster ids

### DIFF
--- a/internal/controlplane/xds_cluster_test.go
+++ b/internal/controlplane/xds_cluster_test.go
@@ -549,6 +549,7 @@ func Test_validateClusters(t *testing.T) {
 		expectError bool
 	}{
 		{c{{Name: "one"}, {Name: "one"}}, true},
+		{c{{Name: "one"}, {Name: "two"}}, false},
 	}
 
 	for _, tc := range testCases {

--- a/internal/controlplane/xds_cluster_test.go
+++ b/internal/controlplane/xds_cluster_test.go
@@ -542,6 +542,25 @@ func Test_buildCluster(t *testing.T) {
 	})
 }
 
+func Test_validateClusters(t *testing.T) {
+	type c []*envoy_config_cluster_v3.Cluster
+	testCases := []struct {
+		clusters    c
+		expectError bool
+	}{
+		{c{{Name: "one"}, {Name: "one"}}, true},
+	}
+
+	for _, tc := range testCases {
+		err := validateClusters(tc.clusters)
+		if tc.expectError {
+			assert.Error(t, err, "%#v", tc.clusters)
+		} else {
+			assert.NoError(t, err, "%#v", tc.clusters)
+		}
+	}
+}
+
 func mustParseWeightedURLs(t *testing.T, urls ...string) []config.WeightedURL {
 	wu, err := config.ParseWeightedUrls(urls...)
 	require.NoError(t, err)

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -96,6 +96,10 @@ func (srv *Server) buildClusters(options *config.Options) ([]*envoy_config_clust
 		}
 	}
 
+	if err = validateClusters(clusters); err != nil {
+		return nil, err
+	}
+
 	return clusters, nil
 }
 
@@ -114,8 +118,9 @@ func (srv *Server) buildInternalCluster(options *config.Options, name string, ds
 
 func (srv *Server) buildPolicyCluster(options *config.Options, policy *config.Policy) (*envoy_config_cluster_v3.Cluster, error) {
 	cluster := policy.EnvoyOpts
+	cluster.AltStatName = getClusterStatsName(policy)
 
-	name := getPolicyName(policy)
+	name := getClusterID(policy)
 	endpoints, err := srv.buildPolicyEndpoints(policy)
 	if err != nil {
 		return nil, err
@@ -406,4 +411,23 @@ func (srv *Server) buildTransportSocketMatches(endpoints []Endpoint) ([]*envoy_c
 		})
 	}
 	return tsms, nil
+}
+
+// validateClusters contains certain rules that must match
+func validateClusters(clusters []*envoy_config_cluster_v3.Cluster) error {
+	return validateClusterNamesUnique(clusters)
+}
+
+// validateClusterNamesUnique checks cluster names are unique, as they're effectively IDs
+func validateClusterNamesUnique(clusters []*envoy_config_cluster_v3.Cluster) error {
+	names := make(map[string]bool, len(clusters))
+
+	for _, c := range clusters {
+		if _, there := names[c.Name]; there {
+			return fmt.Errorf("cluster name %s is not unique", c.Name)
+		}
+		names[c.Name] = true
+	}
+
+	return nil
 }

--- a/internal/controlplane/xds_clusters.go
+++ b/internal/controlplane/xds_clusters.go
@@ -12,6 +12,7 @@ import (
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"github.com/golang/protobuf/proto"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/martinlindhe/base36"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -117,7 +118,9 @@ func (srv *Server) buildInternalCluster(options *config.Options, name string, ds
 }
 
 func (srv *Server) buildPolicyCluster(options *config.Options, policy *config.Policy) (*envoy_config_cluster_v3.Cluster, error) {
-	cluster := policy.EnvoyOpts
+	cluster := new(envoy_config_cluster_v3.Cluster)
+	proto.Merge(cluster, policy.EnvoyOpts)
+
 	cluster.AltStatName = getClusterStatsName(policy)
 
 	name := getClusterID(policy)

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -231,7 +231,7 @@ func (srv *Server) buildControlPlanePrefixRoute(prefix string, protected bool) (
 	return r, nil
 }
 
-// getClusterID returns cluster ID
+// getClusterID returns a cluster ID
 var getClusterID = func(policy *config.Policy) string {
 	prefix := getClusterStatsName(policy)
 	if prefix == "" {

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -231,13 +231,23 @@ func (srv *Server) buildControlPlanePrefixRoute(prefix string, protected bool) (
 	return r, nil
 }
 
-var getPolicyName = func(policy *config.Policy) string {
-	if policy.EnvoyOpts != nil && policy.EnvoyOpts.Name != "" {
-		return policy.EnvoyOpts.Name
+// getClusterID returns cluster ID
+var getClusterID = func(policy *config.Policy) string {
+	prefix := getClusterStatsName(policy)
+	if prefix == "" {
+		prefix = "route"
 	}
 
 	id, _ := policy.RouteID()
-	return fmt.Sprintf("policy-%x", id)
+	return fmt.Sprintf("%s-%x", prefix, id)
+}
+
+// getClusterStatsName returns human readable name that would be used by envoy to emit statistics, available as envoy_cluster_name label
+func getClusterStatsName(policy *config.Policy) string {
+	if policy.EnvoyOpts != nil && policy.EnvoyOpts.Name != "" {
+		return policy.EnvoyOpts.Name
+	}
+	return ""
 }
 
 func (srv *Server) buildPolicyRoutes(options *config.Options, domain string) ([]*envoy_config_route_v3.Route, error) {
@@ -341,7 +351,7 @@ func (srv *Server) buildPolicyRouteRedirectAction(r *config.PolicyRedirect) (*en
 }
 
 func (srv *Server) buildPolicyRouteRouteAction(options *config.Options, policy *config.Policy) (*envoy_config_route_v3.RouteAction, error) {
-	clusterName := getPolicyName(policy)
+	clusterName := getClusterID(policy)
 	routeTimeout := getRouteTimeout(options, policy)
 	idleTimeout := getRouteIdleTimeout(policy)
 	prefixRewrite, regexRewrite := getRewriteOptions(policy)

--- a/internal/controlplane/xds_routes_test.go
+++ b/internal/controlplane/xds_routes_test.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 	"time"
 
@@ -932,8 +933,13 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 }
 
 func TestPolicyName(t *testing.T) {
-	assert.Greater(t, getClusterID(&config.Policy{}), "policy-")
-	assert.Equal(t, getClusterID(&config.Policy{EnvoyOpts: &envoy_config_cluster_v3.Cluster{Name: "my-pomerium-cluster"}}), "my-pomerium-cluster")
+	// policy names should form a unique ID when converted to envoy cluster names
+	// however for metrics purposes we keep original name if present
+	assert.NotEmpty(t, getClusterID(&config.Policy{}))
+	assert.Empty(t, getClusterStatsName(&config.Policy{}))
+	assert.True(t, strings.HasPrefix(getClusterID(&config.Policy{EnvoyOpts: &envoy_config_cluster_v3.Cluster{Name: "my-pomerium-cluster"}}), "my-pomerium-cluster"))
+	assert.NotEqual(t, getClusterID(&config.Policy{EnvoyOpts: &envoy_config_cluster_v3.Cluster{Name: "my-pomerium-cluster"}}), "my-pomerium-cluster")
+	assert.Equal(t, getClusterStatsName(&config.Policy{EnvoyOpts: &envoy_config_cluster_v3.Cluster{Name: "my-pomerium-cluster"}}), "my-pomerium-cluster")
 }
 
 func mustParseURL(t *testing.T, str string) *url.URL {

--- a/internal/controlplane/xds_routes_test.go
+++ b/internal/controlplane/xds_routes_test.go
@@ -202,9 +202,9 @@ func Test_buildControlPlanePrefixRoute(t *testing.T) {
 
 func Test_buildPolicyRoutes(t *testing.T) {
 	defer func(f func(*config.Policy) string) {
-		getPolicyName = f
-	}(getPolicyName)
-	getPolicyName = policyNameFunc()
+		getClusterID = f
+	}(getClusterID)
+	getClusterID = policyNameFunc()
 
 	srv := &Server{filemgr: filemgr.NewManager()}
 	routes, err := srv.buildPolicyRoutes(&config.Options{
@@ -564,9 +564,9 @@ func Test_buildPolicyRoutes(t *testing.T) {
 // See also https://github.com/pomerium/pomerium/issues/901
 func TestAddOptionsHeadersToResponse(t *testing.T) {
 	defer func(f func(*config.Policy) string) {
-		getPolicyName = f
-	}(getPolicyName)
-	getPolicyName = policyNameFunc()
+		getClusterID = f
+	}(getClusterID)
+	getClusterID = policyNameFunc()
 	srv := &Server{filemgr: filemgr.NewManager()}
 	routes, err := srv.buildPolicyRoutes(&config.Options{
 		CookieName:             "pomerium",
@@ -620,9 +620,9 @@ func TestAddOptionsHeadersToResponse(t *testing.T) {
 
 func Test_buildPolicyRoutesRewrite(t *testing.T) {
 	defer func(f func(*config.Policy) string) {
-		getPolicyName = f
-	}(getPolicyName)
-	getPolicyName = policyNameFunc()
+		getClusterID = f
+	}(getClusterID)
+	getClusterID = policyNameFunc()
 	srv := &Server{filemgr: filemgr.NewManager()}
 	routes, err := srv.buildPolicyRoutes(&config.Options{
 		CookieName:             "pomerium",
@@ -932,8 +932,8 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 }
 
 func TestPolicyName(t *testing.T) {
-	assert.Greater(t, getPolicyName(&config.Policy{}), "policy-")
-	assert.Equal(t, getPolicyName(&config.Policy{EnvoyOpts: &envoy_config_cluster_v3.Cluster{Name: "my-pomerium-cluster"}}), "my-pomerium-cluster")
+	assert.Greater(t, getClusterID(&config.Policy{}), "policy-")
+	assert.Equal(t, getClusterID(&config.Policy{EnvoyOpts: &envoy_config_cluster_v3.Cluster{Name: "my-pomerium-cluster"}}), "my-pomerium-cluster")
 }
 
 func mustParseURL(t *testing.T, str string) *url.URL {


### PR DESCRIPTION
## Summary

- make sure envoy cluster names are unique
- keep cluster metrics name w/o prefix for now, subject to change after https://github.com/pomerium/pomerium-console/issues/645 

## Related issues

Fixes https://github.com/pomerium/internal/issues/290 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
