### PR TITLE
authorize: support arbitrary jwt claims

### DIFF
--- a/authorize/evaluator/opa/policy/authz.rego
+++ b/authorize/evaluator/opa/policy/authz.rego
@@ -246,8 +246,6 @@ additional_jwt_claims := [[k, v] |
 	]) == 0
 
 	# the claim value can come from session claims or user claims
-	# claim_value := object.get(session.claims, claim_key, object.get(user.claims, claim_key, null))
-	# claim_value != null
 	claim_value := object.get(session.claims, claim_key, object.get(user.claims, claim_key, null))
 
 	k := claim_key


### PR DESCRIPTION
## Summary
At some point we lost the ability to pass arbitrary IDP claims as headers or in the attestation header. This re-adds them.

The `base_jwt_claims` will take precedence.

## Related issues
- #1588 


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
