### PR TITLE
feat(docs) Add Redis FLUSHALL doc on how and when to execute commands

### DIFF
--- a/docs/docs/topics/data-storage.md
+++ b/docs/docs/topics/data-storage.md
@@ -81,3 +81,11 @@ databroker_storage_ca_file: /tls/ca.pem
 ::: tip
 the second `s` in `rediss` is intentional and turns on TLS support
 :::
+
+::: tip
+It is necessary when regenerating the shared secret between Pomerium and Redis to execute a FLUSHALL or FLUSHDB on the Redis master.
+Be aware that these commands will reset all keys in your database, and they are disabled by default in the Helm Bitnami Redis chart.
+An example of how to do this on Kubernetes with TLS enabled is to use kubectl to execute a command on the master pod, like so:
+`kubectl exec -it pomerium-redis-master-0 -- redis-cli --tls --cert /opt/bitnami/redis/certs/tls.crt --key /opt/bitnami/redis/certs/tls.key --cacert /opt/bitnami/redis/certs/ca.crt FLUSHALL ASYNC`
+If TLS is not enabled, you may omit the TLS options.
+:::

--- a/docs/docs/topics/data-storage.md
+++ b/docs/docs/topics/data-storage.md
@@ -81,3 +81,7 @@ databroker_storage_ca_file: /tls/ca.pem
 ::: tip
 the second `s` in `rediss` is intentional and turns on TLS support
 :::
+
+## Troubleshooting
+
+Most issues with the Databroker service are caused by a [`shared_secret`](/reference/readme.md#shared-secret) mismatch between services. See [Troubleshooting - Shared Secret Mismatch](/docs/troubleshooting.md#shared-secret-mismatch) for details.

--- a/docs/docs/topics/data-storage.md
+++ b/docs/docs/topics/data-storage.md
@@ -81,11 +81,3 @@ databroker_storage_ca_file: /tls/ca.pem
 ::: tip
 the second `s` in `rediss` is intentional and turns on TLS support
 :::
-
-::: tip
-It is necessary when regenerating the shared secret between Pomerium and Redis to execute a FLUSHALL or FLUSHDB on the Redis master.
-Be aware that these commands will reset all keys in your database, and they are disabled by default in the Helm Bitnami Redis chart.
-An example of how to do this on Kubernetes with TLS enabled is to use kubectl to execute a command on the master pod, like so:
-`kubectl exec -it pomerium-redis-master-0 -- redis-cli --tls --cert /opt/bitnami/redis/certs/tls.crt --key /opt/bitnami/redis/certs/tls.key --cacert /opt/bitnami/redis/certs/ca.crt FLUSHALL ASYNC`
-If TLS is not enabled, you may omit the TLS options.
-:::

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -159,9 +159,13 @@ When using Redis, the [shared secret](/reference/readme.md#shared-secret) is use
 
 The resolution is to flush the Redis database with [`FLUSHDB`](https://redis.io/commands/flushdb) or [`FLUSHALL`](https://redis.io/commands/FLUSHALL).
 
-An example of how to do this on Kubernetes with TLS enabled is to use kubectl to execute a command on the master pod, like so:
-`kubectl exec -it pomerium-redis-master-0 -- redis-cli --tls --cert /opt/bitnami/redis/certs/tls.crt --key /opt/bitnami/redis/certs/tls.key --cacert /opt/bitnami/redis/certs/ca.crt FLUSHALL ASYNC`
-If TLS is not enabled, you may omit the TLS options.
+An example of how to do this on Kubernetes with TLS enabled is to use `kubectl` to execute a command on the master pod:
+
+```bash
+kubectl exec -it pomerium-redis-master-0 -- redis-cli --tls --cert /opt/bitnami/redis/certs/tls.crt --key /opt/bitnami/redis/certs/tls.key --cacert /opt/bitnami/redis/certs/ca.crt FLUSHALL ASYNC
+```
+
+Adjust `pomerium-redis-master-0` to match your pod name. If TLS is not enabled, you may omit the TLS options.
 
 ### RPC Errors
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -159,6 +159,10 @@ When using Redis, the [shared secret](/reference/readme.md#shared-secret) is use
 
 The resolution is to flush the Redis database with [`FLUSHDB`](https://redis.io/commands/flushdb) or [`FLUSHALL`](https://redis.io/commands/FLUSHALL).
 
+An example of how to do this on Kubernetes with TLS enabled is to use kubectl to execute a command on the master pod, like so:
+`kubectl exec -it pomerium-redis-master-0 -- redis-cli --tls --cert /opt/bitnami/redis/certs/tls.crt --key /opt/bitnami/redis/certs/tls.key --cacert /opt/bitnami/redis/certs/ca.crt FLUSHALL ASYNC`
+If TLS is not enabled, you may omit the TLS options.
+
 ### RPC Errors
 
 #### certificate signed by unknown authority


### PR DESCRIPTION
## Summary

This adds details on how and when to execute the FLUSHALL command for the Redis storage backend.

## Related issues

Closes [#159](https://github.com/pomerium/pomerium/issues/3187)

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
