### PR TITLE
hadolint dockerfiles

### DIFF
--- a/.github/workflows/docker-master.yaml
+++ b/.github/workflows/docker-master.yaml
@@ -40,6 +40,11 @@ jobs:
           echo ::set-output name=image::${IMAGE}
           echo ::set-output name=sha-tag::${SHA_TAG}
 
+      - name: Hadolint - Master
+        uses: hadolint/hadolint-action@v1.5.0
+        with:
+          Dockerfile: Dockerfile
+
       - name: Docker Publish - Master
         uses: docker/build-push-action@v2
         with:
@@ -51,6 +56,11 @@ jobs:
             org.opencontainers.image.created=${{ steps.metadata.outputs.timestamp }}
             org.opencontainers.image.name=${{ steps.metadata.outputs.name }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Hadolint - Debug
+        uses: hadolint/hadolint-action@v1.5.0
+        with:
+          Dockerfile: Dockerfile.debug
 
       - name: Docker Publish - Debug
         uses: docker/build-push-action@v2


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

uses new hadolint github action to perform linting on dockerfiles

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
