### PR TITLE
Update nginx example with verify port

### DIFF
--- a/examples/nginx/config.yaml
+++ b/examples/nginx/config.yaml
@@ -16,7 +16,7 @@ authenticate_service_url: https://authenticate.localhost.pomerium.io
 
 policy:
   - from: https://verify.localhost.pomerium.io
-    to: https://httpbin
+    to: http://verify:8000
     allowed_domains:
       - pomerium.com
       - gmail.com

--- a/examples/nginx/docker-compose.yaml
+++ b/examples/nginx/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
   verify:
     image: pomerium/verify
     expose:
-      - 80
+      - 8000
   pomerium:
     image: pomerium/pomerium:latest
     volumes:

--- a/examples/nginx/verify.conf
+++ b/examples/nginx/verify.conf
@@ -57,7 +57,7 @@ server {
   }
 
   location / {
-    proxy_pass http://verify;
+    proxy_pass http://verify:8000;
 
     include /etc/nginx/proxy.conf;
     # If we get a 401, respond with a named location


### PR DESCRIPTION
## Summary

I noticed the current example assumes `verify` uses port 80 but it uses 8000.

## Checklist

- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
