### PR TITLE
envoy: add global response headers to local replies

### DIFF
--- a/config/envoyconfig/http_connection_manager.go
+++ b/config/envoyconfig/http_connection_manager.go
@@ -1,0 +1,59 @@
+package envoyconfig
+
+import (
+	envoy_config_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+
+	"github.com/pomerium/pomerium/config"
+)
+
+func (b *Builder) buildVirtualHost(
+	options *config.Options,
+	name string,
+	domain string,
+) (*envoy_config_route_v3.VirtualHost, error) {
+	vh := &envoy_config_route_v3.VirtualHost{
+		Name:    name,
+		Domains: []string{domain},
+	}
+
+	// these routes match /.pomerium/... and similar paths
+	rs, err := b.buildPomeriumHTTPRoutes(options, domain)
+	if err != nil {
+		return nil, err
+	}
+	vh.Routes = append(vh.Routes, rs...)
+
+	// if we're the proxy or authenticate service, add our global headers
+	if config.IsProxy(options.Services) || config.IsAuthenticate(options.Services) {
+		vh.ResponseHeadersToAdd = toEnvoyHeaders(options.GetSetResponseHeaders())
+	}
+
+	return vh, nil
+}
+
+// buildLocalReplyConfig builds the local reply config: the config used to modify "local" replies, that is replies
+// coming directly from envoy
+func (b *Builder) buildLocalReplyConfig(
+	options *config.Options,
+) *envoy_http_connection_manager.LocalReplyConfig {
+	// add global headers for HSTS headers (#2110)
+	var headers []*envoy_config_core_v3.HeaderValueOption
+	// if we're the proxy or authenticate service, add our global headers
+	if config.IsProxy(options.Services) || config.IsAuthenticate(options.Services) {
+		headers = toEnvoyHeaders(options.GetSetResponseHeaders())
+	}
+
+	return &envoy_http_connection_manager.LocalReplyConfig{
+		Mappers: []*envoy_http_connection_manager.ResponseMapper{{
+			Filter: &envoy_config_accesslog_v3.AccessLogFilter{
+				FilterSpecifier: &envoy_config_accesslog_v3.AccessLogFilter_ResponseFlagFilter{
+					ResponseFlagFilter: &envoy_config_accesslog_v3.ResponseFlagFilter{},
+				},
+			},
+			HeadersToAdd: headers,
+		}},
+	}
+}

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -335,6 +335,27 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 					{
 						"name": "catch-all",
 						"domains": ["*"],
+						"responseHeadersToAdd": [{
+							"append": false,
+							"header": {
+								"key": "Strict-Transport-Security",
+								"value": "max-age=31536000; includeSubDomains; preload"
+							}
+						},
+						{
+							"append": false,
+							"header": {
+								"key": "X-Frame-Options",
+								"value": "SAMEORIGIN"
+							}
+						},
+						{
+							"append": false,
+							"header": {
+								"key": "X-XSS-Protection",
+								"value": "1; mode=block"
+							}
+						}],
 						"routes": [
 							{
 								"name": "pomerium-path-/.pomerium/jwt",
@@ -463,7 +484,39 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 			},
 			"useRemoteAddress": true,
 			"skipXffAppend": true,
-			"xffNumTrustedHops": 1
+			"xffNumTrustedHops": 1,
+			"localReplyConfig":{
+				"mappers":[
+					{
+						"filter":{
+							"responseFlagFilter":{}
+						},
+						"headersToAdd":[
+							{
+								"append":false,
+								"header":{
+									"key":"Strict-Transport-Security",
+									"value":"max-age=31536000; includeSubDomains; preload"
+								}
+							},
+							{
+								"append":false,
+								"header":{
+									"key":"X-Frame-Options",
+									"value":"SAMEORIGIN"
+								}
+							},
+							{
+								"append":false,
+								"header":{
+									"key":"X-XSS-Protection",
+									"value":"1; mode=block"
+								}
+							}
+						]
+					}
+				]
+			}
 		}
 	}`, filter)
 }


### PR DESCRIPTION
## Summary
If envoy fails to match a request to a route it responds with a "local" reply. This PR adds a local reply configuration to add our global response headers to this reply.

## Related issues
Fixes #2110 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
