### PR TITLE
docs: update default version to v0.15

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -49,7 +49,7 @@ module.exports = {
         ariaLabel: "Version menu",
         items: [
           { text: "🚧Dev", link: "https://master.docs.pomerium.io/docs" },
-          { text: "v0.15.x", link: "https://0-14-0.docs.pomerium.io/docs" },
+          { text: "v0.15.x", link: "https://0-15-0.docs.pomerium.io/docs" },
           { text: "v0.14.x", link: "https://0-14-0.docs.pomerium.io/docs" },
           { text: "v0.13.x", link: "https://0-13-0.docs.pomerium.io/docs" },
           { text: "v0.12.x", link: "https://0-12-0.docs.pomerium.io/docs" },

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -45,10 +45,11 @@ module.exports = {
         link: "/enterprise/about/",
       },
       {
-        text: "v0.14.x", // current tagged version
+        text: "v0.15.x", // current tagged version
         ariaLabel: "Version menu",
         items: [
           { text: "🚧Dev", link: "https://master.docs.pomerium.io/docs" },
+          { text: "v0.15.x", link: "https://0-14-0.docs.pomerium.io/docs" },
           { text: "v0.14.x", link: "https://0-14-0.docs.pomerium.io/docs" },
           { text: "v0.13.x", link: "https://0-13-0.docs.pomerium.io/docs" },
           { text: "v0.12.x", link: "https://0-12-0.docs.pomerium.io/docs" },


### PR DESCRIPTION
## Summary

Update vuepress config to default to v0.15.

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
