### PR TITLE
docs: add info note to set_response_headers

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -853,10 +853,12 @@ By default, conservative [secure HTTP headers](https://www.owasp.org/index.php/O
 
 ![pomerium security headers](./img/security-headers.png)
 
-:::info
+:::tip
+
 Several security-related headers are not set by default since doing so might break legacy sites. These include:
 `Cross-Origin Resource Policy`, `Cross-Origin Opener Policy` and `Cross-Origin Embedder Policy`. If possible
 users are encouraged to add these to `set_response_headers` or their downstream applications.
+
 :::
 
 

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -853,6 +853,12 @@ By default, conservative [secure HTTP headers](https://www.owasp.org/index.php/O
 
 ![pomerium security headers](./img/security-headers.png)
 
+:::info
+Several security-related headers are not set by default since doing so might break legacy sites. These include:
+`Cross-Origin Resource Policy`, `Cross-Origin Opener Policy` and `Cross-Origin Embedder Policy`. If possible
+users are encouraged to add these to `set_response_headers` or their downstream applications.
+:::
+
 
 ### JWT Claim Headers
 - Environmental Variable: `JWT_CLAIMS_HEADERS`

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -965,10 +965,12 @@ settings:
 
           ![pomerium security headers](./img/security-headers.png)
 
-          :::info
+          :::tip
+
           Several security-related headers are not set by default since doing so might break legacy sites. These include:
           `Cross-Origin Resource Policy`, `Cross-Origin Opener Policy` and `Cross-Origin Embedder Policy`. If possible
           users are encouraged to add these to `set_response_headers` or their downstream applications.
+
           :::
       - name: "JWT Claim Headers"
         keys: ["jwt_claims_headers"]

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -964,6 +964,12 @@ settings:
           By default, conservative [secure HTTP headers](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project) are set.
 
           ![pomerium security headers](./img/security-headers.png)
+
+          :::info
+          Several security-related headers are not set by default since doing so might break legacy sites. These include:
+          `Cross-Origin Resource Policy`, `Cross-Origin Opener Policy` and `Cross-Origin Embedder Policy`. If possible
+          users are encouraged to add these to `set_response_headers` or their downstream applications.
+          :::
       - name: "JWT Claim Headers"
         keys: ["jwt_claims_headers"]
         attributes: |


### PR DESCRIPTION
## Summary
Add an info block recommending setting these headers. It's not safe for us to choose a default value for them.


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
