### PR TITLE
Add docs team as a code owner of packages.json

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,4 @@
 * @pomerium/dev-backend
 /docs/  @pomerium/docs @pomerium/dev
 /docs/.vuepress/ @pomerium/docs @pomerium/dev
+/package.json @pomerium/docs @pomerium/dev


### PR DESCRIPTION
## Summary

`packages.json` Is used by the docs site to manage vuepress and its plugins/dependencies.

## Related issues

https://github.com/pomerium/pomerium/pull/2603

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
