### PR TITLE
DOCS: Note assumed TCP route on all examples

### DIFF
--- a/docs/docs/tcp/git.md
+++ b/docs/docs/tcp/git.md
@@ -7,6 +7,9 @@ description: Tunnel Git connections through Pomerium
 
 When hosting a self-hosted Git server like [GitLab](/guides/gitlab.md) behind Pomerium, you can protect desktop client access to the source code with the same identity-aware access as the web interface using an encrypted TCP tunnel.
 
+::: tip
+This example assumes you've already [created a TCP route](/docs/tcp/readme.md#configure-routes) for this service.
+:::
 
  ## Basic Connection
 

--- a/docs/docs/tcp/mysql.md
+++ b/docs/docs/tcp/mysql.md
@@ -7,7 +7,9 @@ description: Tunnel MySQL connections through Pomerium
 
 This document explains how to connect to a MySQL or MariaDB database through an encrypted TCP tunnel. We use the `mysql` command line utility, but the same tunnel can be used by GUI tools.
 
-
+::: tip
+This example assumes you've already [created a TCP route](/docs/tcp/readme.md#configure-routes) for this service.
+:::
 
  ## Basic Connection
 

--- a/docs/docs/tcp/rdp.md
+++ b/docs/docs/tcp/rdp.md
@@ -7,6 +7,10 @@ description: Tunnel RDP connections through Pomerium
 
 Remote Desktop Protocol (**RDP**) is a standard for using a desktop computer remotely. It was released by Microsoft and is most commonly used to access Windows systems, but can be used for macOS and Linux systems as well.
 
+::: tip
+This example assumes you've already [created a TCP route](/docs/tcp/readme.md#configure-routes) for this service.
+:::
+
 ## Basic Connection
 
 1. Create a TCP tunnel, using either [`pomerium-cli`](/docs/releases.md#pomerium-cli) or the Pomerium Desktop client:

--- a/docs/docs/tcp/redis.md
+++ b/docs/docs/tcp/redis.md
@@ -7,6 +7,10 @@ description: Tunnel Redis connections through Pomerium
 
 Redis is a popular in-memory data structure store. It can be run locally or configured as a single or distributed standalone service.
 
+::: tip
+This example assumes you've already [created a TCP route](/docs/tcp/readme.md#configure-routes) for this service.
+:::
+
 ## Basic Connection
 
  1. Create a TCP tunnel, using either [`pomerium-cli`](/docs/releases.md#pomerium-cli) or the Pomerium Desktop client:

--- a/docs/docs/tcp/service-template.md
+++ b/docs/docs/tcp/service-template.md
@@ -10,7 +10,9 @@ This is a template to standardize how we document connections to popular service
 
 Replace the paragraph above with a brief description of the service, and/or why you would want to tunnel traffic to it.
 
-
+::: tip
+This example assumes you've already [created a TCP route](/docs/tcp/readme.md#configure-routes) for this service.
+:::
 
  ## Basic Connection
 

--- a/docs/docs/tcp/ssh.md
+++ b/docs/docs/tcp/ssh.md
@@ -13,6 +13,10 @@ By tunneling SSH connections through your Pomerium service:
  - The SSH service can remain closed to the internet, or even restricted to only accept connections from the Pomerium Proxy service
  - Authentication and authorization is managed by Pomerium, using your IdP for identity, and can be easily managed at scale.
 
+::: tip
+This example assumes you've already [created a TCP route](/docs/tcp/readme.md#configure-routes) for this service.
+:::
+
  ## Basic Connection
 
  1. Create a TCP tunnel, using either [`pomerium-cli`](/docs/releases.md#pomerium-cli) or the Pomerium Desktop client:


### PR DESCRIPTION
## Summary

Added a note to existing TCP example pages. It specifies that we assume an existing TCP route and links to the related documentation.

## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
