### PR TITLE
ci: support darwn/arm64 aka m1 for cli

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -26,6 +26,9 @@ builds:
     goos:
       - linux
       - darwin
+    ignore:
+      - goos: darwin
+        goarch: arm64
 
     ldflags:
       - -s -w

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
-          version: v0.155.2
+          version: v0.174.2
           args: release --config .github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION

## Summary

Add support for m1 / darwin/arm64 for the CLI. Pomerium itself is still amd64 until envoy supports m1. 

## Related issues

Fixes #2470 


## Checklist

- [x] reference any related issues
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
