### PR TITLE
redis: fix deletion versioning

### DIFF
--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -116,6 +116,7 @@ func (db *DB) Delete(ctx context.Context, id string) (err error) {
 
 			// mark it as deleted
 			record.DeletedAt = timestamppb.Now()
+			record.Version = formatVersion(version)
 
 			return nil
 		},

--- a/pkg/storage/redis/redis_test.go
+++ b/pkg/storage/redis/redis_test.go
@@ -144,11 +144,14 @@ func testDB(t *testing.T) {
 		}
 	})
 	t.Run("delete record", func(t *testing.T) {
+		original, err := db.Get(ctx, id)
+		require.NoError(t, err)
 		assert.NoError(t, db.Delete(ctx, id))
 		record, err := db.Get(ctx, id)
 		require.NoError(t, err)
 		require.NotNil(t, record)
 		assert.NotNil(t, record.DeletedAt)
+		assert.NotEqual(t, original.GetVersion(), record.GetVersion())
 	})
 	t.Run("clear deleted", func(t *testing.T) {
 		db.ClearDeleted(ctx, time.Now().Add(time.Second))


### PR DESCRIPTION
## Summary
The redis implementation of the databroker is not currently incrementing the record version when a record is deleted. Because the version doesn't change, the record change isn't detected by sync and consumers will only pick up the change on restart.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
