### PR TITLE
docs: set v0.14 to non-version url

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -41,7 +41,7 @@ module.exports = {
         ariaLabel: "Version menu",
         items: [
           { text: "🚧Dev", link: "https://master.docs.pomerium.io/docs" },
-          { text: "v0.14.x", link: "https://0-14-0.docs.pomerium.io/docs" },
+          { text: "v0.14.x", link: "https://docs.pomerium.io/docs" },
           { text: "v0.13.x", link: "https://0-13-0.docs.pomerium.io/docs" },
           { text: "v0.12.x", link: "https://0-12-0.docs.pomerium.io/docs" },
           { text: "v0.11.x", link: "https://0-11-0.docs.pomerium.io/docs" },


### PR DESCRIPTION
## Summary

Set the link for v0.14 docs to the main docs URL for now.

## Related issues

n/a



## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
