### PR TITLE
authorize: support boolean deny results

### DIFF
--- a/authorize/evaluator/policy_evaluator.go
+++ b/authorize/evaluator/policy_evaluator.go
@@ -3,6 +3,7 @@ package evaluator
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"strconv"
 	"strings"
 
@@ -164,20 +165,30 @@ func (e *PolicyEvaluator) getDeny(ctx context.Context, vars rego.Vars) *Denial {
 		return nil
 	}
 
-	pair, ok := m["deny"].([]interface{})
-	if !ok {
+	var status int
+	var reason string
+	switch t := m["deny"].(type) {
+	case bool:
+		if t {
+			status = http.StatusForbidden
+			reason = ""
+		} else {
+			return nil
+		}
+	case []interface{}:
+		var err error
+		status, err = strconv.Atoi(fmt.Sprint(t[0]))
+		if err != nil {
+			log.Error(ctx).Err(err).Msg("invalid type in deny")
+			return nil
+		}
+		reason = fmt.Sprint(t[1])
+	default:
 		return nil
 	}
-
-	status, err := strconv.Atoi(fmt.Sprint(pair[0]))
-	if err != nil {
-		log.Error(ctx).Err(err).Msg("invalid type in deny")
-		return nil
-	}
-	msg := fmt.Sprint(pair[1])
 
 	return &Denial{
 		Status:  status,
-		Message: msg,
+		Message: reason,
 	}
 }

--- a/authorize/evaluator/policy_evaluator.go
+++ b/authorize/evaluator/policy_evaluator.go
@@ -176,13 +176,22 @@ func (e *PolicyEvaluator) getDeny(ctx context.Context, vars rego.Vars) *Denial {
 			return nil
 		}
 	case []interface{}:
-		var err error
-		status, err = strconv.Atoi(fmt.Sprint(t[0]))
-		if err != nil {
-			log.Error(ctx).Err(err).Msg("invalid type in deny")
+		switch len(t) {
+		case 0:
 			return nil
+		case 2:
+			var err error
+			status, err = strconv.Atoi(fmt.Sprint(t[0]))
+			if err != nil {
+				log.Error(ctx).Err(err).Msg("invalid type in deny")
+				return nil
+			}
+			reason = fmt.Sprint(t[1])
+		default:
+			log.Error(ctx).Interface("deny", t).Msg("invalid size in deny")
+			return nil
+
 		}
-		reason = fmt.Sprint(t[1])
 	default:
 		return nil
 	}

--- a/authorize/evaluator/policy_evaluator_test.go
+++ b/authorize/evaluator/policy_evaluator_test.go
@@ -3,6 +3,8 @@ package evaluator
 import (
 	"context"
 	"math"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/go-jose/go-jose/v3"
@@ -14,12 +16,10 @@ import (
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/policy"
 )
 
 func TestPolicyEvaluator(t *testing.T) {
-	type A = []interface{}
-	type M = map[string]interface{}
-
 	signingKey, err := cryptutil.NewSigningKey()
 	require.NoError(t, err)
 	encodedSigningKey, err := cryptutil.EncodePrivateKey(signingKey)
@@ -107,5 +107,65 @@ func TestPolicyEvaluator(t *testing.T) {
 		assert.Equal(t, &PolicyResponse{
 			Allow: false,
 		}, output)
+	})
+	t.Run("ppl", func(t *testing.T) {
+		t.Run("allow", func(t *testing.T) {
+			rego, err := policy.GenerateRegoFromReader(strings.NewReader(`
+- allow:
+    and:
+      - accept: 1
+`))
+			require.NoError(t, err)
+			p := &config.Policy{
+				From: "https://from.example.com",
+				To:   config.WeightedURLs{{URL: *mustParseURL("https://to.example.com")}},
+				SubPolicies: []config.SubPolicy{
+					{Rego: []string{rego}},
+				},
+			}
+			output, err := eval(t,
+				p,
+				[]proto.Message{s1, u1, s2, u2},
+				&PolicyRequest{
+					HTTP:    RequestHTTP{Method: "GET", URL: "https://from.example.com/path"},
+					Session: RequestSession{ID: "s1"},
+
+					IsValidClientCertificate: true,
+				})
+			require.NoError(t, err)
+			assert.Equal(t, &PolicyResponse{
+				Allow: true,
+			}, output)
+		})
+		t.Run("deny", func(t *testing.T) {
+			rego, err := policy.GenerateRegoFromReader(strings.NewReader(`
+- deny:
+    and:
+      - accept: 1
+`))
+			require.NoError(t, err)
+			p := &config.Policy{
+				From: "https://from.example.com",
+				To:   config.WeightedURLs{{URL: *mustParseURL("https://to.example.com")}},
+				SubPolicies: []config.SubPolicy{
+					{Rego: []string{rego}},
+				},
+			}
+			output, err := eval(t,
+				p,
+				[]proto.Message{s1, u1, s2, u2},
+				&PolicyRequest{
+					HTTP:    RequestHTTP{Method: "GET", URL: "https://from.example.com/path"},
+					Session: RequestSession{ID: "s1"},
+
+					IsValidClientCertificate: true,
+				})
+			require.NoError(t, err)
+			assert.Equal(t, &PolicyResponse{
+				Deny: &Denial{
+					Status: http.StatusForbidden,
+				},
+			}, output)
+		})
 	})
 }

--- a/pkg/policy/generator/generator_test.go
+++ b/pkg/policy/generator/generator_test.go
@@ -50,6 +50,13 @@ func Test(t *testing.T) {
 					{Name: "accept"},
 				},
 			},
+			{
+				Action: parser.ActionDeny,
+				Nor: []parser.Criterion{
+					{Name: "accept"},
+					{Name: "accept"},
+				},
+			},
 		},
 	})
 	assert.NoError(t, err)
@@ -171,6 +178,23 @@ else = v4 {
 else = v5 {
 	v5 := and_1
 	v5
+}
+
+accept_13 {
+	1 == 1
+}
+
+accept_14 {
+	1 == 1
+}
+
+nor_1 = v {
+	v := count({1 | not accept_13} | {1 | not accept_14}) == 1
+}
+
+deny = v1 {
+	v1 := nor_1
+	v1
 }
 `, string(format.MustAst(mod)))
 }

--- a/pkg/policy/generator/generator_test.go
+++ b/pkg/policy/generator/generator_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/format"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/pkg/policy/parser"
 )
@@ -59,7 +60,7 @@ func Test(t *testing.T) {
 			},
 		},
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, `package pomerium.policy
 
 default allow = false


### PR DESCRIPTION
## Summary
PPL rules generally create simple boolean values. For example `user: x` returns true if the user is `x`. Historically our policy rego script used an array with `[status, reason]` for the deny block. This PR updates the policy evaluator so that it supports either. If the deny block returns true it will set `[403,""]`.

## Related issues
Fixes https://github.com/pomerium/pomerium-console/issues/1473

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
