### PR TITLE
Extract email for active directory users that don't have access to exchange

### DIFF
--- a/internal/directory/azure/api.go
+++ b/internal/directory/azure/api.go
@@ -37,7 +37,7 @@ func (obj apiUser) getEmail() string {
 	email := obj.UserPrincipalName
 	if idx := strings.Index(email, "#EXT"); idx > 0 {
 		email = email[:idx]
-		
+
 		// find the last _ and replace it with @
 		if idx := strings.LastIndex(email, "_"); idx > 0 {
 			email = email[:idx] + "@" + email[idx+1:]

--- a/internal/directory/azure/api.go
+++ b/internal/directory/azure/api.go
@@ -31,15 +31,17 @@ func (obj apiUser) getEmail() string {
 
 	// AD often doesn't have the email address returned, but we can parse it from the UPN
 
-	// UPN looks like:
+	// UPN looks like either:
 	// cdoxsey_pomerium.com#EXT#@cdoxseypomerium.onmicrosoft.com
+	// cdoxsey@pomerium.com
 	email := obj.UserPrincipalName
 	if idx := strings.Index(email, "#EXT"); idx > 0 {
 		email = email[:idx]
-	}
-	// find the last _ and replace it with @
-	if idx := strings.LastIndex(email, "_"); idx > 0 {
-		email = email[:idx] + "@" + email[idx+1:]
+		
+		// find the last _ and replace it with @
+		if idx := strings.LastIndex(email, "_"); idx > 0 {
+			email = email[:idx] + "@" + email[idx+1:]
+		}
 	}
 	return email
 }

--- a/internal/directory/azure/azure_test.go
+++ b/internal/directory/azure/azure_test.go
@@ -62,6 +62,7 @@ func newMockAPI(t *testing.T, srv *httptest.Server) http.Handler {
 						"members@delta": []M{
 							{"@odata.type": "#microsoft.graph.user", "id": "user-2"},
 							{"@odata.type": "#microsoft.graph.user", "id": "user-3"},
+							{"@odata.type": "#microsoft.graph.user", "id": "user-4"},
 						},
 					},
 				},
@@ -73,6 +74,7 @@ func newMockAPI(t *testing.T, srv *httptest.Server) http.Handler {
 					{"id": "user-1", "displayName": "User 1", "mail": "user1@example.com"},
 					{"id": "user-2", "displayName": "User 2", "mail": "user2@example.com"},
 					{"id": "user-3", "displayName": "User 3", "userPrincipalName": "user3_example.com#EXT#@user3example.onmicrosoft.com"},
+					{"id": "user-4", "displayName": "User 4", "userPrincipalName": "user4@example.com"},
 				},
 			})
 		})
@@ -185,6 +187,12 @@ func TestProvider_UserGroups(t *testing.T) {
 			GroupIds:    []string{"test"},
 			DisplayName: "User 3",
 			Email:       "user3@example.com",
+		},
+		{
+			Id:          "user-4",
+			GroupIds:    []string{"test"},
+			DisplayName: "User 4",
+			Email:       "user4@example.com",
 		},
 	}, users)
 	testutil.AssertProtoJSONEqual(t, `[


### PR DESCRIPTION
## Summary

Users that are created in active directory that have not been granted access to Microsoft Exchange do not have an email address however the upn claim is present in the JWT. Currently, the email is transformed incorrectly as it assumes all users without an email are guest accounts, which isn't always the case. Instead we should check if the user is an internal or external user and only apply the transformation on external (guest) users.

## Checklist

- [x] reference any related issues
- [x] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
