### PR TITLE
config: remove headers

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -481,19 +481,11 @@ func (o *Options) parseHeaders(ctx context.Context) error {
 		return nil
 	}
 
-	if o.viperIsSet("headers") {
-		log.Warn(ctx).Msg("config: headers has been renamed to set_response_headers, it will be removed in v0.16")
-	}
-
-	// option was renamed from `headers` to `set_response_headers`. Both config settings are supported.
-	headerKeys := []string{"headers", "set_response_headers"}
-	for _, headerKey := range headerKeys {
-		if o.viperIsSet(headerKey) {
-			if err := o.viper.UnmarshalKey(headerKey, &headers); err != nil {
-				return fmt.Errorf("header %s failed to parse: %w", o.viper.Get(headerKey), err)
-			}
-			o.SetResponseHeaders = headers
+	if o.viperIsSet("set_response_headers") {
+		if err := o.viper.UnmarshalKey("set_response_headers", &headers); err != nil {
+			return fmt.Errorf("header %s failed to parse: %w", o.viper.Get("set_response_headers"), err)
 		}
+		o.SetResponseHeaders = headers
 	}
 	return nil
 }

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -117,18 +117,16 @@ func Test_bindEnvs(t *testing.T) {
 func Test_parseHeaders(t *testing.T) {
 	// t.Parallel()
 	tests := []struct {
-		name           string
-		want           map[string]string
-		envHeaders     string
-		viperHeaderKey string
-		viperHeaders   interface{}
-		wantErr        bool
+		name         string
+		want         map[string]string
+		envHeaders   string
+		viperHeaders interface{}
+		wantErr      bool
 	}{
 		{
 			"good env",
 			map[string]string{"X-Custom-1": "foo", "X-Custom-2": "bar"},
 			`{"X-Custom-1":"foo", "X-Custom-2":"bar"}`,
-			"headers",
 			map[string]string{"X": "foo"},
 			false,
 		},
@@ -136,7 +134,6 @@ func Test_parseHeaders(t *testing.T) {
 			"good env not_json",
 			map[string]string{"X-Custom-1": "foo", "X-Custom-2": "bar"},
 			`X-Custom-1:foo,X-Custom-2:bar`,
-			"headers",
 			map[string]string{"X": "foo"},
 			false,
 		},
@@ -144,7 +141,6 @@ func Test_parseHeaders(t *testing.T) {
 			"bad env",
 			map[string]string{},
 			"xyyyy",
-			"headers",
 			map[string]string{"X": "foo"},
 			true,
 		},
@@ -152,7 +148,6 @@ func Test_parseHeaders(t *testing.T) {
 			"bad env not_json",
 			map[string]string{"X-Custom-1": "foo", "X-Custom-2": "bar"},
 			`X-Custom-1:foo,X-Custom-2bar`,
-			"headers",
 			map[string]string{"X": "foo"},
 			true,
 		},
@@ -160,7 +155,6 @@ func Test_parseHeaders(t *testing.T) {
 			"bad viper",
 			map[string]string{},
 			"",
-			"headers",
 			"notaheaderstruct",
 			true,
 		},
@@ -168,7 +162,6 @@ func Test_parseHeaders(t *testing.T) {
 			"good viper",
 			map[string]string{"X-Custom-1": "foo", "X-Custom-2": "bar"},
 			"",
-			"headers",
 			map[string]string{"X-Custom-1": "foo", "X-Custom-2": "bar"},
 			false,
 		},
@@ -176,7 +169,6 @@ func Test_parseHeaders(t *testing.T) {
 			"new field name",
 			map[string]string{"X-Custom-1": "foo"},
 			"",
-			"set_response_headers",
 			map[string]string{"X-Custom-1": "foo"},
 			false,
 		},
@@ -191,7 +183,7 @@ func Test_parseHeaders(t *testing.T) {
 			mu.Lock()
 			defer mu.Unlock()
 			o = NewDefaultOptions()
-			o.viperSet("headers", tt.viperHeaders)
+			o.viperSet("set_response_headers", tt.viperHeaders)
 			o.viperSet("HeadersEnv", tt.envHeaders)
 			o.HeadersEnv = tt.envHeaders
 			err := o.parseHeaders(context.Background())
@@ -326,7 +318,7 @@ func TestOptionsFromViper(t *testing.T) {
 		},
 		{
 			"good disable header",
-			[]byte(`{"autocert_dir":"","insecure_server":true,"headers": {"disable":"true"},"policy":[{"from": "https://from.example","to":"https://to.example"}]}`),
+			[]byte(`{"autocert_dir":"","insecure_server":true,"set_response_headers": {"disable":"true"},"policy":[{"from": "https://from.example","to":"https://to.example"}]}`),
 			&Options{
 				Policies:                 []Policy{{From: "https://from.example", To: mustParseWeightedURLs(t, "https://to.example")}},
 				CookieName:               "_pomerium",

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -5,6 +5,11 @@ description: >-
   for Pomerium. Please read it carefully.
 ---
 
+# Since 0.15.0
+
+### Removed options
+The deprecated `headers` option has been removed. Use `set_response_headers` instead.
+
 # Since 0.14.0
 
 ## Breaking

--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -8,7 +8,7 @@ description: >-
 # Since 0.15.0
 
 ### Removed options
-The deprecated `headers` option has been removed. Use `set_response_headers` instead.
+The deprecated `headers` option has been removed. Use [`set_response_headers`](/reference/readme.md#set-response-headers) instead.
 
 # Since 0.14.0
 


### PR DESCRIPTION
## Summary
Remove the deprecated `headers` option.

## Related issues
Fixes https://github.com/pomerium/internal/issues/475

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
