### PR TITLE
ci: use default branch name for helmfile repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,7 +123,6 @@ jobs:
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          branch: master
           commit_message: |
             Bump test environment pomerium/pomerium
             Image tag: ${{ needs.goreleaser.outputs.tag }}


### PR DESCRIPTION
## Summary

Remove the explicit specification of `master` branch in our demo environment deployment

## Related issues

n/a


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
