### PR TITLE
Docs: Update metrics address copy

### DIFF
--- a/docs/enterprise/metrics.md
+++ b/docs/enterprise/metrics.md
@@ -14,13 +14,15 @@ For production deployments, we suggest using a dedicated Prometheus instance.
 
 ## Prepare Pomerium
 
-1. In the Pomerium `config.yaml`, define the `metrics_address` key to a network interface and/or port. For example:
+1. In the Pomerium `config.yaml`, define the [`metrics_address`](/reference/readme.md#metrics-address) key to a network interface and/or port. For example:
 
    ```yaml
-   metrics_address: 0.0.0.0:9999
+   metrics_address: 192.0.2.31:9999
    ```
 
-   The example above has Pomerium providing metrics at port `9999` on all network interfaces.
+   The example above has Pomerium providing metrics at port `9999` on an IP address reachable by the Pomerium Console service.
+
+   If you're running Pomerium Enterprise in a distributed environment where the IP address is not known at the time of deployment, you can use the locally resolvable domain name of the Pomerium host (`pomerium.local`, for example), or override this key with the environment variable `METRICS_ADDRESS`. We do not recommend using a FQDN as this endpoint can expose potentially sensitive information.
 
 ## External Prometheus
 

--- a/docs/enterprise/metrics.md
+++ b/docs/enterprise/metrics.md
@@ -22,7 +22,7 @@ For production deployments, we suggest using a dedicated Prometheus instance.
 
    The example above has Pomerium providing metrics at port `9999` on an IP address reachable by the Pomerium Console service.
 
-   If you're running Pomerium Enterprise in a distributed environment where the IP address is not known at the time of deployment, you can use the locally resolvable domain name of the Pomerium host (`pomerium.local`, for example), or override this key with the environment variable `METRICS_ADDRESS`. We do not recommend using a FQDN as this endpoint can expose potentially sensitive information.
+   If you're running Pomerium Enterprise in a distributed environment where the IP address is not known at the time of deployment, you can use the resolvable FQDN of the Pomerium host (`pomerium0.internal.mycompany.com`, for example), or override this key with the environment variable `METRICS_ADDRESS`. We do not recommend exposing this endpoint to public traffic as it can contain potentially sensitive information.
 
 ## External Prometheus
 


### PR DESCRIPTION
## Summary

Updates the Enterprise docs' explanation of the `metrics_address` key.

Note: We discussed using FQDN, but I opted for local DNS based on the warning in the `metrics_address` reference copy.

## Related issues

Fixes https://github.com/pomerium/docs/issues/29

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
