### PR TITLE
envoyconfig: fix metrics ingress listener name

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -25,6 +25,8 @@ import (
 	"google.golang.org/protobuf/types/known/emptypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/pomerium/pomerium/internal/hashutil"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/urlutil"
@@ -239,9 +241,10 @@ func (b *Builder) buildMetricsListener(cfg *config.Config) (*envoy_config_listen
 		host = ""
 	}
 
+	addr := buildAddress(fmt.Sprintf("%s:%s", host, port), 9902)
 	li := &envoy_config_listener_v3.Listener{
-		Name:         "metrics-ingress",
-		Address:      buildAddress(fmt.Sprintf("%s:%s", host, port), 9902),
+		Name:         fmt.Sprintf("metrics-ingress-%d", hashutil.MustHash(addr)),
+		Address:      addr,
 		FilterChains: []*envoy_config_listener_v3.FilterChain{filterChain},
 	}
 	return li, nil

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -35,7 +35,7 @@ func Test_buildMetricsHTTPConnectionManagerFilter(t *testing.T) {
 	require.NoError(t, err)
 	testutil.AssertProtoJSONEqual(t, `
 {
-	"name": "metrics-ingress",
+	"name": "metrics-ingress-1566242852377945326",
 	"address": {
 		"socketAddress": {
 			"address": "127.0.0.1",

--- a/internal/controlplane/xdsmgr/xdsmgr.go
+++ b/internal/controlplane/xdsmgr/xdsmgr.go
@@ -204,7 +204,7 @@ func (mgr *Manager) DeltaAggregatedResources(
 					return ctx.Err()
 				case outgoing <- res:
 					log.Info(changeCtx).
-						Str("nounce", res.Nonce).
+						Str("nonce", res.Nonce).
 						Str("type", res.TypeUrl).
 						Msg("send update")
 				}


### PR DESCRIPTION
## Summary
It appears that envoy doesn't allow you to update a listener address via LDS, so instead we'll name the ingress with a hash of the address. The `xdsmgr` will then remove the previous one and add the new one, thus allowing us to change the metrics address at runtime.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
