### PR TITLE
cryptutil: always use kek public id, add x509 support

### DIFF
--- a/config/crypt.go
+++ b/config/crypt.go
@@ -22,5 +22,5 @@ func (o *Options) GetAuditKey() (*cryptutil.PublicKeyEncryptionKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cryptutil.NewPublicKeyEncryptionKey(o.AuditKey.ID, raw)
+	return cryptutil.NewPublicKeyEncryptionKeyWithID(o.AuditKey.ID, raw)
 }

--- a/pkg/cryptutil/kek_test.go
+++ b/pkg/cryptutil/kek_test.go
@@ -21,7 +21,7 @@ func TestKeyEncryptionKey(t *testing.T) {
 	t.Run("anonymous", func(t *testing.T) {
 		kek, err := GenerateKeyEncryptionKey()
 		require.NoError(t, err)
-		kekPublic, err := NewPublicKeyEncryptionKey(kek.ID(), kek.Public().KeyBytes())
+		kekPublic, err := NewPublicKeyEncryptionKey(kek.Public().KeyBytes())
 		require.NoError(t, err)
 		ciphertext, err := kekPublic.Encrypt([]byte("HELLO WORLD"))
 		require.NoError(t, err)
@@ -43,7 +43,7 @@ func TestKeyEncryptionKey(t *testing.T) {
 	t.Run("ID", func(t *testing.T) {
 		kek, err := GenerateKeyEncryptionKey()
 		require.NoError(t, err)
-		assert.Equal(t, kek.id, kek.ID())
+		assert.Equal(t, kek.Public().id, kek.ID())
 	})
 	t.Run("KeyBytes", func(t *testing.T) {
 		private, err := GenerateKeyEncryptionKey()
@@ -60,12 +60,12 @@ func TestKeyEncryptionKey(t *testing.T) {
 	})
 	t.Run("invalid key", func(t *testing.T) {
 		t.Run("private", func(t *testing.T) {
-			kek, err := NewPrivateKeyEncryptionKey("TEST", []byte("NOT BIG ENOUGH"))
+			kek, err := NewPrivateKeyEncryptionKey([]byte("NOT BIG ENOUGH"))
 			require.Nil(t, kek)
 			require.Error(t, err)
 		})
 		t.Run("public", func(t *testing.T) {
-			kek, err := NewPublicKeyEncryptionKey("TEST", []byte("NOT BIG ENOUGH"))
+			kek, err := NewPublicKeyEncryptionKey([]byte("NOT BIG ENOUGH"))
 			require.Nil(t, kek)
 			require.Error(t, err)
 		})

--- a/pkg/cryptutil/x509.go
+++ b/pkg/cryptutil/x509.go
@@ -1,0 +1,123 @@
+package cryptutil
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"errors"
+	"fmt"
+)
+
+// https://tools.ietf.org/id/draft-ietf-curdle-pkix-05.html#rfc.section.3
+var oidPublicKeyX25519 = asn1.ObjectIdentifier{1, 3, 101, 110}
+
+// from x509, used for ASN.1
+type (
+	pkcs8 struct {
+		Version    int
+		Algo       pkix.AlgorithmIdentifier
+		PrivateKey []byte
+	}
+	pkixPublicKey struct {
+		Algo      pkix.AlgorithmIdentifier
+		BitString asn1.BitString
+	}
+	publicKeyInfo struct {
+		Raw       asn1.RawContent
+		Algorithm pkix.AlgorithmIdentifier
+		PublicKey asn1.BitString
+	}
+)
+
+// MarshalPKCS8PrivateKey wraps x509.MarshalPKCS8PrivateKey with added support for KeyEncryptionKeys.
+func MarshalPKCS8PrivateKey(key interface{}) ([]byte, error) {
+	// also support a pointer to a private key encryption key
+	if kek, ok := key.(*PrivateKeyEncryptionKey); ok {
+		key = *kek
+	}
+	if kek, ok := key.(PrivateKeyEncryptionKey); ok {
+		var privKey pkcs8
+		privKey.Algo = pkix.AlgorithmIdentifier{
+			Algorithm: oidPublicKeyX25519,
+		}
+		curvePrivateKey, err := asn1.Marshal(kek.KeyBytes())
+		if err != nil {
+			return nil, fmt.Errorf("cryptutil: failed to marshal private key: %v", err)
+		}
+		privKey.PrivateKey = curvePrivateKey
+		return asn1.Marshal(privKey)
+	}
+
+	// fall back to the original MarshalPKCS8PrivateKey
+	return x509.MarshalPKCS8PrivateKey(key)
+}
+
+// MarshalPKIXPublicKey wraps x509.MarshalPKIXPublicKey with added support for KeyEncryptionKeys.
+func MarshalPKIXPublicKey(pub interface{}) ([]byte, error) {
+	if kek, ok := pub.(*PublicKeyEncryptionKey); ok {
+		pub = *kek
+	}
+	if kek, ok := pub.(PublicKeyEncryptionKey); ok {
+		val := pkixPublicKey{
+			Algo: pkix.AlgorithmIdentifier{
+				Algorithm: oidPublicKeyX25519,
+			},
+			BitString: asn1.BitString{
+				Bytes:     kek.KeyBytes(),
+				BitLength: 8 * len(kek.KeyBytes()),
+			},
+		}
+		ret, _ := asn1.Marshal(val)
+		return ret, nil
+	}
+
+	// fall back to the original MarshalPKIXPublicKey
+	return x509.MarshalPKIXPublicKey(pub)
+}
+
+// ParsePKCS8PrivateKey wraps x509.ParsePKCS8PrivateKey with added support for KeyEncryptionKeys.
+func ParsePKCS8PrivateKey(der []byte) (interface{}, error) {
+	var privKey pkcs8
+	_, err := asn1.Unmarshal(der, &privKey)
+	if err != nil {
+		return x509.ParsePKCS8PrivateKey(der)
+	}
+
+	if privKey.Algo.Algorithm.Equal(oidPublicKeyX25519) {
+		var bs []byte
+		if _, err := asn1.Unmarshal(privKey.PrivateKey, &bs); err != nil {
+			return nil, fmt.Errorf("cryptutil: invalid X25519 private key: %v", err)
+		}
+		return NewPrivateKeyEncryptionKey(bs)
+	}
+
+	// fallback to the original ParsePKCS8PrivateKey
+	return x509.ParsePKCS8PrivateKey(der)
+}
+
+// ParsePKIXPublicKey wraps x509.ParsePKIXPublicKey with added support for KeyEncryptionKeys.
+func ParsePKIXPublicKey(derBytes []byte) (pub interface{}, err error) {
+	var pki publicKeyInfo
+	rest, err := asn1.Unmarshal(derBytes, &pki)
+	if err != nil || len(rest) > 0 {
+		return x509.ParsePKIXPublicKey(derBytes)
+	}
+
+	if pki.Algorithm.Algorithm.Equal(oidPublicKeyX25519) {
+		asn1Data := pki.PublicKey.RightAlign()
+		// RFC 8410, Section 3
+		// > For all of the OIDs, the parameters MUST be absent.
+		if len(pki.Algorithm.Parameters.FullBytes) != 0 {
+			return nil, errors.New("cryptutil: x25519 key encoded with illegal parameters")
+		}
+		if len(asn1Data) != KeyEncryptionKeySize {
+			return nil, errors.New("cryptutil: wrong x25519 public key size")
+		}
+		pub := make([]byte, KeyEncryptionKeySize)
+		copy(pub, asn1Data)
+		return NewPublicKeyEncryptionKey(pub)
+	}
+
+	// fall back to the original ParsePKIXPublicKey
+	return x509.ParsePKIXPublicKey(derBytes)
+}

--- a/pkg/cryptutil/x509_test.go
+++ b/pkg/cryptutil/x509_test.go
@@ -1,0 +1,59 @@
+package cryptutil
+
+import (
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// generated using:
+//   openssl genpkey -algorithm x25519 -out priv.pem
+//   openssl pkey -in priv.pem -out pub.pem -pubout
+var (
+	rawPrivateX25519Key = []byte(`-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VuBCIEIKALoNgzCksH0v0Bc7Ghl8vGin4MAIKpmtZSmaMN0Vtb
+-----END PRIVATE KEY-----
+`)
+	rawPublicX25519Key = []byte(`-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VuAyEAk63g8PY1JJTkrranWTxGSd/yA5kAgJlPk4/srMKg9mg=
+-----END PUBLIC KEY-----
+`)
+)
+
+func TestPKCS8PrivateKey(t *testing.T) {
+	block, _ := pem.Decode(rawPrivateX25519Key)
+
+	kek, err := ParsePKCS8PrivateKey(block.Bytes)
+	assert.NoError(t, err)
+	assert.IsType(t, &PrivateKeyEncryptionKey{}, kek)
+
+	t.Run("marshal", func(t *testing.T) {
+		der, err := MarshalPKCS8PrivateKey(kek)
+		require.NoError(t, err)
+		actual := pem.EncodeToMemory(&pem.Block{
+			Type:  "PRIVATE KEY",
+			Bytes: der,
+		})
+		assert.Equal(t, rawPrivateX25519Key, actual)
+	})
+}
+
+func TestPKIXPublicKey(t *testing.T) {
+	block, _ := pem.Decode(rawPublicX25519Key)
+
+	kek, err := ParsePKIXPublicKey(block.Bytes)
+	assert.NoError(t, err)
+	assert.IsType(t, &PublicKeyEncryptionKey{}, kek)
+
+	t.Run("marshal", func(t *testing.T) {
+		der, err := MarshalPKIXPublicKey(kek)
+		require.NoError(t, err)
+		actual := pem.EncodeToMemory(&pem.Block{
+			Type:  "PUBLIC KEY",
+			Bytes: der,
+		})
+		assert.Equal(t, rawPublicX25519Key, actual)
+	})
+}


### PR DESCRIPTION
## Summary
Several changes:

1. Generate the key encryption key (KEK) id using the public KEK bytes instead of the private KEK bytes. This way given a public KEK, you can know the key id without needing the private KEK.
2. Add support for marshaling private KEKs via `MarshalPKCS8PrivateKey` similar to ed25519 keys, but with a different algorithm id.
3. Add support for marshaling public KEKs via `MarshalPKIXPublicKey` similar to ed25519 keys, but with a differnet algorithm id.

This should be interoperable with the standard format used by `openssl genpkey` and allows us to store KEKs in a predictable way.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
