### PR TITLE
identity: fix user refresh

### DIFF
--- a/internal/identity/manager/manager.go
+++ b/internal/identity/manager/manager.go
@@ -539,6 +539,7 @@ func (mgr *Manager) onUpdateRecords(ctx context.Context, msg updateRecordsMessag
 				log.Warn(ctx).Msgf("error unmarshaling user: %s", err)
 				continue
 			}
+			mgr.onUpdateUser(ctx, record, &pbUser)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
User refresh was never getting called. This resulted in stale IDP claims in user records (although sessions were getting refreshed, so those claims were updated).

## Related issues
Fixes https://github.com/pomerium/internal/issues/618

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
