### PR TITLE
config: detect changes to the kubernetes service account token file

### DIFF
--- a/config/config_source.go
+++ b/config/config_source.go
@@ -238,6 +238,16 @@ func (src *FileWatcherSource) check(ctx context.Context, cfg *Config) {
 		fs = append(fs, pair.CertFile, pair.KeyFile)
 	}
 
+	for _, policy := range cfg.Options.Policies {
+		fs = append(fs,
+			policy.KubernetesServiceAccountTokenFile,
+			policy.TLSClientCertFile,
+			policy.TLSClientKeyFile,
+			policy.TLSCustomCAFile,
+			policy.TLSDownstreamClientCAFile,
+		)
+	}
+
 	for _, f := range fs {
 		_, _ = h.Write([]byte{0})
 		bs, err := ioutil.ReadFile(f)


### PR DESCRIPTION
## Summary
Update the config source to watch policy files in addition to config changes.

## Related issues
Fixes #2722 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
