### PR TITLE
protoutil: add support for converting arbitrary protobuf messages into structs

### DIFF
--- a/pkg/protoutil/struct.go
+++ b/pkg/protoutil/struct.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 
@@ -43,6 +45,15 @@ func ToStruct(value interface{}) *structpb.Value {
 		return NewStructNumber(float64(v))
 	case uint64:
 		return NewStructNumber(float64(v))
+	}
+
+	if msg, ok := value.(proto.Message); ok {
+		bs, _ := protojson.Marshal(msg)
+		var s structpb.Struct
+		_ = protojson.Unmarshal(bs, &s)
+		return &structpb.Value{
+			Kind: &structpb.Value_StructValue{StructValue: &s},
+		}
 	}
 
 	rv := reflect.ValueOf(value)

--- a/pkg/protoutil/struct_test.go
+++ b/pkg/protoutil/struct_test.go
@@ -3,6 +3,8 @@ package protoutil
 import (
 	"testing"
 
+	"google.golang.org/protobuf/types/known/apipb"
+
 	"github.com/pomerium/pomerium/internal/testutil"
 )
 
@@ -28,6 +30,7 @@ func TestToValue(t *testing.T) {
 		{"uint64", uint64(1), "1"},
 		{"[]interface{}", []interface{}{1, 2, 3, 4}, `[1,2,3,4]`},
 		{"map[string]interface{}", map[string]interface{}{"k1": "v1", "k2": "v2"}, `{"k1":"v1","k2":"v2"}`},
+		{"Message", &apipb.Method{Name: "example"}, `{"name": "example"}`},
 	}
 	for _, tc := range testCases {
 		tc := tc


### PR DESCRIPTION
## Summary
One easy way to support converting any protobuf message into a `structpb.Struct` is to run it through `protojson.Marshal`/`protojson.Unmarshal`. This PR adds code to `ToStruct` to handle protobuf messages..

## Related issues
- https://github.com/pomerium/internal/issues/799


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
