### PR TITLE
authorize: only redirect for HTML pages

### DIFF
--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -165,3 +165,48 @@ func mustParseWeightedURLs(t *testing.T, urls ...string) []config.WeightedURL {
 	require.NoError(t, err)
 	return wu
 }
+
+func TestRequireLogin(t *testing.T) {
+	opt := config.NewDefaultOptions()
+	opt.AuthenticateURLString = "https://authenticate.example.com"
+	opt.DataBrokerURLString = "https://databroker.example.com"
+	opt.SharedKey = "E8wWIMnihUx+AUfRegAQDNs8eRb3UrB5G3zlJW9XJDM="
+	a, err := New(&config.Config{Options: opt})
+	require.NoError(t, err)
+
+	t.Run("accept empty", func(t *testing.T) {
+		res, err := a.requireLoginResponse(context.Background(), &envoy_service_auth_v3.CheckRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusFound, int(res.GetDeniedResponse().GetStatus().GetCode()))
+	})
+	t.Run("accept html", func(t *testing.T) {
+		res, err := a.requireLoginResponse(context.Background(), &envoy_service_auth_v3.CheckRequest{
+			Attributes: &envoy_service_auth_v3.AttributeContext{
+				Request: &envoy_service_auth_v3.AttributeContext_Request{
+					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
+						Headers: map[string]string{
+							"accept": "*/*",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusFound, int(res.GetDeniedResponse().GetStatus().GetCode()))
+	})
+	t.Run("accept json", func(t *testing.T) {
+		res, err := a.requireLoginResponse(context.Background(), &envoy_service_auth_v3.CheckRequest{
+			Attributes: &envoy_service_auth_v3.AttributeContext{
+				Request: &envoy_service_auth_v3.AttributeContext_Request{
+					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
+						Headers: map[string]string{
+							"accept": "application/json",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, int(res.GetDeniedResponse().GetStatus().GetCode()))
+	})
+}

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -84,7 +84,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 		return a.deniedResponse(ctx, in, http.StatusForbidden, http.StatusText(http.StatusForbidden), nil)
 	}
 
-	return a.redirectResponse(ctx, in)
+	return a.requireLoginResponse(ctx, in)
 }
 
 func getForwardAuthURL(r *http.Request) *url.URL {

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -2,7 +2,6 @@ package authorize
 
 import (
 	"context"
-	"net/http"
 	"net/url"
 	"testing"
 
@@ -412,49 +411,4 @@ func TestAuthorize_Check(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestRequireLogin(t *testing.T) {
-	opt := config.NewDefaultOptions()
-	opt.AuthenticateURLString = "https://authenticate.example.com"
-	opt.DataBrokerURLString = "https://databroker.example.com"
-	opt.SharedKey = "E8wWIMnihUx+AUfRegAQDNs8eRb3UrB5G3zlJW9XJDM="
-	a, err := New(&config.Config{Options: opt})
-	require.NoError(t, err)
-
-	t.Run("accept empty", func(t *testing.T) {
-		res, err := a.requireLoginResponse(context.Background(), &envoy_service_auth_v3.CheckRequest{})
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusFound, int(res.GetDeniedResponse().GetStatus().GetCode()))
-	})
-	t.Run("accept html", func(t *testing.T) {
-		res, err := a.requireLoginResponse(context.Background(), &envoy_service_auth_v3.CheckRequest{
-			Attributes: &envoy_service_auth_v3.AttributeContext{
-				Request: &envoy_service_auth_v3.AttributeContext_Request{
-					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
-						Headers: map[string]string{
-							"accept": "*/*",
-						},
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusFound, int(res.GetDeniedResponse().GetStatus().GetCode()))
-	})
-	t.Run("accept json", func(t *testing.T) {
-		res, err := a.requireLoginResponse(context.Background(), &envoy_service_auth_v3.CheckRequest{
-			Attributes: &envoy_service_auth_v3.AttributeContext{
-				Request: &envoy_service_auth_v3.AttributeContext_Request{
-					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
-						Headers: map[string]string{
-							"accept": "application/json",
-						},
-					},
-				},
-			},
-		})
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusUnauthorized, int(res.GetDeniedResponse().GetStatus().GetCode()))
-	})
 }

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -2,6 +2,7 @@ package authorize
 
 import (
 	"context"
+	"net/http"
 	"net/url"
 	"testing"
 
@@ -411,4 +412,49 @@ func TestAuthorize_Check(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRequireLogin(t *testing.T) {
+	opt := config.NewDefaultOptions()
+	opt.AuthenticateURLString = "https://authenticate.example.com"
+	opt.DataBrokerURLString = "https://databroker.example.com"
+	opt.SharedKey = "E8wWIMnihUx+AUfRegAQDNs8eRb3UrB5G3zlJW9XJDM="
+	a, err := New(&config.Config{Options: opt})
+	require.NoError(t, err)
+
+	t.Run("accept empty", func(t *testing.T) {
+		res, err := a.requireLoginResponse(context.Background(), &envoy_service_auth_v3.CheckRequest{})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusFound, int(res.GetDeniedResponse().GetStatus().GetCode()))
+	})
+	t.Run("accept html", func(t *testing.T) {
+		res, err := a.requireLoginResponse(context.Background(), &envoy_service_auth_v3.CheckRequest{
+			Attributes: &envoy_service_auth_v3.AttributeContext{
+				Request: &envoy_service_auth_v3.AttributeContext_Request{
+					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
+						Headers: map[string]string{
+							"accept": "*/*",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusFound, int(res.GetDeniedResponse().GetStatus().GetCode()))
+	})
+	t.Run("accept json", func(t *testing.T) {
+		res, err := a.requireLoginResponse(context.Background(), &envoy_service_auth_v3.CheckRequest{
+			Attributes: &envoy_service_auth_v3.AttributeContext{
+				Request: &envoy_service_auth_v3.AttributeContext_Request{
+					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
+						Headers: map[string]string{
+							"accept": "application/json",
+						},
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusUnauthorized, int(res.GetDeniedResponse().GetStatus().GetCode()))
+	})
 }

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
 	github.com/tklauser/go-sysconf v0.3.6 // indirect
+	github.com/tniswong/go.rfcx v0.0.0-20181019234604-07783c52761f
 	github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80
 	github.com/yuin/gopher-lua v0.0.0-20200816102855-ee81675732da
 	go.opencensus.io v0.23.0

--- a/go.sum
+++ b/go.sum
@@ -637,6 +637,8 @@ github.com/tklauser/numcpus v0.2.2 h1:oyhllyrScuYI6g+h/zUvNXNp1wy7x8qQy3t/piefld
 github.com/tklauser/numcpus v0.2.2/go.mod h1:x3qojaO3uyYt0i56EW/VUYs7uBvdl2fkfZFu0T9wgjM=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
+github.com/tniswong/go.rfcx v0.0.0-20181019234604-07783c52761f h1:C43EMGXFtvYf/zunHR6ivZV7Z6ytg73t0GXwYyicXMQ=
+github.com/tniswong/go.rfcx v0.0.0-20181019234604-07783c52761f/go.mod h1:N+sR0vLSCTtI6o06PMWsjMB4TVqqDttKNq4iC9wvxVY=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80 h1:nrZ3ySNYwJbSpD6ce9duiP+QkD3JuLCcWkdaehUS/3Y=
 github.com/tomnomnom/linkheader v0.0.0-20180905144013-02ca5825eb80/go.mod h1:iFyPdL66DjUD96XmzVL3ZntbzcflLnznH0fr99w5VqE=
 github.com/uber/jaeger-client-go v2.25.0+incompatible h1:IxcNZ7WRY1Y3G4poYlx24szfsn/3LvK9QHCq9oQw8+U=


### PR DESCRIPTION
## Summary
Currently when a user is not logged in and they don't have access to a route, we redirect the user through the Login flow. Unfortunately this causes issues for single page applications, because usually the request that will result in the redirect is done via AJAX or Fetch, and Javascript can't handle the HTML redirect.

This PR changes the behavior slightly so we only do the redirect if a request for an HTML page is made. Other types of requests receive a 401 instead, which applications can detect and handle appropriately. (For example Grafana reloads the page and sends the user through the Login flow again)

## Related issues
Fixes #2176 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
