### PR TITLE
deployment: update goreleaser syntax

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -237,11 +237,13 @@ nfpms:
       preinstall: ospkg/preinstall.sh
       postinstall: ospkg/postinstall.sh
 
-    config_files:
-      "ospkg/conf/config.yaml": "/etc/pomerium/config.yaml"
-
-    files:
-      "ospkg/pomerium.service": "/usr/lib/systemd/system/pomerium.service"
+    contents:
+      - src: ospkg/conf/config.yaml
+        dst: /etc/pomerium/config.yaml
+        type: config|noreplace
+        
+      - src: ospkg/pomerium.service
+        dst: /usr/lib/systemd/system/pomerium.service
 
     overrides:
       deb:


### PR DESCRIPTION
## Summary

To support the latest goreleaser we need to change our `nfpms` syntax.

## Related issues

https://github.com/pomerium/pomerium/pull/2473
https://github.com/pomerium/pomerium/pull/2521

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
