### PR TITLE
use cached envoy

### DIFF
--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -32,7 +32,11 @@ hash_sha256() {
     fi
 }
 
+if [ -f ${_dst} ]; then
+    exit 0
+fi
+
 mkdir -p "$_dir"
-curl -L -o "$_dir/envoy" "https://github.com/pomerium/envoy-binaries/releases/download/v${_envoy_version}/envoy-${_target}"
+curl -L --compressed -o "$_dir/envoy" "https://github.com/pomerium/envoy-binaries/releases/download/v${_envoy_version}/envoy-${_target}"
 
 hash_sha256 "$_dir/envoy" >"$_dir/envoy.sha256"

--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -32,7 +32,7 @@ hash_sha256() {
     fi
 }
 
-if [ -f ${_dst} ]; then
+if [ -f "$_dir/envoy" ]; then
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

Currently envoy is re-downloaded on every `make build`, this changes it to use whatever was previously cached. 

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
