### PR TITLE
directory/azure: add paging support to user group members call

### DIFF
--- a/internal/directory/azure/api.go
+++ b/internal/directory/azure/api.go
@@ -1,0 +1,45 @@
+package azure
+
+import "strings"
+
+type (
+	apiGetUserResponse struct {
+		apiUser
+	}
+	apiGetUserMembersResponse struct {
+		Context  string     `json:"@odata.context"`
+		NextLink string     `json:"@odata.nextLink,omitempty"`
+		Value    []apiGroup `json:"value"`
+	}
+
+	apiGroup struct {
+		ID          string `json:"id"`
+		DisplayName string `json:"displayName"`
+	}
+	apiUser struct {
+		ID                string `json:"id"`
+		DisplayName       string `json:"displayName"`
+		Mail              string `json:"mail"`
+		UserPrincipalName string `json:"userPrincipalName"`
+	}
+)
+
+func (obj apiUser) getEmail() string {
+	if obj.Mail != "" {
+		return obj.Mail
+	}
+
+	// AD often doesn't have the email address returned, but we can parse it from the UPN
+
+	// UPN looks like:
+	// cdoxsey_pomerium.com#EXT#@cdoxseypomerium.onmicrosoft.com
+	email := obj.UserPrincipalName
+	if idx := strings.Index(email, "#EXT"); idx > 0 {
+		email = email[:idx]
+	}
+	// find the last _ and replace it with @
+	if idx := strings.LastIndex(email, "_"); idx > 0 {
+		email = email[:idx] + "@" + email[idx+1:]
+	}
+	return email
+}

--- a/internal/directory/azure/delta.go
+++ b/internal/directory/azure/delta.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"net/url"
 	"sort"
-	"strings"
 
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
@@ -229,10 +228,9 @@ type (
 		Value     []groupsDeltaResponseGroup `json:"value"`
 	}
 	groupsDeltaResponseGroup struct {
-		ID          string                           `json:"id"`
-		DisplayName string                           `json:"displayName"`
-		Members     []groupsDeltaResponseGroupMember `json:"members@delta"`
-		Removed     *deltaResponseRemoved            `json:"@removed,omitempty"`
+		apiGroup
+		Members []groupsDeltaResponseGroupMember `json:"members@delta"`
+		Removed *deltaResponseRemoved            `json:"@removed,omitempty"`
 	}
 	groupsDeltaResponseGroupMember struct {
 		Type    string                `json:"@odata.type"`
@@ -247,30 +245,7 @@ type (
 		Value     []usersDeltaResponseUser `json:"value"`
 	}
 	usersDeltaResponseUser struct {
-		ID                string                `json:"id"`
-		DisplayName       string                `json:"displayName"`
-		Mail              string                `json:"mail"`
-		UserPrincipalName string                `json:"userPrincipalName"`
-		Removed           *deltaResponseRemoved `json:"@removed,omitempty"`
+		apiUser
+		Removed *deltaResponseRemoved `json:"@removed,omitempty"`
 	}
 )
-
-func (obj usersDeltaResponseUser) getEmail() string {
-	if obj.Mail != "" {
-		return obj.Mail
-	}
-
-	// AD often doesn't have the email address returned, but we can parse it from the UPN
-
-	// UPN looks like:
-	// cdoxsey_pomerium.com#EXT#@cdoxseypomerium.onmicrosoft.com
-	email := obj.UserPrincipalName
-	if idx := strings.Index(email, "#EXT"); idx > 0 {
-		email = email[:idx]
-	}
-	// find the last _ and replace it with @
-	if idx := strings.LastIndex(email, "_"); idx > 0 {
-		email = email[:idx] + "@" + email[idx+1:]
-	}
-	return email
-}


### PR DESCRIPTION
## Summary
Currently we only make one call to the azure `transitiveMembersOf` endpoint, but if there are more than 100 groups for a single user, only a subset of them will be set. This PR updates the call to support paging so that we should get all the groups.

I tested this change by manually adding `$top=1` to the API request and saw a request in the logs for each group. Another way to test would be to add more than 100 groups to a user in azure.

## Related issues
Fixes #2299 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
