### PR TITLE
Document tracing sample rate in console

### DIFF
--- a/docs/enterprise/console-settings.yaml
+++ b/docs/enterprise/console-settings.yaml
@@ -211,7 +211,7 @@ settings:
             settings:
               - name: "Tracing Sample Rate"
                 doc: |
-                  Percentage of requests to sample in decimal notation. Default is .01%.
+                  Percentage of requests to sample. Default is .01%.
 
                   Unlike the decimal value notion used for the `tracing_sample_rate` [key](/reference/readme.md#shared-tracing-settings) in open-source Pomerium, this value is a percentage, e.g. a value of `1` equates to 1%
           - name: "Authenticate"

--- a/docs/enterprise/console-settings.yaml
+++ b/docs/enterprise/console-settings.yaml
@@ -204,6 +204,16 @@ settings:
 
                   See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters (opens new window)for details
           - name: "Tracing"
+            doc: |
+              Tracing tracks the progression of a single user request as it is handled by Pomerium.
+
+              Each unit of work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
+            settings:
+              - name: "Tracing Sample Rate"
+                doc: |
+                  Percentage of requests to sample in decimal notation. Default is .01%.
+
+                  Unlike the decimal value notion used for the `tracing_sample_rate` [key](/reference/readme.md#shared-tracing-settings) in open-source Pomerium, this value is a percentage, e.g. a value of `1` equates to 1%
           - name: "Authenticate"
           - name: "Proxy"
             settings:

--- a/docs/enterprise/reference/configure.md
+++ b/docs/enterprise/reference/configure.md
@@ -189,53 +189,15 @@ See https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters (opens n
 
 Tracing tracks the progression of a single user request as it is handled by Pomerium.
 
-Each unit work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
+Each unit of work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
 
-#### Shared Tracing Settings
 
-Config Key          | Description                                                                          | Required
-:------------------ | :----------------------------------------------------------------------------------- | --------
-tracing_provider    | The name of the tracing provider. (e.g. jaeger, zipkin)                              | ✅
-tracing_sample_rate | Percentage of requests to sample in decimal notation. Default is `0.0001`, or `.01%` | ❌
+#### Tracing Sample Rate
 
-#### Datadog
+Percentage of requests to sample in decimal notation. Default is .01%.
 
-Datadog is a real-time monitoring system that supports distributed tracing and monitoring.
+Unlike the decimal value notion used for the `tracing_sample_rate` [key](/reference/readme.md#shared-tracing-settings) in open-source Pomerium, this value is a percentage, e.g. a value of `1` equates to 1%
 
-Config Key              | Description                                                                  | Required
-:---------------------- | :--------------------------------------------------------------------------- | --------
-tracing_datadog_address | `host:port` address of the Datadog Trace Agent. Defaults to `localhost:8126` | ❌
-
-#### Jaeger (partial)
-
-**Warning** At this time, Jaeger protocol does not capture spans inside the proxy service. Please use Zipkin protocol with Jaeger for full support.
-
-[Jaeger](https://www.jaegertracing.io/) is a distributed tracing system released as open source by Uber Technologies. It is used for monitoring and troubleshooting microservices-based distributed systems, including:
-
-- Distributed context propagation
-- Distributed transaction monitoring
-- Root cause analysis
-- Service dependency analysis
-- Performance / latency optimization
-
-Config Key                        | Description                                 | Required
-:-------------------------------- | :------------------------------------------ | --------
-tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅
-tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅
-
-#### Zipkin
-
-Zipkin is an open source distributed tracing system and protocol.
-
-Many tracing backends support zipkin either directly or through intermediary agents, including Jaeger. For full tracing support, we recommend using the Zipkin tracing protocol.
-
-Config Key              | Description                      | Required
-:---------------------- | :------------------------------- | --------
-tracing_zipkin_endpoint | Url to the Zipkin HTTP endpoint. | ✅
-
-#### Example
-
-![jaeger example trace](./img/jaeger.png)
 
 ### Authenticate
 

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -639,14 +639,14 @@ settings:
         doc: |
           Tracing tracks the progression of a single user request as it is handled by Pomerium.
 
-          Each unit work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
+          Each unit of work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
 
           #### Shared Tracing Settings
 
           Config Key          | Description                                                                          | Required
           :------------------ | :----------------------------------------------------------------------------------- | --------
           tracing_provider    | The name of the tracing provider. (e.g. jaeger, zipkin)                              | ✅
-          tracing_sample_rate | Percentage of requests to sample in decimal notation. Default is `0.0001`, or `.01%` | ❌
+          tracing_sample_rate | Percentage of requests to sample in decimal notation. Default is `0.0001`, or .01%   | ❌
 
           #### Datadog
 


### PR DESCRIPTION
## Summary

Documents Tracing Sample Rate notation in the Console, which is different from the OSS key.

## Related issues

Closes https://github.com/pomerium/pomerium-console/issues/1159

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
