### PR TITLE
deployment: multi-arch master images

### DIFF
--- a/.github/workflows/docker-master.yaml
+++ b/.github/workflows/docker-master.yaml
@@ -46,6 +46,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.metadata.outputs.tags }}
           labels: |
             org.opencontainers.image.created=${{ steps.metadata.outputs.timestamp }}
@@ -58,6 +59,7 @@ jobs:
           context: .
           file: ./Dockerfile.debug
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: pomerium/pomerium:debug
           labels: |
             org.opencontainers.image.created=${{ steps.metadata.outputs.timestamp }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+ARG ARCH=amd64
+
 FROM golang:latest as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
@@ -20,7 +22,7 @@ RUN apt-get update && apt-get install -y ca-certificates
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 
-FROM gcr.io/distroless/base:debug
+FROM gcr.io/distroless/base:debug-${ARCH}
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/


### PR DESCRIPTION
## Summary

Enable multi-arch building for `master` and `debug` rolling image tags.

Notes: 

- Only the `distroless` image actually needs the `ARCH` variable specified.  The rest (alpine, go, debian) publish multi-arch images that should get picked up automatically based on the target platform.
- This will not create discrete tags for each platform but I don't think that's very important, especially for the rolling images.  It seems like this isn't common anymore.

## Related issues

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
