### PR TITLE
ci: use github app for backport credentials

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -10,8 +10,15 @@ jobs:
     runs-on: ubuntu-latest
     name: Backport
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.BACKPORT_APP_APPID }}
+          private_key: ${{ secrets.BACKPORT_APP_PRIVATE_KEY }}
+
       - name: Backport
         uses: tibdex/backport@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.generate_token.outputs.token }}
           title_template: "{{originalTitle}}"


### PR DESCRIPTION
## Summary

Change the credentials we use for our backport action.  This should allow tests to automatically run when it creates PRs.

## Related issues

https://github.com/tibdex/backport/issues/61

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
