### PR TITLE
ci: remove hadolint

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -179,24 +179,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Hadolint - Master
-        uses: hadolint/hadolint-action@v1.5.0
-        with:
-          Dockerfile: Dockerfile
-          ignore: DL3059
-          failure-threshold: error
-      - name: Hadolint - Debug
-        uses: hadolint/hadolint-action@v1.5.0
-        with:
-          Dockerfile: Dockerfile.debug
-          ignore: DL3059
-          failure-threshold: error
-      - name: Hadolint - Release
-        uses: hadolint/hadolint-action@v1.5.0
-        with:
-          Dockerfile: .github/Dockerfile-release
-          ignore: DL3059
-          failure-threshold: error
       - name: build
         run: docker build .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-# hadolint ignore=DL3007
 FROM golang:latest as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
-# hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get -y --no-install-recommends install zip
 

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,8 +1,6 @@
-# hadolint ignore=DL3007
 FROM golang:latest as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
-# hadolint ignore=DL3008
 RUN apt-get update \
     && apt-get -y --no-install-recommends install zip
 
@@ -18,11 +16,9 @@ RUN make build-debug NAME=pomerium-cli
 RUN touch /config.yaml
 RUN go get github.com/go-delve/delve/cmd/dlv
 
-# hadolint ignore=DL3007
 FROM alpine:latest
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
-# hadolint ignore=DL3018
 RUN apk add --no-cache ca-certificates libc6-compat gcompat
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates


### PR DESCRIPTION
## Summary

Remove hadolint validation in CI.  While the rules are useful in general, we tend to only violate them in transient build containers and often for good reason.  The number of lint ignore comments we need to keep CI from being noisy isn't worth it.

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
