### PR TITLE
specify expected audience in Console config

### DIFF
--- a/docs/enterprise/install/helm.md
+++ b/docs/enterprise/install/helm.md
@@ -101,6 +101,7 @@ This setup assumes an existing certificate solution using cert-manager, as descr
      databaseEncryptionKey:  #Generate from "head -c32 /dev/urandom | base64"
      administrators: "youruser@yourcompany.com" #This is a hard-coded access, remove once setup is complete
      signing_key: "ZZZZZZZ" #This base64-encoded key is shared with open-source Pomerium
+     audience: console.localhost.pomerium.com # This should match the "from" value in your Pomerium route, excluding protocol.
    tls:
      existingCASecret: pomerium-tls
      caSecretKey: ca.crt

--- a/docs/enterprise/install/quickstart.md
+++ b/docs/enterprise/install/quickstart.md
@@ -158,7 +158,7 @@ administrators: you@mydomain.com
 
 Once you have set permissions in the console UI, you should remove this configuration.
 
-### TLS and Signing Key
+### TLS, Signing Key and Audience
 
 1. If your open-source Pomerium installation is already configured to use TLS to secure back-end communication, you can do the same for the Pomerium Enterprise Console by providing it a certificate, key, and optional custom CA file to validate the `databroker_service_url` connection:
 
@@ -171,6 +171,14 @@ Once you have set permissions in the console UI, you should remove this configur
    For proof-of-concept installations in the same local system, this is not required.
 
 1. Set the [`signing_key`](/enterprise/reference/config.md#signing-key) to match Pomerium's.
+
+1. Set the `audience` key to match the `from` domain value from your [Pomerium configuration](#update-pomerium), excluding protocol:
+
+   ```yaml
+   audience: console.localhost.pomerium.com
+   ```
+
+   This sets the expected "audience" key in the [JWT header](/reference/#jwt-claim-headers) to match what's provided by open-source Pomerium as it proxies traffic to the Enterprise Console UI.
 
 Once complete, your `/etc/pomerium-console/config.yaml` file should look something like this:
 
@@ -188,6 +196,8 @@ tls_cert_file: /etc/pomerium-console/cert.pem
 tls_key_file: /etc/pomerium-console/key.pem
 
 signing_key: "ZZZZZZZZZZZZZZ"
+
+audience: console.localhost.pomerium.com
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Summary

Updates the config for Pomerium Console in both install docs to set the `audience` key to match the domain set as `from` in the route to the console.

## Related issues

https://github.com/pomerium/pomerium-console/issues/1797

## Checklist

- [X] reference any related issues
- [X] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [X] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
