### PR TITLE
deployment: remove DST cert workaround from debug image

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -19,8 +19,6 @@ FROM alpine:latest
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 RUN apk add --no-cache ca-certificates libc6-compat gcompat
-# Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
-RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 COPY --from=build /go/bin/dlv /bin


### PR DESCRIPTION
## Summary

It looks like alpine dropped the expired DST cert so we don't need to remove it anymore.  This only impacts the debug image.

## Related issues

https://github.com/pomerium/pomerium/issues/2653


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
