### PR TITLE
google: support provider URL

### DIFF
--- a/internal/directory/google/google.go
+++ b/internal/directory/google/google.go
@@ -49,6 +49,10 @@ func WithServiceAccount(serviceAccount *ServiceAccount) Option {
 
 // WithURL sets the provider url to use.
 func WithURL(url string) Option {
+	// if the empty string is sent in, use the default provider URL.
+	if url == "" {
+		url = defaultProviderURL
+	}
 	return func(cfg *config) {
 		cfg.url = url
 	}
@@ -56,7 +60,7 @@ func WithURL(url string) Option {
 
 func getConfig(opts ...Option) *config {
 	cfg := new(config)
-	WithURL(defaultProviderURL)(cfg)
+	WithURL("")(cfg)
 	for _, opt := range opts {
 		opt(cfg)
 	}

--- a/internal/directory/google/google.go
+++ b/internal/directory/google/google.go
@@ -49,10 +49,6 @@ func WithServiceAccount(serviceAccount *ServiceAccount) Option {
 
 // WithURL sets the provider url to use.
 func WithURL(url string) Option {
-	// if the empty string is sent in, use the default provider URL.
-	if url == "" {
-		url = defaultProviderURL
-	}
 	return func(cfg *config) {
 		cfg.url = url
 	}
@@ -60,7 +56,7 @@ func WithURL(url string) Option {
 
 func getConfig(opts ...Option) *config {
 	cfg := new(config)
-	WithURL("")(cfg)
+	WithURL(defaultProviderURL)(cfg)
 	for _, opt := range opts {
 		opt(cfg)
 	}

--- a/internal/directory/provider.go
+++ b/internal/directory/provider.go
@@ -116,7 +116,9 @@ func GetProvider(options Options) (provider Provider) {
 	case google.Name:
 		serviceAccount, err := google.ParseServiceAccount(options.ServiceAccount)
 		if err == nil {
-			return google.New(google.WithServiceAccount(serviceAccount))
+			return google.New(
+				google.WithServiceAccount(serviceAccount),
+				google.WithURL(options.ProviderURL))
 		}
 		log.Warn(ctx).
 			Str("service", "directory").

--- a/internal/directory/provider.go
+++ b/internal/directory/provider.go
@@ -116,9 +116,13 @@ func GetProvider(options Options) (provider Provider) {
 	case google.Name:
 		serviceAccount, err := google.ParseServiceAccount(options.ServiceAccount)
 		if err == nil {
-			return google.New(
+			googleOptions := []google.Option{
 				google.WithServiceAccount(serviceAccount),
-				google.WithURL(options.ProviderURL))
+			}
+			if options.ProviderURL != "" {
+				googleOptions = append(googleOptions, google.WithURL(options.ProviderURL))
+			}
+			return google.New(googleOptions...)
 		}
 		log.Warn(ctx).
 			Str("service", "directory").


### PR DESCRIPTION
## Summary
Add support for a provider URL with the google provider. This is so we can mock directory calls in integration tests. If no provider URL is supplied the current default will be used.


## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
