### PR TITLE
fix forward-auth, logging

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -62,7 +62,6 @@ func (a *Authorize) WaitForInitialSync(ctx context.Context) error {
 		return ctx.Err()
 	case <-a.dataBrokerInitialSync:
 	}
-	log.Info(ctx).Msg("initial sync from databroker complete")
 	return nil
 }
 

--- a/authorize/evaluator/google_cloud_serverless.go
+++ b/authorize/evaluator/google_cloud_serverless.go
@@ -18,6 +18,8 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/singleflight"
 	"google.golang.org/api/idtoken"
+
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 // GCP pre-defined values.
@@ -160,11 +162,13 @@ func getGoogleCloudServerlessTokenSource(serviceAccount, audience string) (oauth
 func getGoogleCloudServerlessHeaders(serviceAccount, audience string) (map[string]string, error) {
 	src, err := getGoogleCloudServerlessTokenSource(serviceAccount, audience)
 	if err != nil {
+		log.Error(context.Background()).Err(err).Msg("error retrieving google cloud serverless token source")
 		return nil, err
 	}
 
 	tok, err := src.Token()
 	if err != nil {
+		log.Error(context.Background()).Err(err).Msg("error retrieving google cloud serverless token")
 		return nil, err
 	}
 

--- a/authorize/evaluator/google_cloud_serverless.go
+++ b/authorize/evaluator/google_cloud_serverless.go
@@ -48,6 +48,7 @@ var (
 
 		headers, err := getGoogleCloudServerlessHeaders(string(serviceAccount), string(audience))
 		if err != nil {
+			log.Error(context.Background()).Err(err).Msg("error retrieving google cloud serverless headers")
 			return nil, fmt.Errorf("failed to get google cloud serverless headers: %w", err)
 		}
 		var kvs [][2]*ast.Term
@@ -162,14 +163,12 @@ func getGoogleCloudServerlessTokenSource(serviceAccount, audience string) (oauth
 func getGoogleCloudServerlessHeaders(serviceAccount, audience string) (map[string]string, error) {
 	src, err := getGoogleCloudServerlessTokenSource(serviceAccount, audience)
 	if err != nil {
-		log.Error(context.Background()).Err(err).Msg("error retrieving google cloud serverless token source")
-		return nil, err
+		return nil, fmt.Errorf("error retrieving google cloud serverless token source: %w", err)
 	}
 
 	tok, err := src.Token()
 	if err != nil {
-		log.Error(context.Background()).Err(err).Msg("error retrieving google cloud serverless token")
-		return nil, err
+		return nil, fmt.Errorf("error retrieving google cloud serverless token: %w", err)
 	}
 
 	return map[string]string{

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -81,13 +81,13 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 		return a.okResponse(res), nil
 	}
 
-	if isForwardAuth && hreq.URL.Path == "/verify" {
-		return a.deniedResponse(ctx, in, http.StatusUnauthorized, "Unauthenticated", nil)
-	}
-
 	// if we're logged in, don't redirect, deny with forbidden
 	if req.Session.ID != "" {
 		return a.deniedResponse(ctx, in, denyStatusCode, denyStatusText, nil)
+	}
+
+	if isForwardAuth && hreq.URL.Path == "/verify" {
+		return a.deniedResponse(ctx, in, http.StatusUnauthorized, "Unauthenticated", nil)
 	}
 
 	return a.requireLoginResponse(ctx, in)

--- a/authorize/sync.go
+++ b/authorize/sync.go
@@ -61,6 +61,7 @@ func (syncer *dataBrokerSyncer) UpdateRecords(ctx context.Context, serverVersion
 
 	// the first time we update records we signal the initial sync
 	syncer.signalOnce.Do(func() {
+		log.Info(ctx).Msg("initial sync from databroker complete")
 		close(syncer.authorize.dataBrokerInitialSync)
 	})
 }


### PR DESCRIPTION
## Summary
Discovered while working on integration tests, there are circumstances where forward auth with nginx can get into an infinite redirect loop. Moving the `isForwardAuth` check to after the session id check seems to fix it. It also makes more sense in term of the flow.

Basically we want to Redirect to authenticate if there's no session, but if there is a session we want to return Forbidden. In forward auth mode that means returning a `401 Unauthorized` with no session and a `403 Forbidden` when there is a session.

I also moved a noisy log and added error logging for google cloud serverless.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
