### PR TITLE
ci: use revive instead of golint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,8 +29,6 @@ linters-settings:
     min-complexity: 15
   goimports:
     local-prefixes: github.com/pomerium/pomerium
-  golint:
-    min-confidence: 0
   govet:
     check-shadowing: false
   lll:
@@ -55,7 +53,6 @@ linters:
     - errcheck
     - gofmt
     - goimports
-    - golint
     - goprintffuncname
     - gosec
     - gosimple
@@ -65,6 +62,7 @@ linters:
     - misspell
     - nakedret
     - nolintlint
+    - revive
     - rowserrcheck
     - staticcheck
     - structcheck
@@ -143,8 +141,6 @@ issues:
     - "SA1019"
     # EXC0001 errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
     - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*print(f|ln)?|os\.(Un)?Setenv). is not checked
-
-
 
   exclude-rules:
     # https://github.com/go-critic/go-critic/issues/926

--- a/internal/directory/azure/delta.go
+++ b/internal/directory/azure/delta.go
@@ -58,15 +58,12 @@ func newDeltaCollection(p *Provider) *deltaCollection {
 //
 // Only the changed groups/members are returned. Removed groups/members have an @removed property.
 func (dc *deltaCollection) Sync(ctx context.Context) error {
-	if err := dc.syncGroups(ctx); err != nil {
+	err := dc.syncGroups(ctx)
+	if err != nil {
 		return err
 	}
 
-	if err := dc.syncUsers(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return dc.syncUsers(ctx)
 }
 
 func (dc *deltaCollection) syncGroups(ctx context.Context) error {


### PR DESCRIPTION
## Summary
Apparently `golint` is deprecated, so use `revive` instead.

## Related issues
- https://github.com/pomerium/internal/issues/469

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
