### PR TITLE
config: log config source changes

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -84,7 +84,6 @@ func (a *Authenticate) OnConfigChange(cfg *config.Config) {
 		return
 	}
 
-	log.Info().Str("checksum", fmt.Sprintf("%x", cfg.Options.Checksum())).Msg("authenticate: updating options")
 	a.options.Store(cfg.Options)
 	if state, err := newAuthenticateStateFromConfig(cfg); err != nil {
 		log.Error().Err(err).Msg("authenticate: failed to update state")

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -87,7 +87,6 @@ func newPolicyEvaluator(opts *config.Options, store *evaluator.Store) (*evaluato
 
 // OnConfigChange updates internal structures based on config.Options
 func (a *Authorize) OnConfigChange(cfg *config.Config) {
-	log.Info().Str("checksum", fmt.Sprintf("%x", cfg.Options.Checksum())).Msg("authorize: updating options")
 	a.currentOptions.Store(cfg.Options)
 	if state, err := newAuthorizeStateFromConfig(cfg, a.store); err != nil {
 		log.Error().Err(err).Msg("authorize: error updating state")

--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,10 @@
 package config
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+
+	"github.com/pomerium/pomerium/internal/hashutil"
+)
 
 // Config holds pomerium configuration options.
 type Config struct {
@@ -24,4 +28,9 @@ func (cfg *Config) AllCertificates() []tls.Certificate {
 	certs = append(certs, cfg.Options.Certificates...)
 	certs = append(certs, cfg.AutoCertificates...)
 	return certs
+}
+
+// Checksum returns the config checksum.
+func (cfg *Config) Checksum() uint64 {
+	return hashutil.MustHash(cfg)
 }

--- a/config/config_source.go
+++ b/config/config_source.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/rs/zerolog/log"
 
 	"github.com/pomerium/pomerium/internal/fileutil"
+	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 )
 

--- a/config/options.go
+++ b/config/options.go
@@ -353,8 +353,6 @@ func newOptionsFromConfig(configFile string) (*Options, error) {
 		return int64(len(o.GetAllPolicies()))
 	})
 
-	metrics.SetConfigChecksum(serviceName, o.Checksum())
-
 	return o, nil
 }
 
@@ -1050,31 +1048,6 @@ func (o *Options) ApplySettings(settings *config.Settings) {
 	if settings.SkipXffAppend != nil {
 		o.SkipXffAppend = settings.GetSkipXffAppend()
 	}
-}
-
-// handleConfigUpdate takes configuration file, an existing options struct, and
-// returns new options if any change is detected. If no change was detected, the
-// existing option will be returned.
-func handleConfigUpdate(configFile string, opt *Options) *Options {
-	serviceName := telemetry.ServiceName(opt.Services)
-
-	newOpt, err := newOptionsFromConfig(configFile)
-	if err != nil {
-		log.Error().Err(err).Msg("config: could not reload configuration")
-		metrics.SetConfigInfo(serviceName, false)
-		return opt
-	}
-	optChecksum := opt.Checksum()
-	newOptChecksum := newOpt.Checksum()
-
-	log.Debug().Str("old-checksum", fmt.Sprintf("%x", optChecksum)).Str("new-checksum", fmt.Sprintf("%x", newOptChecksum)).Msg("config: checksum change")
-
-	if newOptChecksum == optChecksum {
-		log.Debug().Msg("config: loaded configuration has not changed")
-		return opt
-	}
-
-	return newOpt
 }
 
 func dataDir() string {

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/hashutil"
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
 	"github.com/pomerium/pomerium/pkg/grpc"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
@@ -134,6 +135,8 @@ func (src *ConfigSource) rebuild(firstTime bool) {
 	if !firstTime {
 		src.Trigger(cfg)
 	}
+
+	metrics.SetConfigInfo(cfg.Options.Services, "databroker", cfg.Checksum(), true)
 }
 
 func (src *ConfigSource) runUpdater(cfg *config.Config) {

--- a/internal/telemetry/metrics/info_test.go
+++ b/internal/telemetry/metrics/info_test.go
@@ -27,7 +27,7 @@ func Test_SetConfigInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			view.Unregister(InfoViews...)
 			view.Register(InfoViews...)
-			SetConfigInfo("test_service", tt.success)
+			SetConfigInfo("test_service", "test config", 0, tt.success)
 
 			testDataRetrieval(ConfigLastReloadView, t, tt.wantLastReload)
 			testDataRetrieval(ConfigLastReloadSuccessView, t, tt.wantLastReloadSuccess)
@@ -61,16 +61,6 @@ func Test_AddPolicyCountCallback(t *testing.T) {
 	AddPolicyCountCallback("test_service", func() int64 { return wantValue })
 
 	testMetricRetrieval(registry.registry.Read(), t, wantLabels, wantValue, metrics.PolicyCountTotal)
-}
-
-func Test_SetConfigChecksum(t *testing.T) {
-	registry = newMetricRegistry()
-
-	wantValue := uint64(42)
-	wantLabels := []metricdata.LabelValue{{Value: "test_service", Present: true}}
-	SetConfigChecksum("test_service", wantValue)
-
-	testMetricRetrieval(registry.registry.Read(), t, wantLabels, float64(wantValue), metrics.ConfigChecksumDecimal)
 }
 
 func Test_RegisterInfoMetrics(t *testing.T) {

--- a/internal/telemetry/metrics/registry.go
+++ b/internal/telemetry/metrics/registry.go
@@ -54,7 +54,7 @@ func (r *metricRegistry) init() {
 
 			r.configChecksum, err = r.registry.AddFloat64Gauge(metrics.ConfigChecksumDecimal,
 				metric.WithDescription("Config checksum represented in decimal notation"),
-				metric.WithLabelKeys(metrics.ServiceLabel),
+				metric.WithLabelKeys(metrics.ServiceLabel, metrics.ConfigLabel),
 			)
 			if err != nil {
 				log.Error().Err(err).Msg("telemetry/metrics: failed to register config checksum metric")
@@ -102,11 +102,11 @@ func (r *metricRegistry) addPolicyCountCallback(service string, f func() int64) 
 	}
 }
 
-func (r *metricRegistry) setConfigChecksum(service string, checksum uint64) {
+func (r *metricRegistry) setConfigChecksum(service string, configName string, checksum uint64) {
 	if r.configChecksum == nil {
 		return
 	}
-	m, err := r.configChecksum.GetEntry(metricdata.NewLabelValue(service))
+	m, err := r.configChecksum.GetEntry(metricdata.NewLabelValue(service), metricdata.NewLabelValue(configName))
 	if err != nil {
 		log.Error().Err(err).Msg("telemetry/metrics: failed to get config checksum metric")
 	}

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -21,6 +21,7 @@ const (
 // labels
 const (
 	ServiceLabel   = "service"
+	ConfigLabel    = "config"
 	VersionLabel   = "version"
 	RevisionLabel  = "revision"
 	GoVersionLabel = "goversion"

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -82,7 +82,6 @@ func (p *Proxy) OnConfigChange(cfg *config.Config) {
 		return
 	}
 
-	log.Info().Str("checksum", fmt.Sprintf("%x", cfg.Options.Checksum())).Msg("proxy: updating options")
 	p.currentOptions.Store(cfg.Options)
 	p.setHandlers(cfg.Options)
 	if state, err := newProxyStateFromConfig(cfg); err != nil {


### PR DESCRIPTION
## Summary
Add a log entry whenever the config changes. We have separate checksums for different config sources: `local` and `databroker`.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
