### PR TITLE
docs/reference: Clarify use of idp_service_account

### DIFF
--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -807,7 +807,7 @@ settings:
           - Type: `string`
           - **Required** for group based policies (most configurations)
         doc: |
-          The identity provider service account setting is used to query associated identity information from your identity provider.
+          The identity provider service account setting is used to query associated identity information from your identity provider.  This is a provider specific value and is not required for all providers.  For example, when using Okta this value will be an Okta API key, and for an OIDC provider that provides groups as a claim, this value will be empty.
 
           :::warning
 


### PR DESCRIPTION
This PR clarifies the use of the `idp_service_account` value which is
not used in all cases, though the warning callout suggests it is
required in all cases.
