### PR TITLE
deployment: enable goreleaser buildx

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -65,6 +65,7 @@ dockers:
   - image_templates:
       - "pomerium/pomerium:amd64-{{ .Tag }}"
     dockerfile: .github/Dockerfile-release
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--build-arg=ARCH=amd64"
@@ -79,6 +80,7 @@ dockers:
   - image_templates:
       - "gcr.io/pomerium-io/pomerium:{{ .Tag }}-cloudrun"
     dockerfile: .github/Dockerfile-cloudrun
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -93,6 +95,7 @@ dockers:
     image_templates:
       - "pomerium/pomerium:arm64v8-{{ .Tag }}"
     dockerfile: .github/Dockerfile-release
+    use: buildx
     build_flag_templates:
       - "--pull"
       - "--build-arg=ARCH=arm64"


### PR DESCRIPTION
## Summary

Explicitly enable buildx in goreleaser to prevent build failures.

## Related issues

https://github.com/pomerium/ingress-controller/pull/127
https://github.com/pomerium/cli/pull/31
https://github.com/pomerium/pomerium/pull/2925


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
