### PR TITLE
fix: timeout in protobuf

### DIFF
--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -497,7 +497,7 @@ func getRouteTimeout(options *config.Options, policy *config.Policy) *durationpb
 	var routeTimeout *durationpb.Duration
 	if policy.UpstreamTimeout != nil {
 		routeTimeout = durationpb.New(*policy.UpstreamTimeout)
-	} else if shouldDisableTimeouts(policy) {
+	} else if shouldDisableStreamIdleTimeout(policy) {
 		// a non-zero value would conflict with idleTimeout and/or websocket / tcp calls
 		routeTimeout = durationpb.New(0)
 	} else {
@@ -510,15 +510,14 @@ func getRouteIdleTimeout(policy *config.Policy) *durationpb.Duration {
 	var idleTimeout *durationpb.Duration
 	if policy.IdleTimeout != nil {
 		idleTimeout = durationpb.New(*policy.IdleTimeout)
-	} else if shouldDisableTimeouts(policy) {
+	} else if shouldDisableStreamIdleTimeout(policy) {
 		idleTimeout = durationpb.New(0)
 	}
 	return idleTimeout
 }
 
-func shouldDisableTimeouts(policy *config.Policy) bool {
-	return policy.IdleTimeout != nil ||
-		policy.AllowWebsockets ||
+func shouldDisableStreamIdleTimeout(policy *config.Policy) bool {
+	return policy.AllowWebsockets ||
 		urlutil.IsTCP(policy.Source.URL) ||
 		policy.IsForKubernetes() // disable for kubernetes so that tailing logs works (#2182)
 }

--- a/config/policy.go
+++ b/config/policy.go
@@ -296,6 +296,8 @@ func (p *Policy) ToProto() (*configpb.Route, error) {
 	var timeout *durationpb.Duration
 	if p.UpstreamTimeout == nil {
 		timeout = durationpb.New(defaultOptions.DefaultUpstreamTimeout)
+	} else {
+		timeout = durationpb.New(*p.UpstreamTimeout)
 	}
 	var idleTimeout *durationpb.Duration
 	if p.IdleTimeout != nil {


### PR DESCRIPTION
## Summary

1. Fix timeout propagation in protobuf
2. Add `allowWebsockets` to `timeout` and `idleTimeout` tests

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
