### PR TITLE
Remove api from GitLab defaultScope

### DIFF
--- a/internal/identity/oidc/gitlab/gitlab.go
+++ b/internal/identity/oidc/gitlab/gitlab.go
@@ -16,7 +16,7 @@ import (
 // Name identifies the GitLab identity provider.
 const Name = "gitlab"
 
-var defaultScopes = []string{oidc.ScopeOpenID, "profile", "email", "openid"}
+var defaultScopes = []string{oidc.ScopeOpenID, "profile", "email"}
 
 const (
 	defaultProviderURL = "https://gitlab.com"

--- a/internal/identity/oidc/gitlab/gitlab.go
+++ b/internal/identity/oidc/gitlab/gitlab.go
@@ -16,7 +16,7 @@ import (
 // Name identifies the GitLab identity provider.
 const Name = "gitlab"
 
-var defaultScopes = []string{oidc.ScopeOpenID, "profile", "email", "api"}
+var defaultScopes = []string{oidc.ScopeOpenID, "profile", "email", "openid"}
 
 const (
 	defaultProviderURL = "https://gitlab.com"


### PR DESCRIPTION
## Summary

Currently, we require a GitLab application with the `api` scope on GitLab (SAAS) to authenticate using it as an IdP. This gives the application full read/write permissions for the entire API, much more than we need.

This change restricts the scope to `email` ~and `openid`~ (already defined). Including `profile` was also discussed, ~but the values therein are already provided by `openid`~ and put back in to match OIDC spec.:

![image](https://user-images.githubusercontent.com/2349184/130684873-7391a8a4-cafd-4b72-a0c4-a4a2bd1fc4d8.png)

I've built and tested this locally, with no problems (other than those caused by my own stupidity :smile: ).

## Related issues

https://github.com/pomerium/docs/issues/25

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
