### PR TITLE
envoyconfig: default zipkin path to / when empty

### DIFF
--- a/config/envoyconfig/tracing.go
+++ b/config/envoyconfig/tracing.go
@@ -113,9 +113,13 @@ func buildTracingHTTP(options *config.Options) (*envoy_config_trace_v3.Tracing_H
 			},
 		}, nil
 	case trace.ZipkinTracingProviderName:
+		path := tracingOptions.ZipkinEndpoint.Path
+		if path == "" {
+			path = "/"
+		}
 		tracingTC, _ := anypb.New(&envoy_config_trace_v3.ZipkinConfig{
 			CollectorCluster:         "zipkin",
-			CollectorEndpoint:        tracingOptions.ZipkinEndpoint.Path,
+			CollectorEndpoint:        path,
 			CollectorEndpointVersion: envoy_config_trace_v3.ZipkinConfig_HTTP_JSON,
 		})
 		return &envoy_config_trace_v3.Tracing_Http{


### PR DESCRIPTION
## Summary
Default zipkin path to / when empty

## Related issues
- https://github.com/pomerium/pomerium-console/issues/1483


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
