### PR TITLE
deployment: Publish OS packages to cloudsmith

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,26 +56,25 @@ jobs:
           echo ::set-output name=tag::${TAG}
           echo ::set-output name=version::${TAG#v}
 
-      - name: Install jfrog cli
-        uses: jfrog/setup-jfrog-cli@v1
-
-      - name: Configure jfrog cli
+      - name: Install Cloudsmith CLI
         run: |
-          jfrog bt config --user ${{ secrets.BINTRAY_USER }} --key ${{ secrets.BINTRAY_KEY }}
+          pip3 install cloudsmith-cli
 
-      - name: Upload packages to bintray beta channel
-        if: "contains(steps.tagName.outputs.version, 'rc') == 1"
-        run: |
-          VERSION=${{ steps.tagName.outputs.version }}
-          jfrog bt upload --publish dist/pomerium-${VERSION}-1.x86_64.rpm pomerium/enterprise-yum/pomerium/${VERSION} centos/8/x86_64/beta/
-          jfrog bt upload --publish dist/pomerium-cli-${VERSION}-1.x86_64.rpm pomerium/enterprise-yum/pomerium/${VERSION} centos/8/x86_64/beta/
-
-      - name: Upload packages to bintray stable channel
-        if: "contains(steps.tagName.outputs.version, 'rc') == 0"
+      - name: Publish to Cloudsmith
+        env:
+          CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+        working-directory: dist/
         run: |
           VERSION=${{ steps.tagName.outputs.version }}
-          jfrog bt upload --publish dist/pomerium-${VERSION}-1.x86_64.rpm pomerium/enterprise-yum/pomerium/${VERSION} centos/8/x86_64/stable/
-          jfrog bt upload --publish dist/pomerium-cli-${VERSION}-1.x86_64.rpm pomerium/enterprise-yum/pomerium/${VERSION} centos/8/x86_64/stable/
+          RPMS="pomerium-${VERSION}-1.x86_64.rpm pomerium-${VERSION}-1.aarch64.rpm pomerium-cli-${VERSION}-1.aarch64.rpm pomerium-cli-${VERSION}-1.x86_64.rpm pomerium-cli-${VERSION}-1.armhf.rpm"
+          for pkg in $(echo $RPMS); do
+            cloudsmith push rpm pomerium/pomerium/el/any-version $pkg
+          done
+
+          DEBS="pomerium-cli_${VERSION}-1_amd64.deb pomerium-cli_${VERSION}-1_arm64.deb pomerium-cli_${VERSION}-1_armhf.deb pomerium_${VERSION}-1_amd64.deb pomerium_${VERSION}-1_arm64.deb"
+          for pkg in $(echo $DEBS); do
+            cloudsmith push deb pomerium/pomerium/debian/any-version $pkg
+          done
 
       - name: Find latest tag
         id: latestTag

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -41,6 +41,7 @@ Official packages can be found on our [GitHub Releases](https://github.com/pomer
 
 [RPM Instructions](https://cloudsmith.io/~pomerium/repos/pomerium/setup/#formats-rpm)
 [Deb Instructions](https://cloudsmith.io/~pomerium/repos/pomerium/setup/#formats-deb)
+
 #### Example yum repo
 
 ```

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -39,8 +39,8 @@ curl -L https://github.com/pomerium/pomerium/releases/download/${VERSION}/pomeri
 
 Official packages can be found on our [GitHub Releases](https://github.com/pomerium/pomerium/releases) page or from [Cloudsmith](https://cloudsmith.io/~pomerium/repos/pomerium/packages/).
 
-[RPM Instructions](https://cloudsmith.io/~pomerium/repos/pomerium/setup/#formats-rpm)
-[Deb Instructions](https://cloudsmith.io/~pomerium/repos/pomerium/setup/#formats-deb)
+- [RPM Instructions](https://cloudsmith.io/~pomerium/repos/pomerium/setup/#formats-rpm)
+- [Deb Instructions](https://cloudsmith.io/~pomerium/repos/pomerium/setup/#formats-deb)
 
 #### Example yum repo
 
@@ -59,10 +59,7 @@ pkg_gpgcheck=1
 
 ```bash
 curl -1sLf 'https://dl.cloudsmith.io/public/pomerium/pomerium/gpg.6E388440B94E1407.key' | apt-key add -
-```
-
-```
-deb https://dl.cloudsmith.io/public/pomerium/pomerium/deb/debian buster main
+echo "deb https://dl.cloudsmith.io/public/pomerium/pomerium/deb/debian buster main" > /etc/apt/sources.list.d/pomerium-pomerium.list
 ```
 
 ### Docker Image

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -37,7 +37,32 @@ curl -L https://github.com/pomerium/pomerium/releases/download/${VERSION}/pomeri
 - Supported formats: `rpm`, `deb`
 - Requires `systemd` support
 
-Official packages can be found on our [GitHub Releases](https://github.com/pomerium/pomerium/releases) page.
+Official packages can be found on our [GitHub Releases](https://github.com/pomerium/pomerium/releases) page or from [Cloudsmith](https://cloudsmith.io/~pomerium/repos/pomerium/packages/).
+
+[RPM Instructions](https://cloudsmith.io/~pomerium/repos/pomerium/setup/#formats-rpm)
+[Deb Instructions](https://cloudsmith.io/~pomerium/repos/pomerium/setup/#formats-deb)
+#### Example yum repo
+
+```
+[pomerium-pomerium]
+name=pomerium-pomerium
+baseurl=https://dl.cloudsmith.io/public/pomerium/pomerium/rpm/el/$releasever/$basearch
+repo_gpgcheck=1
+enabled=1
+gpgkey=https://dl.cloudsmith.io/public/pomerium/pomerium/gpg.6E388440B94E1407.key
+gpgcheck=1
+sslverify=1
+pkg_gpgcheck=1
+```
+#### Example deb setup
+
+```bash
+curl -1sLf 'https://dl.cloudsmith.io/public/pomerium/pomerium/gpg.6E388440B94E1407.key' | apt-key add -
+```
+
+```
+deb https://dl.cloudsmith.io/public/pomerium/pomerium/deb/debian buster main
+```
 
 ### Docker Image
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -133,8 +133,30 @@ curl -L https://github.com/pomerium/pomerium/releases/download/${VERSION}/pomeri
 
 - Supported formats: `rpm`, `deb`
 
-Official packages can be found on our [GitHub Releases](https://github.com/pomerium/pomerium/releases) page.
+Official packages can be found on our [GitHub Releases](https://github.com/pomerium/pomerium/releases) page or from [Cloudsmith](https://cloudsmith.io/~pomerium/repos/pomerium/packages/).
 
+- [RPM Instructions](https://cloudsmith.io/~pomerium/repos/pomerium/setup/#formats-rpm)
+- [Deb Instructions](https://cloudsmith.io/~pomerium/repos/pomerium/setup/#formats-deb)
+
+#### Example yum repo
+
+```
+[pomerium-pomerium]
+name=pomerium-pomerium
+baseurl=https://dl.cloudsmith.io/public/pomerium/pomerium/rpm/el/$releasever/$basearch
+repo_gpgcheck=1
+enabled=1
+gpgkey=https://dl.cloudsmith.io/public/pomerium/pomerium/gpg.6E388440B94E1407.key
+gpgcheck=1
+sslverify=1
+pkg_gpgcheck=1
+```
+#### Example deb setup
+
+```bash
+curl -1sLf 'https://dl.cloudsmith.io/public/pomerium/pomerium/gpg.6E388440B94E1407.key' | apt-key add -
+echo "deb https://dl.cloudsmith.io/public/pomerium/pomerium/deb/debian buster main" > /etc/apt/sources.list.d/pomerium-pomerium.list
+```
 ### Homebrew
 
 ```shell


### PR DESCRIPTION
## Summary

- Remove bintray publishing due to upcoming deprecation
- Publish RPM and DEB packages to cloudsmith repo
- Add basic docs on using the OS package repos

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
