### PR TITLE
Fixed typo in okta identity-provider documentation

### DIFF
--- a/docs/docs/identity-providers/okta.md
+++ b/docs/docs/identity-providers/okta.md
@@ -17,7 +17,7 @@ While we do our best to keep our documentation up to date, changes to third-part
 
 ## Create OpenID Connect Application
 
-1. [Log in to your Okta account](https://login.okta.com) From the left-hand menu,  Select **Applications → Applications** on the top menu.
+1. [Log in to your Okta account](https://login.okta.com) From the left-hand menu, Select **Applications → Applications** on the top menu.
 
    ![Okta Applications Dashboard](./img/okta/okta-app-dashboard.png)
 
@@ -29,13 +29,13 @@ While we do our best to keep our documentation up to date, changes to third-part
 
 1. Provide the following information for your application settings:
 
-   | Field                        | Description                                                               |
-   | ---------------------------- | ------------------------------------------------------------------------- |
-   | Name                         | The name of your application.                                             |
-   | Grant type allowed           | **You must enable Refresh Token.**                                        |
-   | Base URIs                    | **Optional**: The domain(s) of your application.                          |
-   | Sign-in redirect URIs        | Redirect URL (e.g.`https://${authenticate_service_url}/oauth2/callback`). |
-   | Controlled Access            | The user groups that can sign in to this application. See [Group ID] for more information. |
+   | Field                 | Description                                                                                |
+   | --------------------- | ------------------------------------------------------------------------------------------ |
+   | Name                  | The name of your application.                                                              |
+   | Grant type allowed    | **You must enable Refresh Token.**                                                         |
+   | Base URIs             | **Optional**: The domain(s) of your application.                                           |
+   | Sign-in redirect URIs | Redirect URL (e.g.`https://${authenticate_service_url}/oauth2/callback`).                  |
+   | Controlled Access     | The user groups that can sign in to this application. See [Group ID] for more information. |
 
    ![Okta Create Application Settings](./img/okta/okta-create-app-settings.png)
 
@@ -57,7 +57,7 @@ Next, we'll create API token so that Pomerium can retrieve and establish group m
 
    ```json
    {
-   "api_key": "XXXXXXXXXX"
+     "api_key": "XXXXXXXXXX"
    }
    ```
 
@@ -73,15 +73,18 @@ Finally, configure Pomerium with the identity provider settings retrieved in the
 
 :::: tabs
 ::: tab config.yaml
+
 ```yaml
 idp_provider: "okta"
-idp_provider-url: "https://awesomecompany.okta.com"
+idp_provider_url: "https://awesomecompany.okta.com"
 idp_client_id: "REPLACE ME"
 idp_client_secret: "REPLACE ME"
 ipd_service_account: "REPLACE ME" # base64 encoded JSON object
 ```
+
 :::
 ::: tab Environment Variables
+
 ```bash
 IDP_PROVIDER="okta"
 IDP_PROVIDER_URL="https://dev-108295.okta.com"
@@ -89,6 +92,7 @@ IDP_CLIENT_ID="REPLACE_ME"
 IDP_CLIENT_SECRET="REPLACE_ME"
 IDP_SERVICE_ACCOUNT="REPLACE_ME" # base64 encoded JSON object
 ```
+
 :::
 ::::
 
@@ -98,4 +102,5 @@ IDP_SERVICE_ACCOUNT="REPLACE_ME" # base64 encoded JSON object
 [oauth2]: https://oauth.net/2/
 [openid connect]: https://en.wikipedia.org/wiki/OpenID_Connect
 [pomerium-install]: /docs/install/
-[Group ID]: https://developer.okta.com/docs/reference/api/groups/
+[group id]: https://developer.okta.com/docs/reference/api/groups/
+


### PR DESCRIPTION
## Summary

Fixed typo in okta identity-provider documentation: should be a `_` instead of `-` for `idp_provider_url`

## Related issues

- Didn't create an issue since it didn't seem to fall into a category of bug/feature/vulnerability.

## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
