### PR TITLE
log context

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -77,8 +77,7 @@ func New(cfg *config.Config) (*Authenticate, error) {
 }
 
 // OnConfigChange updates internal structures based on config.Options
-func (a *Authenticate) OnConfigChange(cfg *config.Config) {
-	ctx := context.TODO()
+func (a *Authenticate) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	if a == nil {
 		return
 	}

--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -3,6 +3,7 @@
 package authenticate
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"html/template"
@@ -77,18 +78,19 @@ func New(cfg *config.Config) (*Authenticate, error) {
 
 // OnConfigChange updates internal structures based on config.Options
 func (a *Authenticate) OnConfigChange(cfg *config.Config) {
+	ctx := context.TODO()
 	if a == nil {
 		return
 	}
 
 	a.options.Store(cfg.Options)
 	if state, err := newAuthenticateStateFromConfig(cfg); err != nil {
-		log.Error().Err(err).Msg("authenticate: failed to update state")
+		log.Error(ctx).Err(err).Msg("authenticate: failed to update state")
 	} else {
 		a.state.Store(state)
 	}
 	if err := a.updateProvider(cfg); err != nil {
-		log.Error().Err(err).Msg("authenticate: failed to update identity provider")
+		log.Error(ctx).Err(err).Msg("authenticate: failed to update identity provider")
 	}
 }
 

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -275,7 +275,7 @@ func (a *Authenticate) SignOut(w http.ResponseWriter, r *http.Request) error {
 		endSessionURL.RawQuery = params.Encode()
 		redirectString = endSessionURL.String()
 	} else if !errors.Is(err, oidc.ErrSignoutNotImplemented) {
-		log.Warn().Err(err).Msg("authenticate.SignOut: failed getting session")
+		log.Warn(r.Context()).Err(err).Msg("authenticate.SignOut: failed getting session")
 	}
 	if redirectString != "" {
 		httputil.Redirect(w, r, redirectString, http.StatusFound)
@@ -558,7 +558,7 @@ func (a *Authenticate) saveSessionToDataBroker(
 		AccessToken: accessToken.AccessToken,
 	})
 	if err != nil {
-		log.Error().Err(err).Msg("directory: failed to refresh user data")
+		log.Error(ctx).Err(err).Msg("directory: failed to refresh user data")
 	}
 
 	return nil

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -85,7 +85,7 @@ func newPolicyEvaluator(opts *config.Options, store *evaluator.Store) (*evaluato
 func (a *Authorize) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	a.currentOptions.Store(cfg.Options)
 	if state, err := newAuthorizeStateFromConfig(cfg, a.store); err != nil {
-		log.Error(context.TODO()).Err(err).Msg("authorize: error updating state")
+		log.Error(ctx).Err(err).Msg("authorize: error updating state")
 	} else {
 		a.state.Store(state)
 	}

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -82,7 +82,7 @@ func newPolicyEvaluator(opts *config.Options, store *evaluator.Store) (*evaluato
 }
 
 // OnConfigChange updates internal structures based on config.Options
-func (a *Authorize) OnConfigChange(cfg *config.Config) {
+func (a *Authorize) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	a.currentOptions.Store(cfg.Options)
 	if state, err := newAuthorizeStateFromConfig(cfg, a.store); err != nil {
 		log.Error(context.TODO()).Err(err).Msg("authorize: error updating state")

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -56,7 +56,7 @@ func (a *Authorize) WaitForInitialSync(ctx context.Context) error {
 		return ctx.Err()
 	case <-a.dataBrokerInitialSync:
 	}
-	log.Info().Msg("initial sync from databroker complete")
+	log.Info(ctx).Msg("initial sync from databroker complete")
 	return nil
 }
 
@@ -85,7 +85,7 @@ func newPolicyEvaluator(opts *config.Options, store *evaluator.Store) (*evaluato
 func (a *Authorize) OnConfigChange(cfg *config.Config) {
 	a.currentOptions.Store(cfg.Options)
 	if state, err := newAuthorizeStateFromConfig(cfg, a.store); err != nil {
-		log.Error().Err(err).Msg("authorize: error updating state")
+		log.Error(context.TODO()).Err(err).Msg("authorize: error updating state")
 	} else {
 		a.state.Store(state)
 	}

--- a/authorize/authorize_test.go
+++ b/authorize/authorize_test.go
@@ -1,6 +1,7 @@
 package authorize
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -116,7 +117,7 @@ func TestAuthorize_OnConfigChange(t *testing.T) {
 				o.SigningKey = "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUhHNHZDWlJxUFgwNGtmSFQxeVVDM1pUQkF6MFRYWkNtZ043clpDcFE3cHJvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFbzQzdjAwQlR4c3pKZWpmdHhBOWNtVGVUSmtQQXVtOGt1b0UwVlRUZnlId2k3SHJlN2FRUgpHQVJ6Nm0wMjVRdGFiRGxqeDd5MjIyY1gxblhCQXo3MlF3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
 				assertFunc = assert.False
 			}
-			a.OnConfigChange(cfg)
+			a.OnConfigChange(context.Background(), cfg)
 			assertFunc(t, oldPe == a.state.Load().evaluator)
 		})
 	}

--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -2,6 +2,7 @@ package authorize
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/url"
 	"sort"
@@ -103,7 +104,7 @@ func (a *Authorize) htmlDeniedResponse(
 	})
 	if err != nil {
 		buf.WriteString(reason)
-		log.Error().Err(err).Msg("error executing error template")
+		log.Error(context.TODO()).Err(err).Msg("error executing error template")
 	}
 
 	envoyHeaders := []*envoy_config_core_v3.HeaderValueOption{

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -162,7 +162,7 @@ func getJWK(options *config.Options) (*jose.JSONWebKey, error) {
 	if err != nil {
 		return nil, fmt.Errorf("couldn't generate signing key: %w", err)
 	}
-	log.Info().Str("Algorithm", jwk.Algorithm).
+	log.Info(context.TODO()).Str("Algorithm", jwk.Algorithm).
 		Str("KeyID", jwk.KeyID).
 		Interface("Public Key", jwk.Public()).
 		Msg("authorize: signing key")

--- a/authorize/evaluator/functions.go
+++ b/authorize/evaluator/functions.go
@@ -1,6 +1,7 @@
 package evaluator
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
@@ -46,7 +47,7 @@ func isValidClientCertificate(ca, cert string) (bool, error) {
 	valid := verifyErr == nil
 
 	if verifyErr != nil {
-		log.Debug().Err(verifyErr).Msg("client certificate failed verification: %w")
+		log.Debug(context.Background()).Err(verifyErr).Msg("client certificate failed verification: %w")
 	}
 
 	isValidClientCertificateCache.Add(cacheKey, valid)

--- a/authorize/evaluator/result.go
+++ b/authorize/evaluator/result.go
@@ -1,6 +1,7 @@
 package evaluator
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 
@@ -71,7 +72,7 @@ func getDenyVar(vars rego.Vars) []Result {
 
 		status, err := strconv.Atoi(fmt.Sprint(denial[0]))
 		if err != nil {
-			log.Error().Err(err).Msg("invalid type in deny")
+			log.Error(context.TODO()).Err(err).Msg("invalid type in deny")
 			continue
 		}
 		msg := fmt.Sprint(denial[1])

--- a/authorize/evaluator/store.go
+++ b/authorize/evaluator/store.go
@@ -156,11 +156,12 @@ func (s *Store) UpdateSigningKey(signingKey *jose.JSONWebKey) {
 }
 
 func (s *Store) write(rawPath string, value interface{}) {
-	err := storage.Txn(context.Background(), s.Store, storage.WriteParams, func(txn storage.Transaction) error {
+	ctx := context.TODO()
+	err := storage.Txn(ctx, s.Store, storage.WriteParams, func(txn storage.Transaction) error {
 		return s.writeTxn(txn, rawPath, value)
 	})
 	if err != nil {
-		log.Error().Err(err).Msg("opa-store: error writing data")
+		log.Error(ctx).Err(err).Msg("opa-store: error writing data")
 		return
 	}
 }

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -46,19 +46,19 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 
 	u, err := a.forceSync(ctx, sessionState)
 	if err != nil {
-		log.Warn().Err(err).Msg("clearing session due to force sync failed")
+		log.Warn(ctx).Err(err).Msg("clearing session due to force sync failed")
 		sessionState = nil
 	}
 
 	req, err := a.getEvaluatorRequestFromCheckRequest(in, sessionState)
 	if err != nil {
-		log.Warn().Err(err).Msg("error building evaluator request")
+		log.Warn(ctx).Err(err).Msg("error building evaluator request")
 		return nil, err
 	}
 
 	reply, err := state.evaluator.Evaluate(ctx, req)
 	if err != nil {
-		log.Error().Err(err).Msg("error during OPA evaluation")
+		log.Error(ctx).Err(err).Msg("error during OPA evaluation")
 		return nil, err
 	}
 	defer func() {

--- a/authorize/log.go
+++ b/authorize/log.go
@@ -26,7 +26,7 @@ func (a *Authorize) logAuthorizeCheck(
 
 	hdrs := getCheckRequestHeaders(in)
 	hattrs := in.GetAttributes().GetRequest().GetHttp()
-	evt := log.Info().Str("service", "authorize")
+	evt := log.Info(ctx).Str("service", "authorize")
 	// request
 	evt = evt.Str("request-id", requestid.FromContext(ctx))
 	evt = evt.Str("check-request-id", hdrs["X-Request-Id"])
@@ -66,10 +66,10 @@ func (a *Authorize) logAuthorizeCheck(
 		}
 		sealed, err := enc.Encrypt(record)
 		if err != nil {
-			log.Warn().Err(err).Msg("authorize: error encrypting audit record")
+			log.Warn(ctx).Err(err).Msg("authorize: error encrypting audit record")
 			return
 		}
-		log.Info().
+		log.Info(ctx).
 			Str("request-id", requestid.FromContext(ctx)).
 			EmbedObject(sealed).
 			Msg("audit log")

--- a/authorize/sync.go
+++ b/authorize/sync.go
@@ -150,7 +150,7 @@ func (a *Authorize) waitForRecordSync(ctx context.Context, recordTypeURL, record
 			// record not found, so no need to wait
 			return nil, nil
 		} else if err != nil {
-			log.Error().
+			log.Error(ctx).
 				Err(err).
 				Str("type", recordTypeURL).
 				Str("id", recordID).
@@ -160,7 +160,7 @@ func (a *Authorize) waitForRecordSync(ctx context.Context, recordTypeURL, record
 
 		select {
 		case <-ctx.Done():
-			log.Warn().
+			log.Warn(ctx).
 				Str("type", recordTypeURL).
 				Str("id", recordID).
 				Msg("authorize: first sync of record did not complete")

--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -17,10 +17,11 @@ var (
 )
 
 func main() {
-	if err := run(context.Background()); !errors.Is(err, context.Canceled) {
+	ctx := context.Background()
+	if err := run(ctx); !errors.Is(err, context.Canceled) {
 		log.Fatal().Err(err).Msg("cmd/pomerium")
 	}
-	log.Info().Msg("cmd/pomerium: exiting")
+	log.Info(ctx).Msg("cmd/pomerium: exiting")
 }
 
 func run(ctx context.Context) error {

--- a/config/config_source.go
+++ b/config/config_source.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 
 	"github.com/fsnotify/fsnotify"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 
 	"github.com/pomerium/pomerium/internal/fileutil"
 	"github.com/pomerium/pomerium/internal/log"
@@ -14,7 +16,7 @@ import (
 )
 
 // A ChangeListener is called when configuration changes.
-type ChangeListener = func(*Config)
+type ChangeListener = func(context.Context, *Config)
 
 // A ChangeDispatcher manages listeners on config changes.
 type ChangeDispatcher struct {
@@ -23,17 +25,17 @@ type ChangeDispatcher struct {
 }
 
 // Trigger triggers a change.
-func (dispatcher *ChangeDispatcher) Trigger(cfg *Config) {
+func (dispatcher *ChangeDispatcher) Trigger(ctx context.Context, cfg *Config) {
 	dispatcher.Lock()
 	defer dispatcher.Unlock()
 
 	for _, li := range dispatcher.onConfigChangeListeners {
-		li(cfg)
+		li(ctx, cfg)
 	}
 }
 
 // OnConfigChange adds a listener.
-func (dispatcher *ChangeDispatcher) OnConfigChange(li ChangeListener) {
+func (dispatcher *ChangeDispatcher) OnConfigChange(ctx context.Context, li ChangeListener) {
 	dispatcher.Lock()
 	defer dispatcher.Unlock()
 	dispatcher.onConfigChangeListeners = append(dispatcher.onConfigChangeListeners, li)
@@ -42,7 +44,7 @@ func (dispatcher *ChangeDispatcher) OnConfigChange(li ChangeListener) {
 // A Source gets configuration.
 type Source interface {
 	GetConfig() *Config
-	OnConfigChange(ChangeListener)
+	OnConfigChange(context.Context, ChangeListener)
 }
 
 // A StaticSource always returns the same config. Useful for testing.
@@ -66,18 +68,18 @@ func (src *StaticSource) GetConfig() *Config {
 }
 
 // SetConfig sets the config.
-func (src *StaticSource) SetConfig(cfg *Config) {
+func (src *StaticSource) SetConfig(ctx context.Context, cfg *Config) {
 	src.mu.Lock()
 	defer src.mu.Unlock()
 
 	src.cfg = cfg
 	for _, li := range src.lis {
-		li(cfg)
+		li(ctx, cfg)
 	}
 }
 
 // OnConfigChange is ignored for the StaticSource.
-func (src *StaticSource) OnConfigChange(li ChangeListener) {
+func (src *StaticSource) OnConfigChange(ctx context.Context, li ChangeListener) {
 	src.mu.Lock()
 	defer src.mu.Unlock()
 
@@ -96,39 +98,48 @@ type FileOrEnvironmentSource struct {
 
 // NewFileOrEnvironmentSource creates a new FileOrEnvironmentSource.
 func NewFileOrEnvironmentSource(configFile string) (*FileOrEnvironmentSource, error) {
+	ctx := log.WithContext(context.TODO(), func(c zerolog.Context) zerolog.Context {
+		return c.Str("config_file_source", configFile)
+	})
+
 	options, err := newOptionsFromConfig(configFile)
 	if err != nil {
 		return nil, err
 	}
 
 	cfg := &Config{Options: options}
-	metrics.SetConfigInfo(context.TODO(), cfg.Options.Services, "local", cfg.Checksum(), true)
+	metrics.SetConfigInfo(ctx, cfg.Options.Services, "local", cfg.Checksum(), true)
 
 	src := &FileOrEnvironmentSource{
 		configFile: configFile,
 		config:     cfg,
 	}
-	options.viper.OnConfigChange(src.onConfigChange)
+	options.viper.OnConfigChange(src.onConfigChange(ctx))
 	go options.viper.WatchConfig()
 
 	return src, nil
 }
 
-func (src *FileOrEnvironmentSource) onConfigChange(evt fsnotify.Event) {
-	ctx := context.TODO()
-	src.mu.Lock()
-	cfg := src.config
-	options, err := newOptionsFromConfig(src.configFile)
-	if err == nil {
-		cfg = &Config{Options: options}
-		metrics.SetConfigInfo(ctx, cfg.Options.Services, "local", cfg.Checksum(), true)
-	} else {
-		log.Error(ctx).Err(err).Msg("config: error updating config")
-		metrics.SetConfigInfo(ctx, cfg.Options.Services, "local", cfg.Checksum(), false)
-	}
-	src.mu.Unlock()
+func (src *FileOrEnvironmentSource) onConfigChange(ctx context.Context) func(fsnotify.Event) {
+	return func(evt fsnotify.Event) {
+		ctx := log.WithContext(ctx, func(c zerolog.Context) zerolog.Context {
+			return c.Str("config_change_id", uuid.New().String())
+		})
+		log.Info(ctx).Msg("config: file updated, reconfiguring...")
+		src.mu.Lock()
+		cfg := src.config
+		options, err := newOptionsFromConfig(src.configFile)
+		if err == nil {
+			cfg = &Config{Options: options}
+			metrics.SetConfigInfo(ctx, cfg.Options.Services, "local", cfg.Checksum(), true)
+		} else {
+			log.Error(ctx).Err(err).Msg("config: error updating config")
+			metrics.SetConfigInfo(ctx, cfg.Options.Services, "local", cfg.Checksum(), false)
+		}
+		src.mu.Unlock()
 
-	src.Trigger(cfg)
+		src.Trigger(ctx, cfg)
+	}
 }
 
 // GetConfig gets the config.
@@ -151,6 +162,7 @@ type FileWatcherSource struct {
 }
 
 // NewFileWatcherSource creates a new FileWatcherSource.
+// TODO: doesn't seem to be used
 func NewFileWatcherSource(underlying Source) *FileWatcherSource {
 	src := &FileWatcherSource{
 		underlying: underlying,
@@ -160,13 +172,13 @@ func NewFileWatcherSource(underlying Source) *FileWatcherSource {
 	ch := src.watcher.Bind()
 	go func() {
 		for range ch {
-			src.check(underlying.GetConfig())
+			src.check(context.TODO(), underlying.GetConfig())
 		}
 	}()
-	underlying.OnConfigChange(func(cfg *Config) {
-		src.check(cfg)
+	underlying.OnConfigChange(context.TODO(), func(ctx context.Context, cfg *Config) {
+		src.check(ctx, cfg)
 	})
-	src.check(underlying.GetConfig())
+	src.check(context.TODO(), underlying.GetConfig())
 
 	return src
 }
@@ -178,7 +190,7 @@ func (src *FileWatcherSource) GetConfig() *Config {
 	return src.computedConfig
 }
 
-func (src *FileWatcherSource) check(cfg *Config) {
+func (src *FileWatcherSource) check(ctx context.Context, cfg *Config) {
 	if cfg == nil || cfg.Options == nil {
 		return
 	}
@@ -220,5 +232,5 @@ func (src *FileWatcherSource) check(cfg *Config) {
 	src.computedConfig = cfg.Clone()
 
 	// trigger a change
-	src.Trigger(src.computedConfig)
+	src.Trigger(ctx, src.computedConfig)
 }

--- a/config/config_source.go
+++ b/config/config_source.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"crypto/sha256"
 	"io/ioutil"
 	"sync"
@@ -101,7 +102,7 @@ func NewFileOrEnvironmentSource(configFile string) (*FileOrEnvironmentSource, er
 	}
 
 	cfg := &Config{Options: options}
-	metrics.SetConfigInfo(cfg.Options.Services, "local", cfg.Checksum(), true)
+	metrics.SetConfigInfo(context.TODO(), cfg.Options.Services, "local", cfg.Checksum(), true)
 
 	src := &FileOrEnvironmentSource{
 		configFile: configFile,
@@ -114,15 +115,16 @@ func NewFileOrEnvironmentSource(configFile string) (*FileOrEnvironmentSource, er
 }
 
 func (src *FileOrEnvironmentSource) onConfigChange(evt fsnotify.Event) {
+	ctx := context.TODO()
 	src.mu.Lock()
 	cfg := src.config
 	options, err := newOptionsFromConfig(src.configFile)
 	if err == nil {
 		cfg = &Config{Options: options}
-		metrics.SetConfigInfo(cfg.Options.Services, "local", cfg.Checksum(), true)
+		metrics.SetConfigInfo(ctx, cfg.Options.Services, "local", cfg.Checksum(), true)
 	} else {
-		log.Error().Err(err).Msg("config: error updating config")
-		metrics.SetConfigInfo(cfg.Options.Services, "local", cfg.Checksum(), false)
+		log.Error(ctx).Err(err).Msg("config: error updating config")
+		metrics.SetConfigInfo(ctx, cfg.Options.Services, "local", cfg.Checksum(), false)
 	}
 	src.mu.Unlock()
 

--- a/config/config_source.go
+++ b/config/config_source.go
@@ -161,8 +161,7 @@ type FileWatcherSource struct {
 	ChangeDispatcher
 }
 
-// NewFileWatcherSource creates a new FileWatcherSource.
-// TODO: doesn't seem to be used
+// NewFileWatcherSource creates a new FileWatcherSource
 func NewFileWatcherSource(underlying Source) *FileWatcherSource {
 	src := &FileWatcherSource{
 		underlying: underlying,

--- a/config/config_source_test.go
+++ b/config/config_source_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,6 +14,8 @@ import (
 )
 
 func TestFileWatcherSource(t *testing.T) {
+	ctx := context.Background()
+
 	tmpdir := filepath.Join(os.TempDir(), uuid.New().String())
 	err := os.MkdirAll(tmpdir, 0o755)
 	if !assert.NoError(t, err) {
@@ -33,7 +36,7 @@ func TestFileWatcherSource(t *testing.T) {
 	src := NewFileWatcherSource(ssrc)
 	var closeOnce sync.Once
 	ch := make(chan struct{})
-	src.OnConfigChange(func(cfg *Config) {
+	src.OnConfigChange(context.Background(), func(ctx context.Context, cfg *Config) {
 		closeOnce.Do(func() {
 			close(ch)
 		})
@@ -50,7 +53,7 @@ func TestFileWatcherSource(t *testing.T) {
 		t.Error("expected OnConfigChange to be fired after modifying a file")
 	}
 
-	ssrc.SetConfig(&Config{
+	ssrc.SetConfig(ctx, &Config{
 		Options: &Options{
 			CAFile: filepath.Join(tmpdir, "example.txt"),
 		},

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -1,6 +1,7 @@
 package envoyconfig
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net"
@@ -154,13 +155,13 @@ func (b *Builder) buildInternalTransportSocket(options *config.Options, endpoint
 	} else if options.CA != "" {
 		bs, err := base64.StdEncoding.DecodeString(options.CA)
 		if err != nil {
-			log.Error().Err(err).Msg("invalid custom CA certificate")
+			log.Error(context.TODO()).Err(err).Msg("invalid custom CA certificate")
 		}
 		validationContext.TrustedCa = b.filemgr.BytesDataSource("custom-ca.pem", bs)
 	} else {
 		rootCA, err := getRootCertificateAuthority()
 		if err != nil {
-			log.Error().Err(err).Msg("unable to enable certificate verification because no root CAs were found")
+			log.Error(context.TODO()).Err(err).Msg("unable to enable certificate verification because no root CAs were found")
 		} else {
 			validationContext.TrustedCa = b.filemgr.FileDataSource(rootCA)
 		}
@@ -216,7 +217,7 @@ func (b *Builder) buildPolicyTransportSocket(policy *config.Policy, dst url.URL)
 	}
 	if policy.ClientCertificate != nil {
 		tlsContext.CommonTlsContext.TlsCertificates = append(tlsContext.CommonTlsContext.TlsCertificates,
-			b.envoyTLSCertificateFromGoTLSCertificate(policy.ClientCertificate))
+			b.envoyTLSCertificateFromGoTLSCertificate(context.TODO(), policy.ClientCertificate))
 	}
 
 	tlsConfig := marshalAny(tlsContext)
@@ -247,13 +248,13 @@ func (b *Builder) buildPolicyValidationContext(
 	} else if policy.TLSCustomCA != "" {
 		bs, err := base64.StdEncoding.DecodeString(policy.TLSCustomCA)
 		if err != nil {
-			log.Error().Err(err).Msg("invalid custom CA certificate")
+			log.Error(context.TODO()).Err(err).Msg("invalid custom CA certificate")
 		}
 		validationContext.TrustedCa = b.filemgr.BytesDataSource("custom-ca.pem", bs)
 	} else {
 		rootCA, err := getRootCertificateAuthority()
 		if err != nil {
-			log.Error().Err(err).Msg("unable to enable certificate verification because no root CAs were found")
+			log.Error(context.TODO()).Err(err).Msg("unable to enable certificate verification because no root CAs were found")
 		} else {
 			validationContext.TrustedCa = b.filemgr.FileDataSource(rootCA)
 		}

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -223,7 +223,7 @@ func (b *Builder) buildPolicyTransportSocket(ctx context.Context, policy *config
 	}
 	if policy.ClientCertificate != nil {
 		tlsContext.CommonTlsContext.TlsCertificates = append(tlsContext.CommonTlsContext.TlsCertificates,
-			b.envoyTLSCertificateFromGoTLSCertificate(context.TODO(), policy.ClientCertificate))
+			b.envoyTLSCertificateFromGoTLSCertificate(ctx, policy.ClientCertificate))
 	}
 
 	tlsConfig := marshalAny(tlsContext)

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -23,7 +23,7 @@ import (
 )
 
 // BuildClusters builds envoy clusters from the given config.
-func (b *Builder) BuildClusters(cfg *config.Config) ([]*envoy_config_cluster_v3.Cluster, error) {
+func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*envoy_config_cluster_v3.Cluster, error) {
 	grpcURL := &url.URL{
 		Scheme: "http",
 		Host:   b.localGRPCAddress,
@@ -37,15 +37,15 @@ func (b *Builder) BuildClusters(cfg *config.Config) ([]*envoy_config_cluster_v3.
 		return nil, err
 	}
 
-	controlGRPC, err := b.buildInternalCluster(cfg.Options, "pomerium-control-plane-grpc", []*url.URL{grpcURL}, true)
+	controlGRPC, err := b.buildInternalCluster(ctx, cfg.Options, "pomerium-control-plane-grpc", []*url.URL{grpcURL}, true)
 	if err != nil {
 		return nil, err
 	}
-	controlHTTP, err := b.buildInternalCluster(cfg.Options, "pomerium-control-plane-http", []*url.URL{httpURL}, false)
+	controlHTTP, err := b.buildInternalCluster(ctx, cfg.Options, "pomerium-control-plane-http", []*url.URL{httpURL}, false)
 	if err != nil {
 		return nil, err
 	}
-	authZ, err := b.buildInternalCluster(cfg.Options, "pomerium-authorize", authzURLs, true)
+	authZ, err := b.buildInternalCluster(ctx, cfg.Options, "pomerium-authorize", authzURLs, true)
 	if err != nil {
 		return nil, err
 	}
@@ -63,7 +63,7 @@ func (b *Builder) BuildClusters(cfg *config.Config) ([]*envoy_config_cluster_v3.
 				policy.EnvoyOpts = newDefaultEnvoyClusterConfig()
 			}
 			if len(policy.To) > 0 {
-				cluster, err := b.buildPolicyCluster(cfg.Options, &policy)
+				cluster, err := b.buildPolicyCluster(ctx, cfg.Options, &policy)
 				if err != nil {
 					return nil, fmt.Errorf("policy #%d: %w", i, err)
 				}
@@ -79,12 +79,18 @@ func (b *Builder) BuildClusters(cfg *config.Config) ([]*envoy_config_cluster_v3.
 	return clusters, nil
 }
 
-func (b *Builder) buildInternalCluster(options *config.Options, name string, dsts []*url.URL, forceHTTP2 bool) (*envoy_config_cluster_v3.Cluster, error) {
+func (b *Builder) buildInternalCluster(
+	ctx context.Context,
+	options *config.Options,
+	name string,
+	dsts []*url.URL,
+	forceHTTP2 bool,
+) (*envoy_config_cluster_v3.Cluster, error) {
 	cluster := newDefaultEnvoyClusterConfig()
 	cluster.DnsLookupFamily = config.GetEnvoyDNSLookupFamily(options.DNSLookupFamily)
 	var endpoints []Endpoint
 	for _, dst := range dsts {
-		ts, err := b.buildInternalTransportSocket(options, dst)
+		ts, err := b.buildInternalTransportSocket(ctx, options, dst)
 		if err != nil {
 			return nil, err
 		}
@@ -96,14 +102,14 @@ func (b *Builder) buildInternalCluster(options *config.Options, name string, dst
 	return cluster, nil
 }
 
-func (b *Builder) buildPolicyCluster(options *config.Options, policy *config.Policy) (*envoy_config_cluster_v3.Cluster, error) {
+func (b *Builder) buildPolicyCluster(ctx context.Context, options *config.Options, policy *config.Policy) (*envoy_config_cluster_v3.Cluster, error) {
 	cluster := new(envoy_config_cluster_v3.Cluster)
 	proto.Merge(cluster, policy.EnvoyOpts)
 
 	cluster.AltStatName = getClusterStatsName(policy)
 
 	name := getClusterID(policy)
-	endpoints, err := b.buildPolicyEndpoints(policy)
+	endpoints, err := b.buildPolicyEndpoints(ctx, policy)
 	if err != nil {
 		return nil, err
 	}
@@ -123,10 +129,10 @@ func (b *Builder) buildPolicyCluster(options *config.Options, policy *config.Pol
 	return cluster, nil
 }
 
-func (b *Builder) buildPolicyEndpoints(policy *config.Policy) ([]Endpoint, error) {
+func (b *Builder) buildPolicyEndpoints(ctx context.Context, policy *config.Policy) ([]Endpoint, error) {
 	var endpoints []Endpoint
 	for _, dst := range policy.To {
-		ts, err := b.buildPolicyTransportSocket(policy, dst.URL)
+		ts, err := b.buildPolicyTransportSocket(ctx, policy, dst.URL)
 		if err != nil {
 			return nil, err
 		}
@@ -135,7 +141,7 @@ func (b *Builder) buildPolicyEndpoints(policy *config.Policy) ([]Endpoint, error
 	return endpoints, nil
 }
 
-func (b *Builder) buildInternalTransportSocket(options *config.Options, endpoint *url.URL) (*envoy_config_core_v3.TransportSocket, error) {
+func (b *Builder) buildInternalTransportSocket(ctx context.Context, options *config.Options, endpoint *url.URL) (*envoy_config_core_v3.TransportSocket, error) {
 	if endpoint.Scheme != "https" {
 		return nil, nil
 	}
@@ -155,13 +161,13 @@ func (b *Builder) buildInternalTransportSocket(options *config.Options, endpoint
 	} else if options.CA != "" {
 		bs, err := base64.StdEncoding.DecodeString(options.CA)
 		if err != nil {
-			log.Error(context.TODO()).Err(err).Msg("invalid custom CA certificate")
+			log.Error(ctx).Err(err).Msg("invalid custom CA certificate")
 		}
 		validationContext.TrustedCa = b.filemgr.BytesDataSource("custom-ca.pem", bs)
 	} else {
 		rootCA, err := getRootCertificateAuthority()
 		if err != nil {
-			log.Error(context.TODO()).Err(err).Msg("unable to enable certificate verification because no root CAs were found")
+			log.Error(ctx).Err(err).Msg("unable to enable certificate verification because no root CAs were found")
 		} else {
 			validationContext.TrustedCa = b.filemgr.FileDataSource(rootCA)
 		}
@@ -184,12 +190,12 @@ func (b *Builder) buildInternalTransportSocket(options *config.Options, endpoint
 	}, nil
 }
 
-func (b *Builder) buildPolicyTransportSocket(policy *config.Policy, dst url.URL) (*envoy_config_core_v3.TransportSocket, error) {
+func (b *Builder) buildPolicyTransportSocket(ctx context.Context, policy *config.Policy, dst url.URL) (*envoy_config_core_v3.TransportSocket, error) {
 	if dst.Scheme != "https" {
 		return nil, nil
 	}
 
-	vc, err := b.buildPolicyValidationContext(policy, dst)
+	vc, err := b.buildPolicyValidationContext(ctx, policy, dst)
 	if err != nil {
 		return nil, err
 	}
@@ -230,6 +236,7 @@ func (b *Builder) buildPolicyTransportSocket(policy *config.Policy, dst url.URL)
 }
 
 func (b *Builder) buildPolicyValidationContext(
+	ctx context.Context,
 	policy *config.Policy, dst url.URL,
 ) (*envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext, error) {
 	sni := dst.Hostname()
@@ -248,13 +255,13 @@ func (b *Builder) buildPolicyValidationContext(
 	} else if policy.TLSCustomCA != "" {
 		bs, err := base64.StdEncoding.DecodeString(policy.TLSCustomCA)
 		if err != nil {
-			log.Error(context.TODO()).Err(err).Msg("invalid custom CA certificate")
+			log.Error(ctx).Err(err).Msg("invalid custom CA certificate")
 		}
 		validationContext.TrustedCa = b.filemgr.BytesDataSource("custom-ca.pem", bs)
 	} else {
 		rootCA, err := getRootCertificateAuthority()
 		if err != nil {
-			log.Error(context.TODO()).Err(err).Msg("unable to enable certificate verification because no root CAs were found")
+			log.Error(ctx).Err(err).Msg("unable to enable certificate verification because no root CAs were found")
 		} else {
 			validationContext.TrustedCa = b.filemgr.FileDataSource(rootCA)
 		}

--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -133,7 +133,10 @@ func buildAddress(hostport string, defaultPort int) *envoy_config_core_v3.Addres
 	}
 }
 
-func (b *Builder) envoyTLSCertificateFromGoTLSCertificate(ctx context.Context, cert *tls.Certificate) *envoy_extensions_transport_sockets_tls_v3.TlsCertificate {
+func (b *Builder) envoyTLSCertificateFromGoTLSCertificate(
+	ctx context.Context,
+	cert *tls.Certificate,
+) *envoy_extensions_transport_sockets_tls_v3.TlsCertificate {
 	envoyCert := &envoy_extensions_transport_sockets_tls_v3.TlsCertificate{}
 	var chain bytes.Buffer
 	for _, cbs := range cert.Certificate {

--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -3,6 +3,7 @@ package envoyconfig
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
@@ -132,7 +133,7 @@ func buildAddress(hostport string, defaultPort int) *envoy_config_core_v3.Addres
 	}
 }
 
-func (b *Builder) envoyTLSCertificateFromGoTLSCertificate(cert *tls.Certificate) *envoy_extensions_transport_sockets_tls_v3.TlsCertificate {
+func (b *Builder) envoyTLSCertificateFromGoTLSCertificate(ctx context.Context, cert *tls.Certificate) *envoy_extensions_transport_sockets_tls_v3.TlsCertificate {
 	envoyCert := &envoy_extensions_transport_sockets_tls_v3.TlsCertificate{}
 	var chain bytes.Buffer
 	for _, cbs := range cert.Certificate {
@@ -153,7 +154,7 @@ func (b *Builder) envoyTLSCertificateFromGoTLSCertificate(cert *tls.Certificate)
 			},
 		))
 	} else {
-		log.Warn().Err(err).Msg("failed to marshal private key for tls config")
+		log.Warn(ctx).Err(err).Msg("failed to marshal private key for tls config")
 	}
 	for _, scts := range cert.SignedCertificateTimestamps {
 		envoyCert.SignedCertificateTimestamp = append(envoyCert.SignedCertificateTimestamp,
@@ -185,10 +186,10 @@ func getRootCertificateAuthority() (string, error) {
 			}
 		}
 		if rootCABundle.value == "" {
-			log.Error().Strs("known-locations", knownRootLocations).
+			log.Error(context.TODO()).Strs("known-locations", knownRootLocations).
 				Msgf("no root certificates were found in any of the known locations")
 		} else {
-			log.Info().Msgf("using %s as the system root certificate authority bundle", rootCABundle.value)
+			log.Info(context.TODO()).Msgf("using %s as the system root certificate authority bundle", rootCABundle.value)
 		}
 	})
 	if rootCABundle.value == "" {

--- a/config/envoyconfig/filemgr/filemgr.go
+++ b/config/envoyconfig/filemgr/filemgr.go
@@ -2,6 +2,7 @@
 package filemgr
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -34,7 +35,7 @@ func (mgr *Manager) BytesDataSource(fileName string, data []byte) *envoy_config_
 	fileName = fmt.Sprintf("%s-%x%s", fileName[:len(fileName)-len(ext)], h, ext)
 
 	if err := os.MkdirAll(mgr.cfg.cacheDir, 0o700); err != nil {
-		log.Error().Err(err).Msg("filemgr: error creating cache directory, falling back to inline bytes")
+		log.Error(context.TODO()).Err(err).Msg("filemgr: error creating cache directory, falling back to inline bytes")
 		return inlineBytes(data)
 	}
 
@@ -42,11 +43,11 @@ func (mgr *Manager) BytesDataSource(fileName string, data []byte) *envoy_config_
 	if _, err := os.Stat(filePath); os.IsNotExist(err) {
 		err = ioutil.WriteFile(filePath, data, 0o600)
 		if err != nil {
-			log.Error().Err(err).Msg("filemgr: error writing cache file, falling back to inline bytes")
+			log.Error(context.TODO()).Err(err).Msg("filemgr: error writing cache file, falling back to inline bytes")
 			return inlineBytes(data)
 		}
 	} else if err != nil {
-		log.Error().Err(err).Msg("filemgr: error reading cache file, falling back to inline bytes")
+		log.Error(context.TODO()).Err(err).Msg("filemgr: error reading cache file, falling back to inline bytes")
 		return inlineBytes(data)
 	}
 
@@ -62,7 +63,7 @@ func (mgr *Manager) ClearCache() {
 		return os.Remove(p)
 	})
 	if err != nil {
-		log.Error().Err(err).Msg("failed to clear envoy file cache")
+		log.Error(context.TODO()).Err(err).Msg("failed to clear envoy file cache")
 	}
 }
 

--- a/config/http.go
+++ b/config/http.go
@@ -9,6 +9,8 @@ import (
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/tripper"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
+
+	"github.com/rs/zerolog"
 )
 
 type httpTransport struct {
@@ -19,16 +21,19 @@ type httpTransport struct {
 // NewHTTPTransport creates a new http transport. If CA or CAFile is set, the transport will
 // add the CA to system cert pool.
 func NewHTTPTransport(src Source) http.RoundTripper {
+	ctx := log.WithContext(context.TODO(), func(c zerolog.Context) zerolog.Context {
+		return c.Caller()
+	})
 	t := new(httpTransport)
 	t.underlying, _ = http.DefaultTransport.(*http.Transport)
-	src.OnConfigChange(func(cfg *Config) {
-		t.update(cfg.Options)
+	src.OnConfigChange(ctx, func(ctx context.Context, cfg *Config) {
+		t.update(ctx, cfg.Options)
 	})
-	t.update(src.GetConfig().Options)
+	t.update(ctx, src.GetConfig().Options)
 	return t
 }
 
-func (t *httpTransport) update(options *Options) {
+func (t *httpTransport) update(ctx context.Context, options *Options) {
 	nt := new(http.Transport)
 	if t.underlying != nil {
 		nt = t.underlying.Clone()
@@ -41,7 +46,7 @@ func (t *httpTransport) update(options *Options) {
 				MinVersion: tls.VersionTLS12,
 			}
 		} else {
-			log.Error(context.TODO()).Err(err).Msg("config: error getting cert pool")
+			log.Error(ctx).Err(err).Msg("config: error getting cert pool")
 		}
 	}
 	t.transport.Store(nt)

--- a/config/http.go
+++ b/config/http.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http"
 	"sync/atomic"
@@ -40,7 +41,7 @@ func (t *httpTransport) update(options *Options) {
 				MinVersion: tls.VersionTLS12,
 			}
 		} else {
-			log.Error().Err(err).Msg("config: error getting cert pool")
+			log.Error(context.TODO()).Err(err).Msg("config: error getting cert pool")
 		}
 	}
 	t.transport.Store(nt)
@@ -78,7 +79,7 @@ func NewPolicyHTTPTransport(options *Options, policy *Policy) http.RoundTripper 
 			tlsClientConfig.MinVersion = tls.VersionTLS12
 			isCustomClientConfig = true
 		} else {
-			log.Error().Err(err).Msg("config: error getting ca cert pool")
+			log.Error(context.TODO()).Err(err).Msg("config: error getting ca cert pool")
 		}
 	}
 
@@ -89,7 +90,7 @@ func NewPolicyHTTPTransport(options *Options, policy *Policy) http.RoundTripper 
 			tlsClientConfig.MinVersion = tls.VersionTLS12
 			isCustomClientConfig = true
 		} else {
-			log.Error().Err(err).Msg("config: error getting custom ca cert pool")
+			log.Error(context.TODO()).Err(err).Msg("config: error getting custom ca cert pool")
 		}
 	}
 

--- a/config/log.go
+++ b/config/log.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"sync"
 
 	"github.com/pomerium/pomerium/internal/log"
@@ -12,10 +13,10 @@ type LogManager struct {
 }
 
 // NewLogManager creates a new LogManager.
-func NewLogManager(src Source) *LogManager {
+func NewLogManager(ctx context.Context, src Source) *LogManager {
 	mgr := &LogManager{}
-	src.OnConfigChange(mgr.OnConfigChange)
-	mgr.OnConfigChange(src.GetConfig())
+	src.OnConfigChange(ctx, mgr.OnConfigChange)
+	mgr.OnConfigChange(ctx, src.GetConfig())
 	return mgr
 }
 
@@ -25,7 +26,7 @@ func (mgr *LogManager) Close() error {
 }
 
 // OnConfigChange is called whenever configuration changes.
-func (mgr *LogManager) OnConfigChange(cfg *Config) {
+func (mgr *LogManager) OnConfigChange(ctx context.Context, cfg *Config) {
 	if cfg == nil || cfg.Options == nil {
 		return
 	}

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"net/http"
 	"os"
 	"sync"
@@ -63,7 +64,7 @@ func (mgr *MetricsManager) updateInfo(cfg *Config) {
 
 	hostname, err := os.Hostname()
 	if err != nil {
-		log.Error().Err(err).Msg("telemetry/metrics: failed to get OS hostname")
+		log.Error(context.TODO()).Err(err).Msg("telemetry/metrics: failed to get OS hostname")
 		hostname = "__unknown__"
 	}
 
@@ -84,13 +85,13 @@ func (mgr *MetricsManager) updateServer(cfg *Config) {
 	mgr.handler = nil
 
 	if mgr.addr == "" {
-		log.Info().Msg("metrics: http server disabled")
+		log.Info(context.TODO()).Msg("metrics: http server disabled")
 		return
 	}
 
 	handler, err := metrics.PrometheusHandler(EnvoyAdminURL, mgr.installationID)
 	if err != nil {
-		log.Error().Err(err).Msg("metrics: failed to create prometheus handler")
+		log.Error(context.TODO()).Err(err).Msg("metrics: failed to create prometheus handler")
 		return
 	}
 

--- a/config/metrics_test.go
+++ b/config/metrics_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -12,12 +13,13 @@ import (
 )
 
 func TestMetricsManager(t *testing.T) {
+	ctx := context.Background()
 	src := NewStaticSource(&Config{
 		Options: &Options{
 			MetricsAddr: "ADDRESS",
 		},
 	})
-	mgr := NewMetricsManager(src)
+	mgr := NewMetricsManager(ctx, src)
 	srv1 := httptest.NewServer(mgr)
 	defer srv1.Close()
 	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42,7 +44,7 @@ func TestMetricsManagerBasicAuth(t *testing.T) {
 			MetricsBasicAuth: base64.StdEncoding.EncodeToString([]byte("x:y")),
 		},
 	})
-	mgr := NewMetricsManager(src)
+	mgr := NewMetricsManager(context.Background(), src)
 	srv1 := httptest.NewServer(mgr)
 	defer srv1.Close()
 

--- a/config/options.go
+++ b/config/options.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"errors"
@@ -427,7 +428,7 @@ func (o *Options) viperIsSet(key string) bool {
 
 // parseHeaders handles unmarshalling any custom headers correctly from the
 // environment or viper's parsed keys
-func (o *Options) parseHeaders() error {
+func (o *Options) parseHeaders(ctx context.Context) error {
 	var headers map[string]string
 	if o.HeadersEnv != "" {
 		// Handle JSON by default via viper
@@ -450,7 +451,7 @@ func (o *Options) parseHeaders() error {
 	}
 
 	if o.viperIsSet("headers") {
-		log.Warn().Msg("config: headers has been renamed to set_response_headers, it will be removed in v0.16")
+		log.Warn(ctx).Msg("config: headers has been renamed to set_response_headers, it will be removed in v0.16")
 	}
 
 	// option was renamed from `headers` to `set_response_headers`. Both config settings are supported.
@@ -507,6 +508,7 @@ func bindEnvs(o *Options, v *viper.Viper) error {
 
 // Validate ensures the Options fields are valid, and hydrated.
 func (o *Options) Validate() error {
+	ctx := context.TODO()
 	if !IsValidService(o.Services) {
 		return fmt.Errorf("config: %s is an invalid service type", o.Services)
 	}
@@ -591,7 +593,7 @@ func (o *Options) Validate() error {
 		return fmt.Errorf("config: failed to parse policy: %w", err)
 	}
 
-	if err := o.parseHeaders(); err != nil {
+	if err := o.parseHeaders(ctx); err != nil {
 		return fmt.Errorf("config: failed to parse headers: %w", err)
 	}
 
@@ -669,7 +671,7 @@ func (o *Options) Validate() error {
 	// GoogleCloudServerlessAuthenticationServiceAccount
 	if o.Provider == "google" && o.GoogleCloudServerlessAuthenticationServiceAccount == "" {
 		o.GoogleCloudServerlessAuthenticationServiceAccount = o.ServiceAccount
-		log.Info().Msg("defaulting to idp_service_account for google_cloud_serverless_authentication_service_account")
+		log.Info(ctx).Msg("defaulting to idp_service_account for google_cloud_serverless_authentication_service_account")
 	}
 
 	// strip quotes from redirect address (#811)
@@ -683,7 +685,7 @@ func (o *Options) Validate() error {
 	switch o.Provider {
 	case azure.Name, github.Name, gitlab.Name, google.Name, okta.Name, onelogin.Name:
 		if len(o.Scopes) > 0 {
-			log.Warn().Msg(idpCustomScopesWarnMsg)
+			log.Warn(ctx).Msg(idpCustomScopesWarnMsg)
 		}
 	default:
 	}

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"io/ioutil"
@@ -193,7 +194,7 @@ func Test_parseHeaders(t *testing.T) {
 			o.viperSet("headers", tt.viperHeaders)
 			o.viperSet("HeadersEnv", tt.envHeaders)
 			o.HeadersEnv = tt.envHeaders
-			err := o.parseHeaders()
+			err := o.parseHeaders(context.Background())
 
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Error condition unexpected: err=%s", err)

--- a/config/trace.go
+++ b/config/trace.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
@@ -83,14 +84,16 @@ func (mgr *TraceManager) OnConfigChange(cfg *Config) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
+	ctx := context.TODO()
+
 	traceOpts, err := NewTracingOptions(cfg.Options)
 	if err != nil {
-		log.Error().Err(err).Msg("trace: failed to build tracing options")
+		log.Error(ctx).Err(err).Msg("trace: failed to build tracing options")
 		return
 	}
 
 	if reflect.DeepEqual(traceOpts, mgr.traceOpts) {
-		log.Debug().Msg("no change detected in trace options")
+		log.Debug(ctx).Msg("no change detected in trace options")
 		return
 	}
 	mgr.traceOpts = traceOpts
@@ -104,11 +107,11 @@ func (mgr *TraceManager) OnConfigChange(cfg *Config) {
 		return
 	}
 
-	log.Info().Interface("options", traceOpts).Msg("trace: starting exporter")
+	log.Info(ctx).Interface("options", traceOpts).Msg("trace: starting exporter")
 
 	mgr.exporter, err = trace.RegisterTracing(traceOpts)
 	if err != nil {
-		log.Error().Err(err).Msg("trace: failed to register exporter")
+		log.Error(ctx).Err(err).Msg("trace: failed to register exporter")
 		return
 	}
 }

--- a/config/trace_test.go
+++ b/config/trace_test.go
@@ -123,12 +123,12 @@ func TestTraceManager(t *testing.T) {
 		TracingSampleRate: 1,
 	}})
 
-	_ = NewTraceManager(src)
+	_ = NewTraceManager(ctx, src)
 
 	_, span := trace.StartSpan(ctx, "Example")
 	span.End()
 
-	src.SetConfig(&Config{Options: &Options{
+	src.SetConfig(ctx, &Config{Options: &Options{
 		TracingProvider:   "zipkin",
 		ZipkinEndpoint:    srv2.URL,
 		TracingSampleRate: 1,

--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -107,7 +107,7 @@ func New(cfg *config.Config) (*DataBroker, error) {
 func (c *DataBroker) OnConfigChange(cfg *config.Config) {
 	err := c.update(cfg)
 	if err != nil {
-		log.Error().Err(err).Msg("databroker: error updating configuration")
+		log.Error(context.TODO()).Err(err).Msg("databroker: error updating configuration")
 	}
 
 	c.dataBrokerServer.OnConfigChange(cfg)

--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -104,13 +104,13 @@ func New(cfg *config.Config) (*DataBroker, error) {
 }
 
 // OnConfigChange is called whenever configuration is changed.
-func (c *DataBroker) OnConfigChange(cfg *config.Config) {
+func (c *DataBroker) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	err := c.update(cfg)
 	if err != nil {
-		log.Error(context.TODO()).Err(err).Msg("databroker: error updating configuration")
+		log.Error(ctx).Err(err).Msg("databroker: error updating configuration")
 	}
 
-	c.dataBrokerServer.OnConfigChange(cfg)
+	c.dataBrokerServer.OnConfigChange(ctx, cfg)
 }
 
 // Register registers all the gRPC services with the given server.

--- a/databroker/databroker.go
+++ b/databroker/databroker.go
@@ -27,7 +27,7 @@ func newDataBrokerServer(cfg *config.Config) *dataBrokerServer {
 }
 
 // OnConfigChange updates the underlying databroker server whenever configuration is changed.
-func (srv *dataBrokerServer) OnConfigChange(cfg *config.Config) {
+func (srv *dataBrokerServer) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	srv.server.UpdateConfig(srv.getOptions(cfg)...)
 	srv.setKey(cfg)
 }

--- a/integration/internal/cluster/cluster.go
+++ b/integration/internal/cluster/cluster.go
@@ -5,7 +5,8 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 
-	"github.com/rs/zerolog/log"
+	"github.com/pomerium/pomerium/internal/log"
+
 	"golang.org/x/net/publicsuffix"
 )
 

--- a/integration/internal/cluster/cluster.go
+++ b/integration/internal/cluster/cluster.go
@@ -51,6 +51,6 @@ type loggingRoundTripper struct {
 
 func (rt *loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, err error) {
 	res, err = rt.RoundTripper.RoundTrip(req)
-	log.Debug().Str("method", req.Method).Str("url", req.URL.String()).Msg("http request")
+	log.Debug(req.Context()).Str("method", req.Method).Str("url", req.URL.String()).Msg("http request")
 	return res, err
 }

--- a/integration/internal/cluster/cmd.go
+++ b/integration/internal/cluster/cmd.go
@@ -8,7 +8,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/rs/zerolog/log"
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 type cmdOption func(*exec.Cmd)
@@ -53,7 +53,7 @@ func run(ctx context.Context, name string, options ...cmdOption) error {
 		if err != nil {
 			return fmt.Errorf("failed to create stderr pipe for %s: %w", name, err)
 		}
-		go cmdLogger(stderr)
+		go cmdLogger(ctx, stderr)
 		defer stderr.Close()
 	}
 	if cmd.Stdout == nil {
@@ -61,17 +61,17 @@ func run(ctx context.Context, name string, options ...cmdOption) error {
 		if err != nil {
 			return fmt.Errorf("failed to create stdout pipe for %s: %w", name, err)
 		}
-		go cmdLogger(stdout)
+		go cmdLogger(ctx, stdout)
 		defer stdout.Close()
 	}
 
-	log.Debug().Strs("args", cmd.Args).Msgf("running %s", name)
+	log.Debug(ctx).Strs("args", cmd.Args).Msgf("running %s", name)
 	return cmd.Run()
 }
 
-func cmdLogger(rdr io.Reader) {
+func cmdLogger(ctx context.Context, rdr io.Reader) {
 	s := bufio.NewScanner(rdr)
 	for s.Scan() {
-		log.Debug().Msg(s.Text())
+		log.Debug(ctx).Msg(s.Text())
 	}
 }

--- a/integration/internal/cluster/setup.go
+++ b/integration/internal/cluster/setup.go
@@ -15,9 +15,9 @@ import (
 	"time"
 
 	"github.com/google/go-jsonnet"
-	"github.com/rs/zerolog/log"
 
 	"github.com/pomerium/pomerium/integration/internal/netutil"
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 var requiredDeployments = []string{
@@ -180,7 +180,7 @@ func applyManifests(ctx context.Context, jsonsrc string) error {
 		return fmt.Errorf("error applying manifests: %w", err)
 	}
 
-	log.Info().Msg("waiting for deployments to come up")
+	log.Info(ctx).Msg("waiting for deployments to come up")
 	ctx, clearTimeout := context.WithTimeout(ctx, 15*time.Minute)
 	defer clearTimeout()
 	ticker := time.NewTicker(time.Second * 5)
@@ -218,7 +218,7 @@ func applyManifests(ctx context.Context, jsonsrc string) error {
 		for _, dep := range requiredDeployments {
 			if byName[dep] < 1 {
 				done = false
-				log.Warn().Str("deployment", dep).Msg("deployment is not ready yet")
+				log.Warn(ctx).Str("deployment", dep).Msg("deployment is not ready yet")
 			}
 		}
 		if done {
@@ -233,7 +233,7 @@ func applyManifests(ctx context.Context, jsonsrc string) error {
 		<-ticker.C
 	}
 	time.Sleep(time.Minute)
-	log.Info().Msg("all deployments are ready")
+	log.Info(ctx).Msg("all deployments are ready")
 
 	return nil
 }

--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -69,7 +69,7 @@ func newManager(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	mgr.src.OnConfigChange(func(cfg *config.Config) {
+	mgr.src.OnConfigChange(ctx, func(ctx context.Context, cfg *config.Config) {
 		err := mgr.update(cfg)
 		if err != nil {
 			log.Error(context.TODO()).Err(err).Msg("autocert: error updating config")
@@ -77,7 +77,7 @@ func newManager(ctx context.Context,
 		}
 
 		cfg = mgr.GetConfig()
-		mgr.Trigger(cfg)
+		mgr.Trigger(ctx, cfg)
 	})
 	go func() {
 		ticker := time.NewTicker(checkInterval)
@@ -153,7 +153,7 @@ func (mgr *Manager) renewConfigCerts() error {
 	}
 
 	mgr.config = cfg
-	mgr.Trigger(cfg)
+	mgr.Trigger(context.TODO(), cfg)
 	return nil
 }
 

--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -72,7 +72,7 @@ func newManager(ctx context.Context,
 	mgr.src.OnConfigChange(ctx, func(ctx context.Context, cfg *config.Config) {
 		err := mgr.update(cfg)
 		if err != nil {
-			log.Error(context.TODO()).Err(err).Msg("autocert: error updating config")
+			log.Error(ctx).Err(err).Msg("autocert: error updating config")
 			return
 		}
 

--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -72,7 +72,7 @@ func newManager(ctx context.Context,
 	mgr.src.OnConfigChange(func(cfg *config.Config) {
 		err := mgr.update(cfg)
 		if err != nil {
-			log.Error().Err(err).Msg("autocert: error updating config")
+			log.Error(context.TODO()).Err(err).Msg("autocert: error updating config")
 			return
 		}
 
@@ -90,7 +90,7 @@ func newManager(ctx context.Context,
 			case <-ticker.C:
 				err := mgr.renewConfigCerts()
 				if err != nil {
-					log.Error().Err(err).Msg("autocert: error updating config")
+					log.Error(context.TODO()).Err(err).Msg("autocert: error updating config")
 					return
 				}
 			}
@@ -172,10 +172,10 @@ func (mgr *Manager) update(cfg *config.Config) error {
 func (mgr *Manager) obtainCert(domain string, cm *certmagic.Config) (certmagic.Certificate, error) {
 	cert, err := cm.CacheManagedCertificate(domain)
 	if err != nil {
-		log.Info().Str("domain", domain).Msg("obtaining certificate")
+		log.Info(context.TODO()).Str("domain", domain).Msg("obtaining certificate")
 		err = cm.ObtainCert(context.Background(), domain, false)
 		if err != nil {
-			log.Error().Err(err).Msg("autocert failed to obtain client certificate")
+			log.Error(context.TODO()).Err(err).Msg("autocert failed to obtain client certificate")
 			return certmagic.Certificate{}, errObtainCertFailed
 		}
 		metrics.RecordAutocertRenewal()
@@ -187,13 +187,13 @@ func (mgr *Manager) obtainCert(domain string, cm *certmagic.Config) (certmagic.C
 // renewCert attempts to renew given certificate.
 func (mgr *Manager) renewCert(domain string, cert certmagic.Certificate, cm *certmagic.Config) (certmagic.Certificate, error) {
 	expired := time.Now().After(cert.Leaf.NotAfter)
-	log.Info().Str("domain", domain).Msg("renewing certificate")
+	log.Info(context.TODO()).Str("domain", domain).Msg("renewing certificate")
 	err := cm.RenewCert(context.Background(), domain, false)
 	if err != nil {
 		if expired {
 			return certmagic.Certificate{}, errRenewCertFailed
 		}
-		log.Warn().Err(err).Msg("renew client certificated failed, use existing cert")
+		log.Warn(context.TODO()).Err(err).Msg("renew client certificated failed, use existing cert")
 	}
 	return cm.CacheManagedCertificate(domain)
 }
@@ -220,11 +220,11 @@ func (mgr *Manager) updateAutocert(cfg *config.Config) error {
 			return fmt.Errorf("autocert: failed to renew client certificate: %w", err)
 		}
 		if err != nil {
-			log.Error().Err(err).Msg("autocert: failed to obtain client certificate")
+			log.Error(context.TODO()).Err(err).Msg("autocert: failed to obtain client certificate")
 			continue
 		}
 
-		log.Info().Strs("names", cert.Names).Msg("autocert: added certificate")
+		log.Info(context.TODO()).Strs("names", cert.Names).Msg("autocert: added certificate")
 		cfg.AutoCertificates = append(cfg.AutoCertificates, cert.Certificate)
 	}
 
@@ -260,10 +260,10 @@ func (mgr *Manager) updateServer(cfg *config.Config) {
 		}),
 	}
 	go func() {
-		log.Info().Str("addr", hsrv.Addr).Msg("starting http redirect server")
+		log.Info(context.TODO()).Str("addr", hsrv.Addr).Msg("starting http redirect server")
 		err := hsrv.ListenAndServe()
 		if err != nil {
-			log.Error().Err(err).Msg("failed to run http redirect server")
+			log.Error(context.TODO()).Err(err).Msg("failed to run http redirect server")
 		}
 	}()
 	mgr.srv = hsrv

--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -32,7 +32,7 @@ import (
 
 // Run runs the main pomerium application.
 func Run(ctx context.Context, configFile string) error {
-	log.Info().Str("version", version.FullVersion()).Msg("cmd/pomerium")
+	log.Info(ctx).Str("version", version.FullVersion()).Msg("cmd/pomerium")
 
 	var src config.Source
 
@@ -68,7 +68,7 @@ func Run(ctx context.Context, configFile string) error {
 	}
 	src.OnConfigChange(func(cfg *config.Config) {
 		if err := controlPlane.OnConfigChange(cfg); err != nil {
-			log.Error().Err(err).Msg("config change")
+			log.Error(ctx).Err(err).Msg("config change")
 		}
 	})
 
@@ -79,8 +79,8 @@ func Run(ctx context.Context, configFile string) error {
 	_, grpcPort, _ := net.SplitHostPort(controlPlane.GRPCListener.Addr().String())
 	_, httpPort, _ := net.SplitHostPort(controlPlane.HTTPListener.Addr().String())
 
-	log.Info().Str("port", grpcPort).Msg("gRPC server started")
-	log.Info().Str("port", httpPort).Msg("HTTP server started")
+	log.Info(ctx).Str("port", grpcPort).Msg("gRPC server started")
+	log.Info(ctx).Str("port", httpPort).Msg("HTTP server started")
 
 	// create envoy server
 	envoyServer, err := envoy.NewServer(src, grpcPort, httpPort, controlPlane.Builder)
@@ -179,7 +179,7 @@ func setupAuthenticate(src config.Source, controlPlane *controlplane.Server) err
 	host := urlutil.StripPort(authenticateURL.Host)
 	sr := controlPlane.HTTPRouter.Host(host).Subrouter()
 	svc.Mount(sr)
-	log.Info().Str("host", host).Msg("enabled authenticate service")
+	log.Info(context.TODO()).Str("host", host).Msg("enabled authenticate service")
 
 	return nil
 }
@@ -191,7 +191,7 @@ func setupAuthorize(src config.Source, controlPlane *controlplane.Server) (*auth
 	}
 	envoy_service_auth_v3.RegisterAuthorizationServer(controlPlane.GRPCServer, svc)
 
-	log.Info().Msg("enabled authorize service")
+	log.Info(context.TODO()).Msg("enabled authorize service")
 	src.OnConfigChange(svc.OnConfigChange)
 	svc.OnConfigChange(src.GetConfig())
 	return svc, nil
@@ -203,7 +203,7 @@ func setupDataBroker(src config.Source, controlPlane *controlplane.Server) (*dat
 		return nil, fmt.Errorf("error creating databroker service: %w", err)
 	}
 	svc.Register(controlPlane.GRPCServer)
-	log.Info().Msg("enabled databroker service")
+	log.Info(context.TODO()).Msg("enabled databroker service")
 	src.OnConfigChange(svc.OnConfigChange)
 	svc.OnConfigChange(src.GetConfig())
 	return svc, nil
@@ -212,7 +212,7 @@ func setupDataBroker(src config.Source, controlPlane *controlplane.Server) (*dat
 func setupRegistryServer(src config.Source, controlPlane *controlplane.Server) error {
 	svc := registry.NewInMemoryServer(context.TODO(), registryTTL)
 	registry_pb.RegisterRegistryServer(controlPlane.GRPCServer, svc)
-	log.Info().Msg("enabled service discovery")
+	log.Info(context.TODO()).Msg("enabled service discovery")
 	return nil
 }
 
@@ -234,7 +234,7 @@ func setupProxy(src config.Source, controlPlane *controlplane.Server) error {
 	}
 	controlPlane.HTTPRouter.PathPrefix("/").Handler(svc)
 
-	log.Info().Msg("enabled proxy service")
+	log.Info(context.TODO()).Msg("enabled proxy service")
 	src.OnConfigChange(svc.OnConfigChange)
 	svc.OnConfigChange(src.GetConfig())
 

--- a/internal/controlplane/grpc_accesslog.go
+++ b/internal/controlplane/grpc_accesslog.go
@@ -19,7 +19,7 @@ func (srv *Server) StreamAccessLogs(stream envoy_service_accesslog_v3.AccessLogS
 	for {
 		msg, err := stream.Recv()
 		if err != nil {
-			log.Error().Err(err).Msg("access log stream error, disconnecting")
+			log.Error(stream.Context()).Err(err).Msg("access log stream error, disconnecting")
 			return err
 		}
 
@@ -27,9 +27,9 @@ func (srv *Server) StreamAccessLogs(stream envoy_service_accesslog_v3.AccessLogS
 			reqPath := entry.GetRequest().GetPath()
 			var evt *zerolog.Event
 			if reqPath == "/ping" || reqPath == "/healthz" {
-				evt = log.Debug()
+				evt = log.Debug(stream.Context())
 			} else {
-				evt = log.Info()
+				evt = log.Info(stream.Context())
 			}
 			// common properties
 			evt = evt.Str("service", "envoy")

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -9,6 +9,7 @@ import (
 
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"github.com/gorilla/mux"
+	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -106,7 +107,11 @@ func NewServer(name string, metricsMgr *config.MetricsManager) (*Server, error) 
 		srv.reproxy,
 	)
 
-	res, err := srv.buildDiscoveryResources()
+	ctx := log.WithContext(context.Background(), func(c zerolog.Context) zerolog.Context {
+		return c.Str("server_name", name)
+	})
+
+	res, err := srv.buildDiscoveryResources(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -178,17 +183,17 @@ func (srv *Server) Run(ctx context.Context) error {
 }
 
 // OnConfigChange updates the pomerium config options.
-func (srv *Server) OnConfigChange(cfg *config.Config) error {
-	srv.reproxy.Update(cfg)
+func (srv *Server) OnConfigChange(ctx context.Context, cfg *config.Config) error {
+	srv.reproxy.Update(ctx, cfg)
 	prev := srv.currentConfig.Load()
 	srv.currentConfig.Store(versionedConfig{
 		Config:  cfg,
 		version: prev.version + 1,
 	})
-	res, err := srv.buildDiscoveryResources()
+	res, err := srv.buildDiscoveryResources(ctx)
 	if err != nil {
 		return err
 	}
-	srv.xdsmgr.Update(res)
+	srv.xdsmgr.Update(ctx, res)
 	return nil
 }

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -123,7 +123,7 @@ func (srv *Server) Run(ctx context.Context) error {
 
 	// start the gRPC server
 	eg.Go(func() error {
-		log.Info().Str("addr", srv.GRPCListener.Addr().String()).Msg("starting control-plane gRPC server")
+		log.Info(ctx).Str("addr", srv.GRPCListener.Addr().String()).Msg("starting control-plane gRPC server")
 		return srv.GRPCServer.Serve(srv.GRPCListener)
 	})
 
@@ -160,7 +160,7 @@ func (srv *Server) Run(ctx context.Context) error {
 
 	// start the HTTP server
 	eg.Go(func() error {
-		log.Info().Str("addr", srv.HTTPListener.Addr().String()).Msg("starting control-plane HTTP server")
+		log.Info(ctx).Str("addr", srv.HTTPListener.Addr().String()).Msg("starting control-plane HTTP server")
 		return hsrv.Serve(srv.HTTPListener)
 	})
 

--- a/internal/controlplane/xds.go
+++ b/internal/controlplane/xds.go
@@ -1,6 +1,7 @@
 package controlplane
 
 import (
+	"context"
 	"encoding/hex"
 
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -14,11 +15,11 @@ const (
 	listenerTypeURL = "type.googleapis.com/envoy.config.listener.v3.Listener"
 )
 
-func (srv *Server) buildDiscoveryResources() (map[string][]*envoy_service_discovery_v3.Resource, error) {
+func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*envoy_service_discovery_v3.Resource, error) {
 	resources := map[string][]*envoy_service_discovery_v3.Resource{}
 	cfg := srv.currentConfig.Load()
 
-	clusters, err := srv.Builder.BuildClusters(cfg.Config)
+	clusters, err := srv.Builder.BuildClusters(ctx, cfg.Config)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controlplane/xdsmgr/xdsmgr.go
+++ b/internal/controlplane/xdsmgr/xdsmgr.go
@@ -2,6 +2,7 @@
 package xdsmgr
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"sync"
@@ -109,7 +110,7 @@ func (mgr *Manager) DeltaAggregatedResources(
 		case req.GetErrorDetail() != nil:
 			// a NACK
 			bs, _ := json.Marshal(req.ErrorDetail.Details)
-			log.Error().
+			log.Error(context.TODO()).
 				Err(errors.New(req.ErrorDetail.Message)).
 				Int32("code", req.ErrorDetail.Code).
 				RawJSON("details", bs).Msg("error applying configuration")

--- a/internal/controlplane/xdsmgr/xdsmgr.go
+++ b/internal/controlplane/xdsmgr/xdsmgr.go
@@ -52,7 +52,7 @@ func (mgr *Manager) DeltaAggregatedResources(
 
 	stateByTypeURL := map[string]*streamState{}
 
-	getDeltaResponse := func(typeURL string) *envoy_service_discovery_v3.DeltaDiscoveryResponse {
+	getDeltaResponse := func(ctx context.Context, typeURL string) *envoy_service_discovery_v3.DeltaDiscoveryResponse {
 		mgr.mu.Lock()
 		defer mgr.mu.Unlock()
 
@@ -86,7 +86,7 @@ func (mgr *Manager) DeltaAggregatedResources(
 		return res
 	}
 
-	handleDeltaRequest := func(req *envoy_service_discovery_v3.DeltaDiscoveryRequest) {
+	handleDeltaRequest := func(ctx context.Context, req *envoy_service_discovery_v3.DeltaDiscoveryRequest) {
 		mgr.mu.Lock()
 		defer mgr.mu.Unlock()
 
@@ -110,8 +110,9 @@ func (mgr *Manager) DeltaAggregatedResources(
 		case req.GetErrorDetail() != nil:
 			// a NACK
 			bs, _ := json.Marshal(req.ErrorDetail.Details)
-			log.Error(context.TODO()).
+			log.Error(ctx).
 				Err(errors.New(req.ErrorDetail.Message)).
+				Str("nonce", req.ResponseNonce).
 				Int32("code", req.ErrorDetail.Code).
 				RawJSON("details", bs).Msg("error applying configuration")
 			// - set the client resource versions to the current resource versions
@@ -122,12 +123,18 @@ func (mgr *Manager) DeltaAggregatedResources(
 		case req.GetResponseNonce() == mgr.nonce:
 			// an ACK for the last response
 			// - set the client resource versions to the current resource versions
+			log.Debug(ctx).
+				Str("nonce", req.ResponseNonce).
+				Msg("ACK")
 			state.clientResourceVersions = make(map[string]string)
 			for _, resource := range mgr.resources[req.GetTypeUrl()] {
 				state.clientResourceVersions[resource.Name] = resource.Version
 			}
 		default:
 			// an ACK for a response that's not the last response
+			log.Debug(ctx).
+				Str("nonce", req.ResponseNonce).
+				Msg("stale ACK")
 		}
 
 		// update subscriptions
@@ -169,15 +176,16 @@ func (mgr *Manager) DeltaAggregatedResources(
 	})
 	// 2. handle incoming requests or resource changes
 	eg.Go(func() error {
+		changeCtx := ctx
 		for {
 			var typeURLs []string
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
 			case req := <-incoming:
-				handleDeltaRequest(req)
+				handleDeltaRequest(changeCtx, req)
 				typeURLs = []string{req.GetTypeUrl()}
-			case <-ch:
+			case changeCtx = <-ch:
 				mgr.mu.Lock()
 				for typeURL := range mgr.resources {
 					typeURLs = append(typeURLs, typeURL)
@@ -186,7 +194,7 @@ func (mgr *Manager) DeltaAggregatedResources(
 			}
 
 			for _, typeURL := range typeURLs {
-				res := getDeltaResponse(typeURL)
+				res := getDeltaResponse(changeCtx, typeURL)
 				if res == nil {
 					continue
 				}
@@ -195,6 +203,10 @@ func (mgr *Manager) DeltaAggregatedResources(
 				case <-ctx.Done():
 					return ctx.Err()
 				case outgoing <- res:
+					log.Info(changeCtx).
+						Str("nounce", res.Nonce).
+						Str("type", res.TypeUrl).
+						Msg("send update")
 				}
 			}
 		}
@@ -225,11 +237,11 @@ func (mgr *Manager) StreamAggregatedResources(
 
 // Update updates the state of resources. If any changes are made they will be pushed to any listening
 // streams. For each TypeURL the list of resources should be the complete list of resources.
-func (mgr *Manager) Update(resources map[string][]*envoy_service_discovery_v3.Resource) {
+func (mgr *Manager) Update(ctx context.Context, resources map[string][]*envoy_service_discovery_v3.Resource) {
 	mgr.mu.Lock()
 	mgr.nonce = uuid.New().String()
 	mgr.resources = resources
 	mgr.mu.Unlock()
 
-	mgr.signal.Broadcast()
+	mgr.signal.Broadcast(ctx)
 }

--- a/internal/controlplane/xdsmgr/xdsmgr_test.go
+++ b/internal/controlplane/xdsmgr/xdsmgr_test.go
@@ -28,7 +28,7 @@ func TestManager(t *testing.T) {
 	origOnHandleDeltaRequest := onHandleDeltaRequest
 	defer func() { onHandleDeltaRequest = origOnHandleDeltaRequest }()
 	onHandleDeltaRequest = func(state *streamState) {
-		stateChanged.Broadcast()
+		stateChanged.Broadcast(ctx)
 	}
 
 	srv := grpc.NewServer()
@@ -94,7 +94,7 @@ func TestManager(t *testing.T) {
 		}, msg.GetResources())
 		ack(msg.Nonce)
 
-		mgr.Update(map[string][]*envoy_service_discovery_v3.Resource{
+		mgr.Update(ctx, map[string][]*envoy_service_discovery_v3.Resource{
 			typeURL: {{Name: "r1", Version: "2"}},
 		})
 
@@ -105,7 +105,7 @@ func TestManager(t *testing.T) {
 		}, msg.GetResources())
 		ack(msg.Nonce)
 
-		mgr.Update(map[string][]*envoy_service_discovery_v3.Resource{
+		mgr.Update(ctx, map[string][]*envoy_service_discovery_v3.Resource{
 			typeURL: nil,
 		})
 

--- a/internal/databroker/config.go
+++ b/internal/databroker/config.go
@@ -1,6 +1,7 @@
 package databroker
 
 import (
+	"context"
 	"crypto/tls"
 	"encoding/base64"
 	"time"
@@ -65,7 +66,7 @@ func WithSharedKey(sharedKey string) ServerOption {
 	return func(cfg *serverConfig) {
 		key, err := base64.StdEncoding.DecodeString(sharedKey)
 		if err != nil || len(key) != cryptutil.DefaultKeySize {
-			log.Error().Err(err).Msgf("shared key is required and must be %d bytes long", cryptutil.DefaultKeySize)
+			log.Error(context.TODO()).Err(err).Msgf("shared key is required and must be %d bytes long", cryptutil.DefaultKeySize)
 			return
 		}
 		cfg.secret = key

--- a/internal/databroker/config_source_test.go
+++ b/internal/databroker/config_source_test.go
@@ -37,9 +37,9 @@ func TestConfigSource(t *testing.T) {
 	base.InsecureServer = true
 	base.GRPCInsecure = true
 
-	src := NewConfigSource(config.NewStaticSource(&config.Config{
+	src := NewConfigSource(ctx, config.NewStaticSource(&config.Config{
 		Options: base,
-	}), func(cfg *config.Config) {
+	}), func(_ context.Context, cfg *config.Config) {
 		cfgs <- cfg
 	})
 	cfgs <- src.GetConfig()

--- a/internal/databroker/server_test.go
+++ b/internal/databroker/server_test.go
@@ -10,7 +10,6 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 )
@@ -19,7 +18,6 @@ func newServer(cfg *serverConfig) *Server {
 	return &Server{
 		version: 11,
 		cfg:     cfg,
-		log:     log.With().Str("service", "databroker").Logger(),
 	}
 }
 

--- a/internal/directory/provider.go
+++ b/internal/directory/provider.go
@@ -50,8 +50,9 @@ func GetProvider(options Options) (provider Provider) {
 	globalProvider.Lock()
 	defer globalProvider.Unlock()
 
+	ctx := context.TODO()
 	if globalProvider.provider != nil && cmp.Equal(globalProvider.options, options) {
-		log.Debug().Str("provider", options.Provider).Msg("directory: no change detected, reusing existing directory provider")
+		log.Debug(ctx).Str("provider", options.Provider).Msg("directory: no change detected, reusing existing directory provider")
 		return globalProvider.provider
 	}
 	defer func() {
@@ -72,7 +73,7 @@ func GetProvider(options Options) (provider Provider) {
 				auth0.WithDomain(options.ProviderURL),
 				auth0.WithServiceAccount(serviceAccount))
 		}
-		log.Warn().
+		log.Warn(ctx).
 			Str("service", "directory").
 			Str("provider", options.Provider).
 			Err(err).
@@ -82,7 +83,7 @@ func GetProvider(options Options) (provider Provider) {
 		if err == nil {
 			return azure.New(azure.WithServiceAccount(serviceAccount))
 		}
-		log.Warn().
+		log.Warn(ctx).
 			Str("service", "directory").
 			Str("provider", options.Provider).
 			Err(err).
@@ -92,7 +93,7 @@ func GetProvider(options Options) (provider Provider) {
 		if err == nil {
 			return github.New(github.WithServiceAccount(serviceAccount))
 		}
-		log.Warn().
+		log.Warn(ctx).
 			Str("service", "directory").
 			Str("provider", options.Provider).
 			Err(err).
@@ -107,7 +108,7 @@ func GetProvider(options Options) (provider Provider) {
 				gitlab.WithURL(providerURL),
 				gitlab.WithServiceAccount(serviceAccount))
 		}
-		log.Warn().
+		log.Warn(ctx).
 			Str("service", "directory").
 			Str("provider", options.Provider).
 			Err(err).
@@ -117,7 +118,7 @@ func GetProvider(options Options) (provider Provider) {
 		if err == nil {
 			return google.New(google.WithServiceAccount(serviceAccount))
 		}
-		log.Warn().
+		log.Warn(ctx).
 			Str("service", "directory").
 			Str("provider", options.Provider).
 			Err(err).
@@ -129,7 +130,7 @@ func GetProvider(options Options) (provider Provider) {
 				okta.WithProviderURL(providerURL),
 				okta.WithServiceAccount(serviceAccount))
 		}
-		log.Warn().
+		log.Warn(ctx).
 			Str("service", "directory").
 			Str("provider", options.Provider).
 			Err(err).
@@ -139,7 +140,7 @@ func GetProvider(options Options) (provider Provider) {
 		if err == nil {
 			return onelogin.New(onelogin.WithServiceAccount(serviceAccount))
 		}
-		log.Warn().
+		log.Warn(ctx).
 			Str("service", "directory").
 			Str("provider", options.Provider).
 			Err(err).
@@ -151,14 +152,14 @@ func GetProvider(options Options) (provider Provider) {
 				ping.WithProviderURL(providerURL),
 				ping.WithServiceAccount(serviceAccount))
 		}
-		log.Warn().
+		log.Warn(ctx).
 			Str("service", "directory").
 			Str("provider", options.Provider).
 			Err(err).
 			Msg("invalid service account for ping directory provider")
 	}
 
-	log.Warn().
+	log.Warn(ctx).
 		Str("provider", options.Provider).
 		Msg("no directory provider implementation found, disabling support for groups")
 	return nullProvider{}

--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -76,7 +76,7 @@ func NewServer(ctx context.Context, src config.Source, grpcPort, httpPort string
 
 	envoyPath, err := extractEmbeddedEnvoy()
 	if err != nil {
-		log.Warn(context.TODO()).Err(err).Send()
+		log.Warn(ctx).Err(err).Send()
 		envoyPath = "envoy"
 	}
 
@@ -98,7 +98,7 @@ func NewServer(ctx context.Context, src config.Source, grpcPort, httpPort string
 			return nil, fmt.Errorf("invalid envoy binary, expected %s but got %s", Checksum, s)
 		}
 	} else {
-		log.Info(context.TODO()).Msg("no checksum defined, envoy binary will not be verified!")
+		log.Info(ctx).Msg("no checksum defined, envoy binary will not be verified!")
 	}
 
 	srv := &Server{
@@ -108,7 +108,7 @@ func NewServer(ctx context.Context, src config.Source, grpcPort, httpPort string
 		httpPort:  httpPort,
 		envoyPath: envoyPath,
 	}
-	go srv.runProcessCollector(context.TODO())
+	go srv.runProcessCollector(ctx)
 
 	src.OnConfigChange(ctx, srv.onConfigChange)
 	srv.onConfigChange(ctx, src.GetConfig())

--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -76,7 +76,7 @@ func NewServer(src config.Source, grpcPort, httpPort string, builder *envoyconfi
 
 	envoyPath, err := extractEmbeddedEnvoy()
 	if err != nil {
-		log.Warn().Err(err).Send()
+		log.Warn(context.TODO()).Err(err).Send()
 		envoyPath = "envoy"
 	}
 
@@ -98,7 +98,7 @@ func NewServer(src config.Source, grpcPort, httpPort string, builder *envoyconfi
 			return nil, fmt.Errorf("invalid envoy binary, expected %s but got %s", Checksum, s)
 		}
 	} else {
-		log.Info().Msg("no checksum defined, envoy binary will not be verified!")
+		log.Info(context.TODO()).Msg("no checksum defined, envoy binary will not be verified!")
 	}
 
 	srv := &Server{
@@ -108,12 +108,12 @@ func NewServer(src config.Source, grpcPort, httpPort string, builder *envoyconfi
 		httpPort:  httpPort,
 		envoyPath: envoyPath,
 	}
-	go srv.runProcessCollector()
+	go srv.runProcessCollector(context.TODO())
 
 	src.OnConfigChange(srv.onConfigChange)
 	srv.onConfigChange(src.GetConfig())
 
-	log.Info().
+	log.Info(context.TODO()).
 		Str("path", envoyPath).
 		Str("checksum", Checksum).
 		Msg("running envoy")
@@ -130,7 +130,7 @@ func (srv *Server) Close() error {
 	if srv.cmd != nil && srv.cmd.Process != nil {
 		err = srv.cmd.Process.Kill()
 		if err != nil {
-			log.Error().Err(err).Str("service", "envoy").Msg("envoy: failed to kill process on close")
+			log.Error(context.TODO()).Err(err).Str("service", "envoy").Msg("envoy: failed to kill process on close")
 		}
 		srv.cmd = nil
 	}
@@ -146,9 +146,10 @@ func (srv *Server) update(cfg *config.Config) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
 
+	ctx := context.TODO()
 	tracingOptions, err := config.NewTracingOptions(cfg.Options)
 	if err != nil {
-		log.Error().Err(err).Str("service", "envoy").Msg("invalid tracing config")
+		log.Error(ctx).Err(err).Str("service", "envoy").Msg("invalid tracing config")
 		return
 	}
 
@@ -159,24 +160,24 @@ func (srv *Server) update(cfg *config.Config) {
 	}
 
 	if cmp.Equal(srv.options, options, cmp.AllowUnexported(serverOptions{})) {
-		log.Debug().Str("service", "envoy").Msg("envoy: no config changes detected")
+		log.Debug(ctx).Str("service", "envoy").Msg("envoy: no config changes detected")
 		return
 	}
 	srv.options = options
 
-	if err := srv.writeConfig(cfg); err != nil {
-		log.Error().Err(err).Str("service", "envoy").Msg("envoy: failed to write envoy config")
+	if err := srv.writeConfig(ctx, cfg); err != nil {
+		log.Error(ctx).Err(err).Str("service", "envoy").Msg("envoy: failed to write envoy config")
 		return
 	}
 
-	log.Info().Msg("envoy: starting envoy process")
-	if err := srv.run(); err != nil {
-		log.Error().Err(err).Str("service", "envoy").Msg("envoy: failed to run envoy process")
+	log.Info(ctx).Msg("envoy: starting envoy process")
+	if err := srv.run(ctx); err != nil {
+		log.Error(ctx).Err(err).Str("service", "envoy").Msg("envoy: failed to run envoy process")
 		return
 	}
 }
 
-func (srv *Server) run() error {
+func (srv *Server) run(ctx context.Context) error {
 	args := []string{
 		"-c", configFileName,
 		"--log-level", srv.options.logLevel,
@@ -198,13 +199,13 @@ func (srv *Server) run() error {
 	if err != nil {
 		return fmt.Errorf("error creating stderr pipe for envoy: %w", err)
 	}
-	go srv.handleLogs(stderr)
+	go srv.handleLogs(ctx, stderr)
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("error creating stderr pipe for envoy: %w", err)
 	}
-	go srv.handleLogs(stdout)
+	go srv.handleLogs(ctx, stdout)
 
 	// make sure envoy is killed if we're killed
 	cmd.SysProcAttr = sysProcAttr
@@ -216,10 +217,10 @@ func (srv *Server) run() error {
 
 	// release the previous process so we can hot-reload
 	if srv.cmd != nil && srv.cmd.Process != nil {
-		log.Info().Msg("envoy: releasing envoy process for hot-reload")
+		log.Info(ctx).Msg("envoy: releasing envoy process for hot-reload")
 		err := srv.cmd.Process.Release()
 		if err != nil {
-			log.Warn().Err(err).Str("service", "envoy").Msg("envoy: failed to release envoy process for hot-reload")
+			log.Warn(ctx).Err(err).Str("service", "envoy").Msg("envoy: failed to release envoy process for hot-reload")
 		}
 	}
 	srv.cmd = cmd
@@ -227,14 +228,14 @@ func (srv *Server) run() error {
 	return nil
 }
 
-func (srv *Server) writeConfig(cfg *config.Config) error {
+func (srv *Server) writeConfig(ctx context.Context, cfg *config.Config) error {
 	confBytes, err := srv.buildBootstrapConfig(cfg)
 	if err != nil {
 		return err
 	}
 
 	cfgPath := filepath.Join(srv.wd, configFileName)
-	log.Debug().Str("service", "envoy").Str("location", cfgPath).Msg("wrote config file to location")
+	log.Debug(ctx).Str("service", "envoy").Str("location", cfgPath).Msg("wrote config file to location")
 
 	return atomic.WriteFile(cfgPath, bytes.NewReader(confBytes))
 }
@@ -313,9 +314,10 @@ func (srv *Server) parseLog(line string) (name string, logLevel string, msg stri
 	return
 }
 
-func (srv *Server) handleLogs(rc io.ReadCloser) {
+func (srv *Server) handleLogs(ctx context.Context, rc io.ReadCloser) {
 	defer rc.Close()
 
+	l := log.With().Str("service", "envoy").Logger()
 	bo := backoff.NewExponentialBackOff()
 
 	s := bufio.NewReader(rc)
@@ -325,7 +327,7 @@ func (srv *Server) handleLogs(rc io.ReadCloser) {
 			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
 				break
 			}
-			log.Error().Err(err).Msg("failed to read log")
+			log.Error(ctx).Err(err).Msg("failed to read log")
 			time.Sleep(bo.NextBackOff())
 			continue
 		}
@@ -336,9 +338,12 @@ func (srv *Server) handleLogs(rc io.ReadCloser) {
 		if name == "" {
 			name = "envoy"
 		}
+
 		lvl := zerolog.DebugLevel
 		if x, err := zerolog.ParseLevel(logLevel); err == nil {
 			lvl = x
+		} else {
+			lvl = zerolog.ErrorLevel
 		}
 		if msg == "" {
 			msg = ln
@@ -354,14 +359,13 @@ func (srv *Server) handleLogs(rc io.ReadCloser) {
 			continue
 		}
 
-		log.WithLevel(lvl).
-			Str("service", "envoy").
+		l.WithLevel(lvl).
 			Str("name", name).
 			Msg(msg)
 	}
 }
 
-func (srv *Server) runProcessCollector() {
+func (srv *Server) runProcessCollector(ctx context.Context) {
 	// macos is not supported
 	if runtime.GOOS != "linux" {
 		return
@@ -369,7 +373,7 @@ func (srv *Server) runProcessCollector() {
 
 	pc := metrics.NewProcessCollector("envoy")
 	if err := view.Register(pc.Views()...); err != nil {
-		log.Error().Err(err).Msg("failed to register envoy process metric views")
+		log.Error(ctx).Err(err).Msg("failed to register envoy process metric views")
 	}
 
 	const collectInterval = time.Second * 10
@@ -387,7 +391,7 @@ func (srv *Server) runProcessCollector() {
 		if pid > 0 {
 			err := pc.Measure(context.Background(), pid)
 			if err != nil {
-				log.Error().Err(err).Msg("failed to measure envoy process metrics")
+				log.Error(ctx).Err(err).Msg("failed to measure envoy process metrics")
 			}
 		}
 	}

--- a/internal/envoy/envoy_test.go
+++ b/internal/envoy/envoy_test.go
@@ -1,6 +1,7 @@
 package envoy
 
 import (
+	"context"
 	"io/ioutil"
 	"regexp"
 	"strings"
@@ -43,6 +44,6 @@ func Benchmark_handleLogs(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		srv.handleLogs(rc)
+		srv.handleLogs(context.Background(), rc)
 	}
 }

--- a/internal/fileutil/watcher.go
+++ b/internal/fileutil/watcher.go
@@ -1,6 +1,7 @@
 package fileutil
 
 import (
+	"context"
 	"sync"
 
 	"github.com/rjeczalik/notify"
@@ -29,6 +30,8 @@ func (watcher *Watcher) Add(filePath string) {
 	watcher.mu.Lock()
 	defer watcher.mu.Unlock()
 
+	ctx := context.TODO()
+
 	// already watching
 	if _, ok := watcher.filePaths[filePath]; ok {
 		return
@@ -37,18 +40,18 @@ func (watcher *Watcher) Add(filePath string) {
 	ch := make(chan notify.EventInfo, 1)
 	go func() {
 		for evt := range ch {
-			log.Info().Str("path", evt.Path()).Str("event", evt.Event().String()).Msg("filemgr: detected file change")
+			log.Info(ctx).Str("path", evt.Path()).Str("event", evt.Event().String()).Msg("filemgr: detected file change")
 			watcher.Signal.Broadcast()
 		}
 	}()
 	err := notify.Watch(filePath, ch, notify.All)
 	if err != nil {
-		log.Error().Err(err).Str("path", filePath).Msg("filemgr: error watching file path")
+		log.Error(ctx).Err(err).Str("path", filePath).Msg("filemgr: error watching file path")
 		notify.Stop(ch)
 		close(ch)
 		return
 	}
-	log.Debug().Str("path", filePath).Msg("filemgr: watching file for changes")
+	log.Debug(ctx).Str("path", filePath).Msg("filemgr: watching file for changes")
 
 	watcher.filePaths[filePath] = ch
 }

--- a/internal/httputil/reproxy/reproxy.go
+++ b/internal/httputil/reproxy/reproxy.go
@@ -121,7 +121,7 @@ func (h *Handler) Middleware(next http.Handler) http.Handler {
 }
 
 // Update updates the handler with new configuration.
-func (h *Handler) Update(cfg *config.Config) {
+func (h *Handler) Update(ctx context.Context, cfg *config.Config) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -131,7 +131,7 @@ func (h *Handler) Update(cfg *config.Config) {
 	for i, p := range cfg.Options.Policies {
 		id, err := p.RouteID()
 		if err != nil {
-			log.Warn(context.TODO()).Err(err).Msg("reproxy: error getting route id")
+			log.Warn(ctx).Err(err).Msg("reproxy: error getting route id")
 			continue
 		}
 		h.policies[id] = &cfg.Options.Policies[i]

--- a/internal/httputil/reproxy/reproxy.go
+++ b/internal/httputil/reproxy/reproxy.go
@@ -2,6 +2,7 @@
 package reproxy
 
 import (
+	"context"
 	"encoding/base64"
 	"errors"
 	"math/rand"
@@ -130,7 +131,7 @@ func (h *Handler) Update(cfg *config.Config) {
 	for i, p := range cfg.Options.Policies {
 		id, err := p.RouteID()
 		if err != nil {
-			log.Warn().Err(err).Msg("reproxy: error getting route id")
+			log.Warn(context.TODO()).Err(err).Msg("reproxy: error getting route id")
 			continue
 		}
 		h.policies[id] = &cfg.Options.Policies[i]

--- a/internal/httputil/reproxy/reproxy_test.go
+++ b/internal/httputil/reproxy/reproxy_test.go
@@ -1,6 +1,7 @@
 package reproxy
 
 import (
+	"context"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -58,7 +59,7 @@ func TestMiddleware(t *testing.T) {
 				}},
 			},
 		}
-		h.Update(cfg)
+		h.Update(context.Background(), cfg)
 
 		policyID, _ := cfg.Options.Policies[0].RouteID()
 

--- a/internal/httputil/server.go
+++ b/internal/httputil/server.go
@@ -97,8 +97,8 @@ func Shutdown(srv *http.Server) {
 	rec := <-sigint
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	log.Info().Str("signal", rec.String()).Msg("internal/httputil: shutting down servers")
+	log.Info(context.TODO()).Str("signal", rec.String()).Msg("internal/httputil: shutting down servers")
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Error().Err(err).Msg("internal/httputil: shutdown failed")
+		log.Error(context.TODO()).Err(err).Msg("internal/httputil: shutdown failed")
 	}
 }

--- a/internal/identity/manager/sync.go
+++ b/internal/identity/manager/sync.go
@@ -3,14 +3,11 @@ package manager
 import (
 	"context"
 
-	"github.com/rs/zerolog"
-
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
 type dataBrokerSyncer struct {
 	cfg *atomicConfig
-	log zerolog.Logger
 
 	update chan<- updateRecordsMessage
 	clear  chan<- struct{}
@@ -19,14 +16,13 @@ type dataBrokerSyncer struct {
 }
 
 func newDataBrokerSyncer(
+	ctx context.Context,
 	cfg *atomicConfig,
-	log zerolog.Logger,
 	update chan<- updateRecordsMessage,
 	clear chan<- struct{},
 ) *dataBrokerSyncer {
 	syncer := &dataBrokerSyncer{
 		cfg: cfg,
-		log: log,
 
 		update: update,
 		clear:  clear,

--- a/internal/identity/oauth/github/github.go
+++ b/internal/identity/oauth/github/github.go
@@ -142,7 +142,7 @@ func (p *Provider) userEmail(ctx context.Context, t *oauth2.Token, v interface{}
 		Email    string `json:"email"`
 		Verified bool   `json:"email_verified"`
 	}
-	log.Debug().Interface("emails", response).Msg("github: user emails")
+	log.Debug(ctx).Interface("emails", response).Msg("github: user emails")
 	for _, email := range response {
 		if email.Primary && email.Verified {
 			out.Email = email.Email

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -88,35 +88,55 @@ func With() zerolog.Context {
 }
 
 // Level creates a child logger with the minimum accepted level set to level.
-func Level(level zerolog.Level) zerolog.Logger {
-	return Logger().Level(level)
+func Level(ctx context.Context, level zerolog.Level) *zerolog.Logger {
+	l := contextLogger(ctx).Level(level)
+	return &l
 }
 
 // Debug starts a new message with debug level.
 //
 // You must call Msg on the returned event in order to send the event.
-func Debug() *zerolog.Event {
-	return Logger().Debug()
+func Debug(ctx context.Context) *zerolog.Event {
+	return contextLogger(ctx).Debug()
 }
 
 // Info starts a new message with info level.
 //
 // You must call Msg on the returned event in order to send the event.
-func Info() *zerolog.Event {
-	return Logger().Info()
+func Info(ctx context.Context) *zerolog.Event {
+	return contextLogger(ctx).Info()
 }
 
 // Warn starts a new message with warn level.
 //
 // You must call Msg on the returned event in order to send the event.
-func Warn() *zerolog.Event {
-	return Logger().Warn()
+func Warn(ctx context.Context) *zerolog.Event {
+	return contextLogger(ctx).Warn()
+}
+
+func contextLogger(ctx context.Context) *zerolog.Logger {
+	global := Logger()
+	if global.GetLevel() == zerolog.Disabled {
+		return global
+	}
+	l := zerolog.Ctx(ctx)
+	if l.GetLevel() == zerolog.Disabled { // no logger associated with context
+		return global
+	}
+	return l
+}
+
+// WithContext returns a context that has an associated logger and extra fields set via update
+func WithContext(ctx context.Context, update func(c zerolog.Context) zerolog.Context) context.Context {
+	l := Logger().With().Logger()
+	l.UpdateContext(update)
+	return l.WithContext(ctx)
 }
 
 // Error starts a new message with error level.
 //
 // You must call Msg on the returned event in order to send the event.
-func Error() *zerolog.Event {
+func Error(ctx context.Context) *zerolog.Event {
 	return Logger().Error()
 }
 
@@ -136,18 +156,11 @@ func Panic() *zerolog.Event {
 	return Logger().Panic()
 }
 
-// WithLevel starts a new message with level.
-//
-// You must call Msg on the returned event in order to send the event.
-func WithLevel(level zerolog.Level) *zerolog.Event {
-	return Logger().WithLevel(level)
-}
-
 // Log starts a new message with no level. Setting zerolog.GlobalLevel to
 // zerolog.Disabled will still disable events produced by this method.
 //
 // You must call Msg on the returned event in order to send the event.
-func Log() *zerolog.Event {
+func Log(ctx context.Context) *zerolog.Event {
 	return Logger().Log()
 }
 

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -128,7 +128,7 @@ func contextLogger(ctx context.Context) *zerolog.Logger {
 
 // WithContext returns a context that has an associated logger and extra fields set via update
 func WithContext(ctx context.Context, update func(c zerolog.Context) zerolog.Context) context.Context {
-	l := Logger().With().Logger()
+	l := contextLogger(ctx).With().Logger()
 	l.UpdateContext(update)
 	return l.WithContext(ctx)
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,6 +1,7 @@
 package log_test
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"time"
@@ -153,4 +154,26 @@ func ExampleSetLevel() {
 	// {"level":"warn","time":1199811905,"message":"Debug or Info or Warn"}
 	// {"level":"error","time":1199811905,"message":"Debug or Info or Warn or Error"}
 	// {"level":"debug","time":1199811905,"message":"Debug"}
+}
+
+func ExampleContext() {
+	setup()
+
+	bg := context.Background()
+	ctx1 := log.WithContext(bg, func(c zerolog.Context) zerolog.Context {
+		return c.Str("ctx", "one")
+	})
+	ctx2 := log.WithContext(bg, func(c zerolog.Context) zerolog.Context {
+		return c.Str("ctx", "two")
+	})
+
+	log.WarnContext(ctx1).Str("param", "first").Msg("first")
+	log.WarnContext(ctx2).Str("param", "second").Msg("second")
+	log.WarnContext(bg).Str("param", "third").Msg("third")
+
+	/*
+		{"level":"warn","ctx":"one","param":"first","time":1199811905,"message":"first"}
+		{"level":"warn","ctx":"two","param":"second","time":1199811905,"message":"second"}
+		{"level":"warn","param":"third","time":1199811905,"message":"third"}
+	*/
 }

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -55,7 +55,7 @@ func ExamplePrintf() {
 // Example of a log with no particular "level"
 func ExampleLog() {
 	setup()
-	log.Log().Msg("hello world")
+	log.Log(context.Background()).Msg("hello world")
 
 	// Output: {"time":1199811905,"message":"hello world"}
 }
@@ -63,7 +63,7 @@ func ExampleLog() {
 // Example of a log at a particular "level" (in this case, "debug")
 func ExampleDebug() {
 	setup()
-	log.Debug().Msg("hello world")
+	log.Debug(context.Background()).Msg("hello world")
 
 	// Output: {"level":"debug","time":1199811905,"message":"hello world"}
 }
@@ -71,7 +71,7 @@ func ExampleDebug() {
 // Example of a log at a particular "level" (in this case, "info")
 func ExampleInfo() {
 	setup()
-	log.Info().Msg("hello world")
+	log.Info(context.Background()).Msg("hello world")
 
 	// Output: {"level":"info","time":1199811905,"message":"hello world"}
 }
@@ -79,7 +79,7 @@ func ExampleInfo() {
 // Example of a log at a particular "level" (in this case, "warn")
 func ExampleWarn() {
 	setup()
-	log.Warn().Msg("hello world")
+	log.Warn(context.Background()).Msg("hello world")
 
 	// Output: {"level":"warn","time":1199811905,"message":"hello world"}
 }
@@ -87,7 +87,7 @@ func ExampleWarn() {
 // Example of a log at a particular "level" (in this case, "error")
 func ExampleError() {
 	setup()
-	log.Error().Msg("hello world")
+	log.Error(context.Background()).Msg("hello world")
 
 	// Output: {"level":"error","time":1199811905,"message":"hello world"}
 }
@@ -120,10 +120,10 @@ func Example() {
 		zerolog.SetGlobalLevel(zerolog.DebugLevel)
 	}
 
-	log.Debug().Msg("This message appears only when log level set to Debug")
-	log.Info().Msg("This message appears when log level set to Debug or Info")
+	log.Debug(context.Background()).Msg("This message appears only when log level set to Debug")
+	log.Info(context.Background()).Msg("This message appears when log level set to Debug or Info")
 
-	if e := log.Debug(); e.Enabled() {
+	if e := log.Debug(context.Background()); e.Enabled() {
 		// Compute log output only if enabled.
 		value := "bar"
 		e.Str("foo", value).Msg("some debug message")
@@ -135,19 +135,19 @@ func Example() {
 func ExampleSetLevel() {
 	setup()
 	log.SetLevel("info")
-	log.Debug().Msg("Debug")
-	log.Info().Msg("Debug or Info")
+	log.Debug(context.Background()).Msg("Debug")
+	log.Info(context.Background()).Msg("Debug or Info")
 	log.SetLevel("warn")
-	log.Debug().Msg("Debug")
-	log.Info().Msg("Debug or Info")
-	log.Warn().Msg("Debug or Info or Warn")
+	log.Debug(context.Background()).Msg("Debug")
+	log.Info(context.Background()).Msg("Debug or Info")
+	log.Warn(context.Background()).Msg("Debug or Info or Warn")
 	log.SetLevel("error")
-	log.Debug().Msg("Debug")
-	log.Info().Msg("Debug or Info")
-	log.Warn().Msg("Debug or Info or Warn")
-	log.Error().Msg("Debug or Info or Warn or Error")
+	log.Debug(context.Background()).Msg("Debug")
+	log.Info(context.Background()).Msg("Debug or Info")
+	log.Warn(context.Background()).Msg("Debug or Info or Warn")
+	log.Error(context.Background()).Msg("Debug or Info or Warn or Error")
 	log.SetLevel("default-fall-through")
-	log.Debug().Msg("Debug")
+	log.Debug(context.Background()).Msg("Debug")
 
 	// Output:
 	// {"level":"info","time":1199811905,"message":"Debug or Info"}
@@ -161,15 +161,22 @@ func ExampleContext() {
 
 	bg := context.Background()
 	ctx1 := log.WithContext(bg, func(c zerolog.Context) zerolog.Context {
-		return c.Str("ctx", "one")
+		return c.Str("param_one", "one")
 	})
-	ctx2 := log.WithContext(bg, func(c zerolog.Context) zerolog.Context {
-		return c.Str("ctx", "two")
+	ctx2 := log.WithContext(ctx1, func(c zerolog.Context) zerolog.Context {
+		return c.Str("param_two", "two")
 	})
 
-	log.WarnContext(ctx1).Str("param", "first").Msg("first")
-	log.WarnContext(ctx2).Str("param", "second").Msg("second")
-	log.WarnContext(bg).Str("param", "third").Msg("third")
+	log.Warn(bg).Str("non_context_param", "value").Msg("background")
+	log.Warn(ctx1).Str("non_context_param", "value").Msg("first")
+	log.Warn(ctx2).Str("non_context_param", "value").Msg("second")
+
+	for i := 0; i < 10; i++ {
+		ctx1 = log.WithContext(ctx1, func(c zerolog.Context) zerolog.Context {
+			return c.Int("counter", i)
+		})
+	}
+	log.Info(ctx1).Str("non_ctx_param", "value").Msg("after counter")
 
 	/*
 		{"level":"warn","ctx":"one","param":"first","time":1199811905,"message":"first"}

--- a/internal/registry/inmemory.go
+++ b/internal/registry/inmemory.go
@@ -51,7 +51,7 @@ func (s *inMemoryServer) periodicCheck(ctx context.Context) {
 			return
 		case <-time.After(after):
 			if s.lockAndRmExpired() {
-				s.onchange.Broadcast()
+				s.onchange.Broadcast(ctx)
 			}
 		}
 	}
@@ -70,7 +70,7 @@ func (s *inMemoryServer) Report(ctx context.Context, req *pb.RegisterRequest) (*
 	}
 
 	if updated {
-		s.onchange.Broadcast()
+		s.onchange.Broadcast(ctx)
 	}
 
 	return &pb.RegisterResponse{
@@ -171,7 +171,7 @@ func (s *inMemoryServer) Watch(req *pb.ListRequest, srv pb.Registry_WatchServer)
 	}
 }
 
-func (s *inMemoryServer) getServiceUpdates(ctx context.Context, kinds map[pb.ServiceKind]bool, updates chan struct{}) ([]*pb.Service, error) {
+func (s *inMemoryServer) getServiceUpdates(ctx context.Context, kinds map[pb.ServiceKind]bool, updates chan context.Context) ([]*pb.Service, error) {
 	select {
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/internal/registry/reporter.go
+++ b/internal/registry/reporter.go
@@ -24,24 +24,25 @@ type Reporter struct {
 
 // OnConfigChange applies configuration changes to the reporter
 func (r *Reporter) OnConfigChange(cfg *config.Config) {
+	ctx := context.TODO()
 	if r.cancel != nil {
 		r.cancel()
 	}
 
 	services, err := getReportedServices(cfg)
 	if err != nil {
-		log.Warn().Err(err).Msg("metrics announce to service registry is disabled")
+		log.Warn(ctx).Err(err).Msg("metrics announce to service registry is disabled")
 	}
 
 	sharedKey, err := base64.StdEncoding.DecodeString(cfg.Options.SharedKey)
 	if err != nil {
-		log.Error().Err(err).Msg("decoding shared key")
+		log.Error(ctx).Err(err).Msg("decoding shared key")
 		return
 	}
 
 	urls, err := cfg.Options.GetDataBrokerURLs()
 	if err != nil {
-		log.Error().Err(err).Msg("invalid databroker urls")
+		log.Error(ctx).Err(err).Msg("invalid databroker urls")
 		return
 	}
 
@@ -58,7 +59,7 @@ func (r *Reporter) OnConfigChange(cfg *config.Config) {
 		SignedJWTKey:            sharedKey,
 	})
 	if err != nil {
-		log.Error().Err(err).Msg("connecting to registry")
+		log.Error(ctx).Err(err).Msg("connecting to registry")
 		return
 	}
 
@@ -145,7 +146,7 @@ func runReporter(
 			after = resp.CallBackAfter.AsDuration()
 			backoff.Reset()
 		case <-ctx.Done():
-			log.Info().Msg("service registry reporter stopping")
+			log.Info(ctx).Msg("service registry reporter stopping")
 			return
 		}
 	}

--- a/internal/registry/reporter.go
+++ b/internal/registry/reporter.go
@@ -23,8 +23,7 @@ type Reporter struct {
 }
 
 // OnConfigChange applies configuration changes to the reporter
-func (r *Reporter) OnConfigChange(cfg *config.Config) {
-	ctx := context.TODO()
+func (r *Reporter) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	if r.cancel != nil {
 		r.cancel()
 	}

--- a/internal/tcptunnel/config.go
+++ b/internal/tcptunnel/config.go
@@ -1,6 +1,7 @@
 package tcptunnel
 
 import (
+	"context"
 	"crypto/tls"
 
 	"github.com/pomerium/pomerium/internal/cliutil"
@@ -19,7 +20,7 @@ func getConfig(options ...Option) *config {
 	if jwtCache, err := cliutil.NewLocalJWTCache(); err == nil {
 		WithJWTCache(jwtCache)(cfg)
 	} else {
-		log.Error().Err(err).Msg("tcptunnel: error creating local JWT cache, using in-memory JWT cache")
+		log.Error(context.TODO()).Err(err).Msg("tcptunnel: error creating local JWT cache, using in-memory JWT cache")
 		WithJWTCache(cliutil.NewMemoryJWTCache())(cfg)
 	}
 	for _, o := range options {

--- a/internal/tcptunnel/tcptunnel.go
+++ b/internal/tcptunnel/tcptunnel.go
@@ -43,7 +43,7 @@ func (tun *Tunnel) RunListener(ctx context.Context, listenerAddress string) erro
 		return err
 	}
 	defer func() { _ = li.Close() }()
-	log.Info().Msg("tcptunnel: listening on " + li.Addr().String())
+	log.Info(ctx).Msg("tcptunnel: listening on " + li.Addr().String())
 
 	go func() {
 		<-ctx.Done()
@@ -62,7 +62,7 @@ func (tun *Tunnel) RunListener(ctx context.Context, listenerAddress string) erro
 			}
 
 			if nerr, ok := err.(net.Error); ok && nerr.Temporary() {
-				log.Warn().Err(err).Msg("tcptunnel: temporarily failed to accept local connection")
+				log.Warn(ctx).Err(err).Msg("tcptunnel: temporarily failed to accept local connection")
 				select {
 				case <-time.After(bo.NextBackOff()):
 				case <-ctx.Done():
@@ -79,7 +79,7 @@ func (tun *Tunnel) RunListener(ctx context.Context, listenerAddress string) erro
 
 			err := tun.Run(ctx, conn)
 			if err != nil {
-				log.Error().Err(err).Msg("tcptunnel: error serving local connection")
+				log.Error(ctx).Err(err).Msg("tcptunnel: error serving local connection")
 			}
 		}()
 	}
@@ -102,7 +102,7 @@ func (tun *Tunnel) Run(ctx context.Context, local io.ReadWriter) error {
 }
 
 func (tun *Tunnel) run(ctx context.Context, local io.ReadWriter, rawJWT string, retryCount int) error {
-	log.Info().
+	log.Info(ctx).
 		Str("dst", tun.cfg.dstHost).
 		Str("proxy", tun.cfg.proxyHost).
 		Bool("secure", tun.cfg.tlsConfig != nil).
@@ -132,7 +132,7 @@ func (tun *Tunnel) run(ctx context.Context, local io.ReadWriter, rawJWT string, 
 	}
 	defer func() {
 		_ = remote.Close()
-		log.Info().Msg("tcptunnel: connection closed")
+		log.Info(ctx).Msg("tcptunnel: connection closed")
 	}()
 	if done := ctx.Done(); done != nil {
 		go func() {
@@ -189,7 +189,7 @@ func (tun *Tunnel) run(ctx context.Context, local io.ReadWriter, rawJWT string, 
 		return fmt.Errorf("tcptunnel: invalid http response code: %d", res.StatusCode)
 	}
 
-	log.Info().Msg("tcptunnel: connection established")
+	log.Info(ctx).Msg("tcptunnel: connection established")
 
 	errc := make(chan error, 2)
 	go func() {

--- a/internal/telemetry/metrics/grpc.go
+++ b/internal/telemetry/metrics/grpc.go
@@ -142,7 +142,7 @@ func GRPCClientInterceptor(service string) grpc.UnaryClientInterceptor {
 			tag.Upsert(TagKeyGRPCService, rpcService),
 		)
 		if tagErr != nil {
-			log.Warn().Err(tagErr).Str("context", "GRPCClientInterceptor").Msg("telemetry/metrics: failed to create context")
+			log.Warn(ctx).Err(tagErr).Str("context", "GRPCClientInterceptor").Msg("telemetry/metrics: failed to create context")
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
 
@@ -181,7 +181,7 @@ func (h *GRPCServerMetricsHandler) TagRPC(ctx context.Context, tagInfo *grpcstat
 		tag.Upsert(TagKeyGRPCService, rpcService),
 	)
 	if tagErr != nil {
-		log.Warn().Err(tagErr).Str("context", "GRPCServerStatsHandler").Msg("telemetry/metrics: failed to create context")
+		log.Warn(ctx).Err(tagErr).Str("context", "GRPCServerStatsHandler").Msg("telemetry/metrics: failed to create context")
 		return ctx
 
 	}

--- a/internal/telemetry/metrics/http.go
+++ b/internal/telemetry/metrics/http.go
@@ -120,7 +120,7 @@ func HTTPMetricsHandler(getInstallationID func() string, service string) func(ne
 				tag.Upsert(TagKeyHTTPMethod, r.Method),
 			)
 			if tagErr != nil {
-				log.Warn().Err(tagErr).Str("context", "HTTPMetricsHandler").Msg("telemetry/metrics: failed to create metrics tag")
+				log.Warn(ctx).Err(tagErr).Str("context", "HTTPMetricsHandler").Msg("telemetry/metrics: failed to create metrics tag")
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -148,7 +148,7 @@ func HTTPMetricsRoundTripper(getInstallationID func() string, service string, de
 				tag.Upsert(TagKeyDestination, destination),
 			)
 			if tagErr != nil {
-				log.Warn().Err(tagErr).Str("context", "HTTPMetricsRoundTripper").Msg("telemetry/metrics: failed to create metrics tag")
+				log.Warn(ctx).Err(tagErr).Str("context", "HTTPMetricsRoundTripper").Msg("telemetry/metrics: failed to create metrics tag")
 				return next.RoundTrip(r)
 			}
 

--- a/internal/telemetry/metrics/info_test.go
+++ b/internal/telemetry/metrics/info_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"fmt"
 	"runtime"
 	"testing"
@@ -28,7 +29,7 @@ func Test_SetConfigInfo(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			view.Unregister(InfoViews...)
 			view.Register(InfoViews...)
-			SetConfigInfo("test_service", "test config", 0, tt.success)
+			SetConfigInfo(context.Background(), "test_service", "test config", 0, tt.success)
 
 			testDataRetrieval(ConfigLastReloadView, t, tt.wantLastReload)
 			testDataRetrieval(ConfigLastReloadSuccessView, t, tt.wantLastReloadSuccess)
@@ -55,7 +56,7 @@ func Test_SetDBConfigInfo(t *testing.T) {
 		t.Run(fmt.Sprintf("version=%d errors=%d", tt.version, tt.errCount), func(t *testing.T) {
 			view.Unregister(InfoViews...)
 			view.Register(InfoViews...)
-			SetDBConfigInfo("test_service", "test_config", tt.version, tt.errCount)
+			SetDBConfigInfo(context.TODO(), "test_service", "test_config", tt.version, tt.errCount)
 
 			testDataRetrieval(ConfigDBVersionView, t, tt.wantVersion)
 			testDataRetrieval(ConfigDBErrorsView, t, tt.wantErrors)

--- a/internal/telemetry/metrics/providers.go
+++ b/internal/telemetry/metrics/providers.go
@@ -89,26 +89,26 @@ func newProxyMetricsHandler(exporter *ocprom.Exporter, envoyURL url.URL, install
 
 		err := writeMetricsWithInstallationID(w, rec.Body, installationID)
 		if err != nil {
-			log.Error().Err(err).Send()
+			log.Error(r.Context()).Err(err).Send()
 			return
 		}
 
 		req, err := http.NewRequestWithContext(r.Context(), "GET", envoyURL.String(), nil)
 		if err != nil {
-			log.Error().Err(err).Msg("telemetry/metrics: failed to create request for envoy")
+			log.Error(r.Context()).Err(err).Msg("telemetry/metrics: failed to create request for envoy")
 			return
 		}
 
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil {
-			log.Error().Err(err).Msg("telemetry/metrics: fail to fetch proxy metrics")
+			log.Error(r.Context()).Err(err).Msg("telemetry/metrics: fail to fetch proxy metrics")
 			return
 		}
 		defer resp.Body.Close()
 
 		err = writeMetricsWithInstallationID(w, resp.Body, installationID)
 		if err != nil {
-			log.Error().Err(err).Send()
+			log.Error(r.Context()).Err(err).Send()
 			return
 		}
 	}

--- a/internal/telemetry/metrics/registry.go
+++ b/internal/telemetry/metrics/registry.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"runtime"
 	"sync"
 
@@ -34,6 +35,7 @@ func newMetricRegistry() *metricRegistry {
 }
 
 func (r *metricRegistry) init() {
+	ctx := context.TODO()
 	r.Do(
 		func() {
 			r.registry = metric.NewRegistry()
@@ -49,7 +51,7 @@ func (r *metricRegistry) init() {
 				),
 			)
 			if err != nil {
-				log.Error().Err(err).Msg("telemetry/metrics: failed to register build info metric")
+				log.Error(ctx).Err(err).Msg("telemetry/metrics: failed to register build info metric")
 			}
 
 			r.configChecksum, err = r.registry.AddFloat64Gauge(metrics.ConfigChecksumDecimal,
@@ -57,7 +59,7 @@ func (r *metricRegistry) init() {
 				metric.WithLabelKeys(metrics.ServiceLabel, metrics.ConfigLabel),
 			)
 			if err != nil {
-				log.Error().Err(err).Msg("telemetry/metrics: failed to register config checksum metric")
+				log.Error(ctx).Err(err).Msg("telemetry/metrics: failed to register config checksum metric")
 			}
 
 			r.policyCount, err = r.registry.AddInt64DerivedGauge(metrics.PolicyCountTotal,
@@ -65,12 +67,12 @@ func (r *metricRegistry) init() {
 				metric.WithLabelKeys(metrics.ServiceLabel),
 			)
 			if err != nil {
-				log.Error().Err(err).Msg("telemetry/metrics: failed to register policy count metric")
+				log.Error(ctx).Err(err).Msg("telemetry/metrics: failed to register policy count metric")
 			}
 
 			err = registerAutocertMetrics(r.registry)
 			if err != nil {
-				log.Error().Err(err).Msg("telemetry/metrics: failed to register autocert metrics")
+				log.Error(ctx).Err(err).Msg("telemetry/metrics: failed to register autocert metrics")
 			}
 		})
 }
@@ -89,7 +91,7 @@ func (r *metricRegistry) setBuildInfo(service, hostname string) {
 		metricdata.NewLabelValue(hostname),
 	)
 	if err != nil {
-		log.Error().Err(err).Msg("telemetry/metrics: failed to get build info metric")
+		log.Error(context.TODO()).Err(err).Msg("telemetry/metrics: failed to get build info metric")
 	}
 
 	// This sets our build_info metric to a constant 1 per
@@ -103,7 +105,7 @@ func (r *metricRegistry) addPolicyCountCallback(service string, f func() int64) 
 	}
 	err := r.policyCount.UpsertEntry(f, metricdata.NewLabelValue(service))
 	if err != nil {
-		log.Error().Err(err).Msg("telemetry/metrics: failed to get policy count metric")
+		log.Error(context.TODO()).Err(err).Msg("telemetry/metrics: failed to get policy count metric")
 	}
 }
 
@@ -113,7 +115,7 @@ func (r *metricRegistry) setConfigChecksum(service string, configName string, ch
 	}
 	m, err := r.configChecksum.GetEntry(metricdata.NewLabelValue(service), metricdata.NewLabelValue(configName))
 	if err != nil {
-		log.Error().Err(err).Msg("telemetry/metrics: failed to get config checksum metric")
+		log.Error(context.TODO()).Err(err).Msg("telemetry/metrics: failed to get config checksum metric")
 	}
 	m.Set(float64(checksum))
 }
@@ -122,13 +124,13 @@ func (r *metricRegistry) addInt64DerivedGaugeMetric(name, desc, service string, 
 	m, err := r.registry.AddInt64DerivedGauge(name, metric.WithDescription(desc),
 		metric.WithLabelKeys(metrics.ServiceLabel))
 	if err != nil {
-		log.Error().Err(err).Str("service", service).Msg("telemetry/metrics: failed to register metric")
+		log.Error(context.TODO()).Err(err).Str("service", service).Msg("telemetry/metrics: failed to register metric")
 		return
 	}
 
 	err = m.UpsertEntry(f, metricdata.NewLabelValue(service))
 	if err != nil {
-		log.Error().Err(err).Str("service", service).Msg("telemetry/metrics: failed to update metric")
+		log.Error(context.TODO()).Err(err).Str("service", service).Msg("telemetry/metrics: failed to update metric")
 		return
 	}
 }
@@ -137,13 +139,13 @@ func (r *metricRegistry) addInt64DerivedCumulativeMetric(name, desc, service str
 	m, err := r.registry.AddInt64DerivedCumulative(name, metric.WithDescription(desc),
 		metric.WithLabelKeys(metrics.ServiceLabel))
 	if err != nil {
-		log.Error().Err(err).Str("service", service).Msg("telemetry/metrics: failed to register metric")
+		log.Error(context.TODO()).Err(err).Str("service", service).Msg("telemetry/metrics: failed to register metric")
 		return
 	}
 
 	err = m.UpsertEntry(f, metricdata.NewLabelValue(service))
 	if err != nil {
-		log.Error().Err(err).Str("service", service).Msg("telemetry/metrics: failed to update metric")
+		log.Error(context.TODO()).Err(err).Str("service", service).Msg("telemetry/metrics: failed to update metric")
 		return
 	}
 }

--- a/internal/telemetry/metrics/storage.go
+++ b/internal/telemetry/metrics/storage.go
@@ -57,6 +57,6 @@ func RecordStorageOperation(ctx context.Context, tags *StorageOperationTags, dur
 		storageOperationDuration.M(duration.Milliseconds()),
 	)
 	if err != nil {
-		log.Warn().Err(err).Msg("internal/telemetry/metrics: failed to record")
+		log.Warn(ctx).Err(err).Msg("internal/telemetry/metrics: failed to record")
 	}
 }

--- a/internal/telemetry/trace/trace.go
+++ b/internal/telemetry/trace/trace.go
@@ -77,7 +77,7 @@ func RegisterTracing(opts *TracingOptions) (trace.Exporter, error) {
 	}
 	trace.ApplyConfig(trace.Config{DefaultSampler: trace.ProbabilitySampler(opts.SampleRate)})
 
-	log.Debug().Interface("Opts", opts).Msg("telemetry/trace: exporter created")
+	log.Debug(context.TODO()).Interface("Opts", opts).Msg("telemetry/trace: exporter created")
 	return exporter, nil
 }
 

--- a/pkg/cryptutil/tls.go
+++ b/pkg/cryptutil/tls.go
@@ -1,6 +1,7 @@
 package cryptutil
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
@@ -14,9 +15,10 @@ import (
 
 // GetCertPool gets a cert pool for the given CA or CAFile.
 func GetCertPool(ca, caFile string) (*x509.CertPool, error) {
+	ctx := context.TODO()
 	rootCAs, err := x509.SystemCertPool()
 	if err != nil {
-		log.Error().Err(err).Msg("pkg/cryptutil: failed getting system cert pool making new one")
+		log.Error(ctx).Err(err).Msg("pkg/cryptutil: failed getting system cert pool making new one")
 		rootCAs = x509.NewCertPool()
 	}
 	if ca == "" && caFile == "" {
@@ -38,7 +40,7 @@ func GetCertPool(ca, caFile string) (*x509.CertPool, error) {
 	if ok := rootCAs.AppendCertsFromPEM(data); !ok {
 		return nil, fmt.Errorf("failed to append any PEM-encoded certificates")
 	}
-	log.Debug().Msg("pkg/cryptutil: added custom certificate authority")
+	log.Debug(ctx).Msg("pkg/cryptutil: added custom certificate authority")
 	return rootCAs, nil
 }
 

--- a/pkg/grpc/client.go
+++ b/pkg/grpc/client.go
@@ -60,6 +60,7 @@ type Options struct {
 
 // NewGRPCClientConn returns a new gRPC pomerium service client connection.
 func NewGRPCClientConn(opts *Options) (*grpc.ClientConn, error) {
+	ctx := context.TODO()
 	if len(opts.Addrs) == 0 {
 		return nil, errors.New("internal/grpc: connection address required")
 	}
@@ -105,7 +106,7 @@ func NewGRPCClientConn(opts *Options) (*grpc.ClientConn, error) {
 	}
 
 	if opts.WithInsecure {
-		log.Info().Str("addr", connAddr).Msg("internal/grpc: grpc with insecure")
+		log.Info(ctx).Str("addr", connAddr).Msg("internal/grpc: grpc with insecure")
 		dialOptions = append(dialOptions, grpc.WithInsecure())
 	} else {
 		rootCAs, err := cryptutil.GetCertPool(opts.CA, opts.CAFile)
@@ -117,7 +118,7 @@ func NewGRPCClientConn(opts *Options) (*grpc.ClientConn, error) {
 
 		// override allowed certificate name string, typically used when doing behind ingress connection
 		if opts.OverrideCertificateName != "" {
-			log.Debug().Str("cert-override-name", opts.OverrideCertificateName).Msg("internal/grpc: grpc")
+			log.Debug(ctx).Str("cert-override-name", opts.OverrideCertificateName).Msg("internal/grpc: grpc")
 			err := cert.OverrideServerName(opts.OverrideCertificateName)
 			if err != nil {
 				return nil, err
@@ -169,7 +170,7 @@ func GetGRPCClientConn(name string, opts *Options) (*grpc.ClientConn, error) {
 
 		err := current.conn.Close()
 		if err != nil {
-			log.Error().Err(err).Msg("grpc: failed to close existing connection")
+			log.Error(context.TODO()).Err(err).Msg("grpc: failed to close existing connection")
 		}
 	}
 

--- a/pkg/storage/inmemory/stream.go
+++ b/pkg/storage/inmemory/stream.go
@@ -12,7 +12,7 @@ type recordStream struct {
 	ctx     context.Context
 	backend *Backend
 
-	changed chan struct{}
+	changed chan context.Context
 	ready   []*databroker.Record
 	version uint64
 

--- a/pkg/storage/redis/observe.go
+++ b/pkg/storage/redis/observe.go
@@ -15,7 +15,7 @@ type logger struct {
 }
 
 func (l logger) Printf(ctx context.Context, format string, v ...interface{}) {
-	log.Info().Str("service", "redis").Msgf(format, v...)
+	log.Info(ctx).Str("service", "redis").Msgf(format, v...)
 }
 
 func init() {

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -146,7 +146,7 @@ func (backend *Backend) GetAll(ctx context.Context) (records []*databroker.Recor
 		var record databroker.Record
 		err := proto.Unmarshal([]byte(result), &record)
 		if err != nil {
-			log.Warn().Err(err).Msg("redis: invalid record detected")
+			log.Warn(ctx).Err(err).Msg("redis: invalid record detected")
 			continue
 		}
 		records = append(records, &record)
@@ -291,7 +291,7 @@ func (backend *Backend) removeChangesBefore(cutoff time.Time) {
 		})
 		results, err := cmd.Result()
 		if err != nil {
-			log.Error().Err(err).Msg("redis: error retrieving changes for expiration")
+			log.Error(context.TODO()).Err(err).Msg("redis: error retrieving changes for expiration")
 			return
 		}
 
@@ -303,7 +303,7 @@ func (backend *Backend) removeChangesBefore(cutoff time.Time) {
 		var record databroker.Record
 		err = proto.Unmarshal([]byte(results[0]), &record)
 		if err != nil {
-			log.Warn().Err(err).Msg("redis: invalid record detected")
+			log.Warn(ctx).Err(err).Msg("redis: invalid record detected")
 			record.ModifiedAt = timestamppb.New(cutoff.Add(-time.Second)) // set the modified so will delete it
 		}
 
@@ -315,7 +315,7 @@ func (backend *Backend) removeChangesBefore(cutoff time.Time) {
 		// remove the record
 		err = backend.client.ZRem(ctx, changesSetKey, results[0]).Err()
 		if err != nil {
-			log.Error().Err(err).Msg("redis: error removing member")
+			log.Error(context.TODO()).Err(err).Msg("redis: error removing member")
 			return
 		}
 	}

--- a/pkg/storage/redis/redis_test.go
+++ b/pkg/storage/redis/redis_test.go
@@ -181,7 +181,7 @@ func TestExpiry(t *testing.T) {
 		_ = stream.Close()
 		require.Len(t, records, 1000)
 
-		backend.removeChangesBefore(time.Now().Add(time.Second))
+		backend.removeChangesBefore(ctx, time.Now().Add(time.Second))
 
 		stream, err = backend.Sync(ctx, 0)
 		require.NoError(t, err)

--- a/pkg/storage/redis/stream.go
+++ b/pkg/storage/redis/stream.go
@@ -81,7 +81,7 @@ func (stream *recordStream) Next(block bool) bool {
 			var record databroker.Record
 			err = proto.Unmarshal([]byte(result), &record)
 			if err != nil {
-				log.Warn().Err(err).Msg("redis: invalid record detected")
+				log.Warn(stream.ctx).Err(err).Msg("redis: invalid record detected")
 			} else {
 				stream.record = &record
 			}

--- a/pkg/storage/redis/stream.go
+++ b/pkg/storage/redis/stream.go
@@ -17,7 +17,7 @@ type recordStream struct {
 	ctx     context.Context
 	backend *Backend
 
-	changed chan struct{}
+	changed chan context.Context
 	version uint64
 	record  *databroker.Record
 	err     error
@@ -63,6 +63,7 @@ func (stream *recordStream) Next(block bool) bool {
 	ticker := time.NewTicker(watchPollInterval)
 	defer ticker.Stop()
 
+	changeCtx := context.Background()
 	for {
 		cmd := stream.backend.client.ZRangeByScore(stream.ctx, changesSetKey, &redis.ZRangeBy{
 			Min:    fmt.Sprintf("(%d", stream.version),
@@ -81,7 +82,7 @@ func (stream *recordStream) Next(block bool) bool {
 			var record databroker.Record
 			err = proto.Unmarshal([]byte(result), &record)
 			if err != nil {
-				log.Warn(stream.ctx).Err(err).Msg("redis: invalid record detected")
+				log.Warn(changeCtx).Err(err).Msg("redis: invalid record detected")
 			} else {
 				stream.record = &record
 			}
@@ -97,7 +98,7 @@ func (stream *recordStream) Next(block bool) bool {
 			case <-stream.closed:
 				return false
 			case <-ticker.C: // check again
-			case <-stream.changed: // check again
+			case changeCtx = <-stream.changed: // check again
 			}
 		} else {
 			return false

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -57,7 +57,7 @@ func MatchAny(any *anypb.Any, query string) bool {
 	msg, err := any.UnmarshalNew()
 	if err != nil {
 		// ignore invalid any types
-		log.Error().Err(err).Msg("storage: invalid any type")
+		log.Error(context.TODO()).Err(err).Msg("storage: invalid any type")
 		return false
 	}
 

--- a/proxy/forward_auth_test.go
+++ b/proxy/forward_auth_test.go
@@ -35,6 +35,7 @@ func (m *mockCheckClient) Check(ctx context.Context, in *envoy_service_auth_v2.C
 }
 
 func TestProxy_ForwardAuth(t *testing.T) {
+	ctx := context.Background()
 	t.Parallel()
 
 	allowClient := &mockCheckClient{
@@ -85,7 +86,7 @@ func TestProxy_ForwardAuth(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			p.OnConfigChange(&config.Config{Options: tt.options})
+			p.OnConfigChange(ctx, &config.Config{Options: tt.options})
 			state := p.state.Load()
 			state.sessionStore = tt.sessionStore
 			signer, err := jws.NewHS256Signer(nil)

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -2,6 +2,7 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -240,7 +241,7 @@ func TestProxy_Callback(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			p.OnConfigChange(&config.Config{Options: tt.options})
+			p.OnConfigChange(context.Background(), &config.Config{Options: tt.options})
 			state := p.state.Load()
 			state.encoder = tt.cipher
 			state.sessionStore = tt.sessionStore
@@ -486,7 +487,7 @@ func TestProxy_ProgrammaticCallback(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			p.OnConfigChange(&config.Config{Options: tt.options})
+			p.OnConfigChange(context.Background(), &config.Config{Options: tt.options})
 			state := p.state.Load()
 			state.encoder = tt.cipher
 			state.sessionStore = tt.sessionStore

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -77,7 +77,7 @@ func New(cfg *config.Config) (*Proxy, error) {
 }
 
 // OnConfigChange updates internal structures based on config.Options
-func (p *Proxy) OnConfigChange(cfg *config.Config) {
+func (p *Proxy) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	if p == nil {
 		return
 	}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -5,6 +5,7 @@
 package proxy
 
 import (
+	"context"
 	"fmt"
 	"html/template"
 	"net/http"
@@ -83,10 +84,10 @@ func (p *Proxy) OnConfigChange(cfg *config.Config) {
 
 	p.currentOptions.Store(cfg.Options)
 	if err := p.setHandlers(cfg.Options); err != nil {
-		log.Error().Err(err).Msg("proxy: failed to update proxy handlers from configuration settings")
+		log.Error(context.TODO()).Err(err).Msg("proxy: failed to update proxy handlers from configuration settings")
 	}
 	if state, err := newProxyStateFromConfig(cfg); err != nil {
-		log.Error().Err(err).Msg("proxy: failed to update proxy state from configuration settings")
+		log.Error(context.TODO()).Err(err).Msg("proxy: failed to update proxy state from configuration settings")
 	} else {
 		p.state.Store(state)
 	}
@@ -94,7 +95,7 @@ func (p *Proxy) OnConfigChange(cfg *config.Config) {
 
 func (p *Proxy) setHandlers(opts *config.Options) error {
 	if len(opts.GetAllPolicies()) == 0 {
-		log.Warn().Msg("proxy: configuration has no policies")
+		log.Warn(context.TODO()).Msg("proxy: configuration has no policies")
 	}
 	r := httputil.NewRouter()
 	r.NotFoundHandler = httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -197,7 +198,7 @@ func Test_UpdateOptions(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			p.OnConfigChange(&config.Config{Options: tt.updatedOptions})
+			p.OnConfigChange(context.Background(), &config.Config{Options: tt.updatedOptions})
 			r := httptest.NewRequest("GET", tt.host, nil)
 			w := httptest.NewRecorder()
 			p.ServeHTTP(w, r)
@@ -210,5 +211,5 @@ func Test_UpdateOptions(t *testing.T) {
 
 	// Test nil
 	var p *Proxy
-	p.OnConfigChange(&config.Config{})
+	p.OnConfigChange(context.Background(), &config.Config{})
 }


### PR DESCRIPTION
## Summary

As Pomerium code tolerates some errors and emits warnings, and due to asynchronous nature of the system, it is not always obvious which change related to which error message and/or warning in logs. 

By requiring `context.Context` to all log messages, this PR makes a first attempt to propagate change information down the hierarchy. 

Due to the amount of changes, I prefer to commit this initial change, and then continue resolving all `context.TODO()` as some of them require some refactoring as separate, smaller PRs. 

- 
## Related issues

Fixes https://github.com/pomerium/internal/issues/374

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
