### PR TITLE
httputil: fix SPDY support with reverse proxy

### DIFF
--- a/config/http.go
+++ b/config/http.go
@@ -63,11 +63,20 @@ func (t *httpTransport) Clone() *http.Transport {
 }
 
 // NewPolicyHTTPTransport creates a new http RoundTripper for a policy.
-func NewPolicyHTTPTransport(options *Options, policy *Policy) http.RoundTripper {
+func NewPolicyHTTPTransport(options *Options, policy *Policy, disableHTTP2 bool) http.RoundTripper {
 	transport := http.DefaultTransport.(interface {
 		Clone() *http.Transport
 	}).Clone()
 	c := tripper.NewChain()
+
+	// according to the docs:
+	//
+	//    Programs that must disable HTTP/2 can do so by setting Transport.TLSNextProto (for clients) or
+	//    Server.TLSNextProto (for servers) to a non-nil, empty map.
+	//
+	if disableHTTP2 {
+		transport.TLSNextProto = map[string]func(authority string, c *tls.Conn) http.RoundTripper{}
+	}
 
 	var tlsClientConfig tls.Config
 	var isCustomClientConfig bool

--- a/config/http_test.go
+++ b/config/http_test.go
@@ -53,7 +53,7 @@ func TestPolicyHTTPTransport(t *testing.T) {
 	defer s.Close()
 
 	get := func(options *Options, policy *Policy) (*http.Response, error) {
-		transport := NewPolicyHTTPTransport(options, policy)
+		transport := NewPolicyHTTPTransport(options, policy, false)
 		client := &http.Client{
 			Transport: transport,
 		}

--- a/internal/httputil/headers.go
+++ b/internal/httputil/headers.go
@@ -7,6 +7,7 @@ const AuthorizationTypePomerium = "Pomerium"
 const (
 	HeaderReferrer         = "Referer"
 	HeaderImpersonateGroup = "Impersonate-Group"
+	HeaderUpgrade          = "Upgrade"
 )
 
 // Pomerium headers contain information added to a request.


### PR DESCRIPTION
## Summary
`kubectl` uses SPDY for `exec`. When proxying through the control plane we end up using HTTP/2, and the proxy rejects the `Upgrade` header, because SPDY can't be used with HTTP/2 (error is [here](https://github.com/golang/net/blob/0fccb6fa2b5ce302a9da5afc2513d351bd175889/http2/server.go#L2953)). This PR disables support for HTTP/2 in the control plane reverse proxy if SPDY is being used.

This should fix `kubectl exec`:

```bash
† kubectl --context=via-pomerium exec busybox1 -i -t -- /bin/sh
/ # echo hi
hi
/ # 
```

## Related issues
Fixes #2126 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
