### PR TITLE
pomerium-cli: use cache dir instead of config dir

### DIFF
--- a/cmd/pomerium-cli/cache.go
+++ b/cmd/pomerium-cli/cache.go
@@ -11,23 +11,12 @@ import (
 	"time"
 )
 
-func configHome() string {
-	cfgDir, err := os.UserConfigDir()
-	if err != nil {
-		fatalf("error getting user config dir: %v", err)
-	}
-
-	ch := filepath.Join(cfgDir, "pomerium-cli")
-	err = os.MkdirAll(ch, 0o755)
-	if err != nil {
-		fatalf("error creating user config dir: %v", err)
-	}
-
-	return ch
-}
-
 func cachePath() string {
-	return filepath.Join(configHome(), "cache", "exec-credential")
+	root, err := os.UserCacheDir()
+	if err != nil {
+		fatalf("error getting user cache dir: %v", err)
+	}
+	return filepath.Join(root, "pomerium-cli", "exec-credential")
 }
 
 func cachedCredentialPath(serverURL string) string {


### PR DESCRIPTION
## Summary
Use the user's cache directory instead of the config directory.

## Related issues
Fixes https://github.com/pomerium/internal/issues/567

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
