### PR TITLE
docs: update community slack link

### DIFF
--- a/docs/docs/community/readme.md
+++ b/docs/docs/community/readme.md
@@ -21,7 +21,7 @@ On Twitter, we are [@pomerium_io](https://twitter.com/pomerium_io).
 
 ## Get help
 
-If you have a question about using Pomerium, [join our slack channel](http://slack.pomerium.io/)! There will be more people there who can help you than just the Pomerium developers who follow our issue tracker. Issues are not the place for usage questions.
+If you have a question about using Pomerium, [join our slack channel](https://join.slack.com/t/pomerium-io/shared_invite/zt-o2ith4qr-_qYANnwpW09p1R_~fYPP4w)! There will be more people there who can help you than just the Pomerium developers who follow our issue tracker. Issues are not the place for usage questions.
 
 ## Report bugs
 


### PR DESCRIPTION
## Summary

It seems like Slack now supports nearly-never expiring invite URLs, which is a better option than slack-in or slackin-extended.

## Related issues

https://github.com/pomerium/pomerium/issues/2014

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
