### PR TITLE
databroker: remove unused installation id, close streams when backend is closed

### DIFF
--- a/databroker/databroker.go
+++ b/databroker/databroker.go
@@ -35,7 +35,6 @@ func (srv *dataBrokerServer) OnConfigChange(cfg *config.Config) {
 func (srv *dataBrokerServer) getOptions(cfg *config.Config) []databroker.ServerOption {
 	cert, _ := cfg.Options.GetDataBrokerCertificate()
 	return []databroker.ServerOption{
-		databroker.WithInstallationID(cfg.Options.InstallationID),
 		databroker.WithSharedKey(cfg.Options.SharedKey),
 		databroker.WithStorageType(cfg.Options.DataBrokerStorageType),
 		databroker.WithStorageConnectionString(cfg.Options.DataBrokerStorageConnectionString),

--- a/internal/databroker/config.go
+++ b/internal/databroker/config.go
@@ -20,7 +20,6 @@ var (
 )
 
 type serverConfig struct {
-	installationID          string
 	deletePermanentlyAfter  time.Duration
 	secret                  []byte
 	storageType             string
@@ -58,13 +57,6 @@ func WithDeletePermanentlyAfter(dur time.Duration) ServerOption {
 func WithGetAllPageSize(pageSize int) ServerOption {
 	return func(cfg *serverConfig) {
 		cfg.getAllPageSize = pageSize
-	}
-}
-
-// WithInstallationID sets the installation id in the config.
-func WithInstallationID(installationID string) ServerOption {
-	return func(cfg *serverConfig) {
-		cfg.installationID = installationID
 	}
 }
 

--- a/pkg/storage/inmemory/stream.go
+++ b/pkg/storage/inmemory/stream.go
@@ -30,6 +30,14 @@ func newRecordStream(ctx context.Context, backend *Backend, version uint64) *rec
 
 		closed: make(chan struct{}),
 	}
+	// if the backend is closed, close the stream
+	go func() {
+		select {
+		case <-stream.closed:
+		case <-backend.closed:
+			_ = stream.Close()
+		}
+	}()
 	return stream
 }
 

--- a/pkg/storage/redis/stream.go
+++ b/pkg/storage/redis/stream.go
@@ -27,7 +27,7 @@ type recordStream struct {
 }
 
 func newRecordStream(ctx context.Context, backend *Backend, version uint64) *recordStream {
-	return &recordStream{
+	stream := &recordStream{
 		ctx:     ctx,
 		backend: backend,
 
@@ -36,6 +36,15 @@ func newRecordStream(ctx context.Context, backend *Backend, version uint64) *rec
 
 		closed: make(chan struct{}),
 	}
+	// if the backend is closed, close the stream
+	go func() {
+		select {
+		case <-stream.closed:
+		case <-backend.closed:
+			_ = stream.Close()
+		}
+	}()
+	return stream
 }
 
 func (stream *recordStream) Close() error {


### PR DESCRIPTION
## Summary
Updating the installation id was causing the in-memory databroker store to get recreated. This would then close the backend, but corresponding streams weren't being closed. This change fixes it so they're closed explicitly for both the in-memory and redis (which was less prone to the issue because it also periodically polls). I also removed the installation id from the databroker server config, because we actually only use it in the telemetry package, so there's no need to use it directly.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
