### PR TITLE
authenticate: fix expiring user info endpoint

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -16,7 +16,6 @@ import (
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
-	"github.com/pomerium/pomerium/pkg/webauthnutil"
 )
 
 // ValidateOptions checks that configuration are complete and valid.
@@ -123,25 +122,6 @@ func (a *Authenticate) updateProvider(cfg *config.Config) error {
 	a.provider.Store(provider)
 
 	return nil
-}
-
-func (a *Authenticate) getWebAuthnURL(values url.Values) (*url.URL, error) {
-	uri, err := a.options.Load().GetAuthenticateURL()
-	if err != nil {
-		return nil, err
-	}
-
-	uri = uri.ResolveReference(&url.URL{
-		Path: "/.pomerium/webauthn",
-		RawQuery: buildURLValues(values, url.Values{
-			urlutil.QueryDeviceType:      {webauthnutil.DefaultDeviceType},
-			urlutil.QueryEnrollmentToken: nil,
-			urlutil.QueryRedirectURI: {uri.ResolveReference(&url.URL{
-				Path: "/.pomerium/device-enrolled",
-			}).String()},
-		}).Encode(),
-	})
-	return urlutil.NewSignedURL(a.state.Load().sharedKey, uri).Sign(), nil
 }
 
 // buildURLValues creates a new url.Values map by traversing the keys in `defaults` and using the values

--- a/authenticate/url.go
+++ b/authenticate/url.go
@@ -1,0 +1,57 @@
+package authenticate
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/pomerium/pomerium/internal/urlutil"
+	"github.com/pomerium/pomerium/pkg/webauthnutil"
+)
+
+func (a *Authenticate) getRedirectURI(r *http.Request) (string, bool) {
+	if v := r.FormValue(urlutil.QueryRedirectURI); v != "" {
+		return v, true
+	}
+
+	if c, err := r.Cookie(urlutil.QueryRedirectURI); err == nil {
+		return c.Value, true
+	}
+
+	return "", false
+}
+
+func (a *Authenticate) getSignOutURL(r *http.Request) (*url.URL, error) {
+	uri, err := a.options.Load().GetAuthenticateURL()
+	if err != nil {
+		return nil, err
+	}
+
+	uri = uri.ResolveReference(&url.URL{
+		Path: "/.pomerium/sign_out",
+	})
+	if redirectURI, ok := a.getRedirectURI(r); ok {
+		uri.RawQuery = (&url.Values{
+			urlutil.QueryRedirectURI: {redirectURI},
+		}).Encode()
+	}
+	return urlutil.NewSignedURL(a.state.Load().sharedKey, uri).Sign(), nil
+}
+
+func (a *Authenticate) getWebAuthnURL(values url.Values) (*url.URL, error) {
+	uri, err := a.options.Load().GetAuthenticateURL()
+	if err != nil {
+		return nil, err
+	}
+
+	uri = uri.ResolveReference(&url.URL{
+		Path: "/.pomerium/webauthn",
+		RawQuery: buildURLValues(values, url.Values{
+			urlutil.QueryDeviceType:      {webauthnutil.DefaultDeviceType},
+			urlutil.QueryEnrollmentToken: nil,
+			urlutil.QueryRedirectURI: {uri.ResolveReference(&url.URL{
+				Path: "/.pomerium/device-enrolled",
+			}).String()},
+		}).Encode(),
+	})
+	return urlutil.NewSignedURL(a.state.Load().sharedKey, uri).Sign(), nil
+}

--- a/authenticate/url_test.go
+++ b/authenticate/url_test.go
@@ -1,0 +1,52 @@
+package authenticate
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/internal/urlutil"
+)
+
+func TestAuthenticate_getRedirectURI(t *testing.T) {
+	t.Run("query", func(t *testing.T) {
+		r, err := http.NewRequest("GET", "https://www.example.com?"+(url.Values{
+			urlutil.QueryRedirectURI: {"https://www.example.com/redirect"},
+		}).Encode(), nil)
+		require.NoError(t, err)
+
+		a := new(Authenticate)
+		redirectURI, ok := a.getRedirectURI(r)
+		assert.True(t, ok)
+		assert.Equal(t, "https://www.example.com/redirect", redirectURI)
+	})
+	t.Run("form", func(t *testing.T) {
+		r, err := http.NewRequest("POST", "https://www.example.com", strings.NewReader((url.Values{
+			urlutil.QueryRedirectURI: {"https://www.example.com/redirect"},
+		}).Encode()))
+		require.NoError(t, err)
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		a := new(Authenticate)
+		redirectURI, ok := a.getRedirectURI(r)
+		assert.True(t, ok)
+		assert.Equal(t, "https://www.example.com/redirect", redirectURI)
+	})
+	t.Run("cookie", func(t *testing.T) {
+		r, err := http.NewRequest("GET", "https://www.example.com", nil)
+		require.NoError(t, err)
+		r.AddCookie(&http.Cookie{
+			Name:  urlutil.QueryRedirectURI,
+			Value: "https://www.example.com/redirect",
+		})
+
+		a := new(Authenticate)
+		redirectURI, ok := a.getRedirectURI(r)
+		assert.True(t, ok)
+		assert.Equal(t, "https://www.example.com/redirect", redirectURI)
+	})
+}


### PR DESCRIPTION
## Summary
When we redirect to the `/.pomerium` endpoint we include a `?pomerium_redirect_url` parameter on the query string. This is HMAC'd and expires after a few minutes, which means if you refresh the page you sometimes get an error. This PR updates the code so that if we see the redirect url on the userinfo page we save it to a cookie and strip it from the query string.

## Related issues
Fixes #2967 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
