### PR TITLE
pomerium-cli: add support for a custom browser command

### DIFF
--- a/cmd/pomerium-cli/kubernetes.go
+++ b/cmd/pomerium-cli/kubernetes.go
@@ -16,6 +16,7 @@ import (
 )
 
 func init() {
+	addBrowserFlags(kubernetesExecCredentialCmd)
 	addTLSFlags(kubernetesExecCredentialCmd)
 	kubernetesCmd.AddCommand(kubernetesExecCredentialCmd)
 	kubernetesCmd.AddCommand(kubernetesFlushCredentialsCmd)
@@ -61,7 +62,9 @@ var kubernetesExecCredentialCmd = &cobra.Command{
 			tlsConfig = getTLSConfig()
 		}
 
-		ac := authclient.New(authclient.WithTLSConfig(tlsConfig))
+		ac := authclient.New(
+			authclient.WithBrowserCommand(browserOptions.command),
+			authclient.WithTLSConfig(tlsConfig))
 		rawJWT, err := ac.GetJWT(context.Background(), serverURL)
 		if err != nil {
 			fatalf("%s", err)

--- a/cmd/pomerium-cli/main.go
+++ b/cmd/pomerium-cli/main.go
@@ -57,3 +57,13 @@ func getTLSConfig() *tls.Config {
 	}
 	return cfg
 }
+
+var browserOptions struct {
+	command string
+}
+
+func addBrowserFlags(cmd *cobra.Command) {
+	flags := cmd.Flags()
+	flags.StringVar(&browserOptions.command, "browser-cmd", "",
+		"custom browser command to run when opening a URL")
+}

--- a/cmd/pomerium-cli/tcp.go
+++ b/cmd/pomerium-cli/tcp.go
@@ -87,6 +87,7 @@ var tcpCmd = &cobra.Command{
 		}()
 
 		tun := tcptunnel.New(
+			tcptunnel.WithBrowserCommand(browserOptions.command),
 			tcptunnel.WithDestinationHost(dstHost),
 			tcptunnel.WithProxyHost(pomeriumURL.Host),
 			tcptunnel.WithTLSConfig(tlsConfig),

--- a/internal/authclient/authclient.go
+++ b/internal/authclient/authclient.go
@@ -9,13 +9,11 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 
-	"github.com/skratchdot/open-golang/open"
 	"golang.org/x/sync/errgroup"
 )
-
-var openBrowser = open.Run
 
 // An AuthClient retrieves an authentication JWT via the Pomerium login API.
 type AuthClient struct {
@@ -141,5 +139,11 @@ func (client *AuthClient) runOpenBrowser(ctx context.Context, li net.Listener, s
 		return fmt.Errorf("failed to read login url: %w", err)
 	}
 
-	return openBrowser(string(bs))
+	err = client.cfg.open(string(bs))
+	if err != nil {
+		return fmt.Errorf("failed to open browser url: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(os.Stderr, "Your browser has been opened to visit:\n\n%s\n\n", string(bs))
+	return nil
 }

--- a/internal/authclient/authclient_test.go
+++ b/internal/authclient/authclient_test.go
@@ -36,11 +36,8 @@ func TestAuthClient(t *testing.T) {
 		_ = srv.Serve(li)
 	}()
 
-	origOpenBrowser := openBrowser
-	defer func() {
-		openBrowser = origOpenBrowser
-	}()
-	openBrowser = func(input string) error {
+	ac := New()
+	ac.cfg.open = func(input string) error {
 		u, err := url.Parse(input)
 		if err != nil {
 			return err
@@ -64,7 +61,6 @@ func TestAuthClient(t *testing.T) {
 		return nil
 	}
 
-	ac := New()
 	rawJWT, err := ac.GetJWT(ctx, &url.URL{
 		Scheme: "http",
 		Host:   li.Addr().String(),

--- a/internal/authclient/config.go
+++ b/internal/authclient/config.go
@@ -2,14 +2,18 @@ package authclient
 
 import (
 	"crypto/tls"
+
+	"github.com/skratchdot/open-golang/open"
 )
 
 type config struct {
+	open      func(rawURL string) error
 	tlsConfig *tls.Config
 }
 
 func getConfig(options ...Option) *config {
 	cfg := new(config)
+	WithBrowserCommand("")(cfg)
 	for _, o := range options {
 		o(cfg)
 	}
@@ -18,6 +22,19 @@ func getConfig(options ...Option) *config {
 
 // An Option modifies the config.
 type Option func(*config)
+
+// WithBrowserCommand returns an option to configure the browser command.
+func WithBrowserCommand(browserCommand string) Option {
+	return func(cfg *config) {
+		if browserCommand == "" {
+			cfg.open = open.Run
+		} else {
+			cfg.open = func(rawURL string) error {
+				return open.RunWith(rawURL, browserCommand)
+			}
+		}
+	}
+}
 
 // WithTLSConfig returns an option to configure the tls config.
 func WithTLSConfig(tlsConfig *tls.Config) Option {

--- a/internal/tcptunnel/config.go
+++ b/internal/tcptunnel/config.go
@@ -9,10 +9,11 @@ import (
 )
 
 type config struct {
-	jwtCache  cliutil.JWTCache
-	dstHost   string
-	proxyHost string
-	tlsConfig *tls.Config
+	jwtCache      cliutil.JWTCache
+	dstHost       string
+	proxyHost     string
+	tlsConfig     *tls.Config
+	browserConfig string
 }
 
 func getConfig(options ...Option) *config {
@@ -31,6 +32,13 @@ func getConfig(options ...Option) *config {
 
 // An Option modifies the config.
 type Option func(*config)
+
+// WithBrowserCommand returns an option to configure the browser command.
+func WithBrowserCommand(browserCommand string) Option {
+	return func(cfg *config) {
+		cfg.browserConfig = browserCommand
+	}
+}
 
 // WithDestinationHost returns an option to configure the destination host.
 func WithDestinationHost(dstHost string) Option {

--- a/internal/tcptunnel/tcptunnel.go
+++ b/internal/tcptunnel/tcptunnel.go
@@ -30,8 +30,10 @@ type Tunnel struct {
 func New(options ...Option) *Tunnel {
 	cfg := getConfig(options...)
 	return &Tunnel{
-		cfg:  cfg,
-		auth: authclient.New(authclient.WithTLSConfig(cfg.tlsConfig)),
+		cfg: cfg,
+		auth: authclient.New(
+			authclient.WithBrowserCommand(cfg.browserConfig),
+			authclient.WithTLSConfig(cfg.tlsConfig)),
 	}
 }
 


### PR DESCRIPTION
## Summary
Add support for a custom browser command and print the URL similar to how the gcloud CLI does.

## Related issues
Fixes https://github.com/pomerium/internal/issues/544


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
