### PR TITLE
storage/inmemory: add tests for close behavior

### DIFF
--- a/pkg/storage/inmemory/stream.go
+++ b/pkg/storage/inmemory/stream.go
@@ -99,11 +99,20 @@ func (stream *recordStream) Err() error {
 	select {
 	case <-stream.ctx.Done():
 		return stream.ctx.Err()
-	case <-stream.closed:
-		return storage.ErrStreamClosed
+	default:
+	}
+
+	select {
 	case <-stream.backend.closed:
 		return storage.ErrStreamClosed
 	default:
-		return nil
 	}
+
+	select {
+	case <-stream.closed:
+		return storage.ErrStreamClosed
+	default:
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
Coverage for this package was non-deterministic because the various select blocks pseudo-randomly choose when multiple options can proceed. I updated the code to try each possibility in order so that they always come out the same way. I also added some tests for the various ways a stream can be closed.

## Related issues
Fixes https://github.com/pomerium/internal/issues/456


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
