### PR TITLE
deployment: relocate pomerium-cli to /usr/bin

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -276,7 +276,7 @@ nfpms:
       - deb
       - rpm
 
-    bindir: /usr/sbin
+    bindir: /usr/bin
 
     overrides:
       deb:


### PR DESCRIPTION
## Summary

`pomerium-cli` is meant to be a user facing tool but was erroneously packaged in `/usr/sbin` on Linux, which may not be in a normal user's `$PATH`.

Relocate it to `/usr/bin` in accordance with [FHS](https://en.wikipedia.org/wiki/Filesystem_Hierarchy_Standard).

## Related issues

Fixes https://github.com/pomerium/pomerium/issues/2676

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
