### PR TITLE
Wrap mkcert command in quotes

### DIFF
--- a/docs/docs/install/helm.md
+++ b/docs/docs/install/helm.md
@@ -40,7 +40,7 @@ mkcert -install
 The local CA is already installed in the system trust store! 👍
 The local CA is already installed in the Firefox and/or Chrome/Chromium trust store! 👍
 
-ls $(mkcert -CAROOT)
+ls "$(mkcert -CAROOT)"
 rootCA-key.pem  rootCA.pem
 ```
 


### PR DESCRIPTION
## Summary

This fixes the command in environments like macOS where the CAROOT path includes a space.

## Related issues

Closes https://github.com/pomerium/docs/issues/19


## Checklist

- [X] reference any related issues
- [X] updated docs
-  ~updated unit tests~
-  ~updated UPGRADING.md~
- [X] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
