### PR TITLE
autocert: remove log

### DIFF
--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -166,7 +166,7 @@ func (mgr *Manager) renewConfigCerts(ctx context.Context) error {
 	for _, domain := range sourceHostnames(cfg) {
 		cert, err := cm.CacheManagedCertificate(domain)
 		if err != nil {
-			log.Error(ctx).Err(err).Str("domain", domain).Msg("get cert")
+			// this happens for unmanaged certificates
 			continue
 		}
 		if cert.NeedsRenewal(cm) {


### PR DESCRIPTION
## Summary
Remove a noisy error log. This error is returned for domains not managed by certmagic. It's not a real error.

It was introduced in #2286 

## Related issues
Fixes #2559 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
