### PR TITLE
handle device states in deny block, fix default device type

### DIFF
--- a/pkg/policy/criteria/device.go
+++ b/pkg/policy/criteria/device.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/policy/generator"
 	"github.com/pomerium/pomerium/pkg/policy/parser"
 	"github.com/pomerium/pomerium/pkg/policy/rules"
+	"github.com/pomerium/pomerium/pkg/webauthnutil"
 )
 
 const (
@@ -73,7 +74,7 @@ func (c deviceCriterion) GenerateRule(_ string, data parser.Value) (*ast.Rule, [
 		}...)
 	}
 
-	deviceType := "default"
+	deviceType := webauthnutil.DefaultDeviceType
 	if v, ok := obj[deviceOperatorType]; ok {
 		s, ok := v.(parser.String)
 		if !ok {

--- a/pkg/policy/criteria/device_test.go
+++ b/pkg/policy/criteria/device_test.go
@@ -27,7 +27,7 @@ allow:
         is: dc1
 `, []dataBrokerRecord{}, Input{Session: InputSession{ID: "s1"}})
 		require.NoError(t, err)
-		require.Equal(t, A{false, A{ReasonUserUnauthenticated}, M{"device_type": "default"}}, res["allow"])
+		require.Equal(t, A{false, A{ReasonUserUnauthenticated}, M{"device_type": "any"}}, res["allow"])
 		require.Equal(t, A{false, A{}}, res["deny"])
 	})
 	t.Run("no device credential", func(t *testing.T) {
@@ -37,10 +37,10 @@ allow:
     - device:
         is: dc1
 `, []dataBrokerRecord{
-			mkDeviceSession("s1", "default", "dc1"),
+			mkDeviceSession("s1", "any", "dc1"),
 		}, Input{Session: InputSession{ID: "s1"}})
 		require.NoError(t, err)
-		require.Equal(t, A{false, A{ReasonDeviceUnauthenticated}, M{"device_type": "default"}}, res["allow"])
+		require.Equal(t, A{false, A{ReasonDeviceUnauthenticated}, M{"device_type": "any"}}, res["allow"])
 		require.Equal(t, A{false, A{}}, res["deny"])
 	})
 	t.Run("allowed by is", func(t *testing.T) {
@@ -50,12 +50,12 @@ allow:
     - device:
         is: dc1
 `, []dataBrokerRecord{
-			mkDeviceSession("s1", "default", "dc1"),
+			mkDeviceSession("s1", "any", "dc1"),
 			&device.Credential{Id: "dc1", EnrollmentId: "de1"},
 			&device.Enrollment{Id: "de1"},
 		}, Input{Session: InputSession{ID: "s1"}})
 		require.NoError(t, err)
-		require.Equal(t, A{true, A{ReasonDeviceOK}, M{"device_type": "default"}}, res["allow"])
+		require.Equal(t, A{true, A{ReasonDeviceOK}, M{"device_type": "any"}}, res["allow"])
 		require.Equal(t, A{false, A{}}, res["deny"])
 	})
 	t.Run("not allowed by is", func(t *testing.T) {
@@ -65,14 +65,14 @@ allow:
     - device:
         is: dc2
 `, []dataBrokerRecord{
-			mkDeviceSession("s1", "default", "dc1"),
+			mkDeviceSession("s1", "any", "dc1"),
 			&device.Credential{Id: "dc1", EnrollmentId: "de1"},
 			&device.Enrollment{Id: "de1"},
 			&device.Credential{Id: "dc2", EnrollmentId: "de2"},
 			&device.Enrollment{Id: "de2"},
 		}, Input{Session: InputSession{ID: "s1"}})
 		require.NoError(t, err)
-		require.Equal(t, A{false, A{ReasonDeviceUnauthorized}, M{"device_type": "default"}}, res["allow"])
+		require.Equal(t, A{false, A{ReasonDeviceUnauthorized}, M{"device_type": "any"}}, res["allow"])
 		require.Equal(t, A{false, A{}}, res["deny"])
 	})
 	t.Run("allowed by approved", func(t *testing.T) {
@@ -82,12 +82,12 @@ allow:
     - device:
         approved: true
 `, []dataBrokerRecord{
-			mkDeviceSession("s1", "default", "dc1"),
+			mkDeviceSession("s1", "any", "dc1"),
 			&device.Credential{Id: "dc1", EnrollmentId: "de1"},
 			&device.Enrollment{Id: "de1", ApprovedBy: "u1"},
 		}, Input{Session: InputSession{ID: "s1"}})
 		require.NoError(t, err)
-		require.Equal(t, A{true, A{ReasonDeviceOK}, M{"device_type": "default"}}, res["allow"])
+		require.Equal(t, A{true, A{ReasonDeviceOK}, M{"device_type": "any"}}, res["allow"])
 		require.Equal(t, A{false, A{}}, res["deny"])
 	})
 	t.Run("not allowed by approved", func(t *testing.T) {
@@ -97,12 +97,12 @@ allow:
     - device:
         approved: true
 `, []dataBrokerRecord{
-			mkDeviceSession("s1", "default", "dc1"),
+			mkDeviceSession("s1", "any", "dc1"),
 			&device.Credential{Id: "dc1", EnrollmentId: "de1"},
 			&device.Enrollment{Id: "de1"},
 		}, Input{Session: InputSession{ID: "s1"}})
 		require.NoError(t, err)
-		require.Equal(t, A{false, A{ReasonDeviceUnauthorized}, M{"device_type": "default"}}, res["allow"])
+		require.Equal(t, A{false, A{ReasonDeviceUnauthorized}, M{"device_type": "any"}}, res["allow"])
 		require.Equal(t, A{false, A{}}, res["deny"])
 	})
 	t.Run("allowed by not approved", func(t *testing.T) {
@@ -112,12 +112,12 @@ allow:
     - device:
         approved: false
 `, []dataBrokerRecord{
-			mkDeviceSession("s1", "default", "dc1"),
+			mkDeviceSession("s1", "any", "dc1"),
 			&device.Credential{Id: "dc1", EnrollmentId: "de1"},
 			&device.Enrollment{Id: "de1"},
 		}, Input{Session: InputSession{ID: "s1"}})
 		require.NoError(t, err)
-		require.Equal(t, A{true, A{ReasonDeviceOK}, M{"device_type": "default"}}, res["allow"])
+		require.Equal(t, A{true, A{ReasonDeviceOK}, M{"device_type": "any"}}, res["allow"])
 		require.Equal(t, A{false, A{}}, res["deny"])
 	})
 	t.Run("not allowed by not approved", func(t *testing.T) {
@@ -127,12 +127,12 @@ allow:
     - device:
         approved: false
 `, []dataBrokerRecord{
-			mkDeviceSession("s1", "default", "dc1"),
+			mkDeviceSession("s1", "any", "dc1"),
 			&device.Credential{Id: "dc1", EnrollmentId: "de1"},
 			&device.Enrollment{Id: "de1", ApprovedBy: "u1"},
 		}, Input{Session: InputSession{ID: "s1"}})
 		require.NoError(t, err)
-		require.Equal(t, A{false, A{ReasonDeviceUnauthorized}, M{"device_type": "default"}}, res["allow"])
+		require.Equal(t, A{false, A{ReasonDeviceUnauthorized}, M{"device_type": "any"}}, res["allow"])
 		require.Equal(t, A{false, A{}}, res["deny"])
 	})
 	t.Run("allowed by type", func(t *testing.T) {


### PR DESCRIPTION
## Summary
For device handling we rely on `Reasons` returned by PPL. There are two device-specific reasons: `device-unauthenticated` and `device-unauthorized`. The first triggers the device registration/authentication flow. The second results in a special access denied error.

Currently we are only checking these reasons when they are returned by an `allow` block and not a `deny` block. This means that if you were to use a `device` criterion in a `deny` block the user would only ever see forbidden.

This PR updates the code so that both the "Not Allowed" and "Denied" conditions are handled in similar ways so that the user will go through the device authentication flow before (possibly) seeing a forbidden error.

The other issue is that we were still using `default` as the default device type from within the PPL criterion. This meant that if no device type was specified we were triggering registration for a device type that didn't exist, resulting in an error.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/2274


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
