### PR TITLE
authorize: fix X-Pomerium-Claim-Groups

### DIFF
--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -211,13 +211,14 @@ identity_headers := {key: values |
 	h2 := [[header_name, header_value] |
 		some header_name
 		k := data.jwt_claim_headers[header_name]
-		header_value := array.concat(
+		raw_header_value := array.concat(
 			[cv |
 				[ck, cv] := jwt_claims[_]
 				ck == k
 			],
 			[""]
 		)[0]
+		header_value := get_header_string_value(raw_header_value)
 	]
 
 	h3 := kubernetes_headers


### PR DESCRIPTION
## Summary
Fix the `X-Pomerium-Claim-Groups` header. The groups are set as an array of values in the rego. Previously we would join that array with a comma via `get_header_string_value`. Unfortunately after the fix in https://github.com/pomerium/pomerium/pull/2261 that call was accidentally removed, resulting in the default array formatting in Go (e.g. `[x y z]` instead of `x,y,z`)

## Related issues
Fixes #2534

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
