### PR TITLE
docs: fix argo link

### DIFF
--- a/docs/guides/argo.md
+++ b/docs/guides/argo.md
@@ -11,7 +11,7 @@ description: >-
 
 # Securing Argo
 
-[Argo](https://argoproj.github.io/projects/argo) is an open-source container-native workflow engine for orchestrating parallel jobs on Kubernetes. This guide covers how to add authentication and authorization to Argo using Pomerium.
+[Argo](https://argoproj.github.io/workflows) is an open-source container-native workflow engine for orchestrating parallel jobs on Kubernetes. This guide covers how to add authentication and authorization to Argo using Pomerium.
 
 ## Install Argo
 


### PR DESCRIPTION
## Summary

minot fix: link to argo workflows in the Pomerium guide to [secure Argo.](https://www.pomerium.com/guides/argo.html)

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [x] reference any related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
