### PR TITLE
docs: rm broken link

### DIFF
--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -4,38 +4,44 @@ lang: en-US
 sidebarDepth: 0
 meta:
   - name: keywords
-    content: >-
-      pomerium architecture
+    content: pomerium architecture
 ---
 
-## Architecture
+# Architecture
 
-### System Level
+## System Level
 
 Pomerium sits between end users and services requiring strong authentication. After verifying identity with your identity provider (IdP), Pomerium uses a configurable policy to decide how to route your user's request and if they are authorized to access the service.
 
 ![pomerium architecture diagram](./img/pomerium-system-context.svg)
 
-### Component Level
+## Component Level
 
 Pomerium is composed of 4 logical components:
 
 - Proxy Service
+
   - All user traffic flows through the proxy
   - Verifies all requests with Authentication service
   - Directs users to Authentication service to establish session identity
   - Processes policy to determine external/internal route mappings
+
 - Authentication Service
+
   - Handles authentication flow to your IdP as needed
   - Handles identity verification after initial Authentication
   - Establishes user session cookie
   - Stores user OIDC tokens in databroker service
+
 - Authorization Service
+
   - Processes policy to determine permissions for each service
   - Handles authorization check for all user sessions
   - Directs Proxy service to initiate Authentication flow as required
-  - Provides additional security releated headers for upstream services to consume
+  - Provides additional security related headers for upstream services to consume
+
 - Data Broker Service
+
   - Retrieves identity provider related data such as group membership
   - Stores and refreshes identity provider access and refresh tokens
   - Provides streaming authoritative session and identity data to Authorize service
@@ -47,10 +53,10 @@ In test deployments, all four components may run from a single binary and config
 
 ![pomerium architecture diagram](./img/pomerium-container-context.svg)
 
-### Authentication Flow
+## Authentication Flow
 
 Pomerium's internal and external component interactions during full authentication from a fresh user are diagramed below.
 
 After initial authentication to provide a session token, only the authorization check interactions occur.
 
-![pomerium architecture diagram](./img/pomerium-auth-flow.svg)] 
+![pomerium architecture diagram](./img/pomerium-auth-flow.svg)]

--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -53,4 +53,4 @@ Pomerium's internal and external component interactions during full authenticati
 
 After initial authentication to provide a session token, only the authorization check interactions occur.
 
-[![pomerium architecture diagram](./img/pomerium-auth-flow.svg)](/pomerium-auth-flow.svg)
+![pomerium architecture diagram](./img/pomerium-auth-flow.svg)] 


### PR DESCRIPTION

## Summary

The was the only image on this page that was also a link to the image, which failed with a 404 (which is the default Nginx 404 page, BTW).

## Checklist

- [ ] ~reference any related issues~
- [x] updated docs
- [ ] ~updated unit tests~
- [ ] ~updated UPGRADING.md~
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
