### PR TITLE
Docs: Update Securing Kubernetes Guide

### DIFF
--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -141,13 +141,6 @@ This new route requires a kubernetes service account token. Our Helm chart creat
 
 The [pomerium-cli] tool can be used by kubectl as an auth helper. Once configured, connections to the cluster will open a browser window to the Pomerium authenticate service and generate an authorization token that will be used for Kubernetes API calls.
 
-In addition to the methods listed in the page linked above, `pomerium-cli` can be installed via go-get:
-
-```bash
-env GO111MODULE=on GOBIN=$HOME/bin go get github.com/pomerium/pomerium/cmd/pomerium-cli@master
-```
-
-Make sure `$HOME/bin` is on your path.
 
 To use `pomerium-cli` as an exec-credential provider, update your kubectl config:
 

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -116,7 +116,7 @@ This new route requires a kubernetes service account token. Our Helm chart creat
     ```yaml
       routes:
         - from: https://k8s.localhost.pomerium.io
-          to: https://kubernetes
+          to: https://kubernetes.default.svc.cluster.local
           allow_spdy: true
           tls_skip_verify: true
           kubernetes_service_account_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -150,7 +150,7 @@ To use `pomerium-cli` as an exec-credential provider, update your kubectl config
    # Add Context
    kubectl config set-context via-pomerium --user=via-pomerium --cluster=via-pomerium
    # Add credentials command
-   kubectl config set-credentials via-pomerium --exec-command=pomerium-cli --exec-arg=k8s,exec-credential,https://k8s.localhost.pomerium.io
+   kubectl config set-credentials via-pomerium --exec-command=pomerium-cli --exec-arg=k8s,exec-credential,https://k8s.localhost.pomerium.io --exec-api-version=client.authentication.k8s.io/v1beta1
   ```
 
 Here's the resulting configuration:

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -144,14 +144,28 @@ The [pomerium-cli] tool can be used by kubectl as an auth helper. Once configure
 
 To use `pomerium-cli` as an exec-credential provider, update your kubectl config:
 
-   ```shell
-   # Add Cluster
-   kubectl config set-cluster via-pomerium --server=https://k8s.localhost.pomerium.io
-   # Add Context
-   kubectl config set-context via-pomerium --user=via-pomerium --cluster=via-pomerium
-   # Add credentials command
-   kubectl config set-credentials via-pomerium --exec-command=pomerium-cli --exec-arg=k8s,exec-credential,https://k8s.localhost.pomerium.io --exec-api-version=client.authentication.k8s.io/v1beta1
-  ```
+```shell
+# Add Cluster
+kubectl config set-cluster via-pomerium --server=https://k8s.localhost.pomerium.io
+# Add Context
+kubectl config set-context via-pomerium --user=via-pomerium --cluster=via-pomerium
+# Add credentials command
+kubectl config set-credentials via-pomerium --exec-command=pomerium-cli \
+  --exec-arg=k8s,exec-credential,https://k8s.localhost.pomerium.io \
+  --exec-api-version=client.authentication.k8s.io/v1beta1
+```
+
+::: details Skip TLS Verification
+If you're using untrusted certificates or need to debug a certificate issue, configure the credential provider without TLS verification:
+
+```shell
+kubectl config set-cluster via-pomerium --server=https://k8s.localhost.pomerium.io \
+  --insecure-skip-tls-verify=true
+kubectl config set-credentials via-pomerium --exec-command=pomerium-cli \
+  --exec-arg=k8s,exec-credential,https://k8s.localhost.pomerium.io,--disable-tls-verification \
+  --exec-api-version=client.authentication.k8s.io/v1beta1
+```
+:::
 
 Here's the resulting configuration:
 

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -100,35 +100,41 @@ Permissions can also be granted to groups the Pomerium user is a member of.
 
 ## Create an Ingress for the API Server
 
-Create an Ingress for the route to the Kubernetes API server:
+1. Enable API proxying using the Helm chart:
 
-```yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: k8s
-  annotations:
-    cert-manager.io/issuer: pomerium-issuer
-    ingress.pomerium.io/policy: '[{"allow":{"and":[{"domain":{"is":"pomerium.com"}}]}}]'
-    ingress.pomerium.io/secure_upstream: true
-    ingress.pomerium.io/allow_spdy: true
-spec:
-  ingressClassName: pomerium
-  rules:
-  - host: k8s.localhost.pomerium.io
-    http:
-      paths:
-      - backend:
-          service:
-            name: kubernetes.default.svc
-            port:
-              number: 30443
-  tls:
-  - hosts:
-    - k8s.localhost.pomerium.io
-    secretName: k8s.localhost.pomerium.io-tls
+   ```bash
+   helm upgrade --install pomerium/pomerium --set apiProxy.enabled=true
+   ```
 
-```
+1. Create an Ingress for the route to the Kubernetes API server:
+
+   ```yaml
+   apiVersion: networking.k8s.io/v1
+   kind: Ingress
+   metadata:
+     name: k8s
+     annotations:
+       cert-manager.io/issuer: pomerium-issuer
+       ingress.pomerium.io/policy: '[{"allow":{"and":[{"domain":{"is":"pomerium.com"}}]}}]'
+       ingress.pomerium.io/secure_upstream: true
+       ingress.pomerium.io/allow_spdy: true
+   spec:
+     ingressClassName: pomerium
+     rules:
+     - host: k8s.localhost.pomerium.io
+       http:
+         paths:
+         - backend:
+             service:
+               name: kubernetes.default.svc
+               port:
+                 number: 30443
+     tls:
+     - hosts:
+       - k8s.localhost.pomerium.io
+       secretName: k8s.localhost.pomerium.io-tls
+ 
+   ```
 
 ::: details Non-Ingress Route
 

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -105,7 +105,7 @@ kubectl apply -f ./pomerium-k8s.yaml
     kubectl apply -f rbac-someuser.yaml
     ```
 
-Permissions can also be granted to groups the Pomerium user is a member of.
+Permissions can also be granted to groups the Pomerium user is a member of. This allows you to set a single ClusterRoleBinding in Kubernetes and modify access from your IdP.
 
 ## Create a Route for the API server
 

--- a/docs/guides/kubernetes.md
+++ b/docs/guides/kubernetes.md
@@ -139,7 +139,7 @@ This new route requires a kubernetes service account token. Our Helm chart creat
 
 ## Configure Kubectl
 
-The [pomerium-cli] tool can be used by kubectl as an auth helper. Once configured, connections to the cluster will open a browser window to the Pomerium authenticate service and generate an authorization token that will be used for Kubernetes API calls.
+The [pomerium-cli] tool can be used by kubectl as a credential plugin. Once configured, connections to the cluster will open a browser window to the Pomerium authenticate service and generate an authentication token that will be used for Kubernetes API calls.
 
 
 To use `pomerium-cli` as an exec-credential provider, update your kubectl config:


### PR DESCRIPTION
## Summary

Updates [Securing Kubernetes](https://pomerium.com/guides/kubernetes.html) to continue from our Helm-based install instructions, using the service account created in the chart.

## Related issues

Closes https://github.com/pomerium/docs/issues/7
Supersedes #2738 

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
