### PR TITLE
databroker: use contextual logging for errors, use original record type for encryption

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -114,6 +114,13 @@ func Warn(ctx context.Context) *zerolog.Event {
 	return contextLogger(ctx).Warn()
 }
 
+// Error starts a new message with error level.
+//
+// You must call Msg on the returned event in order to send the event.
+func Error(ctx context.Context) *zerolog.Event {
+	return contextLogger(ctx).Error()
+}
+
 func contextLogger(ctx context.Context) *zerolog.Logger {
 	global := Logger()
 	if global.GetLevel() == zerolog.Disabled {
@@ -131,13 +138,6 @@ func WithContext(ctx context.Context, update func(c zerolog.Context) zerolog.Con
 	l := contextLogger(ctx).With().Logger()
 	l.UpdateContext(update)
 	return l.WithContext(ctx)
-}
-
-// Error starts a new message with error level.
-//
-// You must call Msg on the returned event in order to send the event.
-func Error(ctx context.Context) *zerolog.Event {
-	return Logger().Error()
 }
 
 // Fatal starts a new message with fatal level. The os.Exit(1) function

--- a/pkg/storage/encrypted.go
+++ b/pkg/storage/encrypted.go
@@ -146,7 +146,7 @@ func (e *encryptedBackend) decryptRecord(in *databroker.Record) (out *databroker
 	// Create a new record so that we don't re-use any internal state
 	return &databroker.Record{
 		Version:    in.Version,
-		Type:       data.TypeUrl,
+		Type:       in.Type,
 		Id:         in.Id,
 		Data:       data,
 		ModifiedAt: in.ModifiedAt,

--- a/pkg/storage/encrypted_test.go
+++ b/pkg/storage/encrypted_test.go
@@ -81,7 +81,7 @@ func TestEncryptedBackend(t *testing.T) {
 	}
 	assert.Equal(t, any.TypeUrl, record.Data.TypeUrl, "type should be preserved")
 	assert.Equal(t, any.Value, record.Data.Value, "value should be preserved")
-	assert.Equal(t, any.TypeUrl, record.Type, "record type should be preserved")
+	assert.NotEqual(t, any.TypeUrl, record.Type, "record type should be preserved")
 
 	records, _, err := e.GetAll(ctx)
 	if !assert.NoError(t, err) {
@@ -90,6 +90,6 @@ func TestEncryptedBackend(t *testing.T) {
 	if assert.Len(t, records, 1) {
 		assert.Equal(t, any.TypeUrl, records[0].Data.TypeUrl, "type should be preserved")
 		assert.Equal(t, any.Value, records[0].Data.Value, "value should be preserved")
-		assert.Equal(t, any.TypeUrl, records[0].Type, "record type should be preserved")
+		assert.NotEqual(t, any.TypeUrl, records[0].Type, "record type should be preserved")
 	}
 }


### PR DESCRIPTION
## Summary
Currently when decrypting records in the databroker we modify the type URL to match the record type. It is sometimes useful to store records with a different type URL from the type URL used to represent the data itself. This PR updates the decryption code to preserve the type URL on the record.

Also we weren't using the context when logging errors.

## Related issues
https://github.com/pomerium/internal/issues/799

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
