### PR TITLE
propagate changes back from encrypted backend

### DIFF
--- a/pkg/storage/encrypted.go
+++ b/pkg/storage/encrypted.go
@@ -102,7 +102,14 @@ func (e *encryptedBackend) Put(ctx context.Context, record *databroker.Record) e
 	newRecord := proto.Clone(record).(*databroker.Record)
 	newRecord.Data = encrypted
 
-	return e.underlying.Put(ctx, newRecord)
+	if err = e.underlying.Put(ctx, newRecord); err != nil {
+		return err
+	}
+
+	record.ModifiedAt = newRecord.ModifiedAt
+	record.Version = newRecord.Version
+
+	return nil
 }
 
 func (e *encryptedBackend) Sync(ctx context.Context, version uint64) (RecordStream, error) {


### PR DESCRIPTION
## Summary

Fixes version and modified fields not propagating back when encrypted storage is used, that lead to zero version returned in record of GRPC `databroker.Put` call. 

This is a quick fix, probably a better approach would be to alter databroker API so that it would not mutate input arguments and rather return a changed record. 

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
