### PR TITLE
config: remove support for ed25519 signing keys

### DIFF
--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -9,7 +9,14 @@ description: >-
 
 ## Breaking
 
+### Removed GRPC Server Max Connection Age Options
+
 The unused `grpc_server_max_connection_age` and `grpc_server_max_connection_age_grace` options were removed.
+
+### Removed support for Ed25519 Signing Keys
+
+Ed25519 is no longer supported for `signing_key` since OPA Rego only supports ECDSA and RSA.
+
 ## New
 
 ### Updated and expanded policy syntax

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1680,12 +1680,12 @@ If no certificate is specified, one will be generated and the base64'd public ke
 - Environmental Variable: `SIGNING_KEY_ALGORITHM`
 - Config File Key: `signing_key_algorithm`
 - Type: `string`
-- Options: `ES256` or `EdDSA` or `RS256`
+- Options: `ES256` or `RS256`
 - Default: `ES256`
 
 This setting specifies which signing algorithm to use when signing the upstream attestation JWT. Cryptographic algorithm choice is subtle, and beyond the scope of this document, but we suggest sticking to the default `ES256` unless you have a good reason to use something else.
 
-Be aware that any RSA based signature method may be an order of magnitude lower than [elliptic curve] variants like EdDSA (`ed25519`) and ECDSA (`ES256`). For more information, checkout [this article](https://www.scottbrady91.com/JOSE/JWTs-Which-Signing-Algorithm-Should-I-Use).
+Be aware that any RSA based signature method may be an order of magnitude lower than [elliptic curve] variants like ECDSA (`ES256`). For more information, checkout [this article](https://www.scottbrady91.com/JOSE/JWTs-Which-Signing-Algorithm-Should-I-Use).
 
 
 [base64 encoded]: https://en.wikipedia.org/wiki/Base64

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -1825,11 +1825,11 @@ settings:
           - Environmental Variable: `SIGNING_KEY_ALGORITHM`
           - Config File Key: `signing_key_algorithm`
           - Type: `string`
-          - Options: `ES256` or `EdDSA` or `RS256`
+          - Options: `ES256` or `RS256`
           - Default: `ES256`
         doc: |
           This setting specifies which signing algorithm to use when signing the upstream attestation JWT. Cryptographic algorithm choice is subtle, and beyond the scope of this document, but we suggest sticking to the default `ES256` unless you have a good reason to use something else.
 
-          Be aware that any RSA based signature method may be an order of magnitude lower than [elliptic curve] variants like EdDSA (`ed25519`) and ECDSA (`ES256`). For more information, checkout [this article](https://www.scottbrady91.com/JOSE/JWTs-Which-Signing-Algorithm-Should-I-Use).
+          Be aware that any RSA based signature method may be an order of magnitude lower than [elliptic curve] variants like ECDSA (`ES256`). For more information, checkout [this article](https://www.scottbrady91.com/JOSE/JWTs-Which-Signing-Algorithm-Should-I-Use).
         shortdoc: |
           Signing Key Algorithm is the algorithm used to sign a user's attestation JWT.

--- a/pkg/cryptutil/jose.go
+++ b/pkg/cryptutil/jose.go
@@ -3,7 +3,6 @@ package cryptutil
 import (
 	"crypto"
 	"crypto/ecdsa"
-	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/hex"
@@ -75,8 +74,6 @@ func loadPublicKey(b []byte) (interface{}, error) {
 		case *rsa.PrivateKey:
 			return k.Public(), nil
 		case *ecdsa.PrivateKey:
-			return k.Public(), nil
-		case ed25519.PrivateKey: // note, not a pointer
 			return k.Public(), nil
 		default:
 			return nil, fmt.Errorf("private key is unsupported type")

--- a/pkg/cryptutil/jose_test.go
+++ b/pkg/cryptutil/jose_test.go
@@ -81,14 +81,6 @@ func TestPublicJWKFromBytes(t *testing.T) {
 			false,
 		},
 		{
-			"good ed25519",
-			"LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1DNENBUUF3QlFZREsyVndCQ0lFSUZiNDN6SkVqblMvOHdxZVMwRlhiNDNWdlV5ZmhRL3UvWGd3UVV2bDVnaloKLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQo=",
-			jose.EdDSA,
-			`{"use":"sig","kty":"OKP","kid":"9935c8811af93ab090d1cd943e4f1e67ed2a41d630797a8c33f2fb7c4f476a1e","crv":"Ed25519","alg":"EdDSA","x":"xsg1A67wECXAmRnSib8lSsgatcNcYm7vvspQnocPQNc"}`,
-			false,
-		},
-
-		{
 			"bad key decode",
 			"LS0t",
 			jose.RS256,

--- a/scripts/generate_self_signed_signing_key.sh
+++ b/scripts/generate_self_signed_signing_key.sh
@@ -19,8 +19,3 @@ openssl req \
 # uncomment if you want RSA / RS256
 # openssl genpkey -algorithm RSA -out rsa_private.pem -pkeyopt rsa_keygen_bits:2048
 # openssl req -x509 -nodes -newkey rsa:2048 -keyout rsa_private.pem -out rsa_cert.pem -subj "/CN=unused"
-
-# uncomment if you want EdDSA / Ed25519
-# openssl is /usr/local/opt/openssl/bin/openssl on mac with brew otherwise it is libressl
-# openssl genpkey -algorithm ED25519 -out ed25519_private.pem
-# openssl req -x509 -new -key ed25519_private.pem -days 1000000 -out ed25519_public.pem -subj "/CN=unused"


### PR DESCRIPTION
## Summary
Remove support for ed25519 signing keys.

## Related issues
- Fixes https://github.com/pomerium/internal/issues/491
- https://www.openpolicyagent.org/docs/latest/policy-reference/#token-signing
- https://pomerium-com.slack.com/archives/C012D1Q96TX/p1628031934062500
- https://github.com/pomerium/pomerium/issues/1626
- https://pomerium-io.slack.com/archives/CK92MUAES/p1606498282249300
- https://github.com/pomerium/pomerium/pull/1631
- https://github.com/pomerium/pomerium-console/issues/434

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
