### PR TITLE
move NewGRPCClientConn to public package

### DIFF
--- a/internal/tests/xdserr/cmd/main.go
+++ b/internal/tests/xdserr/cmd/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pomerium/pomerium/internal/tests/xdserr"
 	"github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpcutil"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
@@ -136,7 +137,7 @@ func grpcConn(ctx context.Context, addr, keyTxt string) (*grpc.ClientConn, error
 		return nil, err
 	}
 	fmt.Println(keyTxt)
-	return xdserr.NewGRPCClientConn(ctx, &xdserr.Options{
+	return grpcutil.NewGRPCClientConn(ctx, &grpcutil.Options{
 		Address:            u,
 		WithInsecure:       u.Scheme == "http",
 		InsecureSkipVerify: true,

--- a/internal/tests/xdserr/cmd/main.go
+++ b/internal/tests/xdserr/cmd/main.go
@@ -139,7 +139,6 @@ func grpcConn(ctx context.Context, addr, keyTxt string) (*grpc.ClientConn, error
 	fmt.Println(keyTxt)
 	return grpcutil.NewGRPCClientConn(ctx, &grpcutil.Options{
 		Address:            u,
-		WithInsecure:       u.Scheme == "http",
 		InsecureSkipVerify: true,
 		SignedJWTKey:       key,
 	})

--- a/pkg/grpcutil/client.go
+++ b/pkg/grpcutil/client.go
@@ -85,6 +85,7 @@ func NewGRPCClientConn(ctx context.Context, opts *Options, other ...grpc.DialOpt
 		}
 
 		cert := credentials.NewTLS(&tls.Config{
+			// nolint: gosec
 			InsecureSkipVerify: opts.InsecureSkipVerify,
 			RootCAs:            rootCAs,
 			MinVersion:         tls.VersionTLS12,

--- a/pkg/grpcutil/client.go
+++ b/pkg/grpcutil/client.go
@@ -36,10 +36,6 @@ type Options struct {
 	// ClientDNSRoundRobin enables or disables DNS resolver based load balancing
 	ClientDNSRoundRobin bool
 
-	// WithInsecure disables transport security for this ClientConn.
-	// Note that transport security is required unless WithInsecure is set.
-	WithInsecure bool
-
 	// InsecureSkipVerify skips destination hostname and ca check
 	InsecureSkipVerify bool
 
@@ -80,7 +76,7 @@ func NewGRPCClientConn(ctx context.Context, opts *Options, other ...grpc.DialOpt
 
 	dialOptions = append(dialOptions, other...)
 
-	if opts.WithInsecure {
+	if opts.Address.Scheme == "http" {
 		dialOptions = append(dialOptions, grpc.WithInsecure())
 	} else {
 		rootCAs, err := cryptutil.GetCertPool(opts.CA, opts.CAFile)

--- a/pkg/grpcutil/client.go
+++ b/pkg/grpcutil/client.go
@@ -1,4 +1,4 @@
-package xdserr
+package grpcutil
 
 import (
 	"context"
@@ -12,7 +12,6 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"github.com/pomerium/pomerium/pkg/cryptutil"
-	"github.com/pomerium/pomerium/pkg/grpcutil"
 )
 
 const (
@@ -68,8 +67,8 @@ func NewGRPCClientConn(ctx context.Context, opts *Options, other ...grpc.DialOpt
 	}
 	streamClientInterceptors := []grpc.StreamClientInterceptor{}
 	if opts.SignedJWTKey != nil {
-		unaryClientInterceptors = append(unaryClientInterceptors, grpcutil.WithUnarySignedJWT(opts.SignedJWTKey))
-		streamClientInterceptors = append(streamClientInterceptors, grpcutil.WithStreamSignedJWT(opts.SignedJWTKey))
+		unaryClientInterceptors = append(unaryClientInterceptors, WithUnarySignedJWT(opts.SignedJWTKey))
+		streamClientInterceptors = append(streamClientInterceptors, WithStreamSignedJWT(opts.SignedJWTKey))
 	}
 
 	dialOptions := []grpc.DialOption{
@@ -90,7 +89,6 @@ func NewGRPCClientConn(ctx context.Context, opts *Options, other ...grpc.DialOpt
 		}
 
 		cert := credentials.NewTLS(&tls.Config{
-			// nolint: gosec
 			InsecureSkipVerify: opts.InsecureSkipVerify,
 			RootCAs:            rootCAs,
 			MinVersion:         tls.VersionTLS12,


### PR DESCRIPTION
## Summary

`NewGRPCClientConn` snippet exists with minor variations in core, console, ingress-controller and cli. Moving to public package so that other repos can just use it directly.  

## Related issues


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
