### PR TITLE
envoy: upgrade to 1.20.1

### DIFF
--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -5,14 +5,14 @@ PATH="$PATH:$(go env GOPATH)/bin"
 export PATH
 
 _project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/.."
-_envoy_version=1.19.1
+_envoy_version=1.20.1
 _dir="$_project_root/internal/envoy/files"
 _target="${TARGET:-"$(go env GOOS)-$(go env GOARCH)"}"
 
 if [ "$_target" == "darwin-arm64" ]; then
   echo "Using local envoy distribution for Apple M1"
-  cp -f `which envoy` "$_dir/envoy-$_target"
-  (cd internal/envoy/files && sha256sum "$_dir/envoy-$_target" > "$_dir/envoy-$_target.sha256")
+  cp -f "$(which envoy)" "$_dir/envoy-$_target"
+  (cd internal/envoy/files && sha256sum "$_dir/envoy-$_target" >"$_dir/envoy-$_target.sha256")
   echo "1.21.0-dev" >"$_dir/envoy-$_target.version"
   exit 0
 fi


### PR DESCRIPTION
## Summary
Upgrade envoy from 1.19.1 to 1.20.1.

## Related issues
- https://github.com/pomerium/internal/issues/708


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
