### PR TITLE
fix(docs): use correct name for code-server

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -167,7 +167,7 @@ module.exports = {
             "tcp",
             "tiddlywiki",
             "traefik-ingress",
-            "vs-code-server",
+            "code-server",
           ],
         },
       ],
@@ -182,4 +182,4 @@ module.exports = {
       ],
     },
   },
-};
+}

--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -30,7 +30,8 @@
 /recipes/kubernetes.html		/guides/kubernetes.html
 /recipes/local-oidc.html		/guides/local-oidc.html
 /recipes/mtls.html				/guides/mtls.html
-/recipes/vs-code-server.html	/guides/vs-code-server.html
+/recipes/vs-code-server.html	/guides/code-server.html
+/guides/vs-code-server.html	/guides/code-server.html
 
 
 /docs/reference/								/docs/topics/

--- a/docs/guides/code-server.md
+++ b/docs/guides/code-server.md
@@ -1,5 +1,5 @@
 ---
-title: VS Code Server
+title: code-server
 lang: en-US
 meta:
   - name: keywords
@@ -15,19 +15,19 @@ description: >-
 
 ## Background
 
-This guide covers using Pomerium to secure an instance of [Visual Studio Code Server]. Pomerium is an identity-aware access proxy that can add single-sign-on / access control to any service, including visual studio code.
+This guide covers using Pomerium to secure an instance of [code-server]. Pomerium is an identity-aware access proxy that can add single-sign-on / access control to any service, including visual studio code.
 
 ### Visual Studio Code
 
 [Visual Studio Code] is an open source code editor by Microsoft that has become [incredibly popular](https://insights.stackoverflow.com/survey/2019#technology-_-most-popular-development-environments) in the last few years. For many developers, [Visual Studio Code] hits the sweet spot between no frills editors like vim/emacs and full feature IDE's like Eclipse and IntelliJ. VS Code offers some of the creature comforts like intellisense, git integration, and plugins, while staying relatively lightweight.
 
-One of the interesting attributes of [Visual Studio Code] is that it is built on the [Electron](https://en.wikipedia.org/wiki/Electron_(software_framework)) framework which uses a headless instance of Chrome rendered as a desktop application. It didn't take long for folks to realize that if we already had this great IDE written in Javascript, it may be possible to make [Visual Studio Code] run remotely.
+One of the interesting attributes of [Visual Studio Code] is that it is built on the [Electron](<https://en.wikipedia.org/wiki/Electron_(software_framework)>) framework which uses a headless instance of Chrome rendered as a desktop application. It didn't take long for folks to realize that if we already had this great IDE written in Javascript, it may be possible to make [Visual Studio Code] run remotely.
 
 > "Any application that can be written in JavaScript, will eventually be written in JavaScript." -- [Jeff Atwood](https://blog.codinghorror.com/the-principle-of-least-power/)
 
-### VS Code Server
+### code-server
 
-[Visual Studio Code Server] is an open-source project that allows you to run [Visual Studio Code] on a **remote** server, through the browser. For example, this is a screenshot taken at the end of this tutorial.
+[code-server] is an open-source project that allows you to run [Visual Studio Code] on a **remote** server, through the browser. For example, this is a screenshot taken at the end of this tutorial.
 
 ![visual studio code building pomerium](./img/vscode-pomerium.png)
 
@@ -124,4 +124,4 @@ Happy remote hacking!!!😁
 [quick start]: ../docs/quick-start
 [synology nas]: ../docs/quick-start/synology.md
 [visual studio code]: https://code.visualstudio.com/
-[visual studio code server]: https://github.com/cdr/code-server
+[code-server]: https://github.com/cdr/code-server


### PR DESCRIPTION
## Summary

Updates documentation to use the correct name for code-server

## Related issues

Fixes #2222 


## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
- [x] update [config](https://github.com/pomerium/pomerium/blob/master/docs/.vuepress/config.js#L170)
- [x] add [redirect](https://github.com/pomerium/pomerium/blob/master/docs/.vuepress/public/_redirects#L33)
