### PR TITLE
deployment: add `nonroot` release docker images

### DIFF
--- a/.github/Dockerfile-release-nonroot
+++ b/.github/Dockerfile-release-nonroot
@@ -1,0 +1,18 @@
+# build our own root trust store from current stable
+FROM debian:stable as casource
+RUN apt-get update && apt-get install -y ca-certificates
+# Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
+RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
+
+
+FROM busybox:latest as build
+RUN touch /config.yaml
+
+FROM gcr.io/distroless/base-debian10:nonroot-${TARGETARCH:-amd64}
+ENV AUTOCERT_DIR /data/autocert
+WORKDIR /pomerium
+COPY pomerium* /bin/
+COPY --from=build /config.yaml /pomerium/config.yaml
+COPY --from=casource /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+ENTRYPOINT [ "/bin/pomerium" ]
+CMD ["-config","/pomerium/config.yaml"]

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -78,6 +78,21 @@ dockers:
       - "--label=homepage=http://www.pomerium.io"
 
   - image_templates:
+      - "pomerium/pomerium:nonroot-amd64-{{ .Tag }}"
+    dockerfile: .github/Dockerfile-release-nonroot
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=repository=http://github.com/pomerium/pomerium"
+      - "--label=homepage=http://www.pomerium.io"
+
+  - image_templates:
       - "gcr.io/pomerium-io/pomerium:{{ .Tag }}-cloudrun"
     dockerfile: .github/Dockerfile-cloudrun
     use: buildx
@@ -107,11 +122,32 @@ dockers:
       - "--label=repository=http://github.com/pomerium/pomerium"
       - "--label=homepage=http://www.pomerium.io"
 
+  - goarch: arm64
+    image_templates:
+      - "pomerium/pomerium:nonroot-arm64v8-{{ .Tag }}"
+    dockerfile: .github/Dockerfile-release-nonroot
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+      - "--label=repository=http://github.com/pomerium/pomerium"
+      - "--label=homepage=http://www.pomerium.io"
+
 docker_manifests:
   - name_template: "pomerium/pomerium:{{ .Tag }}"
     image_templates:
       - pomerium/pomerium:arm64v8-{{ .Tag }}
       - pomerium/pomerium:amd64-{{ .Tag }}
+
+  - name_template: "pomerium/pomerium:nonroot-{{ .Tag }}"
+    image_templates:
+      - pomerium/pomerium:nonroot-arm64v8-{{ .Tag }}
+      - pomerium/pomerium:nonroot-amd64-{{ .Tag }}
 
 brews:
   - # Name template of the recipe

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,6 +91,9 @@ jobs:
           docker tag gcr.io/pomerium-io/pomerium:${{ steps.tagName.outputs.tag }}-cloudrun gcr.io/pomerium-io/pomerium:latest-cloudrun
           docker push gcr.io/pomerium-io/pomerium:latest-cloudrun
 
+          docker manifest create -a pomerium/pomerium:nonroot pomerium/pomerium:nonroot-amd64-${{ steps.tagName.outputs.tag }} pomerium/pomerium:nonroot-arm64v8-${{ steps.tagName.outputs.tag }}
+          docker manifest push pomerium/pomerium:nonroot
+
   deploy:
     runs-on: ubuntu-latest
     needs: goreleaser

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -88,8 +88,8 @@ Pomerium utilizes a [minimal](https://github.com/GoogleContainerTools/distroless
 
 Rootless image tags for official releases are also published for additional security.  In these images, Pomerium runs as the `nonroot` user.  Depending on your deployment environment, you may need to grant the container additional [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or change the listening port from `443`.
 
-- `rootless-vX.Y.Z`: the rootless image for a specific release
-- `rootless`: the latest rootless image
+- `nonroot-vX.Y.Z`: the rootless image for a specific release
+- `nonroot`: rootles equivilent to the `latest` tag
 
 ### Helm
 

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -9,7 +9,7 @@ description: This article describes various ways to install pomerium
 Pomerium is shipped in multiple formats and architectures to suit a variety of deployment patterns. There are two binaries:
 
 - `pomerium` is the primary server component. It is a monolithic binary that can perform the function of any [services mode](/reference/readme.md#service-mode).
-- `pomerium-cli` (optional) is a command-line client for working with Pomerium.  Functions include acting as an authentication helper for tools like [kubectl](/docs/k8s/readme.md).
+- `pomerium-cli` (optional) is a command-line client for working with Pomerium. Functions include acting as an authentication helper for tools like [kubectl](/docs/k8s/readme.md).
 
 
 [[toc]]
@@ -86,7 +86,7 @@ Pomerium utilizes a [minimal](https://github.com/GoogleContainerTools/distroless
   docker pull pomerium/pomerium:master
   ```
 
-Rootless images for official releases are also published to provide additional security.  In these images, Pomerium runs as the `nonroot` user.  Depending on your deployment environment, you may need to grant the container additional [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or change the listening port from `443`.
+Rootless images for official releases are also published to provide additional security. In these images, Pomerium runs as the `nonroot` user. Depending on your deployment environment, you may need to grant the container additional [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or change the listening port from `443`.
 
 - `nonroot-vX.Y.Z`: the rootless image for a specific release
 - `nonroot`: rootless equivalent to the `latest` tag

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -86,10 +86,10 @@ Pomerium utilizes a [minimal](https://github.com/GoogleContainerTools/distroless
   docker pull pomerium/pomerium:master
   ```
 
-Rootless image tags for official releases are also published for additional security.  In these images, Pomerium runs as the `nonroot` user.  Depending on your deployment environment, you may need to grant the container additional [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or change the listening port from `443`.
+Rootless images for official releases are also published to provide additional security.  In these images, Pomerium runs as the `nonroot` user.  Depending on your deployment environment, you may need to grant the container additional [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or change the listening port from `443`.
 
 - `nonroot-vX.Y.Z`: the rootless image for a specific release
-- `nonroot`: rootles equivilent to the `latest` tag
+- `nonroot`: rootless equivilent to the `latest` tag
 
 ### Helm
 

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -88,8 +88,8 @@ Pomerium utilizes a [minimal](https://github.com/GoogleContainerTools/distroless
 
 Rootless images for official releases are also published to provide additional security. In these images, Pomerium runs as the `nonroot` user. Depending on your deployment environment, you may need to grant the container additional [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or change the listening port from `443`.
 
-- `nonroot-vX.Y.Z`: the rootless image for a specific release
-- `nonroot`: rootless equivalent to the `latest` tag
+- `:nonroot-vX.Y.Z`: the rootless image for a specific release
+- `:nonroot`: rootless equivalent to the `latest` tag
 
 ### Helm
 

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -89,7 +89,7 @@ Pomerium utilizes a [minimal](https://github.com/GoogleContainerTools/distroless
 Rootless images for official releases are also published to provide additional security.  In these images, Pomerium runs as the `nonroot` user.  Depending on your deployment environment, you may need to grant the container additional [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or change the listening port from `443`.
 
 - `nonroot-vX.Y.Z`: the rootless image for a specific release
-- `nonroot`: rootless equivilent to the `latest` tag
+- `nonroot`: rootless equivalent to the `latest` tag
 
 ### Helm
 

--- a/docs/docs/releases.md
+++ b/docs/docs/releases.md
@@ -86,6 +86,11 @@ Pomerium utilizes a [minimal](https://github.com/GoogleContainerTools/distroless
   docker pull pomerium/pomerium:master
   ```
 
+Rootless image tags for official releases are also published for additional security.  In these images, Pomerium runs as the `nonroot` user.  Depending on your deployment environment, you may need to grant the container additional [capabilities](https://linux-audit.com/linux-capabilities-hardening-linux-binaries-by-removing-setuid/) or change the listening port from `443`.
+
+- `rootless-vX.Y.Z`: the rootless image for a specific release
+- `rootless`: the latest rootless image
+
 ### Helm
 
 Pomerium maintains a [helm](https://helm.sh) chart for easy Kubernetes deployment with best practices <https://helm.pomerium.io/>


### PR DESCRIPTION
## Summary

Adds a set of `nonroot` images for releases.  These run under the `nonroot` user from the upstream distroless images.  

- In some environments these could be used as drop-in replacements to increase security.  
- In others, additional capabilities can be set or an alternate listener port can be selected.

## Related issues

closes https://github.com/pomerium/pomerium/issues/835


## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
