### PR TITLE
devices: treat undefined device types as any

### DIFF
--- a/authenticate/handlers/webauthn/webauthn.go
+++ b/authenticate/handlers/webauthn/webauthn.go
@@ -137,10 +137,7 @@ func (h *Handler) handleAuthenticate(w http.ResponseWriter, r *http.Request, sta
 	}
 
 	// get the stored device type
-	deviceType, err := webauthnutil.GetDeviceType(ctx, state.Client, deviceTypeParam)
-	if err != nil {
-		return fmt.Errorf("error retrieving webauthn device type: %w", err)
-	}
+	deviceType := webauthnutil.GetDeviceType(ctx, state.Client, deviceTypeParam)
 
 	// get the device credentials
 	knownDeviceCredentials, err := getKnownDeviceCredentials(ctx, state.Client, u.GetDeviceCredentialIds()...)
@@ -232,10 +229,7 @@ func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request, state *
 	}
 
 	// get the stored device type
-	deviceType, err := webauthnutil.GetDeviceType(ctx, state.Client, deviceTypeParam)
-	if err != nil {
-		return fmt.Errorf("error retrieving webauthn device type: %w", err)
-	}
+	deviceType := webauthnutil.GetDeviceType(ctx, state.Client, deviceTypeParam)
 
 	creationOptions, err := webauthnutil.GetCreationOptionsForCredential(
 		state.SharedKey,
@@ -370,10 +364,7 @@ func (h *Handler) handleView(w http.ResponseWriter, r *http.Request, state *Stat
 	}
 
 	// get the stored device type
-	deviceType, err := webauthnutil.GetDeviceType(ctx, state.Client, deviceTypeParam)
-	if err != nil {
-		return err
-	}
+	deviceType := webauthnutil.GetDeviceType(ctx, state.Client, deviceTypeParam)
 
 	creationOptions := webauthnutil.GenerateCreationOptions(state.SharedKey, deviceType, u)
 	requestOptions := webauthnutil.GenerateRequestOptions(state.SharedKey, deviceType, knownDeviceCredentials)

--- a/pkg/webauthnutil/device_type.go
+++ b/pkg/webauthnutil/device_type.go
@@ -62,14 +62,14 @@ func GetDeviceType(
 	ctx context.Context,
 	client databroker.DataBrokerServiceClient,
 	deviceTypeID string,
-) (*device.Type, error) {
+) *device.Type {
 	deviceType, err := device.GetType(ctx, client, deviceTypeID)
 	if status.Code(err) == codes.NotFound {
-		var ok bool
-		deviceType, ok = predefinedDeviceTypes[deviceTypeID]
-		if ok {
-			err = nil
-		}
+		deviceType = predefinedDeviceTypes[deviceTypeID]
 	}
-	return deviceType, err
+	if deviceType == nil {
+		deviceType = proto.Clone(predefinedDeviceTypes[DefaultDeviceType]).(*device.Type)
+		deviceType.Id = deviceTypeID
+	}
+	return deviceType
 }

--- a/pkg/webauthnutil/device_type_test.go
+++ b/pkg/webauthnutil/device_type_test.go
@@ -35,8 +35,7 @@ func TestGetDeviceType(t *testing.T) {
 				}, nil
 			},
 		}
-		deviceType, err := GetDeviceType(ctx, client, "any")
-		assert.NoError(t, err)
+		deviceType := GetDeviceType(ctx, client, "any")
 		assert.Equal(t, "Example", deviceType.GetName())
 	})
 	t.Run("default", func(t *testing.T) {
@@ -45,17 +44,7 @@ func TestGetDeviceType(t *testing.T) {
 				return nil, status.Error(codes.NotFound, "not found")
 			},
 		}
-		deviceType, err := GetDeviceType(ctx, client, "any")
-		assert.NoError(t, err)
+		deviceType := GetDeviceType(ctx, client, "any")
 		assert.Equal(t, "Any", deviceType.GetName())
-	})
-	t.Run("not found", func(t *testing.T) {
-		client := &mockDataBrokerServiceClient{
-			get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
-				return nil, status.Error(codes.NotFound, "not found")
-			},
-		}
-		_, err := GetDeviceType(ctx, client, "example")
-		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Summary
Treat undefined device types as any.

## Related issues
Fixes https://github.com/pomerium/internal/issues/731


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
