### PR TITLE
document service_proxy_upstream ingress annotation

### DIFF
--- a/docs/docs/k8s/ingress.md
+++ b/docs/docs/k8s/ingress.md
@@ -167,6 +167,7 @@ The remaining annotations are specific to or behave differently than they do whe
 | `ingress.pomerium.io/tls_downstream_client_ca_secret` | Name of Kubernetes `tls` Secret containing a [Client CA][client-certificate-authority] for validating downstream clients. |
 | `ingress.pomerium.io/secure_upstream`                 | When set to `"true"`, use `https` when connecting to the upstream endpoint. |
 | `ingress.pomerium.io/path_regex`                      | When set to `"true"` enables path regex matching. See the [Regular Expressions Path Matching](#regular-expressions-path-matching) section for more information. |
+| `ingress.pomerium.io/service_proxy_upstream`          | When set to `"true"` forces upstream to be k8s service proxy, and not individual endpoints. |
 
 ::: tip
 


### PR DESCRIPTION
## Summary

Adds docs for `service_proxy_upstream` ingress annotation. 

## Related issues

Documents https://github.com/pomerium/ingress-controller/issues/113

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
