### PR TITLE
oidc: use groups claim from ID token if present

### DIFF
--- a/authorize/evaluator/opa/policy/authz.rego
+++ b/authorize/evaluator/opa/policy/authz.rego
@@ -205,6 +205,10 @@ jwt_payload_email = v {
 
 jwt_payload_groups = v {
 	v = array.concat(group_ids, get_databroker_group_names(group_ids))
+	v != []
+} else = v {
+	v = session.claims["groups"]
+	v != null
 } else = [] {
 	true
 }


### PR DESCRIPTION
Signed-off-by: Nandor Kracser <bonifaido@gmail.com>

## Summary

A lot of OIDC providers offer the de-facto "groups" claim, which lists a user's existing group memberships. These are (incomplete list):
- [OneLogin](https://developers.onelogin.com/openid-connect/scopes)
- [Dex](https://dexidp.io/docs/custom-scopes-claims-clients/#scopes)
- [okta](https://developer.okta.com/docs/guides/customize-tokens-groups-claim/add-groups-claim-org-as/)
- [Auth0](https://auth0.com/docs/extensions/authorization-extension?_ga=2.80662615.1996932338.1615212854-499469682.1614950441)

This way group information can be sent back to the backend service via `X-Pomerium-Claim-Groups`, grabbing the `groups` claim from the ID token.

A documentation update would be needed if this is accepted, but first I wanted to make sure this makes sense.

My use is currently with Dex, without this change I couldn't configure Pomerium in a way that it returned the group header properly.

## Related issues


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
