### PR TITLE
cmd/pomerium: exit 0 for normal shutdown

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 
@@ -16,9 +17,10 @@ var (
 )
 
 func main() {
-	if err := run(context.Background()); err != nil {
+	if err := run(context.Background()); !errors.Is(err, context.Canceled) {
 		log.Fatal().Err(err).Msg("cmd/pomerium")
 	}
+	log.Info().Msg("cmd/pomerium: exiting")
 }
 
 func run(ctx context.Context) error {


### PR DESCRIPTION
## Summary
Right now we hit a `Fatal()` log statement for any error reason at exit, including context cancellation resulting from various OS signals.  This results in a non-zero exit code even when the termination was requested gracefully.

This PR checks if the underlying error is a `context.Canceled` and will exit normally in that case.  This should cover most normal shutdowns such as SIGTERM.

## Related issues

Fixes #1935 


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
