### PR TITLE
config: add support for embedded PPL policy

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -36,4 +36,5 @@ var ViperPolicyHooks = viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 	DecodePolicyBase64Hook(),
 	decodeJWTClaimHeadersHookFunc(),
 	decodeCodecTypeHookFunc(),
+	decodePPLPolicyHookFunc(),
 ))

--- a/config/policy.go
+++ b/config/policy.go
@@ -161,6 +161,8 @@ type Policy struct {
 
 	// SetResponseHeaders sets response headers.
 	SetResponseHeaders map[string]string `mapstructure:"set_response_headers" yaml:"set_response_headers,omitempty"`
+
+	Policy *PPLPolicy `mapstructure:"policy" yaml:"policy,omitempty" json:"policy,omitempty"`
 }
 
 // RewriteHeader is a policy configuration option to rewrite an HTTP header.

--- a/config/policy_ppl.go
+++ b/config/policy_ppl.go
@@ -99,5 +99,10 @@ func (p *Policy) ToPPL() *parser.Policy {
 		})
 	ppl.Rules = append(ppl.Rules, denyRule)
 
+	// append embedded PPL policy rules
+	if p.Policy != nil && p.Policy.Policy != nil {
+		ppl.Rules = append(ppl.Rules, p.Policy.Policy.Rules...)
+	}
+
 	return ppl
 }

--- a/config/policy_ppl_test.go
+++ b/config/policy_ppl_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/pkg/policy"
+	"github.com/pomerium/pomerium/pkg/policy/parser"
 )
 
 func TestPolicy_ToPPL(t *testing.T) {
@@ -36,6 +37,19 @@ func TestPolicy_ToPPL(t *testing.T) {
 				AllowedIDPClaims: map[string][]interface{}{
 					"timezone": {"EST"},
 				},
+			},
+		},
+		Policy: &PPLPolicy{
+			Policy: &parser.Policy{
+				Rules: []parser.Rule{{
+					Action: parser.ActionAllow,
+					Or: []parser.Criterion{{
+						Name: "user",
+						Data: parser.Object{
+							"is": parser.String("user6"),
+						},
+					}},
+				}},
 			},
 		},
 	}).ToPPL())
@@ -469,9 +483,26 @@ else = v28 {
 	v28
 }
 
+users_5 {
+	session := get_session(input.session.id)
+	user := get_user(session)
+	user_id := user.id
+	user_id == "user6"
+}
+
+or_1 = v1 {
+	v1 := users_5
+	v1
+}
+
 allow = v1 {
 	v1 := or_0
 	v1
+}
+
+else = v2 {
+	v2 := or_1
+	v2
 }
 
 invalid_client_certificate_0 = reason {
@@ -480,13 +511,13 @@ invalid_client_certificate_0 = reason {
 	not input.is_valid_client_certificate
 }
 
-or_1 = v1 {
+or_2 = v1 {
 	v1 := invalid_client_certificate_0
 	v1
 }
 
 deny = v1 {
-	v1 := or_1
+	v1 := or_2
 	v1
 }
 

--- a/internal/httputil/reproxy/reproxy.go
+++ b/internal/httputil/reproxy/reproxy.go
@@ -29,13 +29,13 @@ type Handler struct {
 	mu       sync.RWMutex
 	key      []byte
 	options  *config.Options
-	policies map[uint64]*config.Policy
+	policies map[uint64]config.Policy
 }
 
 // New creates a new Handler.
 func New() *Handler {
 	h := new(Handler)
-	h.policies = make(map[uint64]*config.Policy)
+	h.policies = make(map[uint64]config.Policy)
 	return h
 }
 
@@ -120,7 +120,7 @@ func (h *Handler) Middleware(next http.Handler) http.Handler {
 
 		h := stdhttputil.NewSingleHostReverseProxy(&dst)
 		h.ErrorLog = stdlog.New(log.Logger(), "", 0)
-		h.Transport = config.NewPolicyHTTPTransport(options, policy, disableHTTP2)
+		h.Transport = config.NewPolicyHTTPTransport(options, &policy, disableHTTP2)
 		h.ServeHTTP(w, r)
 		return nil
 	})
@@ -133,14 +133,14 @@ func (h *Handler) Update(ctx context.Context, cfg *config.Config) {
 
 	h.key, _ = cfg.Options.GetSharedKey()
 	h.options = cfg.Options
-	h.policies = make(map[uint64]*config.Policy)
-	for i, p := range cfg.Options.Policies {
+	h.policies = make(map[uint64]config.Policy)
+	for _, p := range cfg.Options.GetAllPolicies() {
 		id, err := p.RouteID()
 		if err != nil {
 			log.Warn(ctx).Err(err).Msg("reproxy: error getting route id")
 			continue
 		}
-		h.policies[id] = &cfg.Options.Policies[i]
+		h.policies[id] = p
 	}
 }
 


### PR DESCRIPTION
## Summary
Add support for embedded PPL policy. Also add an additional `policy` field in the config: `routes`.

## Related issues
Fixes https://github.com/pomerium/internal/issues/480

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
