### PR TITLE
docs: v0.17 release vuepress config

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -66,10 +66,11 @@ module.exports = {
         link: "/enterprise/about/",
       },
       {
-        text: "v0.16.x", // current tagged version
+        text: "v0.17.x", // current tagged version
         ariaLabel: "Version menu",
         items: [
           { text: "🚧Dev", link: "https://main.docs.pomerium.io/docs" },
+          { text: "v0.17.x", link: "https://0-17-0.docs.pomerium.io/docs" },
           { text: "v0.16.x", link: "https://0-16-0.docs.pomerium.io/docs" },
           { text: "v0.15.x", link: "https://0-15-0.docs.pomerium.io/docs" },
           { text: "v0.14.x", link: "https://0-14-0.docs.pomerium.io/docs" },


### PR DESCRIPTION
## Summary

Add 0-17-0 to vuepress menu and set default text to v0.17.

## Related issues

N/A


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
