### PR TITLE
deployment: update syntax installing `dlv` in debug image

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -28,7 +28,7 @@ COPY --from=ui /build/ui/dist ./ui/dist
 # build
 RUN make build-debug NAME=pomerium
 RUN touch /config.yaml
-RUN go get github.com/go-delve/delve/cmd/dlv
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
 FROM alpine:latest
 ENV AUTOCERT_DIR /data/autocert


### PR DESCRIPTION
## Summary

Starting in `go` 1.18, `go get` no longer works outside of a module.  This updates to the now required `go install` syntax for retrieving `dlv` in our Debug image.

## Related issues

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
