### PR TITLE
authorize: grpc health check

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
 
@@ -24,6 +25,7 @@ import (
 	"github.com/pomerium/pomerium/internal/telemetry"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
 	"github.com/pomerium/pomerium/internal/version"
+	pom_grpc "github.com/pomerium/pomerium/pkg/grpc"
 	"github.com/pomerium/pomerium/pkg/grpc/events"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
 )
@@ -92,6 +94,8 @@ func NewServer(name string, metricsMgr *config.MetricsManager) (*Server, error) 
 	)
 	reflection.Register(srv.GRPCServer)
 	srv.registerAccessLogHandlers()
+
+	grpc_health_v1.RegisterHealthServer(srv.GRPCServer, pom_grpc.NewHealthCheckServer())
 
 	// setup HTTP
 	srv.HTTPListener, err = net.Listen("tcp4", "127.0.0.1:0")

--- a/pkg/grpc/health.go
+++ b/pkg/grpc/health.go
@@ -3,10 +3,11 @@ package grpc
 import (
 	"context"
 
-	"github.com/pomerium/pomerium/internal/log"
 	"google.golang.org/grpc/codes"
 	grpc_health "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
+
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 type healthCheckSrv struct {

--- a/pkg/grpc/health.go
+++ b/pkg/grpc/health.go
@@ -1,0 +1,33 @@
+package grpc
+
+import (
+	"context"
+
+	"github.com/pomerium/pomerium/internal/log"
+	"google.golang.org/grpc/codes"
+	grpc_health "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+)
+
+type healthCheckSrv struct {
+}
+
+// NewHealthCheckServer returns a basic health checker
+func NewHealthCheckServer() grpc_health.HealthServer {
+	return &healthCheckSrv{}
+}
+
+// Check confirms service is reachable, and assumes any service is operational
+// an outlier detection should be used to detect runtime malfunction based on consequitive 5xx
+func (h *healthCheckSrv) Check(ctx context.Context, req *grpc_health.HealthCheckRequest) (*grpc_health.HealthCheckResponse, error) {
+	log.Debug(ctx).Str("service", req.Service).Msg("health check")
+	return &grpc_health.HealthCheckResponse{
+		Status: grpc_health.HealthCheckResponse_SERVING,
+	}, nil
+}
+
+// Watch is not implemented as is not used by Envoy
+func (h *healthCheckSrv) Watch(req *grpc_health.HealthCheckRequest, _ grpc_health.Health_WatchServer) error {
+	log.Error(context.Background()).Str("service", req.Service).Msg("health check watch")
+	return status.Errorf(codes.Unimplemented, "method Watch not implemented")
+}


### PR DESCRIPTION
## Summary

Previously if multiple authorize endpoints are defined and one of them is down, it would continue receive traffic based on default round-robin request load balancing policy, that would result 1/n % of HTTP requests to fail. 

This PR adds GRPC health check for `pomerium-authorize` GRPC cluster, that ensures reachability, and outlier detection that ensures authorize endpoint would be ejected if misconfigured. 

## Related issues

Fixes https://github.com/pomerium/internal/issues/399

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
