### PR TITLE
Clarify configuration between modes

### DIFF
--- a/docs/docs/architecture.md
+++ b/docs/docs/architecture.md
@@ -47,9 +47,9 @@ Pomerium is composed of 4 logical components:
   - Provides streaming authoritative session and identity data to Authorize service
   - Stores session and identity data in persistent storage
 
-In production deployments, it is recommended that you deploy each component separately. This allows you to limit external attack surface, as well as scale and manage the services independently.
+In production deployments, it is recommended that you deploy each component [separately](/reference/readme.md#service-mode). This allows you to limit external attack surface, as well as scale and manage the services independently.
 
-In test deployments, all four components may run from a single binary and configuration.
+In test deployments, all four components may run from a [single binary and configuration](/reference/readme.md#all-in-one-vs-split-service-mode).
 
 ![pomerium architecture diagram](./img/pomerium-container-context.svg)
 

--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -24,6 +24,14 @@ Pomerium can hot-reload route configuration details, authorization policy, certi
 
 :::
 
+## All-In-One vs Split Service mode
+
+When running Pomerium as a single system service or container, all the options on this page can be set in a single `config.yaml` file, or passed to the single instance as environment variables.
+
+When running Pomerium in a distributed environment where there are multiple processes, each handling separate [components](https://www.pomerium.com/docs/architecture.md#component-level), all components can still share a single config file or set of environment variables.
+
+Alternately, you can create individual config files or sets of environment variables for each service. When doing so, each file or set must have matching [shared settings](#shared-settings), as well as settings relevant to that [service mode](#service-mode). The list below is sorted to better differentiate which config options correlate to which service mode.
+
 
 ## Shared Settings
 These configuration variables are shared by all services, in all service modes.

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -25,6 +25,14 @@ preamble: |
 
   :::
 
+  ## All-In-One vs Split Service mode
+
+  When running Pomerium as a single system service or container, all the options on this page can be set in a single `config.yaml` file, or passed to the single instance as environment variables.
+
+  When running Pomerium in a distributed environment where there are multiple processes, each handling separate [components](https://www.pomerium.com/docs/architecture.md#component-level), all components can still share a single config file or set of environment variables.
+
+  Alternately, you can create individual config files or sets of environment variables for each service. When doing so, each file or set must have matching [shared settings](#shared-settings), as well as settings relevant to that [service mode](#service-mode). The list below is sorted to better differentiate which config options correlate to which service mode.
+
 postamble: |
   [base64 encoded]: https://en.wikipedia.org/wiki/Base64
   [elliptic curve]: https://wiki.openssl.org/index.php/Command_Line_Elliptic_Curve_Operations#Generating_EC_Keys_and_Parameters

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -29,7 +29,7 @@ preamble: |
 
   When running Pomerium as a single system service or container, all the options on this page can be set in a single `config.yaml` file, or passed to the single instance as environment variables.
 
-  When running Pomerium in a distributed environment where there are multiple processes, each handling separate [components](https://www.pomerium.com/docs/architecture.md#component-level), all components can still share a single config file or set of environment variables.
+  When running Pomerium in a distributed environment where there are multiple processes, each handling separate [components](https://www.pomerium.com/docs/architecture.md#component-level), all services can still share a single config file or set of environment variables.
 
   Alternately, you can create individual config files or sets of environment variables for each service. When doing so, each file or set must have matching [shared settings](#shared-settings), as well as settings relevant to that [service mode](#service-mode). The list below is sorted to better differentiate which config options correlate to which service mode.
 


### PR DESCRIPTION
## Summary

Adds clarification on how config files/environment variables are set when using Pomerium in all-in-one versus split service modes.

## Related issues

Resolves #3095 

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
