### PR TITLE
Revert "authenticate,proxy: add same site lax to cookies"

### DIFF
--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -5,7 +5,6 @@ import (
 	"crypto/cipher"
 	"encoding/base64"
 	"fmt"
-	"net/http"
 	"net/url"
 	"sync/atomic"
 
@@ -118,7 +117,6 @@ func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, err
 			Secure:   cfg.Options.CookieSecure,
 			HTTPOnly: cfg.Options.CookieHTTPOnly,
 			Expire:   cfg.Options.CookieExpire,
-			SameSite: http.SameSiteLaxMode,
 		}
 	}, state.sharedEncoder)
 	if err != nil {

--- a/internal/sessions/cookie/cookie_store.go
+++ b/internal/sessions/cookie/cookie_store.go
@@ -42,7 +42,6 @@ type Options struct {
 	Expire   time.Duration
 	HTTPOnly bool
 	Secure   bool
-	SameSite http.SameSite
 }
 
 // A GetOptionsFunc is a getter for cookie options.
@@ -93,7 +92,6 @@ func (cs *Store) makeCookie(value string) *http.Cookie {
 		HttpOnly: opts.HTTPOnly,
 		Secure:   opts.Secure,
 		Expires:  timeNow().Add(opts.Expire),
-		SameSite: opts.SameSite,
 	}
 }
 

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -3,7 +3,6 @@ package proxy
 import (
 	"crypto/cipher"
 	"encoding/base64"
-	"net/http"
 	"net/url"
 	"sync/atomic"
 	"time"
@@ -86,7 +85,6 @@ func newProxyStateFromConfig(cfg *config.Config) (*proxyState, error) {
 			Secure:   cfg.Options.CookieSecure,
 			HTTPOnly: cfg.Options.CookieHTTPOnly,
 			Expire:   cfg.Options.CookieExpire,
-			SameSite: http.SameSiteLaxMode,
 		}
 	}, state.encoder)
 	if err != nil {


### PR DESCRIPTION
Reverts pomerium/pomerium#2159

### Summary

In certain situations, when Pomerium is paired with additional single-sign-on (SSO) systems (e.g. SAML) which perform a `POST` following authentication, the `_pomerium` session could would not be set, and would result in an erroneous / blocking redirect flow loop.

### Next steps

We should allow user's to set their desired `SameSite` value as an option, and default to None.
 


```
Q: What is the Lax + POST mitigation?
This is a specific exception made to account for existing cookie usage on some Single Sign-On implementations where a CSRF token is expected on a cross-site POST request. This is purely a temporary solution and will be removed in the future. It does not add any new behavior, but instead is just not applying the new SameSite=Lax default in certain scenarios.
Specifically, a cookie that is at most 2 minutes old will be sent on a top-level cross-site POST request. However, if you rely on this behavior, you should update these cookies with the SameSite=None; Secure attributes to ensure they continue to function in the future.
```