### PR TITLE
deps: increase yarn network timeout

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ snapshot: build-deps ## Builds the cross-compiled binaries, naming them in such 
 .PHONY: yarn
 yarn:
 	@echo "==> $@"
-	cd ui ; yarn install
+	cd ui ; yarn install --network-timeout 30000
 
 .PHONY: help
 help:


### PR DESCRIPTION
## Summary

We appear to be hitting timeouts while installing the new MUI dependencies in our edge docker image.  This is likely only a problem on GH actions runners due to contention and other limitations.

This adds a 30s timeout to the yarn install step in the makefile, which seems to be mitigating the problem.

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
