### PR TITLE
ci: pin goreleaser version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: latest
+          version: v0.155.2
           args: release --config .github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Starting with goreleaser v0.156, go 1.16 is assumed and tries to build for apple arm.  This was previously an ignored target and results in build errors for go 1.15.

This change pins us to v0.155 until we go through the exercise of upgrading for go 1.16.

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
