### PR TITLE
DOCS: Various Link Fixes

### DIFF
--- a/docs/docs/tcp/git.md
+++ b/docs/docs/tcp/git.md
@@ -67,4 +67,4 @@ If you've already defined an SSH configuration for all domains managed by Pomeri
 ## More Resources
 
 - [Git Documentation](https://git-scm.com/doc)
-- [Secure GitLab with Pomerium](/guide/gitlab.mdZ)
+- [Secure GitLab with Pomerium](/guides/gitlab.md)

--- a/docs/docs/topics/device-identity.md
+++ b/docs/docs/topics/device-identity.md
@@ -59,7 +59,7 @@ To get started, review the following pages:
 
 - [Pomerium Policy Language](/docs/topics/ppl.md) to learn how to build policies that use device ID.
 - **End Users** should review [Enroll a Device](/guides/enroll-device.md) to learn how to enroll devices on Pomerium. In Enterprise environments, self-enrollments must be approved by an admin in the Enterprise Console.
-- **Enterprise Administrators** can review the [Devices](/enterprise/reference/manage.html#devices) reference material to create pre-approved enrollment links for users.
+- **Enterprise Administrators** can review the [Devices](/enterprise/reference/manage.md#devices) reference material to create pre-approved enrollment links for users.
 - [pomerium/webauthn](https://github.com/pomerium/webauthn) on GitHub, our implementation of the WebAuthn specification.
 
 ## Looking Ahead: Device Posture

--- a/docs/enterprise/console-settings.yaml
+++ b/docs/enterprise/console-settings.yaml
@@ -177,7 +177,7 @@ settings:
           - name: "Manage Devices"
             doc: |
               From this page, administrators can manage new and existing device enrollments.
-              Device enrollment let's you create [policies](/docs/topics/ppl.html#device-matcher) that use [device identity](/docs/topics/device-identity.md).
+              Device enrollment let's you create [policies](/docs/topics/ppl.md#device-matcher) that use [device identity](/docs/topics/device-identity.md).
               - Users can [self-enroll](/guides/enroll-device.md) devices, which must then be approved in the **Devices List** for policies requiring approved devices.
               - Administrators can use the **New Enrollment** button to create a link for the user to enroll a device as pre-approved. See our [Pre-Approved Device Enrollment](/guides/admin-enroll-device.md) guide for more information.
 

--- a/docs/enterprise/reference/manage.md
+++ b/docs/enterprise/reference/manage.md
@@ -397,7 +397,7 @@ Introduced in v0.16.0, the **Manage Devices** page lets administrators manage us
 ### Manage Devices
 
 From this page, administrators can manage new and existing device enrollments.
-Device enrollment let's you create [policies](/docs/topics/ppl.html#device-matcher) that use [device identity](/docs/topics/device-identity.md).
+Device enrollment let's you create [policies](/docs/topics/ppl.md#device-matcher) that use [device identity](/docs/topics/device-identity.md).
 - Users can [self-enroll](/guides/enroll-device.md) devices, which must then be approved in the **Devices List** for policies requiring approved devices.
 - Administrators can use the **New Enrollment** button to create a link for the user to enroll a device as pre-approved. See our [Pre-Approved Device Enrollment](/guides/admin-enroll-device.md) guide for more information.
 

--- a/docs/guides/code-server.md
+++ b/docs/guides/code-server.md
@@ -86,7 +86,7 @@ services:
 
 As a final touch, now that we've done all this work we might as well use our new development environment to write some real, actual code. And what better project is there than Pomerium? 😉
 
-1. To build Pomerium, we must [install go](https://golang.org/doc/install) which is as simple as running the following commands in the [integrated terminal]:
+1. To build Pomerium, we must [install go](https://golang.org/doc/install) which is as simple as running the following commands in the [integrated terminal] :
 
     ```bash
     # install dependencies with apt
@@ -97,7 +97,7 @@ As a final touch, now that we've done all this work we might as well use our new
     sudo tar -C /usr/local -xzf go1.16.4.linux-amd64.tar.gz
     ```
 
-1. Add Go to our [PATH]:
+1. Add Go to our [PATH] :
 
     ```bash
     # add the following to $HOME/.bashrc

--- a/docs/partials/client-cert-alt-port.md
+++ b/docs/partials/client-cert-alt-port.md
@@ -1,7 +1,0 @@
-### Route doesn't ask for certificate
-
-When Pomerium is configured to listen on alternate ports (as opposed to the standard `443` for TLS traffic), the route-specific mTLS keys `tls_downstream_client_ca` and `tls_downstream_client_ca_file` will not work. The route will not request the client certificate, resulting in an immediate HTTP 495 error:
-
-![HTTP error code 495](./img/client-cert-required.png)
-
-This is a [known bug](https://github.com/pomerium/pomerium/issues/2794). Until it is resolved, mTLS must be set for all routes using `client_ca` or `client_ca_file` when using alternate ports.


### PR DESCRIPTION
## Summary

- Removes an unused partial, so it's no longer in our sitemap.
- Updates several links that used `.html` instead of `.md`, or were otherwise erroneous.
- Adds spaces to links using footer references with a `:` after, so the link checker no longer flags them as false positives.

Fixes https://github.com/pomerium/docs/issues/66

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
