### PR TITLE
Correct domain name

### DIFF
--- a/docs/docs/k8s/helm.md
+++ b/docs/docs/k8s/helm.md
@@ -200,9 +200,9 @@ For development and testing, you can use `kubectl` to create a local proxy:
 sudo -E kubectl --namespace pomerium port-forward service/pomerium-proxy 443:443
 ```
 
-Open a browser and navigate to `hello.localhost.pomerium.com`.
+Open a browser and navigate to `hello.localhost.pomerium.io`.
 
-You can also navigate to the special pomerium endpoint `hello.localhost.pomerium.com/.pomerium/` to see your current user details.
+You can also navigate to the special pomerium endpoint `hello.localhost.pomerium.io/.pomerium/` to see your current user details.
 
 ![currently logged in user](./img/logged-in-as.png)
 

--- a/docs/docs/k8s/helm.md
+++ b/docs/docs/k8s/helm.md
@@ -21,6 +21,7 @@ This quick-start will show you how to deploy Pomerium with [Helm] on [Kubernetes
      See [Organizing Cluster Access Using kubeconfig Files] for more information.
    - A namespace in the cluster for Pomerium. This document assumes the namespace `pomerium`.
 - A configured [identity provider].
+- A domain space. The steps below use `*.localhost.pomerium.io` as a placeholder value. We have set DNS records for this domain space to point to `127.0.0.1` (localhost), so you can use this domain space when testing Pomerium locally.
 - [TLS certificates]. If you don't yet have a production environment with trusted certificates, this page will cover using [mkcert] to create locally trusted certificates, and [cert-manager] to manage them in the cluster.
 
 ::: tip

--- a/docs/guides/upstream-mtls.md
+++ b/docs/guides/upstream-mtls.md
@@ -25,7 +25,8 @@ Generally, every organization has a preferred method of managing internal certif
 
 - This guide uses [mkcert] to provide certificates. mkcert is a development tool, and not designed for production environments. In this guide, mkcert takes the place of your trusted certificate tooling solution.
 
-- We use `*.pomerium.localhost.io` as the placeholder for the Pomerium domain space. If you're testing on your local computer you can edit `/etc/hosts` or use dnsmasq on [macOS](https://blog.thesparktree.com/local-development-with-wildcard-dns) or [Linux](https://sixfeetup.com/blog/local-development-with-wildcard-dns-on-linux) systems to route this domain space to your local computer.
+- We use `*.pomerium.localhost.io` as the placeholder for the Pomerium domain space. We have set DNS records for this domain space to point to `127.0.0.1` (localhost), so you can use this domain space when testing Pomerium locally.
+  If you're testing on your local computer with another domain space, you can edit `/etc/hosts` or use dnsmasq on [macOS](https://blog.thesparktree.com/local-development-with-wildcard-dns) or [Linux](https://sixfeetup.com/blog/local-development-with-wildcard-dns-on-linux) systems to route your domain space to your local computer.
 
 ## Create Certificates
 


### PR DESCRIPTION
hello.localhost.pomerium.com has no dns record associated with it so won't work without hacking `/etc/hosts`
The walkthrough also issues certificates to `*.localhost.pomerium.io`

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->


## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
