### PR TITLE
registry/redis: call publish from within lua function

### DIFF
--- a/internal/registry/redis/lua/registry.lua
+++ b/internal/registry/redis/lua/registry.lua
@@ -1,10 +1,12 @@
 -- ARGV = [current time in seconds, ttl in seconds, services ...]
 local current_time = ARGV[1]
 local ttl = ARGV[2]
+local changed = false
 
 -- update the service list
 for i = 3, #ARGV, 1 do
     redis.call('HSET', KEYS[1], ARGV[i], current_time + ttl)
+    changed = true
 end
 
 -- retrieve all the services, removing any that have expired
@@ -13,8 +15,14 @@ local kvs = redis.call('HGETALL', KEYS[1])
 for i = 1, #kvs, 2 do
     if kvs[i + 1] < current_time then
         redis.call('HDEL', KEYS[1], kvs[i])
+        changed = true
     else
         table.insert(svcs, kvs[i])
     end
 end
+
+if changed then
+    redis.call('PUBLISH', KEYS[2], current_time)
+end
+
 return svcs

--- a/internal/registry/redis/redis.go
+++ b/internal/registry/redis/redis.go
@@ -205,11 +205,7 @@ func (i *impl) runReport(ctx context.Context, updates []*registrypb.Service) ([]
 	for _, svc := range updates {
 		args = append(args, i.getRegistryHashKey(svc))
 	}
-	res, err := i.client.Eval(ctx, lua.Registry, []string{registryKey}, args...).Result()
-	if err != nil {
-		return nil, err
-	}
-	_, err = i.client.Publish(ctx, registryUpdateKey, time.Now().Format(time.RFC3339Nano)).Result()
+	res, err := i.client.Eval(ctx, lua.Registry, []string{registryKey, registryUpdateKey}, args...).Result()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
The `Publish` function was being called any time `List` was called even if there were no changes. Since `List` can sometimes trigger a change (if something has expired), we can't really do the change detection outside of the lua function itself. This PR moves the `Publish` call to the lua function, where it is conditionally executed if something changes.

This should improve `Watch`, which was likely stuck in an infinite change loop.

## Related issues
Fixes https://github.com/pomerium/internal/issues/455

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
