### PR TITLE
devices: shrink credentials by removing unnecessary data

### DIFF
--- a/pkg/grpc/device/device_test.go
+++ b/pkg/grpc/device/device_test.go
@@ -1,0 +1,106 @@
+package device
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShrinkCredential(t *testing.T) {
+	t.Run("authenticate response", func(t *testing.T) {
+		credential := &Credential{
+			Id:           "c1",
+			TypeId:       "t1",
+			EnrollmentId: "e1",
+			UserId:       "u1",
+			Specifier: &Credential_Webauthn{
+				Webauthn: &Credential_WebAuthn{
+					Id:        []byte{0, 1, 2},
+					PublicKey: []byte{3, 4, 5},
+
+					RegisterOptions:  bytes.Repeat([]byte{1}, 10),
+					RegisterResponse: bytes.Repeat([]byte{2}, 10),
+					AuthenticateResponse: [][]byte{
+						bytes.Repeat([]byte{3}, 64*1024),
+						bytes.Repeat([]byte{4}, 64*1024),
+						bytes.Repeat([]byte{5}, 64*1024),
+						bytes.Repeat([]byte{6}, 64*1024),
+						bytes.Repeat([]byte{7}, 64*1024),
+						bytes.Repeat([]byte{8}, 64*1024),
+					},
+				},
+			},
+		}
+		shrinkCredential(credential)
+
+		assert.Equal(t, "c1", credential.GetId())
+		assert.Equal(t, "t1", credential.GetTypeId())
+		assert.Equal(t, "e1", credential.GetEnrollmentId())
+		assert.Equal(t, "u1", credential.GetUserId())
+		assert.Equal(t, []byte{0, 1, 2}, credential.GetWebauthn().GetId())
+		assert.Equal(t, []byte{3, 4, 5}, credential.GetWebauthn().GetPublicKey())
+		assert.Equal(t, bytes.Repeat([]byte{1}, 10), credential.GetWebauthn().GetRegisterOptions())
+		assert.Equal(t, bytes.Repeat([]byte{2}, 10), credential.GetWebauthn().GetRegisterResponse())
+		assert.Equal(t, [][]byte{
+			bytes.Repeat([]byte{6}, 64*1024),
+			bytes.Repeat([]byte{7}, 64*1024),
+			bytes.Repeat([]byte{8}, 64*1024),
+		}, credential.GetWebauthn().GetAuthenticateResponse())
+	})
+	t.Run("register response", func(t *testing.T) {
+		credential := &Credential{
+			Id:           "c1",
+			TypeId:       "t1",
+			EnrollmentId: "e1",
+			UserId:       "u1",
+			Specifier: &Credential_Webauthn{
+				Webauthn: &Credential_WebAuthn{
+					Id:        []byte{0, 1, 2},
+					PublicKey: []byte{3, 4, 5},
+
+					RegisterOptions:  bytes.Repeat([]byte{1}, 10),
+					RegisterResponse: bytes.Repeat([]byte{2}, 256*1024),
+				},
+			},
+		}
+		shrinkCredential(credential)
+
+		assert.Equal(t, "c1", credential.GetId())
+		assert.Equal(t, "t1", credential.GetTypeId())
+		assert.Equal(t, "e1", credential.GetEnrollmentId())
+		assert.Equal(t, "u1", credential.GetUserId())
+		assert.Equal(t, []byte{0, 1, 2}, credential.GetWebauthn().GetId())
+		assert.Equal(t, []byte{3, 4, 5}, credential.GetWebauthn().GetPublicKey())
+		assert.Equal(t, bytes.Repeat([]byte{1}, 10), credential.GetWebauthn().GetRegisterOptions())
+		assert.Empty(t, credential.GetWebauthn().GetRegisterResponse())
+		assert.Empty(t, credential.GetWebauthn().GetAuthenticateResponse())
+	})
+	t.Run("register options", func(t *testing.T) {
+		credential := &Credential{
+			Id:           "c1",
+			TypeId:       "t1",
+			EnrollmentId: "e1",
+			UserId:       "u1",
+			Specifier: &Credential_Webauthn{
+				Webauthn: &Credential_WebAuthn{
+					Id:        []byte{0, 1, 2},
+					PublicKey: []byte{3, 4, 5},
+
+					RegisterOptions: bytes.Repeat([]byte{1}, 256*1024),
+				},
+			},
+		}
+		shrinkCredential(credential)
+
+		assert.Equal(t, "c1", credential.GetId())
+		assert.Equal(t, "t1", credential.GetTypeId())
+		assert.Equal(t, "e1", credential.GetEnrollmentId())
+		assert.Equal(t, "u1", credential.GetUserId())
+		assert.Equal(t, []byte{0, 1, 2}, credential.GetWebauthn().GetId())
+		assert.Equal(t, []byte{3, 4, 5}, credential.GetWebauthn().GetPublicKey())
+		assert.Empty(t, credential.GetWebauthn().GetRegisterOptions())
+		assert.Empty(t, credential.GetWebauthn().GetRegisterResponse())
+		assert.Empty(t, credential.GetWebauthn().GetAuthenticateResponse())
+	})
+}


### PR DESCRIPTION
## Summary
Device credentials contain three properties intended for debugging, but not essential for functionality:

```proto
  message WebAuthn {
    // ...
    // the options that were used to do initial registration
    bytes register_options = 3;
    // the response returned from initial registration
    bytes register_response = 4;
    // subsequent authenticate responses
    repeated bytes authenticate_response = 5;
    // ...
}
```

Sometimes these properties can be quite large, which can cause issues when attempting to store them in a database or send them over the wire via gRPC. This PR adds code to shrink credentials by removing data until the entire payload is less than 256KB.

## Related issues
Fixes https://github.com/pomerium/pomerium-console/issues/2288


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
