### PR TITLE
Drop tun.cfg.dstHost from jwtCacheKey

### DIFF
--- a/internal/tcptunnel/tcptunnel.go
+++ b/internal/tcptunnel/tcptunnel.go
@@ -214,7 +214,7 @@ func (tun *Tunnel) run(ctx context.Context, local io.ReadWriter, rawJWT string, 
 }
 
 func (tun *Tunnel) jwtCacheKey() string {
-	return fmt.Sprintf("%s|%s|%v", tun.cfg.dstHost, tun.cfg.proxyHost, tun.cfg.tlsConfig != nil)
+	return fmt.Sprintf("%s|%v", tun.cfg.proxyHost, tun.cfg.tlsConfig != nil)
 }
 
 func deBuffer(br *bufio.Reader, underlying io.Reader) io.Reader {


### PR DESCRIPTION
## Summary

Remove tun.cfg.dstHost from jwtCacheKey. 
Users that uses an `--pomerium-url` does only need one browser popup per auth cycle (default 14 hours)

This is handy when running an Ansible playbook or similar tools which makes you to connect to multiple hosts and now get one browser popup per server per auth cycle.

Mor information can be found in the related issue.

## Related issues

Implements #2100 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
