### PR TITLE
envoy: check certificates for must-staple flag and drop them if they are missing the response

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -648,6 +648,12 @@ func (b *Builder) buildDownstreamTLSContext(ctx context.Context,
 		return nil
 	}
 
+	err = validateCertificate(cert)
+	if err != nil {
+		log.Warn(ctx).Str("domain", domain).Err(err).Msg("invalid certificate for domain")
+		return nil
+	}
+
 	var alpnProtocols []string
 	switch cfg.Options.GetCodecType() {
 	case config.CodecTypeHTTP1:

--- a/config/envoyconfig/tls_test.go
+++ b/config/envoyconfig/tls_test.go
@@ -1,12 +1,16 @@
 package envoyconfig
 
 import (
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
 func TestBuildSubjectAlternativeNameMatcher(t *testing.T) {
@@ -30,4 +34,16 @@ func TestBuildSubjectNameIndication(t *testing.T) {
 	assert.Equal(t, "example.com", b.buildSubjectNameIndication(&url.URL{Host: "example.com:1234"}, ""))
 	assert.Equal(t, "example.org", b.buildSubjectNameIndication(&url.URL{Host: "example.com:1234"}, "example.org"))
 	assert.Equal(t, "example.example.org", b.buildSubjectNameIndication(&url.URL{Host: "example.com:1234"}, "*.example.org"))
+}
+
+func TestValidateCertificatge(t *testing.T) {
+	cert, err := cryptutil.GenerateSelfSignedCertificate("example.com", func(tpl *x509.Certificate) {
+		// set the must staple flag on the cert
+		tpl.ExtraExtensions = append(tpl.ExtraExtensions, pkix.Extension{
+			Id: oidMustStaple,
+		})
+	})
+	require.NoError(t, err)
+
+	assert.Error(t, validateCertificate(cert), "should return an error for a must-staple TLS certificate that has no stapled OCSP response")
 }

--- a/config/envoyconfig/tls_test.go
+++ b/config/envoyconfig/tls_test.go
@@ -36,7 +36,7 @@ func TestBuildSubjectNameIndication(t *testing.T) {
 	assert.Equal(t, "example.example.org", b.buildSubjectNameIndication(&url.URL{Host: "example.com:1234"}, "*.example.org"))
 }
 
-func TestValidateCertificatge(t *testing.T) {
+func TestValidateCertificate(t *testing.T) {
 	cert, err := cryptutil.GenerateSelfSignedCertificate("example.com", func(tpl *x509.Certificate) {
 		// set the must staple flag on the cert
 		tpl.ExtraExtensions = append(tpl.ExtraExtensions, pkix.Extension{


### PR DESCRIPTION
## Summary
If a TLS certificate has a must-staple extension set, envoy will reject the certificate if doesn't also have an OCSP response. This results in an invalid configuration and a fatal error in Pomerium. When Pomerium restarts it picks the certificate up again and crashes, resulting in rate-limiting from the Let's Encrypt side.

This PR adds a validation step to reject invalid certificates before we hand them to envoy. This allows us to recover if the OCSP response subsequently gets added to the certificate.

The bug can be quite difficult to reproduce: it requires a server accessible from the internet and I had to modify the code to erase the OCSP response to simulate it missing. I wasn't able to come up with a way to build a real integration test, but I did add a unit test.

## Related issues
Fixes #2852 


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
