### PR TITLE
internal/telemetry: fix grpc server metrics

### DIFF
--- a/internal/telemetry/grpc.go
+++ b/internal/telemetry/grpc.go
@@ -67,7 +67,9 @@ func (h *GRPCServerStatsHandler) TagRPC(ctx context.Context, tagInfo *grpcstats.
 			trace.WithSpanKind(trace.SpanKindServer))
 	}
 
-	metricCtx := h.metricsHandler.TagRPC(ctx, tagInfo)
+	// ocgrpc's TagRPC must be called to attach the context rpcDataKey correctly
+	// https://github.com/census-instrumentation/opencensus-go/blob/bf52d9df8bb2d44cad934587ab946794456cf3c8/plugin/ocgrpc/server_stats_handler.go#L45
+	metricCtx := h.metricsHandler.TagRPC(h.Handler.TagRPC(ctx, tagInfo), tagInfo)
 	return metricCtx
 }
 


### PR DESCRIPTION
## Summary

We are missing the per-method server metrics that should come from our grpc metrics handler.  This is due to a missing context key that comes from ocgrpc's Handler; without it, the metrics are never actually recorded at the end of the RPC.

* add a call to the underlying TagRPC to get the required key set
* add a comment since it seems like an unnecessary call

Sample metric:

```
pomerium_grpc_server_request_duration_ms_count{grpc_method="Put",grpc_server_status="OK",grpc_service="databroker.DataBrokerService",service="pomerium",installation_id="",hostname="XXXX"} 6
```

## Related issues

https://github.com/pomerium/pomerium/pull/2376


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
