### PR TITLE
ppl: use session.user_id instead of user.id for user criterion

### DIFF
--- a/config/policy_ppl_test.go
+++ b/config/policy_ppl_test.go
@@ -275,8 +275,7 @@ claims_3 {
 
 users_0 {
 	session := get_session(input.session.id)
-	user := get_user(session)
-	user_id := user.id
+	user_id := session.user_id
 	user_id == "user1"
 }
 
@@ -289,8 +288,7 @@ emails_0 {
 
 users_1 {
 	session := get_session(input.session.id)
-	user := get_user(session)
-	user_id := user.id
+	user_id := session.user_id
 	user_id == "user2"
 }
 
@@ -303,8 +301,7 @@ emails_1 {
 
 users_2 {
 	session := get_session(input.session.id)
-	user := get_user(session)
-	user_id := user.id
+	user_id := session.user_id
 	user_id == "user3"
 }
 
@@ -317,8 +314,7 @@ emails_2 {
 
 users_3 {
 	session := get_session(input.session.id)
-	user := get_user(session)
-	user_id := user.id
+	user_id := session.user_id
 	user_id == "user4"
 }
 
@@ -331,8 +327,7 @@ emails_3 {
 
 users_4 {
 	session := get_session(input.session.id)
-	user := get_user(session)
-	user_id := user.id
+	user_id := session.user_id
 	user_id == "user5"
 }
 
@@ -485,8 +480,7 @@ else = v28 {
 
 users_5 {
 	session := get_session(input.session.id)
-	user := get_user(session)
-	user_id := user.id
+	user_id := session.user_id
 	user_id == "user6"
 }
 

--- a/pkg/policy/criteria/users.go
+++ b/pkg/policy/criteria/users.go
@@ -13,10 +13,7 @@ var usersBody = ast.Body{
 		session := get_session(input.session.id)
 	`),
 	ast.MustParseExpr(`
-		user := get_user(session)
-	`),
-	ast.MustParseExpr(`
-		user_id := user.id
+		user_id := session.user_id
 	`),
 }
 
@@ -43,8 +40,6 @@ func (c usersCriterion) GenerateRule(_ string, data parser.Value) (*ast.Rule, []
 
 	return r, []*ast.Rule{
 		rules.GetSession(),
-		rules.GetUser(),
-		rules.GetUserEmail(),
 	}, nil
 }
 

--- a/pkg/policy/criteria/users_test.go
+++ b/pkg/policy/criteria/users_test.go
@@ -1,0 +1,65 @@
+package criteria
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+)
+
+func TestUser(t *testing.T) {
+	t.Run("no session", func(t *testing.T) {
+		res, err := evaluate(t, `
+allow:
+  and:
+    - user:
+        is: USER_ID
+`, []dataBrokerRecord{}, Input{Session: InputSession{ID: "SESSION_ID"}})
+		require.NoError(t, err)
+		require.Equal(t, false, res["allow"])
+		require.Equal(t, false, res["deny"])
+	})
+	t.Run("by user id", func(t *testing.T) {
+		res, err := evaluate(t, `
+allow:
+  and:
+    - user:
+        is: USER_ID
+`,
+			[]dataBrokerRecord{
+				&session.Session{
+					Id:     "SESSION_ID",
+					UserId: "USER_ID",
+				},
+			},
+			Input{Session: InputSession{ID: "SESSION_ID"}})
+		require.NoError(t, err)
+		require.Equal(t, true, res["allow"])
+		require.Equal(t, false, res["deny"])
+	})
+	t.Run("by impersonate session id", func(t *testing.T) {
+		res, err := evaluate(t, `
+allow:
+  and:
+    - user:
+        is: USER2
+`,
+			[]dataBrokerRecord{
+				&session.Session{
+					Id:                   "SESSION1",
+					UserId:               "USER1",
+					ImpersonateSessionId: proto.String("SESSION2"),
+				},
+				&session.Session{
+					Id:     "SESSION2",
+					UserId: "USER2",
+				},
+			},
+			Input{Session: InputSession{ID: "SESSION1"}})
+		require.NoError(t, err)
+		require.Equal(t, true, res["allow"])
+		require.Equal(t, false, res["deny"])
+	})
+}


### PR DESCRIPTION
## Summary
Use session.user_id instead of user.id for user criterion

## Related issues
- https://github.com/pomerium/pomerium-console/issues/2025


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
