### PR TITLE
redis: increase timeout on test

### DIFF
--- a/pkg/storage/redis/redis_test.go
+++ b/pkg/storage/redis/redis_test.go
@@ -124,12 +124,10 @@ func TestChangeSignal(t *testing.T) {
 	}
 
 	ctx := context.Background()
-	ctx, clearTimeout := context.WithTimeout(ctx, time.Second*10)
-	defer clearTimeout()
-	ctx, cancel := context.WithCancel(ctx)
-	defer cancel()
-
 	require.NoError(t, testutil.WithTestRedis(false, func(rawURL string) error {
+		ctx, clearTimeout := context.WithTimeout(ctx, time.Second*30)
+		defer clearTimeout()
+
 		ready := make(chan struct{})
 		var eg errgroup.Group
 		eg.Go(func() error {


### PR DESCRIPTION
## Summary
I'm hoping this PR fixes our test flakiness with redis.

Move the context timeout to inside the redis cluster start so if we have to pull the docker image down it doesn't count to the timeout. Also increase it a bit.

## Related issues
Fixes #2424 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
