### PR TITLE
authorize: handle grpc-web content types like json

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -197,7 +197,13 @@ func shouldRedirect(in *envoy_service_auth_v3.CheckRequest) bool {
 		return true
 	}
 
-	mediaType, ok := a.MostAcceptable([]string{"text/html", "application/json", "text/plain"})
+	mediaType, ok := a.MostAcceptable([]string{
+		"text/html",
+		"application/json",
+		"text/plain",
+		"application/grpc-web-text",
+		"application/grpc-web+proto",
+	})
 	if !ok {
 		return true
 	}


### PR DESCRIPTION
## Summary
The grpc-web library uses its own content-types instead of application/json. This PR adds them to the list of acceptable media types so that they will be handled like JSON.


## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
