### PR TITLE
fix go get, improve redis test

### DIFF
--- a/pomerium.go
+++ b/pomerium.go
@@ -1,0 +1,2 @@
+// Package pomerium is the root of the pomerium project.
+package pomerium


### PR DESCRIPTION
## Summary
When we added `tools.go` it caused a plain `go get github.com/pomerium/pomerium` to fail because no build constraints matched. This PR adds a blank non-constrained file so that `go get` works again.

```
† go get github.com/pomerium/pomerium@36c2c9b0afe2b659df76610e3690327b3ab5067a
go: downloading github.com/pomerium/pomerium v0.15.1-0.20210806171735-36c2c9b0afe2
go get: upgraded github.com/pomerium/pomerium v0.15.1-0.20210806144600-1e03b0fac135 => v0.15.1-0.20210806171735-36c2c9b0afe2
```

This also includes changes to the redis tests (again). I realized there's a race condition between triggering `ready` and actually having started subscribing to events. So now we'll just call Put multiple times till it gets the event.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
