### PR TITLE
Remove references to idp_provider_url for Google.

### DIFF
--- a/docs/docs/identity-providers/google.md
+++ b/docs/docs/identity-providers/google.md
@@ -126,7 +126,6 @@ Your [environmental variables] should look something like this.
 
 ```bash
 IDP_PROVIDER="google"
-IDP_PROVIDER_URL="https://accounts.google.com"
 IDP_CLIENT_ID="yyyy.apps.googleusercontent.com"
 IDP_CLIENT_SECRET="xxxxxx"
 IDP_SERVICE_ACCOUNT="zzzz" # output of `base64 -i service-account-key.json`

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -827,9 +827,9 @@ If you plan to write authorization policies using groups, or any other data that
 - Environmental Variable: `IDP_PROVIDER_URL`
 - Config File Key: `idp_provider_url`
 - Type: `string`
-- Required, depending on provider
+- Required, depending on provider.  (Do not use with Google)
 
-Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). For example, google's URL would be `https://accounts.google.com` for [their discover document](https://accounts.google.com/.well-known/openid-configuration).
+Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). An example Azure URL would be `https://login.microsoftonline.com/common/v2.0` for [their discover document](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration).
 
 
 ### Identity Provider Request Params

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -943,9 +943,9 @@ settings:
           - Environmental Variable: `IDP_PROVIDER_URL`
           - Config File Key: `idp_provider_url`
           - Type: `string`
-          - Required, depending on provider
+          - Required, depending on provider  (Do not use with Google)
         doc: |
-          Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). For example, google's URL would be `https://accounts.google.com` for [their discover document](https://accounts.google.com/.well-known/openid-configuration).
+          Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). An example Azure URL would be `https://login.microsoftonline.com/common/v2.0` for [their discover document](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration).
         shortdoc: |
           Provider URL is the base path to an identity provider's OpenID connect discovery document.
       - name: "Identity Provider Request Params"

--- a/examples/config/config.example.env
+++ b/examples/config/config.example.env
@@ -47,7 +47,6 @@ export COOKIE_SECRET="$(head -c32 /dev/urandom | base64)"
 
 ## GOOGLE
 export IDP_PROVIDER="google"
-export IDP_PROVIDER_URL="https://accounts.google.com" # optional for google
 
 # OKTA
 # export IDP_PROVIDER="okta"
@@ -69,3 +68,4 @@ export POLICY="$(base64 ./docs/configuration/examples/config/policy.example.yaml
 # For Group data you must set an IDP_SERVICE_ACCOUNT
 # https://www.pomerium.com/configuration/#identity-provider-service-account
 # export IDP_SERVICE_ACCOUNT=$( echo YOUR_SERVICE_ACCOUNT | base64)
+# For Google manually edit the service account to add the impersonate_user field before base64

--- a/examples/config/config.example.yaml
+++ b/examples/config/config.example.yaml
@@ -51,7 +51,6 @@ authenticate_service_url: https://authenticate.localhost.pomerium.io
 
 ## GOOGLE
 # idp_provider: "google"
-# idp_provider_url: "https://accounts.google.com" # optional for google
 # idp_client_id: "REPLACEME
 # idp_client_secret: "REPLACEME
 

--- a/examples/docker/nginx.docker-compose.yml
+++ b/examples/docker/nginx.docker-compose.yml
@@ -18,7 +18,8 @@ services:
       - SERVICES=authenticate
       - INSECURE_SERVER=TRUE
       # NOTE!: Replace with your identity provider settings https://www.pomerium.com/docs/identity-providers.html
-      # - IDP_PROVIDER=google
+      # - IDP_PROVIDER=okta
+      # - IDP_PROVIDER_URL=https://beyondperimeter.okta.com
       # - IDP_CLIENT_ID=REPLACE_ME
       # - IDP_CLIENT_SECRET=REPLACE_ME
       # - IDP_SERVICE_ACCOUNT=REPLACE_ME

--- a/examples/docker/nginx.docker-compose.yml
+++ b/examples/docker/nginx.docker-compose.yml
@@ -19,7 +19,6 @@ services:
       - INSECURE_SERVER=TRUE
       # NOTE!: Replace with your identity provider settings https://www.pomerium.com/docs/identity-providers.html
       # - IDP_PROVIDER=google
-      # - IDP_PROVIDER_URL=https://accounts.google.com
       # - IDP_CLIENT_ID=REPLACE_ME
       # - IDP_CLIENT_SECRET=REPLACE_ME
       # - IDP_SERVICE_ACCOUNT=REPLACE_ME


### PR DESCRIPTION
## Summary

Update documentation to remove references to `idp_provider_url` with Google OAuth, since it will break when used.  (Keep references for other providers)

## Related issues

Partially fixes #2866.

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
