### PR TITLE
authorize: set JWT to expire after 5 minutes

### DIFF
--- a/authorize/evaluator/opa/policy/authz.rego
+++ b/authorize/evaluator/opa/policy/authz.rego
@@ -2,7 +2,7 @@ package pomerium.authz
 
 default allow = false
 
-# 5 minutes from now
+# 5 minutes from now in seconds
 five_minutes := (time.now_ns() / 1e9) + (60 * 5)
 
 route_policy_idx := first_allowed_route_policy_idx(input.http.url)
@@ -169,7 +169,7 @@ jwt_payload_jti = v {
 }
 
 jwt_payload_exp = v {
-	v = min([five_minutes, session.id_token.expires_at.seconds])
+	v = min([five_minutes, session.expires_at.seconds])
 } else = v {
 	v = five_minutes
 } else = null {

--- a/authorize/evaluator/opa/policy/authz.rego
+++ b/authorize/evaluator/opa/policy/authz.rego
@@ -2,6 +2,9 @@ package pomerium.authz
 
 default allow = false
 
+# 5 minutes from now
+five_minutes := (time.now_ns() / 1e9) + (60 * 5)
+
 route_policy_idx := first_allowed_route_policy_idx(input.http.url)
 
 route_policy := data.route_policies[route_policy_idx]
@@ -166,8 +169,9 @@ jwt_payload_jti = v {
 }
 
 jwt_payload_exp = v {
-	# 5 minutes from now
-	v = (time.now_ns() / 1e9) + (60 * 5)
+	v = min([five_minutes, session.id_token.expires_at.seconds])
+} else = v {
+	v = five_minutes
 } else = null {
 	true
 }

--- a/authorize/evaluator/opa/policy/authz.rego
+++ b/authorize/evaluator/opa/policy/authz.rego
@@ -166,7 +166,8 @@ jwt_payload_jti = v {
 }
 
 jwt_payload_exp = v {
-	v = session.expires_at.seconds
+	# 5 minutes from now
+	v = (time.now_ns() / 1e9) + (60 * 5)
 } else = null {
 	true
 }

--- a/authorize/evaluator/opa_test.go
+++ b/authorize/evaluator/opa_test.go
@@ -152,7 +152,6 @@ func TestOPA(t *testing.T) {
 			require.NoError(t, err)
 			assert.LessOrEqual(t, claims["exp"], float64(time.Now().Add(time.Minute*6).Unix()),
 				"JWT should expire within 5 minutes, but got: %v", claims["exp"])
-			delete(claims, "exp")
 			return claims
 		}
 
@@ -177,6 +176,7 @@ func TestOPA(t *testing.T) {
 					Email: "group1@example.com",
 				},
 			)
+			delete(payload, "exp")
 			assert.Equal(t, M{
 				"aud":    "from.example.com",
 				"iss":    "authenticate.example.com",
@@ -216,6 +216,7 @@ func TestOPA(t *testing.T) {
 				"iss":    "authenticate.example.com",
 				"jti":    "session1",
 				"iat":    1612141261.0,
+				"exp":    1609462861.0,
 				"sub":    "user1",
 				"user":   "user1",
 				"email":  "a@example.com",

--- a/authorize/evaluator/opa_test.go
+++ b/authorize/evaluator/opa_test.go
@@ -151,7 +151,7 @@ func TestOPA(t *testing.T) {
 			err = authJWT.Claims(publicJWK, &claims)
 			require.NoError(t, err)
 			assert.LessOrEqual(t, claims["exp"], float64(time.Now().Add(time.Minute*6).Unix()),
-				"JWT should expire after 5 minutes")
+				"JWT should expire within 5 minutes, but got: %v", claims["exp"])
 			delete(claims, "exp")
 			return claims
 		}

--- a/authorize/evaluator/opa_test.go
+++ b/authorize/evaluator/opa_test.go
@@ -150,6 +150,9 @@ func TestOPA(t *testing.T) {
 			var claims M
 			err = authJWT.Claims(publicJWK, &claims)
 			require.NoError(t, err)
+			assert.LessOrEqual(t, claims["exp"], float64(time.Now().Add(time.Minute*6).Unix()),
+				"JWT should expire after 5 minutes")
+			delete(claims, "exp")
 			return claims
 		}
 
@@ -212,7 +215,6 @@ func TestOPA(t *testing.T) {
 				"aud":    "from.example.com",
 				"iss":    "authenticate.example.com",
 				"jti":    "session1",
-				"exp":    1609462861.0,
 				"iat":    1612141261.0,
 				"sub":    "user1",
 				"user":   "user1",


### PR DESCRIPTION
## Summary
Lower the JWT expiration to 5 minutes past the current time.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
