### PR TITLE
envoyconfig: add bootstrap layered runtime configuration

### DIFF
--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -40,6 +40,22 @@ func TestBuilder_BuildBootstrapAdmin(t *testing.T) {
 	})
 }
 
+func TestBuilder_BuildBootstrapLayeredRuntime(t *testing.T) {
+	b := New("localhost:1111", "localhost:2222", filemgr.NewManager(), nil)
+	staticCfg, err := b.BuildBootstrapLayeredRuntime()
+	assert.NoError(t, err)
+	testutil.AssertProtoJSONEqual(t, `
+		{ "layers": [{
+			"name": "static_layer_0",
+			"staticLayer": {
+				"overload": {
+					"global_downstream_max_connections": 50000
+				}
+			}
+		}] }
+	`, staticCfg)
+}
+
 func TestBuilder_BuildBootstrapStaticResources(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		b := New("localhost:1111", "localhost:2222", filemgr.NewManager(), nil)

--- a/internal/envoy/envoy.go
+++ b/internal/envoy/envoy.go
@@ -273,12 +273,18 @@ func (srv *Server) buildBootstrapConfig(cfg *config.Config) ([]byte, error) {
 		return nil, err
 	}
 
+	layeredRuntimeCfg, err := srv.builder.BuildBootstrapLayeredRuntime()
+	if err != nil {
+		return nil, err
+	}
+
 	bootstrapCfg := &envoy_config_bootstrap_v3.Bootstrap{
 		Node:             nodeCfg,
 		Admin:            adminCfg,
 		DynamicResources: dynamicCfg,
 		StaticResources:  staticCfg,
 		StatsConfig:      statsCfg,
+		LayeredRuntime:   layeredRuntimeCfg,
 	}
 
 	jsonBytes, err := protojson.Marshal(proto.MessageV2(bootstrapCfg))


### PR DESCRIPTION
## Summary
Add a bootstrap layered runtime configuration to suppress an envoy warning.

## Related issues
Fixes https://github.com/pomerium/internal/issues/453

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
