### PR TITLE
darwin: use x86 envoy build for arm64

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -26,9 +26,6 @@ builds:
     goos:
       - linux
       - darwin
-    ignore:
-      - goos: darwin
-        goarch: arm64
 
     ldflags:
       - -s -w

--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -8,6 +8,11 @@ _envoy_version=1.17.3
 _dir="${DIR:-"$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/../bin"}"
 _target="${TARGET:-"$(go env GOOS)-$(go env GOARCH)"}"
 
+# until m1 macs are supported, fallback to x86 and use rosetta
+if [ "$_target" == "darwin-arm64" ]; then
+  _target="darwin-amd64"
+fi
+
 is_command() {
     command -v "$1" >/dev/null
 }


### PR DESCRIPTION
## Summary
We don't currently have a build of envoy for darwin/arm64 (ie m1), but we can run the x86 build using rosetta. This updates the envoy script and run command.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
