### PR TITLE
docs: only secure schemes are supported

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1190,7 +1190,7 @@ Specifying `tcp+https` for the scheme enables [TCP proxying](../docs/topics/tcp-
 
 :::warning
 
-Only secure schemes (`https` and `tcp+https`) are supported. 
+Only secure schemes (`https` and `tcp+https`) are supported.
 
 :::
 

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1188,6 +1188,12 @@ Requires setting [Google Cloud Serverless Authentication Service Account](./#goo
 
 Specifying `tcp+https` for the scheme enables [TCP proxying](../docs/topics/tcp-support.md) support for the route. You may map more than one port through the same hostname by specifying a different `:port` in the URL.
 
+:::warning
+
+Only secure schemes (`https` and `tcp+https`) are supported. 
+
+:::
+
 
 ### Kubernetes Service Account Token
 - `yaml`/`json` setting: `kubernetes_service_account_token` / `kubernetes_service_account_token_file`

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -1313,6 +1313,12 @@ settings:
           `From` is the externally accessible URL for the proxied request.
 
           Specifying `tcp+https` for the scheme enables [TCP proxying](../docs/topics/tcp-support.md) support for the route. You may map more than one port through the same hostname by specifying a different `:port` in the URL.
+
+          :::warning
+
+          Only secure schemes (`https` and `tcp+https`) are supported.
+
+          :::
       - name: "Kubernetes Service Account Token"
         keys:
           [


### PR DESCRIPTION

## Summary

Add warning that only secure schemes are supported for security reasons (otherwise credentials / cookies could be easily MITM'd). 

## Related issues

https://pomerium-io.slack.com/archives/CK92MUAES/p1627615869000100?thread_ts=1627567572.143500&cid=CK92MUAES



## Checklist

- [x] updated docs
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
