### PR TITLE
change require_proxy_protocol to use_proxy_protocol

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -265,7 +265,7 @@ type Options struct {
 	GoogleCloudServerlessAuthenticationServiceAccount string `mapstructure:"google_cloud_serverless_authentication_service_account" yaml:"google_cloud_serverless_authentication_service_account,omitempty"` //nolint
 
 	// UseProxyProtocol configures the HTTP listener to require the HAProxy proxy protocol (either v1 or v2) on incoming requests.
-	UseProxyProtocol bool `mapstructure:"require_proxy_protocol" yaml:"require_proxy_protocol,omitempty" json:"require_proxy_protocol,omitempty"`
+	UseProxyProtocol bool `mapstructure:"use_proxy_protocol" yaml:"use_proxy_protocol,omitempty" json:"use_proxy_protocol,omitempty"`
 
 	viper *viper.Viper
 


### PR DESCRIPTION
I set `use_proxy_protocol` to be true in my yaml config. Envoy didn't use proxy protocol albeit. Both the documents and https://github.com/pomerium/pomerium/pull/1777 hint the name should be use_proxy_protocol.