### PR TITLE
cryptutil: add SecureToken

### DIFF
--- a/pkg/cryptutil/token.go
+++ b/pkg/cryptutil/token.go
@@ -101,6 +101,16 @@ func GenerateSecureToken(key []byte, expiry time.Time, token Token) SecureToken 
 	return secureToken
 }
 
+// SecureTokenFromString parses a base58-encoded string into a SecureToken.
+func SecureTokenFromString(rawstr string) (secureToken SecureToken, ok bool) {
+	result := base58.Decode(rawstr)
+	if len(result) != SecureTokenLength {
+		return secureToken, false
+	}
+	copy(secureToken[:], result[:SecureTokenLength])
+	return secureToken, true
+}
+
 // Bytes returns the secret token as bytes.
 func (secureToken SecureToken) Bytes() []byte {
 	return secureToken[:]

--- a/pkg/cryptutil/token_test.go
+++ b/pkg/cryptutil/token_test.go
@@ -91,6 +91,12 @@ func TestSecureToken(t *testing.T) {
 	}, secureToken.Token())
 	assert.Equal(t, expiry, secureToken.Expiry().UTC())
 
+	t.Run("parse", func(t *testing.T) {
+		parsed, ok := SecureTokenFromString("2Y2GNugUpcunes9epx9ehkdHwJvejtnBzNJ5iniiRYv3rMoE7LMN3tZmf7ZGNidJKMSvTtCYEqtE5")
+		assert.True(t, ok)
+		assert.Equal(t, secureToken, parsed)
+	})
+
 	t.Run("valid", func(t *testing.T) {
 		err := secureToken.Verify(key, expiry.Add(-time.Second))
 		assert.NoError(t, err)


### PR DESCRIPTION
## Summary
Add a new `SecureToken` type that `HMAC`s and adds an expiration timestamp to a `Token`. This can be used to securely pass a UUID or similar data.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
