### PR TITLE
envoy: restrict permissions on embedded envoy binary

### DIFF
--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -73,7 +73,7 @@ type Server struct {
 // NewServer creates a new server with traffic routed by envoy.
 func NewServer(src config.Source, grpcPort, httpPort string) (*Server, error) {
 	wd := filepath.Join(os.TempDir(), workingDirectoryName)
-	err := os.MkdirAll(wd, 0o755)
+	err := os.MkdirAll(wd, embeddedEnvoyPermissions)
 	if err != nil {
 		return nil, fmt.Errorf("error creating temporary working directory for envoy: %w", err)
 	}


### PR DESCRIPTION
## Summary
We should be able to have tighter permissions on the embedded envoy binary and config file. This changes them from `755` to `700`.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
