### PR TITLE
deployment: only include pomerium binary

### DIFF
--- a/.github/Dockerfile-release
+++ b/.github/Dockerfile-release
@@ -13,7 +13,7 @@ RUN touch /config.yaml
 FROM gcr.io/distroless/base-debian10:latest-${ARCH}
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
-COPY pomerium* /bin/
+COPY pomerium /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 COPY --from=casource /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 ENTRYPOINT [ "/bin/pomerium" ]


### PR DESCRIPTION
## Summary

In our release dockerfile, we use a file glob to copy the `pomerium` and (in previous releases) `pomerium-cli` binary.  However, it appears that `COPY` command is in a context where already built RPMs might be present and can include them into the image.

Since we no longer build the `pomerium-cli` binary in this repo, there's no need for the wildcard at all and this PR makes the desired artifacts explicit.

## Related issues

Originally found and fixed in https://github.com/pomerium/pomerium/pull/3001 on master.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
