### PR TITLE
envoyconfig: only delete cached files, ignore noisy error

### DIFF
--- a/config/envoyconfig/filemgr/filemgr.go
+++ b/config/envoyconfig/filemgr/filemgr.go
@@ -64,10 +64,13 @@ func (mgr *Manager) ClearCache() {
 		if err != nil {
 			return err
 		}
-		return os.Remove(p)
+		if !fi.IsDir() {
+			return os.Remove(p)
+		}
+		return nil
 	})
 	if err != nil {
-		log.Error(context.TODO()).Err(err).Msg("failed to clear envoy file cache")
+		log.Error(context.Background()).Err(err).Msg("failed to clear envoy file cache")
 	}
 }
 


### PR DESCRIPTION
## Summary
Only delete cached files. Ignore noisy error.

## Related issues
Fixes https://github.com/pomerium/internal/issues/451

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
