### PR TITLE
ci: add mui build to release steps

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -15,6 +15,8 @@ before:
   hooks:
     - go mod download
     - make build-deps
+    - make yarn
+    - make build-ui
 
 builds:
   - id: pomerium
@@ -43,6 +45,7 @@ builds:
         - cmd: ./scripts/get-envoy.bash
           env:
             - TARGET={{ .Os }}-{{ .Arch }}
+
 
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,11 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - increase_yarn_timeout
   pull_request:
 
 name: Test
@@ -214,6 +215,8 @@ jobs:
           context: .
           file: ./Dockerfile
           push: false
+          cache-from: type=registry,ref=pomerium/pomerium:buildcache
+          cache-to: type=registry,ref=pomerium/pomerium:buildcache,mode=max
 
   precommit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -214,8 +214,6 @@ jobs:
           context: .
           file: ./Dockerfile
           push: false
-          cache-from: type=registry,ref=pomerium/pomerium:buildcache
-          cache-to: type=registry,ref=pomerium/pomerium:buildcache,mode=max
 
   precommit:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - master
-      - increase_yarn_timeout
   pull_request:
 
 name: Test

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,3 +1,18 @@
+FROM node:16 as ui
+WORKDIR /build
+
+COPY .git ./.git
+COPY Makefile ./Makefile
+
+# download yarn dependencies
+COPY ui/yarn.lock ./ui/yarn.lock
+COPY ui/package.json ./ui/package.json
+RUN make yarn
+
+# build ui
+COPY ./ui/ ./ui/
+RUN make build-ui
+
 FROM golang:latest as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
@@ -8,9 +23,9 @@ RUN apt-get update \
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+COPY --from=ui /build/ui/dist ./ui/dist
 
 # build
-RUN make build-deps
 RUN make build-debug NAME=pomerium
 RUN touch /config.yaml
 RUN go get github.com/go-delve/delve/cmd/dlv

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ build: build-go build-ui
 	@echo "==> $@"
 
 .PHONY: build-debug
-build-debug: build-deps build-ui ## Builds binaries appropriate for debugging
+build-debug: build-deps ## Builds binaries appropriate for debugging
 	@echo "==> $@"
 	@CGO_ENABLED=0 GO111MODULE=on $(GO) build -gcflags="all=-N -l" -o $(BINDIR)/$(NAME) ./cmd/"$(NAME)"
 


### PR DESCRIPTION
## Summary

We need to run new commands with `yarn` to build the updated user info endpoint UI.  This PR adds the appropriate steps to release and debug builds.

## Related issues

https://github.com/pomerium/pomerium/pull/3004

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
