### PR TITLE
Update security.md

### DIFF
--- a/docs/docs/community/security.md
+++ b/docs/docs/community/security.md
@@ -123,16 +123,16 @@ This process can take some time. Every effort will be made to handle the bug in 
 
 ## Reporting a Security Bug
 
-If you believe you've found a security vulnerability in Pomerium, please notify us; we will work with you to resolve the issue promptly. Thank you for helping to keep Pomerium and our users safe! Though at this time we do not have a paid bug bounty program, we deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
+Please notify us of any potential vulnerability discovered in Pomerium. We will work with you to resolve the issue promptly. Thank you for helping to keep Pomerium and our users safe! Though at this time we do not have a paid bug bounty program, we deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
 
-All security bugs in Pomerium should be reported by email to security@pomerium.com . Your email will be acknowledged within 48 hours, and you'll receive a more detailed response to your email within 72 hours indicating the next steps in handling your report.
+All security bugs in Pomerium should be reported by email to security@pomerium.com . Your email will be acknowledged within 48 hours, and you'll receive a more detailed response to your email within 72 hours indicating the next steps in handling your report. This response policy applies only to Pomerium itself, not to our marketing or docs sites. 
 
 While researching, we'd like you to refrain from:
 
 - Any form of Denial of Service (DoS)
 - Spamming
 - Social engineering or phishing of Pomerium employees or contractors
-- Any attacks against Pomerium's physical property or data centers
+- Any attacks against Pomerium's physical property or data centers 
 
 We may revise these guidelines from time to time. The most current version of the guidelines will be available at <https://pomerium.com/docs/community/security>.
 

--- a/docs/docs/community/security.md
+++ b/docs/docs/community/security.md
@@ -125,7 +125,7 @@ This process can take some time. Every effort will be made to handle the bug in 
 
 Please notify us of any potential vulnerability discovered in Pomerium. We will work with you to resolve the issue promptly. Thank you for helping to keep Pomerium and our users safe! Though at this time we do not have a paid bug bounty program, we deeply appreciate any effort to discover and disclose security vulnerabilities responsibly.
 
-All security bugs in Pomerium should be reported by email to security@pomerium.com . Your email will be acknowledged within 48 hours, and you'll receive a more detailed response to your email within 72 hours indicating the next steps in handling your report. This response policy applies only to Pomerium itself, not to our marketing or docs sites. 
+All security bugs in Pomerium should be reported by email to security@pomerium.com . Your email will be acknowledged within 48 hours, and you'll receive a more detailed response to your email within 72 hours indicating the next steps in handling your report. This response policy applies only to Pomerium itself, not to our marketing or docs sites.
 
 While researching, we'd like you to refrain from:
 

--- a/docs/docs/community/security.md
+++ b/docs/docs/community/security.md
@@ -132,7 +132,7 @@ While researching, we'd like you to refrain from:
 - Any form of Denial of Service (DoS)
 - Spamming
 - Social engineering or phishing of Pomerium employees or contractors
-- Any attacks against Pomerium's physical property or data centers 
+- Any attacks against Pomerium's physical property or data centers
 
 We may revise these guidelines from time to time. The most current version of the guidelines will be available at <https://pomerium.com/docs/community/security>.
 


### PR DESCRIPTION
## Summary

Unfortunately, it looks like all the low-effort security reports we get are coming from [this list](https://github.com/sushiwushi/bug-bounty-dorks/blob/master/dorks.txt#L70
). Many times, the "researcher" is actually reporting a vulnerability on their own machine (foo.localhost.pomerium.io), and always has nothing to do with Pomerium itself.



## Checklist

- [x] updated docs
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
