### PR TITLE
onelogin: fix default scopes for v2

### DIFF
--- a/internal/identity/oidc/onelogin/onelogin.go
+++ b/internal/identity/oidc/onelogin/onelogin.go
@@ -6,6 +6,7 @@ package onelogin
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	oidc "github.com/coreos/go-oidc/v3/oidc"
 
@@ -20,7 +21,10 @@ const (
 	defaultProviderURL = "https://openid-connect.onelogin.com/oidc"
 )
 
-var defaultScopes = []string{oidc.ScopeOpenID, "profile", "email", "groups", "offline_access"}
+var (
+	defaultV1Scopes = []string{oidc.ScopeOpenID, "profile", "email", "groups", "offline_access"}
+	defaultV2Scopes = []string{oidc.ScopeOpenID, "profile", "email", "groups"} // v2 does not support offline_access
+)
 
 // Provider is an OneLogin implementation of the Authenticator interface.
 type Provider struct {
@@ -34,8 +38,10 @@ func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
 	if o.ProviderURL == "" {
 		o.ProviderURL = defaultProviderURL
 	}
-	if len(o.Scopes) == 0 {
-		o.Scopes = defaultScopes
+	if strings.Contains(o.ProviderURL, "/oidc/2") {
+		o.Scopes = defaultV2Scopes
+	} else {
+		o.Scopes = defaultV1Scopes
 	}
 	genericOidc, err := pom_oidc.New(ctx, o)
 	if err != nil {


### PR DESCRIPTION
## Summary
The newer v2 OneLogin OIDC Connect API no longer supports `offline_access`:

> Version 2.0 only.
> When this scope is supplied with Password Grant a refresh_token allowing offline access will be returned.
> Using this scope with Implicit or Authorization Code flow will cause an error.

This PR updates our onelogin code to remove offline access for the v2 URL.

## Related issues
- #1885 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
