### PR TITLE
ci: deploy latest release to test environment

### DIFF
--- a/.github/workflows/docker-master.yaml
+++ b/.github/workflows/docker-master.yaml
@@ -63,27 +63,3 @@ jobs:
             org.opencontainers.image.created=${{ steps.metadata.outputs.timestamp }}
             org.opencontainers.image.name=${{ steps.metadata.outputs.name }}
             org.opencontainers.image.revision=${{ github.sha }}
-
-  deploy:
-    runs-on: ubuntu-latest
-    needs: publish
-    steps:
-      - name: Checkout Helmfile Repo
-        uses: actions/checkout@v2
-        with:
-          repository: pomerium/helmfile
-          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
-
-      - name: Bump test environment
-        uses: mikefarah/yq@v4.5.1
-        with:
-          cmd: yq eval '.image.tag = "${{ needs.publish.outputs.sha-tag }}"' -i environments/internal-prd/values/pomerium-demo.yaml
-
-      - name: Commit changes
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          branch: master
-          commit_message: |
-            Bump test environment ${{ needs.publish.outputs.image }}
-            Image tag: ${{ needs.publish.outputs.sha-tag }}
-            Source Repo: ${{ github.repository }}@${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
+    outputs:
+      tag: ${{ steps.tagName.outputs.tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -89,3 +91,27 @@ jobs:
 
           docker tag gcr.io/pomerium-io/pomerium:${{ steps.tagName.outputs.tag }}-cloudrun gcr.io/pomerium-io/pomerium:latest-cloudrun
           docker push gcr.io/pomerium-io/pomerium:latest-cloudrun
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: goreleaser
+    steps:
+      - name: Checkout Helmfile Repo
+        uses: actions/checkout@v2
+        with:
+          repository: pomerium/helmfile
+          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
+
+      - name: Bump test environment
+        uses: mikefarah/yq@v4.5.1
+        with:
+          cmd: yq eval '.image.tag = "${{ needs.goreleaser.outputs.tag }}"' -i environments/internal-prd/values/pomerium-demo.yaml
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          branch: master
+          commit_message: |
+            Bump test environment pomerium/pomerium
+            Image tag: ${{ needs.goreleaser.outputs.tag }}
+            Source Repo: ${{ github.repository }}@${{ github.sha }}


### PR DESCRIPTION
## Summary

Pin the release testing environment to the latest version release rather than master to ensure compatibility.

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
