### PR TITLE
authenticate: add device-enrolled page

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -137,7 +137,7 @@ func (a *Authenticate) getWebAuthnURL(values url.Values) (*url.URL, error) {
 			urlutil.QueryDeviceType:      {webauthnutil.DefaultDeviceType},
 			urlutil.QueryEnrollmentToken: nil,
 			urlutil.QueryRedirectURI: {uri.ResolveReference(&url.URL{
-				Path: "/.pomerium/",
+				Path: "/.pomerium/device-enrolled",
 			}).String()},
 		}).Encode(),
 	})

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -18,6 +18,7 @@ import (
 	"golang.org/x/oauth2"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/pomerium/pomerium/authenticate/handlers"
 	"github.com/pomerium/pomerium/authenticate/handlers/webauthn"
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/identity"
@@ -98,6 +99,7 @@ func (a *Authenticate) mountDashboard(r *mux.Router) {
 	sr.Path("/sign_in").Handler(a.requireValidSignature(a.SignIn))
 	sr.Path("/sign_out").Handler(a.requireValidSignature(a.SignOut))
 	sr.Path("/webauthn").Handler(webauthn.New(a.getWebauthnState))
+	sr.Path("/device-enrolled").Handler(handlers.DeviceEnrolled())
 }
 
 func (a *Authenticate) mountWellKnown(r *mux.Router) {

--- a/authenticate/handlers/device-enrolled.go
+++ b/authenticate/handlers/device-enrolled.go
@@ -6,18 +6,13 @@ import (
 
 	"github.com/pomerium/pomerium/internal/frontend"
 	"github.com/pomerium/pomerium/internal/httputil"
-	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
 // DeviceEnrolled displays an HTML page informing the user that they've successfully enrolled a device.
 func DeviceEnrolled() http.Handler {
 	tpl := template.Must(frontend.NewTemplates())
-	type TemplateData struct {
-		DeviceCredentialID string
-	}
+	type TemplateData struct{}
 	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		return tpl.ExecuteTemplate(w, "device-enrolled.html", TemplateData{
-			DeviceCredentialID: r.FormValue(urlutil.QueryDeviceCredentialID),
-		})
+		return tpl.ExecuteTemplate(w, "device-enrolled.html", TemplateData{})
 	})
 }

--- a/authenticate/handlers/device-enrolled.go
+++ b/authenticate/handlers/device-enrolled.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"html/template"
+	"net/http"
+
+	"github.com/pomerium/pomerium/internal/frontend"
+	"github.com/pomerium/pomerium/internal/httputil"
+	"github.com/pomerium/pomerium/internal/urlutil"
+)
+
+// DeviceEnrolled displays an HTML page informing the user that they've successfully enrolled a device.
+func DeviceEnrolled() http.Handler {
+	tpl := template.Must(frontend.NewTemplates())
+	type TemplateData struct {
+		DeviceCredentialID string
+	}
+	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return tpl.ExecuteTemplate(w, "device-enrolled.html", TemplateData{
+			DeviceCredentialID: r.FormValue(urlutil.QueryDeviceCredentialID),
+		})
+	})
+}

--- a/authenticate/handlers/handlers.go
+++ b/authenticate/handlers/handlers.go
@@ -1,0 +1,2 @@
+// Package handlers contains various web handlers for the authenticate service.
+package handlers

--- a/authenticate/handlers/webauthn/webauthn.go
+++ b/authenticate/handlers/webauthn/webauthn.go
@@ -303,16 +303,7 @@ func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request, state *
 		},
 	})
 
-	// add the device credential ID to the redirect uri
-	redirectURI, err := urlutil.ParseAndValidateURL(redirectURIParam)
-	if err != nil {
-		return err
-	}
-	q := redirectURI.Query()
-	q.Set(urlutil.QueryDeviceCredentialID, deviceCredentialID)
-	redirectURI.RawQuery = q.Encode()
-
-	return h.saveSessionAndRedirect(w, r, state, redirectURI.String())
+	return h.saveSessionAndRedirect(w, r, state, redirectURIParam)
 }
 
 func (h *Handler) handleUnregister(w http.ResponseWriter, r *http.Request, state *State) error {

--- a/internal/frontend/assets/html/device-enrolled.go.html
+++ b/internal/frontend/assets/html/device-enrolled.go.html
@@ -1,53 +1,30 @@
 {{define "device-enrolled.html"}}<!DOCTYPE html>
 <html lang="en" charset="utf-8">
-
-<head>
+  <head>
     <title>Device Successfully Enrolled</title>
     {{template "header.html"}}
-</head>
+  </head>
 
-<body>
-<div class="inner">
-    <div class="header clearfix">
+  <body>
+    <div class="inner">
+      <div class="header clearfix">
         <div class="heading"></div>
-    </div>
-    <div class="content">
+      </div>
+      <div class="content">
         <div class="white box">
-            <div class="largestatus">
-                <div class="title-wrapper">
-                    <span class="title">Device Successfully Enrolled</span>
-                    <label class="status-time">
-                        <span>
-                            Device was successfully enrolled.
-                        </span>
-                    </label>
-                </div>
+          <div class="largestatus">
+            <div class="title-wrapper">
+              <span class="title">Device Successfully Enrolled</span>
+              <label class="status-time">
+                <span>
+                  Device was successfully enrolled.
+                </span>
+              </label>
             </div>
+          </div>
         </div>
-
-
-        {{if .DeviceCredentialID}}
-        <div class="category white box">
-            <div class="messages">
-                <div class="box-inner">
-                    <div class="category-header clearfix">
-                        <span class="category-title">Details</span>
-                    </div>
-                    </ul>
-                    <table>
-                        <tbody>
-                        <tr>
-                            <td>Device Credential ID</td>
-                            <td>{{.DeviceCredentialID}}</td>
-                        </tr>
-                        </tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-        {{end}}
+      </div>
     </div>
-</div>
-</body>
+  </body>
 </html>
 {{end}}

--- a/internal/frontend/assets/html/device-enrolled.go.html
+++ b/internal/frontend/assets/html/device-enrolled.go.html
@@ -1,0 +1,53 @@
+{{define "device-enrolled.html"}}<!DOCTYPE html>
+<html lang="en" charset="utf-8">
+
+<head>
+    <title>Device Successfully Enrolled</title>
+    {{template "header.html"}}
+</head>
+
+<body>
+<div class="inner">
+    <div class="header clearfix">
+        <div class="heading"></div>
+    </div>
+    <div class="content">
+        <div class="white box">
+            <div class="largestatus">
+                <div class="title-wrapper">
+                    <span class="title">Device Successfully Enrolled</span>
+                    <label class="status-time">
+                        <span>
+                            Device was successfully enrolled.
+                        </span>
+                    </label>
+                </div>
+            </div>
+        </div>
+
+
+        {{if .DeviceCredentialID}}
+        <div class="category white box">
+            <div class="messages">
+                <div class="box-inner">
+                    <div class="category-header clearfix">
+                        <span class="category-title">Details</span>
+                    </div>
+                    </ul>
+                    <table>
+                        <tbody>
+                        <tr>
+                            <td>Device Credential ID</td>
+                            <td>{{.DeviceCredentialID}}</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+        {{end}}
+    </div>
+</div>
+</body>
+</html>
+{{end}}

--- a/internal/urlutil/proxy.go
+++ b/internal/urlutil/proxy.go
@@ -11,7 +11,12 @@ var ErrMissingRedirectURI = errors.New("missing " + QueryRedirectURI)
 
 // GetCallbackURL gets the proxy's callback URL from a request and a base64url encoded + encrypted session state JWT.
 func GetCallbackURL(r *http.Request, encodedSessionJWT string) (*url.URL, error) {
-	rawRedirectURI := r.FormValue(QueryRedirectURI)
+	return GetCallbackURLForRedirectURI(r, encodedSessionJWT, r.FormValue(QueryRedirectURI))
+}
+
+// GetCallbackURLForRedirectURI gets the proxy's callback URL from a request and a base64url encoded + encrypted session
+// state JWT.
+func GetCallbackURLForRedirectURI(r *http.Request, encodedSessionJWT, rawRedirectURI string) (*url.URL, error) {
 	if rawRedirectURI == "" {
 		return nil, ErrMissingRedirectURI
 	}


### PR DESCRIPTION
## Summary
Add a new device-enrolled page that can be shown after a device is enrolled successfully.

## Related issues
Fixes #2891 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
