### PR TITLE
authorize: add request IP to rego evaluation

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -40,16 +40,24 @@ type RequestHTTP struct {
 	URL               string            `json:"url"`
 	Headers           map[string]string `json:"headers"`
 	ClientCertificate string            `json:"client_certificate"`
+	IP                string            `json:"ip"`
 }
 
 // NewRequestHTTP creates a new RequestHTTP.
-func NewRequestHTTP(method string, requestURL url.URL, headers map[string]string, rawClientCertificate string) RequestHTTP {
+func NewRequestHTTP(
+	method string,
+	requestURL url.URL,
+	headers map[string]string,
+	rawClientCertificate string,
+	ip string,
+) RequestHTTP {
 	return RequestHTTP{
 		Method:            method,
 		Path:              requestURL.Path,
 		URL:               requestURL.String(),
 		Headers:           headers,
 		ClientCertificate: rawClientCertificate,
+		IP:                ip,
 	}
 }
 

--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -481,6 +481,7 @@ func TestEvaluator(t *testing.T) {
 				*mustParseURL("https://from.example.com/"),
 				nil,
 				testValidCert,
+				"",
 			),
 		})
 		require.NoError(t, err)
@@ -494,6 +495,7 @@ func TestEvaluator(t *testing.T) {
 				*mustParseURL("https://from.example.com/test"),
 				nil,
 				testValidCert,
+				"",
 			),
 		})
 		require.NoError(t, err)

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -133,6 +133,7 @@ func (a *Authorize) getEvaluatorRequestFromCheckRequest(
 			requestURL,
 			getCheckRequestHeaders(in),
 			getPeerCertificate(in),
+			in.GetAttributes().GetSource().GetAddress().GetSocketAddress().GetAddress(),
 		),
 	}
 	if sessionState != nil {

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -98,6 +98,7 @@ func Test_getEvaluatorRequest(t *testing.T) {
 				"X-Forwarded-Proto": "https",
 			},
 			certPEM,
+			"",
 		),
 	}
 	assert.Equal(t, expect, actual)
@@ -304,6 +305,7 @@ func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 				"X-Forwarded-Proto": "https",
 			},
 			certPEM,
+			"",
 		),
 	}
 	assert.Equal(t, expect, actual)

--- a/authorize/log.go
+++ b/authorize/log.go
@@ -35,6 +35,7 @@ func (a *Authorize) logAuthorizeCheck(
 	evt = evt.Str("path", stripQueryString(hattrs.GetPath()))
 	evt = evt.Str("host", hattrs.GetHost())
 	evt = evt.Str("query", hattrs.GetQuery())
+	evt = evt.Str("ip", in.GetAttributes().GetSource().GetAddress().GetSocketAddress().GetAddress())
 
 	// session information
 	if s, ok := s.(*session.Session); ok {


### PR DESCRIPTION
## Summary
Add the source IP address so it can be used for rego evaluation.

## Related issues
- https://github.com/pomerium/internal/issues/799

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
