### PR TITLE
options: s/shared-key/shared secret

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -535,7 +535,7 @@ func (o *Options) Validate() error {
 
 	_, err := o.GetSharedKey()
 	if err != nil {
-		return fmt.Errorf("config: invalid shared-key: %w", err)
+		return fmt.Errorf("config: invalid shared secret: %w", err)
 	}
 
 	if o.AuthenticateURLString != "" {
@@ -929,10 +929,10 @@ func (o *Options) GetSharedKey() ([]byte, error) {
 		sharedKey = randomSharedKey
 	}
 	if sharedKey == "" {
-		return nil, errors.New("empty shared-key")
+		return nil, errors.New("empty shared secret")
 	}
 	if strings.TrimSpace(sharedKey) != sharedKey {
-		return nil, errors.New("shared-key contains whitespace")
+		return nil, errors.New("shared secret contains whitespace")
 	}
 	return base64.StdEncoding.DecodeString(sharedKey)
 }


### PR DESCRIPTION
Signed-off-by: Bobby DeSimone <bobbydesimone@gmail.com>

## Summary

The `SharedKey` field has struct tags that are `shared_secret` which can result in confusing error messages to users.

`SharedKey` == `shared_secret`

https://github.com/pomerium/pomerium/blob/ca5c78587efc5de3f593b5a32971ed8efa1a96e6/config/options.go#L73-L76



## Related issues

- https://github.com/pomerium/pomerium/pull/2109


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
