### PR TITLE
Docs: document default cert annotation.

### DIFF
--- a/docs/docs/k8s/helm.md
+++ b/docs/docs/k8s/helm.md
@@ -142,6 +142,21 @@ If you haven't already, install cert-manager and create a CA issuer. You can fol
    If you changed the `*.localhost.pomerium.io` value in `pomerium-certificates.yaml` update `config.rootDomain` to match, omitting the `*`.
    :::
 
+   ::: details Default Certificate
+   If you're using a single wildcard certificate for all routes managed by Pomerium, you can set it in an annotation for the ingress controller.
+
+   Add a block defining the default certificate to `pomerium-values.yaml`:
+
+   ```yaml
+   ingressController:
+     ingressClassResource:
+       defaultCertSecret: 'namespace/certSecretName'
+   ```
+
+   Now when defining ingresses you need not specify individual certificates, as documented in our example service below.
+
+   :::
+
 1. Add Pomerium's Helm repo:
 
    ```bash

--- a/docs/docs/k8s/ingress.md
+++ b/docs/docs/k8s/ingress.md
@@ -244,6 +244,9 @@ Additional TLS certificates may be supplied by creating a Kubernetes secret(s) i
 
 Please note that the referenced `tls_client_secret` must be a [TLS Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets). `tls_custom_ca_secret` and `tls_downstream_client_ca_secret` must contain `ca.crt` containing a .PEM encoded (base64-encoded DER format) public certificate.
 
+::: tip
+If you're using a wildcard certificate on all routes using the Pomerium IngressClass, you can set the secret for the cert globally when defining the class. See the [Pomerium Ingress Controller README](https://github.com/pomerium/ingress-controller#ingressclass) for more information.
+:::
 
 ### External services
 

--- a/docs/docs/k8s/ingress.md
+++ b/docs/docs/k8s/ingress.md
@@ -162,12 +162,12 @@ The remaining annotations are specific to or behave differently than they do whe
 
 | Annotation                                            | Description                                                                                                                                                                                   |
 | ----------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ingress.pomerium.io/tls_custom_ca_secret`            | Name of Kubernetes `tls` Secret containing a custom [CA certificate][`tls_custom_ca_secret`] for the upstream.                                                                                |
-| `ingress.pomerium.io/tls_client_secret`               | Name of Kubernetes `tls` Secret containing a [client certificate][tls_client_certificate] for connecting to the upstream.                                                                     |
-| `ingress.pomerium.io/tls_downstream_client_ca_secret` | Name of Kubernetes `tls` Secret containing a [Client CA][client-certificate-authority] for validating downstream clients.                                                                     |
-| `ingress.pomerium.io/secure_upstream`                 | When set to `"true"`, use `https` when connecting to the upstream endpoint.                                                                                                                   |
 | `ingress.pomerium.io/path_regex`                      | When set to `"true"` enables path regex matching. See the [Regular Expressions Path Matching](#regular-expressions-path-matching) section for more information.                               |
+| `ingress.pomerium.io/secure_upstream`                 | When set to `"true"`, use `https` when connecting to the upstream endpoint.                                                                                                                   |
 | `ingress.pomerium.io/service_proxy_upstream`          | When set to `"true"` forces Pomerium to connect to upstreams through the k8s service proxy, and not individual endpoints. <br/> This is useful when deploying Pomerium inside a service mesh. |
+| `ingress.pomerium.io/tls_client_secret`               | Name of Kubernetes `tls` Secret containing a [client certificate][tls_client_certificate] for connecting to the upstream.                                                                     |
+| `ingress.pomerium.io/tls_custom_ca_secret`            | Name of Kubernetes `tls` Secret containing a custom [CA certificate][`tls_custom_ca_secret`] for the upstream.                                                                                |
+| `ingress.pomerium.io/tls_downstream_client_ca_secret` | Name of Kubernetes `tls` Secret containing a [Client CA][client-certificate-authority] for validating downstream clients.                                                                     |
 
 ::: tip
 

--- a/docs/docs/k8s/ingress.md
+++ b/docs/docs/k8s/ingress.md
@@ -244,10 +244,6 @@ Additional TLS certificates may be supplied by creating a Kubernetes secret(s) i
 
 Please note that the referenced `tls_client_secret` must be a [TLS Kubernetes secret](https://kubernetes.io/docs/concepts/configuration/secret/#tls-secrets). `tls_custom_ca_secret` and `tls_downstream_client_ca_secret` must contain `ca.crt` containing a .PEM encoded (base64-encoded DER format) public certificate.
 
-::: tip
-If you're using a wildcard certificate on all routes using the Pomerium IngressClass, you can set the secret for the cert globally when defining the class. See the [Pomerium Ingress Controller README](https://github.com/pomerium/ingress-controller#ingressclass) for more information.
-:::
-
 ### External services
 
 You may refer to external services by defining a [Service](https://kubernetes.io/docs/concepts/services-networking/service/) with `externalName`.


### PR DESCRIPTION
## Summary

- First commit alphabetizes table of annotations.
- ~Second commit adds `ingress.pomerium.io/default-cert-secret` to a tooltip, pointing to the annotations documentation in the project README (staged)~.
- Third commit undoes the second, and documents defining a default cert as a Helm configuration option.

## Related issues

Documents https://github.com/pomerium/ingress-controller/pull/151
Blocked by https://github.com/pomerium/pomerium-helm/pull/276

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review - Tagging @wasaga who created the annotation.
