### PR TITLE
dev build support for darwin-arm64 from envoy tip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,4 +89,6 @@ docs/.vuepress/dist/
 .service-accounts
 
 /bazel-*
-internal/envoy/files/
+internal/envoy/files/envoy-*-?????
+internal/envoy/files/envoy-*-?????.sha256
+internal/envoy/files/envoy-*-?????.version

--- a/internal/envoy/envoy_darwin.go
+++ b/internal/envoy/envoy_darwin.go
@@ -5,7 +5,6 @@ package envoy
 
 import (
 	"context"
-	"runtime"
 	"syscall"
 
 	"github.com/pomerium/pomerium/internal/log"
@@ -25,11 +24,6 @@ func (srv *Server) prepareRunEnvoyCommand(ctx context.Context, sharedArgs []stri
 
 	args = make([]string, len(sharedArgs))
 	copy(args, sharedArgs)
-
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" {
-		// until m1 macs are supported by envoy, fallback to x86 and use rosetta
-		return "arch", append([]string{"-x86_64", srv.envoyPath}, args...)
-	}
 
 	return srv.envoyPath, args
 }

--- a/internal/envoy/files/files_darwin_amd64.go
+++ b/internal/envoy/files/files_darwin_amd64.go
@@ -1,5 +1,5 @@
-//go:build darwin
-// +build darwin
+//go:build darwin && amd64
+// +build darwin,amd64
 
 package files
 

--- a/internal/envoy/files/files_darwin_arm64.go
+++ b/internal/envoy/files/files_darwin_arm64.go
@@ -1,0 +1,15 @@
+//go:build darwin && arm64
+// +build darwin,arm64
+
+package files
+
+import _ "embed" // embed
+
+//go:embed envoy-darwin-arm64
+var rawBinary []byte
+
+//go:embed envoy-darwin-arm64.sha256
+var rawChecksum string
+
+//go:embed envoy-darwin-arm64.version
+var rawVersion string

--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -9,9 +9,12 @@ _envoy_version=1.19.1
 _dir="$_project_root/internal/envoy/files"
 _target="${TARGET:-"$(go env GOOS)-$(go env GOARCH)"}"
 
-# until m1 macs are supported, fallback to x86 and use rosetta
 if [ "$_target" == "darwin-arm64" ]; then
-  _target="darwin-amd64"
+  echo "Using local envoy distribution for Apple M1"
+  cp `which envoy` "$_dir/envoy-$_target"
+  (cd internal/envoy/files && sha256sum "$_dir/envoy-$_target" > "$_dir/envoy-$_target.sha256")
+  echo "1.21.0-dev" >"$_dir/envoy-$_target.version"
+  exit 0
 fi
 
 _url="https://github.com/pomerium/envoy-binaries/releases/download/v${_envoy_version}/envoy-${_target}"


### PR DESCRIPTION
## Summary

Envoy does not yet have an official release build for Apple M1, meanwhile you may install locally: 

1.  Have Xcode installed and development agreement accepted
2. `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`
3. `brew install --HEAD envoy`

After that, you should be able to build Pomerium darwin-arm64 using locally compiled envoy 1.21.0-dev.

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
