### PR TITLE
do not default to grpc.WaitForReady(true)

### DIFF
--- a/pkg/grpc/client.go
+++ b/pkg/grpc/client.go
@@ -99,7 +99,6 @@ func NewGRPCClientConn(opts *Options, other ...grpc.DialOption) (*grpc.ClientCon
 	dialOptions := []grpc.DialOption{
 		grpc.WithChainUnaryInterceptor(unaryClientInterceptors...),
 		grpc.WithChainStreamInterceptor(streamClientInterceptors...),
-		grpc.WithDefaultCallOptions([]grpc.CallOption{grpc.WaitForReady(true)}...),
 		grpc.WithStatsHandler(clientStatsHandler.Handler),
 		grpc.WithDefaultServiceConfig(roundRobinServiceConfig),
 		grpc.WithDisableServiceConfig(),


### PR DESCRIPTION
## Summary

Prefer fail fast in case GRPC upstream cannot be reached, which is default GRPC behaviour. Pomerium code is mostly cyclic and that operation would be retried. When this option is present, in case GRPC upstream cannot be reached for whatever reason, under current GRPC configuration the call would be stuck indefinitely. 

## Related issues

I suspect it to be root case of https://github.com/pomerium/internal/issues/376
The behaviour is very similar to the one observed in https://github.com/pomerium/pomerium-console/issues/1016

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
