### PR TITLE
Fix process cpu usage metric

### DIFF
--- a/internal/telemetry/metrics/processes.go
+++ b/internal/telemetry/metrics/processes.go
@@ -64,7 +64,7 @@ func NewProcessCollector(name string) *ProcessCollector {
 			Name:        pc.cpuTotal.Name(),
 			Description: pc.cpuTotal.Description(),
 			Measure:     pc.cpuTotal,
-			Aggregation: view.Sum(),
+			Aggregation: view.LastValue(),
 		},
 		{
 			Name:        pc.openFDs.Name(),


### PR DESCRIPTION
## Summary

[`CPUTime()`](https://pkg.go.dev/github.com/prometheus/procfs@v0.2.0#ProcStat.CPUTime) is already a SUM

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
