### PR TITLE
envoy: always set jwt claim headers even if no value is available

### DIFF
--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -203,18 +203,16 @@ google_cloud_serverless_headers = h {
 
 identity_headers := {key: values |
 	h1 := [["x-pomerium-jwt-assertion", signed_jwt]]
-	h2 := [[k, v] |
-		[claim_key, claim_value] := jwt_claims[_]
-		claim_value != null
-
-		# only include those headers requested by the user
+	h2 := [[header_name, header_value] |
 		some header_name
-		available := data.jwt_claim_headers[header_name]
-		available == claim_key
-
-		# create the header key and value
-		k := header_name
-		v := get_header_string_value(claim_value)
+		k := data.jwt_claim_headers[header_name]
+		header_value := array.concat(
+			[cv |
+				[ck, cv] := jwt_claims[_]
+				ck == k
+			],
+			[""]
+		)[0]
 	]
 
 	h3 := kubernetes_headers

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -478,9 +478,11 @@ func mkRouteMatch(policy *config.Policy) *envoy_config_route_v3.RouteMatch {
 func getRequestHeadersToRemove(options *config.Options, policy *config.Policy) []string {
 	requestHeadersToRemove := policy.RemoveRequestHeaders
 	if !policy.PassIdentityHeaders {
-		requestHeadersToRemove = append(requestHeadersToRemove, httputil.HeaderPomeriumJWTAssertion, httputil.HeaderPomeriumJWTAssertionFor)
-		for _, claim := range options.JWTClaimsHeaders {
-			requestHeadersToRemove = append(requestHeadersToRemove, httputil.PomeriumJWTHeaderName(claim))
+		requestHeadersToRemove = append(requestHeadersToRemove,
+			httputil.HeaderPomeriumJWTAssertion,
+			httputil.HeaderPomeriumJWTAssertionFor)
+		for headerName := range options.JWTClaimsHeaders {
+			requestHeadersToRemove = append(requestHeadersToRemove, headerName)
 		}
 	}
 	// remove these headers to prevent a user from re-proxying requests through the control plane

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -709,7 +709,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					},
 					"route": {
 						"autoHostRewrite": true,
-						"cluster": "policy-9",
+						"cluster": "policy-12",
 						"timeout": "3s",
 						"upgradeConfigs": [
 							{ "enabled": false, "upgradeType": "websocket"},


### PR DESCRIPTION
## Summary
If no value was defined for a given claim it would be possible for an incoming request to set a value and have it still go through. This makes it so we always set a header even if there is no value, thus overwriting the original request header.

The reason why we only check `PassIdentityHeaders` and don't remove the headers there is that the remove header code is called *after* the extauthz code, which means it removes the headers we added with rego.

## Related issues
Fixes https://github.com/pomerium/internal/issues/423
Fixes https://github.com/pomerium/internal/issues/422

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
