### PR TITLE
docs: mention alternative bearer token header format

### DIFF
--- a/docs/docs/topics/programmatic-access.md
+++ b/docs/docs/topics/programmatic-access.md
@@ -48,6 +48,10 @@ The application interacting with Pomerium must manage the following workflow. Co
 1. The script or application is responsible for handling that http callback request, and securely handling the callback session (`pomerium_jwt`) queryparam.
 1. The script or application can now make any requests as normal to the upstream application by setting the `Authorization: Pomerium ${pomerium_jwt}` header.
 
+:::tip
+Pomerium supports `Authorization: Bearer Pomerium-${pomerium_jwt}` in addition to `Authorization: Pomerium ${pomerium_jwt}` format.
+:::
+
 ## Example Code
 
 Please consider see the following minimal but complete python example.


### PR DESCRIPTION
## Summary

In programmatic access, we support an alternate format for software which requires authorization headers to be `Bearer` type.  Update the docs to mention this.

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
