### PR TITLE
google: support groups for users outside of the organization

### DIFF
--- a/databroker/directory.go
+++ b/databroker/directory.go
@@ -3,6 +3,7 @@ package databroker
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -36,7 +37,7 @@ func (c *DataBroker) RefreshUser(ctx context.Context, req *directory.RefreshUser
 			return new(emptypb.Empty), nil
 		case codes.NotFound: // go ahead and save the user that was returned
 		default:
-			return nil, err
+			return nil, fmt.Errorf("databroker: error retrieving existing user record for refresh: %w", err)
 		}
 	} else if err != nil {
 		return nil, err

--- a/internal/directory/directoryerrors/errors.go
+++ b/internal/directory/directoryerrors/errors.go
@@ -1,0 +1,8 @@
+// Package directoryerrors contains errors used by directory providers.
+package directoryerrors
+
+import "errors"
+
+// ErrPreferExistingInformation indicates that the information returned by the provider should
+// only be used if a record is brand new, otherwise the existing information should be kept as is.
+var ErrPreferExistingInformation = errors.New("user ignored")

--- a/internal/directory/provider.go
+++ b/internal/directory/provider.go
@@ -9,8 +9,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/pomerium/pomerium/internal/directory/ping"
-
 	"github.com/pomerium/pomerium/internal/directory/auth0"
 	"github.com/pomerium/pomerium/internal/directory/azure"
 	"github.com/pomerium/pomerium/internal/directory/github"
@@ -18,6 +16,7 @@ import (
 	"github.com/pomerium/pomerium/internal/directory/google"
 	"github.com/pomerium/pomerium/internal/directory/okta"
 	"github.com/pomerium/pomerium/internal/directory/onelogin"
+	"github.com/pomerium/pomerium/internal/directory/ping"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 )


### PR DESCRIPTION
## Summary
Google groups can contain user members which aren't members of the Group's organization. Currently when this happens we don't create `directory.User` records for these members. This PR updates the code to create `directory.User` records, which in turn makes it possible to support group permission checks for user that aren't also a member of the organization.

For example, previously if we had data like this:

```yaml
organization:
  users:
  - email: user1@inside.test
  - email: user2@inside.test
  groups:
  - email: group1@inside.test
    members:
    - user1@inside.test
    - user2@inside.test
    - user3@outside.test
```

And a policy that required membership in the `group1@inside.test` group, `user3@outside.test` would still not have access to the route, even though they were a member of that group. With this PR this should now work as expected.

To support this I also had to add a new error type: `ErrPreferExistingInformation`, which signals the databroker not to erase the existing `directory.User` entry when refreshing the user. This is necessary because we always refresh the user details on login and the service account for the organization won't have access to the outside user information, resulting in a code path that re-created the `directory.User` with no groups. It should now keep the groups as expected.

## Related issues
Fixes #2945 


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
