### PR TITLE
DOCS: Reference Hotfix

### DIFF
--- a/docs/reference/readme.md
+++ b/docs/reference/readme.md
@@ -1015,7 +1015,7 @@ Use this option if you previously relied on `x-pomerium-authenticated-user-{emai
 ### Override Certificate Name
 - Environmental Variable: `OVERRIDE_CERTIFICATE_NAME`
 - Config File Key: `override_certificate_name`
-- Type: `int`
+- Type: `string`
 - Optional
 - Example: `*.corp.example.com` if wild card or `authenticate.corp.example.com`/`authorize.corp.example.com`
 

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -1144,7 +1144,7 @@ settings:
         attributes: |
           - Environmental Variable: `OVERRIDE_CERTIFICATE_NAME`
           - Config File Key: `override_certificate_name`
-          - Type: `int`
+          - Type: `string`
           - Optional
           - Example: `*.corp.example.com` if wild card or `authenticate.corp.example.com`/`authorize.corp.example.com`
         doc: |


### PR DESCRIPTION
## Summary

Corrects `override_certificate_name` type to `string`



## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
