### PR TITLE
authclient: clone TLS configuration to prevent overriding NextProtos

### DIFF
--- a/internal/authclient/config.go
+++ b/internal/authclient/config.go
@@ -22,6 +22,6 @@ type Option func(*config)
 // WithTLSConfig returns an option to configure the tls config.
 func WithTLSConfig(tlsConfig *tls.Config) Option {
 	return func(cfg *config) {
-		cfg.tlsConfig = tlsConfig
+		cfg.tlsConfig = tlsConfig.Clone()
 	}
 }


### PR DESCRIPTION
## Summary
When using a TLS config in the `authclient` we need to clone it so that we don't inadvertently modify it when enabling the HTTP server. The modification can be seen here: https://cs.opensource.google/go/go/+/master:src/net/http/h2_bundle.go;l=3875?q=NextProtos&ss=go%2Fgo.

This is why HTTP/2 was getting re-enabled.

## Related issues
- #2590 

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
