### PR TITLE
directory: remove provider from user id

### DIFF
--- a/internal/directory/auth0/auth0_test.go
+++ b/internal/directory/auth0/auth0_test.go
@@ -100,12 +100,12 @@ func TestProvider_User(t *testing.T) {
 		WithDomain(srv.URL),
 		WithServiceAccount(&ServiceAccount{ClientID: "CLIENT_ID", Secret: "SECRET"}),
 	)
-	du, err := p.User(ctx, "auth0/user1", "")
+	du, err := p.User(ctx, "user1", "")
 	if !assert.NoError(t, err) {
 		return
 	}
 	testutil.AssertProtoJSONEqual(t, `{
-		"id": "auth0/user1",
+		"id": "user1",
 		"displayName": "User 1",
 		"email": "user1@example.com",
 		"groupIds": ["role1", "role2"]
@@ -359,15 +359,15 @@ func TestProvider_UserGroups(t *testing.T) {
 			},
 			expectedUsers: []*directory.User{
 				{
-					Id:       "auth0/i-am-user-id-1",
+					Id:       "i-am-user-id-1",
 					GroupIds: []string{"i-am-role-id-1"},
 				},
 				{
-					Id:       "auth0/i-am-user-id-2",
+					Id:       "i-am-user-id-2",
 					GroupIds: []string{"i-am-role-id-1"},
 				},
 				{
-					Id:       "auth0/i-am-user-id-3",
+					Id:       "i-am-user-id-3",
 					GroupIds: []string{"i-am-role-id-1"},
 				},
 			},
@@ -446,23 +446,23 @@ func TestProvider_UserGroups(t *testing.T) {
 			},
 			expectedUsers: []*directory.User{
 				{
-					Id:       "auth0/i-am-user-id-1",
+					Id:       "i-am-user-id-1",
 					GroupIds: []string{"i-am-role-id-1", "i-am-role-id-2"},
 				},
 				{
-					Id:       "auth0/i-am-user-id-2",
+					Id:       "i-am-user-id-2",
 					GroupIds: []string{"i-am-role-id-1"},
 				},
 				{
-					Id:       "auth0/i-am-user-id-3",
+					Id:       "i-am-user-id-3",
 					GroupIds: []string{"i-am-role-id-1"},
 				},
 				{
-					Id:       "auth0/i-am-user-id-4",
+					Id:       "i-am-user-id-4",
 					GroupIds: []string{"i-am-role-id-1", "i-am-role-id-2"},
 				},
 				{
-					Id:       "auth0/i-am-user-id-5",
+					Id:       "i-am-user-id-5",
 					GroupIds: []string{"i-am-role-id-2"},
 				},
 			},

--- a/internal/directory/azure/azure.go
+++ b/internal/directory/azure/azure.go
@@ -14,7 +14,6 @@ import (
 
 	"golang.org/x/oauth2"
 
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
 
@@ -108,14 +107,12 @@ func (p *Provider) User(ctx context.Context, userID, accessToken string) (*direc
 		return nil, fmt.Errorf("azure: service account not defined")
 	}
 
-	_, providerUserID := databroker.FromUserID(userID)
-
 	du := &directory.User{
 		Id: userID,
 	}
 
 	userURL := p.cfg.graphURL.ResolveReference(&url.URL{
-		Path: fmt.Sprintf("/v1.0/users/%s", providerUserID),
+		Path: fmt.Sprintf("/v1.0/users/%s", userID),
 	}).String()
 
 	var u usersDeltaResponseUser
@@ -127,7 +124,7 @@ func (p *Provider) User(ctx context.Context, userID, accessToken string) (*direc
 	du.Email = u.getEmail()
 
 	groupURL := p.cfg.graphURL.ResolveReference(&url.URL{
-		Path: fmt.Sprintf("/v1.0/users/%s/transitiveMemberOf", providerUserID),
+		Path: fmt.Sprintf("/v1.0/users/%s/transitiveMemberOf", userID),
 	}).String()
 
 	var res struct {

--- a/internal/directory/azure/azure_test.go
+++ b/internal/directory/azure/azure_test.go
@@ -118,12 +118,12 @@ func TestProvider_User(t *testing.T) {
 		}),
 	)
 
-	du, err := p.User(context.Background(), "azure/user-1", "")
+	du, err := p.User(context.Background(), "user-1", "")
 	if !assert.NoError(t, err) {
 		return
 	}
 	testutil.AssertProtoJSONEqual(t, `{
-		"id": "azure/user-1",
+		"id": "user-1",
 		"displayName": "User 1",
 		"email": "user1@example.com",
 		"groupIds": ["admin"]
@@ -151,19 +151,19 @@ func TestProvider_UserGroups(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []*directory.User{
 		{
-			Id:          "azure/user-1",
+			Id:          "user-1",
 			GroupIds:    []string{"admin"},
 			DisplayName: "User 1",
 			Email:       "user1@example.com",
 		},
 		{
-			Id:          "azure/user-2",
+			Id:          "user-2",
 			GroupIds:    []string{"test"},
 			DisplayName: "User 2",
 			Email:       "user2@example.com",
 		},
 		{
-			Id:          "azure/user-3",
+			Id:          "user-3",
 			GroupIds:    []string{"test"},
 			DisplayName: "User 3",
 			Email:       "user3@example.com",

--- a/internal/directory/azure/delta.go
+++ b/internal/directory/azure/delta.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
 
@@ -204,7 +203,7 @@ func (dc *deltaCollection) CurrentUserGroups() ([]*directory.Group, []*directory
 	var users []*directory.User
 	for _, u := range dc.users {
 		users = append(users, &directory.User{
-			Id:          databroker.GetUserID(Name, u.id),
+			Id:          u.id,
 			GroupIds:    groupLookup.getGroupIDsForUser(u.id),
 			DisplayName: u.displayName,
 			Email:       u.email,

--- a/internal/directory/github/github.go
+++ b/internal/directory/github/github.go
@@ -17,7 +17,6 @@ import (
 	"github.com/tomnomnom/linkheader"
 
 	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
 
@@ -89,12 +88,11 @@ func (p *Provider) User(ctx context.Context, userID, accessToken string) (*direc
 		return nil, fmt.Errorf("github: service account not defined")
 	}
 
-	_, providerUserID := databroker.FromUserID(userID)
 	du := &directory.User{
 		Id: userID,
 	}
 
-	au, err := p.getUser(ctx, providerUserID)
+	au, err := p.getUser(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -107,7 +105,7 @@ func (p *Provider) User(ctx context.Context, userID, accessToken string) (*direc
 		return nil, err
 	}
 	for _, orgSlug := range orgSlugs {
-		teamIDs, err := p.listUserOrganizationTeams(ctx, providerUserID, orgSlug)
+		teamIDs, err := p.listUserOrganizationTeams(ctx, userID, orgSlug)
 		if err != nil {
 			return nil, err
 		}
@@ -166,7 +164,7 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.Group, []*direc
 		}
 
 		user := &directory.User{
-			Id:          databroker.GetUserID(Name, userLogin),
+			Id:          userLogin,
 			GroupIds:    groups,
 			DisplayName: u.Name,
 			Email:       u.Email,

--- a/internal/directory/github/github_test.go
+++ b/internal/directory/github/github_test.go
@@ -130,12 +130,12 @@ func TestProvider_User(t *testing.T) {
 			PersonalAccessToken: "xyz",
 		}),
 	)
-	du, err := p.User(context.Background(), "github/user1", "")
+	du, err := p.User(context.Background(), "user1", "")
 	if !assert.NoError(t, err) {
 		return
 	}
 	testutil.AssertProtoJSONEqual(t, `{
-		"id": "github/user1",
+		"id": "user1",
 		"groupIds": ["1", "2", "3"],
 		"displayName": "User 1",
 		"email": "user1@example.com"
@@ -160,10 +160,10 @@ func TestProvider_UserGroups(t *testing.T) {
 	groups, users, err := p.UserGroups(context.Background())
 	assert.NoError(t, err)
 	testutil.AssertProtoJSONEqual(t, `[
-		{ "id": "github/user1", "groupIds": ["1", "2", "3"], "displayName": "User 1", "email": "user1@example.com" },
-		{ "id": "github/user2", "groupIds": ["1", "3"], "displayName": "User 2", "email": "user2@example.com" },
-		{ "id": "github/user3", "groupIds": ["3"], "displayName": "User 3", "email": "user3@example.com" },
-		{ "id": "github/user4", "groupIds": ["4"], "displayName": "User 4", "email": "user4@example.com" }
+		{ "id": "user1", "groupIds": ["1", "2", "3"], "displayName": "User 1", "email": "user1@example.com" },
+		{ "id": "user2", "groupIds": ["1", "3"], "displayName": "User 2", "email": "user2@example.com" },
+		{ "id": "user3", "groupIds": ["3"], "displayName": "User 3", "email": "user3@example.com" },
+		{ "id": "user4", "groupIds": ["4"], "displayName": "User 4", "email": "user4@example.com" }
 	]`, users)
 	testutil.AssertProtoJSONEqual(t, `[
 		{ "id": "1", "name": "team1" },

--- a/internal/directory/gitlab/gitlab.go
+++ b/internal/directory/gitlab/gitlab.go
@@ -15,7 +15,6 @@ import (
 	"github.com/tomnomnom/linkheader"
 
 	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
 
@@ -83,12 +82,11 @@ func New(options ...Option) *Provider {
 
 // User returns the user record for the given id.
 func (p *Provider) User(ctx context.Context, userID, accessToken string) (*directory.User, error) {
-	_, providerUserID := databroker.FromUserID(userID)
 	du := &directory.User{
 		Id: userID,
 	}
 
-	au, err := p.getUser(ctx, providerUserID, accessToken)
+	au, err := p.getUser(ctx, userID, accessToken)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +135,7 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.Group, []*direc
 	var users []*directory.User
 	for _, u := range userLookup {
 		user := &directory.User{
-			Id:          databroker.GetUserID(Name, fmt.Sprint(u.ID)),
+			Id:          fmt.Sprint(u.ID),
 			DisplayName: u.Name,
 			Email:       u.Email,
 		}

--- a/internal/directory/gitlab/gitlab_test.go
+++ b/internal/directory/gitlab/gitlab_test.go
@@ -69,9 +69,9 @@ func Test(t *testing.T) {
 	groups, users, err := p.UserGroups(context.Background())
 	assert.NoError(t, err)
 	testutil.AssertProtoJSONEqual(t, `[
-		{ "id": "gitlab/11", "groupIds": ["1"], "displayName": "User 1", "email": "user1@example.com" },
-		{ "id": "gitlab/12", "groupIds": ["2"], "displayName": "User 2", "email": "user2@example.com" },
-		{ "id": "gitlab/13", "groupIds": ["2"], "displayName": "User 3", "email": "user3@example.com" }
+		{ "id": "11", "groupIds": ["1"], "displayName": "User 1", "email": "user1@example.com" },
+		{ "id": "12", "groupIds": ["2"], "displayName": "User 2", "email": "user2@example.com" },
+		{ "id": "13", "groupIds": ["2"], "displayName": "User 3", "email": "user3@example.com" }
 	]`, users)
 	testutil.AssertProtoJSONEqual(t, `[
 		{ "id": "1", "name": "Group 1" },

--- a/internal/directory/google/google_test.go
+++ b/internal/directory/google/google_test.go
@@ -200,6 +200,6 @@ func TestProvider_UserGroups(t *testing.T) {
 		{Id: "group1"},
 	}, dgs)
 	assert.Equal(t, []*directory.User{
-		{Id: "google/user1", Email: "user1@example.com", GroupIds: []string{"group1"}},
+		{Id: "user1", Email: "user1@example.com", GroupIds: []string{"group1"}},
 	}, dus)
 }

--- a/internal/directory/okta/okta.go
+++ b/internal/directory/okta/okta.go
@@ -19,7 +19,6 @@ import (
 	"github.com/tomnomnom/linkheader"
 
 	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
 
@@ -114,19 +113,18 @@ func (p *Provider) User(ctx context.Context, userID, accessToken string) (*direc
 		return nil, ErrServiceAccountNotDefined
 	}
 
-	_, providerUserID := databroker.FromUserID(userID)
 	du := &directory.User{
 		Id: userID,
 	}
 
-	au, err := p.getUser(ctx, providerUserID)
+	au, err := p.getUser(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
 	du.DisplayName = au.getDisplayName()
 	du.Email = au.Profile.Email
 
-	groups, err := p.listUserGroups(ctx, providerUserID)
+	groups, err := p.listUserGroups(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -187,7 +185,7 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.Group, []*direc
 		groups := userIDToGroups[u.ID]
 		sort.Strings(groups)
 		users = append(users, &directory.User{
-			Id:          databroker.GetUserID(Name, u.ID),
+			Id:          u.ID,
 			GroupIds:    groups,
 			DisplayName: u.getDisplayName(),
 			Email:       u.Profile.Email,

--- a/internal/directory/okta/okta_test.go
+++ b/internal/directory/okta/okta_test.go
@@ -168,12 +168,12 @@ func TestProvider_User(t *testing.T) {
 		WithServiceAccount(&ServiceAccount{APIKey: "APITOKEN"}),
 		WithProviderURL(mustParseURL(srv.URL)),
 	)
-	user, err := p.User(context.Background(), "okta/a@example.com", "")
+	user, err := p.User(context.Background(), "a@example.com", "")
 	if !assert.NoError(t, err) {
 		return
 	}
 	testutil.AssertProtoJSONEqual(t, `{
-		"id": "okta/a@example.com",
+		"id": "a@example.com",
 		"groupIds": ["admin","user"],
 		"displayName": "first last",
 		"email": "a@example.com"
@@ -200,19 +200,19 @@ func TestProvider_UserGroups(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []*directory.User{
 		{
-			Id:          "okta/a@example.com",
+			Id:          "a@example.com",
 			GroupIds:    []string{"admin", "user"},
 			DisplayName: "first last",
 			Email:       "a@example.com",
 		},
 		{
-			Id:          "okta/b@example.com",
+			Id:          "b@example.com",
 			GroupIds:    []string{"test", "user"},
 			DisplayName: "first last",
 			Email:       "b@example.com",
 		},
 		{
-			Id:          "okta/c@example.com",
+			Id:          "c@example.com",
 			GroupIds:    []string{"user"},
 			DisplayName: "first last",
 			Email:       "c@example.com",
@@ -243,19 +243,19 @@ func TestProvider_UserGroupsQueryUpdated(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []*directory.User{
 		{
-			Id:          "okta/a@example.com",
+			Id:          "a@example.com",
 			GroupIds:    []string{"admin", "user"},
 			DisplayName: "first last",
 			Email:       "a@example.com",
 		},
 		{
-			Id:          "okta/b@example.com",
+			Id:          "b@example.com",
 			GroupIds:    []string{"test", "user"},
 			DisplayName: "first last",
 			Email:       "b@example.com",
 		},
 		{
-			Id:          "okta/c@example.com",
+			Id:          "c@example.com",
 			GroupIds:    []string{"user"},
 			DisplayName: "first last",
 			Email:       "c@example.com",
@@ -267,25 +267,25 @@ func TestProvider_UserGroupsQueryUpdated(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []*directory.User{
 		{
-			Id:          "okta/a@example.com",
+			Id:          "a@example.com",
 			GroupIds:    []string{"admin", "user"},
 			DisplayName: "first last",
 			Email:       "a@example.com",
 		},
 		{
-			Id:          "okta/b@example.com",
+			Id:          "b@example.com",
 			GroupIds:    []string{"test", "user"},
 			DisplayName: "first last",
 			Email:       "b@example.com",
 		},
 		{
-			Id:          "okta/c@example.com",
+			Id:          "c@example.com",
 			GroupIds:    []string{"user"},
 			DisplayName: "first last",
 			Email:       "c@example.com",
 		},
 		{
-			Id:          "okta/updated@example.com",
+			Id:          "updated@example.com",
 			GroupIds:    []string{"user-updated"},
 			DisplayName: "first last",
 			Email:       "updated@example.com",
@@ -299,25 +299,25 @@ func TestProvider_UserGroupsQueryUpdated(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []*directory.User{
 		{
-			Id:          "okta/a@example.com",
+			Id:          "a@example.com",
 			GroupIds:    []string{"admin", "user"},
 			DisplayName: "first last",
 			Email:       "a@example.com",
 		},
 		{
-			Id:          "okta/b@example.com",
+			Id:          "b@example.com",
 			GroupIds:    []string{"user"},
 			DisplayName: "first last",
 			Email:       "b@example.com",
 		},
 		{
-			Id:          "okta/c@example.com",
+			Id:          "c@example.com",
 			GroupIds:    []string{"user"},
 			DisplayName: "first last",
 			Email:       "c@example.com",
 		},
 		{
-			Id:          "okta/updated@example.com",
+			Id:          "updated@example.com",
 			GroupIds:    []string{"user-updated"},
 			DisplayName: "first last",
 			Email:       "updated@example.com",

--- a/internal/directory/onelogin/onelogin.go
+++ b/internal/directory/onelogin/onelogin.go
@@ -17,7 +17,6 @@ import (
 	"golang.org/x/oauth2"
 
 	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
 
@@ -99,7 +98,6 @@ func (p *Provider) User(ctx context.Context, userID, accessToken string) (*direc
 	if p.cfg.serviceAccount == nil {
 		return nil, fmt.Errorf("onelogin: service account not defined")
 	}
-	_, providerUserID := databroker.FromUserID(userID)
 	du := &directory.User{
 		Id: userID,
 	}
@@ -109,7 +107,7 @@ func (p *Provider) User(ctx context.Context, userID, accessToken string) (*direc
 		return nil, err
 	}
 
-	au, err := p.getUser(ctx, token.AccessToken, providerUserID)
+	au, err := p.getUser(ctx, token.AccessToken, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +144,7 @@ func (p *Provider) UserGroups(ctx context.Context) ([]*directory.Group, []*direc
 	var users []*directory.User
 	for _, u := range apiUsers {
 		users = append(users, &directory.User{
-			Id:          databroker.GetUserID(Name, strconv.Itoa(u.ID)),
+			Id:          strconv.Itoa(u.ID),
 			GroupIds:    []string{strconv.Itoa(u.GroupID)},
 			DisplayName: u.FirstName + " " + u.LastName,
 			Email:       u.Email,

--- a/internal/directory/onelogin/onelogin_test.go
+++ b/internal/directory/onelogin/onelogin_test.go
@@ -172,12 +172,12 @@ func TestProvider_User(t *testing.T) {
 		}),
 		WithURL(mustParseURL(srv.URL)),
 	)
-	user, err := p.User(context.Background(), "onelogin/111", "ACCESSTOKEN")
+	user, err := p.User(context.Background(), "111", "ACCESSTOKEN")
 	if !assert.NoError(t, err) {
 		return
 	}
 	testutil.AssertProtoJSONEqual(t, `{
-		"id": "onelogin/111",
+		"id": "111",
 		"groupIds": ["0"],
 		"displayName": "User 111",
 		"email": "admin@example.com"
@@ -206,9 +206,9 @@ func TestProvider_UserGroups(t *testing.T) {
 	groups, users, err := p.UserGroups(context.Background())
 	assert.NoError(t, err)
 	testutil.AssertProtoJSONEqual(t, `[
-		{ "id": "onelogin/111", "groupIds": ["0"], "displayName": "User 111", "email": "admin@example.com" },
-		{ "id": "onelogin/222", "groupIds": ["1"], "displayName": "User 222", "email": "test@example.com" },
-		{ "id": "onelogin/333", "groupIds": ["2"], "displayName": "User 333", "email": "user@example.com" }
+		{ "id": "111", "groupIds": ["0"], "displayName": "User 111", "email": "admin@example.com" },
+		{ "id": "222", "groupIds": ["1"], "displayName": "User 222", "email": "test@example.com" },
+		{ "id": "333", "groupIds": ["2"], "displayName": "User 333", "email": "user@example.com" }
 	]`, users)
 	testutil.AssertProtoJSONEqual(t, `[
 		{ "id": "0", "name": "admin" },

--- a/internal/sessions/state.go
+++ b/internal/sessions/state.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"gopkg.in/square/go-jose.v2/jwt"
-
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
 // ErrMissingID is the error for a session state that has no ID set.
@@ -86,9 +84,9 @@ func (s *State) IsExpired() bool {
 // UserID returns the corresponding user ID for a session.
 func (s *State) UserID(provider string) string {
 	if s.OID != "" {
-		return databroker.GetUserID(provider, s.OID)
+		return s.OID
 	}
-	return databroker.GetUserID(provider, s.Subject)
+	return s.Subject
 }
 
 // UnmarshalJSON returns a State struct from JSON. Additionally munges

--- a/pkg/grpc/databroker/databroker.go
+++ b/pkg/grpc/databroker/databroker.go
@@ -5,22 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strings"
 )
-
-// GetUserID gets the databroker user id from a provider user id.
-func GetUserID(provider, providerUserID string) string {
-	return provider + "/" + providerUserID
-}
-
-// FromUserID gets the provider and provider user id from a databroker user id.
-func FromUserID(userID string) (provider, providerUserID string) {
-	ps := strings.SplitN(userID, "/", 2)
-	if len(ps) < 2 {
-		return "", userID
-	}
-	return ps[0], ps[1]
-}
 
 // ApplyOffsetAndLimit applies the offset and limit to the list of records.
 func ApplyOffsetAndLimit(all []*Record, offset, limit int) (records []*Record, totalCount int) {

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -27,10 +27,10 @@ const (
 
 	// we rely on transactions in redis, so all redis-cluster keys need to be
 	// on the same node. Using a `hash tag` gives us this capability.
-	lastVersionKey   = "{pomerium}.last_version"
-	lastVersionChKey = "{pomerium}.last_version_ch"
-	recordHashKey    = "{pomerium}.records"
-	changesSetKey    = "{pomerium}.changes"
+	lastVersionKey   = "{pomerium_v2}.last_version"
+	lastVersionChKey = "{pomerium_v2}.last_version_ch"
+	recordHashKey    = "{pomerium_v2}.records"
+	changesSetKey    = "{pomerium_v2}.changes"
 )
 
 // custom errors


### PR DESCRIPTION
## Summary
Remove the provider name from the user id. For example `okta/12345` will now be `12345`.

This was originally added to perhaps support multiple providers, but ended up causing more problems than it was worth. We can solve multiple providers in a different way (if we ever pursue it).

I also updated the key in redis so all users will have to login again and get the new ids.

## Related issues
Fixes #2025 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
