### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/enterprise/install/helm.md
+++ b/docs/enterprise/install/helm.md
@@ -146,7 +146,7 @@ This setup assumes an existing certificate solution using cert-manager, as descr
    sudo -E kubectl --namespace pomerium port-forward service/pomerium-proxy 443:443
    ```
 
-1. When visiting `https://console.localhost.pomerium.io`, you should se the Session List page:
+1. When visiting `https://console.localhost.pomerium.io`, you should see the Session List page:
 
    ![The Session List page after installing Pomerium Enterprise](../img/console-session-landing.png)
 


### PR DESCRIPTION
## Summary

Fixes typo in `docs/enterprise/install/helm.md`
