### PR TITLE
DOCS: Collapse IDP Header

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -113,7 +113,7 @@ module.exports = {
         },
         {
           title: "Identity Providers",
-          collapsable: false,
+          collapsable: true,
           path: "/docs/identity-providers/",
           type: "group",
           sidebarDepth: 0,


### PR DESCRIPTION
## Summary

IdP configuration need only be done once, and users are only interested in the IdP they use. Making this section collapsible frees up space on the ever-growing menu.

@desimone we discussed this before and I know you had some concerns, but the conversation is not historically accessible. Please outline any concerns on this PR. 

## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
