### PR TITLE
protoutil: add NewAny method for deterministic serialization

### DIFF
--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/config"
@@ -23,6 +22,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 func TestEvaluator(t *testing.T) {
@@ -480,7 +480,7 @@ func BenchmarkEvaluator_Evaluate(b *testing.B) {
 		sessionID := uuid.New().String()
 		lastSessionID = sessionID
 		userID := uuid.New().String()
-		data, _ := anypb.New(&session.Session{
+		data := protoutil.NewAny(&session.Session{
 			Version: fmt.Sprint(i),
 			Id:      sessionID,
 			UserId:  userID,
@@ -501,7 +501,7 @@ func BenchmarkEvaluator_Evaluate(b *testing.B) {
 			Id:      sessionID,
 			Data:    data,
 		})
-		data, _ = anypb.New(&user.User{
+		data = protoutil.NewAny(&user.User{
 			Version: fmt.Sprint(i),
 			Id:      userID,
 		})
@@ -512,7 +512,7 @@ func BenchmarkEvaluator_Evaluate(b *testing.B) {
 			Data:    data,
 		})
 
-		data, _ = anypb.New(&directory.User{
+		data = protoutil.NewAny(&directory.User{
 			Version:  fmt.Sprint(i),
 			Id:       userID,
 			GroupIds: []string{"1", "2", "3", "4"},
@@ -524,7 +524,7 @@ func BenchmarkEvaluator_Evaluate(b *testing.B) {
 			Data:    data,
 		})
 
-		data, _ = anypb.New(&directory.Group{
+		data = protoutil.NewAny(&directory.Group{
 			Version: fmt.Sprint(i),
 			Id:      fmt.Sprint(i),
 		})

--- a/authorize/evaluator/store.go
+++ b/authorize/evaluator/store.go
@@ -15,13 +15,13 @@ import (
 	"github.com/open-policy-agent/opa/storage/inmem"
 	"github.com/open-policy-agent/opa/types"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 type dataBrokerData struct {
@@ -102,11 +102,7 @@ func NewStore() *Store {
 func NewStoreFromProtos(serverVersion uint64, msgs ...proto.Message) *Store {
 	s := NewStore()
 	for _, msg := range msgs {
-		any, err := anypb.New(msg)
-		if err != nil {
-			continue
-		}
-
+		any := protoutil.NewAny(msg)
 		record := new(databroker.Record)
 		record.ModifiedAt = timestamppb.Now()
 		record.Version = cryptutil.NewRandomUInt64()

--- a/authorize/evaluator/store_test.go
+++ b/authorize/evaluator/store_test.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 func TestStore(t *testing.T) {
@@ -20,7 +20,7 @@ func TestStore(t *testing.T) {
 			Name:    "name",
 			Email:   "name@example.com",
 		}
-		any, _ := anypb.New(u)
+		any := protoutil.NewAny(u)
 		s.UpdateRecord(0, &databroker.Record{
 			Version: 1,
 			Type:    any.GetTypeUrl(),

--- a/authorize/sync_test.go
+++ b/authorize/sync_test.go
@@ -11,12 +11,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 func TestAuthorize_waitForRecordSync(t *testing.T) {
@@ -103,10 +103,7 @@ type storableMessage interface {
 }
 
 func newRecord(msg storableMessage) *databroker.Record {
-	any, err := anypb.New(msg)
-	if err != nil {
-		panic(err)
-	}
+	any := protoutil.NewAny(msg)
 	return &databroker.Record{
 		Version: 1,
 		Type:    any.GetTypeUrl(),

--- a/config/envoyconfig/tracing.go
+++ b/config/envoyconfig/tracing.go
@@ -7,11 +7,11 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_config_trace_v3 "github.com/envoyproxy/go-control-plane/envoy/config/trace/v3"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 func buildTracingCluster(options *config.Options) (*envoy_config_cluster_v3.Cluster, error) {
@@ -102,7 +102,7 @@ func buildTracingHTTP(options *config.Options) (*envoy_config_trace_v3.Tracing_H
 
 	switch tracingOptions.Provider {
 	case trace.DatadogTracingProviderName:
-		tracingTC, _ := anypb.New(&envoy_config_trace_v3.DatadogConfig{
+		tracingTC := protoutil.NewAny(&envoy_config_trace_v3.DatadogConfig{
 			CollectorCluster: "datadog-apm",
 			ServiceName:      tracingOptions.Service,
 		})
@@ -117,7 +117,7 @@ func buildTracingHTTP(options *config.Options) (*envoy_config_trace_v3.Tracing_H
 		if path == "" {
 			path = "/"
 		}
-		tracingTC, _ := anypb.New(&envoy_config_trace_v3.ZipkinConfig{
+		tracingTC := protoutil.NewAny(&envoy_config_trace_v3.ZipkinConfig{
 			CollectorCluster:         "zipkin",
 			CollectorEndpoint:        path,
 			CollectorEndpointVersion: envoy_config_trace_v3.ZipkinConfig_HTTP_JSON,

--- a/databroker/directory.go
+++ b/databroker/directory.go
@@ -4,11 +4,11 @@ import (
 	"context"
 	"errors"
 
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 // RefreshUser refreshes a user's directory information.
@@ -26,11 +26,7 @@ func (c *DataBroker) RefreshUser(ctx context.Context, req *directory.RefreshUser
 		return nil, err
 	}
 
-	any, err := anypb.New(u)
-	if err != nil {
-		return nil, err
-	}
-
+	any := protoutil.NewAny(u)
 	_, err = c.dataBrokerServer.Put(ctx, &databroker.PutRequest{
 		Record: &databroker.Record{
 			Type: any.GetTypeUrl(),

--- a/internal/controlplane/events.go
+++ b/internal/controlplane/events.go
@@ -10,12 +10,12 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc"
 	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/events"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 const maxEnvoyConfigurationEvents = 50
@@ -46,10 +46,7 @@ func (srv *Server) runEnvoyConfigurationEventHandler(ctx context.Context) error 
 }
 
 func (srv *Server) storeEnvoyConfigurationEvent(ctx context.Context, evt *events.EnvoyConfigurationEvent) error {
-	any, err := anypb.New(evt)
-	if err != nil {
-		return err
-	}
+	any := protoutil.NewAny(evt)
 
 	client, err := srv.getDataBrokerClient(ctx)
 	if err != nil {

--- a/internal/controlplane/xds.go
+++ b/internal/controlplane/xds.go
@@ -5,9 +5,9 @@ import (
 	"encoding/hex"
 
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 const (
@@ -24,7 +24,7 @@ func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*e
 		return nil, err
 	}
 	for _, cluster := range clusters {
-		any, _ := anypb.New(cluster)
+		any := protoutil.NewAny(cluster)
 		resources[clusterTypeURL] = append(resources[clusterTypeURL], &envoy_service_discovery_v3.Resource{
 			Name:     cluster.Name,
 			Version:  hex.EncodeToString(cryptutil.HashProto(cluster)),
@@ -37,7 +37,7 @@ func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*e
 		return nil, err
 	}
 	for _, listener := range listeners {
-		any, _ := anypb.New(listener)
+		any := protoutil.NewAny(listener)
 		resources[listenerTypeURL] = append(resources[listenerTypeURL], &envoy_service_discovery_v3.Resource{
 			Name:     listener.Name,
 			Version:  hex.EncodeToString(cryptutil.HashProto(listener)),

--- a/internal/databroker/config_source_test.go
+++ b/internal/databroker/config_source_test.go
@@ -9,11 +9,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/pomerium/pomerium/config"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 func TestConfigSource(t *testing.T) {
@@ -52,7 +52,7 @@ func TestConfigSource(t *testing.T) {
 	})
 	cfgs <- src.GetConfig()
 
-	data, _ := anypb.New(&configpb.Config{
+	data := protoutil.NewAny(&configpb.Config{
 		Name: "config",
 		Routes: []*configpb.Route{
 			{

--- a/internal/databroker/server_test.go
+++ b/internal/databroker/server_test.go
@@ -15,16 +15,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/pomerium/pomerium/pkg/cryptutil"
-
 	"github.com/pomerium/pomerium/internal/testutil"
-
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 type testSyncerHandler struct {
@@ -58,10 +56,8 @@ func TestServer_Get(t *testing.T) {
 
 		s := new(session.Session)
 		s.Id = "1"
-		any, err := anypb.New(s)
-		assert.NoError(t, err)
-
-		_, err = srv.Put(context.Background(), &databroker.PutRequest{
+		any := protoutil.NewAny(s)
+		_, err := srv.Put(context.Background(), &databroker.PutRequest{
 			Record: &databroker.Record{
 				Type: any.TypeUrl,
 				Id:   s.Id,
@@ -92,10 +88,8 @@ func TestServer_Options(t *testing.T) {
 
 	s := new(session.Session)
 	s.Id = "1"
-	any, err := anypb.New(s)
-	assert.NoError(t, err)
-
-	_, err = srv.Put(context.Background(), &databroker.PutRequest{
+	any := protoutil.NewAny(s)
+	_, err := srv.Put(context.Background(), &databroker.PutRequest{
 		Record: &databroker.Record{
 			Type: any.TypeUrl,
 			Id:   s.Id,
@@ -143,10 +137,8 @@ func TestServer_Query(t *testing.T) {
 
 	s := new(session.Session)
 	s.Id = "1"
-	any, err := anypb.New(s)
-	assert.NoError(t, err)
-
-	_, err = srv.Put(context.Background(), &databroker.PutRequest{
+	any := protoutil.NewAny(s)
+	_, err := srv.Put(context.Background(), &databroker.PutRequest{
 		Record: &databroker.Record{
 			Type: any.TypeUrl,
 			Id:   s.Id,
@@ -166,10 +158,8 @@ func TestServer_Sync(t *testing.T) {
 
 	s := new(session.Session)
 	s.Id = "1"
-	any, err := anypb.New(s)
-	assert.NoError(t, err)
-
-	_, err = srv.Put(context.Background(), &databroker.PutRequest{
+	any := protoutil.NewAny(s)
+	_, err := srv.Put(context.Background(), &databroker.PutRequest{
 		Record: &databroker.Record{
 			Type: any.TypeUrl,
 			Id:   s.Id,
@@ -252,10 +242,8 @@ func TestServerInvalidStorage(t *testing.T) {
 
 	s := new(session.Session)
 	s.Id = "1"
-	any, err := anypb.New(s)
-	assert.NoError(t, err)
-
-	_, err = srv.Put(context.Background(), &databroker.PutRequest{
+	any := protoutil.NewAny(s)
+	_, err := srv.Put(context.Background(), &databroker.PutRequest{
 		Record: &databroker.Record{
 			Type: any.TypeUrl,
 			Id:   s.Id,
@@ -275,10 +263,8 @@ func TestServerRedis(t *testing.T) {
 
 		s := new(session.Session)
 		s.Id = "1"
-		any, err := anypb.New(s)
-		assert.NoError(t, err)
-
-		_, err = srv.Put(context.Background(), &databroker.PutRequest{
+		any := protoutil.NewAny(s)
+		_, err := srv.Put(context.Background(), &databroker.PutRequest{
 			Record: &databroker.Record{
 				Type: any.TypeUrl,
 				Id:   s.Id,

--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -5,17 +5,17 @@ import (
 	context "context"
 	"fmt"
 
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/internal/identity"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 // Delete deletes a session from the databroker.
 func Delete(ctx context.Context, client databroker.DataBrokerServiceClient, sessionID string) error {
-	any, _ := anypb.New(new(Session))
+	any := protoutil.NewAny(new(Session))
 	_, err := client.Put(ctx, &databroker.PutRequest{
 		Record: &databroker.Record{
 			Type:      any.GetTypeUrl(),
@@ -29,8 +29,7 @@ func Delete(ctx context.Context, client databroker.DataBrokerServiceClient, sess
 
 // Get gets a session from the databroker.
 func Get(ctx context.Context, client databroker.DataBrokerServiceClient, sessionID string) (*Session, error) {
-	any, _ := anypb.New(new(Session))
-
+	any := protoutil.NewAny(new(Session))
 	res, err := client.Get(ctx, &databroker.GetRequest{
 		Type: any.GetTypeUrl(),
 		Id:   sessionID,
@@ -49,7 +48,7 @@ func Get(ctx context.Context, client databroker.DataBrokerServiceClient, session
 
 // Put sets a session in the databroker.
 func Put(ctx context.Context, client databroker.DataBrokerServiceClient, s *Session) (*databroker.PutResponse, error) {
-	any, _ := anypb.New(s)
+	any := protoutil.NewAny(s)
 	res, err := client.Put(ctx, &databroker.PutRequest{
 		Record: &databroker.Record{
 			Type: any.GetTypeUrl(),

--- a/pkg/grpc/user/user.go
+++ b/pkg/grpc/user/user.go
@@ -5,16 +5,16 @@ import (
 	context "context"
 	"fmt"
 
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pomerium/pomerium/internal/identity"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 // Get gets a user from the databroker.
 func Get(ctx context.Context, client databroker.DataBrokerServiceClient, userID string) (*User, error) {
-	any, _ := anypb.New(new(User))
+	any := protoutil.NewAny(new(User))
 
 	res, err := client.Get(ctx, &databroker.GetRequest{
 		Type: any.GetTypeUrl(),
@@ -34,7 +34,7 @@ func Get(ctx context.Context, client databroker.DataBrokerServiceClient, userID 
 
 // Put sets a user in the databroker.
 func Put(ctx context.Context, client databroker.DataBrokerServiceClient, u *User) (*databroker.Record, error) {
-	any, _ := anypb.New(u)
+	any := protoutil.NewAny(u)
 	res, err := client.Put(ctx, &databroker.PutRequest{
 		Record: &databroker.Record{
 			Type: any.GetTypeUrl(),
@@ -50,7 +50,7 @@ func Put(ctx context.Context, client databroker.DataBrokerServiceClient, u *User
 
 // PutServiceAccount sets a service account in the databroker.
 func PutServiceAccount(ctx context.Context, client databroker.DataBrokerServiceClient, sa *ServiceAccount) (*databroker.Record, error) {
-	any, _ := anypb.New(sa)
+	any := protoutil.NewAny(sa)
 	res, err := client.Put(ctx, &databroker.PutRequest{
 		Record: &databroker.Record{
 			Type: any.GetTypeUrl(),

--- a/pkg/logutil/scrub.go
+++ b/pkg/logutil/scrub.go
@@ -9,6 +9,8 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 // A Scrubber scrubs potentially sensitive strings from protobuf messages.
@@ -90,7 +92,7 @@ func (s *Scrubber) scrubProtoAny(dst, src *anypb.Any) {
 	if err != nil {
 		// this will happen if a type isn't registered.
 		// So we will just hash the raw data.
-		a, _ := anypb.New(wrapperspb.Bytes(s.hmacBytes(src.Value)))
+		a := protoutil.NewAny(wrapperspb.Bytes(s.hmacBytes(src.Value)))
 		dst.TypeUrl = a.TypeUrl
 		dst.Value = a.Value
 		return
@@ -101,12 +103,7 @@ func (s *Scrubber) scrubProtoAny(dst, src *anypb.Any) {
 
 	s.scrubProtoMessage(dstmsg, srcmsg)
 
-	a, err := anypb.New(dstmsg.Interface())
-	if err != nil {
-		// this really shouldn't happen, but in case it does,
-		// we hash the raw data as above.
-		a, _ = anypb.New(wrapperspb.Bytes(s.hmacBytes(src.Value)))
-	}
+	a := protoutil.NewAny(dstmsg.Interface())
 	dst.TypeUrl = a.TypeUrl
 	dst.Value = a.Value
 }

--- a/pkg/policy/criteria/criteria_test.go
+++ b/pkg/policy/criteria/criteria_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/types"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/pomerium/pomerium/pkg/policy/generator"
 	"github.com/pomerium/pomerium/pkg/policy/parser"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 var testingNow = time.Date(2021, 5, 11, 13, 43, 0, 0, time.Local)
@@ -94,11 +94,7 @@ func evaluate(t *testing.T,
 			}
 
 			for _, record := range dataBrokerRecords {
-				any, err := anypb.New(record)
-				if err != nil {
-					return nil, err
-				}
-
+				any := protoutil.NewAny(record)
 				if string(recordType) == any.GetTypeUrl() &&
 					string(recordID) == record.GetId() {
 					bs, _ := json.Marshal(record)

--- a/pkg/protoutil/any.go
+++ b/pkg/protoutil/any.go
@@ -40,72 +40,72 @@ func ToAny(value interface{}) *anypb.Any {
 	case uint64:
 		return NewAnyUInt64(v)
 	default:
-		a, err := anypb.New(ToStruct(value))
-		if err != nil {
-			return NewAnyNull()
-		}
-		return a
+		return NewAny(ToStruct(value))
 	}
+}
+
+// NewAny creates a new Any using deterministic serialization.
+func NewAny(msg proto.Message) *anypb.Any {
+	a := new(anypb.Any)
+	err := anypb.MarshalFrom(a, msg, proto.MarshalOptions{
+		AllowPartial:  true,
+		Deterministic: true,
+	})
+	if err != nil {
+		// on error, which doesn't really happen in practice, return null
+		return NewAnyNull()
+	}
+	return a
 }
 
 // NewAnyBool creates a new any type from a bool.
 func NewAnyBool(v bool) *anypb.Any {
-	a, _ := anypb.New(wrapperspb.Bool(v))
-	return a
+	return NewAny(wrapperspb.Bool(v))
 }
 
 // NewAnyBytes creates a new any type from bytes.
 func NewAnyBytes(v []byte) *anypb.Any {
-	a, _ := anypb.New(wrapperspb.Bytes(v))
-	return a
+	return NewAny(wrapperspb.Bytes(v))
 }
 
 // NewAnyDouble creates a new any type from a float64.
 func NewAnyDouble(v float64) *anypb.Any {
-	a, _ := anypb.New(wrapperspb.Double(v))
-	return a
+	return NewAny(wrapperspb.Double(v))
 }
 
 // NewAnyFloat creates a new any type from a float32.
 func NewAnyFloat(v float32) *anypb.Any {
-	a, _ := anypb.New(wrapperspb.Float(v))
-	return a
+	return NewAny(wrapperspb.Float(v))
 }
 
 // NewAnyInt64 creates a new any type from an int64.
 func NewAnyInt64(v int64) *anypb.Any {
-	a, _ := anypb.New(wrapperspb.Int64(v))
-	return a
+	return NewAny(wrapperspb.Int64(v))
 }
 
 // NewAnyInt32 creates a new any type from an int32.
 func NewAnyInt32(v int32) *anypb.Any {
-	a, _ := anypb.New(wrapperspb.Int32(v))
-	return a
+	return NewAny(wrapperspb.Int32(v))
 }
 
 // NewAnyNull creates a new any type from a null struct.
 func NewAnyNull() *anypb.Any {
-	a, _ := anypb.New(NewStructNull())
-	return a
+	return NewAny(NewStructNull())
 }
 
 // NewAnyString creates a new any type from a string.
 func NewAnyString(v string) *anypb.Any {
-	a, _ := anypb.New(wrapperspb.String(v))
-	return a
+	return NewAny(wrapperspb.String(v))
 }
 
 // NewAnyUInt64 creates a new any type from an uint64.
 func NewAnyUInt64(v uint64) *anypb.Any {
-	a, _ := anypb.New(wrapperspb.UInt64(v))
-	return a
+	return NewAny(wrapperspb.UInt64(v))
 }
 
 // NewAnyUInt32 creates a new any type from an uint32.
 func NewAnyUInt32(v uint32) *anypb.Any {
-	a, _ := anypb.New(wrapperspb.UInt32(v))
-	return a
+	return NewAny(wrapperspb.UInt32(v))
 }
 
 // GetTypeURL gets the TypeURL for a protobuf message.

--- a/pkg/protoutil/transform.go
+++ b/pkg/protoutil/transform.go
@@ -39,10 +39,7 @@ func (t transformer) transformAny(dst, src *anypb.Any) error {
 		return err
 	}
 
-	a, err := anypb.New(dstMsg.Interface())
-	if err != nil {
-		return err
-	}
+	a := NewAny(dstMsg.Interface())
 	dst.TypeUrl = a.TypeUrl
 	dst.Value = a.Value
 	return nil

--- a/pkg/storage/encrypted.go
+++ b/pkg/storage/encrypted.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 type encryptedRecordStream struct {
@@ -185,13 +186,8 @@ func (e *encryptedBackend) encrypt(in *anypb.Any) (out *anypb.Any, err error) {
 	}
 
 	encrypted := cryptutil.Encrypt(e.cipher, plaintext, nil)
-
-	out, err = anypb.New(&wrapperspb.BytesValue{
+	out = protoutil.NewAny(&wrapperspb.BytesValue{
 		Value: encrypted,
 	})
-	if err != nil {
-		return nil, err
-	}
-
 	return out, nil
 }

--- a/pkg/storage/encrypted_test.go
+++ b/pkg/storage/encrypted_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 func TestEncryptedBackend(t *testing.T) {
@@ -56,7 +57,7 @@ func TestEncryptedBackend(t *testing.T) {
 		return
 	}
 
-	any, _ := anypb.New(wrapperspb.String("HELLO WORLD"))
+	any := protoutil.NewAny(wrapperspb.String("HELLO WORLD"))
 
 	rec := &databroker.Record{
 		Type: "",

--- a/pkg/storage/storage_test.go
+++ b/pkg/storage/storage_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 type mockBackend struct {
@@ -36,7 +36,7 @@ func (m *mockBackend) GetAll(ctx context.Context) ([]*databroker.Record, *databr
 
 func TestMatchAny(t *testing.T) {
 	u := &user.User{Id: "id", Name: "name", Email: "email"}
-	data, _ := anypb.New(u)
+	data := protoutil.NewAny(u)
 	assert.True(t, MatchAny(data, ""))
 	assert.True(t, MatchAny(data, "id"))
 	assert.True(t, MatchAny(data, "name"))


### PR DESCRIPTION
## Summary
By default `anypb.New` creates Anys without using deterministic serialization. (i.e. sorted map order) This has unfortunate consequences when comparing two Anys.

This PR updates anywhere we've used `anypb.New` with `protoutil.NewAny` and turns on deterministic serialization.


## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
