### PR TITLE
Docs bug fixes

### DIFF
--- a/docs/docs/identity-providers/readme.md
+++ b/docs/docs/identity-providers/readme.md
@@ -24,6 +24,8 @@ In this guide we'll cover how to do the following for each identity provider:
 
 You must configure an IdP **[Service Account]** to write policy against group membership, or any other data that does not uniquely identify an end-user.
 
+:::
+
 [client id]: ../../reference/readme.md#identity-provider-client-id
 [client secret]: ../../reference/readme.md#identity-provider-client-secret
 [environmental variables]: https://en.wikipedia.org/wiki/Environment_variable
@@ -71,7 +73,7 @@ Now to implement this flow we have configured static dex client ```pom``` with p
 
 ```Note: I am using dex helm chart and in backend freeipa as a ldap server```
 
-```
+```yaml
 connectors:
       - config:
           bindDN: uid=dex,cn=sysaccounts,cn=etc,dc=YOURDOMAIN,dc=dev
@@ -119,11 +121,12 @@ connectors:
         secret: pomerium
 
 ```
+
 Below is configuration which supposed to be done in Pomerium
 
 ```Note: I am using Pomerium helm chart```
 
-```
+```yaml
 config:
   # routes under this wildcard domain are handled by pomerium
   rootDomain: YOURDOMAIN.dev

--- a/docs/guides/local-oidc.md
+++ b/docs/guides/local-oidc.md
@@ -8,7 +8,9 @@ description: >-
   This guide covers how to use Pomerium with a local OIDC provider using [qlik/simple-oidc-provider].
 ---
 
-You can use the same below configs for other supported [identity provider].
+# Local OIDC Provider
+
+You can use the same below configs for other supported [identity providers](/docs/identity-providers).
 
 ## Configure
 ### Docker-compose


### PR DESCRIPTION
## Summary

Fixes a few small docs problems that were bugging me:

 - Warning block consumed all content in Identity Providers
 - OIDC guide had no title
 - OIDC title used a link convention that didn't work with English grammar.

## Checklist

- [ ] ~reference any related issues~
- [X] updated docs
- [ ] ~updated unit tests~
- [ ] ~updated UPGRADING.md~
- [X] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
