### PR TITLE
logs: strip query string

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -329,7 +329,7 @@ func logAuthorizeCheck(
 	evt = evt.Str("request-id", requestid.FromContext(ctx))
 	evt = evt.Str("check-request-id", hdrs["X-Request-Id"])
 	evt = evt.Str("method", hattrs.GetMethod())
-	evt = evt.Str("path", hattrs.GetPath())
+	evt = evt.Str("path", stripQueryString(hattrs.GetPath()))
 	evt = evt.Str("host", hattrs.GetHost())
 	evt = evt.Str("query", hattrs.GetQuery())
 	// reply
@@ -347,4 +347,11 @@ func logAuthorizeCheck(
 	}
 
 	evt.Msg("authorize check")
+}
+
+func stripQueryString(str string) string {
+	if idx := strings.Index(str, "?"); idx != -1 {
+		str = str[:idx]
+	}
+	return str
 }

--- a/go.sum
+++ b/go.sum
@@ -565,6 +565,7 @@ github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkU
 github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
 github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=

--- a/internal/controlplane/grpc_accesslog.go
+++ b/internal/controlplane/grpc_accesslog.go
@@ -1,6 +1,8 @@
 package controlplane
 
 import (
+	"strings"
+
 	envoy_service_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/rs/zerolog"
@@ -35,9 +37,9 @@ func (srv *Server) StreamAccessLogs(stream envoy_service_accesslog_v2.AccessLogS
 			// request properties
 			evt = evt.Str("method", entry.GetRequest().GetRequestMethod().String())
 			evt = evt.Str("authority", entry.GetRequest().GetAuthority())
-			evt = evt.Str("path", reqPath)
+			evt = evt.Str("path", stripQueryString(reqPath))
 			evt = evt.Str("user-agent", entry.GetRequest().GetUserAgent())
-			evt = evt.Str("referer", entry.GetRequest().GetReferer())
+			evt = evt.Str("referer", stripQueryString(entry.GetRequest().GetReferer()))
 			evt = evt.Str("forwarded-for", entry.GetRequest().GetForwardedFor())
 			evt = evt.Str("request-id", entry.GetRequest().GetRequestId())
 			// response properties
@@ -49,4 +51,11 @@ func (srv *Server) StreamAccessLogs(stream envoy_service_accesslog_v2.AccessLogS
 			evt.Msg("http-request")
 		}
 	}
+}
+
+func stripQueryString(str string) string {
+	if idx := strings.Index(str, "?"); idx != -1 {
+		str = str[:idx]
+	}
+	return str
 }


### PR DESCRIPTION
## Summary
Remove the query string from the logs. Envoy adds them to `path` which is confusing. I don't think they're really needed in the logs, so this removes them.

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
