### PR TITLE
tcptunnel: force the use of HTTP/1.1 during ALPN

### DIFF
--- a/cmd/pomerium-cli/main.go
+++ b/cmd/pomerium-cli/main.go
@@ -55,5 +55,9 @@ func getTLSConfig() *tls.Config {
 			fatalf("%s", err)
 		}
 	}
+	cfg.GetConfigForClient = func(info *tls.ClientHelloInfo) (*tls.Config, error) {
+		info.SupportedProtos = []string{"http/1.1"}
+		return cfg, nil
+	}
 	return cfg
 }

--- a/cmd/pomerium-cli/main.go
+++ b/cmd/pomerium-cli/main.go
@@ -55,9 +55,5 @@ func getTLSConfig() *tls.Config {
 			fatalf("%s", err)
 		}
 	}
-	cfg.GetConfigForClient = func(info *tls.ClientHelloInfo) (*tls.Config, error) {
-		info.SupportedProtos = []string{"http/1.1"}
-		return cfg, nil
-	}
 	return cfg
 }

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,6 @@ require (
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.30.0
 	github.com/prometheus/procfs v0.7.3
-	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/rjeczalik/notify v0.9.3-0.20201210012515-e2a77dcc14cf
 	github.com/rs/cors v1.8.0
 	github.com/rs/zerolog v1.24.0
@@ -198,6 +197,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/polyfloyd/go-errorlint v0.0.0-20210722154253-910bb7978349 // indirect
+	github.com/prometheus/statsd_exporter v0.21.0 // indirect
 	github.com/quasilyte/go-ruleguard v0.3.4 // indirect
 	github.com/quasilyte/regex/syntax v0.0.0-20200407221936-30656e2c4a95 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect

--- a/internal/tcptunnel/config.go
+++ b/internal/tcptunnel/config.go
@@ -56,6 +56,10 @@ func WithProxyHost(proxyHost string) Option {
 // WithTLSConfig returns an option to configure the tls config.
 func WithTLSConfig(tlsConfig *tls.Config) Option {
 	return func(cfg *config) {
+		if tlsConfig != nil {
+			tlsConfig = tlsConfig.Clone()
+			tlsConfig.NextProtos = []string{"http/1.1"} // disable http/2 in ALPN
+		}
 		cfg.tlsConfig = tlsConfig
 	}
 }


### PR DESCRIPTION
## Summary
It appears that when using TLS with the tcptunnel we sometimes negotiate HTTP/2, which won't work with the CONNECT upgrade connection. These changes should make it so that we never negotiate HTTP/2 when using ALPN.

## Related issues
- #2590

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
