### PR TITLE
envoy: only allow embedding

### DIFF
--- a/internal/envoy/embed.go
+++ b/internal/envoy/embed.go
@@ -20,6 +20,9 @@ const (
 	embeddedDirectoryPermissions fs.FileMode = 0o755
 )
 
+// OverrideEnvoyPath is an override for using an envoy path instead of the embedded envoy path.
+var OverrideEnvoyPath = ""
+
 var (
 	embeddedFilesBaseDirectory = filepath.Join(os.TempDir(), "pomerium-embedded-files")
 	extractEmbeddedEnvoyOnce   sync.Once


### PR DESCRIPTION
## Summary
Only allow embedded envoy unless `OverrideEnvoyPath` is set.

## Related issues
Fixes https://github.com/pomerium/internal/issues/436


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
