### PR TITLE
control plane: add request id to all error pages

### DIFF
--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -1,6 +1,7 @@
 package authorize
 
 import (
+	"context"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -192,7 +193,7 @@ func TestAuthorize_deniedResponse(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := a.deniedResponse(tc.in, tc.code, tc.reason, tc.headers)
+			got, err := a.deniedResponse(context.TODO(), tc.in, tc.code, tc.reason, tc.headers)
 			require.NoError(t, err)
 			assert.Equal(t, tc.want.Status.Code, got.Status.Code)
 			assert.Equal(t, tc.want.Status.Message, got.Status.Message)

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -152,36 +152,8 @@ func TestAuthorize_deniedResponse(t *testing.T) {
 							Code: envoy_type_v3.StatusCode(codes.InvalidArgument),
 						},
 						Headers: []*envoy_config_core_v3.HeaderValueOption{
-							mkHeader("Content-Type", "text/html", false),
-						},
-						Body: "Access Denied",
-					},
-				},
-			},
-		},
-		{
-			"plain text denied",
-			&envoy_service_auth_v3.CheckRequest{
-				Attributes: &envoy_service_auth_v3.AttributeContext{
-					Request: &envoy_service_auth_v3.AttributeContext_Request{
-						Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
-							Headers: map[string]string{},
-						},
-					},
-				},
-			},
-			http.StatusBadRequest,
-			"Access Denied",
-			map[string]string{},
-			&envoy_service_auth_v3.CheckResponse{
-				Status: &status.Status{Code: int32(codes.PermissionDenied), Message: "Access Denied"},
-				HttpResponse: &envoy_service_auth_v3.CheckResponse_DeniedResponse{
-					DeniedResponse: &envoy_service_auth_v3.DeniedHttpResponse{
-						Status: &envoy_type_v3.HttpStatus{
-							Code: envoy_type_v3.StatusCode(codes.InvalidArgument),
-						},
-						Headers: []*envoy_config_core_v3.HeaderValueOption{
-							mkHeader("Content-Type", "text/plain", false),
+							mkHeader("Content-Type", "text/html; charset=UTF-8", false),
+							mkHeader("X-Pomerium-Intercepted-Response", "true", false),
 						},
 						Body: "Access Denied",
 					},

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -70,11 +70,11 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 		return a.okResponse(reply), nil
 	case reply.Status == http.StatusUnauthorized:
 		if isForwardAuth && hreq.URL.Path == "/verify" {
-			return a.deniedResponse(in, http.StatusUnauthorized, "Unauthenticated", nil)
+			return a.deniedResponse(ctx, in, http.StatusUnauthorized, "Unauthenticated", nil)
 		}
-		return a.redirectResponse(in)
+		return a.redirectResponse(ctx, in)
 	}
-	return a.deniedResponse(in, int32(reply.Status), reply.Message, nil)
+	return a.deniedResponse(ctx, in, int32(reply.Status), reply.Message, nil)
 }
 
 func getForwardAuthURL(r *http.Request) *url.URL {

--- a/internal/frontend/assets/html/error.go.html
+++ b/internal/frontend/assets/html/error.go.html
@@ -24,8 +24,17 @@
           </div>
         </div>
         <div class="category-link">
-          {{if and .CanDebug .DebugURL }}
-            If you should have access, contact your administrator with your <a href="{{.DebugURL}}">session details</a>.
+          {{if .CanDebug}}
+            If you should have access, contact your administrator with your
+            {{if .RequestID }}
+            request id {{.RequestID}}
+            {{end}}
+            {{if and .RequestID .DebugURL }}
+            and
+            {{end}}
+            {{if .DebugURL }}
+            <a href="{{.DebugURL}}">session details</a>.
+            {{end}}
           {{end}}
         </div>
       </div>

--- a/internal/httputil/errors.go
+++ b/internal/httputil/errors.go
@@ -3,9 +3,9 @@ package httputil
 import (
 	"html/template"
 	"net/http"
+	"net/url"
 
 	"github.com/pomerium/pomerium/internal/frontend"
-	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
 )
 
@@ -15,8 +15,12 @@ var errorTemplate = template.Must(frontend.NewTemplates())
 type HTTPError struct {
 	// HTTP status codes as registered with IANA.
 	Status int
-	// Err is the wrapped error
+	// Err is the wrapped error.
 	Err error
+	// DebugURL is the URL to the debug endpoint.
+	DebugURL *url.URL
+	// The request ID.
+	RequestID string
 }
 
 // NewError returns an error that contains a HTTP status and error.
@@ -36,32 +40,35 @@ func (e *HTTPError) Unwrap() error { return e.Err }
 // It does not otherwise end the request; the caller should ensure no further
 // writes are done to w.
 func (e *HTTPError) ErrorResponse(w http.ResponseWriter, r *http.Request) {
-	// indicate to clients that the error originates from Pomerium, not the app
-	w.Header().Set(HeaderPomeriumResponse, "true")
-	w.WriteHeader(e.Status)
-
-	log.FromRequest(r).Info().Err(e).Msg("httputil: ErrorResponse")
-	requestID := requestid.FromContext(r.Context())
-
+	reqID := e.RequestID
+	if e.RequestID == "" {
+		// if empty, try to grab from the request id from the request context
+		reqID = requestid.FromContext(r.Context())
+	}
 	response := struct {
 		Status     int
 		Error      string
-		StatusText string `json:"-"`
-		RequestID  string `json:",omitempty"`
-		CanDebug   bool   `json:"-"`
-		Version    string `json:"-"`
+		StatusText string   `json:"-"`
+		RequestID  string   `json:",omitempty"`
+		CanDebug   bool     `json:"-"`
+		Version    string   `json:"-"`
+		DebugURL   *url.URL `json:",omitempty"`
 	}{
 		Status:     e.Status,
 		StatusText: http.StatusText(e.Status),
 		Error:      e.Error(),
-		RequestID:  requestID,
-		CanDebug:   e.Status/100 == 4,
+		RequestID:  reqID,
+		CanDebug:   e.Status/100 == 4 && (e.DebugURL != nil || reqID != ""),
+		DebugURL:   e.DebugURL,
 	}
+	// indicate to clients that the error originates from Pomerium, not the app
+	w.Header().Set(HeaderPomeriumResponse, "true")
 
 	if r.Header.Get("Accept") == "application/json" {
 		RenderJSON(w, e.Status, response)
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	w.WriteHeader(e.Status)
 	errorTemplate.ExecuteTemplate(w, "error.html", response)
 }

--- a/internal/httputil/handlers.go
+++ b/internal/httputil/handlers.go
@@ -59,7 +59,7 @@ func (f HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if err := f(w, r); err != nil {
 		var e *HTTPError
 		if !errors.As(err, &e) {
-			e = &HTTPError{http.StatusInternalServerError, err}
+			e = &HTTPError{Status: http.StatusInternalServerError, Err: err}
 		}
 		e.ErrorResponse(w, r)
 	}

--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -4,3 +4,13 @@ package httputil
 // client's certificate is invalid. This is the same status code used
 // by nginx for this purpose.
 const StatusInvalidClientCertificate = 495
+
+var statusText = map[int]string{
+	StatusInvalidClientCertificate: "a valid client certificate is required to access this page",
+}
+
+// StatusText returns a text for the HTTP status code. It returns the empty
+// string if the code is unknown.
+func StatusText(code int) string {
+	return statusText[code]
+}


### PR DESCRIPTION
## Summary

This PR adds the request id to all debugable error pages, and  makes sure that both go and envoy based control planes are leveraging the same http error template code. 

control plane: add request id to all error pages
- use a single http error handler for both envoy and go control plane
- add http lib style status text for our custom statuses.

<img width="981" alt="Screen Shot 2021-04-28 at 1 39 51 PM" src="https://user-images.githubusercontent.com/1544881/116469613-361d1a80-a827-11eb-9c69-35e9448cd4ef.png">


## Related issues

Closes https://github.com/pomerium/pomerium-console/issues/424


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
