### PR TITLE
grpc: remove ptypes references

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -17,7 +17,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/csrf"
-
 	"github.com/pomerium/pomerium/authenticate/handlers"
 	"github.com/pomerium/pomerium/authenticate/handlers/webauthn"
 	"github.com/pomerium/pomerium/internal/httputil"
@@ -30,6 +29,7 @@ import (
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/directory"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
@@ -626,7 +626,7 @@ func (a *Authenticate) saveSessionToDataBroker(
 	if err != nil {
 		return fmt.Errorf("authenticate: error retrieving user info: %w", err)
 	}
-	_, err = user.Put(ctx, state.dataBrokerClient, managerUser.User)
+	_, err = databroker.Put(ctx, state.dataBrokerClient, managerUser.User)
 	if err != nil {
 		return fmt.Errorf("authenticate: error saving user: %w", err)
 	}
@@ -703,13 +703,11 @@ func (a *Authenticate) getCurrentSession(ctx context.Context) (s *session.Sessio
 
 func (a *Authenticate) getUser(ctx context.Context, userID string) (*user.User, error) {
 	client := a.state.Load().dataBrokerClient
-
 	return user.Get(ctx, client, userID)
 }
 
 func (a *Authenticate) getDirectoryUser(ctx context.Context, userID string) (*directory.User, error) {
 	client := a.state.Load().dataBrokerClient
-
 	return directory.GetUser(ctx, client, userID)
 }
 

--- a/authenticate/handlers/webauthn/webauthn.go
+++ b/authenticate/handlers/webauthn/webauthn.go
@@ -321,7 +321,7 @@ func (h *Handler) handleRegister(w http.ResponseWriter, r *http.Request, state *
 
 	// save the user
 	u.DeviceCredentialIds = append(u.DeviceCredentialIds, deviceCredential.GetId())
-	_, err = user.Put(ctx, state.Client, u)
+	_, err = databroker.Put(ctx, state.Client, u)
 	if err != nil {
 		return err
 	}
@@ -370,7 +370,7 @@ func (h *Handler) handleUnregister(w http.ResponseWriter, r *http.Request, state
 
 	// remove the credential from the user
 	u.DeviceCredentialIds = removeString(u.DeviceCredentialIds, deviceCredentialID)
-	_, err = user.Put(ctx, state.Client, u)
+	_, err = databroker.Put(ctx, state.Client, u)
 	if err != nil {
 		return err
 	}

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -18,7 +18,6 @@ import (
 	envoy_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/golang/protobuf/ptypes/any"
 	"github.com/golang/protobuf/ptypes/wrappers"
 	"github.com/scylladb/go-set"
@@ -432,7 +431,7 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 
 	var maxStreamDuration *durationpb.Duration
 	if options.WriteTimeout > 0 {
-		maxStreamDuration = ptypes.DurationProto(options.WriteTimeout)
+		maxStreamDuration = durationpb.New(options.WriteTimeout)
 	}
 
 	rc, err := b.buildRouteConfiguration("main", virtualHosts)
@@ -452,10 +451,10 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 		HttpFilters: filters,
 		AccessLog:   buildAccessLogs(options),
 		CommonHttpProtocolOptions: &envoy_config_core_v3.HttpProtocolOptions{
-			IdleTimeout:       ptypes.DurationProto(options.IdleTimeout),
+			IdleTimeout:       durationpb.New(options.IdleTimeout),
 			MaxStreamDuration: maxStreamDuration,
 		},
-		RequestTimeout: ptypes.DurationProto(options.ReadTimeout),
+		RequestTimeout: durationpb.New(options.ReadTimeout),
 		Tracing: &envoy_http_connection_manager.HttpConnectionManager_Tracing{
 			RandomSampling: &envoy_type_v3.Percent{Value: options.TracingSampleRate * 100},
 			Provider:       tracingProvider,

--- a/databroker/databroker_test.go
+++ b/databroker/databroker_test.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/golang/protobuf/ptypes"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -18,6 +17,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 const bufSize = 1024 * 1024
@@ -49,7 +49,7 @@ func TestServerSync(t *testing.T) {
 	require.NoError(t, err)
 	defer conn.Close()
 	c := databroker.NewDataBrokerServiceClient(conn)
-	any, _ := ptypes.MarshalAny(new(user.User))
+	any := protoutil.NewAny(new(user.User))
 	numRecords := 200
 
 	var serverVersion uint64
@@ -101,7 +101,7 @@ func BenchmarkSync(b *testing.B) {
 	}
 	defer conn.Close()
 	c := databroker.NewDataBrokerServiceClient(conn)
-	any, _ := ptypes.MarshalAny(new(session.Session))
+	any := protoutil.NewAny(new(session.Session))
 	numRecords := 10000
 
 	for i := 0; i < numRecords; i++ {

--- a/internal/controlplane/grpc_accesslog.go
+++ b/internal/controlplane/grpc_accesslog.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	envoy_service_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v3"
-	"github.com/golang/protobuf/ptypes"
 	"github.com/rs/zerolog"
 
 	"github.com/pomerium/pomerium/internal/log"
@@ -43,7 +42,7 @@ func (srv *Server) StreamAccessLogs(stream envoy_service_accesslog_v3.AccessLogS
 			evt = evt.Str("forwarded-for", entry.GetRequest().GetForwardedFor())
 			evt = evt.Str("request-id", entry.GetRequest().GetRequestId())
 			// response properties
-			dur, _ := ptypes.Duration(entry.CommonProperties.TimeToLastDownstreamTxByte)
+			dur := entry.CommonProperties.TimeToLastDownstreamTxByte.AsDuration()
 			evt = evt.Dur("duration", dur)
 			evt = evt.Uint64("size", entry.Response.ResponseBodyBytes)
 			evt = evt.Uint32("response-code", entry.GetResponse().GetResponseCode().GetValue())

--- a/internal/identity/manager/manager.go
+++ b/internal/identity/manager/manager.go
@@ -490,7 +490,7 @@ func (mgr *Manager) refreshUser(ctx context.Context, userID string) {
 			continue
 		}
 
-		record, err := user.Put(ctx, mgr.cfg.Load().dataBrokerClient, u.User)
+		res, err := databroker.Put(ctx, mgr.cfg.Load().dataBrokerClient, u.User)
 		if err != nil {
 			log.Error(ctx).Err(err).
 				Str("user_id", s.GetUserId()).
@@ -499,7 +499,7 @@ func (mgr *Manager) refreshUser(ctx context.Context, userID string) {
 			continue
 		}
 
-		mgr.onUpdateUser(ctx, record, u.User)
+		mgr.onUpdateUser(ctx, res.GetRecord(), u.User)
 	}
 }
 

--- a/internal/registry/inmemory/inmemory.go
+++ b/internal/registry/inmemory/inmemory.go
@@ -10,7 +10,6 @@ import (
 	"github.com/pomerium/pomerium/internal/signal"
 	pb "github.com/pomerium/pomerium/pkg/grpc/registry"
 
-	"github.com/golang/protobuf/ptypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -116,10 +115,7 @@ func (s *inMemoryServer) lockAndReport(services []*pb.Service) (bool, error) {
 
 // reportLocked updates registration and also returns an indication whether service list was updated
 func (s *inMemoryServer) reportLocked(services []*pb.Service) (bool, error) {
-	expires, err := ptypes.TimestampProto(time.Now().Add(s.ttl))
-	if err != nil {
-		return false, err
-	}
+	expires := timestamppb.New(time.Now().Add(s.ttl))
 
 	inserted := false
 	for _, svc := range services {

--- a/pkg/grpc/directory/directory.go
+++ b/pkg/grpc/directory/directory.go
@@ -4,49 +4,19 @@ package directory
 import (
 	context "context"
 
-	"github.com/golang/protobuf/ptypes"
-
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
 // GetGroup gets a directory group from the databroker.
 func GetGroup(ctx context.Context, client databroker.DataBrokerServiceClient, groupID string) (*Group, error) {
-	any, _ := ptypes.MarshalAny(new(Group))
-
-	res, err := client.Get(ctx, &databroker.GetRequest{
-		Type: any.GetTypeUrl(),
-		Id:   groupID,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	var g Group
-	err = ptypes.UnmarshalAny(res.GetRecord().GetData(), &g)
-	if err != nil {
-		return nil, err
-	}
-	return &g, nil
+	g := Group{Id: groupID}
+	return &g, databroker.Get(ctx, client, &g)
 }
 
 // GetUser gets a directory user from the databroker.
 func GetUser(ctx context.Context, client databroker.DataBrokerServiceClient, userID string) (*User, error) {
-	any, _ := ptypes.MarshalAny(new(User))
-
-	res, err := client.Get(ctx, &databroker.GetRequest{
-		Type: any.GetTypeUrl(),
-		Id:   userID,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	var u User
-	err = ptypes.UnmarshalAny(res.GetRecord().GetData(), &u)
-	if err != nil {
-		return nil, err
-	}
-	return &u, nil
+	u := User{Id: userID}
+	return &u, databroker.Get(ctx, client, &u)
 }
 
 // Options are directory provider options.

--- a/pkg/grpc/user/user.go
+++ b/pkg/grpc/user/user.go
@@ -3,66 +3,17 @@ package user
 
 import (
 	context "context"
-	"fmt"
 
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pomerium/pomerium/internal/identity"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
-	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 // Get gets a user from the databroker.
 func Get(ctx context.Context, client databroker.DataBrokerServiceClient, userID string) (*User, error) {
-	any := protoutil.NewAny(new(User))
-
-	res, err := client.Get(ctx, &databroker.GetRequest{
-		Type: any.GetTypeUrl(),
-		Id:   userID,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	var u User
-	err = res.GetRecord().GetData().UnmarshalTo(&u)
-	if err != nil {
-		return nil, fmt.Errorf("error unmarshaling user from databroker: %w", err)
-	}
-
-	return &u, nil
-}
-
-// Put sets a user in the databroker.
-func Put(ctx context.Context, client databroker.DataBrokerServiceClient, u *User) (*databroker.Record, error) {
-	any := protoutil.NewAny(u)
-	res, err := client.Put(ctx, &databroker.PutRequest{
-		Record: &databroker.Record{
-			Type: any.GetTypeUrl(),
-			Id:   u.Id,
-			Data: any,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.GetRecord(), nil
-}
-
-// PutServiceAccount sets a service account in the databroker.
-func PutServiceAccount(ctx context.Context, client databroker.DataBrokerServiceClient, sa *ServiceAccount) (*databroker.Record, error) {
-	any := protoutil.NewAny(sa)
-	res, err := client.Put(ctx, &databroker.PutRequest{
-		Record: &databroker.Record{
-			Type: any.GetTypeUrl(),
-			Id:   sa.GetId(),
-			Data: any,
-		},
-	})
-	if err != nil {
-		return nil, err
-	}
-	return res.GetRecord(), nil
+	u := &User{Id: userID}
+	return u, databroker.Get(ctx, client, u)
 }
 
 // AddClaims adds the flattened claims to the user.


### PR DESCRIPTION
## Summary
The `ptypes` package is deprecated. This PR updates references to it with references to the individual `xxxpb` packages.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
