### PR TITLE
skip REDIS cluster test if GOOS != linux

### DIFF
--- a/pkg/storage/redis/redis_test.go
+++ b/pkg/storage/redis/redis_test.go
@@ -91,17 +91,19 @@ func TestBackend(t *testing.T) {
 		}))
 	})
 
-	t.Run("cluster", func(t *testing.T) {
-		require.NoError(t, testutil.WithTestRedisCluster(func(rawURL string) error {
-			return handler(t, false, rawURL)
-		}))
-	})
+	if runtime.GOOS == "linux" {
+		t.Run("cluster", func(t *testing.T) {
+			require.NoError(t, testutil.WithTestRedisCluster(func(rawURL string) error {
+				return handler(t, false, rawURL)
+			}))
+		})
 
-	t.Run("sentinel", func(t *testing.T) {
-		require.NoError(t, testutil.WithTestRedisSentinel(func(rawURL string) error {
-			return handler(t, false, rawURL)
-		}))
-	})
+		t.Run("sentinel", func(t *testing.T) {
+			require.NoError(t, testutil.WithTestRedisSentinel(func(rawURL string) error {
+				return handler(t, false, rawURL)
+			}))
+		})
+	}
 }
 
 func TestChangeSignal(t *testing.T) {


### PR DESCRIPTION
## Summary

There are issues running REDIS cluster tests on MacOS. This PR restricts these tests to just Linux. 

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
