### PR TITLE
config: use tls_custom_ca from policy when available

### DIFF
--- a/config/http.go
+++ b/config/http.go
@@ -78,7 +78,18 @@ func NewPolicyHTTPTransport(options *Options, policy *Policy) http.RoundTripper 
 			tlsClientConfig.MinVersion = tls.VersionTLS12
 			isCustomClientConfig = true
 		} else {
-			log.Error().Err(err).Msg("config: error getting cert pool")
+			log.Error().Err(err).Msg("config: error getting ca cert pool")
+		}
+	}
+
+	if policy.TLSCustomCA != "" || policy.TLSCustomCAFile != "" {
+		rootCAs, err := cryptutil.GetCertPool(policy.TLSCustomCA, policy.TLSCustomCAFile)
+		if err == nil {
+			tlsClientConfig.RootCAs = rootCAs
+			tlsClientConfig.MinVersion = tls.VersionTLS12
+			isCustomClientConfig = true
+		} else {
+			log.Error().Err(err).Msg("config: error getting custom ca cert pool")
 		}
 	}
 

--- a/config/http_test.go
+++ b/config/http_test.go
@@ -45,3 +45,39 @@ func TestHTTPTransport(t *testing.T) {
 	_, err := client.Get(s.URL)
 	assert.NoError(t, err)
 }
+
+func TestPolicyHTTPTransport(t *testing.T) {
+	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer s.Close()
+
+	get := func(options *Options, policy *Policy) (*http.Response, error) {
+		transport := NewPolicyHTTPTransport(options, policy)
+		client := &http.Client{
+			Transport: transport,
+		}
+		return client.Get(s.URL)
+	}
+
+	t.Run("default", func(t *testing.T) {
+		_, err := get(&Options{}, &Policy{})
+		assert.Error(t, err)
+	})
+	t.Run("skip verify", func(t *testing.T) {
+		_, err := get(&Options{}, &Policy{TLSSkipVerify: true})
+		assert.NoError(t, err)
+	})
+	t.Run("ca", func(t *testing.T) {
+		_, err := get(&Options{
+			CA: base64.StdEncoding.EncodeToString([]byte(localCert)),
+		}, &Policy{})
+		assert.NoError(t, err)
+	})
+	t.Run("custom ca", func(t *testing.T) {
+		_, err := get(&Options{}, &Policy{
+			TLSCustomCA: base64.StdEncoding.EncodeToString([]byte(localCert)),
+		})
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
This newer option was forgotten when we implemented the policy transport. It will now use the `tls_custom_ca` when set in the options.

There's also `tls_downstream_client_ca`, but that should still be handled by envoy.

## Related issues
- #2076 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
