### PR TITLE
identity: only assign `access_type` uri params to google.

### DIFF
--- a/docs/docs/upgrading.md
+++ b/docs/docs/upgrading.md
@@ -7,6 +7,10 @@ description: >-
 
 # Since 0.15.0
 
+### OIDC flow no longer sets default uri params
+
+Previously, Pomerium would default to setting the uri param `access_type` to `offline` for all OpenID Connect based identity providers. However, using uri params to get ensure offline access (e.g. `refresh_tokens` used to keep user's sessions alive) [is unique to Google](https://developers.google.com/identity/protocols/oauth2/web-server#offline). Those query params will now only be set for Google. Other OIDC based IdP's should continue to work using [OIDC's](https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess) `offline_access` scope.
+
 ### Removed options
 The deprecated `headers` option has been removed. Use [`set_response_headers`](/reference/readme.md#set-response-headers) instead.
 

--- a/internal/identity/oidc/google/google.go
+++ b/internal/identity/oidc/google/google.go
@@ -23,8 +23,15 @@ const (
 
 var defaultScopes = []string{oidc.ScopeOpenID, "profile", "email"}
 
-// https://developers.google.com/identity/protocols/oauth2/openid-connect#authenticationuriparameters
-var defaultAuthCodeOptions = map[string]string{"prompt": "select_account consent"}
+// unlike other identity providers, google does not support the `offline_access` scope and instead
+// requires we set this on a custom uri param. Also, ` prompt` must be set to `consent`to ensure
+// that our application always receives a refresh token (ask google). And finally, we default to
+// having the user select which Google account they'd like to use.
+//
+// For more details, please see google's documentation:
+// 	https://developers.google.com/identity/protocols/oauth2/web-server#offline
+// 	https://developers.google.com/identity/protocols/oauth2/openid-connect#authenticationuriparameters
+var defaultAuthCodeOptions = map[string]string{"prompt": "select_account consent", "access_type": "offline"}
 
 // Provider is a Google implementation of the Authenticator interface.
 type Provider struct {

--- a/internal/identity/oidc/oidc.go
+++ b/internal/identity/oidc/oidc.go
@@ -27,7 +27,7 @@ const Name = "oidc"
 
 var defaultScopes = []string{go_oidc.ScopeOpenID, "profile", "email", "offline_access"}
 
-var defaultAuthCodeOptions = []oauth2.AuthCodeOption{oauth2.AccessTypeOffline}
+var defaultAuthCodeOptions = []oauth2.AuthCodeOption{}
 
 // Provider provides a standard, OpenID Connect implementation
 // of an authorization identity provider.


### PR DESCRIPTION
## Summary

During OIDC authentication flow, Pomerium will no longer default to setting the uri param for `access_type` to `offline` which is custom and unique to google's IdP. Other identity providers should be able to depend on the `offline_access` scope for `refresh_tokens`. 

## Related issues

- Fixes #2773 
- https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess 
- https://developers.google.com/identity/protocols/oauth2/web-server#offline

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [x] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
