### PR TITLE
authorize: fix google cloudrun header audience

### DIFF
--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -31,7 +31,7 @@ func NewHeadersRequestFromPolicy(policy *config.Policy) *HeadersRequest {
 	}
 	input.KubernetesServiceAccountToken = policy.KubernetesServiceAccountToken
 	for _, wu := range policy.To {
-		input.ToAudience = wu.URL.Hostname()
+		input.ToAudience = "https://" + wu.URL.Hostname()
 	}
 	return input
 }

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -19,6 +19,23 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 )
 
+func TestNewHeadersRequestFromPolicy(t *testing.T) {
+	req := NewHeadersRequestFromPolicy(&config.Policy{
+		EnableGoogleCloudServerlessAuthentication: true,
+		From: "https://from.example.com",
+		To: config.WeightedURLs{
+			{
+				URL: *mustParseURL("http://to.example.com"),
+			},
+		},
+	})
+	assert.Equal(t, &HeadersRequest{
+		EnableGoogleCloudServerlessAuthentication: true,
+		FromAudience: "from.example.com",
+		ToAudience:   "https://to.example.com",
+	}, req)
+}
+
 func TestHeadersEvaluator(t *testing.T) {
 	type A = []interface{}
 	type M = map[string]interface{}


### PR DESCRIPTION
## Summary
Fix the google cloudrun header audience field. It was supposed to have `https://` in front of it. (which is confusing because our audience doesn't).

## Related issues
- #2454


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
