### PR TITLE
try pinning docker dependency

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,5 @@
 # See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.137.0/containers/go/.devcontainer/base.Dockerfile
-ARG VARIANT="1"
-FROM mcr.microsoft.com/vscode/devcontainers/go:0-${VARIANT}
+FROM mcr.microsoft.com/vscode/devcontainers/go:0-1@sha256:ec4067ba197ea0c44268641bd252c0bdfa61228202cee5f447925f9ac76d59b3
 
 # [Optional] Install a version of Node.js using nvm for front end dev
 ARG INSTALL_NODE="true"

--- a/.github/Dockerfile-cloudrun
+++ b/.github/Dockerfile-cloudrun
@@ -1,9 +1,9 @@
-FROM pomerium/vals-entrypoint as entrypoint
+FROM pomerium/vals-entrypoint:latest@sha256:7a5726b04cb080722e458296dd3ca1386d474b139c074af862aa164ccd829441 as entrypoint
 
-FROM busybox:latest as build
+FROM busybox:latest@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a as build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base:latest@sha256:b0216a38315e7d4e14a70338f4bcfdf622bcd2ca2f3fcb48de446c4bb51f7243
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY pomerium* /bin/

--- a/.github/Dockerfile-release
+++ b/.github/Dockerfile-release
@@ -1,14 +1,14 @@
 # build our own root trust store from current stable
-FROM debian:stable as casource
+FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
 RUN apt-get update && apt-get install -y ca-certificates
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 
 
-FROM busybox:latest as build
+FROM busybox:latest@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a as build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/base-debian10:latest-${TARGETARCH:-amd64}
+FROM gcr.io/distroless/base:latest@sha256:b0216a38315e7d4e14a70338f4bcfdf622bcd2ca2f3fcb48de446c4bb51f7243
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY pomerium /bin/

--- a/.github/Dockerfile-release-debug
+++ b/.github/Dockerfile-release-debug
@@ -1,14 +1,14 @@
 # build our own root trust store from current stable
-FROM debian:stable as casource
+FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
 RUN apt-get update && apt-get install -y ca-certificates
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 
 
-FROM busybox:latest as build
+FROM busybox:latest@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a as build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/base-debian10:debug-${TARGETARCH:-amd64}
+FROM gcr.io/distroless/base:latest@sha256:b0216a38315e7d4e14a70338f4bcfdf622bcd2ca2f3fcb48de446c4bb51f7243
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY pomerium /bin/

--- a/.github/Dockerfile-release-debug-nonroot
+++ b/.github/Dockerfile-release-debug-nonroot
@@ -1,14 +1,14 @@
 # build our own root trust store from current stable
-FROM debian:stable as casource
+FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
 RUN apt-get update && apt-get install -y ca-certificates
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 
 
-FROM busybox:latest as build
+FROM busybox:latest@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a as build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/base-debian10:debug-nonroot-${TARGETARCH:-amd64}
+FROM gcr.io/distroless/base:latest@sha256:b0216a38315e7d4e14a70338f4bcfdf622bcd2ca2f3fcb48de446c4bb51f7243
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY pomerium /bin/

--- a/.github/Dockerfile-release-nonroot
+++ b/.github/Dockerfile-release-nonroot
@@ -1,14 +1,14 @@
 # build our own root trust store from current stable
-FROM debian:stable as casource
+FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
 RUN apt-get update && apt-get install -y ca-certificates
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 
 
-FROM busybox:latest as build
+FROM busybox:latest@sha256:caa382c432891547782ce7140fb3b7304613d3b0438834dce1cad68896ab110a as build
 RUN touch /config.yaml
 
-FROM gcr.io/distroless/base-debian10:nonroot-${TARGETARCH:-amd64}
+FROM gcr.io/distroless/base:latest@sha256:b0216a38315e7d4e14a70338f4bcfdf622bcd2ca2f3fcb48de446c4bb51f7243
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY pomerium /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN make yarn
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.17-buster as build
+FROM golang:1.17-buster@sha256:e9f0ce41eac62541ecbd9b7115916617c96a070fe0cca8e494eff829b234b31b as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \
@@ -30,12 +30,12 @@ RUN make build-go NAME=pomerium
 RUN touch /config.yaml
 
 # build our own root trust store from current stable
-FROM debian:stable as casource
+FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
 RUN apt-get update && apt-get install -y ca-certificates
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 
-FROM gcr.io/distroless/base:debug-${TARGETARCH:-amd64}
+FROM gcr.io/distroless/base:debug@sha256:d6db59952a608d2f5696f40f3cb4c97d607d6eec59a5f95f7a9ef189734c2062
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16 as ui
+FROM node:16@sha256:68e34cfcd8276ad531b12b3454af5c24cd028752dfccacce4e19efef6f7cdbe0 as ui
 WORKDIR /build
 
 COPY .git ./.git

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,4 +1,4 @@
-FROM node:16 as ui
+FROM node:16@sha256:68e34cfcd8276ad531b12b3454af5c24cd028752dfccacce4e19efef6f7cdbe0 as ui
 WORKDIR /build
 
 COPY .git ./.git
@@ -13,7 +13,7 @@ RUN make yarn
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:latest as build
+FROM golang:1.17-buster@sha256:e9f0ce41eac62541ecbd9b7115916617c96a070fe0cca8e494eff829b234b31b as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \
@@ -30,7 +30,7 @@ RUN make build-debug NAME=pomerium
 RUN touch /config.yaml
 RUN go install github.com/go-delve/delve/cmd/dlv@latest
 
-FROM alpine:latest
+FROM alpine:latest@sha256:6af1b11bbb17f4c311e269db6530e4da2738262af5fd9064ccdf109b765860fb
 ENV AUTOCERT_DIR /data/autocert
 WORKDIR /pomerium
 RUN apk add --no-cache ca-certificates libc6-compat gcompat

--- a/examples/mutual-tls/Dockerfile
+++ b/examples/mutual-tls/Dockerfile
@@ -6,6 +6,6 @@ ADD . /go/src/app
 RUN go get -d -v ./...
 RUN go install -v ./...
 
-FROM gcr.io/distroless/base
+FROM gcr.io/distroless/base:latest@sha256:b0216a38315e7d4e14a70338f4bcfdf622bcd2ca2f3fcb48de446c4bb51f7243
 COPY --from=build-env /go/bin/app /
 CMD ["/app"]

--- a/internal/testutil/testdata/Dockerfile
+++ b/internal/testutil/testdata/Dockerfile
@@ -1,3 +1,3 @@
-FROM bitnami/redis:latest
+FROM bitnami/redis:latest@sha256:35347816a3d837db19cdf37f98346ab53aa2fc3389bbd1935ddc39e7d7f1dbff
 
 Add tls /tls


### PR DESCRIPTION
## Summary
Pinning docker dependencies. I thought this wouldn't work because the digest manifests were platform-specific, but it turns out there's a hash of the manifest file which should work.

## Related issues


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
