### PR TITLE
DOCS: Update timeoutes reference

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -411,11 +411,12 @@ services:
 - Example: `TIMEOUT_READ=30s`
 - Defaults: `TIMEOUT_READ=30s` `TIMEOUT_WRITE=0` `TIMEOUT_IDLE=5m`
 
-Timeouts set the global server timeouts. Timeouts can also be set for individual [routes](#policy).
+Timeouts set the global server timeouts. Timeouts can also be set for individual [routes](#routes).
 
-![cloudflare blog on timeouts](https://blog.cloudflare.com/content/images/2016/06/Timeouts-001.png)
-
-> For a deep dive on timeout values see [these](https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/) [two](https://blog.cloudflare.com/exposing-go-on-the-internet/) excellent blog posts.
+- `idle_timeout`: The idle timeout is the time at which a downstream or upstream connection will be terminated if there are no active streams.
+- `write_timeout`: The max stream duration is the maximum time that a stream’s lifetime will span. An HTTP request/response exchange fully consumes a single stream.
+  Therefore, this value must be greater than read_timeout as it covers both request and response time.
+- `read_timeout`: The amount of time for the entire request stream to be received from the client.
 
 
 ### GRPC Options

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -467,11 +467,12 @@ settings:
           - Example: `TIMEOUT_READ=30s`
           - Defaults: `TIMEOUT_READ=30s` `TIMEOUT_WRITE=0` `TIMEOUT_IDLE=5m`
         doc: |
-          Timeouts set the global server timeouts. Timeouts can also be set for individual [routes](#policy).
+          Timeouts set the global server timeouts. Timeouts can also be set for individual [routes](#routes).
 
-          ![cloudflare blog on timeouts](https://blog.cloudflare.com/content/images/2016/06/Timeouts-001.png)
-
-          > For a deep dive on timeout values see [these](https://blog.cloudflare.com/the-complete-guide-to-golang-net-http-timeouts/) [two](https://blog.cloudflare.com/exposing-go-on-the-internet/) excellent blog posts.
+          - `idle_timeout`: The idle timeout is the time at which a downstream or upstream connection will be terminated if there are no active streams.
+          - `write_timeout`: The max stream duration is the maximum time that a stream’s lifetime will span. An HTTP request/response exchange fully consumes a single stream.
+            Therefore, this value must be greater than read_timeout as it covers both request and response time.
+          - `read_timeout`: The amount of time for the entire request stream to be received from the client.
         shortdoc: |
           Timeouts set the global server timeouts. Timeouts can also be set for individual routes.
       - name: "GRPC Options"


### PR DESCRIPTION
## Summary

Adds @wasaga's updated reference copy for timeout settings.

## Related issues

Fixes https://github.com/pomerium/internal/issues/466


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
