### PR TITLE
DOCS: Document duplicate routes in Console

### DIFF
--- a/docs/enterprise/concepts.md
+++ b/docs/enterprise/concepts.md
@@ -75,6 +75,12 @@ A user with the Viewer role can:
 
 In addition to the access provided by the Viewer role, a Manager can create, read, update, and delete routes, policies, and certificates in a Namespace (as well as its children). A Manager may also reference policies and certificates in the parent Namespace.
 
+::: warning
+Managers in any Namespace should note: while creating a route for an [upstream](/docs/glossary.md#upstream-downstream) path prevents additional routes to that path *in the same namespace*, Managers in other namespaces can create alternate routes to the same path.
+
+If you need to ensure that access to a service is only accessible from a single route, consider implementing [Mutual Authentication](/docs/topics/mutual-auth.md) between Pomerium and the upstream service. This can be achieved using one of several methods, including [mTLS](/guides/upstream-mtls.md) and [JWT verification](/guides/jwt-verification.md). You can also utilize a service mesh like [Istio](/guides/istio.html)
+:::
+
 #### Admin
 
 An Admin user has permissions across all Namespaces. They can manage global settings, sessions, and service accounts, as well as view events and runtime data.

--- a/docs/enterprise/console-settings.yaml
+++ b/docs/enterprise/console-settings.yaml
@@ -207,8 +207,12 @@ settings:
                 doc: "Specify if the user can enroll any device identity, or restrict it to a [secure enclave](/docs/topics/device-identity.md#secure-enclaves)."
                 more: '/guides/admin-enroll-device.html'
   - name: "Configure"
+    doc: |
+      The **Configure** section of the Pomerium Enterprise Console houses settings that affect the entirety of the Console environment, i.e. across all Namespaces. Adjust these settings with care.
     settings:
       - name: "Settings"
+        doc: |
+          The **Settings** section holds global settings that affect how the Pomerium Enterprise Console runs, logs, and communicates. Values set here are applied globally, except for settings documented to override global options.
         settings:
           - name: "Global"
             settings:

--- a/docs/enterprise/reference/configure.md
+++ b/docs/enterprise/reference/configure.md
@@ -9,7 +9,11 @@ meta:
 
 # Configure
 
+The **Configure** section of the Pomerium Enterprise Console houses settings that affect the entirety of the Console environment, i.e. across all Namespaces. Adjust these settings with care.
+
 ## Settings
+
+The **Settings** section holds global settings that affect how the Pomerium Enterprise Console runs, logs, and communicates. Values set here are applied globally, except for settings documented to override global options.
 
 
 ### Global


### PR DESCRIPTION
## Summary

Documents that managers in different Namespaces can create alternate routes to the same service. Includes possible solutions.

Also adds some form to the "Configure" section of Enterprise Reference docs.

## Related issues

Fixes https://github.com/pomerium/pomerium-console/issues/1637

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
