### PR TITLE
docs: update _redirects

### DIFF
--- a/docs/.vuepress/public/_redirects
+++ b/docs/.vuepress/public/_redirects
@@ -1,7 +1,7 @@
 /docs/reference/reference			/configuration/
 /docs/reference/reference.html		/configuration/
 /docs/configuration/				/configuration/
-
+/docs/config-reference.html				/configuration/
 /configuration/						/reference/
 
 


### PR DESCRIPTION
## Summary

Adds a redirect to an old reference page currently referenced on the helm chart. 

https://github.com/pomerium/pomerium-helm/blob/master/charts/pomerium/values.yaml

## Related issues

## Checklist

- [x] updated docs
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
