### PR TITLE
authenticate: fix internal url with webauthn

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -744,20 +744,26 @@ func (a *Authenticate) getWebauthnState(ctx context.Context) (*webauthn.State, e
 		return nil, err
 	}
 
+	internalAuthenticateURL, err := a.options.Load().GetInternalAuthenticateURL()
+	if err != nil {
+		return nil, err
+	}
+
 	pomeriumDomains, err := a.options.Load().GetAllRouteableHTTPDomains()
 	if err != nil {
 		return nil, err
 	}
 
 	return &webauthn.State{
-		AuthenticateURL: authenticateURL,
-		SharedKey:       state.sharedKey,
-		Client:          state.dataBrokerClient,
-		PomeriumDomains: pomeriumDomains,
-		Session:         s,
-		SessionState:    ss,
-		SessionStore:    state.sessionStore,
-		RelyingParty:    state.webauthnRelyingParty,
+		AuthenticateURL:         authenticateURL,
+		InternalAuthenticateURL: internalAuthenticateURL,
+		SharedKey:               state.sharedKey,
+		Client:                  state.dataBrokerClient,
+		PomeriumDomains:         pomeriumDomains,
+		Session:                 s,
+		SessionState:            ss,
+		SessionStore:            state.sessionStore,
+		RelyingParty:            state.webauthnRelyingParty,
 	}, nil
 }
 

--- a/authenticate/handlers/webauthn/webauthn.go
+++ b/authenticate/handlers/webauthn/webauthn.go
@@ -47,14 +47,15 @@ var (
 
 // State is the state needed by the Handler to handle requests.
 type State struct {
-	AuthenticateURL *url.URL
-	Client          databroker.DataBrokerServiceClient
-	PomeriumDomains []string
-	RelyingParty    *webauthn.RelyingParty
-	Session         *session.Session
-	SessionState    *sessions.State
-	SessionStore    sessions.SessionStore
-	SharedKey       []byte
+	AuthenticateURL         *url.URL
+	InternalAuthenticateURL *url.URL
+	Client                  databroker.DataBrokerServiceClient
+	PomeriumDomains         []string
+	RelyingParty            *webauthn.RelyingParty
+	Session                 *session.Session
+	SessionState            *sessions.State
+	SessionStore            sessions.SessionStore
+	SharedKey               []byte
 }
 
 // A StateProvider provides state for the handler.
@@ -122,7 +123,10 @@ func (h *Handler) handle(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	err = middleware.ValidateRequestURL(r, s.SharedKey)
+	err = middleware.ValidateRequestURL(
+		urlutil.GetExternalRequest(s.InternalAuthenticateURL, s.AuthenticateURL, r),
+		s.SharedKey,
+	)
 	if err != nil {
 		return err
 	}

--- a/authenticate/middleware.go
+++ b/authenticate/middleware.go
@@ -46,18 +46,5 @@ func (a *Authenticate) getExternalRequest(r *http.Request) *http.Request {
 		return r
 	}
 
-	// if we're not using a different internal URL there's nothing to do
-	if externalURL.String() == internalURL.String() {
-		return r
-	}
-
-	// replace the internal host with the external host
-	er := r.Clone(r.Context())
-	if er.URL.Host == internalURL.Host {
-		er.URL.Host = externalURL.Host
-	}
-	if er.Host == internalURL.Host {
-		er.Host = externalURL.Host
-	}
-	return er
+	return urlutil.GetExternalRequest(internalURL, externalURL, r)
 }

--- a/internal/urlutil/url.go
+++ b/internal/urlutil/url.go
@@ -141,3 +141,22 @@ func Join(elements ...string) string {
 	}
 	return builder.String()
 }
+
+// GetExternalRequest modifies a request so that it appears to be for an external URL instead of
+// an internal URL.
+func GetExternalRequest(internalURL, externalURL *url.URL, r *http.Request) *http.Request {
+	// if we're not using a different internal URL there's nothing to do
+	if externalURL.String() == internalURL.String() {
+		return r
+	}
+
+	// replace the internal host with the external host
+	er := r.Clone(r.Context())
+	if er.URL.Host == internalURL.Host {
+		er.URL.Host = externalURL.Host
+	}
+	if er.Host == internalURL.Host {
+		er.Host = externalURL.Host
+	}
+	return er
+}


### PR DESCRIPTION
## Summary
The WebAuthn handler was checking the HMAC on the URL against the internal authenticate URL, but the HMAC was generated for the external authenticate URL.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3191


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
