### PR TITLE
Document moving routes

### DIFF
--- a/docs/enterprise/concepts.md
+++ b/docs/enterprise/concepts.md
@@ -108,7 +108,7 @@ This term refers to the system or service the route provides or restricts access
 
 ### Moving Routes
 
-When moving a Route from one [Namespace](#namespace) to another, enforced policies will automatically be removed or applied. Optional policies available in the source Namespace but not the target will prevent the move. This is intentional, to prevent unassociated policies.
+When moving a Route from one [Namespace](#namespace) to another, enforced policies will automatically be removed or applied. Optional policies available in the source Namespace but not the target will prevent the move. This is intentional to prevent unassociated policies.
 
 ## Policies
 

--- a/docs/enterprise/concepts.md
+++ b/docs/enterprise/concepts.md
@@ -1,6 +1,6 @@
 ---
 title: Concepts
-sidebarDepth: 2
+sidebarDepth: 1
 description: Learn how Pomerium Enterprise works.
 ---
 
@@ -105,6 +105,10 @@ Routes define the connection pathway and configuration from the internet to your
 ### Protected Endpoints
 
 This term refers to the system or service the route provides or restricts access to.
+
+### Moving Routes
+
+When moving a Route from one [Namespace](#namespace) to another, enforced policies will automatically be removed or applied. Optional policies available in the source Namespace but not the target will prevent the move. This is intentional, to prevent unassociated policies.
 
 ## Policies
 


### PR DESCRIPTION
## Summary

Adds a new section to Concepts describing how associated policies could prevent routes from being moved.

## Related issues

https://github.com/pomerium/pomerium-console/pull/1865

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
