### PR TITLE
internal/envoy: always extract envoy

### DIFF
--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -74,7 +74,7 @@ func NewServer(ctx context.Context, src config.Source, grpcPort, httpPort string
 		return nil, fmt.Errorf("error creating temporary working directory for envoy: %w", err)
 	}
 
-	envoyPath, err := extractEmbeddedEnvoy()
+	envoyPath, err := extractEmbeddedEnvoy(ctx)
 	if err != nil {
 		log.Warn(ctx).Err(err).Send()
 		envoyPath = "envoy"


### PR DESCRIPTION
## Summary

We currently optimize for startup time and attempt to cache the envoy binary once we've extracted it on a system.  This creates starting security conditions that are hard to validate even with checksumming of the binary and atomic creation.

Changes:

- switch to a randomized subdirectory created on-demand, to help ensure we are running the same binary we checksum
- clean the entire base directory before extraction, so that we don't consume additional disk space every time we start on a system
- always extract a fresh copy of envoy

## Related issues

https://github.com/pomerium/pomerium/pull/1908

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
