### PR TITLE
autocert: remove non-determinism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,7 @@ cover: ## Runs go test with coverage
 	@sed -i.bak '/\.pb\.go\:/d' coverage.txt
 	@sed -i.bak '/\/statik\.go\:/d' coverage.txt
 	@sed -i.bak '/\/mock\.go\:/d' coverage.txt
+	@sort -o coverage.txt coverage.txt
 
 .PHONY: clean
 clean: ## Cleanup any build binaries or packages.

--- a/internal/autocert/manager_test.go
+++ b/internal/autocert/manager_test.go
@@ -167,7 +167,7 @@ func TestConfig(t *testing.T) {
 	}), certmagic.ACMEManager{
 		CA:     srv.URL + "/acme/directory",
 		TestCA: srv.URL + "/acme/directory",
-	}, time.Second)
+	}, time.Millisecond*100)
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
## Summary
This test would fluctuate on test coverage because the ticker didn't always fire before completing. By making the ticker fire faster, it should always happen at least once before the test loop finishes.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
