### PR TITLE
userinfo: fix missing profile picture

### DIFF
--- a/ui/src/components/Avatar.tsx
+++ b/ui/src/components/Avatar.tsx
@@ -10,7 +10,7 @@ type AvatarProps = {
 
 export const Avatar = ({ url, name }: AvatarProps): JSX.Element => {
   if (isArray(url)) {
-    url = url?.pop();
+    url = url?.[0];
   }
 
   if (url === "https://graph.microsoft.com/v1.0/me/photo/$value") {


### PR DESCRIPTION
## Summary
We were using `.pop` which modifies the original array leading to weird behavior where the next react render would show the default avatar image instead of the profile picture. Using `[0]` instead fixes it.

## Related issues
Fixes #3146.

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
