### PR TITLE
authorize: round timestamp

### DIFF
--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -56,6 +56,8 @@ func TestHeadersEvaluator(t *testing.T) {
 		err = rawJWT.Claims(publicJWK, &claims)
 		require.NoError(t, err)
 
+		assert.Equal(t, claims["exp"], math.Round(claims["exp"].(float64)))
+
 		assert.LessOrEqual(t, claims["exp"], float64(time.Now().Add(time.Minute*6).Unix()),
 			"JWT should expire within 5 minutes, but got: %v", claims["exp"])
 	})

--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -142,7 +142,7 @@ base_jwt_claims := [
 	["iss", jwt_payload_iss],
 	["aud", jwt_payload_aud],
 	["jti", jwt_payload_jti],
-	["exp", jwt_payload_exp],
+	["exp", round(jwt_payload_exp)],
 	["iat", jwt_payload_iat],
 	["sub", jwt_payload_sub],
 	["user", jwt_payload_user],
@@ -224,10 +224,10 @@ identity_headers := {key: values |
 
 	some i
 	[key, v1] := h[i]
-	values := [ v2 |
-	    some j
-	    [k2, v2] := h[j]
-	    key == k2
+	values := [v2 |
+		some j
+		[k2, v2] := h[j]
+		key == k2
 	]
 }
 

--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -24,7 +24,7 @@ package pomerium.headers
 #   identity_headers: map[string][]string
 
 # 5 minutes from now in seconds
-five_minutes := (time.now_ns() / 1e9) + (60 * 5)
+five_minutes := round((time.now_ns() / 1e9) + (60 * 5))
 
 session = s {
 	s = get_databroker_record("type.googleapis.com/user.ServiceAccount", input.session.id)
@@ -89,7 +89,7 @@ jwt_payload_jti = v {
 }
 
 jwt_payload_exp = v {
-	v = min([five_minutes, session.expires_at.seconds])
+	v = min([five_minutes, round(session.expires_at.seconds)])
 } else = v {
 	v = five_minutes
 } else = null {
@@ -98,10 +98,10 @@ jwt_payload_exp = v {
 
 jwt_payload_iat = v {
 	# sessions store the issued_at on the id_token
-	v = session.id_token.issued_at.seconds
+	v = round(session.id_token.issued_at.seconds)
 } else = v {
 	# service accounts store the issued at directly
-	v = session.issued_at.seconds
+	v = round(session.issued_at.seconds)
 } else = null {
 	true
 }
@@ -142,8 +142,8 @@ base_jwt_claims := [
 	["iss", jwt_payload_iss],
 	["aud", jwt_payload_aud],
 	["jti", jwt_payload_jti],
-	["exp", round(jwt_payload_exp)],
-	["iat", round(jwt_payload_iat)],
+	["exp", jwt_payload_exp],
+	["iat", jwt_payload_iat],
 	["sub", jwt_payload_sub],
 	["user", jwt_payload_user],
 	["email", jwt_payload_email],

--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -143,7 +143,7 @@ base_jwt_claims := [
 	["aud", jwt_payload_aud],
 	["jti", jwt_payload_jti],
 	["exp", round(jwt_payload_exp)],
-	["iat", jwt_payload_iat],
+	["iat", round(jwt_payload_iat)],
 	["sub", jwt_payload_sub],
 	["user", jwt_payload_user],
 	["email", jwt_payload_email],


### PR DESCRIPTION
## Summary

round timestamp for 'exp' and 'iat' claim that some SDKs expect to be whole unix seconds.

## Related issues

#2248 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
