### PR TITLE
envoy: disable hot-reload for macos

### DIFF
--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -58,7 +58,6 @@ type Server struct {
 	builder            *envoyconfig.Builder
 	grpcPort, httpPort string
 	envoyPath          string
-	restartEpoch       int
 
 	monitorProcessCancel context.CancelFunc
 

--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -384,7 +384,7 @@ func (srv *Server) monitorProcess(ctx context.Context, pid int32) {
 
 		running, err := proc.IsRunningWithContext(ctx)
 		if err != nil {
-			log.Fatal().Err(err).
+			log.Error(ctx).Err(err).
 				Int32("pid", pid).
 				Msg("envoy: error retrieving subprocess status")
 		} else if !running {

--- a/internal/envoy/envoy_darwin.go
+++ b/internal/envoy/envoy_darwin.go
@@ -4,7 +4,10 @@ package envoy
 
 import (
 	"context"
+	"runtime"
 	"syscall"
+
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 var sysProcAttr = &syscall.SysProcAttr{
@@ -12,3 +15,20 @@ var sysProcAttr = &syscall.SysProcAttr{
 }
 
 func (srv *Server) runProcessCollector(ctx context.Context) {}
+
+func (srv *Server) prepareRunEnvoyCommand(ctx context.Context, sharedArgs []string) (exePath string, args []string) {
+	if srv.cmd != nil && srv.cmd.Process != nil {
+		log.Info(ctx).Msg("envoy: terminating previous envoy process")
+		_ = srv.cmd.Process.Kill()
+	}
+
+	args = make([]string, len(sharedArgs))
+	copy(args, sharedArgs)
+
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
+		// until m1 macs are supported by envoy, fallback to x86 and use rosetta
+		return "arch", append([]string{"-x86_64", srv.envoyPath}, args...)
+	}
+
+	return srv.envoyPath, args
+}

--- a/internal/envoy/envoy_other.go
+++ b/internal/envoy/envoy_other.go
@@ -4,6 +4,20 @@ package envoy
 
 import (
 	"context"
+
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 func (srv *Server) runProcessCollector(ctx context.Context) {}
+
+func (srv *Server) prepareRunEnvoyCommand(ctx context.Context, sharedArgs []string) (exePath string, args []string) {
+	if srv.cmd != nil && srv.cmd.Process != nil {
+		log.Info(ctx).Msg("envoy: terminating previous envoy process")
+		_ = srv.cmd.Process.Kill()
+	}
+
+	args = make([]string, len(sharedArgs))
+	copy(args, sharedArgs)
+
+	return srv.envoyPath, args
+}

--- a/internal/envoy/misc.go
+++ b/internal/envoy/misc.go
@@ -2,14 +2,11 @@ package envoy
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"strconv"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 )
-
-const baseIDPath = "/tmp/pomerium-envoy-base-id"
 
 func firstNonEmpty(args ...string) string {
 	for _, a := range args {
@@ -18,20 +15,6 @@ func firstNonEmpty(args ...string) string {
 		}
 	}
 	return ""
-}
-
-func readBaseID() (int, bool) {
-	bs, err := ioutil.ReadFile(baseIDPath)
-	if err != nil {
-		return 0, false
-	}
-
-	baseID, err := strconv.Atoi(string(bs))
-	if err != nil {
-		return 0, false
-	}
-
-	return baseID, true
 }
 
 // ParseAddress parses a string address into an envoy address.


### PR DESCRIPTION
## Summary
Disable envoy hot-reload for MacOS, because it doesn't appear to work. Instead we kill the previous process and start a brand new.

Also change the fatal "error retrieving subprocess status" to an error. For some reason on MacOS this will sometimes return "signal: killed". My search on google didn't turn up anything. 

## Related issues
Fixes https://github.com/pomerium/internal/issues/424
Fixes https://github.com/pomerium/pomerium/issues/2212


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
