### PR TITLE
add default gitlab url

### DIFF
--- a/internal/directory/provider.go
+++ b/internal/directory/provider.go
@@ -59,7 +59,11 @@ func GetProvider(options Options) (provider Provider) {
 		globalProvider.options = options
 	}()
 
-	providerURL, _ := url.Parse(options.ProviderURL)
+	var providerURL *url.URL
+	// url.Parse will succeed even if we pass an empty string
+	if options.ProviderURL != "" {
+		providerURL, _ = url.Parse(options.ProviderURL)
+	}
 	switch options.Provider {
 	case auth0.Name:
 		serviceAccount, err := auth0.ParseServiceAccount(options)


### PR DESCRIPTION
## Summary
The document about how to set gitlab.com as a idp provider https://www.pomerium.com/docs/identity-providers/gitlab.html#gitlab-com didn't mention we need to specify `idp_provider_url: "https://gitlab.com/"` in the config file.
I only set `id_provider`, `idp_client_id`, `idp_client_secret` and `idp_service_account` as in the document. I was baffled  by the error 
```
8:54PM WRN failed to refresh directory users and groups error="gitlab: error querying groups: Get \"/api/v4/groups\": unsupported protocol scheme \"\"" service=identity_manager
```

This error is due to pomerium actually tried to request url `/api/v4/groups` instead of `https://gitlab.com/api/v4/groups`. I think it is more reasonable to set a default endpoint `https://gitlab.com/` for gitlab.

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
