### PR TITLE
telemetry: improve zipkin error logs

### DIFF
--- a/internal/telemetry/trace/zipkin.go
+++ b/internal/telemetry/trace/zipkin.go
@@ -24,8 +24,11 @@ func (provider *zipkinProvider) Register(opts *TracingOptions) error {
 		return fmt.Errorf("telemetry/trace: could not create local endpoint: %w", err)
 	}
 
-	provider.reporter = zipkinHTTP.NewReporter(opts.ZipkinEndpoint.String(),
-		zipkinHTTP.Logger(stdlog.New(log.Logger(), "", 0)))
+	logger := log.With().Str("service", "zipkin").Logger()
+	logWriter := &log.StdLogWrapper{Logger: &logger}
+	stdLogger := stdlog.New(logWriter, "", 0)
+
+	provider.reporter = zipkinHTTP.NewReporter(opts.ZipkinEndpoint.String(), zipkinHTTP.Logger(stdLogger))
 	provider.exporter = oczipkin.NewExporter(provider.reporter, localEndpoint)
 	octrace.RegisterExporter(provider.exporter)
 	return nil


### PR DESCRIPTION
## Summary
Improve the zipkin error logs. They will now include a log level and service tag:

```json
{"level":"error","service":"zipkin","time":"2021-10-26T09:13:27-06:00","message":"failed to send the request: Post \"http://localhost:9411/api/v2/spans\": dial tcp [::1]:9411: connect: connection refused"}
```

## Related issues
Fixes https://github.com/pomerium/internal/issues/611


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
