### PR TITLE
docs: fix generation of the public key

### DIFF
--- a/docs/docs/topics/getting-users-identity.md
+++ b/docs/docs/topics/getting-users-identity.md
@@ -72,9 +72,8 @@ Though you will very likely be verifying signed-headers programmatically in your
 1. Provide pomerium with a base64 encoded Elliptic Curve ([NIST P-256] aka [secp256r1] aka prime256v1) Private Key. In production, you'd likely want to get these from your KMS.
 
 ```bash
-# see ./scripts/generate_self_signed_signing_key.sh
-openssl ecparam  -genkey  -name prime256v1  -noout  -out ec_private.pem
-openssl req  -x509  -new  -key ec_private.pem  -days 1000000  -out ec_public.pem  -subj "/CN=unused"
+openssl ecparam -genkey -name prime256v1 -noout -out ec_private.pem
+openssl ec -in ec_private.pem -pubout -out ec_public.pem
 # careful! this will output your private key in terminal
 cat ec_private.pem | base64
 ```


### PR DESCRIPTION
Signed-off-by: Sylvain Rabot <sylvain@abstraction.fr>

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
