### PR TITLE
deployment: update get-envoy script and release hooks

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -39,10 +39,13 @@ builds:
       - -X github.com/pomerium/pomerium/internal/version.ProjectURL=https://wwww.pomerium.io
 
     hooks:
+      pre:
+        - cmd: ./scripts/get-envoy.bash
+          env:
+            - TARGET={{ .Os }}-{{ .Arch }}
+            - DIR={{ dir .Path }}
       post:
         - cmd: ./scripts/embed-envoy.bash {{ .Path }}
-          env: # e.g. darwin_amd64
-            - TARGET={{ .Target }}
 
   - id: pomerium-cli
     main: ./cmd/pomerium-cli

--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -5,17 +5,8 @@ PATH="$PATH:$(go env GOPATH)/bin"
 export PATH
 
 _envoy_version=1.17.1
-_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../bin"
-_target="${TARGET:-"$(go env GOOS)_$(go env GOARCH)"}"
-
-if [[ "${_target}" == darwin_* ]]; then
-    _envoy_platform="darwin"
-elif [[ "${_target}" == linux_* ]]; then
-    _envoy_platform="linux_glibc"
-else
-    echo "unsupported TARGET: ${_target}"
-    exit 1
-fi
+_dir="${DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../bin"}"
+_target="${TARGET:-"$(go env GOOS)-$(go env GOARCH)"}"
 
 is_command() {
     command -v "$1" >/dev/null
@@ -42,13 +33,6 @@ hash_sha256() {
 }
 
 mkdir -p "$_dir"
-
-if [ "$_target" == "linux_arm64" ]; then
-    mkdir -p "$_dir"
-    curl -L -o "$_dir/envoy" https://github.com/pomerium/envoy-binaries/releases/download/v${_envoy_version}/envoy-linux-arm64
-else
-    env HOME="$_dir" getenvoy fetch standard:${_envoy_version}/${_envoy_platform}
-    cp -f "$_dir/.getenvoy/builds/standard/${_envoy_version}/${_envoy_platform}/bin/envoy" "$_dir/envoy"
-fi
+curl -L -o "$_dir/envoy" "https://github.com/pomerium/envoy-binaries/releases/download/v${_envoy_version}/envoy-${_target}"
 
 hash_sha256 "$_dir/envoy" >"$_dir/envoy.sha256"


### PR DESCRIPTION
## Summary

- Refactor goreleaser hooks for split get/embed scripts
- Update `get-envoy` script to pull from our binary source
- Update `get-envoy` script to accept an optional target directory env var

## Related issues

https://github.com/pomerium/pomerium/pull/1908

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
