### PR TITLE
envoyconfig: fallback to global custom ca when no policy ca is defined

### DIFF
--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -5,6 +5,14 @@ description: >-
   for Pomerium. Please read it carefully.
 ---
 
+# Since 0.14.0
+
+## Breaking
+
+### Policy Certificate Authority
+
+The globally configured certificate authority (`ca` or `ca_file`) previously only applied to internal connections between pomerium services. It will now also be used for upstream policy connections if no policy-specific certificate authority is specified.
+
 # Since 0.13.0
 
 ## New

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -5,14 +5,6 @@ description: >-
   for Pomerium. Please read it carefully.
 ---
 
-# Since 0.14.0
-
-## Breaking
-
-### Policy Certificate Authority
-
-The globally configured certificate authority (`ca` or `ca_file`) previously only applied to internal connections between pomerium services. It will now also be used for upstream policy connections if no policy-specific certificate authority is specified.
-
 # Since 0.13.0
 
 ## New


### PR DESCRIPTION
## Summary
Fallback to the custom ca defined in the global options when no policy ca is defined. 

There's a non-trivial chance this may break existing users, since previously we only validated internal connections between pomerium services using this certificate authority, and now we will be validating all upstream services.

## Related issues
Fixes https://github.com/pomerium/internal/issues/417

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
