### PR TITLE
redirect logo to the marketing site

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -229,4 +229,31 @@ module.exports = {
       ],
     },
   },
+  head: [
+    //Hack: Make clicking on the logo go to home url
+    ["script",
+      {},
+      `
+      const logoUrlChanger = setInterval(function() {
+      //Anchor above the logo image
+      const homeEls = document.getElementsByClassName("home-link");
+      if(homeEls.length > 0) {
+        const homeEl = homeEls[0];
+        homeEl.setAttribute("href", "https://www.pomerium.com");
+        homeEl.setAttribute("onclick", "document.location='https://www.pomerium.com';return false;");
+        clearInterval(logoUrlChanger);
+      }
+
+      //Actual logo image
+      const logoEls = document.getElementsByClassName("logo")
+      if(logoEls.length > 0) {
+        const logoEl = logoEls[0]
+        logoEl.setAttribute("onclick", "document.location='https://www.pomerium.com';return false;");
+        clearInterval(logoUrlChanger);
+      }
+      }, 1000)
+
+      `
+    ]
+  ],
 };


### PR DESCRIPTION
## Summary

This brings users back to the marketing site when they click on the Pomerium logo.

## Checklist

- [ ] reference any related issues
- [X] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
