### PR TITLE
envoy: upgrade to 1.21.1

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -13,7 +13,6 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
-	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -209,8 +208,8 @@ func (b *Builder) buildInternalTransportSocket(
 	}
 
 	validationContext := &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
-		MatchSubjectAltNames: []*envoy_type_matcher_v3.StringMatcher{
-			b.buildSubjectAlternativeNameMatcher(endpoint, options.OverrideCertificateName),
+		MatchTypedSubjectAltNames: []*envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher{
+			b.buildSubjectAltNameMatcher(endpoint, options.OverrideCertificateName),
 		},
 	}
 	bs, err := getCombinedCertificateAuthority(options.CA, options.CAFile)
@@ -312,8 +311,8 @@ func (b *Builder) buildPolicyValidationContext(
 	dst url.URL,
 ) (*envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext, error) {
 	validationContext := &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
-		MatchSubjectAltNames: []*envoy_type_matcher_v3.StringMatcher{
-			b.buildSubjectAlternativeNameMatcher(&dst, policy.TLSServerName),
+		MatchTypedSubjectAltNames: []*envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher{
+			b.buildSubjectAltNameMatcher(&dst, policy.TLSServerName),
 		},
 	}
 	if policy.TLSCustomCAFile != "" {

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -80,8 +80,11 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 							]
 						},
 						"validationContext": {
-							"matchSubjectAltNames": [{
-								"exact": "example.com"
+							"matchTypedSubjectAltNames": [{
+								"sanType": "DNS",
+								"matcher": {
+									"exact": "example.com"
+								}
 							}],
 							"trustedCa": {
 								"filename": "`+rootCA+`"
@@ -131,8 +134,11 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 							]
 						},
 						"validationContext": {
-							"matchSubjectAltNames": [{
-								"exact": "use-this-name.example.com"
+							"matchTypedSubjectAltNames": [{
+								"sanType": "DNS",
+								"matcher": {
+									"exact": "use-this-name.example.com"
+								}
 							}],
 							"trustedCa": {
 								"filename": "`+rootCA+`"
@@ -182,8 +188,11 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 							]
 						},
 						"validationContext": {
-							"matchSubjectAltNames": [{
-								"exact": "example.com"
+							"matchTypedSubjectAltNames": [{
+								"sanType": "DNS",
+								"matcher": {
+									"exact": "example.com"
+								}
 							}],
 							"trustedCa": {
 								"filename": "`+rootCA+`"
@@ -234,8 +243,11 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 							]
 						},
 						"validationContext": {
-							"matchSubjectAltNames": [{
-								"exact": "example.com"
+							"matchTypedSubjectAltNames": [{
+								"sanType": "DNS",
+								"matcher": {
+									"exact": "example.com"
+								}
 							}],
 							"trustedCa": {
 								"filename": "`+customCA+`"
@@ -284,8 +296,11 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 							]
 						},
 						"validationContext": {
-							"matchSubjectAltNames": [{
-								"exact": "example.com"
+							"matchTypedSubjectAltNames": [{
+								"sanType": "DNS",
+								"matcher": {
+									"exact": "example.com"
+								}
 							}],
 							"trustedCa": {
 								"filename": "`+combinedCA+`"
@@ -344,8 +359,11 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 							}
 						}],
 						"validationContext": {
-							"matchSubjectAltNames": [{
-								"exact": "example.com"
+							"matchTypedSubjectAltNames": [{
+								"sanType": "DNS",
+								"matcher": {
+									"exact": "example.com"
+								}
 							}],
 							"trustedCa": {
 								"filename": "`+rootCA+`"
@@ -478,8 +496,11 @@ func Test_buildCluster(t *testing.T) {
 									]
 								},
 								"validationContext": {
-									"matchSubjectAltNames": [{
-										"exact": "example.com"
+									"matchTypedSubjectAltNames": [{
+										"sanType": "DNS",
+										"matcher": {
+											"exact": "example.com"
+										}
 									}],
 									"trustedCa": {
 										"filename": "`+rootCA+`"
@@ -521,8 +542,11 @@ func Test_buildCluster(t *testing.T) {
 								]
 							},
 							"validationContext": {
-								"matchSubjectAltNames": [{
-									"exact": "example.com"
+								"matchTypedSubjectAltNames": [{
+									"sanType": "DNS",
+									"matcher": {
+										"exact": "example.com"
+									}
 								}],
 								"trustedCa": {
 									"filename": "`+rootCA+`"

--- a/config/envoyconfig/tls.go
+++ b/config/envoyconfig/tls.go
@@ -9,15 +9,16 @@ import (
 	"regexp"
 	"strings"
 
+	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 )
 
 var oidMustStaple = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
 
-func (b *Builder) buildSubjectAlternativeNameMatcher(
+func (b *Builder) buildSubjectAltNameMatcher(
 	dst *url.URL,
 	overrideName string,
-) *envoy_type_matcher_v3.StringMatcher {
+) *envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher {
 	sni := dst.Hostname()
 	if overrideName != "" {
 		sni = overrideName
@@ -26,21 +27,27 @@ func (b *Builder) buildSubjectAlternativeNameMatcher(
 	if strings.Contains(sni, "*") {
 		pattern := regexp.QuoteMeta(sni)
 		pattern = strings.Replace(pattern, "\\*", ".*", -1)
-		return &envoy_type_matcher_v3.StringMatcher{
-			MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
-				SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-					EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-						GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
+		return &envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher{
+			SanType: envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher_DNS,
+			Matcher: &envoy_type_matcher_v3.StringMatcher{
+				MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
+					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
+						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
+							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
+						},
+						Regex: pattern,
 					},
-					Regex: pattern,
 				},
 			},
 		}
 	}
 
-	return &envoy_type_matcher_v3.StringMatcher{
-		MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
-			Exact: sni,
+	return &envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher{
+		SanType: envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher_DNS,
+		Matcher: &envoy_type_matcher_v3.StringMatcher{
+			MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+				Exact: sni,
+			},
 		},
 	}
 }

--- a/config/envoyconfig/tls_test.go
+++ b/config/envoyconfig/tls_test.go
@@ -13,20 +13,29 @@ import (
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
-func TestBuildSubjectAlternativeNameMatcher(t *testing.T) {
+func TestBuildSubjectAltNameMatcher(t *testing.T) {
 	b := new(Builder)
-	testutil.AssertProtoJSONEqual(t, `
-		{ "exact": "example.com" }
-	`, b.buildSubjectAlternativeNameMatcher(&url.URL{Host: "example.com:1234"}, ""))
-	testutil.AssertProtoJSONEqual(t, `
-		{ "exact": "example.org" }
-	`, b.buildSubjectAlternativeNameMatcher(&url.URL{Host: "example.com:1234"}, "example.org"))
-	testutil.AssertProtoJSONEqual(t, `
-		{ "safeRegex": {
-			"googleRe2": {},
-			"regex": ".*\\.example\\.org"
-		} }
-	`, b.buildSubjectAlternativeNameMatcher(&url.URL{Host: "example.com:1234"}, "*.example.org"))
+	testutil.AssertProtoJSONEqual(t, `{
+		"sanType": "DNS",
+		"matcher": {
+			"exact": "example.com"
+		}
+	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "example.com:1234"}, ""))
+	testutil.AssertProtoJSONEqual(t, `{
+		"sanType": "DNS",
+		"matcher": {
+			"exact": "example.org"
+		}
+	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "example.com:1234"}, "example.org"))
+	testutil.AssertProtoJSONEqual(t, `{
+		"sanType": "DNS",
+		"matcher": {
+			"safeRegex": {
+				"googleRe2": {},
+				"regex": ".*\\.example\\.org"
+			}
+		}
+	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "example.com:1234"}, "*.example.org"))
 }
 
 func TestBuildSubjectNameIndication(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/client9/misspell v0.3.4
 	github.com/coreos/go-oidc/v3 v3.1.0
 	github.com/docker/docker v20.10.13+incompatible
-	github.com/envoyproxy/go-control-plane v0.10.1
+	github.com/envoyproxy/go-control-plane v0.10.2-0.20220321192244-599ed26f5104
 	github.com/envoyproxy/protoc-gen-validate v0.6.7
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/go-chi/chi/v5 v5.0.7

--- a/go.sum
+++ b/go.sum
@@ -428,8 +428,9 @@ github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.m
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210512163311-63b5d3c536b0/go.mod h1:hliV/p42l8fGbc6Y9bQ70uLwIvmJyVE5k4iMKlh8wCQ=
 github.com/envoyproxy/go-control-plane v0.9.10-0.20210907150352-cf90f659a021/go.mod h1:AFq3mo9L8Lqqiid3OhADV3RfLJnjiw63cSpi+fDTRC0=
-github.com/envoyproxy/go-control-plane v0.10.1 h1:cgDRLG7bs59Zd+apAWuzLQL95obVYAymNJek76W3mgw=
 github.com/envoyproxy/go-control-plane v0.10.1/go.mod h1:AY7fTTXNdv/aJ2O5jwpxAPOWUZ7hQAEvzN5Pf27BkQQ=
+github.com/envoyproxy/go-control-plane v0.10.2-0.20220321192244-599ed26f5104 h1:zOF+uqSY6LF8hS0a6bcwNhuULsqi5GIrjxKAfNWrTFU=
+github.com/envoyproxy/go-control-plane v0.10.2-0.20220321192244-599ed26f5104/go.mod h1:KJwIaB5Mv44NWtYuAOFCVOjcI94vtpEz2JU/D2v6IjE=
 github.com/envoyproxy/protoc-gen-validate v0.0.14/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/envoyproxy/protoc-gen-validate v0.6.2/go.mod h1:2t7qjJNvHPx8IjnBOzl9E9/baC+qXE/TeeyBRzgJDws=

--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -5,17 +5,9 @@ PATH="$PATH:$(go env GOPATH)/bin"
 export PATH
 
 _project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/.."
-_envoy_version=1.20.2
+_envoy_version=1.21.1
 _dir="$_project_root/internal/envoy/files"
 _target="${TARGET:-"$(go env GOOS)-$(go env GOARCH)"}"
-
-if [ "$_target" == "darwin-arm64" ]; then
-  echo "Using local envoy distribution for Apple M1"
-  cp -f "$(which envoy)" "$_dir/envoy-$_target"
-  (cd internal/envoy/files && sha256sum "$_dir/envoy-$_target" >"$_dir/envoy-$_target.sha256")
-  echo "1.21.0-dev" >"$_dir/envoy-$_target.version"
-  exit 0
-fi
 
 _url="https://github.com/pomerium/envoy-binaries/releases/download/v${_envoy_version}/envoy-${_target}"
 


### PR DESCRIPTION
## Summary
Upgrade to envoy 1.21.1. `matchSubjectAltNames` was deprecated so I updated the config generation to use `matchTypedSubjectAltNames`.

## Related issues
Fixes https://github.com/pomerium/internal/issues/709


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
