### PR TITLE
ci: increase yarn timeout more

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -205,9 +205,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
@@ -217,7 +214,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: false
-          platforms: linux/amd64,linux/arm64
 
   precommit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -204,8 +204,20 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: build
-        run: docker build .
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Docker Build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          platforms: linux/amd64,linux/arm64
 
   precommit:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ snapshot: build-deps ## Builds the cross-compiled binaries, naming them in such 
 .PHONY: yarn
 yarn:
 	@echo "==> $@"
-	cd ui ; yarn install --network-timeout 30000
+	cd ui ; yarn install --network-timeout 120000
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ snapshot: build-deps ## Builds the cross-compiled binaries, naming them in such 
 .PHONY: yarn
 yarn:
 	@echo "==> $@"
-	cd ui ; yarn install --network-timeout 120000
+	cd ui ; yarn install --network-timeout 30000
 
 .PHONY: help
 help:


### PR DESCRIPTION
## Summary

Increase yarn network timeout further.  We're experiencing slow installs during the arm64 image build because it runs under qemu.

## Related issues

#3018 
https://github.com/nodejs/docker-node/issues/1335

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
