### PR TITLE
userinfo: format exp, iat and updated_at

### DIFF
--- a/internal/frontend/assets/html/userInfo.html
+++ b/internal/frontend/assets/html/userInfo.html
@@ -122,7 +122,11 @@
                   <td>{{$k}}</td>
                   <td>
                     {{range $v.AsSlice}}
+                      {{if eq $k "exp" "iat" "updated_at"}}
+                    <p>{{formatTime .}}</p>
+                      {{else}}
                     <p>{{.}}</p>
+                      {{end}}
                     {{end}}
                   </td>
                 </tr>

--- a/internal/frontend/templates.go
+++ b/internal/frontend/templates.go
@@ -65,7 +65,20 @@ func NewTemplates() (*template.Template, error) {
 		"dataURL": func(p string) template.URL {
 			return dataURLs[strings.TrimPrefix(p, "/.pomerium/assets/")]
 		},
-		"formatTime": func(tm time.Time) string {
+		"formatTime": func(arg interface{}) string {
+			var tm time.Time
+			switch t := arg.(type) {
+			case float64:
+				tm = time.Unix(int64(t), 0)
+			case int:
+				tm = time.Unix(int64(t), 0)
+			case int64:
+				tm = time.Unix(t, 0)
+			case time.Time:
+				tm = t
+			default:
+				return "<INVALID TIME>"
+			}
 			return tm.Format("2006-01-02 15:04:05 MST")
 		},
 	})


### PR DESCRIPTION
## Summary
Format the `exp`, `iat` and `updated_at` claims on the userinfo page.

## Related issues
Fixes #2578 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
