### PR TITLE
config: add CertificateFiles to FileWatcherSource list

### DIFF
--- a/config/config_source.go
+++ b/config/config_source.go
@@ -186,6 +186,11 @@ func (src *FileWatcherSource) check(cfg *Config) {
 		cfg.Options.KeyFile,
 		cfg.Options.PolicyFile,
 	}
+
+	for _, pair := range cfg.Options.CertificateFiles {
+		fs = append(fs, pair.CertFile, pair.KeyFile)
+	}
+
 	for _, f := range fs {
 		_, _ = h.Write([]byte{0})
 		bs, err := ioutil.ReadFile(f)


### PR DESCRIPTION
## Summary

Support dynamic reloading of the certificate file list in `certs`.

Tweaking docs regarding hot reloading in a follow up.

## Related issues

#1775 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
