### PR TITLE
authorize: add sid to JWT claims

### DIFF
--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -12,10 +12,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/pomerium/pomerium/pkg/grpc/session"
-
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
 )
 
 func TestHeadersEvaluator(t *testing.T) {

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
@@ -41,10 +43,16 @@ func TestHeadersEvaluator(t *testing.T) {
 
 	t.Run("jwt", func(t *testing.T) {
 		output, err := eval(t,
-			[]proto.Message{},
+			[]proto.Message{
+				&session.Session{Id: "s1", ImpersonateSessionId: proto.String("s2")},
+				&session.Session{Id: "s2"},
+			},
 			&HeadersRequest{
 				FromAudience: "from.example.com",
 				ToAudience:   "to.example.com",
+				Session: RequestSession{
+					ID: "s1",
+				},
 			})
 		require.NoError(t, err)
 
@@ -56,8 +64,8 @@ func TestHeadersEvaluator(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, claims["exp"], math.Round(claims["exp"].(float64)))
-
 		assert.LessOrEqual(t, claims["exp"], float64(time.Now().Add(time.Minute*6).Unix()),
 			"JWT should expire within 5 minutes, but got: %v", claims["exp"])
+		assert.Equal(t, "s1", claims["sid"], "should set session id to input session id")
 	})
 }

--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -139,6 +139,9 @@ jwt_payload_groups = v {
 	true
 }
 
+# the session id is always set to the input session id, even if impersonating
+jwt_payload_sid := input.session.id
+
 base_jwt_claims := [
 	["iss", jwt_payload_iss],
 	["aud", jwt_payload_aud],
@@ -149,6 +152,7 @@ base_jwt_claims := [
 	["user", jwt_payload_user],
 	["email", jwt_payload_email],
 	["groups", jwt_payload_groups],
+	["sid", jwt_payload_sid]
 ]
 
 additional_jwt_claims := [[k, v] |


### PR DESCRIPTION
## Summary
Add a new `sid` claim to the assertion JWT. This can be used by applications to determine the session of the user. It's different from the `jti` in that the `sid` is always set to the input session id, regardless of impersonation.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/1770

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
