### PR TITLE
config: don't change address value on databroker or authorize

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -541,16 +541,6 @@ func (o *Options) Validate() error {
 		return errors.New("config: unknown databroker storage backend type")
 	}
 
-	if IsAuthorize(o.Services) || IsDataBroker(o.Services) {
-		// if authorize is set, we don't really need a http server
-		// but we'll still set one up incase the user wants to use
-		// the HTTP health check api
-		if o.Addr == o.GRPCAddr {
-			o.Addr = DefaultAlternativeAddr
-			log.Warn().Str("Addr", o.Addr).Str("GRPCAddr", o.Addr).Msg("config: default http handler changed")
-		}
-	}
-
 	if o.SharedKey == "" {
 		return errors.New("config: shared-key cannot be empty")
 	}


### PR DESCRIPTION
## Summary

Removes a legacy mutation on the `address` parameter which breaks GRPC TLS lookup.  See #2091 for additional context.

## Related issues

Closes #2091 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
