### PR TITLE
authenticate: always update user record on login

### DIFF
--- a/internal/identity/manager/config.go
+++ b/internal/identity/manager/config.go
@@ -23,6 +23,7 @@ type config struct {
 	groupRefreshTimeout           time.Duration
 	sessionRefreshGracePeriod     time.Duration
 	sessionRefreshCoolOffDuration time.Duration
+	now                           func() time.Time
 }
 
 func newConfig(options ...Option) *config {
@@ -31,6 +32,7 @@ func newConfig(options ...Option) *config {
 	WithGroupRefreshTimeout(defaultGroupRefreshTimeout)(cfg)
 	WithSessionRefreshGracePeriod(defaultSessionRefreshGracePeriod)(cfg)
 	WithSessionRefreshCoolOffDuration(defaultSessionRefreshCoolOffDuration)(cfg)
+	WithNow(time.Now)
 	for _, option := range options {
 		option(cfg)
 	}
@@ -86,6 +88,13 @@ func WithSessionRefreshGracePeriod(dur time.Duration) Option {
 func WithSessionRefreshCoolOffDuration(dur time.Duration) Option {
 	return func(cfg *config) {
 		cfg.sessionRefreshCoolOffDuration = dur
+	}
+}
+
+// WithNow customizes the time.Now function used by the manager.
+func WithNow(now func() time.Time) Option {
+	return func(cfg *config) {
+		cfg.now = now
 	}
 }
 

--- a/internal/identity/manager/config.go
+++ b/internal/identity/manager/config.go
@@ -32,7 +32,7 @@ func newConfig(options ...Option) *config {
 	WithGroupRefreshTimeout(defaultGroupRefreshTimeout)(cfg)
 	WithSessionRefreshGracePeriod(defaultSessionRefreshGracePeriod)(cfg)
 	WithSessionRefreshCoolOffDuration(defaultSessionRefreshCoolOffDuration)(cfg)
-	WithNow(time.Now)
+	WithNow(time.Now)(cfg)
 	for _, option := range options {
 		option(cfg)
 	}

--- a/internal/identity/manager/manager.go
+++ b/internal/identity/manager/manager.go
@@ -539,6 +539,7 @@ func (mgr *Manager) onUpdateRecords(ctx context.Context, msg updateRecordsMessag
 				log.Warn(ctx).Msgf("error unmarshaling user: %s", err)
 				continue
 			}
+			mgr.onUpdateUser(ctx, record, &pbUser)
 		}
 	}
 }

--- a/internal/identity/manager/manager_test.go
+++ b/internal/identity/manager/manager_test.go
@@ -7,8 +7,13 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/pomerium/pomerium/internal/directory"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 type mockProvider struct {
@@ -22,6 +27,43 @@ func (mock mockProvider) User(ctx context.Context, userID, accessToken string) (
 
 func (mock mockProvider) UserGroups(ctx context.Context) ([]*directory.Group, []*directory.User, error) {
 	return mock.userGroups(ctx)
+}
+
+func TestManager_onUpdateRecords(t *testing.T) {
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	defer clearTimeout()
+
+	now := time.Now()
+
+	mgr := New(
+		WithDirectoryProvider(mockProvider{}),
+		WithGroupRefreshInterval(time.Hour),
+		WithNow(func() time.Time {
+			return now
+		}),
+	)
+	mgr.directoryBackoff.RandomizationFactor = 0 // disable randomization for deterministic testing
+
+	mgr.onUpdateRecords(ctx, updateRecordsMessage{
+		records: []*databroker.Record{
+			mkRecord(&directory.Group{Id: "group1", Name: "group 1", Email: "group1@example.com"}),
+			mkRecord(&directory.User{Id: "user1", DisplayName: "user 1", Email: "user1@example.com", GroupIds: []string{"group1s"}}),
+			mkRecord(&session.Session{Id: "session1", UserId: "user1"}),
+			mkRecord(&user.User{Id: "user1", Name: "user 1", Email: "user1@example.com"}),
+		},
+	})
+
+	assert.NotNil(t, mgr.directoryGroups["group1"])
+	assert.NotNil(t, mgr.directoryUsers["user1"])
+	if _, ok := mgr.sessions.Get("user1", "session1"); assert.True(t, ok) {
+
+	}
+	if _, ok := mgr.users.Get("user1"); assert.True(t, ok) {
+		tm, id := mgr.userScheduler.Next()
+		assert.Equal(t, now.Add(time.Hour), tm)
+		assert.Equal(t, "user1", id)
+	}
+
 }
 
 func TestManager_refreshDirectoryUserGroups(t *testing.T) {
@@ -55,4 +97,18 @@ func TestManager_refreshDirectoryUserGroups(t *testing.T) {
 		assert.Greater(t, dur3, dur2)
 		assert.Equal(t, time.Hour, dur3)
 	})
+}
+
+func mkRecord(msg recordable) *databroker.Record {
+	any := protoutil.NewAny(msg)
+	return &databroker.Record{
+		Type: any.GetTypeUrl(),
+		Id:   msg.GetId(),
+		Data: any,
+	}
+}
+
+type recordable interface {
+	proto.Message
+	GetId() string
 }


### PR DESCRIPTION
## Summary
Currently we only update user info on login if a user record doesn't already exist. This change makes it so we always update the user info.

## Related issues
Fixes https://github.com/pomerium/internal/issues/618

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
