### PR TITLE
Docs: exclude template from sitemap

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -30,6 +30,7 @@ module.exports = {
         exclude: [
           '/partials/generate-recovery-token.html',
           '/partials/install-mkcert.html',
+          '/tcp/service-template.html',
         ],
       },
     ],


### PR DESCRIPTION
## Summary

Adds a template file used to create TCP route examples to the exclusion list for the sitemap.

## Related issues

Coverage issue warnings from Google.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
