### PR TITLE
use build_info as liveness gauge metric

### DIFF
--- a/config/metrics.go
+++ b/config/metrics.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"net/http"
+	"os"
 	"sync"
 
 	"github.com/pomerium/pomerium/internal/httputil"
@@ -57,7 +58,13 @@ func (mgr *MetricsManager) updateInfo(cfg *Config) {
 		return
 	}
 
-	metrics.SetBuildInfo(serviceName)
+	hostname, err := os.Hostname()
+	if err != nil {
+		log.Error().Err(err).Msg("telemetry/metrics: failed to get OS hostname")
+		hostname = "__unknown__"
+	}
+
+	metrics.SetBuildInfo(serviceName, hostname)
 	mgr.serviceName = serviceName
 }
 

--- a/internal/telemetry/metrics/helpers_test.go
+++ b/internal/telemetry/metrics/helpers_test.go
@@ -8,6 +8,8 @@ import (
 )
 
 func testMetricRetrieval(metrics []*metricdata.Metric, t *testing.T, labels []metricdata.LabelValue, value interface{}, name string) {
+	t.Helper()
+
 	switch value.(type) {
 	case int64:
 	case float64:

--- a/internal/telemetry/metrics/info.go
+++ b/internal/telemetry/metrics/info.go
@@ -98,8 +98,8 @@ func SetConfigInfo(service string, success bool) {
 
 // SetBuildInfo records the pomerium build info. You must call RegisterInfoMetrics to
 // have this exported
-func SetBuildInfo(service string) {
-	registry.setBuildInfo(service)
+func SetBuildInfo(service, hostname string) {
+	registry.setBuildInfo(service, hostname)
 }
 
 // RegisterInfoMetrics registers non-view based metrics registry globally for export

--- a/internal/telemetry/metrics/info.go
+++ b/internal/telemetry/metrics/info.go
@@ -10,6 +10,7 @@ import (
 	"go.opencensus.io/tag"
 
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/pkg/metrics"
 )
 
 var (
@@ -22,15 +23,15 @@ var (
 	}
 
 	configLastReload = stats.Int64(
-		"config_last_reload_success_timestamp",
+		metrics.ConfigLastReloadTimestampSeconds,
 		"Timestamp of last successful config reload",
 		"seconds")
 	configLastReloadSuccess = stats.Int64(
-		"config_last_reload_success",
+		metrics.ConfigLastReloadSuccess,
 		"Returns 1 if last reload was successful",
 		"1")
 	identityManagerLastRefresh = stats.Int64(
-		"identity_manager_last_refresh_timestamp",
+		metrics.IdentityManagerLastRefreshTimestamp,
 		"Timestamp of last directory refresh",
 		"seconds",
 	)

--- a/internal/telemetry/metrics/info_test.go
+++ b/internal/telemetry/metrics/info_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/pomerium/pomerium/internal/version"
+	"github.com/pomerium/pomerium/pkg/metrics"
 
 	"go.opencensus.io/metric/metricdata"
 	"go.opencensus.io/metric/metricproducer"
@@ -48,7 +49,7 @@ func Test_SetBuildInfo(t *testing.T) {
 	}
 
 	SetBuildInfo("test_service")
-	testMetricRetrieval(registry.registry.Read(), t, wantLabels, int64(1), "build_info")
+	testMetricRetrieval(registry.registry.Read(), t, wantLabels, int64(1), metrics.BuildInfo)
 }
 
 func Test_AddPolicyCountCallback(t *testing.T) {
@@ -58,7 +59,7 @@ func Test_AddPolicyCountCallback(t *testing.T) {
 	wantLabels := []metricdata.LabelValue{{Value: "test_service", Present: true}}
 	AddPolicyCountCallback("test_service", func() int64 { return wantValue })
 
-	testMetricRetrieval(registry.registry.Read(), t, wantLabels, wantValue, "policy_count_total")
+	testMetricRetrieval(registry.registry.Read(), t, wantLabels, wantValue, metrics.PolicyCountTotal)
 }
 
 func Test_SetConfigChecksum(t *testing.T) {
@@ -68,7 +69,7 @@ func Test_SetConfigChecksum(t *testing.T) {
 	wantLabels := []metricdata.LabelValue{{Value: "test_service", Present: true}}
 	SetConfigChecksum("test_service", wantValue)
 
-	testMetricRetrieval(registry.registry.Read(), t, wantLabels, float64(wantValue), "config_checksum_decimal")
+	testMetricRetrieval(registry.registry.Read(), t, wantLabels, float64(wantValue), metrics.ConfigChecksumDecimal)
 }
 
 func Test_RegisterInfoMetrics(t *testing.T) {

--- a/internal/telemetry/metrics/info_test.go
+++ b/internal/telemetry/metrics/info_test.go
@@ -46,9 +46,10 @@ func Test_SetBuildInfo(t *testing.T) {
 		{Value: version.FullVersion(), Present: true},
 		{Value: version.GitCommit, Present: true},
 		{Value: runtime.Version(), Present: true},
+		{Value: "test_host", Present: true},
 	}
 
-	SetBuildInfo("test_service")
+	SetBuildInfo("test_service", "test_host")
 	testMetricRetrieval(registry.registry.Read(), t, wantLabels, int64(1), metrics.BuildInfo)
 }
 

--- a/internal/telemetry/metrics/registry.go
+++ b/internal/telemetry/metrics/registry.go
@@ -1,7 +1,6 @@
 package metrics
 
 import (
-	"os"
 	"runtime"
 	"sync"
 
@@ -73,14 +72,9 @@ func (r *metricRegistry) init() {
 
 // SetBuildInfo records the pomerium build info. You must call RegisterInfoMetrics to
 // have this exported
-func (r *metricRegistry) setBuildInfo(service string) {
+func (r *metricRegistry) setBuildInfo(service, hostname string) {
 	if registry.buildInfo == nil {
 		return
-	}
-	hostname, err := os.Hostname()
-	if err != nil {
-		log.Error().Err(err).Msg("telemetry/metrics: failed to get OS hostname")
-		hostname = "__unknown__"
 	}
 	m, err := registry.buildInfo.GetEntry(
 		metricdata.NewLabelValue(service),

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -1,3 +1,5 @@
+// Package metrics declares metrics names and labels that pomerium exposes
+// as constants that could be referred to from other projects
 package metrics
 
 // metrics

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -1,0 +1,26 @@
+package metrics
+
+// metrics
+const (
+	// ConfigLastReloadTimestampSeconds is unix timestamp when configuration was last reloaded
+	ConfigLastReloadTimestampSeconds = "config_last_reload_success_timestamp"
+	// ConfigLastReloadSuccess is set to 1 if last configuration was successfully reloaded
+	ConfigLastReloadSuccess = "config_last_reload_success"
+	// IdentityManagerLastRefreshTimestamp is IdP sync timestamp
+	IdentityManagerLastRefreshTimestamp = "identity_manager_last_refresh_timestamp"
+	// BuildInfo is a gauge that may be used to detect whether component is live, and also has version
+	BuildInfo = "build_info"
+	// PolicyCountTotal is total amount of routes currently configured
+	PolicyCountTotal = "policy_count_total"
+	// ConfigChecksumDecimal should only be used to compare config on a single node, it will be different in multi-node environment
+	ConfigChecksumDecimal = "config_checksum_decimal"
+)
+
+// labels
+const (
+	ServiceLabel   = "service"
+	VersionLabel   = "version"
+	RevisionLabel  = "revision"
+	GoVersionLabel = "goversion"
+	HostLabel      = "host"
+)


### PR DESCRIPTION
- add hostname
- move metrics and labels into separate public package to refer to from console