### PR TITLE
telemetry: add hostname tag to metrics

### DIFF
--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -32,6 +32,7 @@ const (
 // labels
 const (
 	InstallationIDLabel = "installation_id"
+	HostnameLabel       = "hostname"
 	ServiceLabel        = "service"
 	ConfigLabel         = "config"
 	VersionLabel        = "version"


### PR DESCRIPTION
## Summary

Adds `hostname` label to each metric. 

## Related issues

Implements OSS side of https://github.com/pomerium/internal/issues/397

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
