### PR TITLE
identity: infer email from mail claim

### DIFF
--- a/internal/identity/oidc/userinfo_test.go
+++ b/internal/identity/oidc/userinfo_test.go
@@ -49,7 +49,7 @@ func TestUserInfoRoundTrip(t *testing.T) {
             }`)
 		case "/oauth2/userInfo":
 			w.Header().Set("Content-Type", "application/json")
-			io.WriteString(w, `{ "email_verified": "true" }`)
+			io.WriteString(w, `{ "email_verified": "true", "mail": "test@example.com" }`)
 		}
 	}))
 	defer srv.Close()
@@ -71,4 +71,5 @@ func TestUserInfoRoundTrip(t *testing.T) {
 		return
 	}
 	assert.True(t, userInfo.EmailVerified)
+	assert.Equal(t, "test@example.com", userInfo.Email)
 }


### PR DESCRIPTION
## Summary
Some providers (ping) return a `mail` claim instead of `email`. This change will copy the claim into `email` if there's nothing there and `mail` looks like an email address.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
