### PR TITLE
dashboard: add confirmation dialog, fix button in firefox

### DIFF
--- a/internal/frontend/assets/html/userInfo.html
+++ b/internal/frontend/assets/html/userInfo.html
@@ -198,7 +198,7 @@
               <tr>
                 <td>{{.ID}}</td>
                 <td>
-                  <form action="{{$.WebAuthnURL}}" method="POST">
+                  <form action="{{$.WebAuthnURL}}" method="POST" class="delete-credential-form">
                     {{$.csrfField}}
                     <input type="hidden" name="action" value="unregister">
                     <input type="hidden" name="pomerium_device_credential_id" value="{{.ID}}">
@@ -229,7 +229,7 @@
               <tr>
                 <td>{{.ID}}</td>
                 <td>
-                  <form action="{{$.WebAuthnURL}}" method="POST">
+                  <form action="{{$.WebAuthnURL}}" method="POST" class="delete-credential-form">
                     {{$.csrfField}}
                     <input type="hidden" name="action" value="unregister">
                     <input type="hidden" name="pomerium_device_credential_id" value="{{.ID}}">
@@ -261,6 +261,19 @@
         <p>© Pomerium, Inc.</p>
       </div>
 </body>
+
+
+<script>
+  function onDeleteDeviceCredential(evt) {
+    if (!confirm("Are you sure you want to delete this device credential? If a policy requires an approved device you may need to request a new approval from your administrator.")) {
+      evt.preventDefault();
+    }
+  }
+
+  Array.from(document.getElementsByClassName("delete-credential-form")).forEach(function(el) {
+    el.addEventListener("submit", onDeleteDeviceCredential);
+  });
+</script>
 
 </html>
 {{end}}

--- a/internal/frontend/assets/style/main.css
+++ b/internal/frontend/assets/style/main.css
@@ -488,6 +488,7 @@ a.button {
   display: inline-block;
   text-decoration: none;
   text-transform: none;
+  white-space: nowrap;
   transition: box-shadow 150ms ease-in-out;
 }
 


### PR DESCRIPTION
## Summary
Add a confirmation dialog to the delete button and fix the display of the button in firefox.

## Related issues
Fixes https://github.com/pomerium/internal/issues/702
Fixes https://github.com/pomerium/pomerium/issues/2837

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
