### PR TITLE
urlutil: improve error message for urls with port in path

### DIFF
--- a/config/custom.go
+++ b/config/custom.go
@@ -18,6 +18,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/pomerium/pomerium/internal/httputil"
+	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
 // JWTClaimHeaders are headers to add to a request based on IDP claims.
@@ -215,7 +216,7 @@ func ParseWeightedURL(dst string) (*WeightedURL, error) {
 		return nil, err
 	}
 
-	u, err := url.Parse(to)
+	u, err := urlutil.ParseAndValidateURL(to)
 	if err != nil {
 		return nil, fmt.Errorf("%s: %w", to, err)
 	}

--- a/internal/urlutil/url.go
+++ b/internal/urlutil/url.go
@@ -39,6 +39,9 @@ func ParseAndValidateURL(rawurl string) (*url.URL, error) {
 	}
 	u, err := url.Parse(rawurl)
 	if err != nil {
+		if strings.Contains(err.Error(), "first path segment in URL cannot contain colon") {
+			err = fmt.Errorf("%w, have you specified protocol (ex: https)", err)
+		}
 		return nil, err
 	}
 	if err := ValidateURL(u); err != nil {

--- a/internal/urlutil/url_test.go
+++ b/internal/urlutil/url_test.go
@@ -48,6 +48,7 @@ func TestParseAndValidateURL(t *testing.T) {
 		{"bad hostname", "https://", nil, true},
 		{"bad parse", "https://^", nil, true},
 		{"empty string error", "", nil, true},
+		{"path segment", "192.168.0.1:1234/path", nil, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
Improve parse error message for URLs with port in path.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/1590

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
