### PR TITLE
deployment: update alpine debug image dependencies

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -19,7 +19,7 @@ RUN go get github.com/go-delve/delve/cmd/dlv
 FROM alpine:latest
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates libc6-compat gcompat
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 COPY --from=build /go/bin/dlv /bin


### PR DESCRIPTION
## Summary

Currently the debug image is missing some glibc packages and executing envoy will error out with a misleading message.  This adds the missing packages.

## Related issues

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
