### PR TITLE
evaluator: use `cryptutil.Hash` for script spans

### DIFF
--- a/authorize/evaluator/policy_evaluator.go
+++ b/authorize/evaluator/policy_evaluator.go
@@ -2,8 +2,6 @@ package evaluator
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -15,6 +13,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/policy"
 )
 
@@ -116,13 +115,9 @@ func NewPolicyEvaluator(ctx context.Context, store *Store, configPolicy *config.
 			return nil, err
 		}
 
-		h := sha256.New()
-		h.Write([]byte(script))
-		checksum := hex.EncodeToString(h.Sum(nil))
-
 		e.queries = append(e.queries, policyQuery{
 			PreparedEvalQuery: q,
-			checksum:          checksum,
+			checksum:          fmt.Sprintf("%x", cryptutil.Hash("script", []byte(script))),
 		})
 	}
 


### PR DESCRIPTION
## Summary

Use cryptutil's `Hash` the scripts to be consistent. 

This should be pretty darn fast, but would probably be fine to use something like `xxhash` via `cryptuil.MustHash` if it adds up. 

## Related issues

- #2383 


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
