### PR TITLE
Docs: Ingress routing order

### DIFF
--- a/docs/docs/k8s/ingress.md
+++ b/docs/docs/k8s/ingress.md
@@ -124,6 +124,18 @@ metadata:
 
 :::
 
+::: tip
+Routes are sorted and applied in the following order:
+
+- ascending by `from`,
+- descending by `path`,
+- descending by `regex`,
+- descending by `prefix`,
+- ascending by `id`.
+
+This sorting order helps ensure that more restrictive routes for specific paths and regexes are applied correctly.
+:::
+
 ### Supported Annotations
 
 Most configuration keys in non-Kubernetes deployments can be specified as annotation in an Ingress Resource definition. The format is `ingress.pomerium.io/${OPTION_NAME}`. The expandable list below contains the annotations available, which behave as described in our reference documentation (with links to the appropriate reference documentation).

--- a/docs/docs/k8s/ingress.md
+++ b/docs/docs/k8s/ingress.md
@@ -127,11 +127,11 @@ metadata:
 ::: tip
 Routes are sorted and applied in the following order:
 
-- ascending by `from`,
-- descending by `path`,
-- descending by `regex`,
-- descending by `prefix`,
-- ascending by `id`.
+1. ascending by `from`,
+1. descending by `path`,
+1. descending by `regex`,
+1. descending by `prefix`,
+1. ascending by `id`.
 
 This sorting order helps ensure that more restrictive routes for specific paths and regexes are applied correctly.
 :::

--- a/docs/docs/k8s/ingress.md
+++ b/docs/docs/k8s/ingress.md
@@ -125,13 +125,13 @@ metadata:
 :::
 
 ::: tip
-Routes are sorted and applied in the following order:
+Routes are sorted and applied in the following order.
 
-1. ascending by `from`,
-1. descending by `path`,
-1. descending by `regex`,
-1. descending by `prefix`,
-1. ascending by `id`.
+1. Ascending by `from`.
+1. Descending by `path`.
+1. Descending by `regex`.
+1. Descending by `prefix`.
+1. Ascending by `id`.
 
 This sorting order helps ensure that more restrictive routes for specific paths and regexes are applied correctly.
 :::


### PR DESCRIPTION
## Summary

Documents the order in which routes are applied when using the Ingress Controller.

## Related issues

Documents https://github.com/pomerium/ingress-controller/pull/145

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
