### PR TITLE
DOCS: Clarify renaming of claims with underscores

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -976,14 +976,14 @@ users are encouraged to add these to `set_response_headers` or their downstream 
 - Environmental Variable: `JWT_CLAIMS_HEADERS`
 - Config File Key: `jwt_claims_headers`
 - Type: slice of `string`
-- Example: `email`,`groups`, `user`
+- Example: `email`, `groups`, `user`, `given_name`
 - Optional
 
 The JWT Claim Headers setting allows you to pass specific user session data down to upstream applications as HTTP request headers. Note, unlike the header `x-pomerium-jwt-assertion` these values are not signed by the authorization service.
 
 Any claim in the pomerium session JWT can be placed into a corresponding header for upstream consumption. This claim information is sourced from your Identity Provider (IdP) and Pomerium's own session metadata. The header will have the following format:
 
-`X-Pomerium-Claim-{Name}` where `{Name}` is the name of the claim requested.
+`X-Pomerium-Claim-{Name}` where `{Name}` is the name of the claim requested.  Underscores will be replaced with dashes; e.g. `X-Pomerium-Claim-Given-Name`.
 
 This option also supports a nested object to customize the header name. For example:
 

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -1101,14 +1101,14 @@ settings:
           - Environmental Variable: `JWT_CLAIMS_HEADERS`
           - Config File Key: `jwt_claims_headers`
           - Type: slice of `string`
-          - Example: `email`,`groups`, `user`
+          - Example: `email`, `groups`, `user`, `given_name`
           - Optional
         doc: |
           The JWT Claim Headers setting allows you to pass specific user session data down to upstream applications as HTTP request headers. Note, unlike the header `x-pomerium-jwt-assertion` these values are not signed by the authorization service.
 
           Any claim in the pomerium session JWT can be placed into a corresponding header for upstream consumption. This claim information is sourced from your Identity Provider (IdP) and Pomerium's own session metadata. The header will have the following format:
 
-          `X-Pomerium-Claim-{Name}` where `{Name}` is the name of the claim requested.
+          `X-Pomerium-Claim-{Name}` where `{Name}` is the name of the claim requested.  Underscores will be replaced with dashes; e.g. `X-Pomerium-Claim-Given-Name`.
 
           This option also supports a nested object to customize the header name. For example:
 


### PR DESCRIPTION
## Summary

Update documentation to clarify renaming of `X-Pomerium-Claim-{Name}` where the name has an underscore.
e.g. claim `given_name` becomes `X-Pomerium-Claim-Given-Name` and not `X-Pomerium-Claim-Given_name`.

It would have saved me some troubleshooting :)

## Related issues

N/A

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
