### PR TITLE
authenticate: fix default sign out url

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -598,7 +598,7 @@ func (a *Authenticate) getSignOutURL(r *http.Request) (*url.URL, error) {
 		return nil, err
 	}
 
-	uri.ResolveReference(&url.URL{
+	uri = uri.ResolveReference(&url.URL{
 		Path: "/.pomerium/sign_out",
 	})
 	if redirectURI := r.FormValue(urlutil.QueryRedirectURI); redirectURI != "" {

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -57,7 +57,7 @@ func (p *Proxy) RobotsTxt(w http.ResponseWriter, _ *http.Request) {
 func (p *Proxy) SignOut(w http.ResponseWriter, r *http.Request) error {
 	state := p.state.Load()
 
-	redirectURL := &url.URL{Scheme: "https", Host: r.Host, Path: "/"}
+	var redirectURL *url.URL
 	signOutURL, err := p.currentOptions.Load().GetSignOutRedirectURL()
 	if err != nil {
 		return httputil.NewError(http.StatusInternalServerError, err)
@@ -71,7 +71,9 @@ func (p *Proxy) SignOut(w http.ResponseWriter, r *http.Request) error {
 
 	dashboardURL := *state.authenticateDashboardURL
 	q := dashboardURL.Query()
-	q.Set(urlutil.QueryRedirectURI, redirectURL.String())
+	if redirectURL != nil {
+		q.Set(urlutil.QueryRedirectURI, redirectURL.String())
+	}
 	dashboardURL.RawQuery = q.Encode()
 
 	state.sessionStore.ClearSession(w, r)


### PR DESCRIPTION
## Summary
Remove the default redirect to `/` when logging out from the proxy. We already have code in authenticate to show a `OK: user logged out` message. 

Also fix an issue where the logout button was pointing to the authenticate root path instead of `/.pomerium/sign_out`.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
