### PR TITLE
docs: clarify device identity, not state via client certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Pomerium is an identity-aware proxy that enables secure access to internal appli
 Pomerium can be used to:
 
 - provide a **single-sign-on gateway** to internal applications.
-- enforce **dynamic access policy** based on **context**, **identity**, and **device state**.
+- enforce **dynamic access policy** based on **context**, **identity**, and **device identity**.
 - aggregate access logs and telemetry data.
 - a **VPN alternative**.
 

--- a/docs/docs/readme.md
+++ b/docs/docs/readme.md
@@ -18,7 +18,7 @@ Pomerium is an identity-aware proxy that enables secure access to internal appli
 Pomerium can be used to:
 
 - provide a **single-sign-on gateway** to internal applications.
-- enforce **dynamic access policy** based on **context**, **identity**, and **device state**.
+- enforce **dynamic access policy** based on **context**, **identity**, and **device identity**.
 - aggregate access logs and telemetry data.
 - perform delegated user authorization for service-based authorization systems:
   - [Istio](/guides/istio.md)


### PR DESCRIPTION
## Summary
 
Clarify that device state is really device identity via client certificates for the moment. Proper device state context coming in future integrations. 

## Related issues

- Fixes #2283 
- Related #1835 
- https://github.com/pomerium/pomerium/pull/2280#issuecomment-858283296

## Checklist

- [x] reference any related issues
- [x] updated docs
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
