### PR TITLE
deployment: fix distroless base arch

### DIFF
--- a/.github/Dockerfile-release
+++ b/.github/Dockerfile-release
@@ -8,7 +8,7 @@ RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certif
 FROM busybox:latest as build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/base-debian10:latest-${TARGETARCH}
+FROM gcr.io/distroless/base-debian10:latest-${TARGETARCH:-amd64}
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY pomerium* /bin/

--- a/.github/Dockerfile-release
+++ b/.github/Dockerfile-release
@@ -1,4 +1,4 @@
-ARG ARCH
+ARG TARGETARCH
 
 # build our own root trust store from current stable
 FROM debian:stable as casource
@@ -10,7 +10,7 @@ RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certif
 FROM busybox:latest as build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/base-debian10:latest-${ARCH}
+FROM gcr.io/distroless/base-debian10:latest-${TARGETARCH}
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY pomerium* /bin/

--- a/.github/Dockerfile-release
+++ b/.github/Dockerfile-release
@@ -1,5 +1,3 @@
-ARG TARGETARCH
-
 # build our own root trust store from current stable
 FROM debian:stable as casource
 RUN apt-get update && apt-get install -y ca-certificates

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -67,7 +67,7 @@ dockers:
     dockerfile: .github/Dockerfile-release
     build_flag_templates:
       - "--pull"
-      - "--build-arg=TARGETARCH=amd64"
+      - "--platform=linux/amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -95,7 +95,7 @@ dockers:
     dockerfile: .github/Dockerfile-release
     build_flag_templates:
       - "--pull"
-      - "--build-arg=TARGETARCH=arm64"
+      - "--platform=linux/arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -67,7 +67,7 @@ dockers:
     dockerfile: .github/Dockerfile-release
     build_flag_templates:
       - "--pull"
-      - "--build-arg=ARCH=amd64"
+      - "--build-arg=TARGETARCH=amd64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -95,7 +95,7 @@ dockers:
     dockerfile: .github/Dockerfile-release
     build_flag_templates:
       - "--pull"
-      - "--build-arg=ARCH=arm64"
+      - "--build-arg=TARGETARCH=arm64"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ARCH=amd64
+ARG TARGETARCH=amd64
 
 FROM golang:latest as build
 WORKDIR /go/src/github.com/pomerium/pomerium
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y ca-certificates
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 
-FROM gcr.io/distroless/base:debug-${ARCH}
+FROM gcr.io/distroless/base:debug-${TARGETARCH}
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,3 @@
-ARG TARGETARCH=amd64
-
 FROM golang:latest as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y ca-certificates
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 
-FROM gcr.io/distroless/base:debug-${TARGETARCH}
+FROM gcr.io/distroless/base:debug-${TARGETARCH:-amd64}
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/


### PR DESCRIPTION
## Summary

It seems like we're using the wrong env var to detect the target platform when building the image from master.  We should be using `TARGETARCH` rather than `ARCH` per [the docs](https://docs.docker.com/engine/reference/builder/#automatic-platform-args-in-the-global-scope).

- Update the top level `Dockerfile` to use the correct variable name
- Update our release pipeline and `Dockerfile` to use the same variable name for consistency
- Set target platform explicitly in goreleaser config

## Related issues

#2896


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
