### PR TITLE
authenticate: redirect / to /.pomerium/

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -67,6 +67,9 @@ func (a *Authenticate) Mount(r *mux.Router) {
 		)(h)
 	})
 
+	// redirect / to /.pomerium/
+	r.Path("/").Handler(http.RedirectHandler("/.pomerium/", http.StatusFound))
+
 	r.Path("/robots.txt").HandlerFunc(a.RobotsTxt).Methods(http.MethodGet)
 	// Identity Provider (IdP) endpoints
 	r.Path("/oauth2/callback").Handler(httputil.HandlerFunc(a.OAuthCallback)).Methods(http.MethodGet)

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -110,7 +110,7 @@ func (b *Builder) buildPomeriumHTTPRoutes(options *config.Options, domain string
 		return nil, err
 	}
 	if config.IsAuthenticate(options.Services) && hostMatchesDomain(authenticateURL, domain) {
-		r, err := b.buildControlPlanePathRoute(options.AuthenticateCallbackPath, false)
+		r, err := b.buildControlPlanePrefixRoute("/", false)
 		if err != nil {
 			return nil, err
 		}

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -96,7 +96,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 			`+routeString("path", "/.well-known/pomerium", false)+`,
 			`+routeString("prefix", "/.well-known/pomerium/", false)+`,
 			`+routeString("path", "/robots.txt", false)+`,
-			`+routeString("path", "/oauth2/callback", false)+`
+			`+routeString("prefix", "/", false)+`
 		]`, routes)
 	})
 	t.Run("proxy fronting authenticate", func(t *testing.T) {


### PR DESCRIPTION
## Summary
Redirect the root path in authenticate to `/.pomerium/` for easier debugging.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/2766


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
