### PR TITLE
support host:port in metrics_address

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -690,7 +690,7 @@ func (o *Options) Validate() error {
 	}
 
 	if o.MetricsAddr != "" {
-		if err := ValidateListenerAddress(o.MetricsAddr); err != nil {
+		if err := ValidateMetricsAddress(o.MetricsAddr); err != nil {
 			return fmt.Errorf("config: invalid metrics_addr: %w", err)
 		}
 	}

--- a/config/validate.go
+++ b/config/validate.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
@@ -39,15 +40,19 @@ func GetEnvoyDNSLookupFamily(value string) envoy_config_cluster_v3.Cluster_DnsLo
 	return envoy_config_cluster_v3.Cluster_AUTO
 }
 
-// ValidateListenerAddress validates that a listener address is ip:port, not host:port.
-func ValidateListenerAddress(addr string) error {
-	host, _, err := net.SplitHostPort(addr)
-	if err != nil {
-		return fmt.Errorf("invalid address, expected host:port")
+// ValidateMetricsAddress validates address for the metrics
+func ValidateMetricsAddress(addr string) error {
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil || port == "" {
+		return fmt.Errorf("expected host:port")
 	}
 
-	if host != "" && net.ParseIP(host) == nil {
-		return fmt.Errorf("invalid address, expected ip for host")
+	p, err := strconv.Atoi(port)
+	if err != nil {
+		return fmt.Errorf("port must be a number")
+	}
+	if p <= 0 {
+		return fmt.Errorf("expected positive port number")
 	}
 
 	return nil

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -224,9 +224,17 @@ func (srv *Server) buildMetricsListener(cfg *config.Config) (*envoy_config_liste
 		}
 	}
 
+	// we ignore the host part of the address, only binding to
+	_, port, err := net.SplitHostPort(cfg.Options.MetricsAddr)
+	if err != nil {
+		return nil, fmt.Errorf("metrics_addr %s: %w", cfg.Options.MetricsAddr, err)
+	} else if port == "" {
+		return nil, fmt.Errorf("metrics_addr %s: port is required", cfg.Options.MetricsAddr)
+	}
+
 	li := &envoy_config_listener_v3.Listener{
 		Name:         "metrics-ingress",
-		Address:      buildAddress(cfg.Options.MetricsAddr, 9902),
+		Address:      buildAddress(fmt.Sprintf(":%s", port), 9902),
 		FilterChains: []*envoy_config_listener_v3.FilterChain{filterChain},
 	}
 	return li, nil

--- a/internal/controlplane/xds_listeners.go
+++ b/internal/controlplane/xds_listeners.go
@@ -225,16 +225,21 @@ func (srv *Server) buildMetricsListener(cfg *config.Config) (*envoy_config_liste
 	}
 
 	// we ignore the host part of the address, only binding to
-	_, port, err := net.SplitHostPort(cfg.Options.MetricsAddr)
+	host, port, err := net.SplitHostPort(cfg.Options.MetricsAddr)
 	if err != nil {
 		return nil, fmt.Errorf("metrics_addr %s: %w", cfg.Options.MetricsAddr, err)
-	} else if port == "" {
+	}
+	if port == "" {
 		return nil, fmt.Errorf("metrics_addr %s: port is required", cfg.Options.MetricsAddr)
+	}
+	// unless an explicit IP address was provided, and bind to all interfaces if hostname was provided
+	if net.ParseIP(host) == nil {
+		host = ""
 	}
 
 	li := &envoy_config_listener_v3.Listener{
 		Name:         "metrics-ingress",
-		Address:      buildAddress(fmt.Sprintf(":%s", port), 9902),
+		Address:      buildAddress(fmt.Sprintf("%s:%s", host, port), 9902),
 		FilterChains: []*envoy_config_listener_v3.FilterChain{filterChain},
 	}
 	return li, nil

--- a/internal/registry/constants.go
+++ b/internal/registry/constants.go
@@ -19,4 +19,5 @@ const (
 var (
 	errNoMetricsAddr = errors.New("no metrics address provided")
 	errNoMetricsPort = errors.New("no metrics port provided")
+	errNoMetricsHost = errors.New("no metrics host provided")
 )

--- a/internal/registry/reporter_test.go
+++ b/internal/registry/reporter_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/pomerium/pomerium/config"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/registry/reporter_test.go
+++ b/internal/registry/reporter_test.go
@@ -1,0 +1,32 @@
+package registry
+
+import (
+	"testing"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMetricsURL(t *testing.T) {
+	for opt, expect := range map[*config.Options]string{
+		{MetricsAddr: "my.host:9090"}: "http://my.host:9090/metrics",
+		{MetricsAddr: "my.host:9090", MetricsBasicAuth: "bXl1c2VyOm15cGFzc3dvcmQ="}: "http://myuser:mypassword@my.host:9090/metrics",
+		{MetricsAddr: "my.host:9090", MetricsCertificate: "CERT"}:                   "https://my.host:9090/metrics",
+		{MetricsAddr: "my.host:9090", MetricsCertificateFile: "CERT"}:               "https://my.host:9090/metrics",
+	} {
+		u, err := metricsURL(*opt)
+		if assert.NoError(t, err, opt) {
+			assert.Equal(t, expect, u.String())
+		}
+	}
+
+	for _, opt := range []config.Options{
+		{MetricsAddr: "my.host:"},
+		{MetricsAddr: "my.host:9090", MetricsBasicAuth: "SMTH"},
+		{MetricsAddr: ":9090"},
+		{MetricsAddr: "my.host"},
+	} {
+		_, err := metricsURL(opt)
+		assert.Error(t, err, opt)
+	}
+}


### PR DESCRIPTION
## Summary

`metrics_address` logic [was previously altered](https://github.com/pomerium/pomerium/pull/1939/files#diff-22920b1b96bb2c68825bb4d927afa5c33804be1939b99d76476e5e307ea669eeR49-R51) to only allow IP addresses.

This field is also used by metrics reporter, that previously relied on a hostname to determine the metrics scraping address it can advertise via service registry. 

There's no uniform way for an application to know its DNS hostname, which is why it has to be supplied externally. 

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
