### PR TITLE
google: fix default provider URL

### DIFF
--- a/internal/directory/google/google.go
+++ b/internal/directory/google/google.go
@@ -30,7 +30,7 @@ const (
 )
 
 const (
-	defaultProviderURL = "https://www.googleapis.com/admin/directory/v1/"
+	defaultProviderURL = "https://www.googleapis.com/"
 )
 
 type config struct {


### PR DESCRIPTION
## Summary
The endpoint URL for google changed when we upgraded to the latest version of the library, but we didn't update the default URL, so it was querying the wrong endpoint.

## Related issues
Fixes #1926 


## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
