### PR TITLE
envoy: treat configuration errors as fatal

### DIFF
--- a/internal/controlplane/xdsmgr/xdsmgr.go
+++ b/internal/controlplane/xdsmgr/xdsmgr.go
@@ -285,7 +285,7 @@ func (mgr *Manager) nackEvent(ctx context.Context, req *envoy_service_discovery_
 	})
 
 	bs, _ := json.Marshal(req.ErrorDetail.Details)
-	log.Error(ctx).
+	log.Fatal().
 		Err(errors.New(req.ErrorDetail.Message)).
 		Str("resource_type", req.TypeUrl).
 		Strs("resources_unsubscribe", req.ResourceNamesUnsubscribe).


### PR DESCRIPTION
## Summary
When Envoy is unable to apply a configuration it will `NACK` the request. Currently we log these as errors. This PR treats them as fatal errors.

## Related issues
- https://github.com/pomerium/internal/issues/632


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
