### PR TITLE
grpc: disable gRPC connection re-use across services

### DIFF
--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -25,6 +25,8 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )
 
+var outboundGRPCConnection = new(grpc.CachedOutboundGRPClientConn)
+
 type authenticateState struct {
 	redirectURL *url.URL
 	// sharedEncoder is the encoder to use to serialize data to be consumed
@@ -146,7 +148,7 @@ func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, err
 		return nil, err
 	}
 
-	dataBrokerConn, err := grpc.GetOutboundGRPCClientConn(context.Background(), &grpc.OutboundOptions{
+	dataBrokerConn, err := outboundGRPCConnection.Get(context.Background(), &grpc.OutboundOptions{
 		OutboundPort:   cfg.OutboundPort,
 		InstallationID: cfg.Options.InstallationID,
 		ServiceName:    cfg.Options.Services,

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -14,6 +14,8 @@ import (
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
+var outboundGRPCConnection = new(grpc.CachedOutboundGRPClientConn)
+
 type authorizeState struct {
 	sharedKey        []byte
 	evaluator        *evaluator.Evaluator
@@ -51,7 +53,7 @@ func newAuthorizeStateFromConfig(cfg *config.Config, store *evaluator.Store) (*a
 		return nil, err
 	}
 
-	cc, err := grpc.GetOutboundGRPCClientConn(context.Background(), &grpc.OutboundOptions{
+	cc, err := outboundGRPCConnection.Get(context.Background(), &grpc.OutboundOptions{
 		OutboundPort:   cfg.OutboundPort,
 		InstallationID: cfg.Options.InstallationID,
 		ServiceName:    cfg.Options.Services,

--- a/internal/cmd/pomerium/pomerium.go
+++ b/internal/cmd/pomerium/pomerium.go
@@ -205,7 +205,7 @@ func setupDataBroker(ctx context.Context, src config.Source, controlPlane *contr
 }
 
 func setupRegistryReporter(ctx context.Context, src config.Source) error {
-	reporter := new(registry.Reporter)
+	reporter := registry.NewReporter()
 	src.OnConfigChange(ctx, reporter.OnConfigChange)
 	reporter.OnConfigChange(ctx, src.GetConfig())
 	return nil

--- a/internal/controlplane/events.go
+++ b/internal/controlplane/events.go
@@ -20,6 +20,8 @@ import (
 
 const maxEnvoyConfigurationEvents = 50
 
+var outboundGRPCConnection = new(grpc.CachedOutboundGRPClientConn)
+
 func (srv *Server) handleEnvoyConfigurationEvent(evt *events.EnvoyConfigurationEvent) {
 	select {
 	case srv.envoyConfigurationEvents <- evt:
@@ -88,7 +90,7 @@ func (srv *Server) getDataBrokerClient(ctx context.Context) (databrokerpb.DataBr
 		return nil, err
 	}
 
-	cc, err := grpc.GetOutboundGRPCClientConn(context.Background(), &grpc.OutboundOptions{
+	cc, err := outboundGRPCConnection.Get(context.Background(), &grpc.OutboundOptions{
 		OutboundPort:   cfg.OutboundPort,
 		InstallationID: cfg.Options.InstallationID,
 		ServiceName:    cfg.Options.Services,

--- a/internal/registry/reporter.go
+++ b/internal/registry/reporter.go
@@ -19,7 +19,15 @@ import (
 
 // Reporter periodically submits a list of services available on this instance to the service registry
 type Reporter struct {
-	cancel func()
+	cancel                 func()
+	outboundGRPCConnection *grpc.CachedOutboundGRPClientConn
+}
+
+// NewReporter creates a new Reporter.
+func NewReporter() *Reporter {
+	return &Reporter{
+		outboundGRPCConnection: new(grpc.CachedOutboundGRPClientConn),
+	}
 }
 
 // OnConfigChange applies configuration changes to the reporter
@@ -39,7 +47,7 @@ func (r *Reporter) OnConfigChange(ctx context.Context, cfg *config.Config) {
 		return
 	}
 
-	registryConn, err := grpc.GetOutboundGRPCClientConn(ctx, &grpc.OutboundOptions{
+	registryConn, err := r.outboundGRPCConnection.Get(ctx, &grpc.OutboundOptions{
 		OutboundPort:   cfg.OutboundPort,
 		InstallationID: cfg.Options.InstallationID,
 		ServiceName:    cfg.Options.Services,


### PR DESCRIPTION
## Summary
This PR updates the gRPC client cache so that it's not shared across services. This is so that if a service closes the connection it won't inadvertently close it for another service.

## Related issues
Fixes https://github.com/pomerium/internal/issues/535

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
