### PR TITLE
cli: use proxy from environment

### DIFF
--- a/internal/authclient/authclient.go
+++ b/internal/authclient/authclient.go
@@ -119,9 +119,9 @@ func (client *AuthClient) runOpenBrowser(ctx context.Context, li net.Listener, s
 		return err
 	}
 
-	transport := &http.Transport{
-		TLSClientConfig: client.cfg.tlsConfig,
-	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = client.cfg.tlsConfig
+
 	hc := &http.Client{
 		Transport: transport,
 	}


### PR DESCRIPTION
## Summary

The existing implementation of pomerium-cli does not respect the http proxy env vars so here we add the default http.Transport behavior back with [ProxyFromEnvironment](https://golang.org/pkg/net/http/#ProxyFromEnvironment).

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
