### PR TITLE
desktop client api

### DIFF
--- a/pkg/grpc/cli/api.proto
+++ b/pkg/grpc/cli/api.proto
@@ -1,40 +1,44 @@
 syntax = "proto3";
 
-package client;
+package pomerium.cli;
+option go_package = "github.com/pomerium/pomerium/pkg/grpc/cli";
 
 service Config {
-  rpc List(ListConnectionsRequest) returns (ListConnectionsResponse);
-  rpc Delete(DeleteConnectionsRequest) returns (DeleteConnectionsResponse);
-  rpc UpsertConnection(ConnectionRecord) returns (ConnectionRecord);
+  rpc List(Selector) returns (ListRecordsResponse);
+  rpc Delete(Selector) returns (DeleteRecordsResponse);
+  rpc Upsert(Record) returns (Record);
   rpc Export(ExportRequest) returns (ConfigData);
   rpc Import(ImportRequest) returns (ImportResponse);
 }
 
-message ConnectionRecord {
+message Record {
+  // if omitted, a new record would be created
   optional string id = 1;
-  repeated tags = 2;
+  repeated string tags = 2;
   // connection data may be omitted if i.e. just manipulating the tags data
   optional Connection conn = 3;
 }
 
-message ListConnectionsRequest {
-  oneof {
-    // only return connections matching a particular tag
-    string tag = 1;
+message Selector {
+  message IdFilter { repeated string ids = 1; }
+  message TagFilter { repeated string tags = 2; }
+
+  oneof filter {
+    // all records
+    bool all = 1;
+    // only return connections matching tag(s)
+    TagFilter tag = 2;
     // only return specific connection(s)
-    repeated connection_ids = 2;
+    IdFilter id_filter = 3;
   }
 }
-message ListConnectionsResponse { repeated ConnectionRecords records = 1; }
-
-message DeleteConnectionsRequest { repeated string connection_ids = 1; }
-message DeleteConnectionsResponse {}
+message ListRecordsResponse { repeated Record records = 1; }
+message DeleteRecordsResponse {}
 
 // Export dumps configuration (or subset of, based on provided tag filter)
 // in the JSON format
 message ExportRequest {
-  // only export for a specific tag
-  optional string tag = 1;
+  Selector selector = 1;
   // remove_tags to strip tags from output
   bool remove_tags = 2;
   enum Format {
@@ -42,7 +46,7 @@ message ExportRequest {
     EXPORT_FORMAT_JSON_COMPACT = 1;
     EXPORT_FORMAT_JSON_PRETTY = 2;
   }
-  Format format = 1;
+  Format format = 3;
 }
 
 message ConfigData { bytes data = 1; }
@@ -60,62 +64,61 @@ message ImportRequest {
 message ImportResponse {}
 
 // Listener service controls listeners
-message service Listener {
+service Listener {
   // Listen starts connection listener
-  rpc Listen(ListenRequest) returns (ListenResponse);
-  // Close closes listener
-  rpc Close(CloseRequest) returns (CloseResponse);
+  rpc Update(ListenerUpdateRequest) returns (ListenerStatus);
   // StatusUpdates opens a stream to listen to connection status updates
   // a client has to subscribe and continuously
   // listen to the broadcasted updates
-  rpc StatusUpdates(EventsRequest) returns (stream ConnectionStatusUpdates);
+  rpc StatusUpdates(Selector) returns (stream ConnectionStatusUpdates);
 }
 
-message ConnectRequest {
-  oneof action {
-    bool connect = 1;
-    bool disconnect = 2;
-  }
+message ListenerUpdateRequest {
   // omit connection ids to connect all connections
-  repeated string connection_ids = 3;
+  repeated string connection_ids = 1;
+  bool connected = 2;
 }
-message ConnectionListenerStatus {
-  oneof {
-    // a port this connection listening on
-    uint32 port = 1;
-    // an error that has occured (i.e. cannot bind to requested host:port)
-    string last_error = 2;
-  }
+
+message ListenerStatus {
+  // active listeners with their current ports
+  map<string, uint32> active = 1;
+  // if some listeners were unable to start up
+  map<string, string> errors = 2;
 }
+
+message StatusUpdatesRequest {}
 
 // ConnectionStatusUpdates represent connection state changes
 message ConnectionStatusUpdates {
-  // connection this event relates to
-  string connection_id = 1;
-  // peer_addr represents connecting party remote address
+  // record this event relates to
+  string id = 1;
+  // peer_addr represents connecting party remote address and may be used to
+  // distinguish between individual TCP connections
   string peer_addr = 2;
   enum ConnectionStatus {
     CONNECTION_STATUS_UNDEFINED = 0;
     CONNECTION_STATUS_CONNECTING = 1;
-    CONNECTION_STATUS_AUTH_REQUIRED = 3;
-    CONNECTION_STATUS_CONNECTED = 2;
-    CONNECTION_STATUS_DISCONNECTED = 3;
+    CONNECTION_STATUS_AUTH_REQUIRED = 2;
+    CONNECTION_STATUS_CONNECTED = 3;
+    CONNECTION_STATUS_DISCONNECTED = 4;
   }
-  ConnectionStatus status = 2;
+  ConnectionStatus status = 3;
   // in case the connection failed or terminated, last error may be available
-  optional string last_error = 3;
+  optional string last_error = 4;
 }
 
-// ConnectionInfo represents a stored connection
+// Connection
 message Connection {
   // name is a user friendly connection name that a user may define
   optional string name = 1;
   // remote_addr is a remote pomerium host:port
   string remote_addr = 2;
   // listen_address, if not provided, will assign a random port each time
-  optional listen_addr = 3;
+  optional string listen_addr = 3;
+  // the URL of the pomerium server to connect to
+  optional string pomerium_url = 4;
   oneof tls_options {
-    bool disable_tls_verification = 4;
-    bytes ca_cert = 5;
+    bool disable_tls_verification = 5;
+    bytes ca_cert = 6;
   }
 }

--- a/pkg/grpc/protoc.bash
+++ b/pkg/grpc/protoc.bash
@@ -112,3 +112,7 @@ _import_paths=$(join_by , "${_imports[@]}")
 ../../scripts/protoc -I ./events/ -I ./ \
   --go_out="$_import_paths,plugins=grpc,paths=source_relative:./events/." \
   ./events/xds.proto
+
+../../scripts/protoc -I ./cli/ -I ./ \
+  --go_out="$_import_paths,plugins=grpc,paths=source_relative:./cli/." \
+  ./cli/api.proto


### PR DESCRIPTION
## Summary

The change would allow desktop client to utilize `pomerium-cli` as an API server, and manage multiple connections simultaneously. 

A new command `api` would be introduced, taking the following args (or env variables):

- `config-path`: path to load / store configuration definitions from
- `api-address`: `host:port` to listen to API requests from 

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
