### PR TITLE
tracing: support dynamic reloading, more aggressive envoy restart

### DIFF
--- a/config/trace.go
+++ b/config/trace.go
@@ -116,4 +116,10 @@ func (mgr *TraceManager) OnConfigChange(ctx context.Context, cfg *Config) {
 		log.Error(ctx).Err(err).Msg("trace: failed to register exporter")
 		return
 	}
+
+	err = mgr.provider.Register(traceOpts)
+	if err != nil {
+		log.Error(ctx).Err(err).Msg("trace: failed to register exporter")
+		return
+	}
 }

--- a/internal/envoy/envoy_linux.go
+++ b/internal/envoy/envoy_linux.go
@@ -76,10 +76,19 @@ func (srv *Server) prepareRunEnvoyCommand(ctx context.Context, sharedArgs []stri
 
 	restartEpoch.Lock()
 	if baseID, ok := readBaseID(); ok {
-		args = append(args, "--base-id", strconv.Itoa(baseID), "--restart-epoch", strconv.Itoa(restartEpoch.value))
+		args = append(args,
+			"--base-id", strconv.Itoa(baseID),
+			"--restart-epoch", strconv.Itoa(restartEpoch.value),
+			"--drain-time-s", "60",
+			"--parent-shutdown-time-s", "120",
+			"--drain-strategy", "immediate",
+		)
 		restartEpoch.value++
 	} else {
-		args = append(args, "--use-dynamic-base-id", "--base-id-path", baseIDPath)
+		args = append(args,
+			"--use-dynamic-base-id",
+			"--base-id-path", baseIDPath,
+		)
 		restartEpoch.value = 1
 	}
 	restartEpoch.Unlock()

--- a/internal/telemetry/trace/datadog.go
+++ b/internal/telemetry/trace/datadog.go
@@ -1,0 +1,34 @@
+package trace
+
+import (
+	datadog "github.com/DataDog/opencensus-go-exporter-datadog"
+	octrace "go.opencensus.io/trace"
+)
+
+type datadogProvider struct {
+	exporter *datadog.Exporter
+}
+
+func (provider *datadogProvider) Register(opts *TracingOptions) error {
+	dOpts := datadog.Options{
+		Service:   opts.Service,
+		TraceAddr: opts.DatadogAddress,
+	}
+	dex, err := datadog.NewExporter(dOpts)
+	if err != nil {
+		return err
+	}
+	octrace.RegisterExporter(dex)
+	provider.exporter = dex
+	return nil
+}
+
+func (provider *datadogProvider) Unregister() error {
+	if provider.exporter == nil {
+		return nil
+	}
+	octrace.UnregisterExporter(provider.exporter)
+	provider.exporter.Stop()
+	provider.exporter = nil
+	return nil
+}

--- a/internal/telemetry/trace/jaeger.go
+++ b/internal/telemetry/trace/jaeger.go
@@ -32,5 +32,6 @@ func (provider *jaegerProvider) Unregister() error {
 	}
 	octrace.UnregisterExporter(provider.exporter)
 	provider.exporter.Flush()
+	provider.exporter = nil
 	return nil
 }

--- a/internal/telemetry/trace/jaeger.go
+++ b/internal/telemetry/trace/jaeger.go
@@ -1,0 +1,36 @@
+package trace
+
+import (
+	"contrib.go.opencensus.io/exporter/jaeger"
+	octrace "go.opencensus.io/trace"
+)
+
+type jaegerProvider struct {
+	exporter *jaeger.Exporter
+}
+
+func (provider *jaegerProvider) Register(opts *TracingOptions) error {
+	jOpts := jaeger.Options{
+		ServiceName:   opts.Service,
+		AgentEndpoint: opts.JaegerAgentEndpoint,
+	}
+	if opts.JaegerCollectorEndpoint != nil {
+		jOpts.CollectorEndpoint = opts.JaegerCollectorEndpoint.String()
+	}
+	jex, err := jaeger.NewExporter(jOpts)
+	if err != nil {
+		return err
+	}
+	octrace.RegisterExporter(jex)
+	provider.exporter = jex
+	return nil
+}
+
+func (provider *jaegerProvider) Unregister() error {
+	if provider.exporter == nil {
+		return nil
+	}
+	octrace.UnregisterExporter(provider.exporter)
+	provider.exporter.Flush()
+	return nil
+}

--- a/internal/telemetry/trace/trace_test.go
+++ b/internal/telemetry/trace/trace_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 )
 
-func TestRegisterTracing(t *testing.T) {
+func TestGetProvider(t *testing.T) {
 	tests := []struct {
 		name    string
 		opts    *TracingOptions
@@ -13,13 +13,13 @@ func TestRegisterTracing(t *testing.T) {
 	}{
 		{"jaeger", &TracingOptions{JaegerAgentEndpoint: "localhost:6831", Service: "all", Provider: "jaeger"}, false},
 		{"jaeger with debug", &TracingOptions{JaegerAgentEndpoint: "localhost:6831", Service: "all", Provider: "jaeger", Debug: true}, false},
-		{"jaeger no endpoint", &TracingOptions{JaegerAgentEndpoint: "", Service: "all", Provider: "jaeger"}, true},
+		{"jaeger no endpoint", &TracingOptions{JaegerAgentEndpoint: "", Service: "all", Provider: "jaeger"}, false},
 		{"unknown provider", &TracingOptions{JaegerAgentEndpoint: "localhost:0", Service: "all", Provider: "Lucius Cornelius Sulla"}, true},
 		{"zipkin with debug", &TracingOptions{ZipkinEndpoint: &url.URL{Host: "localhost"}, Service: "all", Provider: "zipkin", Debug: true}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if _, err := RegisterTracing(tt.opts); (err != nil) != tt.wantErr {
+			if _, err := GetProvider(tt.opts); (err != nil) != tt.wantErr {
 				t.Errorf("RegisterTracing() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/internal/telemetry/trace/zipkin.go
+++ b/internal/telemetry/trace/zipkin.go
@@ -1,0 +1,46 @@
+package trace
+
+import (
+	"fmt"
+	stdlog "log"
+
+	oczipkin "contrib.go.opencensus.io/exporter/zipkin"
+	"github.com/openzipkin/zipkin-go"
+	"github.com/openzipkin/zipkin-go/reporter"
+	zipkinHTTP "github.com/openzipkin/zipkin-go/reporter/http"
+	octrace "go.opencensus.io/trace"
+
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+type zipkinProvider struct {
+	reporter reporter.Reporter
+	exporter *oczipkin.Exporter
+}
+
+func (provider *zipkinProvider) Register(opts *TracingOptions) error {
+	localEndpoint, err := zipkin.NewEndpoint(opts.Service, "")
+	if err != nil {
+		return fmt.Errorf("telemetry/trace: could not create local endpoint: %w", err)
+	}
+
+	provider.reporter = zipkinHTTP.NewReporter(opts.ZipkinEndpoint.String(),
+		zipkinHTTP.Logger(stdlog.New(log.Logger(), "", 0)))
+	provider.exporter = oczipkin.NewExporter(provider.reporter, localEndpoint)
+	octrace.RegisterExporter(provider.exporter)
+	return nil
+}
+
+func (provider *zipkinProvider) Unregister() error {
+	if provider.exporter != nil {
+		octrace.UnregisterExporter(provider.exporter)
+		provider.exporter = nil
+	}
+
+	var err error
+	if provider.reporter != nil {
+		err = provider.reporter.Close()
+		provider.reporter = nil
+	}
+	return err
+}


### PR DESCRIPTION
## Summary
The zipkin trace exporter also started an HTTP reporter that needs to be terminated when a different trace provider is dynamically configured. This updates the code to better handle changes.

I also updated the envoy restart so that we more aggressively drain and terminate the original process. During hot-reload the old envoy process will continue to send tracing information to the previous zipkin URL, but once the new one takes over the new URL should be used.

I also updated the logging provider for zipkin so logs are JSON formatted.

## Related issues
Fixes https://github.com/pomerium/pomerium-console/issues/1265

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
