### PR TITLE
proxy / controplane: use old upstream cipher suite

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -214,7 +214,6 @@ func (b *Builder) buildPolicyTransportSocket(ctx context.Context, policy *config
 					"ECDHE-RSA-AES128-GCM-SHA256",
 					"ECDHE-ECDSA-CHACHA20-POLY1305",
 					"ECDHE-RSA-CHACHA20-POLY1305",
-					// end of modern suite
 					"ECDHE-ECDSA-AES128-SHA",
 					"ECDHE-RSA-AES128-SHA",
 					"AES128-GCM-SHA256",

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -207,6 +207,23 @@ func (b *Builder) buildPolicyTransportSocket(ctx context.Context, policy *config
 	tlsContext := &envoy_extensions_transport_sockets_tls_v3.UpstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
 			TlsParams: &envoy_extensions_transport_sockets_tls_v3.TlsParameters{
+				CipherSuites: []string{
+					"ECDHE-ECDSA-AES256-GCM-SHA384",
+					"ECDHE-RSA-AES256-GCM-SHA384",
+					"ECDHE-ECDSA-AES128-GCM-SHA256",
+					"ECDHE-RSA-AES128-GCM-SHA256",
+					"ECDHE-ECDSA-CHACHA20-POLY1305",
+					"ECDHE-RSA-CHACHA20-POLY1305",
+					// end of modern suite
+					"ECDHE-ECDSA-AES128-SHA",
+					"ECDHE-RSA-AES128-SHA",
+					"AES128-GCM-SHA256",
+					"AES128-SHA",
+					"ECDHE-ECDSA-AES256-SHA",
+					"ECDHE-RSA-AES256-SHA",
+					"AES256-GCM-SHA384",
+					"AES256-SHA",
+				},
 				EcdhCurves: []string{
 					"X25519",
 					"P-256",

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -47,6 +47,22 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 					"commonTlsContext": {
 						"alpnProtocols": ["h2", "http/1.1"],
 						"tlsParams": {
+							"cipherSuites": [
+            	            	"ECDHE-ECDSA-AES256-GCM-SHA384",
+            	            	"ECDHE-RSA-AES256-GCM-SHA384",
+            	            	"ECDHE-ECDSA-AES128-GCM-SHA256",
+            	            	"ECDHE-RSA-AES128-GCM-SHA256",
+            	            	"ECDHE-ECDSA-CHACHA20-POLY1305",
+            	            	"ECDHE-RSA-CHACHA20-POLY1305",
+            	            	"ECDHE-ECDSA-AES128-SHA",
+            	            	"ECDHE-RSA-AES128-SHA",
+            	            	"AES128-GCM-SHA256",
+            	            	"AES128-SHA",
+            	            	"ECDHE-ECDSA-AES256-SHA",
+            	            	"ECDHE-RSA-AES256-SHA",
+            	            	"AES256-GCM-SHA384",
+            	            	"AES256-SHA"
+            	            ],
 							"ecdhCurves": [
 								"X25519",
 								"P-256",
@@ -82,6 +98,22 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 					"commonTlsContext": {
 						"alpnProtocols": ["h2", "http/1.1"],
 						"tlsParams": {
+							"cipherSuites": [
+            	            	"ECDHE-ECDSA-AES256-GCM-SHA384",
+            	            	"ECDHE-RSA-AES256-GCM-SHA384",
+            	            	"ECDHE-ECDSA-AES128-GCM-SHA256",
+            	            	"ECDHE-RSA-AES128-GCM-SHA256",
+            	            	"ECDHE-ECDSA-CHACHA20-POLY1305",
+            	            	"ECDHE-RSA-CHACHA20-POLY1305",
+            	            	"ECDHE-ECDSA-AES128-SHA",
+            	            	"ECDHE-RSA-AES128-SHA",
+            	            	"AES128-GCM-SHA256",
+            	            	"AES128-SHA",
+            	            	"ECDHE-ECDSA-AES256-SHA",
+            	            	"ECDHE-RSA-AES256-SHA",
+            	            	"AES256-GCM-SHA384",
+            	            	"AES256-SHA"
+            	            ],
 							"ecdhCurves": [
 								"X25519",
 								"P-256",
@@ -117,6 +149,22 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 					"commonTlsContext": {
 						"alpnProtocols": ["h2", "http/1.1"],
 						"tlsParams": {
+							"cipherSuites": [
+            	            	"ECDHE-ECDSA-AES256-GCM-SHA384",
+            	            	"ECDHE-RSA-AES256-GCM-SHA384",
+            	            	"ECDHE-ECDSA-AES128-GCM-SHA256",
+            	            	"ECDHE-RSA-AES128-GCM-SHA256",
+            	            	"ECDHE-ECDSA-CHACHA20-POLY1305",
+            	            	"ECDHE-RSA-CHACHA20-POLY1305",
+            	            	"ECDHE-ECDSA-AES128-SHA",
+            	            	"ECDHE-RSA-AES128-SHA",
+            	            	"AES128-GCM-SHA256",
+            	            	"AES128-SHA",
+            	            	"ECDHE-ECDSA-AES256-SHA",
+            	            	"ECDHE-RSA-AES256-SHA",
+            	            	"AES256-GCM-SHA384",
+            	            	"AES256-SHA"
+            	            ],
 							"ecdhCurves": [
 								"X25519",
 								"P-256",
@@ -153,6 +201,22 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 					"commonTlsContext": {
 						"alpnProtocols": ["h2", "http/1.1"],
 						"tlsParams": {
+							"cipherSuites": [
+            	            	"ECDHE-ECDSA-AES256-GCM-SHA384",
+            	            	"ECDHE-RSA-AES256-GCM-SHA384",
+            	            	"ECDHE-ECDSA-AES128-GCM-SHA256",
+            	            	"ECDHE-RSA-AES128-GCM-SHA256",
+            	            	"ECDHE-ECDSA-CHACHA20-POLY1305",
+            	            	"ECDHE-RSA-CHACHA20-POLY1305",
+            	            	"ECDHE-ECDSA-AES128-SHA",
+            	            	"ECDHE-RSA-AES128-SHA",
+            	            	"AES128-GCM-SHA256",
+            	            	"AES128-SHA",
+            	            	"ECDHE-ECDSA-AES256-SHA",
+            	            	"ECDHE-RSA-AES256-SHA",
+            	            	"AES256-GCM-SHA384",
+            	            	"AES256-SHA"
+            	            ],
 							"ecdhCurves": [
 								"X25519",
 								"P-256",
@@ -189,6 +253,22 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 					"commonTlsContext": {
 						"alpnProtocols": ["h2", "http/1.1"],
 						"tlsParams": {
+							"cipherSuites": [
+            	            	"ECDHE-ECDSA-AES256-GCM-SHA384",
+            	            	"ECDHE-RSA-AES256-GCM-SHA384",
+            	            	"ECDHE-ECDSA-AES128-GCM-SHA256",
+            	            	"ECDHE-RSA-AES128-GCM-SHA256",
+            	            	"ECDHE-ECDSA-CHACHA20-POLY1305",
+            	            	"ECDHE-RSA-CHACHA20-POLY1305",
+            	            	"ECDHE-ECDSA-AES128-SHA",
+            	            	"ECDHE-RSA-AES128-SHA",
+            	            	"AES128-GCM-SHA256",
+            	            	"AES128-SHA",
+            	            	"ECDHE-ECDSA-AES256-SHA",
+            	            	"ECDHE-RSA-AES256-SHA",
+            	            	"AES256-GCM-SHA384",
+            	            	"AES256-SHA"
+            	            ],
 							"ecdhCurves": [
 								"X25519",
 								"P-256",
@@ -314,6 +394,22 @@ func Test_buildCluster(t *testing.T) {
 							"commonTlsContext": {
 								"alpnProtocols": ["h2", "http/1.1"],
 									"tlsParams": {
+										"cipherSuites": [
+											"ECDHE-ECDSA-AES256-GCM-SHA384",
+											"ECDHE-RSA-AES256-GCM-SHA384",
+											"ECDHE-ECDSA-AES128-GCM-SHA256",
+											"ECDHE-RSA-AES128-GCM-SHA256",
+											"ECDHE-ECDSA-CHACHA20-POLY1305",
+											"ECDHE-RSA-CHACHA20-POLY1305",
+											"ECDHE-ECDSA-AES128-SHA",
+											"ECDHE-RSA-AES128-SHA",
+											"AES128-GCM-SHA256",
+											"AES128-SHA",
+											"ECDHE-ECDSA-AES256-SHA",
+											"ECDHE-RSA-AES256-SHA",
+											"AES256-GCM-SHA384",
+											"AES256-SHA"
+										],
 									"ecdhCurves": [
 										"X25519",
 										"P-256",
@@ -341,6 +437,22 @@ func Test_buildCluster(t *testing.T) {
 						"commonTlsContext": {
 							"alpnProtocols": ["h2", "http/1.1"],
 								"tlsParams": {
+									"cipherSuites": [
+										"ECDHE-ECDSA-AES256-GCM-SHA384",
+										"ECDHE-RSA-AES256-GCM-SHA384",
+										"ECDHE-ECDSA-AES128-GCM-SHA256",
+										"ECDHE-RSA-AES128-GCM-SHA256",
+										"ECDHE-ECDSA-CHACHA20-POLY1305",
+										"ECDHE-RSA-CHACHA20-POLY1305",
+										"ECDHE-ECDSA-AES128-SHA",
+										"ECDHE-RSA-AES128-SHA",
+										"AES128-GCM-SHA256",
+										"AES128-SHA",
+										"ECDHE-ECDSA-AES256-SHA",
+										"ECDHE-RSA-AES256-SHA",
+										"AES256-GCM-SHA384",
+										"AES256-SHA"
+									],
 								"ecdhCurves": [
 									"X25519",
 									"P-256",

--- a/docs/docs/community/security.md
+++ b/docs/docs/community/security.md
@@ -74,7 +74,7 @@ Encryption in transit:
     - X25519
     - secp256r1
 
-- For upstream TLS (connection from Pomerium to the application or service)
+- For upstream TLS (connections from Pomerium to the application or service)
 
   - The minimum accepted version of TLS is 1.2.
   - For TLS 1.2, the following cipher suites are supported:

--- a/docs/docs/community/security.md
+++ b/docs/docs/community/security.md
@@ -55,28 +55,51 @@ Encryption at rest:
 
 Encryption in transit:
 
-- Data in transit is protected by Transport Layer Security ([TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security)) . See our lab's [SSL Labs report](https://www.ssllabs.com/ssltest/analyze.html?d=authenticate.demo.pomerium.com&latest) .
+- Data in transit is protected by Transport Layer Security ([TLS](https://en.wikipedia.org/wiki/Transport_Layer_Security)). See our lab's [SSL Labs report](https://www.ssllabs.com/ssltest/analyze.html?d=authenticate.demo.pomerium.com&latest) .
+
+- For downstream TLS (connections from the user's client to Pomerium)
 
   - The minimum accepted version of TLS is 1.2.
-  - For TLS 1.3, the following cipher suites are offered:
-
-    - TLS_AES_128_GCM_SHA256
-    - TLS_AES_256_GCM_SHA384
-    - TLS_CHACHA20_POLY1305_SHA256
-
   - For TLS 1.2, the following cipher suites are offered, in this order:
 
-    - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
-    - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
-    - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+    - ECDHE-ECDSA-AES256-GCM-SHA384
+    - ECDHE-RSA-AES256-GCM-SHA384
+    - ECDHE-ECDSA-AES128-GCM-SHA256
+    - ECDHE-RSA-AES128-GCM-SHA256
+    - ECDHE-ECDSA-CHACHA20-POLY1305
+    - ECDHE-RSA-CHACHA20-POLY1305
 
   - The following elliptic curves are offered, in this order:
 
     - X25519
     - secp256r1
-    - X448
-    - secp521r1
-    - secp384r1
+
+- For upstream TLS (connection from Pomerium to the application or service)
+
+  - The minimum accepted version of TLS is 1.2.
+  - For TLS 1.2, the following cipher suites are supported:
+
+    - ECDHE-ECDSA-AES256-GCM-SHA384
+    - ECDHE-RSA-AES256-GCM-SHA384
+    - ECDHE-ECDSA-AES128-GCM-SHA256
+    - ECDHE-RSA-AES128-GCM-SHA256
+    - ECDHE-ECDSA-CHACHA20-POLY1305
+    - ECDHE-RSA-CHACHA20-POLY1305
+    - ECDHE-ECDSA-AES128-SHA
+    - ECDHE-RSA-AES128-SHA
+    - AES128-GCM-SHA256
+    - AES128-SHA
+    - ECDHE-ECDSA-AES256-SHA
+    - ECDHE-RSA-AES256-SHA
+    - AES256-GCM-SHA384
+    - AES256-SHA
+
+  - The following elliptic curves are supported:
+
+    - X25519
+    - P-256
+    - P-384
+    - P-521
 
 - [HTTP Strict Transport Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) (HSTS) with a long duration is used by default.
 


### PR DESCRIPTION
## Summary

Pomerium 0.13 used Envoy v1.16's pretty liberal upstream cipher suite. Envoy 1.17 changed that cipher suite to be essentially TLS 1.13. This reverts that change.


## Related issues

Fixes #2195


## Checklist

- [x] reference any related issues
- [x] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
