### PR TITLE
ppl: add version to generator

### DIFF
--- a/authorize/evaluator/policy_evaluator_test.go
+++ b/authorize/evaluator/policy_evaluator_test.go
@@ -196,4 +196,15 @@ func TestPolicyEvaluator(t *testing.T) {
 			}, output)
 		})
 	})
+	t.Run("incompatible version", func(t *testing.T) {
+		ctx := context.Background()
+		_, err := NewPolicyEvaluator(ctx, NewStoreFromProtos(math.MaxUint64), &config.Policy{
+			SubPolicies: []config.SubPolicy{{
+				Rego: []string{
+					`package pomerium.policy #version=9999999`,
+				},
+			}},
+		})
+		assert.ErrorIs(t, err, ErrIncompatibleRegoScript)
+	})
 }

--- a/config/policy_ppl_test.go
+++ b/config/policy_ppl_test.go
@@ -54,7 +54,7 @@ func TestPolicy_ToPPL(t *testing.T) {
 		},
 	}).ToPPL())
 	require.NoError(t, err)
-	assert.Equal(t, `package pomerium.policy
+	assert.Equal(t, `package pomerium.policy #version=1
 
 default allow = [false, set()]
 

--- a/pkg/policy/generator/generator.go
+++ b/pkg/policy/generator/generator.go
@@ -114,6 +114,9 @@ func (g *Generator) Generate(policy *parser.Policy) (*ast.Module, error) {
 				ast.StringTerm("policy"),
 			},
 		},
+		Comments: []*ast.Comment{
+			ast.NewComment([]byte(fmt.Sprintf("version=%d", Version))),
+		},
 		Rules: rs,
 	}
 

--- a/pkg/policy/generator/generator_test.go
+++ b/pkg/policy/generator/generator_test.go
@@ -61,7 +61,7 @@ func Test(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	assert.Equal(t, `package pomerium.policy
+	assert.Equal(t, `package pomerium.policy #version=1
 
 default allow = [false, set()]
 

--- a/pkg/policy/generator/version.go
+++ b/pkg/policy/generator/version.go
@@ -1,0 +1,25 @@
+package generator
+
+import (
+	"regexp"
+	"strconv"
+)
+
+// Version is the generated rego language version number. When changed it means the contract between authorize and rego
+// has changed in a breaking way, so older versions of Pomerium should not run the newer code.
+const Version = 1
+
+var versionRE = regexp.MustCompile(`package pomerium.policy #version=([0-9]+)`)
+
+// GetVersionFromRego gets the generator version from rego. If no version is found the current version is returned.
+func GetVersionFromRego(rawRego string) int {
+	matches := versionRE.FindStringSubmatch(rawRego)
+	if len(matches) < 2 {
+		return Version
+	}
+	v, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return Version
+	}
+	return v
+}

--- a/pkg/policy/generator/version_test.go
+++ b/pkg/policy/generator/version_test.go
@@ -1,0 +1,22 @@
+package generator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetVersionFromRego(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		v := GetVersionFromRego(`package pomerium.policy #version=123`)
+		assert.Equal(t, 123, v)
+	})
+	t.Run("missing", func(t *testing.T) {
+		v := GetVersionFromRego(`package pomerium.policy`)
+		assert.Equal(t, Version, v)
+	})
+	t.Run("non-number", func(t *testing.T) {
+		v := GetVersionFromRego(`package pomerium.policy #version=XYZ`)
+		assert.Equal(t, Version, v)
+	})
+}


### PR DESCRIPTION
## Summary
The PPL generator converts PPL into rego. That rego code is then evaluated by Authorize which expects data in a certain format. That format may change in the future, so this PR adds a version comment that specifies the expected version to work properly.

## Related issues
- https://github.com/pomerium/internal/issues/602


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
