### PR TITLE
config: expose viper policy hooks

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -29,8 +29,8 @@ var (
 
 var (
 
-	// viperPolicyHooks are used to decode options and policy coming from YAML and env vars
-	viperPolicyHooks = viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
+	// ViperPolicyHooks are used to decode options and policy coming from YAML and env vars
+	ViperPolicyHooks = viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		mapstructure.StringToTimeDurationHookFunc(),
 		mapstructure.StringToSliceHookFunc(","),
 		// decode policy including all protobuf-native notations - i.e. duration as `1s`

--- a/config/options.go
+++ b/config/options.go
@@ -375,7 +375,7 @@ func optionsFromViper(configFile string) (*Options, error) {
 		}
 	}
 
-	if err := v.Unmarshal(o, viperPolicyHooks); err != nil {
+	if err := v.Unmarshal(o, ViperPolicyHooks); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal config: %w", err)
 	}
 
@@ -392,7 +392,7 @@ func optionsFromViper(configFile string) (*Options, error) {
 // variables or from a file
 func (o *Options) parsePolicy() error {
 	var policies []Policy
-	if err := o.viper.UnmarshalKey("policy", &policies, viperPolicyHooks); err != nil {
+	if err := o.viper.UnmarshalKey("policy", &policies, ViperPolicyHooks); err != nil {
 		return err
 	}
 	if len(policies) != 0 {

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -94,7 +94,7 @@ func Test_bindEnvs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to bind options to env vars: %s", err)
 	}
-	err = v.Unmarshal(o, viperPolicyHooks)
+	err = v.Unmarshal(o, ViperPolicyHooks)
 	if err != nil {
 		t.Errorf("Could not unmarshal %#v: %s", o, err)
 	}


### PR DESCRIPTION
## Summary
So we can use these policy hooks in other projects to fill config options.


## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
