### PR TITLE
authorize: do not send redirects to gRPC 

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -192,6 +192,10 @@ func shouldRedirect(in *envoy_service_auth_v3.CheckRequest) bool {
 		return true
 	}
 
+	if strings.HasPrefix(requestHeaders["content-type"], "application/grpc") {
+		return false
+	}
+
 	a, err := rfc7231.ParseAccept(requestHeaders["accept"])
 	if err != nil {
 		return true

--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -203,6 +203,7 @@ func shouldRedirect(in *envoy_service_auth_v3.CheckRequest) bool {
 		"text/plain",
 		"application/grpc-web-text",
 		"application/grpc-web+proto",
+		"application/grpc+proto",
 	})
 	if !ok {
 		return true


### PR DESCRIPTION
## Summary

According to https://chromium.googlesource.com/external/github.com/grpc/grpc/+/HEAD/doc/PROTOCOL-HTTP2.md

> If Content-Type does not begin with “application/grpc”, gRPC servers SHOULD respond with HTTP status of 415 (Unsupported Media Type). 

which hints that content-type should always be present for gRPC requests. 

## Related issues

Fixes https://github.com/pomerium/internal/issues/446

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
