### PR TITLE
DOCS: Clarify base path for idp_provider_url

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -831,6 +831,8 @@ If you plan to write authorization policies using groups, or any other data that
 
 Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). An example Azure URL would be `https://login.microsoftonline.com/common/v2.0` for [their discover document](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration).
 
+"Base path" is defined as the section of the URL to the discovery document up to (but not including) `/.well-known/openid-configuration`.
+
 
 ### Identity Provider Request Params
 - Environmental Variable: `IDP_REQUEST_PARAMS`

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -946,6 +946,8 @@ settings:
           - Required, depending on provider (Do not use with Google).
         doc: |
           Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). An example Azure URL would be `https://login.microsoftonline.com/common/v2.0` for [their discover document](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration).
+
+          "Base path" is defined as the section of the URL to the discovery document up to (but not including) `/.well-known/openid-configuration`.
         shortdoc: |
           Provider URL is the base path to an identity provider's OpenID connect discovery document.
       - name: "Identity Provider Request Params"


### PR DESCRIPTION
## Summary

Small clarification on the reference section for `idp_provider_url`. Defines how we use "base path" to determine the path to a discovery document.

## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
