### PR TITLE
authorize: audit log had duplicate "message" key

### DIFF
--- a/authorize/log.go
+++ b/authorize/log.go
@@ -37,8 +37,8 @@ func (a *Authorize) logAuthorizeCheck(
 	// reply
 	if reply != nil {
 		evt = evt.Bool("allow", reply.Status == http.StatusOK)
-		evt = evt.Int("status", reply.Status)
-		evt = evt.Str("reply", reply.Message)
+		evt = evt.Int("reply-status", reply.Status)
+		evt = evt.Str("reply-message", reply.Message)
 		evt = evt.Str("user", u.GetId())
 		evt = evt.Str("email", u.GetEmail())
 		evt = evt.Uint64("databroker_server_version", reply.DataBrokerServerVersion)

--- a/authorize/log.go
+++ b/authorize/log.go
@@ -38,7 +38,7 @@ func (a *Authorize) logAuthorizeCheck(
 	if reply != nil {
 		evt = evt.Bool("allow", reply.Status == http.StatusOK)
 		evt = evt.Int("status", reply.Status)
-		evt = evt.Str("message", reply.Message)
+		evt = evt.Str("reply", reply.Message)
 		evt = evt.Str("user", u.GetId())
 		evt = evt.Str("email", u.GetEmail())
 		evt = evt.Uint64("databroker_server_version", reply.DataBrokerServerVersion)


### PR DESCRIPTION
Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>

## Summary

This removes the duplicate `message` key in the authorize access logs. Message is both the default key for zero log, and was being used to set the reply message. This makes that explicit. 

## Checklist

- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
