### PR TITLE
authorize: fix unsigned URL

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -80,6 +80,8 @@ func (a *Authorize) htmlDeniedResponse(
 		}.Encode(),
 	})
 
+	debugEndpoint = urlutil.NewSignedURL(a.state.Load().sharedKey, debugEndpoint).Sign()
+
 	var details string
 	switch code {
 	case httputil.StatusInvalidClientCertificate:


### PR DESCRIPTION
## Summary
We started requiring this URL to be signed with https://github.com/pomerium/pomerium/pull/2048. Unfortunately we didn't update the "session details" link when you get a 403 error.

## Related issues
Fixes #2117 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
