### PR TITLE
authenticate,proxy: add same site lax to cookies

### DIFF
--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -5,6 +5,7 @@ import (
 	"crypto/cipher"
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"net/url"
 	"sync/atomic"
 
@@ -117,6 +118,7 @@ func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, err
 			Secure:   cfg.Options.CookieSecure,
 			HTTPOnly: cfg.Options.CookieHTTPOnly,
 			Expire:   cfg.Options.CookieExpire,
+			SameSite: http.SameSiteLaxMode,
 		}
 	}, state.sharedEncoder)
 	if err != nil {

--- a/internal/sessions/cookie/cookie_store.go
+++ b/internal/sessions/cookie/cookie_store.go
@@ -42,6 +42,7 @@ type Options struct {
 	Expire   time.Duration
 	HTTPOnly bool
 	Secure   bool
+	SameSite http.SameSite
 }
 
 // A GetOptionsFunc is a getter for cookie options.
@@ -92,6 +93,7 @@ func (cs *Store) makeCookie(value string) *http.Cookie {
 		HttpOnly: opts.HTTPOnly,
 		Secure:   opts.Secure,
 		Expires:  timeNow().Add(opts.Expire),
+		SameSite: opts.SameSite,
 	}
 }
 

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"crypto/cipher"
 	"encoding/base64"
+	"net/http"
 	"net/url"
 	"sync/atomic"
 	"time"
@@ -85,6 +86,7 @@ func newProxyStateFromConfig(cfg *config.Config) (*proxyState, error) {
 			Secure:   cfg.Options.CookieSecure,
 			HTTPOnly: cfg.Options.CookieHTTPOnly,
 			Expire:   cfg.Options.CookieExpire,
+			SameSite: http.SameSiteLaxMode,
 		}
 	}, state.encoder)
 	if err != nil {


### PR DESCRIPTION
## Summary
Explicitly set the `SameSite` flag on cookies to `Lax`. As expected `Strict` does not work with authenticate or proxy. (FWIW `Lax` is the default, so this doesn't change anything)

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
