### PR TITLE
Docs: cross-reference links between concepts and reference

### DIFF
--- a/docs/enterprise/concepts.md
+++ b/docs/enterprise/concepts.md
@@ -21,6 +21,8 @@ Namespaces enable:
 
 Each of these sub-concepts are related and build on each other to form a unified security model.
 
+See [Reference: Namespace] for more information.
+
 ### Self-Service Capabilities
 
 One of the benefits of an identity-aware access proxy is that, once in place, developers and owners of enterprise applications have an incentive to configure their services to be accessible via the proxy.
@@ -102,6 +104,8 @@ A service account identity can either be based on a user entry in your IdP Direc
 
 Routes define the connection pathway and configuration from the internet to your internal service. As a very basic level, a route sends traffic from `external-address.company.com` to `internalService-address.localdomain`, restricted by the policies associated with it, and encrypted by your TLS certificates. But more advanced configurations allow identity header pass-through, path and prefix rewrites, request and response header modification, load balancer services, and other full featured ingress capabilities.
 
+For more information, see [Reference: Routes]
+
 ### Protected Endpoints
 
 This term refers to the system or service the route provides or restricts access to.
@@ -146,3 +150,5 @@ With Pomerium:
 - Pomerium provides detailed audit logs for all activity in your environment. Quickly detect anomalies to mitigate bad actors and revoke access with a click of a button. Simplify life-cycle management and access reviews.
 
 [Reference: Policies]: /enterprise/reference/manage.md#policies-2
+[Reference: Namespace]: /enterprise/reference/configure.md#namespaces
+[Reference: Routes]: /enterprise/reference/manage.md#routes

--- a/docs/enterprise/console-settings.yaml
+++ b/docs/enterprise/console-settings.yaml
@@ -36,7 +36,7 @@ settings:
     settings:
       - name: "Routes"
         doc: |
-          A Route defines how to access a service running behind Pomerium. This includes authentication (both for Pomerium and passed through to the service), rewrites, header management, load balancing, etc.
+          A [Route](/enterprise/concepts.md#routes) defines how to access a service running behind Pomerium. This includes authentication (both for Pomerium and passed through to the service), rewrites, header management, load balancing, etc.
         settings:
           - name: "General"
             doc: |
@@ -90,7 +90,7 @@ settings:
       - name: "Policies"
         keys: ["Policy"]
         doc: |
-          A Policy defines what permissions a set of users or groups has. Policies are applied to Namespaces or Routes to associate the set of permissions with a service or set of service, completing the authentication model.
+          A [Policy](/enterprise/concepts.md#policies) defines what permissions a set of users or groups has. Policies are applied to Namespaces or Routes to associate the set of permissions with a service or set of service, completing the authentication model.
 
           Policies can be constructed three ways:
 
@@ -226,7 +226,7 @@ settings:
                 keys: ["set_response_headers"]
       - name: "Service Accounts"
         doc: |
-          Service accounts offer a protected and standardized method of authenticating machine-to-machine communication between services protected by Pomerium.
+          [Service accounts](/enterprise/concepts.md#service-accounts) offer a protected and standardized method of authenticating machine-to-machine communication between services protected by Pomerium.
 
           ::: tip
           Before you begin, confirm you are in the correct Namespace. A service account can only be used in the Namespace it was created in, including its children Namespaces.

--- a/docs/enterprise/reference/configure.md
+++ b/docs/enterprise/reference/configure.md
@@ -245,7 +245,7 @@ Set Response Headers allows you to set static values for the given response head
 
 ## Service Accounts
 
-Service accounts offer a protected and standardized method of authenticating machine-to-machine communication between services protected by Pomerium.
+[Service accounts](/enterprise/concepts.md#service-accounts) offer a protected and standardized method of authenticating machine-to-machine communication between services protected by Pomerium.
 
 ::: tip
 Before you begin, confirm you are in the correct Namespace. A service account can only be used in the Namespace it was created in, including its children Namespaces.

--- a/docs/enterprise/reference/manage.md
+++ b/docs/enterprise/reference/manage.md
@@ -11,7 +11,7 @@ meta:
 
 ## Routes
 
-A Route defines how to access a service running behind Pomerium. This includes authentication (both for Pomerium and passed through to the service), rewrites, header management, load balancing, etc.
+A [Route](/enterprise/concepts.md#routes) defines how to access a service running behind Pomerium. This includes authentication (both for Pomerium and passed through to the service), rewrites, header management, load balancing, etc.
 
 
 ### General
@@ -281,7 +281,7 @@ Some policy types support additional [configuration](/reference/readme.md#load-b
 
 ## Policies
 
-A Policy defines what permissions a set of users or groups has. Policies are applied to Namespaces or Routes to associate the set of permissions with a service or set of service, completing the authentication model.
+A [Policy](/enterprise/concepts.md#policies) defines what permissions a set of users or groups has. Policies are applied to Namespaces or Routes to associate the set of permissions with a service or set of service, completing the authentication model.
 
 Policies can be constructed three ways:
 


### PR DESCRIPTION
## Summary

Cross-links terms that have entries in both Enterprise Concepts and Enterprise Reference.

## Related issues

Last nit in https://github.com/pomerium/docs/issues/40

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
