### PR TITLE
config: use getters for certificates

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -228,21 +228,20 @@ func (a *Authorize) getEvaluatorRequestFromCheckRequest(
 
 func (a *Authorize) getDownstreamClientCA(policy *config.Policy) (string, error) {
 	options := a.currentOptions.Load()
-	switch {
-	case policy != nil && policy.TLSDownstreamClientCA != "":
+
+	if policy != nil && policy.TLSDownstreamClientCA != "" {
 		bs, err := base64.StdEncoding.DecodeString(policy.TLSDownstreamClientCA)
 		if err != nil {
 			return "", err
 		}
 		return string(bs), nil
-	case options.ClientCA != "":
-		bs, err := base64.StdEncoding.DecodeString(options.ClientCA)
-		if err != nil {
-			return "", err
-		}
-		return string(bs), nil
 	}
-	return "", nil
+
+	ca, err := options.GetClientCA()
+	if err != nil {
+		return "", err
+	}
+	return string(ca), nil
 }
 
 func (a *Authorize) getMatchingPolicy(requestURL url.URL) *config.Policy {

--- a/config/config.go
+++ b/config/config.go
@@ -23,11 +23,16 @@ func (cfg *Config) Clone() *Config {
 }
 
 // AllCertificates returns all the certificates in the config.
-func (cfg *Config) AllCertificates() []tls.Certificate {
+func (cfg *Config) AllCertificates() ([]tls.Certificate, error) {
+	optionCertificates, err := cfg.Options.GetCertificates()
+	if err != nil {
+		return nil, err
+	}
+
 	var certs []tls.Certificate
-	certs = append(certs, cfg.Options.Certificates...)
+	certs = append(certs, optionCertificates...)
 	certs = append(certs, cfg.AutoCertificates...)
-	return certs
+	return certs, nil
 }
 
 // Checksum returns the config checksum.

--- a/config/config_source.go
+++ b/config/config_source.go
@@ -216,8 +216,6 @@ func (src *FileWatcherSource) check(cfg *Config) {
 
 	// update the computed config
 	src.computedConfig = cfg.Clone()
-	src.computedConfig.Options.Certificates = nil
-	_ = src.computedConfig.Options.Validate()
 
 	// trigger a change
 	src.Trigger(src.computedConfig)

--- a/databroker/databroker.go
+++ b/databroker/databroker.go
@@ -33,12 +33,13 @@ func (srv *dataBrokerServer) OnConfigChange(cfg *config.Config) {
 }
 
 func (srv *dataBrokerServer) getOptions(cfg *config.Config) []databroker.ServerOption {
+	cert, _ := cfg.Options.GetDataBrokerCertificate()
 	return []databroker.ServerOption{
 		databroker.WithSharedKey(cfg.Options.SharedKey),
 		databroker.WithStorageType(cfg.Options.DataBrokerStorageType),
 		databroker.WithStorageConnectionString(cfg.Options.DataBrokerStorageConnectionString),
 		databroker.WithStorageCAFile(cfg.Options.DataBrokerStorageCAFile),
-		databroker.WithStorageCertificate(cfg.Options.DataBrokerCertificate),
+		databroker.WithStorageCertificate(cert),
 		databroker.WithStorageCertSkipVerify(cfg.Options.DataBrokerStorageCertSkipVerify),
 	}
 }

--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -102,8 +102,12 @@ func (mgr *Manager) getCertMagicConfig(cfg *config.Config) (*certmagic.Config, e
 	mgr.certmagic.MustStaple = cfg.Options.AutocertOptions.MustStaple
 	mgr.certmagic.OnDemand = nil // disable on-demand
 	mgr.certmagic.Storage = &certmagic.FileStorage{Path: cfg.Options.AutocertOptions.Folder}
+	certs, err := cfg.AllCertificates()
+	if err != nil {
+		return nil, err
+	}
 	// add existing certs to the cache, and staple OCSP
-	for _, cert := range cfg.AllCertificates() {
+	for _, cert := range certs {
 		if err := mgr.certmagic.CacheUnmanagedTLSCertificate(cert, nil); err != nil {
 			return nil, fmt.Errorf("config: failed caching cert: %w", err)
 		}

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -630,7 +630,13 @@ func (srv *Server) buildRouteConfiguration(name string, virtualHosts []*envoy_co
 }
 
 func (srv *Server) buildDownstreamTLSContext(cfg *config.Config, domain string) *envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext {
-	cert, err := cryptutil.GetCertificateForDomain(cfg.AllCertificates(), domain)
+	certs, err := cfg.AllCertificates()
+	if err != nil {
+		log.Warn().Str("domain", domain).Err(err).Msg("failed to get certificate for domain")
+		return nil
+	}
+
+	cert, err := cryptutil.GetCertificateForDomain(certs, domain)
 	if err != nil {
 		log.Warn().Str("domain", domain).Err(err).Msg("failed to get certificate for domain")
 		return nil
@@ -791,7 +797,7 @@ func getDownstreamValidationContext(
 ) *envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext {
 	needsClientCert := false
 
-	if cfg.Options.ClientCA != "" {
+	if ca, _ := cfg.Options.GetClientCA(); len(ca) > 0 {
 		needsClientCert = true
 	}
 	if !needsClientCert {

--- a/internal/controlplane/xds_listeners_test.go
+++ b/internal/controlplane/xds_listeners_test.go
@@ -1,7 +1,6 @@
 package controlplane
 
 import (
-	"crypto/tls"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +12,6 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/controlplane/filemgr"
 	"github.com/pomerium/pomerium/internal/testutil"
-	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
 const (
@@ -467,11 +465,6 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 }
 
 func Test_buildDownstreamTLSContext(t *testing.T) {
-	certA, err := cryptutil.CertificateFromBase64(aExampleComCert, aExampleComKey)
-	if !assert.NoError(t, err) {
-		return
-	}
-
 	srv, _ := NewServer("TEST", nil)
 
 	cacheDir, _ := os.UserCacheDir()
@@ -480,7 +473,8 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 
 	t.Run("no-validation", func(t *testing.T) {
 		downstreamTLSContext := srv.buildDownstreamTLSContext(&config.Config{Options: &config.Options{
-			Certificates: []tls.Certificate{*certA},
+			Cert: aExampleComCert,
+			Key:  aExampleComKey,
 		}}, "a.example.com")
 
 		testutil.AssertProtoJSONEqual(t, `{
@@ -512,8 +506,9 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 	})
 	t.Run("client-ca", func(t *testing.T) {
 		downstreamTLSContext := srv.buildDownstreamTLSContext(&config.Config{Options: &config.Options{
-			Certificates: []tls.Certificate{*certA},
-			ClientCA:     "TEST",
+			Cert:     aExampleComCert,
+			Key:      aExampleComKey,
+			ClientCA: "TEST",
 		}}, "a.example.com")
 
 		testutil.AssertProtoJSONEqual(t, `{
@@ -548,7 +543,8 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 	})
 	t.Run("policy-client-ca", func(t *testing.T) {
 		downstreamTLSContext := srv.buildDownstreamTLSContext(&config.Config{Options: &config.Options{
-			Certificates: []tls.Certificate{*certA},
+			Cert: aExampleComCert,
+			Key:  aExampleComKey,
 			Policies: []config.Policy{
 				{
 					Source:                &config.StringURL{URL: mustParseURL(t, "https://a.example.com")},


### PR DESCRIPTION
## Summary
As part of removing side-effects from config option validation, this PR uses `Get`... methods for certificates.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
