### PR TITLE
envoy: fix usage of codec_type with alpn

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -642,12 +642,22 @@ func (b *Builder) buildDownstreamTLSContext(ctx context.Context,
 		return nil
 	}
 
+	var alpnProtocols []string
+	switch cfg.Options.GetCodecType() {
+	case config.CodecTypeHTTP1:
+		alpnProtocols = []string{"http/1.1"}
+	case config.CodecTypeHTTP2:
+		alpnProtocols = []string{"h2"}
+	default:
+		alpnProtocols = []string{"h2", "http/1.1"}
+	}
+
 	envoyCert := b.envoyTLSCertificateFromGoTLSCertificate(ctx, cert)
 	return &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
 			TlsParams:             tlsParams,
 			TlsCertificates:       []*envoy_extensions_transport_sockets_tls_v3.TlsCertificate{envoyCert},
-			AlpnProtocols:         []string{"h2", "http/1.1"},
+			AlpnProtocols:         alpnProtocols,
 			ValidationContextType: b.buildDownstreamValidationContext(ctx, cfg, domain),
 		},
 	}

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -640,6 +640,74 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 			}
 		}`, downstreamTLSContext)
 	})
+	t.Run("http1", func(t *testing.T) {
+		downstreamTLSContext := b.buildDownstreamTLSContext(context.Background(), &config.Config{Options: &config.Options{
+			Cert:      aExampleComCert,
+			Key:       aExampleComKey,
+			CodecType: config.CodecTypeHTTP1,
+		}}, "a.example.com")
+
+		testutil.AssertProtoJSONEqual(t, `{
+			"commonTlsContext": {
+				"tlsParams": {
+					"cipherSuites": [
+						"ECDHE-ECDSA-AES256-GCM-SHA384",
+						"ECDHE-RSA-AES256-GCM-SHA384",
+						"ECDHE-ECDSA-AES128-GCM-SHA256",
+						"ECDHE-RSA-AES128-GCM-SHA256",
+						"ECDHE-ECDSA-CHACHA20-POLY1305",
+						"ECDHE-RSA-CHACHA20-POLY1305"
+					],
+					"tlsMinimumProtocolVersion": "TLSv1_2"
+				},
+				"alpnProtocols": ["http/1.1"],
+				"tlsCertificates": [
+					{
+						"certificateChain": {
+							"filename": "`+certFileName+`"
+						},
+						"privateKey": {
+							"filename": "`+keyFileName+`"
+						}
+					}
+				]
+			}
+		}`, downstreamTLSContext)
+	})
+	t.Run("http2", func(t *testing.T) {
+		downstreamTLSContext := b.buildDownstreamTLSContext(context.Background(), &config.Config{Options: &config.Options{
+			Cert:      aExampleComCert,
+			Key:       aExampleComKey,
+			CodecType: config.CodecTypeHTTP2,
+		}}, "a.example.com")
+
+		testutil.AssertProtoJSONEqual(t, `{
+			"commonTlsContext": {
+				"tlsParams": {
+					"cipherSuites": [
+						"ECDHE-ECDSA-AES256-GCM-SHA384",
+						"ECDHE-RSA-AES256-GCM-SHA384",
+						"ECDHE-ECDSA-AES128-GCM-SHA256",
+						"ECDHE-RSA-AES128-GCM-SHA256",
+						"ECDHE-ECDSA-CHACHA20-POLY1305",
+						"ECDHE-RSA-CHACHA20-POLY1305"
+					],
+					"tlsMinimumProtocolVersion": "TLSv1_2"
+				},
+				"alpnProtocols": ["h2"],
+				"tlsCertificates": [
+					{
+						"certificateChain": {
+							"filename": "`+certFileName+`"
+						},
+						"privateKey": {
+							"filename": "`+keyFileName+`"
+						}
+					}
+				]
+			}
+		}`, downstreamTLSContext)
+	})
 }
 
 func Test_getAllDomains(t *testing.T) {


### PR DESCRIPTION
## Summary
The `codecType` option needs to match `alpnProtocols`. Because they didn't match the browser was making an HTTP/2 request to a server that only accepted HTTP/1 (or vice-versa).

## Related issues
Fixes #2271 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
