### PR TITLE
docs: use generic email

### DIFF
--- a/docs/enterprise/reference/manage.md
+++ b/docs/enterprise/reference/manage.md
@@ -213,7 +213,7 @@ Set Request Headers allows you to set static values for given request headers. T
     - allow:
         or:
           - email:
-              is: bdd@pomerium.io
+              is: user@example.com
   set_request_headers:
     # works auto-magically!
     # https://verify.corp.example.com/basic-auth/root/hunter42
@@ -232,7 +232,7 @@ Remove Request Headers allows you to remove given request headers. This can be u
     - allow:
         or:
           - email:
-              is: bdd@pomerium.io
+              is: user@example.com
   remove_request_headers:
     - X-Email
     - X-Username

--- a/docs/guides/argo.md
+++ b/docs/guides/argo.md
@@ -75,7 +75,7 @@ config:
         - allow:
             or:
               - email:
-                  is: bdd@pomerium.io
+                  is: user@example.com
 
 authenticate:
   idp:

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1355,7 +1355,7 @@ Set Request Headers allows you to set static values for given request headers. T
     - allow:
         or:
           - email:
-              is: bdd@pomerium.io
+              is: user@example.com
   set_request_headers:
     # works auto-magically!
     # https://verify.corp.example.com/basic-auth/root/hunter42
@@ -1383,7 +1383,7 @@ Remove Request Headers allows you to remove given request headers. This can be u
     - allow:
         or:
           - email:
-              is: bdd@pomerium.io
+              is: user@example.com
   remove_request_headers:
     - X-Email
     - X-Username

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -1486,7 +1486,7 @@ settings:
               - allow:
                   or:
                     - email:
-                        is: bdd@pomerium.io
+                        is: user@example.com
             set_request_headers:
               # works auto-magically!
               # https://verify.corp.example.com/basic-auth/root/hunter42
@@ -1514,7 +1514,7 @@ settings:
               - allow:
                   or:
                     - email:
-                        is: bdd@pomerium.io
+                        is: user@example.com
             remove_request_headers:
               - X-Email
               - X-Username

--- a/examples/config/config.example.yaml
+++ b/examples/config/config.example.yaml
@@ -57,7 +57,7 @@ authenticate_service_url: https://authenticate.localhost.pomerium.io
 
 # IF GSUITE and you want to get user groups you will need to set a service account
 # see identity provider docs for gooogle for more info :
-# idp_service_account: $(echo '{"impersonate_user": "bdd@pomerium.io"}' | base64)
+# idp_service_account: $(echo '{"impersonate_user": "user@example.com"}' | base64)
 
 # OKTA
 # idp_provider: "okta"
@@ -98,7 +98,7 @@ routes:
       - allow:
           or:
             - email:
-                is: bdd@pomerium.io
+                is: user@example.com
             - groups:
                 has: "admins"
             - groups:

--- a/examples/config/config.minimal.yaml
+++ b/examples/config/config.minimal.yaml
@@ -26,5 +26,5 @@ routes:
       - allow:
           or:
             - email:
-                is: bdd@pomerium.io
+                is: user@example.com
     pass_identity_headers: true

--- a/examples/config/policy.example.yaml
+++ b/examples/config/policy.example.yaml
@@ -22,7 +22,7 @@
 - from: https://weirdlyssl.localhost.pomerium.io
   to: http://neverssl.com
   allowed_users:
-    - bdd@pomerium.io
+    - user@example.com
   allowed_groups:
     - admins
     - developers

--- a/examples/config/route.example.yaml
+++ b/examples/config/route.example.yaml
@@ -29,7 +29,7 @@ routes:
       - allow:
           or:
             - email:
-                is: bdd@pomerium.io
+                is: user@example.com
             - groups:
                 has: "admins"
             - groups:


### PR DESCRIPTION
## Summary

Standardizing on `user@example.com` as the example email address for configs.


## Checklist

- ~reference any related issues~
- [X] updated docs
-  ~updated unit tests~
-  ~updated UPGRADING.md~
- [X] add appropriate tag (`improvement` / `bug` / etc)
- [X] ready for review
