### PR TITLE
Docs: Mark redirect URL as optional

### DIFF
--- a/docs/enterprise/console-settings.yaml
+++ b/docs/enterprise/console-settings.yaml
@@ -197,7 +197,7 @@ settings:
               - name: "Search Users"
                 doc: "New Enrollment URLs are only valid for the specified user."
               - name: "Redirect URL"
-                doc: "**Required**: The URL the user will be taken to after device enrollment is successful."
+                doc: "**Optional**: The URL the user will be taken to after device enrollment is successful."
               - name: "Enrollment Type"
                 doc: "Specify if the user can enroll any device identity, or restrict it to a [secure enclave](/docs/topics/device-identity.md#secure-enclaves)."
   - name: "Configure"

--- a/docs/enterprise/reference/manage.md
+++ b/docs/enterprise/reference/manage.md
@@ -424,7 +424,7 @@ New Enrollment URLs are only valid for the specified user.
 
 #### Redirect URL
 
-**Required**: The URL the user will be taken to after device enrollment is successful.
+**Optional**: The URL the user will be taken to after device enrollment is successful.
 
 #### Enrollment Type
 


### PR DESCRIPTION
## Summary

Updates Console docs for the device enrollment redirect URL as optional. 

## Related issues

Dependent on https://github.com/pomerium/pomerium-console/pull/2330. Currently it appears this should not be backported.

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
