### PR TITLE
device: attempt to recover from resource exhausted error

### DIFF
--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -5,10 +5,13 @@ import (
 	context "context"
 	"fmt"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/internal/identity"
+	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
@@ -56,6 +59,9 @@ func Put(ctx context.Context, client databroker.DataBrokerServiceClient, s *Sess
 			Data: any,
 		},
 	})
+	if status.Code(err) == codes.ResourceExhausted {
+		log.Warn(ctx).Msg("session: saving session resulted in resource exhausted error")
+	}
 	return res, err
 }
 

--- a/pkg/grpc/user/user.go
+++ b/pkg/grpc/user/user.go
@@ -5,9 +5,12 @@ import (
 	context "context"
 	"fmt"
 
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pomerium/pomerium/internal/identity"
+	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
@@ -43,6 +46,9 @@ func Put(ctx context.Context, client databroker.DataBrokerServiceClient, u *User
 			Data: any,
 		},
 	})
+	if status.Code(err) == codes.ResourceExhausted {
+		log.Warn(ctx).Msg("user: saving user resulted in resource exhausted error")
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -59,6 +65,9 @@ func PutServiceAccount(ctx context.Context, client databroker.DataBrokerServiceC
 			Data: any,
 		},
 	})
+	if status.Code(err) == codes.ResourceExhausted {
+		log.Warn(ctx).Msg("user: saving service account resulted in resource exhausted error")
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Add code to saving the device credential to remove the responses if we exceed the max message size in gRPC.

## Related issues
Fixes https://github.com/pomerium/pomerium-console/issues/2281


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
