### PR TITLE
integration: fix default port for verify service

### DIFF
--- a/integration/clusters/auth0-kubernetes/compose.yml
+++ b/integration/clusters/auth0-kubernetes/compose.yml
@@ -545,7 +545,7 @@ services:
                   "name": "verify",
                   "ports": [
                     {
-                      "containerPort": 80,
+                      "containerPort": 8000,
                       "name": "http"
                     }
                   ]

--- a/integration/clusters/auth0-multi/compose.yml
+++ b/integration/clusters/auth0-multi/compose.yml
@@ -848,7 +848,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/auth0-nginx/compose.yml
+++ b/integration/clusters/auth0-nginx/compose.yml
@@ -922,7 +922,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/auth0-single/compose.yml
+++ b/integration/clusters/auth0-single/compose.yml
@@ -666,7 +666,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/auth0-traefik/compose.yml
+++ b/integration/clusters/auth0-traefik/compose.yml
@@ -1450,7 +1450,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/azure-kubernetes/compose.yml
+++ b/integration/clusters/azure-kubernetes/compose.yml
@@ -545,7 +545,7 @@ services:
                   "name": "verify",
                   "ports": [
                     {
-                      "containerPort": 80,
+                      "containerPort": 8000,
                       "name": "http"
                     }
                   ]

--- a/integration/clusters/azure-multi/compose.yml
+++ b/integration/clusters/azure-multi/compose.yml
@@ -848,7 +848,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/azure-nginx/compose.yml
+++ b/integration/clusters/azure-nginx/compose.yml
@@ -922,7 +922,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/azure-single/compose.yml
+++ b/integration/clusters/azure-single/compose.yml
@@ -666,7 +666,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/azure-traefik/compose.yml
+++ b/integration/clusters/azure-traefik/compose.yml
@@ -1450,7 +1450,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/github-kubernetes/compose.yml
+++ b/integration/clusters/github-kubernetes/compose.yml
@@ -545,7 +545,7 @@ services:
                   "name": "verify",
                   "ports": [
                     {
-                      "containerPort": 80,
+                      "containerPort": 8000,
                       "name": "http"
                     }
                   ]

--- a/integration/clusters/github-multi/compose.yml
+++ b/integration/clusters/github-multi/compose.yml
@@ -848,7 +848,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/github-nginx/compose.yml
+++ b/integration/clusters/github-nginx/compose.yml
@@ -922,7 +922,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/github-single/compose.yml
+++ b/integration/clusters/github-single/compose.yml
@@ -666,7 +666,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/github-traefik/compose.yml
+++ b/integration/clusters/github-traefik/compose.yml
@@ -1450,7 +1450,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/gitlab-kubernetes/compose.yml
+++ b/integration/clusters/gitlab-kubernetes/compose.yml
@@ -545,7 +545,7 @@ services:
                   "name": "verify",
                   "ports": [
                     {
-                      "containerPort": 80,
+                      "containerPort": 8000,
                       "name": "http"
                     }
                   ]

--- a/integration/clusters/gitlab-multi/compose.yml
+++ b/integration/clusters/gitlab-multi/compose.yml
@@ -848,7 +848,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/gitlab-nginx/compose.yml
+++ b/integration/clusters/gitlab-nginx/compose.yml
@@ -922,7 +922,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/gitlab-single/compose.yml
+++ b/integration/clusters/gitlab-single/compose.yml
@@ -666,7 +666,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/gitlab-traefik/compose.yml
+++ b/integration/clusters/gitlab-traefik/compose.yml
@@ -1450,7 +1450,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/google-kubernetes/compose.yml
+++ b/integration/clusters/google-kubernetes/compose.yml
@@ -545,7 +545,7 @@ services:
                   "name": "verify",
                   "ports": [
                     {
-                      "containerPort": 80,
+                      "containerPort": 8000,
                       "name": "http"
                     }
                   ]

--- a/integration/clusters/google-multi/compose.yml
+++ b/integration/clusters/google-multi/compose.yml
@@ -848,7 +848,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/google-nginx/compose.yml
+++ b/integration/clusters/google-nginx/compose.yml
@@ -922,7 +922,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/google-single/compose.yml
+++ b/integration/clusters/google-single/compose.yml
@@ -666,7 +666,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/google-traefik/compose.yml
+++ b/integration/clusters/google-traefik/compose.yml
@@ -1450,7 +1450,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/oidc-kubernetes/compose.yml
+++ b/integration/clusters/oidc-kubernetes/compose.yml
@@ -545,7 +545,7 @@ services:
                   "name": "verify",
                   "ports": [
                     {
-                      "containerPort": 80,
+                      "containerPort": 8000,
                       "name": "http"
                     }
                   ]

--- a/integration/clusters/oidc-multi/compose.yml
+++ b/integration/clusters/oidc-multi/compose.yml
@@ -848,7 +848,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/oidc-nginx/compose.yml
+++ b/integration/clusters/oidc-nginx/compose.yml
@@ -922,7 +922,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/oidc-single/compose.yml
+++ b/integration/clusters/oidc-single/compose.yml
@@ -666,7 +666,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/oidc-traefik/compose.yml
+++ b/integration/clusters/oidc-traefik/compose.yml
@@ -1450,7 +1450,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/okta-kubernetes/compose.yml
+++ b/integration/clusters/okta-kubernetes/compose.yml
@@ -545,7 +545,7 @@ services:
                   "name": "verify",
                   "ports": [
                     {
-                      "containerPort": 80,
+                      "containerPort": 8000,
                       "name": "http"
                     }
                   ]

--- a/integration/clusters/okta-multi/compose.yml
+++ b/integration/clusters/okta-multi/compose.yml
@@ -848,7 +848,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/okta-nginx/compose.yml
+++ b/integration/clusters/okta-nginx/compose.yml
@@ -922,7 +922,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/okta-single/compose.yml
+++ b/integration/clusters/okta-single/compose.yml
@@ -666,7 +666,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/okta-traefik/compose.yml
+++ b/integration/clusters/okta-traefik/compose.yml
@@ -1450,7 +1450,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/onelogin-kubernetes/compose.yml
+++ b/integration/clusters/onelogin-kubernetes/compose.yml
@@ -545,7 +545,7 @@ services:
                   "name": "verify",
                   "ports": [
                     {
-                      "containerPort": 80,
+                      "containerPort": 8000,
                       "name": "http"
                     }
                   ]

--- a/integration/clusters/onelogin-multi/compose.yml
+++ b/integration/clusters/onelogin-multi/compose.yml
@@ -848,7 +848,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/onelogin-nginx/compose.yml
+++ b/integration/clusters/onelogin-nginx/compose.yml
@@ -922,7 +922,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/onelogin-single/compose.yml
+++ b/integration/clusters/onelogin-single/compose.yml
@@ -666,7 +666,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/onelogin-traefik/compose.yml
+++ b/integration/clusters/onelogin-traefik/compose.yml
@@ -1450,7 +1450,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/ping-kubernetes/compose.yml
+++ b/integration/clusters/ping-kubernetes/compose.yml
@@ -545,7 +545,7 @@ services:
                   "name": "verify",
                   "ports": [
                     {
-                      "containerPort": 80,
+                      "containerPort": 8000,
                       "name": "http"
                     }
                   ]

--- a/integration/clusters/ping-multi/compose.yml
+++ b/integration/clusters/ping-multi/compose.yml
@@ -848,7 +848,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/ping-nginx/compose.yml
+++ b/integration/clusters/ping-nginx/compose.yml
@@ -922,7 +922,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/ping-single/compose.yml
+++ b/integration/clusters/ping-single/compose.yml
@@ -666,7 +666,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/clusters/ping-traefik/compose.yml
+++ b/integration/clusters/ping-traefik/compose.yml
@@ -1450,7 +1450,7 @@ services:
   verify-ready:
     command:
     - -wait
-    - http://verify:80/
+    - http://verify:8000/
     - -timeout
     - 10m
     image: jwilder/dockerize:0.6.1

--- a/integration/tpl/backends/verify.libsonnet
+++ b/integration/tpl/backends/verify.libsonnet
@@ -35,7 +35,7 @@ function(mode) {
         image: 'jwilder/dockerize:0.6.1',
         command: [
           '-wait',
-          'http://' + name + ':80/',
+          'http://' + name + ':8000/',
           '-timeout',
           '10m',
         ],
@@ -49,7 +49,7 @@ function(mode) {
       { name: 'http', port: 80, targetPort: 'http' },
     ]),
     utils.KubernetesDeployment(name, image, null, [
-      { name: 'http', containerPort: 80 },
+      { name: 'http', containerPort: 8000 },
     ]),
   ],
 }


### PR DESCRIPTION
## Summary
The default port for the verify service was changed from `80` to `8000`. This PR should fix the broken integration tests.

## Related issues
Fixes #2894 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
