### PR TITLE
ci: cache build and test binaries

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,17 +21,26 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+      - name: cache go binaries
+        uses: actions/cache@v2
+        id: cache-go-bin
+        with:
+          path: ~/go/bin
+          key: ${{ runner.os }}-${{ hashFiles('**/go.mod') }}
+
       - uses: actions/cache@v2
         with:
           path: |
-            ~/go/pkg
+            ~/go/pkg/mod
             ~/.cache/go-build
             ~/Library/Caches/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
       - run: make deps-lint
+        if: steps.cache-go-pkg-mod.outputs.cache-hit != 'true' || steps.cache-go-pkg-mod.outcome == 'failure'
       - run: make deps-build
+        if: steps.cache-go-bin.outputs.cache-hit != 'true' || steps.cache-go-bin.outcome == 'failure'
       - name: Lint
         if: runner.os == 'Linux'
         run: make lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,9 +38,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - run: make deps-lint
-        if: steps.cache-go-pkg-mod.outputs.cache-hit != 'true' || steps.cache-go-pkg-mod.outcome == 'failure'
       - run: make deps-build
-        if: steps.cache-go-bin.outputs.cache-hit != 'true' || steps.cache-go-bin.outcome == 'failure'
       - name: Lint
         if: runner.os == 'Linux'
         run: make lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -27,6 +27,7 @@ jobs:
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-${{ hashFiles('**/go.mod') }}
+          restore-keys: ${{ runner.os }}-go-bin
 
       - uses: actions/cache@v2
         with:
@@ -35,8 +36,7 @@ jobs:
             ~/.cache/go-build
             ~/Library/Caches/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          restore-keys: ${{ runner.os }}-go-
       - run: make deps-lint
       - run: make deps-build
       - name: Lint


### PR DESCRIPTION
## Summary

Caches the binaries used to make the build including opa, mispell, etc. 

## Related issues

- #1938 

## Checklist

- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
