### PR TITLE
deps: unpin go version to 0.16.x

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.16.12
+          go-version: 1.16.x
 
       - name: Set up Docker
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes


### PR DESCRIPTION
## Summary

Previously we pinned the go release to 0.16.12 to force the updated version of go. The .X branch should now be autoupdated. 

## Related issues

- fixes #2828 


## Checklist

- [x] reference any related issues
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
