### PR TITLE
ocsp: reload on response changes

### DIFF
--- a/internal/autocert/ocsp.go
+++ b/internal/autocert/ocsp.go
@@ -1,0 +1,33 @@
+package autocert
+
+import (
+	"bytes"
+
+	lru "github.com/hashicorp/golang-lru"
+)
+
+type ocspCache struct {
+	*lru.Cache
+}
+
+func newOCSPCache(size int) (*ocspCache, error) {
+	c, err := lru.New(size)
+	if err != nil {
+		return nil, err
+	}
+	return &ocspCache{c}, nil
+}
+
+// updated checks if OCSP response for this certificate was updated
+func (c ocspCache) updated(key string, ocspResp []byte) bool {
+	current, there := c.Get(key)
+	if !there {
+		_ = c.Add(key, ocspResp)
+		return false // to avoid triggering reload first time we see this response
+	}
+	if bytes.Equal(current.([]byte), ocspResp) {
+		return false
+	}
+	_ = c.Add(key, ocspResp)
+	return true
+}

--- a/internal/autocert/ocsp_test.go
+++ b/internal/autocert/ocsp_test.go
@@ -1,0 +1,31 @@
+package autocert
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOcspCache(t *testing.T) {
+	c, err := newOCSPCache(10)
+	require.NoError(t, err)
+
+	cases := []struct {
+		data      []byte
+		isUpdated bool
+	}{
+		{nil, false},
+		{nil, false},
+		{[]byte("a"), true},
+		{[]byte("a"), false},
+		{[]byte("b"), true},
+		{[]byte("b"), false},
+		{nil, true},
+		{nil, false},
+	}
+
+	for i, tc := range cases {
+		assert.Equal(t, tc.isUpdated, c.updated("key", tc.data), "#%d: %v", i, tc)
+	}
+}


### PR DESCRIPTION
## Summary

Certificates with OCSP must-staple will become invalid and cause connection handshake failures unless an up to date OCSP response is stapled to it. 

## Related issues

Fixes #1946 https://github.com/pomerium/internal/issues/440

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
