### PR TITLE
symlink security policy to root of project

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,1 @@
+docs/docs/community/security.md

--- a/docs/docs/community/security.md
+++ b/docs/docs/community/security.md
@@ -123,7 +123,7 @@ This process can take some time. Every effort will be made to handle the bug in 
 
 ## Reporting a Security Bug
 
-If you believe you've found a security vulnerability in Pomerium, please notify us; we will work with you to resolve the issue promptly. Thank you for helping to keep Pomerium and our users safe! We deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
+If you believe you've found a security vulnerability in Pomerium, please notify us; we will work with you to resolve the issue promptly. Thank you for helping to keep Pomerium and our users safe! Though at this time we do not have a paid bug bounty program, we deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
 
 All security bugs in Pomerium should be reported by email to security@pomerium.com . Your email will be acknowledged within 48 hours, and you'll receive a more detailed response to your email within 72 hours indicating the next steps in handling your report.
 


### PR DESCRIPTION
## Summary

Symlink the security policy in our docs so that Github recognizes it. 


## Checklist

- [x] updated docs
- [x] ready for review
