### PR TITLE
authorize: remove HTML forbidden page, always return 404s

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -1,11 +1,9 @@
 package authorize
 
 import (
-	"bytes"
 	"net/http"
 	"net/url"
 	"sort"
-	"strings"
 
 	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
 	envoy_service_auth_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
@@ -15,8 +13,6 @@ import (
 	"google.golang.org/grpc/codes"
 
 	"github.com/pomerium/pomerium/authorize/evaluator"
-	"github.com/pomerium/pomerium/internal/httputil"
-	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
@@ -30,7 +26,7 @@ func (a *Authorize) okResponse(reply *evaluator.Result) *envoy_service_auth_v2.C
 		return requestHeaders[i].Header.Key < requestHeaders[j].Header.Value
 	})
 	return &envoy_service_auth_v2.CheckResponse{
-		Status: &status.Status{Code: int32(codes.OK), Message: reply.Message},
+		Status: &status.Status{Code: int32(codes.OK), Message: http.StatusText(http.StatusOK)},
 		HttpResponse: &envoy_service_auth_v2.CheckResponse_OkResponse{
 			OkResponse: &envoy_service_auth_v2.OkHttpResponse{
 				Headers: requestHeaders,
@@ -41,93 +37,8 @@ func (a *Authorize) okResponse(reply *evaluator.Result) *envoy_service_auth_v2.C
 
 func (a *Authorize) deniedResponse(
 	in *envoy_service_auth_v2.CheckRequest,
-	code int32, reason string, headers map[string]string,
-) (*envoy_service_auth_v2.CheckResponse, error) {
-	returnHTMLError := true
-	inHeaders := in.GetAttributes().GetRequest().GetHttp().GetHeaders()
-	if inHeaders != nil {
-		returnHTMLError = strings.Contains(inHeaders["accept"], "text/html")
-	}
-
-	if returnHTMLError {
-		return a.htmlDeniedResponse(in, code, reason, headers)
-	}
-	return a.plainTextDeniedResponse(code, reason, headers), nil
-}
-
-func (a *Authorize) htmlDeniedResponse(
-	in *envoy_service_auth_v2.CheckRequest,
-	code int32, reason string, headers map[string]string,
-) (*envoy_service_auth_v2.CheckResponse, error) {
-	opts := a.currentOptions.Load()
-	authenticateURL, err := opts.GetAuthenticateURL()
-	if err != nil {
-		return nil, err
-	}
-	debugEndpoint := authenticateURL.ResolveReference(&url.URL{Path: "/.pomerium/"})
-
-	// create go-style http request
-	r := getHTTPRequestFromCheckRequest(in)
-	redirectURL := urlutil.GetAbsoluteURL(r).String()
-	if ref := r.Header.Get(httputil.HeaderReferrer); ref != "" {
-		redirectURL = ref
-	}
-
-	debugEndpoint = debugEndpoint.ResolveReference(&url.URL{
-		RawQuery: url.Values{
-			urlutil.QueryRedirectURI: {redirectURL},
-		}.Encode(),
-	})
-
-	var details string
-	switch code {
-	case httputil.StatusInvalidClientCertificate:
-		details = "a valid client certificate is required to access this page"
-	case http.StatusForbidden:
-		details = "access to this page is forbidden"
-	default:
-		details = reason
-	}
-
-	if reason == "" {
-		reason = http.StatusText(int(code))
-	}
-
-	var buf bytes.Buffer
-	err = a.templates.ExecuteTemplate(&buf, "error.html", map[string]interface{}{
-		"Status":     code,
-		"StatusText": reason,
-		"CanDebug":   code/100 == 4,
-		"DebugURL":   debugEndpoint,
-		"Error":      details,
-	})
-	if err != nil {
-		buf.WriteString(reason)
-		log.Error().Err(err).Msg("error executing error template")
-	}
-
-	envoyHeaders := []*envoy_api_v2_core.HeaderValueOption{
-		mkHeader("Content-Type", "text/html", false),
-	}
-	for k, v := range headers {
-		envoyHeaders = append(envoyHeaders, mkHeader(k, v, false))
-	}
-
-	return &envoy_service_auth_v2.CheckResponse{
-		Status: &status.Status{Code: int32(codes.PermissionDenied), Message: "Access Denied"},
-		HttpResponse: &envoy_service_auth_v2.CheckResponse_DeniedResponse{
-			DeniedResponse: &envoy_service_auth_v2.DeniedHttpResponse{
-				Status: &envoy_type.HttpStatus{
-					Code: envoy_type.StatusCode(code),
-				},
-				Headers: envoyHeaders,
-				Body:    buf.String(),
-			},
-		},
-	}, nil
-}
-
-func (a *Authorize) plainTextDeniedResponse(code int32, reason string, headers map[string]string) *envoy_service_auth_v2.CheckResponse {
+	code int32, headers map[string]string,
+) *envoy_service_auth_v2.CheckResponse {
 	envoyHeaders := []*envoy_api_v2_core.HeaderValueOption{
 		mkHeader("Content-Type", "text/plain", false),
 	}
@@ -143,7 +54,6 @@ func (a *Authorize) plainTextDeniedResponse(code int32, reason string, headers m
 					Code: envoy_type.StatusCode(code),
 				},
 				Headers: envoyHeaders,
-				Body:    reason,
 			},
 		},
 	}
@@ -169,9 +79,9 @@ func (a *Authorize) redirectResponse(in *envoy_service_auth_v2.CheckRequest) (*e
 	signinURL.RawQuery = q.Encode()
 	redirectTo := urlutil.NewSignedURL(opts.SharedKey, signinURL).String()
 
-	return a.deniedResponse(in, http.StatusFound, "Login", map[string]string{
+	return a.deniedResponse(in, http.StatusFound, map[string]string{
 		"Location": redirectTo,
-	})
+	}), nil
 }
 
 func mkHeader(k, v string, shouldAppend bool) *envoy_api_v2_core.HeaderValueOption {

--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -88,9 +88,9 @@ func TestEvaluator_Evaluate(t *testing.T) {
 		expectedStatus int
 	}{
 		{"allowed", "https://foo.com/path", allowedPolicy, nil, sessionID, http.StatusOK},
-		{"forbidden", "https://bar.com/path", forbiddenPolicy, nil, sessionID, http.StatusForbidden},
+		{"forbidden", "https://bar.com/path", forbiddenPolicy, nil, sessionID, http.StatusNotFound},
 		{"unauthorized", "https://foo.com/path", allowedPolicy, nil, "", http.StatusUnauthorized},
-		{"custom policy overwrite main policy", "https://foo.com/path", allowedPolicy, []string{"deny = true"}, sessionID, http.StatusForbidden},
+		{"custom policy overwrite main policy", "https://foo.com/path", allowedPolicy, []string{"deny = true"}, sessionID, http.StatusNotFound},
 	}
 
 	for _, tc := range tests {

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -81,11 +81,11 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v2.CheckRe
 		return a.okResponse(reply), nil
 	case reply.Status == http.StatusUnauthorized:
 		if isForwardAuth && hreq.URL.Path == "/verify" {
-			return a.deniedResponse(in, http.StatusUnauthorized, "Unauthenticated", nil)
+			return a.deniedResponse(in, http.StatusUnauthorized, nil), nil
 		}
 		return a.redirectResponse(in)
 	}
-	return a.deniedResponse(in, int32(reply.Status), reply.Message, nil)
+	return a.deniedResponse(in, int32(reply.Status), nil), nil
 }
 
 func (a *Authorize) forceSync(ctx context.Context, ss *sessions.State) (*user.User, error) {
@@ -336,7 +336,6 @@ func logAuthorizeCheck(
 	if reply != nil {
 		evt = evt.Bool("allow", reply.Status == http.StatusOK)
 		evt = evt.Int("status", reply.Status)
-		evt = evt.Str("message", reply.Message)
 		evt = evt.Str("user", u.GetId())
 		evt = evt.Str("email", u.GetEmail())
 	}

--- a/integration/authorization_test.go
+++ b/integration/authorization_test.go
@@ -55,7 +55,7 @@ func TestAuthorization(t *testing.T) {
 					res, err := flows.Authenticate(ctx, client, mustParseURL("https://httpdetails.localhost.pomerium.io/by-domain"),
 						withAPI, flows.WithEmail("joe@cats.test"), flows.WithGroups("user"))
 					if assert.NoError(t, err) {
-						assertDeniedAccess(t, res, "expected Forbidden for cats.test")
+						assert.Equal(t, http.StatusNotFound, res.StatusCode, "expected Not Found for cats.test")
 					}
 				})
 			})
@@ -73,7 +73,7 @@ func TestAuthorization(t *testing.T) {
 					res, err := flows.Authenticate(ctx, client, mustParseURL("https://httpdetails.localhost.pomerium.io/by-user"),
 						withAPI, flows.WithEmail("joe@cats.test"), flows.WithGroups("user"))
 					if assert.NoError(t, err) {
-						assertDeniedAccess(t, res, "expected Forbidden for joe@cats.test")
+						assert.Equal(t, http.StatusNotFound, res.StatusCode, "expected Not Found for joe@cats.test")
 					}
 				})
 			})
@@ -87,10 +87,4 @@ func mustParseURL(str string) *url.URL {
 		panic(err)
 	}
 	return u
-}
-
-func assertDeniedAccess(t *testing.T, res *http.Response, msgAndArgs ...interface{}) bool {
-	return assert.Condition(t, func() bool {
-		return res.StatusCode == http.StatusForbidden || res.StatusCode == http.StatusUnauthorized
-	}, msgAndArgs...)
 }


### PR DESCRIPTION
## Summary
This PR removes the special HTML forbidden page and always returns 404s for forbidden errors. This is to avoid leaking information about the existence of a route. 495s will still be returned for client certificate issues.


## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
