### PR TITLE
authenticate: support webauthn redirects to non-pomerium domains

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -686,13 +686,19 @@ func (a *Authenticate) getWebauthnState(ctx context.Context) (*webauthn.State, e
 		return nil, err
 	}
 
+	pomeriumDomains, err := a.options.Load().GetAllRouteableHTTPDomains()
+	if err != nil {
+		return nil, err
+	}
+
 	return &webauthn.State{
-		SharedKey:    state.sharedKey,
-		Client:       state.dataBrokerClient,
-		Session:      s,
-		SessionState: ss,
-		SessionStore: state.sessionStore,
-		RelyingParty: state.webauthnRelyingParty,
+		SharedKey:       state.sharedKey,
+		Client:          state.dataBrokerClient,
+		PomeriumDomains: pomeriumDomains,
+		Session:         s,
+		SessionState:    ss,
+		SessionStore:    state.sessionStore,
+		RelyingParty:    state.webauthnRelyingParty,
 	}, nil
 }
 

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -734,89 +734,15 @@ func getRouteableDomainsForTLSDomain(options *config.Options, addr string, tlsDo
 }
 
 func getAllRouteableDomains(options *config.Options, addr string) ([]string, error) {
-	forwardAuthURL, err := options.GetForwardAuthURL()
-	if err != nil {
-		return nil, err
+	switch addr {
+	case options.Addr:
+		return options.GetAllRouteableHTTPDomains()
+	case options.GetGRPCAddr():
+		return options.GetAllRouteableGRPCDomains()
 	}
 
-	lookup := map[string]struct{}{}
-	if config.IsAuthenticate(options.Services) && addr == options.Addr {
-		authenticateURL, err := options.GetInternalAuthenticateURL()
-		if err != nil {
-			return nil, err
-		}
-		for _, h := range urlutil.GetDomainsForURL(*authenticateURL) {
-			lookup[h] = struct{}{}
-		}
-	}
-
-	// authorize urls
-	if config.IsAll(options.Services) && addr == options.GetGRPCAddr() {
-		authorizeURLs, err := options.GetAuthorizeURLs()
-		if err != nil {
-			return nil, err
-		}
-		for _, u := range authorizeURLs {
-			for _, h := range urlutil.GetDomainsForURL(*u) {
-				lookup[h] = struct{}{}
-			}
-		}
-	} else if config.IsAuthorize(options.Services) && addr == options.GetGRPCAddr() {
-		authorizeURLs, err := options.GetInternalAuthorizeURLs()
-		if err != nil {
-			return nil, err
-		}
-		for _, u := range authorizeURLs {
-			for _, h := range urlutil.GetDomainsForURL(*u) {
-				lookup[h] = struct{}{}
-			}
-		}
-	}
-
-	// databroker urls
-	if config.IsAll(options.Services) && addr == options.GetGRPCAddr() {
-		dataBrokerURLs, err := options.GetDataBrokerURLs()
-		if err != nil {
-			return nil, err
-		}
-		for _, u := range dataBrokerURLs {
-			for _, h := range urlutil.GetDomainsForURL(*u) {
-				lookup[h] = struct{}{}
-			}
-		}
-	} else if config.IsDataBroker(options.Services) && addr == options.GetGRPCAddr() {
-		dataBrokerURLs, err := options.GetInternalDataBrokerURLs()
-		if err != nil {
-			return nil, err
-		}
-		for _, u := range dataBrokerURLs {
-			for _, h := range urlutil.GetDomainsForURL(*u) {
-				lookup[h] = struct{}{}
-			}
-		}
-	}
-
-	// policy urls
-	if config.IsProxy(options.Services) && addr == options.Addr {
-		for _, policy := range options.GetAllPolicies() {
-			for _, h := range urlutil.GetDomainsForURL(*policy.Source.URL) {
-				lookup[h] = struct{}{}
-			}
-		}
-		if forwardAuthURL != nil {
-			for _, h := range urlutil.GetDomainsForURL(*forwardAuthURL) {
-				lookup[h] = struct{}{}
-			}
-		}
-	}
-
-	domains := make([]string, 0, len(lookup))
-	for domain := range lookup {
-		domains = append(domains, domain)
-	}
-	sort.Strings(domains)
-
-	return domains, nil
+	// no other domains supported
+	return nil, nil
 }
 
 func getAllTLSDomains(options *config.Options, addr string) ([]string, error) {

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -727,12 +726,6 @@ func TestOptions_GetAllRouteableHTTPDomains(t *testing.T) {
 		"from2.example.com",
 		"from2.example.com:443",
 	}, domains)
-}
-
-func mustParseURL(t *testing.T, rawURL string) *url.URL {
-	u, err := urlutil.ParseAndValidateURL(rawURL)
-	require.NoError(t, err)
-	return u
 }
 
 func mustParseWeightedURLs(t *testing.T, urls ...string) []WeightedURL {


### PR DESCRIPTION
## Summary
When redirecting to a Pomerium domain from authenticate we typically use the `/.pomerium/callback` handler so that we can update the cookie for that route. However if we have a non-Pomerium redirect URI, that domain won't have that path, so we should just redirect without modifying it.

The `GetAllRouteableHTTPDomains` function basically already existed in the envoy config subpackage, so I pulled it so that webauthn could use it.

## Related issues
Fixes https://github.com/pomerium/pomerium-console/issues/2262


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
