### PR TITLE
docs: fix query param name

### DIFF
--- a/docs/docs/topics/programmatic-access.md
+++ b/docs/docs/topics/programmatic-access.md
@@ -13,19 +13,19 @@ This page describes how to obtain Pomerium access credentials programmatically v
 
 ### Login API
 
-The API returns a cryptographically signed sign-in url that can be used to complete a user-driven login process with Pomerium and your identity provider. The login API endpoint takes a `redirect_uri` query parameter as an argument which points to the location of the callback server to be called following a successful login.
+The API returns a cryptographically signed sign-in url that can be used to complete a user-driven login process with Pomerium and your identity provider. The login API endpoint takes a `pomerium_redirect_uri` query parameter as an argument which points to the location of the callback server to be called following a successful login.
 
 For example:
 
 ```bash
-$ curl "https://verify.example.com/.pomerium/api/v1/login?redirect_uri=http://localhost:8000"
+$ curl "https://verify.example.com/.pomerium/api/v1/login?pomerium_redirect_uri=http://localhost:8000"
 
-https://authenticate.example.com/.pomerium/sign_in?redirect_uri=http%3A%2F%2Flocalhost%3Fpomerium_callback_uri%3Dhttps%253A%252F%verify.corp.example%252F.pomerium%252Fapi%252Fv1%252Flogin%253Fredirect_uri%253Dhttp%253A%252F%252Flocalhost&sig=hsLuzJctmgsN4kbMeQL16fe_FahjDBEcX0_kPYfg8bs%3D&ts=1573262981
+https://authenticate.example.com/.pomerium/sign_in?pomerium_redirect_uri=http%3A%2F%2Flocalhost%3Fpomerium_callback_uri%3Dhttps%253A%252F%verify.corp.example%252F.pomerium%252Fapi%252Fv1%252Flogin%253Fpomerium_redirect_uri%253Dhttp%253A%252F%252Flocalhost&sig=hsLuzJctmgsN4kbMeQL16fe_FahjDBEcX0_kPYfg8bs%3D&ts=1573262981
 ```
 
 ### Callback handler
 
-It is the script or application's responsibility to create a HTTP callback handler. Authenticated sessions are returned in the form of a [callback](https://developer.okta.com/docs/concepts/auth-overview/#what-kind-of-client-are-you-building) from pomerium to a HTTP server. This is the `redirect_uri` value used to build login API's URL, and represents the URL of a (usually local) HTTP server responsible for receiving the resulting user session in the form of `pomerium_jwt` query parameters.
+It is the script or application's responsibility to create a HTTP callback handler. Authenticated sessions are returned in the form of a [callback](https://developer.okta.com/docs/concepts/auth-overview/#what-kind-of-client-are-you-building) from pomerium to a HTTP server. This is the `pomerium_redirect_uri` value used to build login API's URL, and represents the URL of a (usually local) HTTP server responsible for receiving the resulting user session in the form of `pomerium_jwt` query parameters.
 
 See the python script below for example of how to start a callback server, and store the session payload.
 
@@ -37,12 +37,12 @@ Your script or application should anticipate the possibility that your underlyin
 
 The application interacting with Pomerium must manage the following workflow. Consider the following example where a script or program desires delegated, programmatic access to the domain `verify.corp.domain.example`:
 
-1. The script or application requests a new login url from the pomerium managed endpoint (e.g. `https://verify.corp.domain.example/.pomerium/api/v1/login`) and takes a `redirect_uri` as an argument.
+1. The script or application requests a new login url from the pomerium managed endpoint (e.g. `https://verify.corp.domain.example/.pomerium/api/v1/login`) and takes a `pomerium_redirect_uri` as an argument.
 1. The script or application opens a browser or redirects the user to the returned login page.
 1. The user completes the identity providers login flow.
 1. The identity provider makes a callback to pomerium's authenticate service (e.g. `authenticate.corp.domain.example`) .
 1. Pomerium's authenticate service creates a user session and redirect token, then redirects back to the managed endpoint (e.g. `verify.corp.domain.example`)
-1. Pomerium's proxy service makes a callback request to the original `redirect_uri` with the user session and as an argument.
+1. Pomerium's proxy service makes a callback request to the original `pomerium_redirect_uri` with the user session and as an argument.
 1. The script or application is responsible for handling that http callback request, and securely handling the callback session (`pomerium_jwt`) queryparam.
 1. The script or application can now make any requests as normal to the upstream application by setting the `Authorization: Pomerium ${pomerium_jwt}` header.
 


### PR DESCRIPTION
## Summary
The progammatic login docs said to pass `redirect_uri` but the actual expected query param is `pomerium_redirect_uri`.

## Related issues
Fixes #1877 

## Checklist
- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
