### PR TITLE
authorize: fix empty sub policy arrays

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -97,6 +97,11 @@ func (e *Evaluator) Evaluate(ctx context.Context, req *Request) (*Result, error)
 	)
 
 	allow := getAllowVar(res[0].Bindings.WithoutWildcards())
+	log.Info(ctx).
+		Bool("ALLOW", allow).
+		Interface("SESSION", req.Session).
+		Interface("RESULT", res[0].Bindings.WithoutWildcards()).
+		Send()
 	// evaluate any custom policies
 	if allow {
 		for _, src := range req.CustomPolicies {

--- a/authorize/evaluator/opa/policy/authz.rego
+++ b/authorize/evaluator/opa/policy/authz.rego
@@ -394,16 +394,21 @@ element_in_list(list, elem) {
 }
 
 get_allowed_users(policy) = v {
-	sub_allowed_users = [sp.allowed_users | sp := policy.sub_policies[_]]
-	v := {x | x = array.concat(policy.allowed_users, [u | u := policy.sub_policies[_].allowed_users[_]])[_]}
+	sub_array := [x | x = policy.sub_policies[_].allowed_users[_]]
+	main_array := [x | x = policy.allowed_users[_]]
+	v := {x | x = array.concat(main_array, sub_array)[_]}
 }
 
 get_allowed_domains(policy) = v {
-	v := {x | x = array.concat(policy.allowed_domains, [u | u := policy.sub_policies[_].allowed_domains[_]])[_]}
+	sub_array := [x | x = policy.sub_policies[_].allowed_domains[_]]
+	main_array := [x | x = policy.allowed_domains[_]]
+	v := {x | x = array.concat(main_array, sub_array)[_]}
 }
 
 get_allowed_groups(policy) = v {
-	v := {x | x = array.concat(policy.allowed_groups, [u | u := policy.sub_policies[_].allowed_groups[_]])[_]}
+	sub_array := [x | x = policy.sub_policies[_].allowed_groups[_]]
+	main_array := [x | x = policy.allowed_groups[_]]
+	v := {x | x = array.concat(main_array, sub_array)[_]}
 }
 
 get_allowed_idp_claims(policy) = v {


### PR DESCRIPTION
## Summary
With the way this rego was written if there were no entries in the main policy `allowed_x` lists, we wouldn't actually concatenate the sub policy lists. By using a generator on the main array we should always default to at least an empty array which allows the sub policies to be handled properly. I added a test to make sure this works now.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
