### PR TITLE
docs: update enterprise helm instructions to use main repo

### DIFF
--- a/docs/enterprise/install/helm.md
+++ b/docs/enterprise/install/helm.md
@@ -115,14 +115,14 @@ This setup assumes an existing certificate solution using cert-manager, as descr
 1. Add the Pomerium Enterprise repository to your Helm configuration:
 
    ```bash
-   helm repo add pomerium-enterprise https://releases.pomerium.com
+   helm repo add pomerium https://helm.pomerium.com
    helm repo update
    ```
 
 1. Install Pomerium Enterprise:
 
    ```bash
-   helm install pomerium-console pomerium-enterprise/pomerium-console --values=pomerium-console-values.yaml
+   helm install pomerium-console pomerium/pomerium-console --values=pomerium-console-values.yaml
    ```
 
 1. If you haven't configured a public DNS record for your Pomerium domain space, you can use `kubectl` to generate a local proxy:

--- a/docs/enterprise/install/helm.md
+++ b/docs/enterprise/install/helm.md
@@ -112,7 +112,7 @@ This setup assumes an existing certificate solution using cert-manager, as descr
      pullPassword: your-access-key
    ```
 
-1. Add the Pomerium repository to your Helm configuration:
+1. The Pomerium repository should already be in your Helm configuration per [Pomerium using Helm]. If not, add it now:
 
    ```bash
    helm repo add pomerium https://helm.pomerium.io

--- a/docs/enterprise/install/helm.md
+++ b/docs/enterprise/install/helm.md
@@ -115,7 +115,7 @@ This setup assumes an existing certificate solution using cert-manager, as descr
 1. Add the Pomerium Enterprise repository to your Helm configuration:
 
    ```bash
-   helm repo add pomerium https://helm.pomerium.com
+   helm repo add pomerium https://helm.pomerium.io
    helm repo update
    ```
 

--- a/docs/enterprise/install/helm.md
+++ b/docs/enterprise/install/helm.md
@@ -112,26 +112,26 @@ This setup assumes an existing certificate solution using cert-manager, as descr
      pullPassword: your-access-key
    ```
 
-1. Add the Pomerium Enterprise repository to your Helm configuration:
+2. Add the Pomerium repository to your Helm configuration:
 
    ```bash
    helm repo add pomerium https://helm.pomerium.io
    helm repo update
    ```
 
-1. Install Pomerium Enterprise:
+3. Install Pomerium Enterprise:
 
    ```bash
    helm install pomerium-console pomerium/pomerium-console --values=pomerium-console-values.yaml
    ```
 
-1. If you haven't configured a public DNS record for your Pomerium domain space, you can use `kubectl` to generate a local proxy:
+4. If you haven't configured a public DNS record for your Pomerium domain space, you can use `kubectl` to generate a local proxy:
 
    ```bash
    sudo -E kubectl --namespace pomerium port-forward service/pomerium-proxy 443:443
    ```
 
-1. When visiting `https://console.localhost.pomerium.io`, you should se the Session List page:
+5. When visiting `https://console.localhost.pomerium.io`, you should se the Session List page:
 
    ![The Session List page after installing Pomerium Enterprise](../img/console-session-landing.png)
 

--- a/docs/enterprise/install/helm.md
+++ b/docs/enterprise/install/helm.md
@@ -112,26 +112,26 @@ This setup assumes an existing certificate solution using cert-manager, as descr
      pullPassword: your-access-key
    ```
 
-2. Add the Pomerium repository to your Helm configuration:
+1. Add the Pomerium repository to your Helm configuration:
 
    ```bash
    helm repo add pomerium https://helm.pomerium.io
    helm repo update
    ```
 
-3. Install Pomerium Enterprise:
+1. Install Pomerium Enterprise:
 
    ```bash
    helm install pomerium-console pomerium/pomerium-console --values=pomerium-console-values.yaml
    ```
 
-4. If you haven't configured a public DNS record for your Pomerium domain space, you can use `kubectl` to generate a local proxy:
+1. If you haven't configured a public DNS record for your Pomerium domain space, you can use `kubectl` to generate a local proxy:
 
    ```bash
    sudo -E kubectl --namespace pomerium port-forward service/pomerium-proxy 443:443
    ```
 
-5. When visiting `https://console.localhost.pomerium.io`, you should se the Session List page:
+1. When visiting `https://console.localhost.pomerium.io`, you should se the Session List page:
 
    ![The Session List page after installing Pomerium Enterprise](../img/console-session-landing.png)
 


### PR DESCRIPTION
## Summary

We're going to host the enterprise charts next to open source.  Updating the docs to reflect that.

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
