### PR TITLE
DOCS: Add copy button to code snippets

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -7,6 +7,10 @@ module.exports = {
     "vuepress-plugin-element-tabs",
     'vuepress-plugin-mermaidjs',
     [
+      'vuepress-plugin-code-copy',
+      true
+    ],
+    [
       "check-md",
       {
         pattern: "**/*.md",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "esm": "3.2.25",
-    "markdown-it-include": "^2.0.0"
+    "markdown-it-include": "^2.0.0",
+    "vuepress-plugin-code-copy": "^1.0.6"
   }
 }


### PR DESCRIPTION
## Summary

Adds `vuepress-plugin-code-copy` ([link](https://www.npmjs.com/package/vuepress-plugin-code-copy)) to provide a one-click copy button to code snippets.


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
