### PR TITLE
authorize: preserve original context

### DIFF
--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -478,7 +478,7 @@ func mkRouteMatch(policy *config.Policy) *envoy_config_route_v3.RouteMatch {
 func getRequestHeadersToRemove(options *config.Options, policy *config.Policy) []string {
 	requestHeadersToRemove := policy.RemoveRequestHeaders
 	if !policy.PassIdentityHeaders {
-		requestHeadersToRemove = append(requestHeadersToRemove, httputil.HeaderPomeriumJWTAssertion)
+		requestHeadersToRemove = append(requestHeadersToRemove, httputil.HeaderPomeriumJWTAssertion, httputil.HeaderPomeriumJWTAssertionFor)
 		for _, claim := range options.JWTClaimsHeaders {
 			requestHeadersToRemove = append(requestHeadersToRemove, httputil.PomeriumJWTHeaderName(claim))
 		}

--- a/internal/httputil/headers.go
+++ b/internal/httputil/headers.go
@@ -11,7 +11,7 @@ const (
 )
 
 // Pomerium headers contain information added to a request.
-var (
+const (
 	// HeaderPomeriumResponse is set when pomerium itself creates a response,
 	// as opposed to the upstream application and can be used to distinguish
 	// between an application error, and a pomerium related error when debugging.

--- a/internal/httputil/headers.go
+++ b/internal/httputil/headers.go
@@ -19,7 +19,7 @@ var (
 	HeaderPomeriumResponse = "x-pomerium-intercepted-response"
 	// HeaderPomeriumJWTAssertion is the header key containing JWT signed user details.
 	HeaderPomeriumJWTAssertion = "x-pomerium-jwt-assertion"
-	// HeaderPomeriumJWTAssertionFor carries over original user identity from a chain of network calls
+	// HeaderPomeriumJWTAssertionFor carries over original user identity from a chain of network calls.
 	HeaderPomeriumJWTAssertionFor = "x-pomerium-jwt-assertion-for"
 	// HeaderPomeriumReproxyPolicy is the header key containing the policy to reproxy a request to.
 	HeaderPomeriumReproxyPolicy = "x-pomerium-reproxy-policy"

--- a/internal/httputil/headers.go
+++ b/internal/httputil/headers.go
@@ -11,7 +11,7 @@ const (
 )
 
 // Pomerium headers contain information added to a request.
-const (
+var (
 	// HeaderPomeriumResponse is set when pomerium itself creates a response,
 	// as opposed to the upstream application and can be used to distinguish
 	// between an application error, and a pomerium related error when debugging.
@@ -19,6 +19,8 @@ const (
 	HeaderPomeriumResponse = "x-pomerium-intercepted-response"
 	// HeaderPomeriumJWTAssertion is the header key containing JWT signed user details.
 	HeaderPomeriumJWTAssertion = "x-pomerium-jwt-assertion"
+	// HeaderPomeriumJWTAssertionFor carries over original user identity from a chain of network calls
+	HeaderPomeriumJWTAssertionFor = "x-pomerium-jwt-assertion-for"
 	// HeaderPomeriumReproxyPolicy is the header key containing the policy to reproxy a request to.
 	HeaderPomeriumReproxyPolicy = "x-pomerium-reproxy-policy"
 	// HeaderPomeriumReproxyPolicyHMAC is an HMAC of the HeaderPomeriumReproxyPolicy header.


### PR DESCRIPTION
## Summary

If an incoming request contains X-Pomerium-Jwt-Assertion and does not contain X-Pomerium-Jwt-Assertion-For, copy X-Pomerium-Jwt-Assertion into X-Pomerium-Jwt-Assertion-For when proxying to the upstream.

## Related issues

Implements https://github.com/pomerium/internal/issues/410

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
