### PR TITLE
config: warn about unrecognized keys 

### DIFF
--- a/docs/docs/topics/load-balancing.md
+++ b/docs/docs/topics/load-balancing.md
@@ -32,6 +32,7 @@ Active health checks issue periodic requests to each upstream to determine its h
 See [Health Checking](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a comprehensive overview.
 
 ### HTTP Example
+
 ```yaml
 policy:
   - from: https://myapp.localhost.pomerium.io
@@ -48,8 +49,9 @@ policy:
 ```
 
 ### TCP Example
+
 ```yaml
-policies:
+policy:
   - from: tcp+https://tcp-service.localhost.pomerium.io
     to:
       - tcp://tcp-1.local
@@ -105,8 +107,10 @@ policy:
     least_request_lb_config:
       choice_count: 2 # current envoy default
 ```
+
 ## Load Balancing Weight
-When a list of upstream URLs is specified in the `to` field, you may append an optional load balancing weight parameter.  The individual [`lb_policy`](#load-balancing-method) settings will take this weighting into account when making routing decisions.
+
+When a list of upstream URLs is specified in the `to` field, you may append an optional load balancing weight parameter. The individual [`lb_policy`](#load-balancing-method) settings will take this weighting into account when making routing decisions.
 
 ### Example
 
@@ -122,6 +126,7 @@ policy:
       - http://myapp-srv-4:8080,20
       - http://myapp-srv-5:8080,10
 ```
+
 ## Further reading
 
 - [Introduction to modern network load balancing and proxying](https://blog.envoyproxy.io/introduction-to-modern-network-load-balancing-and-proxying-a57f6ff80236)

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -24,12 +24,12 @@ Pomerium can hot-reload route configuration details, authorization policy, certi
 
 :::
 
-## Shared Settings
 
+## Shared Settings
 These configuration variables are shared by all services, in all service modes.
 
-### Address
 
+### Address
 - Environmental Variable: `ADDRESS`
 - Config File Key: `address`
 - Type: `string`
@@ -39,14 +39,14 @@ These configuration variables are shared by all services, in all service modes.
 
 Address specifies the host and port to serve HTTP requests from. If empty, `:443` is used. Note, in all-in-one deployments, gRPC traffic will be served on loopback on port `:5443`.
 
-### Autocert
 
+### Autocert
 - Environmental Variable: `AUTOCERT`
 - Config File Key: `autocert`
 - Type: `bool`
 - Optional
 
-Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from [Let's Encrypt][letsencrypt] which includes managed routes and the authenticate service. [Autocert Directory](./#autocert-directory) must be used with Autocert must have a place to persist, and share certificate data between services. Note that autocert also provides [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling).
+Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from [Let's Encrypt][letsencrypt] which includes managed routes and the authenticate service.  [Autocert Directory](./#autocert-directory) must be used with Autocert must have a place to persist, and share certificate data between services. Note that autocert also provides [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling).
 
 This setting can be useful in situations where you may not have Pomerium behind a TLS terminating ingress or proxy that is already handling your public certificates on your behalf.
 
@@ -62,8 +62,8 @@ Autocert requires that ports `80`/`443` be accessible from the internet in order
 
 :::
 
-### Autocert Must-Staple
 
+### Autocert Must-Staple
 - Environmental Variable: `AUTOCERT_MUST_STAPLE`
 - Config File Key: `autocert_must_staple`
 - Type: `bool`
@@ -79,8 +79,8 @@ This setting will only take effect when you request or renew your certificates.
 
 For more details, please see [RFC7633](https://tools.ietf.org/html/rfc7633) .
 
-### Autocert Directory
 
+### Autocert Directory
 - Environmental Variable: either `AUTOCERT_DIR`
 - Config File Key: `autocert_dir`
 - Type: `string` pointing to the path of the directory
@@ -88,13 +88,13 @@ For more details, please see [RFC7633](https://tools.ietf.org/html/rfc7633) .
 - Default:
 
   - `/data/autocert` in published Pomerium docker images
-  - [\$XDG_DATA_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+  - [$XDG_DATA_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
   - `$HOME/.local/share/pomerium`
 
 Autocert directory is the path which autocert will store x509 certificate data.
 
-### Autocert Use Staging
 
+### Autocert Use Staging
 - Environmental Variable: `AUTOCERT_USE_STAGING`
 - Config File Key: `autocert_use_staging`
 - Type: `bool`
@@ -102,8 +102,8 @@ Autocert directory is the path which autocert will store x509 certificate data.
 
 Let's Encrypt has strict [usage limits](https://letsencrypt.org/docs/rate-limits/). Enabling this setting allows you to use Let's Encrypt's [staging environment](https://letsencrypt.org/docs/staging-environment/) which has much more lax usage limits.
 
-### Certificates
 
+### Certificates
 - Config File Key: `certificates` (not yet settable using environmental variables)
 - Config File Key: `certificate` / `certificate_key`
 - Config File Key: `certificate_file` / `certificate_key_file`
@@ -128,8 +128,8 @@ certificates:
     key: "$HOME/.acme.sh/prometheus.example.com_ecc/prometheus.example.com.key"
 ```
 
-### Client Certificate Authority
 
+### Client Certificate Authority
 - Environment Variable: `CLIENT_CA` / `CLIENT_CA_FILE`
 - Config File Key: `client_ca` / `client_ca_file`
 - Type: [base64 encoded] `string` or relative file location
@@ -137,8 +137,8 @@ certificates:
 
 The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) client certificates. If not set, no client certificate will be required.
 
-### Client CRL
 
+### Client CRL
 - Environment Variable: `CLIENT_CRL` / `CLIENT_CRL_FILE`
 - Config File Key: `client_crl` / `client_crl_file`
 - Type: [base64 encoded] `string` or relative file location
@@ -147,10 +147,10 @@ The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS
 The Client CRL is the [certificate revocation list](https://en.wikipedia.org/wiki/Certificate_revocation_list)
 (in PEM format) for client certificates. If not set, no CRL will be used.
 
+
 ### Cookie Options
 
 #### Cookie Name
-
 - Environmental Variable: `COOKIE_NAME`
 - Config File Key: `cookie_name`
 - Type: `string`
@@ -158,8 +158,8 @@ The Client CRL is the [certificate revocation list](https://en.wikipedia.org/wik
 
 The name of the session cookie sent to clients.
 
-#### Cookie Secret
 
+#### Cookie Secret
 - Environmental Variable: `COOKIE_SECRET`
 - Config File Key: `cookie_secret`
 - Type: [base64 encoded] `string`
@@ -167,8 +167,8 @@ The name of the session cookie sent to clients.
 
 Secret used to encrypt and sign session cookies. You can generate a random key with `head -c32 /dev/urandom | base64`.
 
-#### Cookie Domain
 
+#### Cookie Domain
 - Environmental Variable: `COOKIE_DOMAIN`
 - Config File Key: `cookie_domain`
 - Type: `string`
@@ -177,8 +177,8 @@ Secret used to encrypt and sign session cookies. You can generate a random key w
 
 The scope of session cookies issued by Pomerium.
 
-#### HTTPS only
 
+#### HTTPS only
 - Environmental Variable: `COOKIE_SECURE`
 - Config File Key: `cookie_secure`
 - Type: `bool`
@@ -192,8 +192,8 @@ Setting this to false may result in session cookies being sent in cleartext.
 
 :::
 
-#### Javascript Security
 
+#### Javascript Security
 - Environmental Variable: `COOKIE_HTTP_ONLY`
 - Config File Key: `cookie_http_only`
 - Type: `bool`
@@ -207,8 +207,8 @@ Setting this to false enables hostile javascript to steal session cookies and im
 
 :::
 
-#### Expiration
 
+#### Expiration
 - Environmental Variable: `COOKIE_EXPIRE`
 - Config File Key: `cookie_expire`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -216,8 +216,8 @@ Setting this to false enables hostile javascript to steal session cookies and im
 
 Sets the lifetime of session cookies. After this interval, users must reauthenticate.
 
-### Debug
 
+### Debug
 - Environmental Variable: `POMERIUM_DEBUG`
 - Config File Key: `pomerium_debug`
 - Type: `bool`
@@ -229,7 +229,7 @@ Enabling the debug flag could result in sensitive information being logged!!!
 
 :::
 
-By default, JSON encoded logs are produced. Debug enables colored, human-readable logs to be streamed to [standard out](<https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)>>>>). In production, it is recommended to be set to `false`.
+By default, JSON encoded logs are produced. Debug enables colored, human-readable logs to be streamed to [standard out](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)>>>). In production, it is recommended to be set to `false`.
 
 For example, if `true`
 
@@ -249,8 +249,8 @@ If `false`
 {"level":"info","OverrideCertificateName":"","addr":"auth.localhost.pomerium.io:443","time":"2019-02-18T10:41:03-08:00","message":"proxy/authenticator: grpc connection"}
 ```
 
-### Forward Auth
 
+### Forward Auth
 - Environmental Variable: `FORWARD_AUTH_URL`
 - Config File Key: `forward_auth_url`
 - Type: `URL` (must contain a scheme and hostname)
@@ -331,8 +331,8 @@ services:
       - "traefik.http.routers.verify.middlewares=test-auth@docker"
 ```
 
-### Global Timeouts
 
+### Global Timeouts
 - Environmental Variables: `TIMEOUT_READ` `TIMEOUT_WRITE` `TIMEOUT_IDLE`
 - Config File Key: `timeout_read` `timeout_write` `timeout_idle`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -345,10 +345,10 @@ Timeouts set the global server timeouts. Timeouts can also be set for individual
 
 > For a deep dive on timeout values see [these](https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/) [two](https://blog.cloudflare.com/exposing-go-on-the-internet/) excellent blog posts.
 
+
 ### GRPC Options
 
 #### GRPC Address
-
 - Environmental Variable: `GRPC_ADDRESS`
 - Config File Key: `grpc_address`
 - Type: `string`
@@ -357,16 +357,16 @@ Timeouts set the global server timeouts. Timeouts can also be set for individual
 
 gRPC Address specifies the host and port to serve gRPC requests from.
 
-#### GRPC Insecure
 
+#### GRPC Insecure
 - Environmental Variable: `GRPC_INSECURE`
 - Config File Key: `grpc_insecure`
 - Type: `bool`
 
 This setting disables transport security for gRPC communication. If running in all-in-one mode, defaults to true as communication will run over localhost's own socket.
 
-#### GRPC Client Timeout
 
+#### GRPC Client Timeout
 - Environmental Variable: `GRPC_CLIENT_TIMEOUT`
 - Config File Key: `grpc_client_timeout`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -374,8 +374,8 @@ This setting disables transport security for gRPC communication. If running in a
 
 Maximum time before canceling an upstream gRPC request. During transient failures, the proxy will retry upstreams for this duration. You should leave this high enough to handle backend service restart and rediscovery so that client requests do not fail.
 
-#### GRPC Client DNS RoundRobin
 
+#### GRPC Client DNS RoundRobin
 - Environmental Variable: `GRPC_CLIENT_DNS_ROUNDROBIN`
 - Config File Key: `grpc_client_dns_roundrobin`
 - Type: `bool`
@@ -383,8 +383,8 @@ Maximum time before canceling an upstream gRPC request. During transient failure
 
 Enable gRPC DNS based round robin load balancing. This method uses DNS to resolve endpoints and does client side load balancing of _all_ addresses returned by the DNS record. Do not disable unless you have a specific use case.
 
-#### GRPC Server Max Connection Age
 
+#### GRPC Server Max Connection Age
 - Environmental Variable: `GRPC_SERVER_MAX_CONNECTION_AGE`
 - Config File Key: `grpc_server_max_connection_age`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -394,8 +394,8 @@ Set max connection age for GRPC servers. After this interval, servers ask client
 
 See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> for details
 
-#### GRPC Server Max Connection Age Grace
 
+#### GRPC Server Max Connection Age Grace
 - Environmental Variable: `GRPC_SERVER_MAX_CONNECTION_AGE_GRACE`
 - Config File Key: `grpc_server_max_connection_age_grace`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -405,8 +405,8 @@ Additive period with `grpc_server_max_connection_age`, after which servers will 
 
 See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> for details
 
-### HTTP Redirect Address
 
+### HTTP Redirect Address
 - Environmental Variable: `HTTP_REDIRECT_ADDR`
 - Config File Key: `http_redirect_addr`
 - Type: `string`
@@ -415,8 +415,8 @@ See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> for de
 
 If set, the HTTP Redirect Address specifies the host and port to redirect http to https traffic on. If unset, no redirect server is started.
 
-### Insecure Server
 
+### Insecure Server
 - Environmental Variable: `INSECURE_SERVER`
 - Config File Key: `insecure_server`
 - Type: `bool`
@@ -432,8 +432,8 @@ Pomerium should _never_ be exposed to the internet without TLS encryption.
 
 :::
 
-### DNS Lookup Family
 
+### DNS Lookup Family
 - Environmental Variable: `DNS_LOOKUP_FAMILY`
 - Config File Key: `dns_lookup_family`
 - Type: `string`
@@ -442,8 +442,8 @@ Pomerium should _never_ be exposed to the internet without TLS encryption.
 
 The DNS IP address resolution policy. If not specified, the value defaults to `AUTO`.
 
-### Log Level
 
+### Log Level
 - Environmental Variable: `LOG_LEVEL`
 - Config File Key: `log_level`
 - Type: `string`
@@ -452,8 +452,8 @@ The DNS IP address resolution policy. If not specified, the value defaults to `A
 
 Log level sets the global logging level for pomerium. Only logs of the desired level and above will be logged.
 
-### Metrics Address
 
+### Metrics Address
 - Environmental Variable: `METRICS_ADDRESS`
 - Config File Key: `metrics_address`
 - Type: `string`
@@ -471,33 +471,33 @@ Expose a prometheus endpoint on the specified port.
 
 #### Pomerium Metrics Tracked
 
-| Name                                          | Type      | Description                                                             |
-| --------------------------------------------- | --------- | ----------------------------------------------------------------------- |
-| grpc_client_request_duration_ms               | Histogram | GRPC client request duration by service                                 |
-| grpc_client_request_size_bytes                | Histogram | GRPC client request size by service                                     |
-| grpc_client_requests_total                    | Counter   | Total GRPC client requests made by service                              |
-| grpc_client_response_size_bytes               | Histogram | GRPC client response size by service                                    |
-| grpc_server_request_duration_ms               | Histogram | GRPC server request duration by service                                 |
-| grpc_server_request_size_bytes                | Histogram | GRPC server request size by service                                     |
-| grpc_server_requests_total                    | Counter   | Total GRPC server requests made by service                              |
-| grpc_server_response_size_bytes               | Histogram | GRPC server response size by service                                    |
-| http_client_request_duration_ms               | Histogram | HTTP client request duration by service                                 |
-| http_client_request_size_bytes                | Histogram | HTTP client request size by service                                     |
-| http_client_requests_total                    | Counter   | Total HTTP client requests made by service                              |
-| http_client_response_size_bytes               | Histogram | HTTP client response size by service                                    |
-| http_server_request_duration_ms               | Histogram | HTTP server request duration by service                                 |
-| http_server_request_size_bytes                | Histogram | HTTP server request size by service                                     |
-| http_server_requests_total                    | Counter   | Total HTTP server requests handled by service                           |
-| http_server_response_size_bytes               | Histogram | HTTP server response size by service                                    |
-| pomerium_build_info                           | Gauge     | Pomerium build metadata by git revision, service, version and goversion |
-| pomerium_config_checksum_int64                | Gauge     | Currently loaded configuration checksum by service                      |
-| pomerium_config_last_reload_success           | Gauge     | Whether the last configuration reload succeeded by service              |
-| pomerium_config_last_reload_success_timestamp | Gauge     | The timestamp of the last successful configuration reload by service    |
-| redis_conns                                   | Gauge     | Number of total connections in the pool                                 |
-| redis_idle_conns                              | Gauge     | Total number of times free connection was found in the pool             |
-| redis_wait_count_total                        | Counter   | Total number of connections waited for                                  |
-| redis_wait_duration_ms_total                  | Counter   | Total time spent waiting for connections                                |
-| storage_operation_duration_ms                 | Histogram | Storage operation duration by operation, result, backend and service    |
+Name                                          | Type      | Description
+--------------------------------------------- | --------- | -----------------------------------------------------------------------
+grpc_client_request_duration_ms               | Histogram | GRPC client request duration by service
+grpc_client_request_size_bytes                | Histogram | GRPC client request size by service
+grpc_client_requests_total                    | Counter   | Total GRPC client requests made by service
+grpc_client_response_size_bytes               | Histogram | GRPC client response size by service
+grpc_server_request_duration_ms               | Histogram | GRPC server request duration by service
+grpc_server_request_size_bytes                | Histogram | GRPC server request size by service
+grpc_server_requests_total                    | Counter   | Total GRPC server requests made by service
+grpc_server_response_size_bytes               | Histogram | GRPC server response size by service
+http_client_request_duration_ms               | Histogram | HTTP client request duration by service
+http_client_request_size_bytes                | Histogram | HTTP client request size by service
+http_client_requests_total                    | Counter   | Total HTTP client requests made by service
+http_client_response_size_bytes               | Histogram | HTTP client response size by service
+http_server_request_duration_ms               | Histogram | HTTP server request duration by service
+http_server_request_size_bytes                | Histogram | HTTP server request size by service
+http_server_requests_total                    | Counter   | Total HTTP server requests handled by service
+http_server_response_size_bytes               | Histogram | HTTP server response size by service
+pomerium_build_info                           | Gauge     | Pomerium build metadata by git revision, service, version and goversion
+pomerium_config_checksum_int64                | Gauge     | Currently loaded configuration checksum by service
+pomerium_config_last_reload_success           | Gauge     | Whether the last configuration reload succeeded by service
+pomerium_config_last_reload_success_timestamp | Gauge     | The timestamp of the last successful configuration reload by service
+redis_conns                                   | Gauge     | Number of total connections in the pool
+redis_idle_conns                              | Gauge     | Total number of times free connection was found in the pool
+redis_wait_count_total                        | Counter   | Total number of connections waited for
+redis_wait_duration_ms_total                  | Counter   | Total time spent waiting for connections
+storage_operation_duration_ms                 | Histogram | Storage operation duration by operation, result, backend and service
 
 #### Envoy Proxy Metrics
 
@@ -505,8 +505,8 @@ As of `v0.9`, Pomerium uses [envoy](https://www.envoyproxy.io/) for the data pla
 
 All metrics coming from envoy will be labeled with `service="pomerium"` or `service="pomerium-proxy"`, depending if you're running all-in-one or distributed service mode.
 
-### Metrics Basic Authentication
 
+### Metrics Basic Authentication
 - Environmental Variable: `METRICS_BASIC_AUTH`
 - Config File Key: `metrics_basic_auth`
 - Type: base64 encoded `string` of `username:password`
@@ -519,8 +519,8 @@ Require [Basic HTTP Authentication](https://tools.ietf.org/html/rfc7617) to acce
 To support this in Prometheus, consult the `basic_auth` option in the [`scrape_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)
 documentation.
 
-### Metrics Certificate
 
+### Metrics Certificate
 - Config File Key: `metrics_certificate` / `metrics_certificate_key`
 - Config File Key: `metrics_certificate_file` / `metrics_certificate_key_file`
 - Environmental Variable: `METRICS_CERTIFICATE` / `METRICS_CERTIFICATE_KEY`
@@ -531,8 +531,8 @@ documentation.
 
 Certificates are the x509 _public-key_ and _private-key_ used to secure the metrics endpoint.
 
-### Metrics Client Certificate Authority
 
+### Metrics Client Certificate Authority
 - Environment Variable: `METRICS_CLIENT_CA` / `METRICS_CLIENT_CA_FILE`
 - Config File Key: `metrics_client_ca` / `metrics_client_ca_file`
 - Type: [base64 encoded] `string` or relative file location
@@ -540,8 +540,8 @@ Certificates are the x509 _public-key_ and _private-key_ used to secure the metr
 
 The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) client certificates for the metrics endpoint. If not set, no client certificate will be required.
 
-### Proxy Log Level
 
+### Proxy Log Level
 - Environmental Variable: `PROXY_LOG_LEVEL`
 - Config File Key: `proxy_log_level`
 - Type: `string`
@@ -550,8 +550,8 @@ The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS
 
 Proxy log level sets the logging level for the pomerium proxy service access logs. Only logs of the desired level and above will be logged.
 
-### Service Mode
 
+### Service Mode
 - Environmental Variable: `SERVICES`
 - Config File Key: `services`
 - Type: `string`
@@ -560,8 +560,8 @@ Proxy log level sets the logging level for the pomerium proxy service access log
 
 Service mode sets which service(s) to run. If testing, you may want to set to `all` and run pomerium in "all-in-one mode." In production, you'll likely want to spin up several instances of each service mode for high availability.
 
-### Shared Secret
 
+### Shared Secret
 - Environmental Variable: `SHARED_SECRET`
 - Config File Key: `shared_secret`
 - Type: [base64 encoded] `string`
@@ -573,26 +573,26 @@ Shared Secret is the base64 encoded 256-bit key used to mutually authenticate re
 head -c32 /dev/urandom | base64
 ```
 
-### Tracing
 
+### Tracing
 Tracing tracks the progression of a single user request as it is handled by Pomerium.
 
 Each unit work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
 
 #### Shared Tracing Settings
 
-| Config Key          | Description                                                                          | Required |
-| :------------------ | :----------------------------------------------------------------------------------- | -------- |
-| tracing_provider    | The name of the tracing provider. (e.g. jaeger, zipkin)                              | ✅       |
-| tracing_sample_rate | Percentage of requests to sample in decimal notation. Default is `0.0001`, or `.01%` | ❌       |
+Config Key          | Description                                                                          | Required
+:------------------ | :----------------------------------------------------------------------------------- | --------
+tracing_provider    | The name of the tracing provider. (e.g. jaeger, zipkin)                              | ✅
+tracing_sample_rate | Percentage of requests to sample in decimal notation. Default is `0.0001`, or `.01%` | ❌
 
 #### Datadog
 
 Datadog is a real-time monitoring system that supports distributed tracing and monitoring.
 
-| Config Key              | Description                                                                  | Required |
-| :---------------------- | :--------------------------------------------------------------------------- | -------- |
-| tracing_datadog_address | `host:port` address of the Datadog Trace Agent. Defaults to `localhost:8126` | ❌       |
+Config Key              | Description                                                                  | Required
+:---------------------- | :--------------------------------------------------------------------------- | --------
+tracing_datadog_address | `host:port` address of the Datadog Trace Agent. Defaults to `localhost:8126` | ❌
 
 #### Jaeger (partial)
 
@@ -606,10 +606,10 @@ Datadog is a real-time monitoring system that supports distributed tracing and m
 - Service dependency analysis
 - Performance / latency optimization
 
-| Config Key                        | Description                                 | Required |
-| :-------------------------------- | :------------------------------------------ | -------- |
-| tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅       |
-| tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅       |
+Config Key                        | Description                                 | Required
+:-------------------------------- | :------------------------------------------ | --------
+tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅
+tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅
 
 #### Zipkin
 
@@ -617,16 +617,16 @@ Zipkin is an open source distributed tracing system and protocol.
 
 Many tracing backends support zipkin either directly or through intermediary agents, including Jaeger. For full tracing support, we recommend using the Zipkin tracing protocol.
 
-| Config Key              | Description                      | Required |
-| :---------------------- | :------------------------------- | -------- |
-| tracing_zipkin_endpoint | Url to the Zipkin HTTP endpoint. | ✅       |
+Config Key              | Description                      | Required
+:---------------------- | :------------------------------- | --------
+tracing_zipkin_endpoint | Url to the Zipkin HTTP endpoint. | ✅
 
 #### Example
 
 ![jaeger example trace](./img/jaeger.png)
 
-### Use Proxy Protocol
 
+### Use Proxy Protocol
 - Environment Variable: `USE_PROXY_PROTOCOL`
 - Config File Key: `use_proxy_protocol`
 - Type: `bool`
@@ -634,8 +634,8 @@ Many tracing backends support zipkin either directly or through intermediary age
 
 Setting `use_proxy_protocol` will configure Pomerium to require the [HAProxy proxy protocol](https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt) on incoming connections. Versions 1 and 2 of the protocol are supported.
 
-### Envoy Admin Options
 
+### Envoy Admin Options
 - Environment Variable: `ENVOY_ADMIN_ADDRESS`, `ENVOY_ADMIN_ACCESS_LOG_PATH`, `ENVOY_ADMIN_PROFILE_PATH`
 - Config File Keys: `envoy_admin_address`, `envoy_admin_access_log_path`, `envoy_admin_profile_path`
 - Type: `string`
@@ -643,10 +643,10 @@ Setting `use_proxy_protocol` will configure Pomerium to require the [HAProxy pro
 
 These options customize Envoy's [bootstrap configuration](https://www.envoyproxy.io/docs/envoy/latest/operations/admin#operations-admin-interface). They cannot be modified at runtime.
 
+
 ## Authenticate Service
 
 ### Authenticate Callback Path
-
 - Environmental Variable: `AUTHENTICATE_CALLBACK_PATH`
 - Config File Key: `authenticate_callback_path`
 - Type: `string`
@@ -663,8 +663,8 @@ See also:
 - [OIDC Spec][oidc rfc]
 - [Google - Setting Redirect URI](https://developers.google.com/identity/protocols/OpenIDConnect#setredirecturi)
 
-### Authenticate Service URL
 
+### Authenticate Service URL
 - Environmental Variable: `AUTHENTICATE_SERVICE_URL`
 - Config File Key: `authenticate_service_url`
 - Type: `URL`
@@ -673,8 +673,8 @@ See also:
 
 Authenticate Service URL is the externally accessible URL for the authenticate service.
 
-### Identity Provider Client ID
 
+### Identity Provider Client ID
 - Environmental Variable: `IDP_CLIENT_ID`
 - Config File Key: `idp_client_id`
 - Type: `string`
@@ -682,8 +682,8 @@ Authenticate Service URL is the externally accessible URL for the authenticate s
 
 Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider] docs for details.
 
-### Identity Provider Client Secret
 
+### Identity Provider Client Secret
 - Environmental Variable: `IDP_CLIENT_SECRET`
 - Config File Key: `idp_client_secret`
 - Type: `string`
@@ -691,8 +691,8 @@ Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provid
 
 Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider] docs for details.
 
-### Identity Provider Name
 
+### Identity Provider Name
 - Environmental Variable: `IDP_PROVIDER`
 - Config File Key: `idp_provider`
 - Type: `string`
@@ -703,8 +703,8 @@ Provider is the short-hand name of a built-in OpenID Connect (oidc) identity pro
 
 See [identity provider] for details.
 
-### Identity Provider Scopes
 
+### Identity Provider Scopes
 - Environmental Variable: `IDP_SCOPES`
 - Config File Key: `idp_scopes`
 - Type: list of `string`
@@ -725,8 +725,8 @@ Some providers, like Amazon Cognito, _do not_ support the `offline_access` scope
 
 :::
 
-### Identity Provider Service Account
 
+### Identity Provider Service Account
 - Environmental Variable: `IDP_SERVICE_ACCOUNT`
 - Config File Key: `idp_service_account`
 - Type: `string`
@@ -740,8 +740,8 @@ If you plan to write authorization policies using groups, or any other data that
 
 :::
 
-### Identity Provider URL
 
+### Identity Provider URL
 - Environmental Variable: `IDP_PROVIDER_URL`
 - Config File Key: `idp_provider_url`
 - Type: `string`
@@ -749,8 +749,8 @@ If you plan to write authorization policies using groups, or any other data that
 
 Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). For example, google's URL would be `https://accounts.google.com` for [their discover document](https://accounts.google.com/.well-known/openid-configuration).
 
-### Identity Provider Request Params
 
+### Identity Provider Request Params
 - Environmental Variable: `IDP_REQUEST_PARAMS`
 - Config File Key: `idp_request_params`
 - Type: map of `strings` key value pairs
@@ -765,8 +765,8 @@ For more information see:
 - [Microsoft Azure Request params](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code)
 - [Google Authentication URI parameters](https://developers.google.com/identity/protocols/oauth2/openid-connect)
 
-### Identity Provider Refresh Directory Settings
 
+### Identity Provider Refresh Directory Settings
 - Environmental Variables: `IDP_REFRESH_DIRECTORY_INTERVAL` `IDP_REFRESH_DIRECTORY_TIMEOUT`
 - Config File Key: `idp_refresh_directory_interval` `idp_refresh_directory_timeout`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -781,10 +781,10 @@ Use it at your own risk, if you set a too low value, you may reach IDP API rate 
 
 :::
 
+
 ## Proxy Service
 
 ### Authenticate Service URL
-
 - Environmental Variable: `AUTHENTICATE_SERVICE_URL`
 - Config File Key: `authenticate_service_url`
 - Type: `URL`
@@ -793,8 +793,8 @@ Use it at your own risk, if you set a too low value, you may reach IDP API rate 
 
 Authenticate Service URL is the externally accessible URL for the authenticate service.
 
-### Authorize Service URL
 
+### Authorize Service URL
 - Environmental Variable: `AUTHORIZE_SERVICE_URL`
 - Config File Key: `authorize_service_url`
 - Type: `URL`
@@ -805,8 +805,8 @@ Authorize Service URL is the location of the internally accessible authorize ser
 
 If your load balancer does not support gRPC pass-through you'll need to set this value to an internally routable location (`https://pomerium-authorize-service.default.svc.cluster.local`) instead of an externally routable one (`https://authorize.corp.example.com`).
 
-### Certificate Authority
 
+### Certificate Authority
 - Environmental Variable: `CERTIFICATE_AUTHORITY` or `CERTIFICATE_AUTHORITY_FILE`
 - Config File Key: `certificate_authority` or `certificate_authority_file`
 - Type: [base64 encoded] `string` or relative file location
@@ -820,8 +820,8 @@ Be sure to include the intermediary certificate.
 
 :::
 
-### Default Upstream Timeout
 
+### Default Upstream Timeout
 - Environmental Variable: `DEFAULT_UPSTREAM_TIMEOUT`
 - Config File Key: `default_upstream_timeout`
 - Type: [Duration](https://golang.org/pkg/time/#Duration) `string`
@@ -830,8 +830,8 @@ Be sure to include the intermediary certificate.
 
 Default Upstream Timeout is the default timeout applied to a proxied route when no `timeout` key is specified by the policy.
 
-### Set Response Headers
 
+### Set Response Headers
 - Environmental Variable: `SET_RESPONSE_HEADERS`
 - Config File Key: `set_response_headers`
 - Type: map of `strings` key value pairs
@@ -871,8 +871,8 @@ users are encouraged to add these to `set_response_headers` or their downstream 
 
 :::
 
-### JWT Claim Headers
 
+### JWT Claim Headers
 - Environmental Variable: `JWT_CLAIMS_HEADERS`
 - Config File Key: `jwt_claims_headers`
 - Type: slice of `string`
@@ -896,8 +896,8 @@ Will add an `X-Email` header with a value of the `email` claim.
 
 Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}`.
 
-### Override Certificate Name
 
+### Override Certificate Name
 - Environmental Variable: `OVERRIDE_CERTIFICATE_NAME`
 - Config File Key: `override_certificate_name`
 - Type: `int`
@@ -906,8 +906,8 @@ Use this option if you previously relied on `x-pomerium-authenticated-user-{emai
 
 Secure service communication can fail if the external certificate does not match the internally routed service hostname/[SNI](https://en.wikipedia.org/wiki/Server_Name_Indication). This setting allows you to override that value.
 
-### Programmatic Redirect Domain Whitelist
 
+### Programmatic Redirect Domain Whitelist
 - Config File Key: `programmatic_redirect_domain_whitelist`
 - Type: array of `string`
 - Optional
@@ -915,8 +915,8 @@ Secure service communication can fail if the external certificate does not match
 
 The programmatic redirect domain whitelist is used to restrict the allowed redirect URLs when using programmatic login. By default only `localhost` URLs are allowed.
 
-### Refresh Cooldown
 
+### Refresh Cooldown
 - Environmental Variable: `REFRESH_COOLDOWN`
 - Config File Key: `refresh_cooldown`
 - Type: [Duration](https://golang.org/pkg/time/#Duration) `string`
@@ -925,8 +925,8 @@ The programmatic redirect domain whitelist is used to restrict the allowed redir
 
 Refresh cooldown is the minimum amount of time between allowed manually refreshed sessions.
 
-### X-Forwarded-For HTTP Header
 
+### X-Forwarded-For HTTP Header
 - Environmental Variable: `SKIP_XFF_APPEND`
 - Config File Key: `skip_xff_append`
 - Type: `bool`
@@ -934,8 +934,8 @@ Refresh cooldown is the minimum amount of time between allowed manually refreshe
 
 Do not append proxy IP address to `x-forwarded-for` HTTP header. See [Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=skip_xff_append#x-forwarded-for) docs for more detail.
 
-### The number of trusted hops
 
+### The number of trusted hops
 - Environmental Variable: `XFF_NUM_TRUSTED_HOPS`
 - Config File Key: `xff_num_trusted_hops`
 - Type: `uint32`
@@ -943,8 +943,8 @@ Do not append proxy IP address to `x-forwarded-for` HTTP header. See [Envoy](htt
 
 The number of trusted reverse proxies in front of pomerium. This affects `x-forwarded-proto` header and [`x-envoy-external-address` header](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-envoy-external-address), which reports tursted client address. [Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=xff_num_trusted_hops#x-forwarded-for) docs for more detail.
 
-### Codec Type
 
+### Codec Type
 - Environment Variable: `CODEC_TYPE`
 - Config File Key: `codec_type`
 - Type: `string`
@@ -977,12 +977,12 @@ More details on this problem are available in [Github Issue #2150](https://githu
 
 :::
 
-## Data Broker Service
 
+## Data Broker Service
 The databroker service is used for storing user session data.
 
-### Data Broker Service URL
 
+### Data Broker Service URL
 - Environmental Variable: `DATABROKER_SERVICE_URL` or `DATABROKER_SERVICE_URLS`
 - Config File Key: `databroker_service_url` or `databroker_service_urls`
 - Type: `URL`
@@ -1001,8 +1001,8 @@ For an example implementation, the in-memory database used by the databroker ser
 
 - [pkg/databroker/memory](https://github.com/pomerium/pomerium/tree/master/pkg/databroker/memory)
 
-### Data Broker Storage Type
 
+### Data Broker Storage Type
 - Environmental Variable: `DATABROKER_STORAGE_TYPE`
 - Config File Key: `databroker_storage_type`
 - Type: `string`
@@ -1012,8 +1012,8 @@ For an example implementation, the in-memory database used by the databroker ser
 
 The backend storage that databroker server will use.
 
-### Data Broker Storage Connection String
 
+### Data Broker Storage Connection String
 - Environmental Variable: `DATABROKER_STORAGE_CONNECTION_STRING`
 - Config File Key: `databroker_storage_connection_string`
 - Type: `string`
@@ -1030,8 +1030,8 @@ For `redis`, the following URL types are supported:
 
 You can also enable TLS with `rediss://`, `rediss+sentinel://` and `rediss+cluster://`.
 
-### Data Broker Storage Certificate File
 
+### Data Broker Storage Certificate File
 - Environment Variable: `DATABROKER_STORAGE_CERT_FILE`
 - Config File Key: `databroker_storage_cert_file`
 - Type: relative file location
@@ -1039,8 +1039,8 @@ You can also enable TLS with `rediss://`, `rediss+sentinel://` and `rediss+clust
 
 The certificate used to connect to a storage backend.
 
-### Data Broker Storage Certificate Key File
 
+### Data Broker Storage Certificate Key File
 - Environment Variable: `DATABROKER_STORAGE_KEY_FILE`
 - Config File Key: `databroker_storage_key_file`
 - Type: relative file location
@@ -1048,8 +1048,8 @@ The certificate used to connect to a storage backend.
 
 The certificate key used to connect to a storage backend.
 
-### Data Broker Storage Certificate Authority
 
+### Data Broker Storage Certificate Authority
 - Environment Variable: `DATABROKER_STORAGE_CA_FILE`
 - Config File Key: `databroker_storage_ca_file`
 - Type: relative file location
@@ -1057,8 +1057,8 @@ The certificate key used to connect to a storage backend.
 
 This setting defines the set of root certificates used when verifying storage server connections.
 
-### Data Broker Storage TLS Skip Verify
 
+### Data Broker Storage TLS Skip Verify
 - Environment Variable: `DATABROKER_STORAGE_TLS_SKIP_VERIFY`
 - Config File Key: `databroker_storage_tls_skip_verify`
 - Type: relative file location
@@ -1066,8 +1066,8 @@ This setting defines the set of root certificates used when verifying storage se
 
 If set, the TLS connection to the storage backend will not be verified.
 
-## Policy
 
+## Policy
 - Environmental Variable: `POLICY`
 - Config File Key: `policy`
 - Type: [base64 encoded] `string` or inline policy structure in config file
@@ -1094,8 +1094,8 @@ In this example, an incoming request with a path prefix of `/admin` would be han
 
 A list of policy configuration variables follows.
 
-### Allowed Domains
 
+### Allowed Domains
 - `yaml`/`json` setting: `allowed_domains`
 - Type: list of `string`
 - Required
@@ -1103,8 +1103,8 @@ A list of policy configuration variables follows.
 
 Allowed domains is a collection of whitelisted domains to authorize for a given route.
 
-### Allowed Groups
 
+### Allowed Groups
 - `yaml`/`json` setting: `allowed_groups`
 - Type: list of `string`
 - Required
@@ -1112,25 +1112,25 @@ Allowed domains is a collection of whitelisted domains to authorize for a given 
 
 Allowed groups is a collection of whitelisted groups to authorize for a given route.
 
-### Allowed IdP Claims
 
+### Allowed IdP Claims
 - `yaml`/`json` setting: `allowed_idp_claims`
 - Type: map of `strings` lists
 - Required
 
 Allowed IdP Claims is a collection of whitelisted claim key-value pairs to authorize for a given route.
 
-This is useful if your identity provider has extra information about a user that is not in the directory. It can also be useful if you wish to use groups with the generic OIDC provider.
+This is useful if your identity provider has extra information about a user that is not in the directory.  It can also be useful if you wish to use groups with the generic OIDC provider.
 
 Example:
 
 ```yaml
-- from: http://from.example.com
-  to: http://to.example.com
-  allowed_idp_claims:
-    family_name:
-      - Doe
-      - Smith
+  - from: http://from.example.com
+    to: http://to.example.com
+    allowed_idp_claims:
+      family_name:
+        - Doe
+        - Smith
 ```
 
 This policy would match users with the `family_name` claim containing `Smith` or `Doe`.
@@ -1147,8 +1147,8 @@ Claims are represented as a map of strings to a list of values:
 - Nested maps are flattened: `{ "a": { "b": ["c"] } }` becomes `{ "a.b": ["c"] }`
 - Values are always a list: `{ "a": "b" }` becomes `{ "a": ["b"] }`
 
-### Allowed Users
 
+### Allowed Users
 - `yaml`/`json` setting: `allowed_users`
 - Type: list of `string`
 - Required
@@ -1156,8 +1156,8 @@ Claims are represented as a map of strings to a list of values:
 
 Allowed users is a collection of whitelisted users to authorize for a given route.
 
-### CORS Preflight
 
+### CORS Preflight
 - `yaml`/`json` setting: `cors_allow_preflight`
 - Type: `bool`
 - Optional
@@ -1165,8 +1165,8 @@ Allowed users is a collection of whitelisted users to authorize for a given rout
 
 Allow unauthenticated HTTP OPTIONS requests as [per the CORS spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests).
 
-### Enable Google Cloud Serverless Authentication
 
+### Enable Google Cloud Serverless Authentication
 - Environmental Variable: `ENABLE_GOOGLE_CLOUD_SERVERLESS_AUTHENTICATION`
 - Config File Key: `enable_google_cloud_serverless_authentication`
 - Type: `bool`
@@ -1176,8 +1176,8 @@ Enable sending a signed [Authorization Header](https://cloud.google.com/run/docs
 
 Requires setting [Google Cloud Serverless Authentication Service Account](./#google-cloud-serverless-authentication-service-account) or running Pomerium in an environment with a GCP service account present in default locations.
 
-### From
 
+### From
 - `yaml`/`json` setting: `from`
 - Type: `URL` (must contain a scheme and hostname, must not contain a path)
 - Schemes: `https`, `tcp+https`
@@ -1188,8 +1188,8 @@ Requires setting [Google Cloud Serverless Authentication Service Account](./#goo
 
 Specifying `tcp+https` for the scheme enables [TCP proxying](../docs/topics/tcp-support.md) support for the route. You may map more than one port through the same hostname by specifying a different `:port` in the URL.
 
-### Kubernetes Service Account Token
 
+### Kubernetes Service Account Token
 - `yaml`/`json` setting: `kubernetes_service_account_token` / `kubernetes_service_account_token_file`
 - Type: `string` or relative file location containing a Kubernetes bearer token
 - Optional
@@ -1199,8 +1199,8 @@ Use this token to authenticate requests to a Kubernetes API server.
 
 Pomerium will [impersonate](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation) the Pomerium user's identity, and Kubernetes RBAC can be applied to IdP user and groups.
 
-### Signout Redirect URL
 
+### Signout Redirect URL
 - Environmental Variable: `SIGNOUT_REDIRECT_URL`
 - Config File Key: `signout_redirect_url`
 - Type: `URL`
@@ -1212,8 +1212,8 @@ Signout redirect url is the url user will be redirected to after signing out.
 You can overwrite this behavior by passing the query param `pomerium_redirect_uri` or post value `pomerium_redirect_uri`
 to the `/.pomerium/signout/` endpoint.
 
-### Path
 
+### Path
 - `yaml`/`json` setting: `path`
 - Type: `string`
 - Optional
@@ -1221,8 +1221,8 @@ to the `/.pomerium/signout/` endpoint.
 
 If set, the route will only match incoming requests with a path that is an exact match for the specified path.
 
-### Prefix
 
+### Prefix
 - `yaml`/`json` setting: `prefix`
 - Type: `string`
 - Optional
@@ -1230,8 +1230,8 @@ If set, the route will only match incoming requests with a path that is an exact
 
 If set, the route will only match incoming requests with a path that begins with the specified prefix.
 
-### Prefix Rewrite
 
+### Prefix Rewrite
 - `yaml`/`json` setting: `prefix_rewrite`
 - Type: `string`
 - Optional
@@ -1249,8 +1249,8 @@ prefix_rewrite: /
 
 A request to `https://from.example.com/admin` would be forwarded to `https://to.example.com/`.
 
-### Host Rewrite
 
+### Host Rewrite
 - `yaml`/`json` settings: `host_rewrite`, `host_rewrite_header`, `host_path_regex_rewrite_pattern`, `host_path_regex_rewrite_substitution`
 - Type: `string`
 - Optional
@@ -1259,22 +1259,22 @@ A request to `https://from.example.com/admin` would be forwarded to `https://to.
 The `host` header can be preserved via the `preserve_host_header` setting or customized via 3 mutually exclusive options:
 
 1. `preserve_host_header` when enabled, this option will pass the host header from the incoming request to the proxied host, instead of the destination hostname. It's an optional parameter of type `bool` that defaults to `false`.
-   See [ProxyPreserveHost](http://httpd.apache.org/docs/2.0/mod/mod_proxy.html#proxypreservehost).
+    See [ProxyPreserveHost](http://httpd.apache.org/docs/2.0/mod/mod_proxy.html#proxypreservehost).
 2. `host_rewrite` which will rewrite the host to a new literal value.
 3. `host_rewrite_header` which will rewrite the host to match an incoming header value.
 4. `host_path_regex_rewrite_pattern`, `host_path_regex_rewrite_substitution` which will rewrite the host according to a regex matching the path. For example with the following config:
 
-   ```yaml
-   host_path_regex_rewrite_pattern: "^/(.+)/.+$"
-   host_path_regex_rewrite_substitution: \1
-   ```
+    ```yaml
+    host_path_regex_rewrite_pattern: "^/(.+)/.+$"
+    host_path_regex_rewrite_substitution: \1
+    ```
 
-   Would rewrite the host header to `example.com` given the path `/example.com/some/path`.
+    Would rewrite the host header to `example.com` given the path `/example.com/some/path`.
 
 The 2nd, 3rd and 4th options correspond to the envoy route action host related options, which can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html#config-route-v3-routeaction).
 
-### Public Access
 
+### Public Access
 - `yaml`/`json` setting: `allow_public_unauthenticated_access`
 - Type: `bool`
 - Optional
@@ -1284,8 +1284,8 @@ The 2nd, 3rd and 4th options correspond to the envoy route action host related o
 
 If this setting is enabled, no whitelists (e.g. Allowed Users) should be provided in this route.
 
-### Allow Any Authenticated User
 
+### Allow Any Authenticated User
 - `yaml`/`json` setting: `allow_any_authenticated_user`
 - Type: `bool`
 - Optional
@@ -1295,8 +1295,8 @@ If this setting is enabled, no whitelists (e.g. Allowed Users) should be provide
 
 Use of this setting means Pomerium **will not enforce centralized authorization policy** for this route. The upstream is responsible for handling any authorization.
 
-### Regex
 
+### Regex
 - `yaml`/`json` setting: `regex`
 - Type: `string` (containing a regular expression)
 - Optional
@@ -1304,8 +1304,8 @@ Use of this setting means Pomerium **will not enforce centralized authorization 
 
 If set, the route will only match incoming requests with a path that matches the specified regular expression. The supported syntax is the same as the Go [regexp package](https://golang.org/pkg/regexp/) which is based on [re2](https://github.com/google/re2/wiki/Syntax).
 
-### Regex Rewrite
 
+### Regex Rewrite
 - `yaml`/`json` setting: `regex_rewrite_pattern`, `regex_rewrite_substitution`
 - Type: `string`
 - Optional
@@ -1313,8 +1313,8 @@ If set, the route will only match incoming requests with a path that matches the
 
 If set, the URL path will be rewritten according to the pattern and substitution, similar to `prefix_rewrite`.
 
-### Outlier Detection
 
+### Outlier Detection
 - `yaml`/`json` setting: `outlier_detection`
 - Type: `object`
 - Optional
@@ -1324,8 +1324,8 @@ Outlier detection and ejection is the process of dynamically determining whether
 
 See Envoy [documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier#arch-overview-outlier-detection) and [API](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/outlier_detection.proto#envoy-v3-api-msg-config-cluster-v3-outlierdetection) for more details.
 
-### Route Timeout
 
+### Route Timeout
 - `yaml`/`json` setting: `timeout`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
 - Optional
@@ -1333,8 +1333,8 @@ See Envoy [documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch
 
 Policy timeout establishes the per-route timeout value. Cannot exceed global timeout values.
 
-### Set Request Headers
 
+### Set Request Headers
 - Config File Key: `set_request_headers`
 - Type: map of `strings` key value pairs
 - Optional
@@ -1353,8 +1353,8 @@ Set Request Headers allows you to set static values for given request headers. T
     X-Your-favorite-authenticating-Proxy: "Pomerium"
 ```
 
-### Remove Request Headers
 
+### Remove Request Headers
 - Config File Key: `remove_request_headers`
 - Type: array of `strings`
 - Optional
@@ -1371,16 +1371,16 @@ Remove Request Headers allows you to remove given request headers. This can be u
     - X-Username
 ```
 
-### Set Response Headers
 
+### Set Response Headers
 - Config File Key: `set_response_headers`
 - Type: map of `strings` key value pairs
 - Optional
 
 Set Response Headers allows you to set static values for the given response headers. These headers will take precedence over the global `set_response_headers`.
 
-### Rewrite Response Headers
 
+### Rewrite Response Headers
 - Config File Key: `rewrite_response_headers`
 - Type: `object`
 - Optional
@@ -1403,8 +1403,8 @@ rewrite_response_headers:
 
 The browser would be redirected to: `http://frontend/one/some/path/`. This is similar to nginx's [`proxy_redirect` option](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect), but can be used for any header.
 
-### Redirect
 
+### Redirect
 - `yaml`/`json` setting: 'redirect'
 - Type: object
 - Optional
@@ -1424,8 +1424,8 @@ options:
 
 Either `redirect` or `to` must be set.
 
-### To
 
+### To
 - `yaml`/`json` setting: `to`
 - Type: `URL` or list of `URL`s (must contain a scheme and hostname) with an optional weight
 - Schemes: `http`, `https`, `tcp`
@@ -1437,11 +1437,11 @@ Either `redirect` or `to` must be set.
 ```yaml
 - from: https://example.com
   to:
-    - https://a.example.com
-    - https://b.example.com
+  - https://a.example.com
+  - https://b.example.com
 ```
 
-A load balancing weight may be associated with a particular upstream by appending `,[weight]` to the URL. The exact behavior depends on your [`lb_policy`](#load-balancing-policy) setting. See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.html#load-balancing-weight).
+A load balancing weight may be associated with a particular upstream by appending `,[weight]` to the URL.  The exact behavior depends on your [`lb_policy`](#load-balancing-policy) setting.  See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.html#load-balancing-weight).
 
 Must be `tcp` if `from` is `tcp+https`.
 
@@ -1471,24 +1471,24 @@ Either `redirect` or `to` must be set.
 
 :::
 
-### TLS Skip Verification
 
+### TLS Skip Verification
 - Config File Key: `tls_skip_verify`
 - Type: `bool`
 - Default: `false`
 
 TLS Skip Verification controls whether a client verifies the server's certificate chain and host name. If enabled, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks. This should be used only for testing.
 
-### TLS Server Name
 
+### TLS Server Name
 - Config File Key: `tls_server_name`
 - Type: `string`
 - Optional
 
 TLS Server Name overrides the hostname specified in the `to` field. If set, this server name will be used to verify the certificate name. This is useful when the backend of your service is an TLS server with a valid certificate, but mismatched name.
 
-### TLS Custom Certificate Authority
 
+### TLS Custom Certificate Authority
 - Config File Key: `tls_custom_ca` or `tls_custom_ca_file`
 - Type: [base64 encoded] `string` or relative file location
 - Optional
@@ -1497,8 +1497,8 @@ TLS Custom Certificate Authority defines a set of root certificate authorities t
 
 Note: This setting will replace (not append) the system's trust store for a given route.
 
-### TLS Downstream Client Certificate Authority
 
+### TLS Downstream Client Certificate Authority
 - Config File Key: `tls_downstream_client_ca` or `tls_downstream_client_ca_file`
 - Type: [base64 encoded] `string` or relative file location
 - Optional
@@ -1506,16 +1506,16 @@ Note: This setting will replace (not append) the system's trust store for a give
 If specified downstream clients (eg a user's browser) will be required to provide a valid client TLS
 certificate. This overrides the global `client_ca` option for this route.
 
-### TLS Client Certificate
 
+### TLS Client Certificate
 - Config File Key: `tls_client_cert` and `tls_client_key` or `tls_client_cert_file` and `tls_client_key_file`
 - Type: [base64 encoded] `string` or relative file location
 - Optional
 
 Pomerium supports client certificates which can be used to enforce [mutually authenticated and encrypted TLS connections](https://en.wikipedia.org/wiki/Mutual_authentication) (mTLS). For more details, see our [mTLS example repository](https://github.com/pomerium/pomerium/tree/master/examples/mutual-tls) and the [certificate docs](../docs/topics/certificates.md).
 
-### Pass Identity Headers
 
+### Pass Identity Headers
 - `yaml`/`json` setting: `pass_identity_headers`
 - Type: `bool`
 - Optional
@@ -1524,26 +1524,26 @@ Pomerium supports client certificates which can be used to enforce [mutually aut
 When enabled, this option will pass identity headers to upstream applications. These headers include:
 
 - X-Pomerium-Jwt-Assertion
-- X-Pomerium-Claim-\*
+- X-Pomerium-Claim-*
+
 
 ### SPDY
-
 - Config File Key: `allow_spdy`
 - Type: `bool`
 - Default: `false`
 
 If set, enables proxying of SPDY protocol upgrades.
 
-### Cluster Name
 
+### Cluster Name
 - Config File Key: `name`
 - Type: `string`
 - Optional
 
-Runtime metrics for this policy would be available under `envoy_cluster_`_`name`_ prefix.
+Runtime metrics for this policy would be available under `envoy_cluster_`*`name`* prefix.
+
 
 ### Load Balancing Policy
-
 - Config File Key: `lb_policy`
 - Type: `enum`
 - Optional
@@ -1560,8 +1560,8 @@ See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/con
 
 Some policy types support additional [configuration](#load-balancing-policy-config).
 
-### Load Balancing Policy Config
 
+### Load Balancing Policy Config
 - Config File Key: `least_request_lb_config`, `ring_hash_lb_config`, `maglev_lb_config`
 - Type: `object`
 - Optional
@@ -1574,8 +1574,8 @@ When [`lb_policy`](#load-balancing-policy) is configured, you may further custom
 
 See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.html#load-balancing-method)
 
-### Health Checks
 
+### Health Checks
 - Config File Key: `health_checks`
 - Type: `array of objects`
 - Optional
@@ -1594,8 +1594,8 @@ Only one of `http_health_check`, `tcp_health_check`, or `grpc_health_check` may 
 
 See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.html#active-health-checks).
 
-### Websocket Connections
 
+### Websocket Connections
 - Config File Key: `allow_websockets`
 - Type: `bool`
 - Default: `false`
@@ -1608,10 +1608,10 @@ If set, enables proxying of websocket connections.
 
 :::
 
+
 ## Authorize Service
 
 ### Authorize Service URL
-
 - Environmental Variable: `AUTHORIZE_SERVICE_URL` or `AUTHORIZE_SERVICE_URLS`
 - Config File Key: `authorize_service_url` or `authorize_service_urls`
 - Type: `URL`
@@ -1620,8 +1620,8 @@ If set, enables proxying of websocket connections.
 
 Authorize Service URL is the location of the internally accessible authorize service. Multiple URLs can be specified with `authorize_service_url`.
 
-### Google Cloud Serverless Authentication Service Account
 
+### Google Cloud Serverless Authentication Service Account
 - Environmental Variable: `GOOGLE_CLOUD_SERVERLESS_AUTHENTICATION_SERVICE_ACCOUNT`
 - Config File Key: `google_cloud_serverless_authentication_service_account`
 - Type: [base64 encoded] `string`
@@ -1634,8 +1634,8 @@ If unspecified:
 - If [Identity Provider Name](#identity-provider-name) is set to `google`, will default to [Identity Provider Service Account](#identity-provider-service-account)
 - Otherwise, will default to ambient credentials in the default locations searched by the Google SDK. This includes GCE metadata server tokens.
 
-### Signing Key
 
+### Signing Key
 - Environmental Variable: `SIGNING_KEY`
 - Config File Key: `signing_key`
 - Type: [base64 encoded] `string`
@@ -1678,8 +1678,8 @@ $ curl https://authenticate.int.example.com/.well-known/pomerium/jwks.json | jq
 
 If no certificate is specified, one will be generated and the base64'd public key will be added to the logs. Note, however, that this key be unique to each service, ephemeral, and will not be accessible via the authenticate service's `jwks_uri` endpoint.
 
-### Signing Key Algorithm
 
+### Signing Key Algorithm
 - Environmental Variable: `SIGNING_KEY_ALGORITHM`
 - Config File Key: `signing_key_algorithm`
 - Type: `string`
@@ -1689,6 +1689,7 @@ If no certificate is specified, one will be generated and the base64'd public ke
 This setting specifies which signing algorithm to use when signing the upstream attestation JWT. Cryptographic algorithm choice is subtle, and beyond the scope of this document, but we suggest sticking to the default `ES256` unless you have a good reason to use something else.
 
 Be aware that any RSA based signature method may be an order of magnitude lower than [elliptic curve] variants like EdDSA (`ed25519`) and ECDSA (`ES256`). For more information, checkout [this article](https://www.scottbrady91.com/JOSE/JWTs-Which-Signing-Algorithm-Should-I-Use).
+
 
 [base64 encoded]: https://en.wikipedia.org/wiki/Base64
 [elliptic curve]: https://wiki.openssl.org/index.php/Command_Line_Elliptic_Curve_Operations#Generating_EC_Keys_and_Parameters

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -24,12 +24,12 @@ Pomerium can hot-reload route configuration details, authorization policy, certi
 
 :::
 
-
 ## Shared Settings
+
 These configuration variables are shared by all services, in all service modes.
 
-
 ### Address
+
 - Environmental Variable: `ADDRESS`
 - Config File Key: `address`
 - Type: `string`
@@ -39,14 +39,14 @@ These configuration variables are shared by all services, in all service modes.
 
 Address specifies the host and port to serve HTTP requests from. If empty, `:443` is used. Note, in all-in-one deployments, gRPC traffic will be served on loopback on port `:5443`.
 
-
 ### Autocert
+
 - Environmental Variable: `AUTOCERT`
 - Config File Key: `autocert`
 - Type: `bool`
 - Optional
 
-Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from [Let's Encrypt][letsencrypt] which includes managed routes and the authenticate service.  [Autocert Directory](./#autocert-directory) must be used with Autocert must have a place to persist, and share certificate data between services. Note that autocert also provides [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling).
+Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from [Let's Encrypt][letsencrypt] which includes managed routes and the authenticate service. [Autocert Directory](./#autocert-directory) must be used with Autocert must have a place to persist, and share certificate data between services. Note that autocert also provides [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling).
 
 This setting can be useful in situations where you may not have Pomerium behind a TLS terminating ingress or proxy that is already handling your public certificates on your behalf.
 
@@ -62,8 +62,8 @@ Autocert requires that ports `80`/`443` be accessible from the internet in order
 
 :::
 
-
 ### Autocert Must-Staple
+
 - Environmental Variable: `AUTOCERT_MUST_STAPLE`
 - Config File Key: `autocert_must_staple`
 - Type: `bool`
@@ -79,8 +79,8 @@ This setting will only take effect when you request or renew your certificates.
 
 For more details, please see [RFC7633](https://tools.ietf.org/html/rfc7633) .
 
-
 ### Autocert Directory
+
 - Environmental Variable: either `AUTOCERT_DIR`
 - Config File Key: `autocert_dir`
 - Type: `string` pointing to the path of the directory
@@ -88,13 +88,13 @@ For more details, please see [RFC7633](https://tools.ietf.org/html/rfc7633) .
 - Default:
 
   - `/data/autocert` in published Pomerium docker images
-  - [$XDG_DATA_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+  - [\$XDG_DATA_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
   - `$HOME/.local/share/pomerium`
 
 Autocert directory is the path which autocert will store x509 certificate data.
 
-
 ### Autocert Use Staging
+
 - Environmental Variable: `AUTOCERT_USE_STAGING`
 - Config File Key: `autocert_use_staging`
 - Type: `bool`
@@ -102,8 +102,8 @@ Autocert directory is the path which autocert will store x509 certificate data.
 
 Let's Encrypt has strict [usage limits](https://letsencrypt.org/docs/rate-limits/). Enabling this setting allows you to use Let's Encrypt's [staging environment](https://letsencrypt.org/docs/staging-environment/) which has much more lax usage limits.
 
-
 ### Certificates
+
 - Config File Key: `certificates` (not yet settable using environmental variables)
 - Config File Key: `certificate` / `certificate_key`
 - Config File Key: `certificate_file` / `certificate_key_file`
@@ -128,8 +128,8 @@ certificates:
     key: "$HOME/.acme.sh/prometheus.example.com_ecc/prometheus.example.com.key"
 ```
 
-
 ### Client Certificate Authority
+
 - Environment Variable: `CLIENT_CA` / `CLIENT_CA_FILE`
 - Config File Key: `client_ca` / `client_ca_file`
 - Type: [base64 encoded] `string` or relative file location
@@ -137,8 +137,8 @@ certificates:
 
 The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) client certificates. If not set, no client certificate will be required.
 
-
 ### Client CRL
+
 - Environment Variable: `CLIENT_CRL` / `CLIENT_CRL_FILE`
 - Config File Key: `client_crl` / `client_crl_file`
 - Type: [base64 encoded] `string` or relative file location
@@ -147,10 +147,10 @@ The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS
 The Client CRL is the [certificate revocation list](https://en.wikipedia.org/wiki/Certificate_revocation_list)
 (in PEM format) for client certificates. If not set, no CRL will be used.
 
-
 ### Cookie Options
 
 #### Cookie Name
+
 - Environmental Variable: `COOKIE_NAME`
 - Config File Key: `cookie_name`
 - Type: `string`
@@ -158,8 +158,8 @@ The Client CRL is the [certificate revocation list](https://en.wikipedia.org/wik
 
 The name of the session cookie sent to clients.
 
-
 #### Cookie Secret
+
 - Environmental Variable: `COOKIE_SECRET`
 - Config File Key: `cookie_secret`
 - Type: [base64 encoded] `string`
@@ -167,8 +167,8 @@ The name of the session cookie sent to clients.
 
 Secret used to encrypt and sign session cookies. You can generate a random key with `head -c32 /dev/urandom | base64`.
 
-
 #### Cookie Domain
+
 - Environmental Variable: `COOKIE_DOMAIN`
 - Config File Key: `cookie_domain`
 - Type: `string`
@@ -177,8 +177,8 @@ Secret used to encrypt and sign session cookies. You can generate a random key w
 
 The scope of session cookies issued by Pomerium.
 
-
 #### HTTPS only
+
 - Environmental Variable: `COOKIE_SECURE`
 - Config File Key: `cookie_secure`
 - Type: `bool`
@@ -192,8 +192,8 @@ Setting this to false may result in session cookies being sent in cleartext.
 
 :::
 
-
 #### Javascript Security
+
 - Environmental Variable: `COOKIE_HTTP_ONLY`
 - Config File Key: `cookie_http_only`
 - Type: `bool`
@@ -207,8 +207,8 @@ Setting this to false enables hostile javascript to steal session cookies and im
 
 :::
 
-
 #### Expiration
+
 - Environmental Variable: `COOKIE_EXPIRE`
 - Config File Key: `cookie_expire`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -216,8 +216,8 @@ Setting this to false enables hostile javascript to steal session cookies and im
 
 Sets the lifetime of session cookies. After this interval, users must reauthenticate.
 
-
 ### Debug
+
 - Environmental Variable: `POMERIUM_DEBUG`
 - Config File Key: `pomerium_debug`
 - Type: `bool`
@@ -229,7 +229,7 @@ Enabling the debug flag could result in sensitive information being logged!!!
 
 :::
 
-By default, JSON encoded logs are produced. Debug enables colored, human-readable logs to be streamed to [standard out](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)>>>). In production, it is recommended to be set to `false`.
+By default, JSON encoded logs are produced. Debug enables colored, human-readable logs to be streamed to [standard out](<https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)>>>>). In production, it is recommended to be set to `false`.
 
 For example, if `true`
 
@@ -249,8 +249,8 @@ If `false`
 {"level":"info","OverrideCertificateName":"","addr":"auth.localhost.pomerium.io:443","time":"2019-02-18T10:41:03-08:00","message":"proxy/authenticator: grpc connection"}
 ```
 
-
 ### Forward Auth
+
 - Environmental Variable: `FORWARD_AUTH_URL`
 - Config File Key: `forward_auth_url`
 - Type: `URL` (must contain a scheme and hostname)
@@ -331,8 +331,8 @@ services:
       - "traefik.http.routers.verify.middlewares=test-auth@docker"
 ```
 
-
 ### Global Timeouts
+
 - Environmental Variables: `TIMEOUT_READ` `TIMEOUT_WRITE` `TIMEOUT_IDLE`
 - Config File Key: `timeout_read` `timeout_write` `timeout_idle`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -345,10 +345,10 @@ Timeouts set the global server timeouts. Timeouts can also be set for individual
 
 > For a deep dive on timeout values see [these](https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/) [two](https://blog.cloudflare.com/exposing-go-on-the-internet/) excellent blog posts.
 
-
 ### GRPC Options
 
 #### GRPC Address
+
 - Environmental Variable: `GRPC_ADDRESS`
 - Config File Key: `grpc_address`
 - Type: `string`
@@ -357,16 +357,16 @@ Timeouts set the global server timeouts. Timeouts can also be set for individual
 
 gRPC Address specifies the host and port to serve gRPC requests from.
 
-
 #### GRPC Insecure
+
 - Environmental Variable: `GRPC_INSECURE`
 - Config File Key: `grpc_insecure`
 - Type: `bool`
 
 This setting disables transport security for gRPC communication. If running in all-in-one mode, defaults to true as communication will run over localhost's own socket.
 
-
 #### GRPC Client Timeout
+
 - Environmental Variable: `GRPC_CLIENT_TIMEOUT`
 - Config File Key: `grpc_client_timeout`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -374,8 +374,8 @@ This setting disables transport security for gRPC communication. If running in a
 
 Maximum time before canceling an upstream gRPC request. During transient failures, the proxy will retry upstreams for this duration. You should leave this high enough to handle backend service restart and rediscovery so that client requests do not fail.
 
-
 #### GRPC Client DNS RoundRobin
+
 - Environmental Variable: `GRPC_CLIENT_DNS_ROUNDROBIN`
 - Config File Key: `grpc_client_dns_roundrobin`
 - Type: `bool`
@@ -383,8 +383,8 @@ Maximum time before canceling an upstream gRPC request. During transient failure
 
 Enable gRPC DNS based round robin load balancing. This method uses DNS to resolve endpoints and does client side load balancing of _all_ addresses returned by the DNS record. Do not disable unless you have a specific use case.
 
-
 #### GRPC Server Max Connection Age
+
 - Environmental Variable: `GRPC_SERVER_MAX_CONNECTION_AGE`
 - Config File Key: `grpc_server_max_connection_age`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -394,8 +394,8 @@ Set max connection age for GRPC servers. After this interval, servers ask client
 
 See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> for details
 
-
 #### GRPC Server Max Connection Age Grace
+
 - Environmental Variable: `GRPC_SERVER_MAX_CONNECTION_AGE_GRACE`
 - Config File Key: `grpc_server_max_connection_age_grace`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -405,8 +405,8 @@ Additive period with `grpc_server_max_connection_age`, after which servers will 
 
 See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> for details
 
-
 ### HTTP Redirect Address
+
 - Environmental Variable: `HTTP_REDIRECT_ADDR`
 - Config File Key: `http_redirect_addr`
 - Type: `string`
@@ -415,8 +415,8 @@ See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> for de
 
 If set, the HTTP Redirect Address specifies the host and port to redirect http to https traffic on. If unset, no redirect server is started.
 
-
 ### Insecure Server
+
 - Environmental Variable: `INSECURE_SERVER`
 - Config File Key: `insecure_server`
 - Type: `bool`
@@ -432,8 +432,8 @@ Pomerium should _never_ be exposed to the internet without TLS encryption.
 
 :::
 
-
 ### DNS Lookup Family
+
 - Environmental Variable: `DNS_LOOKUP_FAMILY`
 - Config File Key: `dns_lookup_family`
 - Type: `string`
@@ -442,8 +442,8 @@ Pomerium should _never_ be exposed to the internet without TLS encryption.
 
 The DNS IP address resolution policy. If not specified, the value defaults to `AUTO`.
 
-
 ### Log Level
+
 - Environmental Variable: `LOG_LEVEL`
 - Config File Key: `log_level`
 - Type: `string`
@@ -452,8 +452,8 @@ The DNS IP address resolution policy. If not specified, the value defaults to `A
 
 Log level sets the global logging level for pomerium. Only logs of the desired level and above will be logged.
 
-
 ### Metrics Address
+
 - Environmental Variable: `METRICS_ADDRESS`
 - Config File Key: `metrics_address`
 - Type: `string`
@@ -471,33 +471,33 @@ Expose a prometheus endpoint on the specified port.
 
 #### Pomerium Metrics Tracked
 
-Name                                          | Type      | Description
---------------------------------------------- | --------- | -----------------------------------------------------------------------
-grpc_client_request_duration_ms               | Histogram | GRPC client request duration by service
-grpc_client_request_size_bytes                | Histogram | GRPC client request size by service
-grpc_client_requests_total                    | Counter   | Total GRPC client requests made by service
-grpc_client_response_size_bytes               | Histogram | GRPC client response size by service
-grpc_server_request_duration_ms               | Histogram | GRPC server request duration by service
-grpc_server_request_size_bytes                | Histogram | GRPC server request size by service
-grpc_server_requests_total                    | Counter   | Total GRPC server requests made by service
-grpc_server_response_size_bytes               | Histogram | GRPC server response size by service
-http_client_request_duration_ms               | Histogram | HTTP client request duration by service
-http_client_request_size_bytes                | Histogram | HTTP client request size by service
-http_client_requests_total                    | Counter   | Total HTTP client requests made by service
-http_client_response_size_bytes               | Histogram | HTTP client response size by service
-http_server_request_duration_ms               | Histogram | HTTP server request duration by service
-http_server_request_size_bytes                | Histogram | HTTP server request size by service
-http_server_requests_total                    | Counter   | Total HTTP server requests handled by service
-http_server_response_size_bytes               | Histogram | HTTP server response size by service
-pomerium_build_info                           | Gauge     | Pomerium build metadata by git revision, service, version and goversion
-pomerium_config_checksum_int64                | Gauge     | Currently loaded configuration checksum by service
-pomerium_config_last_reload_success           | Gauge     | Whether the last configuration reload succeeded by service
-pomerium_config_last_reload_success_timestamp | Gauge     | The timestamp of the last successful configuration reload by service
-redis_conns                                   | Gauge     | Number of total connections in the pool
-redis_idle_conns                              | Gauge     | Total number of times free connection was found in the pool
-redis_wait_count_total                        | Counter   | Total number of connections waited for
-redis_wait_duration_ms_total                  | Counter   | Total time spent waiting for connections
-storage_operation_duration_ms                 | Histogram | Storage operation duration by operation, result, backend and service
+| Name                                          | Type      | Description                                                             |
+| --------------------------------------------- | --------- | ----------------------------------------------------------------------- |
+| grpc_client_request_duration_ms               | Histogram | GRPC client request duration by service                                 |
+| grpc_client_request_size_bytes                | Histogram | GRPC client request size by service                                     |
+| grpc_client_requests_total                    | Counter   | Total GRPC client requests made by service                              |
+| grpc_client_response_size_bytes               | Histogram | GRPC client response size by service                                    |
+| grpc_server_request_duration_ms               | Histogram | GRPC server request duration by service                                 |
+| grpc_server_request_size_bytes                | Histogram | GRPC server request size by service                                     |
+| grpc_server_requests_total                    | Counter   | Total GRPC server requests made by service                              |
+| grpc_server_response_size_bytes               | Histogram | GRPC server response size by service                                    |
+| http_client_request_duration_ms               | Histogram | HTTP client request duration by service                                 |
+| http_client_request_size_bytes                | Histogram | HTTP client request size by service                                     |
+| http_client_requests_total                    | Counter   | Total HTTP client requests made by service                              |
+| http_client_response_size_bytes               | Histogram | HTTP client response size by service                                    |
+| http_server_request_duration_ms               | Histogram | HTTP server request duration by service                                 |
+| http_server_request_size_bytes                | Histogram | HTTP server request size by service                                     |
+| http_server_requests_total                    | Counter   | Total HTTP server requests handled by service                           |
+| http_server_response_size_bytes               | Histogram | HTTP server response size by service                                    |
+| pomerium_build_info                           | Gauge     | Pomerium build metadata by git revision, service, version and goversion |
+| pomerium_config_checksum_int64                | Gauge     | Currently loaded configuration checksum by service                      |
+| pomerium_config_last_reload_success           | Gauge     | Whether the last configuration reload succeeded by service              |
+| pomerium_config_last_reload_success_timestamp | Gauge     | The timestamp of the last successful configuration reload by service    |
+| redis_conns                                   | Gauge     | Number of total connections in the pool                                 |
+| redis_idle_conns                              | Gauge     | Total number of times free connection was found in the pool             |
+| redis_wait_count_total                        | Counter   | Total number of connections waited for                                  |
+| redis_wait_duration_ms_total                  | Counter   | Total time spent waiting for connections                                |
+| storage_operation_duration_ms                 | Histogram | Storage operation duration by operation, result, backend and service    |
 
 #### Envoy Proxy Metrics
 
@@ -505,8 +505,8 @@ As of `v0.9`, Pomerium uses [envoy](https://www.envoyproxy.io/) for the data pla
 
 All metrics coming from envoy will be labeled with `service="pomerium"` or `service="pomerium-proxy"`, depending if you're running all-in-one or distributed service mode.
 
-
 ### Metrics Basic Authentication
+
 - Environmental Variable: `METRICS_BASIC_AUTH`
 - Config File Key: `metrics_basic_auth`
 - Type: base64 encoded `string` of `username:password`
@@ -519,8 +519,8 @@ Require [Basic HTTP Authentication](https://tools.ietf.org/html/rfc7617) to acce
 To support this in Prometheus, consult the `basic_auth` option in the [`scrape_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)
 documentation.
 
-
 ### Metrics Certificate
+
 - Config File Key: `metrics_certificate` / `metrics_certificate_key`
 - Config File Key: `metrics_certificate_file` / `metrics_certificate_key_file`
 - Environmental Variable: `METRICS_CERTIFICATE` / `METRICS_CERTIFICATE_KEY`
@@ -531,8 +531,8 @@ documentation.
 
 Certificates are the x509 _public-key_ and _private-key_ used to secure the metrics endpoint.
 
-
 ### Metrics Client Certificate Authority
+
 - Environment Variable: `METRICS_CLIENT_CA` / `METRICS_CLIENT_CA_FILE`
 - Config File Key: `metrics_client_ca` / `metrics_client_ca_file`
 - Type: [base64 encoded] `string` or relative file location
@@ -540,8 +540,8 @@ Certificates are the x509 _public-key_ and _private-key_ used to secure the metr
 
 The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) client certificates for the metrics endpoint. If not set, no client certificate will be required.
 
-
 ### Proxy Log Level
+
 - Environmental Variable: `PROXY_LOG_LEVEL`
 - Config File Key: `proxy_log_level`
 - Type: `string`
@@ -550,8 +550,8 @@ The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS
 
 Proxy log level sets the logging level for the pomerium proxy service access logs. Only logs of the desired level and above will be logged.
 
-
 ### Service Mode
+
 - Environmental Variable: `SERVICES`
 - Config File Key: `services`
 - Type: `string`
@@ -560,8 +560,8 @@ Proxy log level sets the logging level for the pomerium proxy service access log
 
 Service mode sets which service(s) to run. If testing, you may want to set to `all` and run pomerium in "all-in-one mode." In production, you'll likely want to spin up several instances of each service mode for high availability.
 
-
 ### Shared Secret
+
 - Environmental Variable: `SHARED_SECRET`
 - Config File Key: `shared_secret`
 - Type: [base64 encoded] `string`
@@ -573,26 +573,26 @@ Shared Secret is the base64 encoded 256-bit key used to mutually authenticate re
 head -c32 /dev/urandom | base64
 ```
 
-
 ### Tracing
+
 Tracing tracks the progression of a single user request as it is handled by Pomerium.
 
 Each unit work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
 
 #### Shared Tracing Settings
 
-Config Key          | Description                                                                          | Required
-:------------------ | :----------------------------------------------------------------------------------- | --------
-tracing_provider    | The name of the tracing provider. (e.g. jaeger, zipkin)                              | ✅
-tracing_sample_rate | Percentage of requests to sample in decimal notation. Default is `0.0001`, or `.01%` | ❌
+| Config Key          | Description                                                                          | Required |
+| :------------------ | :----------------------------------------------------------------------------------- | -------- |
+| tracing_provider    | The name of the tracing provider. (e.g. jaeger, zipkin)                              | ✅       |
+| tracing_sample_rate | Percentage of requests to sample in decimal notation. Default is `0.0001`, or `.01%` | ❌       |
 
 #### Datadog
 
 Datadog is a real-time monitoring system that supports distributed tracing and monitoring.
 
-Config Key              | Description                                                                  | Required
-:---------------------- | :--------------------------------------------------------------------------- | --------
-tracing_datadog_address | `host:port` address of the Datadog Trace Agent. Defaults to `localhost:8126` | ❌
+| Config Key              | Description                                                                  | Required |
+| :---------------------- | :--------------------------------------------------------------------------- | -------- |
+| tracing_datadog_address | `host:port` address of the Datadog Trace Agent. Defaults to `localhost:8126` | ❌       |
 
 #### Jaeger (partial)
 
@@ -606,10 +606,10 @@ tracing_datadog_address | `host:port` address of the Datadog Trace Agent. Defaul
 - Service dependency analysis
 - Performance / latency optimization
 
-Config Key                        | Description                                 | Required
-:-------------------------------- | :------------------------------------------ | --------
-tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅
-tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅
+| Config Key                        | Description                                 | Required |
+| :-------------------------------- | :------------------------------------------ | -------- |
+| tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅       |
+| tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅       |
 
 #### Zipkin
 
@@ -617,16 +617,16 @@ Zipkin is an open source distributed tracing system and protocol.
 
 Many tracing backends support zipkin either directly or through intermediary agents, including Jaeger. For full tracing support, we recommend using the Zipkin tracing protocol.
 
-Config Key              | Description                      | Required
-:---------------------- | :------------------------------- | --------
-tracing_zipkin_endpoint | Url to the Zipkin HTTP endpoint. | ✅
+| Config Key              | Description                      | Required |
+| :---------------------- | :------------------------------- | -------- |
+| tracing_zipkin_endpoint | Url to the Zipkin HTTP endpoint. | ✅       |
 
 #### Example
 
 ![jaeger example trace](./img/jaeger.png)
 
-
 ### Use Proxy Protocol
+
 - Environment Variable: `USE_PROXY_PROTOCOL`
 - Config File Key: `use_proxy_protocol`
 - Type: `bool`
@@ -634,8 +634,8 @@ tracing_zipkin_endpoint | Url to the Zipkin HTTP endpoint. | ✅
 
 Setting `use_proxy_protocol` will configure Pomerium to require the [HAProxy proxy protocol](https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt) on incoming connections. Versions 1 and 2 of the protocol are supported.
 
-
 ### Envoy Admin Options
+
 - Environment Variable: `ENVOY_ADMIN_ADDRESS`, `ENVOY_ADMIN_ACCESS_LOG_PATH`, `ENVOY_ADMIN_PROFILE_PATH`
 - Config File Keys: `envoy_admin_address`, `envoy_admin_access_log_path`, `envoy_admin_profile_path`
 - Type: `string`
@@ -643,10 +643,10 @@ Setting `use_proxy_protocol` will configure Pomerium to require the [HAProxy pro
 
 These options customize Envoy's [bootstrap configuration](https://www.envoyproxy.io/docs/envoy/latest/operations/admin#operations-admin-interface). They cannot be modified at runtime.
 
-
 ## Authenticate Service
 
 ### Authenticate Callback Path
+
 - Environmental Variable: `AUTHENTICATE_CALLBACK_PATH`
 - Config File Key: `authenticate_callback_path`
 - Type: `string`
@@ -663,8 +663,8 @@ See also:
 - [OIDC Spec][oidc rfc]
 - [Google - Setting Redirect URI](https://developers.google.com/identity/protocols/OpenIDConnect#setredirecturi)
 
-
 ### Authenticate Service URL
+
 - Environmental Variable: `AUTHENTICATE_SERVICE_URL`
 - Config File Key: `authenticate_service_url`
 - Type: `URL`
@@ -673,8 +673,8 @@ See also:
 
 Authenticate Service URL is the externally accessible URL for the authenticate service.
 
-
 ### Identity Provider Client ID
+
 - Environmental Variable: `IDP_CLIENT_ID`
 - Config File Key: `idp_client_id`
 - Type: `string`
@@ -682,8 +682,8 @@ Authenticate Service URL is the externally accessible URL for the authenticate s
 
 Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider] docs for details.
 
-
 ### Identity Provider Client Secret
+
 - Environmental Variable: `IDP_CLIENT_SECRET`
 - Config File Key: `idp_client_secret`
 - Type: `string`
@@ -691,8 +691,8 @@ Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provid
 
 Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider] docs for details.
 
-
 ### Identity Provider Name
+
 - Environmental Variable: `IDP_PROVIDER`
 - Config File Key: `idp_provider`
 - Type: `string`
@@ -703,8 +703,8 @@ Provider is the short-hand name of a built-in OpenID Connect (oidc) identity pro
 
 See [identity provider] for details.
 
-
 ### Identity Provider Scopes
+
 - Environmental Variable: `IDP_SCOPES`
 - Config File Key: `idp_scopes`
 - Type: list of `string`
@@ -725,8 +725,8 @@ Some providers, like Amazon Cognito, _do not_ support the `offline_access` scope
 
 :::
 
-
 ### Identity Provider Service Account
+
 - Environmental Variable: `IDP_SERVICE_ACCOUNT`
 - Config File Key: `idp_service_account`
 - Type: `string`
@@ -740,8 +740,8 @@ If you plan to write authorization policies using groups, or any other data that
 
 :::
 
-
 ### Identity Provider URL
+
 - Environmental Variable: `IDP_PROVIDER_URL`
 - Config File Key: `idp_provider_url`
 - Type: `string`
@@ -749,8 +749,8 @@ If you plan to write authorization policies using groups, or any other data that
 
 Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). For example, google's URL would be `https://accounts.google.com` for [their discover document](https://accounts.google.com/.well-known/openid-configuration).
 
-
 ### Identity Provider Request Params
+
 - Environmental Variable: `IDP_REQUEST_PARAMS`
 - Config File Key: `idp_request_params`
 - Type: map of `strings` key value pairs
@@ -765,8 +765,8 @@ For more information see:
 - [Microsoft Azure Request params](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code)
 - [Google Authentication URI parameters](https://developers.google.com/identity/protocols/oauth2/openid-connect)
 
-
 ### Identity Provider Refresh Directory Settings
+
 - Environmental Variables: `IDP_REFRESH_DIRECTORY_INTERVAL` `IDP_REFRESH_DIRECTORY_TIMEOUT`
 - Config File Key: `idp_refresh_directory_interval` `idp_refresh_directory_timeout`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
@@ -781,10 +781,10 @@ Use it at your own risk, if you set a too low value, you may reach IDP API rate 
 
 :::
 
-
 ## Proxy Service
 
 ### Authenticate Service URL
+
 - Environmental Variable: `AUTHENTICATE_SERVICE_URL`
 - Config File Key: `authenticate_service_url`
 - Type: `URL`
@@ -793,8 +793,8 @@ Use it at your own risk, if you set a too low value, you may reach IDP API rate 
 
 Authenticate Service URL is the externally accessible URL for the authenticate service.
 
-
 ### Authorize Service URL
+
 - Environmental Variable: `AUTHORIZE_SERVICE_URL`
 - Config File Key: `authorize_service_url`
 - Type: `URL`
@@ -805,8 +805,8 @@ Authorize Service URL is the location of the internally accessible authorize ser
 
 If your load balancer does not support gRPC pass-through you'll need to set this value to an internally routable location (`https://pomerium-authorize-service.default.svc.cluster.local`) instead of an externally routable one (`https://authorize.corp.example.com`).
 
-
 ### Certificate Authority
+
 - Environmental Variable: `CERTIFICATE_AUTHORITY` or `CERTIFICATE_AUTHORITY_FILE`
 - Config File Key: `certificate_authority` or `certificate_authority_file`
 - Type: [base64 encoded] `string` or relative file location
@@ -820,8 +820,8 @@ Be sure to include the intermediary certificate.
 
 :::
 
-
 ### Default Upstream Timeout
+
 - Environmental Variable: `DEFAULT_UPSTREAM_TIMEOUT`
 - Config File Key: `default_upstream_timeout`
 - Type: [Duration](https://golang.org/pkg/time/#Duration) `string`
@@ -830,8 +830,8 @@ Be sure to include the intermediary certificate.
 
 Default Upstream Timeout is the default timeout applied to a proxied route when no `timeout` key is specified by the policy.
 
-
 ### Set Response Headers
+
 - Environmental Variable: `SET_RESPONSE_HEADERS`
 - Config File Key: `set_response_headers`
 - Type: map of `strings` key value pairs
@@ -871,8 +871,8 @@ users are encouraged to add these to `set_response_headers` or their downstream 
 
 :::
 
-
 ### JWT Claim Headers
+
 - Environmental Variable: `JWT_CLAIMS_HEADERS`
 - Config File Key: `jwt_claims_headers`
 - Type: slice of `string`
@@ -896,8 +896,8 @@ Will add an `X-Email` header with a value of the `email` claim.
 
 Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}`.
 
-
 ### Override Certificate Name
+
 - Environmental Variable: `OVERRIDE_CERTIFICATE_NAME`
 - Config File Key: `override_certificate_name`
 - Type: `int`
@@ -906,8 +906,8 @@ Use this option if you previously relied on `x-pomerium-authenticated-user-{emai
 
 Secure service communication can fail if the external certificate does not match the internally routed service hostname/[SNI](https://en.wikipedia.org/wiki/Server_Name_Indication). This setting allows you to override that value.
 
-
 ### Programmatic Redirect Domain Whitelist
+
 - Config File Key: `programmatic_redirect_domain_whitelist`
 - Type: array of `string`
 - Optional
@@ -915,8 +915,8 @@ Secure service communication can fail if the external certificate does not match
 
 The programmatic redirect domain whitelist is used to restrict the allowed redirect URLs when using programmatic login. By default only `localhost` URLs are allowed.
 
-
 ### Refresh Cooldown
+
 - Environmental Variable: `REFRESH_COOLDOWN`
 - Config File Key: `refresh_cooldown`
 - Type: [Duration](https://golang.org/pkg/time/#Duration) `string`
@@ -925,8 +925,8 @@ The programmatic redirect domain whitelist is used to restrict the allowed redir
 
 Refresh cooldown is the minimum amount of time between allowed manually refreshed sessions.
 
-
 ### X-Forwarded-For HTTP Header
+
 - Environmental Variable: `SKIP_XFF_APPEND`
 - Config File Key: `skip_xff_append`
 - Type: `bool`
@@ -934,8 +934,8 @@ Refresh cooldown is the minimum amount of time between allowed manually refreshe
 
 Do not append proxy IP address to `x-forwarded-for` HTTP header. See [Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=skip_xff_append#x-forwarded-for) docs for more detail.
 
-
 ### The number of trusted hops
+
 - Environmental Variable: `XFF_NUM_TRUSTED_HOPS`
 - Config File Key: `xff_num_trusted_hops`
 - Type: `uint32`
@@ -943,8 +943,8 @@ Do not append proxy IP address to `x-forwarded-for` HTTP header. See [Envoy](htt
 
 The number of trusted reverse proxies in front of pomerium. This affects `x-forwarded-proto` header and [`x-envoy-external-address` header](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-envoy-external-address), which reports tursted client address. [Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=xff_num_trusted_hops#x-forwarded-for) docs for more detail.
 
-
 ### Codec Type
+
 - Environment Variable: `CODEC_TYPE`
 - Config File Key: `codec_type`
 - Type: `string`
@@ -977,12 +977,12 @@ More details on this problem are available in [Github Issue #2150](https://githu
 
 :::
 
-
 ## Data Broker Service
+
 The databroker service is used for storing user session data.
 
-
 ### Data Broker Service URL
+
 - Environmental Variable: `DATABROKER_SERVICE_URL` or `DATABROKER_SERVICE_URLS`
 - Config File Key: `databroker_service_url` or `databroker_service_urls`
 - Type: `URL`
@@ -1001,8 +1001,8 @@ For an example implementation, the in-memory database used by the databroker ser
 
 - [pkg/databroker/memory](https://github.com/pomerium/pomerium/tree/master/pkg/databroker/memory)
 
-
 ### Data Broker Storage Type
+
 - Environmental Variable: `DATABROKER_STORAGE_TYPE`
 - Config File Key: `databroker_storage_type`
 - Type: `string`
@@ -1012,8 +1012,8 @@ For an example implementation, the in-memory database used by the databroker ser
 
 The backend storage that databroker server will use.
 
-
 ### Data Broker Storage Connection String
+
 - Environmental Variable: `DATABROKER_STORAGE_CONNECTION_STRING`
 - Config File Key: `databroker_storage_connection_string`
 - Type: `string`
@@ -1030,8 +1030,8 @@ For `redis`, the following URL types are supported:
 
 You can also enable TLS with `rediss://`, `rediss+sentinel://` and `rediss+cluster://`.
 
-
 ### Data Broker Storage Certificate File
+
 - Environment Variable: `DATABROKER_STORAGE_CERT_FILE`
 - Config File Key: `databroker_storage_cert_file`
 - Type: relative file location
@@ -1039,8 +1039,8 @@ You can also enable TLS with `rediss://`, `rediss+sentinel://` and `rediss+clust
 
 The certificate used to connect to a storage backend.
 
-
 ### Data Broker Storage Certificate Key File
+
 - Environment Variable: `DATABROKER_STORAGE_KEY_FILE`
 - Config File Key: `databroker_storage_key_file`
 - Type: relative file location
@@ -1048,8 +1048,8 @@ The certificate used to connect to a storage backend.
 
 The certificate key used to connect to a storage backend.
 
-
 ### Data Broker Storage Certificate Authority
+
 - Environment Variable: `DATABROKER_STORAGE_CA_FILE`
 - Config File Key: `databroker_storage_ca_file`
 - Type: relative file location
@@ -1057,8 +1057,8 @@ The certificate key used to connect to a storage backend.
 
 This setting defines the set of root certificates used when verifying storage server connections.
 
-
 ### Data Broker Storage TLS Skip Verify
+
 - Environment Variable: `DATABROKER_STORAGE_TLS_SKIP_VERIFY`
 - Config File Key: `databroker_storage_tls_skip_verify`
 - Type: relative file location
@@ -1066,8 +1066,8 @@ This setting defines the set of root certificates used when verifying storage se
 
 If set, the TLS connection to the storage backend will not be verified.
 
-
 ## Policy
+
 - Environmental Variable: `POLICY`
 - Config File Key: `policy`
 - Type: [base64 encoded] `string` or inline policy structure in config file
@@ -1080,7 +1080,7 @@ Policy contains route specific settings, and access control details. If you are 
 Policy routes are checked in the order they appear in the policy, so more specific routes should appear before less specific routes. For example:
 
 ```yaml
-policies:
+policy:
   - from: http://from.example.com
     to: http://to.example.com
     prefix: /admin
@@ -1094,8 +1094,8 @@ In this example, an incoming request with a path prefix of `/admin` would be han
 
 A list of policy configuration variables follows.
 
-
 ### Allowed Domains
+
 - `yaml`/`json` setting: `allowed_domains`
 - Type: list of `string`
 - Required
@@ -1103,8 +1103,8 @@ A list of policy configuration variables follows.
 
 Allowed domains is a collection of whitelisted domains to authorize for a given route.
 
-
 ### Allowed Groups
+
 - `yaml`/`json` setting: `allowed_groups`
 - Type: list of `string`
 - Required
@@ -1112,25 +1112,25 @@ Allowed domains is a collection of whitelisted domains to authorize for a given 
 
 Allowed groups is a collection of whitelisted groups to authorize for a given route.
 
-
 ### Allowed IdP Claims
+
 - `yaml`/`json` setting: `allowed_idp_claims`
 - Type: map of `strings` lists
 - Required
 
 Allowed IdP Claims is a collection of whitelisted claim key-value pairs to authorize for a given route.
 
-This is useful if your identity provider has extra information about a user that is not in the directory.  It can also be useful if you wish to use groups with the generic OIDC provider.
+This is useful if your identity provider has extra information about a user that is not in the directory. It can also be useful if you wish to use groups with the generic OIDC provider.
 
 Example:
 
 ```yaml
-  - from: http://from.example.com
-    to: http://to.example.com
-    allowed_idp_claims:
-      family_name:
-        - Doe
-        - Smith
+- from: http://from.example.com
+  to: http://to.example.com
+  allowed_idp_claims:
+    family_name:
+      - Doe
+      - Smith
 ```
 
 This policy would match users with the `family_name` claim containing `Smith` or `Doe`.
@@ -1147,8 +1147,8 @@ Claims are represented as a map of strings to a list of values:
 - Nested maps are flattened: `{ "a": { "b": ["c"] } }` becomes `{ "a.b": ["c"] }`
 - Values are always a list: `{ "a": "b" }` becomes `{ "a": ["b"] }`
 
-
 ### Allowed Users
+
 - `yaml`/`json` setting: `allowed_users`
 - Type: list of `string`
 - Required
@@ -1156,8 +1156,8 @@ Claims are represented as a map of strings to a list of values:
 
 Allowed users is a collection of whitelisted users to authorize for a given route.
 
-
 ### CORS Preflight
+
 - `yaml`/`json` setting: `cors_allow_preflight`
 - Type: `bool`
 - Optional
@@ -1165,8 +1165,8 @@ Allowed users is a collection of whitelisted users to authorize for a given rout
 
 Allow unauthenticated HTTP OPTIONS requests as [per the CORS spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests).
 
-
 ### Enable Google Cloud Serverless Authentication
+
 - Environmental Variable: `ENABLE_GOOGLE_CLOUD_SERVERLESS_AUTHENTICATION`
 - Config File Key: `enable_google_cloud_serverless_authentication`
 - Type: `bool`
@@ -1176,8 +1176,8 @@ Enable sending a signed [Authorization Header](https://cloud.google.com/run/docs
 
 Requires setting [Google Cloud Serverless Authentication Service Account](./#google-cloud-serverless-authentication-service-account) or running Pomerium in an environment with a GCP service account present in default locations.
 
-
 ### From
+
 - `yaml`/`json` setting: `from`
 - Type: `URL` (must contain a scheme and hostname, must not contain a path)
 - Schemes: `https`, `tcp+https`
@@ -1188,8 +1188,8 @@ Requires setting [Google Cloud Serverless Authentication Service Account](./#goo
 
 Specifying `tcp+https` for the scheme enables [TCP proxying](../docs/topics/tcp-support.md) support for the route. You may map more than one port through the same hostname by specifying a different `:port` in the URL.
 
-
 ### Kubernetes Service Account Token
+
 - `yaml`/`json` setting: `kubernetes_service_account_token` / `kubernetes_service_account_token_file`
 - Type: `string` or relative file location containing a Kubernetes bearer token
 - Optional
@@ -1199,8 +1199,8 @@ Use this token to authenticate requests to a Kubernetes API server.
 
 Pomerium will [impersonate](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation) the Pomerium user's identity, and Kubernetes RBAC can be applied to IdP user and groups.
 
-
 ### Signout Redirect URL
+
 - Environmental Variable: `SIGNOUT_REDIRECT_URL`
 - Config File Key: `signout_redirect_url`
 - Type: `URL`
@@ -1212,8 +1212,8 @@ Signout redirect url is the url user will be redirected to after signing out.
 You can overwrite this behavior by passing the query param `pomerium_redirect_uri` or post value `pomerium_redirect_uri`
 to the `/.pomerium/signout/` endpoint.
 
-
 ### Path
+
 - `yaml`/`json` setting: `path`
 - Type: `string`
 - Optional
@@ -1221,8 +1221,8 @@ to the `/.pomerium/signout/` endpoint.
 
 If set, the route will only match incoming requests with a path that is an exact match for the specified path.
 
-
 ### Prefix
+
 - `yaml`/`json` setting: `prefix`
 - Type: `string`
 - Optional
@@ -1230,8 +1230,8 @@ If set, the route will only match incoming requests with a path that is an exact
 
 If set, the route will only match incoming requests with a path that begins with the specified prefix.
 
-
 ### Prefix Rewrite
+
 - `yaml`/`json` setting: `prefix_rewrite`
 - Type: `string`
 - Optional
@@ -1249,8 +1249,8 @@ prefix_rewrite: /
 
 A request to `https://from.example.com/admin` would be forwarded to `https://to.example.com/`.
 
-
 ### Host Rewrite
+
 - `yaml`/`json` settings: `host_rewrite`, `host_rewrite_header`, `host_path_regex_rewrite_pattern`, `host_path_regex_rewrite_substitution`
 - Type: `string`
 - Optional
@@ -1259,22 +1259,22 @@ A request to `https://from.example.com/admin` would be forwarded to `https://to.
 The `host` header can be preserved via the `preserve_host_header` setting or customized via 3 mutually exclusive options:
 
 1. `preserve_host_header` when enabled, this option will pass the host header from the incoming request to the proxied host, instead of the destination hostname. It's an optional parameter of type `bool` that defaults to `false`.
-    See [ProxyPreserveHost](http://httpd.apache.org/docs/2.0/mod/mod_proxy.html#proxypreservehost).
+   See [ProxyPreserveHost](http://httpd.apache.org/docs/2.0/mod/mod_proxy.html#proxypreservehost).
 2. `host_rewrite` which will rewrite the host to a new literal value.
 3. `host_rewrite_header` which will rewrite the host to match an incoming header value.
 4. `host_path_regex_rewrite_pattern`, `host_path_regex_rewrite_substitution` which will rewrite the host according to a regex matching the path. For example with the following config:
 
-    ```yaml
-    host_path_regex_rewrite_pattern: "^/(.+)/.+$"
-    host_path_regex_rewrite_substitution: \1
-    ```
+   ```yaml
+   host_path_regex_rewrite_pattern: "^/(.+)/.+$"
+   host_path_regex_rewrite_substitution: \1
+   ```
 
-    Would rewrite the host header to `example.com` given the path `/example.com/some/path`.
+   Would rewrite the host header to `example.com` given the path `/example.com/some/path`.
 
 The 2nd, 3rd and 4th options correspond to the envoy route action host related options, which can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html#config-route-v3-routeaction).
 
-
 ### Public Access
+
 - `yaml`/`json` setting: `allow_public_unauthenticated_access`
 - Type: `bool`
 - Optional
@@ -1284,8 +1284,8 @@ The 2nd, 3rd and 4th options correspond to the envoy route action host related o
 
 If this setting is enabled, no whitelists (e.g. Allowed Users) should be provided in this route.
 
-
 ### Allow Any Authenticated User
+
 - `yaml`/`json` setting: `allow_any_authenticated_user`
 - Type: `bool`
 - Optional
@@ -1295,8 +1295,8 @@ If this setting is enabled, no whitelists (e.g. Allowed Users) should be provide
 
 Use of this setting means Pomerium **will not enforce centralized authorization policy** for this route. The upstream is responsible for handling any authorization.
 
-
 ### Regex
+
 - `yaml`/`json` setting: `regex`
 - Type: `string` (containing a regular expression)
 - Optional
@@ -1304,8 +1304,8 @@ Use of this setting means Pomerium **will not enforce centralized authorization 
 
 If set, the route will only match incoming requests with a path that matches the specified regular expression. The supported syntax is the same as the Go [regexp package](https://golang.org/pkg/regexp/) which is based on [re2](https://github.com/google/re2/wiki/Syntax).
 
-
 ### Regex Rewrite
+
 - `yaml`/`json` setting: `regex_rewrite_pattern`, `regex_rewrite_substitution`
 - Type: `string`
 - Optional
@@ -1313,8 +1313,8 @@ If set, the route will only match incoming requests with a path that matches the
 
 If set, the URL path will be rewritten according to the pattern and substitution, similar to `prefix_rewrite`.
 
-
 ### Outlier Detection
+
 - `yaml`/`json` setting: `outlier_detection`
 - Type: `object`
 - Optional
@@ -1324,8 +1324,8 @@ Outlier detection and ejection is the process of dynamically determining whether
 
 See Envoy [documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier#arch-overview-outlier-detection) and [API](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/outlier_detection.proto#envoy-v3-api-msg-config-cluster-v3-outlierdetection) for more details.
 
-
 ### Route Timeout
+
 - `yaml`/`json` setting: `timeout`
 - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
 - Optional
@@ -1333,8 +1333,8 @@ See Envoy [documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch
 
 Policy timeout establishes the per-route timeout value. Cannot exceed global timeout values.
 
-
 ### Set Request Headers
+
 - Config File Key: `set_request_headers`
 - Type: map of `strings` key value pairs
 - Optional
@@ -1353,8 +1353,8 @@ Set Request Headers allows you to set static values for given request headers. T
     X-Your-favorite-authenticating-Proxy: "Pomerium"
 ```
 
-
 ### Remove Request Headers
+
 - Config File Key: `remove_request_headers`
 - Type: array of `strings`
 - Optional
@@ -1371,16 +1371,16 @@ Remove Request Headers allows you to remove given request headers. This can be u
     - X-Username
 ```
 
-
 ### Set Response Headers
+
 - Config File Key: `set_response_headers`
 - Type: map of `strings` key value pairs
 - Optional
 
 Set Response Headers allows you to set static values for the given response headers. These headers will take precedence over the global `set_response_headers`.
 
-
 ### Rewrite Response Headers
+
 - Config File Key: `rewrite_response_headers`
 - Type: `object`
 - Optional
@@ -1403,8 +1403,8 @@ rewrite_response_headers:
 
 The browser would be redirected to: `http://frontend/one/some/path/`. This is similar to nginx's [`proxy_redirect` option](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect), but can be used for any header.
 
-
 ### Redirect
+
 - `yaml`/`json` setting: 'redirect'
 - Type: object
 - Optional
@@ -1424,8 +1424,8 @@ options:
 
 Either `redirect` or `to` must be set.
 
-
 ### To
+
 - `yaml`/`json` setting: `to`
 - Type: `URL` or list of `URL`s (must contain a scheme and hostname) with an optional weight
 - Schemes: `http`, `https`, `tcp`
@@ -1437,11 +1437,11 @@ Either `redirect` or `to` must be set.
 ```yaml
 - from: https://example.com
   to:
-  - https://a.example.com
-  - https://b.example.com
+    - https://a.example.com
+    - https://b.example.com
 ```
 
-A load balancing weight may be associated with a particular upstream by appending `,[weight]` to the URL.  The exact behavior depends on your [`lb_policy`](#load-balancing-policy) setting.  See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.html#load-balancing-weight).
+A load balancing weight may be associated with a particular upstream by appending `,[weight]` to the URL. The exact behavior depends on your [`lb_policy`](#load-balancing-policy) setting. See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.html#load-balancing-weight).
 
 Must be `tcp` if `from` is `tcp+https`.
 
@@ -1471,24 +1471,24 @@ Either `redirect` or `to` must be set.
 
 :::
 
-
 ### TLS Skip Verification
+
 - Config File Key: `tls_skip_verify`
 - Type: `bool`
 - Default: `false`
 
 TLS Skip Verification controls whether a client verifies the server's certificate chain and host name. If enabled, TLS accepts any certificate presented by the server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks. This should be used only for testing.
 
-
 ### TLS Server Name
+
 - Config File Key: `tls_server_name`
 - Type: `string`
 - Optional
 
 TLS Server Name overrides the hostname specified in the `to` field. If set, this server name will be used to verify the certificate name. This is useful when the backend of your service is an TLS server with a valid certificate, but mismatched name.
 
-
 ### TLS Custom Certificate Authority
+
 - Config File Key: `tls_custom_ca` or `tls_custom_ca_file`
 - Type: [base64 encoded] `string` or relative file location
 - Optional
@@ -1497,8 +1497,8 @@ TLS Custom Certificate Authority defines a set of root certificate authorities t
 
 Note: This setting will replace (not append) the system's trust store for a given route.
 
-
 ### TLS Downstream Client Certificate Authority
+
 - Config File Key: `tls_downstream_client_ca` or `tls_downstream_client_ca_file`
 - Type: [base64 encoded] `string` or relative file location
 - Optional
@@ -1506,16 +1506,16 @@ Note: This setting will replace (not append) the system's trust store for a give
 If specified downstream clients (eg a user's browser) will be required to provide a valid client TLS
 certificate. This overrides the global `client_ca` option for this route.
 
-
 ### TLS Client Certificate
+
 - Config File Key: `tls_client_cert` and `tls_client_key` or `tls_client_cert_file` and `tls_client_key_file`
 - Type: [base64 encoded] `string` or relative file location
 - Optional
 
 Pomerium supports client certificates which can be used to enforce [mutually authenticated and encrypted TLS connections](https://en.wikipedia.org/wiki/Mutual_authentication) (mTLS). For more details, see our [mTLS example repository](https://github.com/pomerium/pomerium/tree/master/examples/mutual-tls) and the [certificate docs](../docs/topics/certificates.md).
 
-
 ### Pass Identity Headers
+
 - `yaml`/`json` setting: `pass_identity_headers`
 - Type: `bool`
 - Optional
@@ -1524,26 +1524,26 @@ Pomerium supports client certificates which can be used to enforce [mutually aut
 When enabled, this option will pass identity headers to upstream applications. These headers include:
 
 - X-Pomerium-Jwt-Assertion
-- X-Pomerium-Claim-*
-
+- X-Pomerium-Claim-\*
 
 ### SPDY
+
 - Config File Key: `allow_spdy`
 - Type: `bool`
 - Default: `false`
 
 If set, enables proxying of SPDY protocol upgrades.
 
-
 ### Cluster Name
+
 - Config File Key: `name`
 - Type: `string`
 - Optional
 
-Runtime metrics for this policy would be available under `envoy_cluster_`*`name`* prefix.
-
+Runtime metrics for this policy would be available under `envoy_cluster_`_`name`_ prefix.
 
 ### Load Balancing Policy
+
 - Config File Key: `lb_policy`
 - Type: `enum`
 - Optional
@@ -1560,8 +1560,8 @@ See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/con
 
 Some policy types support additional [configuration](#load-balancing-policy-config).
 
-
 ### Load Balancing Policy Config
+
 - Config File Key: `least_request_lb_config`, `ring_hash_lb_config`, `maglev_lb_config`
 - Type: `object`
 - Optional
@@ -1574,8 +1574,8 @@ When [`lb_policy`](#load-balancing-policy) is configured, you may further custom
 
 See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.html#load-balancing-method)
 
-
 ### Health Checks
+
 - Config File Key: `health_checks`
 - Type: `array of objects`
 - Optional
@@ -1594,8 +1594,8 @@ Only one of `http_health_check`, `tcp_health_check`, or `grpc_health_check` may 
 
 See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.html#active-health-checks).
 
-
 ### Websocket Connections
+
 - Config File Key: `allow_websockets`
 - Type: `bool`
 - Default: `false`
@@ -1608,10 +1608,10 @@ If set, enables proxying of websocket connections.
 
 :::
 
-
 ## Authorize Service
 
 ### Authorize Service URL
+
 - Environmental Variable: `AUTHORIZE_SERVICE_URL` or `AUTHORIZE_SERVICE_URLS`
 - Config File Key: `authorize_service_url` or `authorize_service_urls`
 - Type: `URL`
@@ -1620,8 +1620,8 @@ If set, enables proxying of websocket connections.
 
 Authorize Service URL is the location of the internally accessible authorize service. Multiple URLs can be specified with `authorize_service_url`.
 
-
 ### Google Cloud Serverless Authentication Service Account
+
 - Environmental Variable: `GOOGLE_CLOUD_SERVERLESS_AUTHENTICATION_SERVICE_ACCOUNT`
 - Config File Key: `google_cloud_serverless_authentication_service_account`
 - Type: [base64 encoded] `string`
@@ -1634,8 +1634,8 @@ If unspecified:
 - If [Identity Provider Name](#identity-provider-name) is set to `google`, will default to [Identity Provider Service Account](#identity-provider-service-account)
 - Otherwise, will default to ambient credentials in the default locations searched by the Google SDK. This includes GCE metadata server tokens.
 
-
 ### Signing Key
+
 - Environmental Variable: `SIGNING_KEY`
 - Config File Key: `signing_key`
 - Type: [base64 encoded] `string`
@@ -1678,8 +1678,8 @@ $ curl https://authenticate.int.example.com/.well-known/pomerium/jwks.json | jq
 
 If no certificate is specified, one will be generated and the base64'd public key will be added to the logs. Note, however, that this key be unique to each service, ephemeral, and will not be accessible via the authenticate service's `jwks_uri` endpoint.
 
-
 ### Signing Key Algorithm
+
 - Environmental Variable: `SIGNING_KEY_ALGORITHM`
 - Config File Key: `signing_key_algorithm`
 - Type: `string`
@@ -1689,7 +1689,6 @@ If no certificate is specified, one will be generated and the base64'd public ke
 This setting specifies which signing algorithm to use when signing the upstream attestation JWT. Cryptographic algorithm choice is subtle, and beyond the scope of this document, but we suggest sticking to the default `ES256` unless you have a good reason to use something else.
 
 Be aware that any RSA based signature method may be an order of magnitude lower than [elliptic curve] variants like EdDSA (`ed25519`) and ECDSA (`ES256`). For more information, checkout [this article](https://www.scottbrady91.com/JOSE/JWTs-Which-Signing-Algorithm-Should-I-Use).
-
 
 [base64 encoded]: https://en.wikipedia.org/wiki/Base64
 [elliptic curve]: https://wiki.openssl.org/index.php/Command_Line_Elliptic_Curve_Operations#Generating_EC_Keys_and_Parameters

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -1202,7 +1202,7 @@ settings:
       Policy routes are checked in the order they appear in the policy, so more specific routes should appear before less specific routes. For example:
 
       ```yaml
-      policies:
+      policy:
         - from: http://from.example.com
           to: http://to.example.com
           prefix: /admin


### PR DESCRIPTION
## Summary

Warn if some config keys cannot be recognized.
Also fixes few typos in the docs. 

## Related issues

Fixes https://github.com/pomerium/internal/issues/358 https://github.com/pomerium/internal/issues/413

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
