### PR TITLE
authorize: refactor store locking

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"html/template"
+	"sync"
 
 	"github.com/pomerium/pomerium/authorize/evaluator"
 	"github.com/pomerium/pomerium/config"
@@ -24,6 +25,11 @@ type Authorize struct {
 	templates      *template.Template
 
 	dataBrokerInitialSync chan struct{}
+
+	// The stateLock prevents updating the evaluator store simultaneously with an evaluation.
+	// This should provide a consistent view of the data at a given server/record version and
+	// avoid partial updates.
+	stateLock sync.RWMutex
 }
 
 // New validates and creates a new Authorize service from a set of config options.

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -56,7 +56,10 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 		return nil, err
 	}
 
+	// take the state lock here so we don't update while evaluating
+	a.stateLock.RLock()
 	reply, err := state.evaluator.Evaluate(ctx, req)
+	a.stateLock.RUnlock()
 	if err != nil {
 		log.Error(ctx).Err(err).Msg("error during OPA evaluation")
 		return nil, err

--- a/authorize/sync.go
+++ b/authorize/sync.go
@@ -47,13 +47,17 @@ func (syncer *dataBrokerSyncer) GetDataBrokerServiceClient() databroker.DataBrok
 }
 
 func (syncer *dataBrokerSyncer) ClearRecords(ctx context.Context) {
+	syncer.authorize.stateLock.Lock()
 	syncer.authorize.store.ClearRecords()
+	syncer.authorize.stateLock.Unlock()
 }
 
 func (syncer *dataBrokerSyncer) UpdateRecords(ctx context.Context, serverVersion uint64, records []*databroker.Record) {
+	syncer.authorize.stateLock.Lock()
 	for _, record := range records {
 		syncer.authorize.store.UpdateRecord(serverVersion, record)
 	}
+	syncer.authorize.stateLock.Unlock()
 
 	// the first time we update records we signal the initial sync
 	syncer.signalOnce.Do(func() {

--- a/pkg/grpc/databroker/syncer.go
+++ b/pkg/grpc/databroker/syncer.go
@@ -156,8 +156,8 @@ func (syncer *Syncer) sync(ctx context.Context) error {
 		}
 
 		log.Debug(syncer.logCtx(ctx)).
-			Uint("version", uint(res.Record.GetVersion())).
-			Str("id", res.Record.Id).
+			Uint("version", uint(res.GetRecord().GetVersion())).
+			Str("id", res.GetRecord().GetId()).
 			Msg("syncer got record")
 
 		if syncer.recordVersion != res.GetRecord().GetVersion()-1 {


### PR DESCRIPTION
## Summary
It looks like the way we're doing locking with the OPA evaluator store is causing deadlocks. I misunderstood how the `RWMutex` works, and it turns out it can't reliably be used recursively:

> If a goroutine holds a RWMutex for reading and another goroutine might
> call Lock, no goroutine should expect to be able to acquire a read lock
> until the initial read lock is released. In particular, this prohibits
> recursive read locking. This is to ensure that the lock eventually becomes
> available; a blocked Lock call excludes new readers from acquiring the
> lock.

I believe the deadlock happens like this:

1. We perform an evaluation which takes a read-only transaction to the store `RLock`
2. During sync we update a record `Lock`
3. During policy evaluation we attempt to retrieve a record `RLock`

Step (2) is blocked on (1) and step (3) is blocked on (2). But step (1) is blocked on (3), because the policy evaluation can't be completed until we get the record. This PR removes taking a read lock in the transaction, and instead only uses the lock for map access (which is very short and non-recursive).

The original purpose of the transaction lock was to prevent an update while we were evaluating a policy. This is so that the version numbers we get back from evaluation (server version / record version) reflect the data that was actually used during evaluation. So to preserve this behavior I introduce another lock in the authorize service itself. The syncer's update and evaluator will never run simultaneously, and since they don't directly depend on each other, we should have no issues with deadlocks.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
