### PR TITLE
authorize: use session.user_id in headers

### DIFF
--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -80,8 +80,8 @@ func TestHeadersEvaluator(t *testing.T) {
 	t.Run("jwt", func(t *testing.T) {
 		output, err := eval(t,
 			[]proto.Message{
-				&session.Session{Id: "s1", ImpersonateSessionId: proto.String("s2")},
-				&session.Session{Id: "s2"},
+				&session.Session{Id: "s1", ImpersonateSessionId: proto.String("s2"), UserId: "u1"},
+				&session.Session{Id: "s2", UserId: "u2"},
 			},
 			&HeadersRequest{
 				FromAudience: "from.example.com",
@@ -103,5 +103,7 @@ func TestHeadersEvaluator(t *testing.T) {
 		assert.LessOrEqual(t, claims["exp"], float64(time.Now().Add(time.Minute*6).Unix()),
 			"JWT should expire within 5 minutes, but got: %v", claims["exp"])
 		assert.Equal(t, "s1", claims["sid"], "should set session id to input session id")
+		assert.Equal(t, "u2", claims["sub"], "should set subject to user id")
+		assert.Equal(t, "u2", claims["user"], "should set user to user id")
 	})
 }

--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -110,13 +110,13 @@ jwt_payload_iat = v {
 }
 
 jwt_payload_sub = v {
-	v = user.id
+	v = session.user_id
 } else = "" {
 	true
 }
 
 jwt_payload_user = v {
-	v = user.id
+	v = session.user_id
 } else = "" {
 	true
 }


### PR DESCRIPTION
## Summary
Instead of relying on the user record id for the `sub` and `user` JWT claims we should use the `session.user_id`.

## Related issues
Fixes https://github.com/pomerium/internal/issues/565

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
