### PR TITLE
envoy: upgrade to v1.17.1

### DIFF
--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -6,9 +6,9 @@ import (
 	"net/url"
 	"testing"
 
-	envoy_api_v2_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
-	envoy_service_auth_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
-	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/genproto/googleapis/rpc/status"
@@ -57,12 +57,12 @@ func TestAuthorize_okResponse(t *testing.T) {
 	tests := []struct {
 		name  string
 		reply *evaluator.Result
-		want  *envoy_service_auth_v2.CheckResponse
+		want  *envoy_service_auth_v3.CheckResponse
 	}{
 		{
 			"ok reply",
 			&evaluator.Result{Status: 0, Message: "ok"},
-			&envoy_service_auth_v2.CheckResponse{
+			&envoy_service_auth_v3.CheckResponse{
 				Status: &status.Status{Code: 0, Message: "ok"},
 			},
 		},
@@ -75,7 +75,7 @@ func TestAuthorize_okResponse(t *testing.T) {
 					KubernetesServiceAccountToken: "k8s-svc-account",
 				},
 			},
-			&envoy_service_auth_v2.CheckResponse{
+			&envoy_service_auth_v3.CheckResponse{
 				Status: &status.Status{Code: 0, Message: "ok"},
 			},
 		},
@@ -88,7 +88,7 @@ func TestAuthorize_okResponse(t *testing.T) {
 					KubernetesServiceAccountToken: "k8s-svc-account",
 				},
 			},
-			&envoy_service_auth_v2.CheckResponse{
+			&envoy_service_auth_v3.CheckResponse{
 				Status: &status.Status{Code: 0, Message: "ok"},
 			},
 		},
@@ -98,7 +98,7 @@ func TestAuthorize_okResponse(t *testing.T) {
 				Status:  0,
 				Message: "ok",
 			},
-			&envoy_service_auth_v2.CheckResponse{
+			&envoy_service_auth_v3.CheckResponse{
 				Status: &status.Status{Code: 0, Message: "ok"},
 			},
 		},
@@ -131,11 +131,11 @@ func TestAuthorize_deniedResponse(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		in      *envoy_service_auth_v2.CheckRequest
+		in      *envoy_service_auth_v3.CheckRequest
 		code    int32
 		reason  string
 		headers map[string]string
-		want    *envoy_service_auth_v2.CheckResponse
+		want    *envoy_service_auth_v3.CheckResponse
 	}{
 		{
 			"html denied",
@@ -143,14 +143,14 @@ func TestAuthorize_deniedResponse(t *testing.T) {
 			http.StatusBadRequest,
 			"Access Denied",
 			nil,
-			&envoy_service_auth_v2.CheckResponse{
+			&envoy_service_auth_v3.CheckResponse{
 				Status: &status.Status{Code: int32(codes.PermissionDenied), Message: "Access Denied"},
-				HttpResponse: &envoy_service_auth_v2.CheckResponse_DeniedResponse{
-					DeniedResponse: &envoy_service_auth_v2.DeniedHttpResponse{
-						Status: &envoy_type.HttpStatus{
-							Code: envoy_type.StatusCode(codes.InvalidArgument),
+				HttpResponse: &envoy_service_auth_v3.CheckResponse_DeniedResponse{
+					DeniedResponse: &envoy_service_auth_v3.DeniedHttpResponse{
+						Status: &envoy_type_v3.HttpStatus{
+							Code: envoy_type_v3.StatusCode(codes.InvalidArgument),
 						},
-						Headers: []*envoy_api_v2_core.HeaderValueOption{
+						Headers: []*envoy_config_core_v3.HeaderValueOption{
 							mkHeader("Content-Type", "text/html", false),
 						},
 						Body: "Access Denied",
@@ -160,10 +160,10 @@ func TestAuthorize_deniedResponse(t *testing.T) {
 		},
 		{
 			"plain text denied",
-			&envoy_service_auth_v2.CheckRequest{
-				Attributes: &envoy_service_auth_v2.AttributeContext{
-					Request: &envoy_service_auth_v2.AttributeContext_Request{
-						Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+			&envoy_service_auth_v3.CheckRequest{
+				Attributes: &envoy_service_auth_v3.AttributeContext{
+					Request: &envoy_service_auth_v3.AttributeContext_Request{
+						Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 							Headers: map[string]string{},
 						},
 					},
@@ -172,14 +172,14 @@ func TestAuthorize_deniedResponse(t *testing.T) {
 			http.StatusBadRequest,
 			"Access Denied",
 			map[string]string{},
-			&envoy_service_auth_v2.CheckResponse{
+			&envoy_service_auth_v3.CheckResponse{
 				Status: &status.Status{Code: int32(codes.PermissionDenied), Message: "Access Denied"},
-				HttpResponse: &envoy_service_auth_v2.CheckResponse_DeniedResponse{
-					DeniedResponse: &envoy_service_auth_v2.DeniedHttpResponse{
-						Status: &envoy_type.HttpStatus{
-							Code: envoy_type.StatusCode(codes.InvalidArgument),
+				HttpResponse: &envoy_service_auth_v3.CheckResponse_DeniedResponse{
+					DeniedResponse: &envoy_service_auth_v3.DeniedHttpResponse{
+						Status: &envoy_type_v3.HttpStatus{
+							Code: envoy_type_v3.StatusCode(codes.InvalidArgument),
 						},
-						Headers: []*envoy_api_v2_core.HeaderValueOption{
+						Headers: []*envoy_config_core_v3.HeaderValueOption{
 							mkHeader("Content-Type", "text/plain", false),
 						},
 						Body: "Access Denied",

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -24,11 +24,11 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
 
-	envoy_service_auth_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 )
 
 // Check implements the envoy auth server gRPC endpoint.
-func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v2.CheckRequest) (*envoy_service_auth_v2.CheckResponse, error) {
+func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRequest) (*envoy_service_auth_v3.CheckResponse, error) {
 	ctx, span := trace.StartSpan(ctx, "authorize.grpc.Check")
 	defer span.End()
 
@@ -179,7 +179,7 @@ func getForwardAuthURL(r *http.Request) *url.URL {
 }
 
 // isForwardAuth returns if the current request is a forward auth route.
-func (a *Authorize) isForwardAuth(req *envoy_service_auth_v2.CheckRequest) bool {
+func (a *Authorize) isForwardAuth(req *envoy_service_auth_v3.CheckRequest) bool {
 	opts := a.currentOptions.Load()
 
 	if opts.ForwardAuthURL == nil {
@@ -197,7 +197,7 @@ func (a *Authorize) isForwardAuth(req *envoy_service_auth_v2.CheckRequest) bool 
 }
 
 func (a *Authorize) getEvaluatorRequestFromCheckRequest(
-	in *envoy_service_auth_v2.CheckRequest,
+	in *envoy_service_auth_v3.CheckRequest,
 	sessionState *sessions.State,
 ) (*evaluator.Request, error) {
 	requestURL := getCheckRequestURL(in)
@@ -261,7 +261,7 @@ func (a *Authorize) getMatchingPolicy(requestURL url.URL) *config.Policy {
 	return nil
 }
 
-func getHTTPRequestFromCheckRequest(req *envoy_service_auth_v2.CheckRequest) *http.Request {
+func getHTTPRequestFromCheckRequest(req *envoy_service_auth_v3.CheckRequest) *http.Request {
 	hattrs := req.GetAttributes().GetRequest().GetHttp()
 	u := getCheckRequestURL(req)
 	hreq := &http.Request{
@@ -278,7 +278,7 @@ func getHTTPRequestFromCheckRequest(req *envoy_service_auth_v2.CheckRequest) *ht
 	return hreq
 }
 
-func getCheckRequestHeaders(req *envoy_service_auth_v2.CheckRequest) map[string]string {
+func getCheckRequestHeaders(req *envoy_service_auth_v3.CheckRequest) map[string]string {
 	hdrs := make(map[string]string)
 	ch := req.GetAttributes().GetRequest().GetHttp().GetHeaders()
 	for k, v := range ch {
@@ -287,7 +287,7 @@ func getCheckRequestHeaders(req *envoy_service_auth_v2.CheckRequest) map[string]
 	return hdrs
 }
 
-func getCheckRequestURL(req *envoy_service_auth_v2.CheckRequest) url.URL {
+func getCheckRequestURL(req *envoy_service_auth_v3.CheckRequest) url.URL {
 	h := req.GetAttributes().GetRequest().GetHttp()
 	u := url.URL{
 		Scheme: h.GetScheme(),
@@ -305,7 +305,7 @@ func getCheckRequestURL(req *envoy_service_auth_v2.CheckRequest) url.URL {
 }
 
 // getPeerCertificate gets the PEM-encoded peer certificate from the check request
-func getPeerCertificate(in *envoy_service_auth_v2.CheckRequest) string {
+func getPeerCertificate(in *envoy_service_auth_v3.CheckRequest) string {
 	// ignore the error as we will just return the empty string in that case
 	cert, _ := url.QueryUnescape(in.GetAttributes().GetSource().GetCertificate())
 	return cert
@@ -313,7 +313,7 @@ func getPeerCertificate(in *envoy_service_auth_v2.CheckRequest) string {
 
 func logAuthorizeCheck(
 	ctx context.Context,
-	in *envoy_service_auth_v2.CheckRequest,
+	in *envoy_service_auth_v3.CheckRequest,
 	reply *evaluator.Result,
 	u *user.User,
 ) {

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -6,7 +6,7 @@ import (
 	"net/url"
 	"testing"
 
-	envoy_service_auth_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -63,13 +63,13 @@ func Test_getEvaluatorRequest(t *testing.T) {
 	})
 
 	actual, err := a.getEvaluatorRequestFromCheckRequest(
-		&envoy_service_auth_v2.CheckRequest{
-			Attributes: &envoy_service_auth_v2.AttributeContext{
-				Source: &envoy_service_auth_v2.AttributeContext_Peer{
+		&envoy_service_auth_v3.CheckRequest{
+			Attributes: &envoy_service_auth_v3.AttributeContext{
+				Source: &envoy_service_auth_v3.AttributeContext_Peer{
 					Certificate: url.QueryEscape(certPEM),
 				},
-				Request: &envoy_service_auth_v2.AttributeContext_Request{
-					Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+				Request: &envoy_service_auth_v3.AttributeContext_Request{
+					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 						Id:     "id-1234",
 						Method: "GET",
 						Headers: map[string]string{
@@ -110,19 +110,19 @@ func Test_getEvaluatorRequest(t *testing.T) {
 func Test_handleForwardAuth(t *testing.T) {
 	tests := []struct {
 		name           string
-		checkReq       *envoy_service_auth_v2.CheckRequest
+		checkReq       *envoy_service_auth_v3.CheckRequest
 		forwardAuthURL string
 		want           bool
 	}{
 		{
 			name: "enabled",
-			checkReq: &envoy_service_auth_v2.CheckRequest{
-				Attributes: &envoy_service_auth_v2.AttributeContext{
-					Source: &envoy_service_auth_v2.AttributeContext_Peer{
+			checkReq: &envoy_service_auth_v3.CheckRequest{
+				Attributes: &envoy_service_auth_v3.AttributeContext{
+					Source: &envoy_service_auth_v3.AttributeContext_Peer{
 						Certificate: url.QueryEscape(certPEM),
 					},
-					Request: &envoy_service_auth_v2.AttributeContext_Request{
-						Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+					Request: &envoy_service_auth_v3.AttributeContext_Request{
+						Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 							Method: "GET",
 							Path:   "/verify?uri=" + url.QueryEscape("https://example.com/some/path?qs=1"),
 							Host:   "forward-auth.example.com",
@@ -142,13 +142,13 @@ func Test_handleForwardAuth(t *testing.T) {
 		},
 		{
 			name: "honor x-forwarded-uri set",
-			checkReq: &envoy_service_auth_v2.CheckRequest{
-				Attributes: &envoy_service_auth_v2.AttributeContext{
-					Source: &envoy_service_auth_v2.AttributeContext_Peer{
+			checkReq: &envoy_service_auth_v3.CheckRequest{
+				Attributes: &envoy_service_auth_v3.AttributeContext{
+					Source: &envoy_service_auth_v3.AttributeContext_Peer{
 						Certificate: url.QueryEscape(certPEM),
 					},
-					Request: &envoy_service_auth_v2.AttributeContext_Request{
-						Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+					Request: &envoy_service_auth_v3.AttributeContext_Request{
+						Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 							Method: "GET",
 							Path:   "/",
 							Host:   "forward-auth.example.com",
@@ -167,13 +167,13 @@ func Test_handleForwardAuth(t *testing.T) {
 		},
 		{
 			name: "request with invalid forward auth url",
-			checkReq: &envoy_service_auth_v2.CheckRequest{
-				Attributes: &envoy_service_auth_v2.AttributeContext{
-					Source: &envoy_service_auth_v2.AttributeContext_Peer{
+			checkReq: &envoy_service_auth_v3.CheckRequest{
+				Attributes: &envoy_service_auth_v3.AttributeContext{
+					Source: &envoy_service_auth_v3.AttributeContext_Peer{
 						Certificate: url.QueryEscape(certPEM),
 					},
-					Request: &envoy_service_auth_v2.AttributeContext_Request{
-						Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+					Request: &envoy_service_auth_v3.AttributeContext_Request{
+						Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 							Method: "GET",
 							Path:   "/verify?uri=" + url.QueryEscape("https://example.com?q=foo"),
 							Host:   "fake-forward-auth.example.com",
@@ -187,13 +187,13 @@ func Test_handleForwardAuth(t *testing.T) {
 		},
 		{
 			name: "request with invalid path",
-			checkReq: &envoy_service_auth_v2.CheckRequest{
-				Attributes: &envoy_service_auth_v2.AttributeContext{
-					Source: &envoy_service_auth_v2.AttributeContext_Peer{
+			checkReq: &envoy_service_auth_v3.CheckRequest{
+				Attributes: &envoy_service_auth_v3.AttributeContext{
+					Source: &envoy_service_auth_v3.AttributeContext_Peer{
 						Certificate: url.QueryEscape(certPEM),
 					},
-					Request: &envoy_service_auth_v2.AttributeContext_Request{
-						Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+					Request: &envoy_service_auth_v3.AttributeContext_Request{
+						Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 							Method: "GET",
 							Path:   "/foo?uri=" + url.QueryEscape("https://example.com?q=foo"),
 							Host:   "forward-auth.example.com",
@@ -207,13 +207,13 @@ func Test_handleForwardAuth(t *testing.T) {
 		},
 		{
 			name: "request with empty uri",
-			checkReq: &envoy_service_auth_v2.CheckRequest{
-				Attributes: &envoy_service_auth_v2.AttributeContext{
-					Source: &envoy_service_auth_v2.AttributeContext_Peer{
+			checkReq: &envoy_service_auth_v3.CheckRequest{
+				Attributes: &envoy_service_auth_v3.AttributeContext{
+					Source: &envoy_service_auth_v3.AttributeContext_Peer{
 						Certificate: url.QueryEscape(certPEM),
 					},
-					Request: &envoy_service_auth_v2.AttributeContext_Request{
-						Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+					Request: &envoy_service_auth_v3.AttributeContext_Request{
+						Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 							Method: "GET",
 							Path:   "/verify?uri=",
 							Host:   "forward-auth.example.com",
@@ -227,13 +227,13 @@ func Test_handleForwardAuth(t *testing.T) {
 		},
 		{
 			name: "request with invalid uri",
-			checkReq: &envoy_service_auth_v2.CheckRequest{
-				Attributes: &envoy_service_auth_v2.AttributeContext{
-					Source: &envoy_service_auth_v2.AttributeContext_Peer{
+			checkReq: &envoy_service_auth_v3.CheckRequest{
+				Attributes: &envoy_service_auth_v3.AttributeContext{
+					Source: &envoy_service_auth_v3.AttributeContext_Peer{
 						Certificate: url.QueryEscape(certPEM),
 					},
-					Request: &envoy_service_auth_v2.AttributeContext_Request{
-						Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+					Request: &envoy_service_auth_v3.AttributeContext_Request{
+						Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 							Method: "GET",
 							Path:   "/verify?uri= http://example.com/foo",
 							Host:   "forward-auth.example.com",
@@ -279,13 +279,13 @@ func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 		}},
 	})
 
-	actual, err := a.getEvaluatorRequestFromCheckRequest(&envoy_service_auth_v2.CheckRequest{
-		Attributes: &envoy_service_auth_v2.AttributeContext{
-			Source: &envoy_service_auth_v2.AttributeContext_Peer{
+	actual, err := a.getEvaluatorRequestFromCheckRequest(&envoy_service_auth_v3.CheckRequest{
+		Attributes: &envoy_service_auth_v3.AttributeContext{
+			Source: &envoy_service_auth_v3.AttributeContext_Peer{
 				Certificate: url.QueryEscape(certPEM),
 			},
-			Request: &envoy_service_auth_v2.AttributeContext_Request{
-				Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+			Request: &envoy_service_auth_v3.AttributeContext_Request{
+				Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 					Id:     "id-1234",
 					Method: "GET",
 					Headers: map[string]string{
@@ -473,25 +473,25 @@ func TestAuthorize_Check(t *testing.T) {
 	a.currentOptions.Store(&config.Options{ForwardAuthURL: mustParseURL("https://forward-auth.example.com")})
 
 	cmpOpts := []cmp.Option{
-		cmpopts.IgnoreUnexported(envoy_service_auth_v2.CheckResponse{}),
+		cmpopts.IgnoreUnexported(envoy_service_auth_v3.CheckResponse{}),
 		cmpopts.IgnoreUnexported(status.Status{}),
-		cmpopts.IgnoreTypes(envoy_service_auth_v2.DeniedHttpResponse{}),
+		cmpopts.IgnoreTypes(envoy_service_auth_v3.DeniedHttpResponse{}),
 	}
 	tests := []struct {
 		name    string
-		in      *envoy_service_auth_v2.CheckRequest
-		want    *envoy_service_auth_v2.CheckResponse
+		in      *envoy_service_auth_v3.CheckRequest
+		want    *envoy_service_auth_v3.CheckResponse
 		wantErr bool
 	}{
 		{
 			"basic deny",
-			&envoy_service_auth_v2.CheckRequest{
-				Attributes: &envoy_service_auth_v2.AttributeContext{
-					Source: &envoy_service_auth_v2.AttributeContext_Peer{
+			&envoy_service_auth_v3.CheckRequest{
+				Attributes: &envoy_service_auth_v3.AttributeContext{
+					Source: &envoy_service_auth_v3.AttributeContext_Peer{
 						Certificate: url.QueryEscape(certPEM),
 					},
-					Request: &envoy_service_auth_v2.AttributeContext_Request{
-						Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+					Request: &envoy_service_auth_v3.AttributeContext_Request{
+						Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 							Id:     "id-1234",
 							Method: "GET",
 							Headers: map[string]string{
@@ -506,23 +506,23 @@ func TestAuthorize_Check(t *testing.T) {
 					},
 				},
 			},
-			&envoy_service_auth_v2.CheckResponse{
+			&envoy_service_auth_v3.CheckResponse{
 				Status: &status.Status{Code: 7, Message: "Access Denied"},
-				HttpResponse: &envoy_service_auth_v2.CheckResponse_DeniedResponse{
-					DeniedResponse: &envoy_service_auth_v2.DeniedHttpResponse{},
+				HttpResponse: &envoy_service_auth_v3.CheckResponse_DeniedResponse{
+					DeniedResponse: &envoy_service_auth_v3.DeniedHttpResponse{},
 				},
 			},
 			false,
 		},
 		{
 			"basic forward-auth deny",
-			&envoy_service_auth_v2.CheckRequest{
-				Attributes: &envoy_service_auth_v2.AttributeContext{
-					Source: &envoy_service_auth_v2.AttributeContext_Peer{
+			&envoy_service_auth_v3.CheckRequest{
+				Attributes: &envoy_service_auth_v3.AttributeContext{
+					Source: &envoy_service_auth_v3.AttributeContext_Peer{
 						Certificate: url.QueryEscape(certPEM),
 					},
-					Request: &envoy_service_auth_v2.AttributeContext_Request{
-						Http: &envoy_service_auth_v2.AttributeContext_HttpRequest{
+					Request: &envoy_service_auth_v3.AttributeContext_Request{
+						Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 							Method: "GET",
 							Path:   "/verify?uri=" + url.QueryEscape("https://example.com/some/path?qs=1"),
 							Host:   "forward-auth.example.com",
@@ -531,10 +531,10 @@ func TestAuthorize_Check(t *testing.T) {
 					},
 				},
 			},
-			&envoy_service_auth_v2.CheckResponse{
+			&envoy_service_auth_v3.CheckResponse{
 				Status: &status.Status{Code: 7, Message: "Access Denied"},
-				HttpResponse: &envoy_service_auth_v2.CheckResponse_DeniedResponse{
-					DeniedResponse: &envoy_service_auth_v2.DeniedHttpResponse{},
+				HttpResponse: &envoy_service_auth_v3.CheckResponse_DeniedResponse{
+					DeniedResponse: &envoy_service_auth_v3.DeniedHttpResponse{},
 				},
 			},
 			false,

--- a/authorize/session_test.go
+++ b/authorize/session_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	envoy_service_auth_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pomerium/pomerium/config"
@@ -25,10 +25,10 @@ func TestLoadSession(t *testing.T) {
 		return
 	}
 
-	load := func(t *testing.T, hattrs *envoy_service_auth_v2.AttributeContext_HttpRequest) (*sessions.State, error) {
-		req := getHTTPRequestFromCheckRequest(&envoy_service_auth_v2.CheckRequest{
-			Attributes: &envoy_service_auth_v2.AttributeContext{
-				Request: &envoy_service_auth_v2.AttributeContext_Request{
+	load := func(t *testing.T, hattrs *envoy_service_auth_v3.AttributeContext_HttpRequest) (*sessions.State, error) {
+		req := getHTTPRequestFromCheckRequest(&envoy_service_auth_v3.CheckRequest{
+			Attributes: &envoy_service_auth_v3.AttributeContext{
+				Request: &envoy_service_auth_v3.AttributeContext_Request{
 					Http: hattrs,
 				},
 			},
@@ -56,7 +56,7 @@ func TestLoadSession(t *testing.T) {
 		}
 		cookie := regexp.MustCompile(`^([^;]+)(;.*)?$`).ReplaceAllString(hdrs["Set-Cookie"], "$1")
 
-		hattrs := &envoy_service_auth_v2.AttributeContext_HttpRequest{
+		hattrs := &envoy_service_auth_v3.AttributeContext_HttpRequest{
 			Id:     "req-1",
 			Method: "GET",
 			Headers: map[string]string{
@@ -71,7 +71,7 @@ func TestLoadSession(t *testing.T) {
 		assert.NotNil(t, sess)
 	})
 	t.Run("header", func(t *testing.T) {
-		hattrs := &envoy_service_auth_v2.AttributeContext_HttpRequest{
+		hattrs := &envoy_service_auth_v3.AttributeContext_HttpRequest{
 			Id:     "req-1",
 			Method: "GET",
 			Headers: map[string]string{
@@ -86,7 +86,7 @@ func TestLoadSession(t *testing.T) {
 		assert.NotNil(t, sess)
 	})
 	t.Run("query param", func(t *testing.T) {
-		hattrs := &envoy_service_auth_v2.AttributeContext_HttpRequest{
+		hattrs := &envoy_service_auth_v3.AttributeContext_HttpRequest{
 			Id:     "req-1",
 			Method: "GET",
 			Path: "/hello/world?" + url.Values{

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/mitchellh/hashstructure/v2 v2.0.1
 	github.com/mitchellh/mapstructure v1.4.1
 	github.com/natefinch/atomic v0.0.0-20200526193002-18c0533a5b09
-	github.com/nsf/jsondiff v0.0.0-20210303162244-6ea32392771e
 	github.com/onsi/gocleanup v0.0.0-20140331211545-c1a5478700b5
 	github.com/open-policy-agent/opa v0.27.1
 	github.com/openzipkin/zipkin-go v0.2.5

--- a/go.sum
+++ b/go.sum
@@ -429,8 +429,6 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
-github.com/nsf/jsondiff v0.0.0-20210303162244-6ea32392771e h1:S+/ptYdZtpK/MDstwCyt+ZHdXEpz86RJZ5gyZU4txJY=
-github.com/nsf/jsondiff v0.0.0-20210303162244-6ea32392771e/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=

--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -11,7 +11,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	envoy_service_auth_v2 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/pomerium/pomerium/authenticate"
@@ -189,7 +189,7 @@ func setupAuthorize(src config.Source, controlPlane *controlplane.Server) (*auth
 	if err != nil {
 		return nil, fmt.Errorf("error creating authorize service: %w", err)
 	}
-	envoy_service_auth_v2.RegisterAuthorizationServer(controlPlane.GRPCServer, svc)
+	envoy_service_auth_v3.RegisterAuthorizationServer(controlPlane.GRPCServer, svc)
 
 	log.Info().Msg("enabled authorize service")
 	src.OnConfigChange(svc.OnConfigChange)

--- a/internal/controlplane/grpc_accesslog.go
+++ b/internal/controlplane/grpc_accesslog.go
@@ -3,7 +3,7 @@ package controlplane
 import (
 	"strings"
 
-	envoy_service_accesslog_v2 "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v2"
+	envoy_service_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v3"
 	"github.com/golang/protobuf/ptypes"
 	"github.com/rs/zerolog"
 
@@ -11,11 +11,11 @@ import (
 )
 
 func (srv *Server) registerAccessLogHandlers() {
-	envoy_service_accesslog_v2.RegisterAccessLogServiceServer(srv.GRPCServer, srv)
+	envoy_service_accesslog_v3.RegisterAccessLogServiceServer(srv.GRPCServer, srv)
 }
 
 // StreamAccessLogs receives logs from envoy and prints them to stdout.
-func (srv *Server) StreamAccessLogs(stream envoy_service_accesslog_v2.AccessLogService_StreamAccessLogsServer) error {
+func (srv *Server) StreamAccessLogs(stream envoy_service_accesslog_v3.AccessLogService_StreamAccessLogsServer) error {
 	for {
 		msg, err := stream.Recv()
 		if err != nil {

--- a/internal/controlplane/xds.go
+++ b/internal/controlplane/xds.go
@@ -89,6 +89,7 @@ func buildAccessLogs(options *config.Options) []*envoy_config_accesslog_v3.Acces
 					},
 				},
 			},
+			TransportApiVersion: envoy_config_core_v3.ApiVersion_V3,
 		},
 	})
 	return []*envoy_config_accesslog_v3.AccessLog{{

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -128,7 +128,8 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 								"clusterName": "pomerium-control-plane-grpc"
 							}
 						},
-						"logName": "ingress-http"
+						"logName": "ingress-http",
+						"transportApiVersion": "V3"
 					}
 				}
 			}],
@@ -156,7 +157,8 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 						"includePeerCertificate": true,
 						"statusOnError": {
 							"code": "InternalServerError"
-						}
+						},
+						"transportApiVersion": "V3"
 					}
 				},
 				{

--- a/internal/controlplane/xds_tracing.go
+++ b/internal/controlplane/xds_tracing.go
@@ -1,0 +1,62 @@
+package controlplane
+
+import (
+	"fmt"
+
+	envoy_config_trace_v3 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/telemetry/trace"
+)
+
+func (srv *Server) buildTracingProvider(options *config.Options) (*envoy_config_trace_v3.Tracing_Http, error) {
+	tracingOptions, err := config.NewTracingOptions(options)
+	if err != nil {
+		return nil, fmt.Errorf("invalid tracing config: %w", err)
+	}
+
+	switch tracingOptions.Provider {
+	case trace.DatadogTracingProviderName:
+		tracingTC, _ := anypb.New(&envoy_config_trace_v3.DatadogConfig{
+			CollectorCluster: "datadog-apm",
+			ServiceName:      tracingOptions.Service,
+		})
+		return &envoy_config_trace_v3.Tracing_Http{
+			Name: "envoy.tracers.datadog",
+			ConfigType: &envoy_config_trace_v3.Tracing_Http_TypedConfig{
+				TypedConfig: tracingTC,
+			},
+		}, nil
+	case trace.ZipkinTracingProviderName:
+		if tracingOptions.ZipkinEndpoint.String() == "" {
+			return nil, fmt.Errorf("missing zipkin url")
+		}
+
+		tracingTC, _ := anypb.New(
+			&envoy_config_trace_v3.OpenCensusConfig{
+				ZipkinExporterEnabled: true,
+				ZipkinUrl:             tracingOptions.ZipkinEndpoint.String(),
+				IncomingTraceContext: []envoy_config_trace_v3.OpenCensusConfig_TraceContext{
+					envoy_config_trace_v3.OpenCensusConfig_B3,
+					envoy_config_trace_v3.OpenCensusConfig_TRACE_CONTEXT,
+					envoy_config_trace_v3.OpenCensusConfig_CLOUD_TRACE_CONTEXT,
+					envoy_config_trace_v3.OpenCensusConfig_GRPC_TRACE_BIN,
+				},
+				OutgoingTraceContext: []envoy_config_trace_v3.OpenCensusConfig_TraceContext{
+					envoy_config_trace_v3.OpenCensusConfig_B3,
+					envoy_config_trace_v3.OpenCensusConfig_TRACE_CONTEXT,
+					envoy_config_trace_v3.OpenCensusConfig_GRPC_TRACE_BIN,
+				},
+			},
+		)
+		return &envoy_config_trace_v3.Tracing_Http{
+			Name: "envoy.tracers.opencensus",
+			ConfigType: &envoy_config_trace_v3.Tracing_Http_TypedConfig{
+				TypedConfig: tracingTC,
+			},
+		}, nil
+	default:
+		return nil, nil
+	}
+}

--- a/internal/envoy/envoy_test.go
+++ b/internal/envoy/envoy_test.go
@@ -1,82 +1,16 @@
 package envoy
 
 import (
-	"fmt"
 	"io/ioutil"
-	"net/url"
 	"regexp"
 	"strings"
 	"testing"
 
-	envoy_config_bootstrap_v3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
-	"github.com/golang/protobuf/proto"
-	"github.com/nsf/jsondiff"
 	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/telemetry/trace"
 	"github.com/pomerium/pomerium/internal/testutil"
 )
-
-func jsonDump(t *testing.T, m proto.GeneratedMessage) []byte {
-	t.Helper()
-
-	jsonBytes, err := protojson.Marshal(proto.MessageV2(m))
-	if err != nil {
-		t.Fatalf("failed to marshal json: %s", err)
-	}
-	return jsonBytes
-}
-
-func Test_addTraceConfig(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name    string
-		opts    *config.TracingOptions
-		want    string
-		wantErr bool
-	}{
-		{
-			"good zipkin",
-			&config.TracingOptions{Provider: trace.ZipkinTracingProviderName, ZipkinEndpoint: &url.URL{Host: "localhost:9411"}},
-			`{"tracing":{"http":{"name":"envoy.tracers.opencensus","typedConfig":{"@type":"type.googleapis.com/envoy.config.trace.v3.OpenCensusConfig","zipkinExporterEnabled":true,"zipkinUrl":"//localhost:9411","incomingTraceContext":["B3","TRACE_CONTEXT","CLOUD_TRACE_CONTEXT","GRPC_TRACE_BIN"],"outgoingTraceContext":["B3","TRACE_CONTEXT","GRPC_TRACE_BIN"]}}}}`,
-			false,
-		},
-		{
-			"good jaeger",
-			&config.TracingOptions{Provider: trace.JaegerTracingProviderName},
-			`{}`,
-			false,
-		},
-		{
-			"bad zipkin",
-			&config.TracingOptions{Provider: trace.ZipkinTracingProviderName, ZipkinEndpoint: &url.URL{}},
-			`{}`,
-			true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			srv := &Server{
-				options: serverOptions{
-					tracingOptions: *tt.opts,
-				},
-			}
-			baseCfg := &envoy_config_bootstrap_v3.Bootstrap{}
-
-			err := srv.addTraceConfig(baseCfg)
-
-			assert.Equal(t, tt.wantErr, err != nil, "unexpected error state")
-
-			diff, diffStr := jsondiff.Compare([]byte(tt.want), jsonDump(t, baseCfg), &jsondiff.Options{})
-			assert.Equal(t, jsondiff.FullMatch, diff, fmt.Sprintf("%s: differences: %s", diff.String(), diffStr))
-		})
-	}
-}
 
 func Test_buildStatsConfig(t *testing.T) {
 	tests := []struct {

--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -4,7 +4,7 @@ set -euo pipefail
 PATH="$PATH:$(go env GOPATH)/bin"
 export PATH
 
-_envoy_version=1.16.2
+_envoy_version=1.17.1
 _dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../bin"
 _target="${TARGET:-"$(go env GOOS)_$(go env GOARCH)"}"
 


### PR DESCRIPTION
## Summary
Upgrade envoy to v1.17.1. The `v2` API is deprecated, so we switch the authorize service to the v3 API as well as several typed configs. Tracing also had to move to the control plane instead of the bootstrap.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
