### PR TITLE
Fix IdP client metrics

### DIFF
--- a/internal/directory/azure/azure.go
+++ b/internal/directory/azure/azure.go
@@ -57,7 +57,7 @@ func WithLoginURL(loginURL *url.URL) Option {
 // WithHTTPClient sets the http client to use for requests to the Azure APIs.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+		cfg.httpClient = httputil.NewLoggingClient(httpClient, "azure_idp_client",
 			func(evt *zerolog.Event) *zerolog.Event {
 				return evt.Str("provider", "azure")
 			})

--- a/internal/directory/github/github.go
+++ b/internal/directory/github/github.go
@@ -46,7 +46,7 @@ func WithServiceAccount(serviceAccount *ServiceAccount) Option {
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+		cfg.httpClient = httputil.NewLoggingClient(httpClient, "github_idp_client",
 			func(evt *zerolog.Event) *zerolog.Event {
 				return evt.Str("provider", "github")
 			})

--- a/internal/directory/gitlab/gitlab.go
+++ b/internal/directory/gitlab/gitlab.go
@@ -46,7 +46,7 @@ func WithServiceAccount(serviceAccount *ServiceAccount) Option {
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+		cfg.httpClient = httputil.NewLoggingClient(httpClient, "gitlab_idp_client",
 			func(evt *zerolog.Event) *zerolog.Event {
 				return evt.Str("provider", "azure")
 			})

--- a/internal/directory/okta/okta.go
+++ b/internal/directory/okta/okta.go
@@ -62,7 +62,7 @@ func WithBatchSize(batchSize int) Option {
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+		cfg.httpClient = httputil.NewLoggingClient(httpClient, "okta_idp_client",
 			func(evt *zerolog.Event) *zerolog.Event {
 				return evt.Str("provider", "okta")
 			})

--- a/internal/directory/onelogin/onelogin.go
+++ b/internal/directory/onelogin/onelogin.go
@@ -44,7 +44,7 @@ func WithBatchSize(batchSize int) Option {
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+		cfg.httpClient = httputil.NewLoggingClient(httpClient, "onelogin_idp_client",
 			func(evt *zerolog.Event) *zerolog.Event {
 				return evt.Str("provider", "onelogin")
 			})

--- a/internal/directory/ping/config.go
+++ b/internal/directory/ping/config.go
@@ -47,7 +47,7 @@ func WithEnvironmentID(environmentID string) Option {
 // WithHTTPClient sets the http client option.
 func WithHTTPClient(httpClient *http.Client) Option {
 	return func(cfg *config) {
-		cfg.httpClient = httputil.NewLoggingClient(httpClient,
+		cfg.httpClient = httputil.NewLoggingClient(httpClient, "ping_idp_client",
 			func(evt *zerolog.Event) *zerolog.Event {
 				return evt.Str("provider", "ping")
 			})

--- a/internal/telemetry/http.go
+++ b/internal/telemetry/http.go
@@ -7,8 +7,8 @@ import (
 )
 
 // HTTPStatsRoundTripper creates tracing and metrics RoundTripper for a pomerium service
-func HTTPStatsRoundTripper(getInstallationID func() string, service string, destination string) func(next http.RoundTripper) http.RoundTripper {
-	return metrics.HTTPMetricsRoundTripper(getInstallationID, ServiceName(service), destination)
+func HTTPStatsRoundTripper(getInstallationID func() string, service string) func(next http.RoundTripper) http.RoundTripper {
+	return metrics.HTTPMetricsRoundTripper(getInstallationID, ServiceName(service))
 }
 
 // HTTPStatsHandler creates tracing and metrics Handler for a pomerium service

--- a/internal/telemetry/metrics/const.go
+++ b/internal/telemetry/metrics/const.go
@@ -14,7 +14,6 @@ var (
 	TagKeyGRPCService = tag.MustNewKey("grpc_service")
 	TagKeyGRPCMethod  = tag.MustNewKey("grpc_method")
 	TagKeyHost        = tag.MustNewKey("host")
-	TagKeyDestination = tag.MustNewKey("destination")
 
 	TagKeyStorageOperation = tag.MustNewKey("operation")
 	TagKeyStorageResult    = tag.MustNewKey("result")

--- a/internal/telemetry/metrics/http.go
+++ b/internal/telemetry/metrics/http.go
@@ -137,7 +137,7 @@ func HTTPMetricsHandler(getInstallationID func() string, service string) func(ne
 }
 
 // HTTPMetricsRoundTripper creates a metrics tracking tripper for outbound HTTP Requests
-func HTTPMetricsRoundTripper(getInstallationID func() string, service string, destination string) func(next http.RoundTripper) http.RoundTripper {
+func HTTPMetricsRoundTripper(getInstallationID func() string, service string) func(next http.RoundTripper) http.RoundTripper {
 	return func(next http.RoundTripper) http.RoundTripper {
 		return tripper.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
 			ctx, tagErr := tag.New(
@@ -145,7 +145,6 @@ func HTTPMetricsRoundTripper(getInstallationID func() string, service string, de
 				tag.Upsert(TagKeyService, service),
 				tag.Upsert(TagKeyHost, r.Host),
 				tag.Upsert(TagKeyHTTPMethod, r.Method),
-				tag.Upsert(TagKeyDestination, destination),
 			)
 			if tagErr != nil {
 				log.Warn(ctx).Err(tagErr).Str("context", "HTTPMetricsRoundTripper").Msg("telemetry/metrics: failed to create metrics tag")

--- a/internal/telemetry/metrics/http.go
+++ b/internal/telemetry/metrics/http.go
@@ -74,7 +74,7 @@ var (
 		Name:        "http/client/requests_total",
 		Measure:     ochttp.ClientRoundtripLatency,
 		Description: "Total HTTP Client Requests",
-		TagKeys:     []tag.Key{TagKeyService, TagKeyHost, TagKeyHTTPMethod, ochttp.StatusCode, TagKeyDestination},
+		TagKeys:     []tag.Key{TagKeyService, TagKeyHost, TagKeyHTTPMethod, ochttp.StatusCode},
 		Aggregation: view.Count(),
 	}
 
@@ -84,7 +84,7 @@ var (
 		Name:        "http/client/request_duration_ms",
 		Measure:     ochttp.ClientRoundtripLatency,
 		Description: "HTTP Client Request duration in ms",
-		TagKeys:     []tag.Key{TagKeyService, TagKeyHost, TagKeyHTTPMethod, ochttp.StatusCode, TagKeyDestination},
+		TagKeys:     []tag.Key{TagKeyService, TagKeyHost, TagKeyHTTPMethod, ochttp.StatusCode},
 		Aggregation: DefaultHTTPLatencyDistrubtion,
 	}
 
@@ -94,7 +94,7 @@ var (
 		Name:        "http/client/response_size_bytes",
 		Measure:     ochttp.ClientReceivedBytes,
 		Description: "HTTP Client Response Size in bytes",
-		TagKeys:     []tag.Key{TagKeyService, TagKeyHost, TagKeyHTTPMethod, ochttp.StatusCode, TagKeyDestination},
+		TagKeys:     []tag.Key{TagKeyService, TagKeyHost, TagKeyHTTPMethod, ochttp.StatusCode},
 		Aggregation: DefaulHTTPSizeDistribution,
 	}
 
@@ -104,7 +104,7 @@ var (
 		Name:        "http/client/response_size_bytes",
 		Measure:     ochttp.ClientSentBytes,
 		Description: "HTTP Client Response Size in bytes",
-		TagKeys:     []tag.Key{TagKeyService, TagKeyHost, TagKeyHTTPMethod, TagKeyDestination},
+		TagKeys:     []tag.Key{TagKeyService, TagKeyHost, TagKeyHTTPMethod},
 		Aggregation: DefaulHTTPSizeDistribution,
 	}
 )

--- a/internal/telemetry/metrics/http_test.go
+++ b/internal/telemetry/metrics/http_test.go
@@ -129,7 +129,7 @@ func newFailingTestTransport() http.RoundTripper {
 }
 
 func Test_HTTPMetricsRoundTripper(t *testing.T) {
-	chain := tripper.NewChain(HTTPMetricsRoundTripper(func() string { return "test_installation_id" }, "test_service", "test_destination"))
+	chain := tripper.NewChain(HTTPMetricsRoundTripper(func() string { return "test_installation_id" }, "test_service"))
 	rt := chain.Then(newTestTransport())
 	client := http.Client{Transport: rt}
 
@@ -146,28 +146,28 @@ func Test_HTTPMetricsRoundTripper(t *testing.T) {
 			name:                          "good get",
 			url:                           "http://test.local/good",
 			verb:                          "GET",
-			wanthttpClientRequestSize:     "{ { {destination test_destination}{host test.local}{http.status 200}{http_method GET}{service test_service} }&{1 5 5 5 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
-			wanthttpClientResponseSize:    "{ { {destination test_destination}{host test.local}{http.status 200}{http_method GET}{service test_service} }&{1 5 5 5 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
-			wanthttpClientRequestDuration: "{ { {destination test_destination}{host test.local}{http.status 200}{http_method GET}{service test_service} }",
-			wanthttpClientRequestCount:    "{ { {destination test_destination}{host test.local}{http.status 200}{http_method GET}{service test_service} }",
+			wanthttpClientRequestSize:     "{ { {host test.local}{http.status 200}{http_method GET}{service test_service} }&{1 5 5 5 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
+			wanthttpClientResponseSize:    "{ { {host test.local}{http.status 200}{http_method GET}{service test_service} }&{1 5 5 5 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
+			wanthttpClientRequestDuration: "{ { {host test.local}{http.status 200}{http_method GET}{service test_service} }",
+			wanthttpClientRequestCount:    "{ { {host test.local}{http.status 200}{http_method GET}{service test_service} }",
 		},
 		{
 			name:                          "good post",
 			url:                           "http://test.local/good",
 			verb:                          "POST",
-			wanthttpClientRequestSize:     "{ { {destination test_destination}{host test.local}{http.status 200}{http_method POST}{service test_service} }&{1 5 5 5 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
-			wanthttpClientResponseSize:    "{ { {destination test_destination}{host test.local}{http.status 200}{http_method POST}{service test_service} }&{1 5 5 5 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
-			wanthttpClientRequestDuration: "{ { {destination test_destination}{host test.local}{http.status 200}{http_method POST}{service test_service} }",
-			wanthttpClientRequestCount:    "{ { {destination test_destination}{host test.local}{http.status 200}{http_method POST}{service test_service} }",
+			wanthttpClientRequestSize:     "{ { {host test.local}{http.status 200}{http_method POST}{service test_service} }&{1 5 5 5 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
+			wanthttpClientResponseSize:    "{ { {host test.local}{http.status 200}{http_method POST}{service test_service} }&{1 5 5 5 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
+			wanthttpClientRequestDuration: "{ { {host test.local}{http.status 200}{http_method POST}{service test_service} }",
+			wanthttpClientRequestCount:    "{ { {host test.local}{http.status 200}{http_method POST}{service test_service} }",
 		},
 		{
 			name:                          "bad post",
 			url:                           "http://test.local/bad",
 			verb:                          "POST",
-			wanthttpClientRequestSize:     "{ { {destination test_destination}{host test.local}{http.status 404}{http_method POST}{service test_service} }&{1 19 19 19 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
-			wanthttpClientResponseSize:    "{ { {destination test_destination}{host test.local}{http.status 404}{http_method POST}{service test_service} }&{1 19 19 19 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
-			wanthttpClientRequestDuration: "{ { {destination test_destination}{host test.local}{http.status 404}{http_method POST}{service test_service} }",
-			wanthttpClientRequestCount:    "{ { {destination test_destination}{host test.local}{http.status 404}{http_method POST}{service test_service} }",
+			wanthttpClientRequestSize:     "{ { {host test.local}{http.status 404}{http_method POST}{service test_service} }&{1 19 19 19 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
+			wanthttpClientResponseSize:    "{ { {host test.local}{http.status 404}{http_method POST}{service test_service} }&{1 19 19 19 0 [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]",
+			wanthttpClientRequestDuration: "{ { {host test.local}{http.status 404}{http_method POST}{service test_service} }",
+			wanthttpClientRequestCount:    "{ { {host test.local}{http.status 404}{http_method POST}{service test_service} }",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

The HTTP client we are using for communicating with the Identity Provider wasn't using a metrics-enabled RoundTripper so we are missing RED type metrics around user/directory/session requests. 

This refactors the metrics roundtripper signature to remove the deprecated `destination` label and adds metrics to the httputil logging client.  It also adds in a `name` field for passing in a name of the client consumer.

Sample of resulting metrics:

```
pomerium_http_client_request_duration_ms_bucket{host="dev-YYY.okta.com",http_method="GET",http_status="200",service="okta_idp_client",installation_id="",hostname="XXXXX",le="100"} 2
pomerium_http_client_request_duration_ms_bucket{host="dev-YYY.okta.com",http_method="GET",http_status="200",service="okta_idp_client",installation_id="",hostname="XXXXX",le="250"} 31
pomerium_http_client_request_duration_ms_bucket{host="dev-YYY.okta.com",http_method="GET",http_status="200",service="okta_idp_client",installation_id="",hostname="XXXXX",le="500"} 31
pomerium_http_client_request_duration_ms_bucket{host="dev-YYY.okta.com",http_method="GET",http_status="200",service="okta_idp_client",installation_id="",hostname="XXXXX",le="750"} 32
....
pomerium_http_client_requests_total{host="dev-YYY.okta.com",http_method="GET",http_status="200",service="okta_idp_client",installation_id="",hostname="XXXXX"} 357
pomerium_http_client_requests_total{host="dev-YYY.okta.com",http_method="GET",http_status="429",service="okta_idp_client",installation_id="",hostname="XXXXX"} 9
```

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
