### PR TITLE
authorize: fix nginx infinite redirect

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -76,13 +76,13 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 		return a.okResponse(res), nil
 	}
 
-	if isForwardAuth && hreq.URL.Path == "/verify" {
-		return a.deniedResponse(ctx, in, http.StatusUnauthorized, "Unauthenticated", nil)
-	}
-
 	// if we're logged in, don't redirect, deny with forbidden
 	if req.Session.ID != "" {
 		return a.deniedResponse(ctx, in, denyStatusCode, denyStatusText, nil)
+	}
+
+	if isForwardAuth && hreq.URL.Path == "/verify" {
+		return a.deniedResponse(ctx, in, http.StatusUnauthorized, "Unauthenticated", nil)
 	}
 
 	return a.requireLoginResponse(ctx, in)


### PR DESCRIPTION
## Summary
Fix for an nginx infinite redirect due to always returning 401. This appears to already be fixed on master, but this section of the code has radically changed and can't be backported.

## Related issues
Fixes #2796 


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
