### PR TITLE
allow pomerium to start without certs

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -681,8 +681,8 @@ func (o *Options) Validate() error {
 	o.HTTPRedirectAddr = strings.Trim(o.HTTPRedirectAddr, `"'`)
 
 	if !o.InsecureServer && !hasCert && !o.AutocertOptions.Enable {
-		return fmt.Errorf("config: server must be run with `autocert`, " +
-			"`insecure_server` or manually provided certificates to start")
+		log.Warn(ctx).Msg("neither `autocert`, " +
+			"`insecure_server` or manually provided certificates were provided, server will be using a self-signed certificate")
 	}
 
 	switch o.Provider {
@@ -1012,8 +1012,9 @@ func (o Options) indexCerts(ctx context.Context) certsIndex {
 		cert, err := cryptutil.ParsePEMCertificateFromFile(c.CertFile)
 		if err != nil {
 			log.Error(ctx).Err(err).Str("file", c.CertFile).Msg("parsing local cert: skipped")
+		} else {
+			idx.addCert(cert)
 		}
-		idx.addCert(cert)
 	}
 	return idx
 }

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -374,7 +374,7 @@ func Test_NewOptionsFromConfigEnvVar(t *testing.T) {
 		{"bad authorize url", map[string]string{"AUTHORIZE_SERVICE_URL": "authorize.example", "INSECURE_SERVER": "true", "SHARED_SECRET": "YixWi1MYh77NMECGGIJQevoonYtVF+ZPRkQZrrmeRqM="}, true},
 		{"bad cert base64", map[string]string{"CERTIFICATE": "bad cert", "SHARED_SECRET": "YixWi1MYh77NMECGGIJQevoonYtVF+ZPRkQZrrmeRqM="}, true},
 		{"bad cert key base64", map[string]string{"CERTIFICATE_KEY": "bad cert", "SHARED_SECRET": "YixWi1MYh77NMECGGIJQevoonYtVF+ZPRkQZrrmeRqM="}, true},
-		{"bad no certs no insecure mode set", map[string]string{"SHARED_SECRET": "YixWi1MYh77NMECGGIJQevoonYtVF+ZPRkQZrrmeRqM="}, true},
+		{"no certs no insecure mode set", map[string]string{"SHARED_SECRET": "YixWi1MYh77NMECGGIJQevoonYtVF+ZPRkQZrrmeRqM="}, false},
 		{"good disable headers ", map[string]string{"HEADERS": "disable:true", "INSECURE_SERVER": "true", "SHARED_SECRET": "YixWi1MYh77NMECGGIJQevoonYtVF+ZPRkQZrrmeRqM="}, false},
 		{"bad whitespace in secret", map[string]string{"INSECURE_SERVER": "true", "SERVICES": "authenticate", "SHARED_SECRET": "YixWi1MYh77NMECGGIJQevoonYtVF+ZPRkQZrrmeRqM=\n"}, true},
 		{"good forward auth url", map[string]string{"FORWARD_AUTH_URL": "https://databroker.example", "INSECURE_SERVER": "true", "SHARED_SECRET": "YixWi1MYh77NMECGGIJQevoonYtVF+ZPRkQZrrmeRqM="}, false},


### PR DESCRIPTION
## Summary

In some cases certificates may be entirely supplied from external source, i.e. via ingress-controller. 
Allow Pomerium to start with a warning and self-signed certificate if none are supplied via local configuraiton.

## Related issues

Fixes https://github.com/pomerium/internal/issues/532

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
