### PR TITLE
docs: remove extra word / updated docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Pomerium can be used to:
 
 For comprehensive docs, and tutorials see our [documentation].
 
-[documentation]: https://www.pomerium.io/
+[documentation]: https://pomerium.com/docs/
 [go environment]: https://golang.org/doc/install
 [godocs]: https://godoc.org/github.com/pomerium/pomerium
 [quick start guide]: https://www.pomerium.io/guide/

--- a/docs/enterprise/about.md
+++ b/docs/enterprise/about.md
@@ -32,7 +32,7 @@ Quickly view who is logged in your infrastructure, with easy access to revoke se
 
 Easily define who can control access to what areas of your infrastructure. Our [Namespaces](/enterprise/concepts.md#namespaces) make it easy to allow teams to self-manage access to the infrastructure they build from or depend on.
 
-[User roles](/enterprise/concepts.md#rbac-for-enterprise-console-users) are granted along Namespace hierarchy, with in inheritance from parents.
+[User roles](/enterprise/concepts.md#rbac-for-enterprise-console-users) are granted along Namespace hierarchy, with inheritance from parents.
 
 Pomerium Enterprise uses teams and groups defined by your IdP, so you can build stable policies that don't need to be adjusted as your company changes.
 


### PR DESCRIPTION
## Summary
I updated the documentation link, deleted a superfluous word in another page.
<!--  
-->

## Related issues
Grammar change
<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [X] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
