### PR TITLE
databroker: only tag contexts used for UpdateRecords

### DIFF
--- a/internal/contextkeys/contextkeys.go
+++ b/internal/contextkeys/contextkeys.go
@@ -4,12 +4,12 @@ package contextkeys
 type contextKey int
 
 const (
-	// DatabrokerConfigVersion identifies the uint64 databroker version of the config
-	DatabrokerConfigVersion contextKey = iota
+	// UpdateRecordsVersion identifies the uint64 databroker version of the config
+	UpdateRecordsVersion contextKey = iota
 )
 
 func (x contextKey) String() string {
 	return map[contextKey]string{
-		DatabrokerConfigVersion: "db_config_version",
+		UpdateRecordsVersion: "update_records_version",
 	}[x]
 }


### PR DESCRIPTION
## Summary

There was an issue that could result in context being tagged with a wrong version. 

## Related issues

Related to https://github.com/pomerium/pomerium-console/issues/1269 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
