### PR TITLE
github: support provider URL

### DIFF
--- a/internal/httputil/client.go
+++ b/internal/httputil/client.go
@@ -80,10 +80,12 @@ func (c *httpClient) Do(req *http.Request) (*http.Response, error) {
 	return c.Client.Do(req)
 }
 
-// defaultClient avoids leaks by setting an upper limit for timeouts.
-var defaultClient = &httpClient{
-	&http.Client{Timeout: 1 * time.Minute},
-	requestid.NewRoundTripper(http.DefaultTransport),
+// getDefaultClient returns an HTTP client that avoids leaks by setting an upper limit for timeouts.
+func getDefaultClient() *httpClient {
+	return &httpClient{
+		&http.Client{Timeout: 1 * time.Minute},
+		requestid.NewRoundTripper(http.DefaultTransport),
+	}
 }
 
 // Do provides a simple helper interface to make HTTP requests
@@ -113,7 +115,7 @@ func Do(ctx context.Context, method, endpoint, userAgent string, headers map[str
 		req.Header.Set(k, v)
 	}
 
-	resp, err := defaultClient.Do(req)
+	resp, err := getDefaultClient().Do(req)
 	if err != nil {
 		return err
 	}

--- a/internal/httputil/client_test.go
+++ b/internal/httputil/client_test.go
@@ -21,5 +21,5 @@ func TestDefaultClient(t *testing.T) {
 	defer ts.Close()
 	req, _ := http.NewRequest(http.MethodGet, ts.URL, nil)
 	req = req.WithContext(requestid.WithValue(context.Background(), "foo"))
-	_, _ = defaultClient.Do(req)
+	_, _ = getDefaultClient().Do(req)
 }

--- a/internal/urlutil/url.go
+++ b/internal/urlutil/url.go
@@ -113,3 +113,21 @@ func GetDomainsForURL(u url.URL) []string {
 func IsTCP(u *url.URL) bool {
 	return u.Scheme == "tcp+http" || u.Scheme == "tcp+https"
 }
+
+// Join joins elements of a URL with '/'.
+func Join(elements ...string) string {
+	var builder strings.Builder
+	appendSlash := false
+	for i, el := range elements {
+		if appendSlash {
+			builder.WriteByte('/')
+		}
+		if i > 0 && strings.HasPrefix(el, "/") {
+			builder.WriteString(el[1:])
+		} else {
+			builder.WriteString(el)
+		}
+		appendSlash = !strings.HasSuffix(el, "/")
+	}
+	return builder.String()
+}

--- a/internal/urlutil/url_test.go
+++ b/internal/urlutil/url_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_StripPort(t *testing.T) {
@@ -157,4 +158,11 @@ func TestGetDomainsForURL(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestJoin(t *testing.T) {
+	assert.Equal(t, "/x/y/z/", Join("/x", "y/z/"))
+	assert.Equal(t, "/x/y/z/", Join("/x/", "y/z/"))
+	assert.Equal(t, "/x/y/z/", Join("/x", "/y/z/"))
+	assert.Equal(t, "/x/y/z/", Join("/x/", "/y/z/"))
 }


### PR DESCRIPTION
## Summary
Update the Github IDP to support a custom provider URL. It already had some support for this, but URLs that ended with `/` didn't work, and the user info was always retrieved from the Github API. It will now be retrieved from the custom provider URL if it's not the default.

The `defaultClient` in `httputil` was changed to a method so that it would pick up the default HTTP transport built in `config`. (which allows all the custom TLS settings to get picked up)

## Related issues
- https://github.com/pomerium/internal/issues/514

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
