### PR TITLE
Update create TLS command to quote strings.

### DIFF
--- a/docs/docs/install/helm.md
+++ b/docs/docs/install/helm.md
@@ -76,7 +76,7 @@ If you haven't already, install cert-manager and create a CA issuer. You can fol
 
    ```bash
    kubectl create secret tls pomerium-tls-ca --namespace=pomerium \
-   --cert=$(mkcert -CAROOT)/rootCA.pem --key=$(mkcert -CAROOT)/rootCA-key.pem
+   --cert="$(mkcert -CAROOT)/rootCA.pem" --key="$(mkcert -CAROOT)/rootCA-key.pem"
    ```
 
 1. Define an Issuer configuration in `issuer.yaml`:


### PR DESCRIPTION
In some instances the cert and key path returned from `mkcert -CAROOT` might contain spaces. If it does the example command fails with the somewhat cryptic error `error: exactly one NAME is required, got 3`. Quoting the values resolves the issue.
