### PR TITLE
proxy: redirect to dashboard for logout

### DIFF
--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -65,13 +65,13 @@ func (p *Proxy) SignOut(w http.ResponseWriter, r *http.Request) {
 		redirectURL = uri
 	}
 
-	signoutURL := *state.authenticateSignoutURL
-	q := signoutURL.Query()
+	dashboardURL := *state.authenticateDashboardURL
+	q := dashboardURL.Query()
 	q.Set(urlutil.QueryRedirectURI, redirectURL.String())
-	signoutURL.RawQuery = q.Encode()
+	dashboardURL.RawQuery = q.Encode()
 
 	state.sessionStore.ClearSession(w, r)
-	httputil.Redirect(w, r, urlutil.NewSignedURL(state.sharedKey, &signoutURL).String(), http.StatusFound)
+	httputil.Redirect(w, r, urlutil.NewSignedURL(state.sharedKey, &dashboardURL).String(), http.StatusFound)
 }
 
 func (p *Proxy) userInfo(w http.ResponseWriter, r *http.Request) {

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -25,7 +25,6 @@ const (
 	// authenticate urls
 	dashboardPath = "/.pomerium"
 	signinURL     = "/.pomerium/sign_in"
-	signoutURL    = "/.pomerium/sign_out"
 	refreshURL    = "/.pomerium/refresh"
 )
 

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -26,7 +26,6 @@ type proxyState struct {
 	authenticateURL          *url.URL
 	authenticateDashboardURL *url.URL
 	authenticateSigninURL    *url.URL
-	authenticateSignoutURL   *url.URL
 	authenticateRefreshURL   *url.URL
 
 	encoder         encoding.MarshalUnmarshaler
@@ -61,7 +60,6 @@ func newProxyStateFromConfig(cfg *config.Config) (*proxyState, error) {
 	state.authenticateURL, _ = urlutil.DeepCopy(cfg.Options.AuthenticateURL)
 	state.authenticateDashboardURL = state.authenticateURL.ResolveReference(&url.URL{Path: dashboardPath})
 	state.authenticateSigninURL = state.authenticateURL.ResolveReference(&url.URL{Path: signinURL})
-	state.authenticateSignoutURL = state.authenticateURL.ResolveReference(&url.URL{Path: signoutURL})
 	state.authenticateRefreshURL = state.authenticateURL.ResolveReference(&url.URL{Path: refreshURL})
 
 	state.sessionStore, err = cookie.NewStore(func() cookie.Options {


### PR DESCRIPTION
## Summary
Due to the addition of a CSRF check we can no longer sign out directly from the proxy, so I updated the handler to redirect to the dashboard, which has a logout button.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
