### PR TITLE
directory: add logging http client to help with debugging outbound http requests

### DIFF
--- a/internal/databroker/server.go
+++ b/internal/databroker/server.go
@@ -226,7 +226,7 @@ func (srv *Server) ReleaseLease(ctx context.Context, req *databroker.ReleaseLeas
 func (srv *Server) RenewLease(ctx context.Context, req *databroker.RenewLeaseRequest) (*emptypb.Empty, error) {
 	_, span := trace.StartSpan(ctx, "databroker.grpc.RenewLease")
 	defer span.End()
-	log.Info(ctx).
+	log.Debug(ctx).
 		Str("peer", grpcutil.GetPeerAddr(ctx)).
 		Str("name", req.GetName()).
 		Str("id", req.GetId()).

--- a/internal/directory/azure/azure.go
+++ b/internal/directory/azure/azure.go
@@ -12,8 +12,10 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/rs/zerolog"
 	"golang.org/x/oauth2"
 
+	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
 
@@ -55,7 +57,10 @@ func WithLoginURL(loginURL *url.URL) Option {
 // WithHTTPClient sets the http client to use for requests to the Azure APIs.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httpClient
+		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+			func(evt *zerolog.Event) *zerolog.Event {
+				return evt.Str("provider", "azure")
+			})
 	}
 }
 

--- a/internal/directory/github/github.go
+++ b/internal/directory/github/github.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/tomnomnom/linkheader"
 
+	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
@@ -47,7 +48,10 @@ func WithServiceAccount(serviceAccount *ServiceAccount) Option {
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httpClient
+		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+			func(evt *zerolog.Event) *zerolog.Event {
+				return evt.Str("provider", "github")
+			})
 	}
 }
 

--- a/internal/directory/gitlab/gitlab.go
+++ b/internal/directory/gitlab/gitlab.go
@@ -14,6 +14,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/tomnomnom/linkheader"
 
+	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
@@ -45,7 +46,10 @@ func WithServiceAccount(serviceAccount *ServiceAccount) Option {
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httpClient
+		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+			func(evt *zerolog.Event) *zerolog.Event {
+				return evt.Str("provider", "azure")
+			})
 	}
 }
 

--- a/internal/directory/okta/okta.go
+++ b/internal/directory/okta/okta.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/tomnomnom/linkheader"
 
+	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
@@ -61,7 +62,10 @@ func WithBatchSize(batchSize int) Option {
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httpClient
+		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+			func(evt *zerolog.Event) *zerolog.Event {
+				return evt.Str("provider", "okta")
+			})
 	}
 }
 

--- a/internal/directory/onelogin/onelogin.go
+++ b/internal/directory/onelogin/onelogin.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 	"golang.org/x/oauth2"
 
+	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
@@ -43,7 +44,10 @@ func WithBatchSize(batchSize int) Option {
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httpClient
+		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+			func(evt *zerolog.Event) *zerolog.Event {
+				return evt.Str("provider", "onelogin")
+			})
 	}
 }
 

--- a/internal/directory/ping/config.go
+++ b/internal/directory/ping/config.go
@@ -6,7 +6,10 @@ import (
 	"net/url"
 	"strings"
 
+	"github.com/rs/zerolog"
+
 	"github.com/pomerium/pomerium/internal/encoding"
+	"github.com/pomerium/pomerium/internal/httputil"
 )
 
 type config struct {
@@ -44,7 +47,10 @@ func WithEnvironmentID(environmentID string) Option {
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httpClient
+		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+			func(evt *zerolog.Event) *zerolog.Event {
+				return evt.Str("provider", "ping")
+			})
 	}
 }
 

--- a/internal/httputil/client_test.go
+++ b/internal/httputil/client_test.go
@@ -21,5 +21,5 @@ func TestDefaultClient(t *testing.T) {
 	defer ts.Close()
 	req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
 	req = req.WithContext(requestid.WithValue(context.Background(), "foo"))
-	_, _ = DefaultClient.Do(req)
+	_, _ = defaultClient.Do(req)
 }

--- a/internal/identity/oauth/github/github.go
+++ b/internal/identity/oauth/github/github.go
@@ -134,7 +134,7 @@ func (p *Provider) userEmail(ctx context.Context, t *oauth2.Token, v interface{}
 	}
 	headers := map[string]string{"Authorization": fmt.Sprintf("token %s", t.AccessToken)}
 	emailURL := githubAPIURL + emailPath
-	err := httputil.Client(ctx, http.MethodGet, emailURL, version.UserAgent(), headers, nil, &response)
+	err := httputil.Do(ctx, http.MethodGet, emailURL, version.UserAgent(), headers, nil, &response)
 	if err != nil {
 		return err
 	}
@@ -169,7 +169,7 @@ func (p *Provider) userInfo(ctx context.Context, t *oauth2.Token, v interface{})
 		"Authorization": fmt.Sprintf("token %s", t.AccessToken),
 		"Accept":        "application/vnd.github.v3+json",
 	}
-	err := httputil.Client(ctx, http.MethodGet, p.userEndpoint, version.UserAgent(), headers, nil, &response)
+	err := httputil.Do(ctx, http.MethodGet, p.userEndpoint, version.UserAgent(), headers, nil, &response)
 	if err != nil {
 		return err
 	}

--- a/internal/identity/oidc/oidc.go
+++ b/internal/identity/oidc/oidc.go
@@ -251,7 +251,7 @@ func (p *Provider) Revoke(ctx context.Context, t *oauth2.Token) error {
 	params.Add("client_id", oa.ClientID)
 	params.Add("client_secret", oa.ClientSecret)
 
-	err = httputil.Client(ctx, http.MethodPost, p.RevocationURL, version.UserAgent(), nil, params, nil)
+	err = httputil.Do(ctx, http.MethodPost, p.RevocationURL, version.UserAgent(), nil, params, nil)
 	if err != nil && errors.Is(err, httputil.ErrTokenRevoked) {
 		return fmt.Errorf("internal/oidc: unexpected revoke error: %w", err)
 	}

--- a/pkg/grpc/databroker/leaser.go
+++ b/pkg/grpc/databroker/leaser.go
@@ -97,7 +97,7 @@ func (locker *Leaser) runOnce(ctx context.Context, resetBackoff func()) error {
 	resetBackoff()
 	leaseID := res.Id
 
-	log.Info(ctx).
+	log.Debug(ctx).
 		Str("lease_name", locker.leaseName).
 		Str("lease_id", leaseID).
 		Msg("leaser: lease acquired")
@@ -136,7 +136,7 @@ func (locker *Leaser) withLease(ctx context.Context, leaseID string) error {
 				Duration: durationpb.New(locker.ttl),
 			})
 			if status.Code(err) == codes.AlreadyExists {
-				log.Info(ctx).
+				log.Debug(ctx).
 					Str("lease_name", locker.leaseName).
 					Str("lease_id", leaseID).
 					Msg("leaser: lease lost")


### PR DESCRIPTION
## Summary
Add a new logging http transport that the directory providers can use.

## Related issues
Fixes #2382 

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
