### PR TITLE
controlplane: add global headers to virtualhost

### DIFF
--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -198,8 +198,9 @@ func (srv *Server) buildMainHTTPConnectionManagerFilter(
 	var virtualHosts []*envoy_config_route_v3.VirtualHost
 	for _, domain := range domains {
 		vh := &envoy_config_route_v3.VirtualHost{
-			Name:    domain,
-			Domains: []string{domain},
+			Name:                 domain,
+			Domains:              []string{domain},
+			ResponseHeadersToAdd: toEnvoyHeaders(options.Headers),
 		}
 
 		if options.Addr == options.GRPCAddr {

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -198,9 +198,8 @@ func (srv *Server) buildMainHTTPConnectionManagerFilter(
 	var virtualHosts []*envoy_config_route_v3.VirtualHost
 	for _, domain := range domains {
 		vh := &envoy_config_route_v3.VirtualHost{
-			Name:                 domain,
-			Domains:              []string{domain},
-			ResponseHeadersToAdd: toEnvoyHeaders(options.Headers),
+			Name:    domain,
+			Domains: []string{domain},
 		}
 
 		if options.Addr == options.GRPCAddr {
@@ -229,6 +228,11 @@ func (srv *Server) buildMainHTTPConnectionManagerFilter(
 				return nil, err
 			}
 			vh.Routes = append(vh.Routes, rs...)
+		}
+
+		// if we're the proxy or authenticate service, add our global headers
+		if config.IsProxy(options.Services) || config.IsAuthenticate(options.Services) {
+			vh.ResponseHeadersToAdd = toEnvoyHeaders(options.Headers)
 		}
 
 		if len(vh.Routes) > 0 {

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -118,7 +118,7 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 								"key": "X-XSS-Protection",
 								"value": "1; mode=block"
 							}
-						}],		
+						}],
 						"routes": [
 							{
 								"name": "pomerium-path-/.pomerium/jwt",

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -98,6 +98,27 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 					{
 						"name": "example.com",
 						"domains": ["example.com"],
+						"responseHeadersToAdd": [{
+							"append": false,
+							"header": {
+								"key": "Strict-Transport-Security",
+								"value": "max-age=31536000; includeSubDomains; preload"
+							}
+						},
+						{
+							"append": false,
+							"header": {
+								"key": "X-Frame-Options",
+								"value": "SAMEORIGIN"
+							}
+						},
+						{
+							"append": false,
+							"header": {
+								"key": "X-XSS-Protection",
+								"value": "1; mode=block"
+							}
+						}],		
 						"routes": [
 							{
 								"name": "pomerium-path-/.pomerium/jwt",

--- a/internal/controlplane/xds_routes.go
+++ b/internal/controlplane/xds_routes.go
@@ -252,7 +252,6 @@ func getClusterStatsName(policy *config.Policy) string {
 
 func (srv *Server) buildPolicyRoutes(options *config.Options, domain string) ([]*envoy_config_route_v3.Route, error) {
 	var routes []*envoy_config_route_v3.Route
-	responseHeadersToAdd := toEnvoyHeaders(options.Headers)
 
 	for i, p := range options.GetAllPolicies() {
 		policy := p
@@ -292,7 +291,6 @@ func (srv *Server) buildPolicyRoutes(options *config.Options, domain string) ([]
 			},
 			RequestHeadersToAdd:    requestHeadersToAdd,
 			RequestHeadersToRemove: requestHeadersToRemove,
-			ResponseHeadersToAdd:   responseHeadersToAdd,
 		}
 		if policy.Redirect != nil {
 			action, err := srv.buildPolicyRouteRedirectAction(policy.Redirect)


### PR DESCRIPTION
## Summary

These changes add the response headers to add to the route virtual host. 

## Related issues

- Fixes #1860
- https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-virtualhost

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
