### PR TITLE
Docs: Google IDP without Service Account

### DIFF
--- a/docs/docs/identity-providers/google.md
+++ b/docs/docs/identity-providers/google.md
@@ -148,6 +148,13 @@ IDP_SERVICE_ACCOUNT="zzzz" # output of `base64 -i service-account-key.json`
 ::::
 :::::
 
+## Troubleshooting
+
+### `invalid service account for Google directory provider`
+
+This error message in Pomerium log output coincides with an empty **Groups** field in the `/.pomerium` endpoint. It indicates that your [service account](#create-a-service-account) is missing or incorrectly configured. Revisit the linked section above to adjust your service account settings as needed.
+
+
 [client id]: ../../reference/readme.md#identity-provider-client-id
 [client secret]: ../../reference/readme.md#identity-provider-client-secret
 [environment variables]: https://en.wikipedia.org/wiki/Environment_variable

--- a/docs/docs/identity-providers/google.md
+++ b/docs/docs/identity-providers/google.md
@@ -132,7 +132,7 @@ Your `config.yaml` values or [environment variables] should look something like 
 idp-provider: "google"
 idp-client-id: "yyyy.apps.googleusercontent.com"
 idp-client-secret: "xxxxxx"
-idp-service-account: "zzzz" # output of `base64 -i service-account-key.json`
+idp-service-account: "zzzz" # output of `base64 -i service-account-key.json`, with impersonate_user set.
 ```
 
 ::::
@@ -142,7 +142,7 @@ idp-service-account: "zzzz" # output of `base64 -i service-account-key.json`
 IDP_PROVIDER="google"
 IDP_CLIENT_ID="yyyy.apps.googleusercontent.com"
 IDP_CLIENT_SECRET="xxxxxx"
-IDP_SERVICE_ACCOUNT="zzzz" # output of `base64 -i service-account-key.json`
+IDP_SERVICE_ACCOUNT="zzzz" # output of `base64 -i service-account-key.json`, with impersonate_user set.
 ```
 
 ::::

--- a/docs/docs/identity-providers/google.md
+++ b/docs/docs/identity-providers/google.md
@@ -122,7 +122,21 @@ Next, we need to give that service account permissionson the GSuite / Workspace 
 
 ![Google create service account](./img/google/google-gsuite-add-scopes.png)
 
-Your [environmental variables] should look something like this.
+
+Your `config.yaml` values or [environment variables] should look something like this:
+
+::::: tabs
+:::: tab config.yaml
+
+```yaml
+idp-provider: "google"
+idp-client-id: "yyyy.apps.googleusercontent.com"
+idp-client-secret: "xxxxxx"
+idp-service-account: "zzzz" # output of `base64 -i service-account-key.json`
+```
+
+::::
+:::: tab Environment Variables
 
 ```bash
 IDP_PROVIDER="google"
@@ -131,9 +145,12 @@ IDP_CLIENT_SECRET="xxxxxx"
 IDP_SERVICE_ACCOUNT="zzzz" # output of `base64 -i service-account-key.json`
 ```
 
+::::
+:::::
+
 [client id]: ../../reference/readme.md#identity-provider-client-id
 [client secret]: ../../reference/readme.md#identity-provider-client-secret
-[environmental variables]: https://en.wikipedia.org/wiki/Environment_variable
+[environment variables]: https://en.wikipedia.org/wiki/Environment_variable
 [oauth2]: https://oauth.net/2/
 [openid connect]: https://en.wikipedia.org/wiki/OpenID_Connect
 [service account]: ../../reference/readme.md#identity-provider-service-account

--- a/examples/config/config.docker.yaml
+++ b/examples/config/config.docker.yaml
@@ -20,6 +20,7 @@ certificate_key_file: /pomerium/privkey.pem
 idp_provider: google
 idp_client_id: REPLACE_ME
 idp_client_secret: REPLACE_ME
+#idp_service_account: REPLACE_ME # Required by some identity providers for directory sync
 
 # Generate 256 bit random keys  e.g. `head -c32 /dev/urandom | base64`
 cookie_secret: V2JBZk0zWGtsL29UcFUvWjVDWWQ2UHExNXJ0b2VhcDI=


### PR DESCRIPTION
## Summary

- Adds `config.yaml` example config
- Documents the error a user gets when the service account is not configured.
- Adds commented service account key to docker config example.

## Related issues

Fixes #3139 

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
