### PR TITLE
authorize: fix custom rego panic

### DIFF
--- a/authorize/evaluator/custom.go
+++ b/authorize/evaluator/custom.go
@@ -65,7 +65,7 @@ func (ce *CustomEvaluator) Evaluate(ctx context.Context, req *CustomEvaluatorReq
 	res := &CustomEvaluatorResponse{
 		Headers: getHeadersVar(vars),
 	}
-	if result, ok := vars["result"].(rego.Vars); ok {
+	if result, ok := vars["result"].(map[string]interface{}); ok {
 		res.Allowed, _ = result["allow"].(bool)
 		if v, ok := result["deny"]; ok {
 			// support `deny = true`

--- a/authorize/evaluator/custom_test.go
+++ b/authorize/evaluator/custom_test.go
@@ -53,4 +53,17 @@ func TestCustomEvaluator(t *testing.T) {
 		}
 		assert.NotNil(t, res)
 	})
+	t.Run("invalid package", func(t *testing.T) {
+		ce := NewCustomEvaluator(store)
+		res, err := ce.Evaluate(ctx, &CustomEvaluatorRequest{
+			RegoPolicy: `package custom_ext_authz.rego
+allow {
+  true
+}`,
+		})
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, res)
+	})
 }


### PR DESCRIPTION
## Summary
Fix a panic in custom rego. If a different package name was used the result set was empty which cause an out of bounds panic.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
