### PR TITLE
databroker: add additional log for config source

### DIFF
--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -197,7 +197,19 @@ func (src *ConfigSource) runUpdater(cfg *config.Config) {
 		src:    src,
 	}, databroker.WithTypeURL(grpcutil.GetTypeURL(new(configpb.Config))),
 		databroker.WithFastForward())
-	go func() { _ = syncer.Run(ctx) }()
+	go func() {
+		var databrokerURLs []string
+		urls, _ := cfg.Options.GetDataBrokerURLs()
+		for _, url := range urls {
+			databrokerURLs = append(databrokerURLs, url.String())
+		}
+
+		log.Info(ctx).
+			Str("outbound_port", cfg.OutboundPort).
+			Strs("databroker_urls", databrokerURLs).
+			Msg("config: starting databroker config source syncer")
+		_ = syncer.Run(ctx)
+	}()
 }
 
 type syncerHandler struct {


### PR DESCRIPTION
## Summary
Add an additional log for synchronization with the databroker for config updates.

## Related issues
Fixes https://github.com/pomerium/internal/issues/615

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
