### PR TITLE
docs: Add UUID to docs yaml blocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,7 @@ gen-docs:
 	@echo "==> $@"
 	pip3 install ruamel.yaml
 	python3 ./scripts/generate-settings-docs.py
+	node scripts/generate-console-pages.js
 
 .PHONY: help
 help:

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,12 @@ yarn:
 	@echo "==> $@"
 	cd ui ; yarn install --network-timeout 120000
 
+.PHONY: gen-docs
+gen-docs:
+	@echo "==> $@"
+	pip3 install ruamel.yaml
+	python3 ./scripts/generate-settings-docs.py
+
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/docs/enterprise/console-settings.yaml
+++ b/docs/enterprise/console-settings.yaml
@@ -1,329 +1,406 @@
 settings:
-  - name: "Reports"
-    settings:
-      - name: "Traffic"
-        doc: |
-          View the traffic running through Pomerium. Filter by [Route][route-concept] name, or date range.
-
-          ![The Traffic page in Pomerium Enterprise](./img/traffic-fullpage.png)
-      - name: "Runtime"
-        doc: |
-          Monitor how many system resources Pomerium is consuming. Filter by date range, service, and instance.
-
-          ![The Runtime Info page in Pomerium Enterprise](./img/runtime-fullpage.png)
-      - name: "Sessions"
-        doc: |
-          View active Sessions. From here you can revoke sessions, filter by session or user information, or revoke one or multiple sessions. You can also export the data.
-
-          ![The Sessions page in Pomerium Enterprise](./img/sessions-fullpage.png)
-      - name: "Events"
-        doc: |
-          The events page displays the log output of Envoy as it process changes from Pomerium and applies updates to the underlying services.
-
-          ![The Events page in Pomerium Enterprise](./img/events-fullpage.png)
-
-          The most common updates are to Pomerium Proxy services, which are updated every time a Route or Policy is created or updated.
-
-          The value under **Resource ID** will usually match the resource ID of a [Policy][policy-reference], visible in the Policy under **Change History** or in the URL. A value of "Pomerium Restarted" refers to when services are reloaded, usually due to a system update.
-      - name: "Deployments"
-        doc: |
-          From the **Deployment History** page administrators can review changes made to their Pomerium configuration.
-
-          The default view shows all changes made through Pomerium Enterprise. Use the **COMPARE** button next to an entry to filter to only changes that affected that resource. Select two versions of that resource, then **DIFF** to see what changed:
-
-          ![A screenshot showing the diff of a change to a route, adding a policy](./img/deployment-diff.png)
-  - name: "Manage"
-    settings:
-      - name: "Routes"
-        doc: |
-          A [Route](/enterprise/concepts.md#routes) defines how to access a service running behind Pomerium. This includes authentication (both for Pomerium and passed through to the service), rewrites, header management, load balancing, etc.
-
-          When first installing Pomerium Enterprise, users may want to import existing routes from the open-source Pomerium core. The **Import Routes** button accepts the open-source `config.yaml` file and imports routes from it to Pomerium Enterprise.
-
-          From the main Routes page you can view and manage existing routes. From the table of routes you can:
-            - filter visible routes,
-            - delete one or more routes,
-            - move routes between Namespaces,
-            - export one or more route definitions to a CSV file,
-            - create a JSON-formatted policy report on one or more selected routes.
-
-          The sections below cover the options available when creating or editing a route.
-        settings:
-          - name: "General"
-            doc: |
-              The **General** tab defines the route path, both from the internet and to the internal service, and the policies attached. Note that policies enforced on a [Namespace][namespace-reference] the route resides in will also be applied.
-            settings:
-              - name: "Name"
-                doc: This value is only visible in the Console UI.
-                more: '/enterprise/reference/manage.html#name'
-              - name: "From"
-              - name: "Metrics Name"
-                doc: |
-                  Once a Route is created, the Metric Name field will populate. You can use this name to scrape the Prometheus service for metrics on this Route when making custom dashboards.
-              - name: "To"
-              - name: "Redirect"
-              - name: "Pass Identity Headers"
-              - name: "Policies"
-                doc: Add or remove Policies to be applied to the Route. Note that Policies enforced in the Route's Namespace will be applied automatically.
-                more: '/enterprise/reference/manage.html#policies-2'
-              - name: "Enable Google Cloud Serverless Authentication"
-          - name: "Matchers"
-            settings:
-              - name: Path
-              - name: Prefix
-              - name: Regex
-          - name: "Rewrite"
-            settings:
-              - name: "Prefix Rewrite"
-              - name: "Regex Rewrite Pattern"
-                keys: ["regex_rewrite_pattern"]
-                doc: |
-                  The pattern to match before rewriting, ex: `^/service/([^/]+)(/.*)$`.
-              - name: "Regex Rewrite Substitution"
-                keys: ["regex_rewrite_substitution"]
-                doc: |
-                  The substitution for your regex pattern, ex: `\\2/instance/\\1`.
-          - name: "Timeouts"
-            settings:
-              - name: "Allow Websockets"
-                keys: ["allow_websockets"]
-              - name: "Allow SPDY"
-                keys: ["allow_spdy"]
-              - name: "Timeout"
-                keys: ["timeout"]
-              - name: "Idle Timeout"
-                keys: ["idle_timeout"]
-          - name: "Headers"
-            settings:
-              - name: "Host Headers"
-                keys: ["host_rewrite"]
-              - name: "Set Request Headers"
-              - name: "Remove Request Headers"
-              - name: "Rewrite Response Headers"
-          - name: "Load Balancer"
-            settings:
-              - name: "Load Balancing Policy"
-      - name: "Policies"
-        keys: ["Policy"]
-        doc: |
-          A [Policy](/enterprise/concepts.md#policies) defines what permissions a set of users or groups has. Policies are applied to Namespaces or Routes to associate the set of permissions with a service or set of service, completing the authentication model.
-
-          Policies can be constructed three ways:
-
-          ### Web UI
-
-          From the **BUILDER** tab, users can add allow or deny blocks to a policy, containing and/or/not/nor logic to allow or deny sets of users and groups.
-
-          ![A policy being constructed in Pomerium Enterprise allowing a single user access](./img/example-policy-single-user.png)
-
-          ### Pomerium Policy Language
-
-          From the **EDITOR** tab users can write policies in Pomerium Policy Language (**PPL**), a YAML-based notation.
-
-          ![A policy as viewed from the editor tab](./img/example-policy-editor.png)
-
-          PPL documents contain one or more rules. Each rule has a corresponding action and one or more logical operators.
-          Each logical operator contains criteria and each criterion has a name and corresponding data.
-
-          PPL documents are defined via YAML:
-
-          ```yaml
-          - allow:
-              or:
-                - email:
-                    is: x@example.com
-                - email:
-                    is: y@example.com
-          ```
-
-          The available rule actions are:
-
-          - `allow`
-          - `deny`
-
-          The available logical operators are:
-
-          - `and`
-          - `or`
-          - `not`
-          - `nor`
-
-          The available criteria types are:
-
-          - `accept`
-          - `authenticated_user`
-          - `claim`
-          - `date`
-          - `day_of_week`
-          - `domain`
-          - `email`
-          - `groups`
-          - `http_method`
-          - `http_path`
-          - `reject`
-          - `time_of_day`
-          - `user`
-
-          Some criteria also support a sub-path as part of the criterion name:
-
-          ```yaml
-          - allow:
-              or:
-                - claim/family_name: Smith
-          ```
-
-          ### Rego
-
-          For those using [OPA](https://www.openpolicyagent.org/), the **REGO** tab will accept policies written in Rego.
-
-          ::: tip
-          A policy can only support PPL or Rego. Once one is set, the other tab is disabled.
-          :::
-
-          ### Overrides
-
-          - **Any Authenticated User**: This setting will allow access to a route with this policy attached to any user who can authenticate to your Identity Provider (**IdP**).
-          - **CORS Preflight**: Allow unauthenticated HTTP OPTIONS requests as per the CORS spec.
-          - **Public Access**: This setting allows complete, unrestricted access to an associated route. Use this setting with caution.
-      - name: "Certificates"
-      - name: "Devices"
-        doc: |
-          Introduced in v0.16.0, the **Manage Devices** page lets administrators manage user devices for policy-based authorization.
-        settings:
-          - name: "Manage Devices"
-            doc: |
-              From this page, administrators can manage new and existing device enrollments.
-              Device enrollment let's you create [policies](/docs/topics/ppl.md#device-matcher) that use [device identity](/docs/topics/device-identity.md).
-              - Users can [self-enroll](/guides/enroll-device.md) devices, which must then be approved in the **Devices List** for policies requiring approved devices.
-              - Administrators can use the **New Enrollment** button to create a link for the user to enroll a device as pre-approved. See our [Pre-Approved Device Enrollment](/guides/admin-enroll-device.md) guide for more information.
-            more: '/enterprise/reference/manage.html#manage-devices'
-          - name: "Devices List"
-            doc: |
-              Displays the currently enrolled devices for each user, along with their current approval status.
-              Administrators can inspect, approve, or delete registered devices from this table.
-
-              ![List of user devices](./img/console-devices.png)
-          - name: "New Enrollment"
-            doc: |
-              The **New Enrollment** button allows administrators to create a custom link for a specific user to use to register a new device, which will automatically be approved.
-              This scheme is known as [Trust on First Use (TOFU)](https://en.wikipedia.org/wiki/Trust_on_first_use).
-
-              ![Example device enrollment](./img/new-enrollment.png)
-            more: '/guides/admin-enroll-device.html'
-            settings:
-              - name: "Search Users"
-                doc: "New Enrollment URLs are only valid for the specified user."
-                more: '/guides/admin-enroll-device.html'
-              - name: "Redirect URL"
-                doc: "**Optional**: The URL the user will be taken to after device enrollment is successful."
-                more: '/guides/admin-enroll-device.html'
-              - name: "Enrollment Type"
-                doc: "Specify if the user can enroll any device identity, or restrict it to a [secure enclave](/docs/topics/device-identity.md#secure-enclaves)."
-                more: '/guides/admin-enroll-device.html'
-  - name: "Configure"
+- name: Reports
+  settings:
+  - name: Traffic
     doc: |
-      The **Configure** section of the Pomerium Enterprise Console houses settings that affect the entirety of the Console environment, i.e. across all Namespaces. Adjust these settings with care.
+      View the traffic running through Pomerium. Filter by [Route][route-concept] name, or date range.
+
+      ![The Traffic page in Pomerium Enterprise](./img/traffic-fullpage.png)
+    uuid: fbf40372-9895-4ca7-95d3-5e18f8f56413
+  - name: Runtime
+    doc: |
+      Monitor how many system resources Pomerium is consuming. Filter by date range, service, and instance.
+
+      ![The Runtime Info page in Pomerium Enterprise](./img/runtime-fullpage.png)
+    uuid: 2edcf120-b62c-464b-a3a7-e5b14e3e6400
+  - name: Sessions
+    doc: |
+      View active Sessions. From here you can revoke sessions, filter by session or user information, or revoke one or multiple sessions. You can also export the data.
+
+      ![The Sessions page in Pomerium Enterprise](./img/sessions-fullpage.png)
+    uuid: d11acb05-65cc-4c65-9f92-4b1f08b622ef
+  - name: Events
+    doc: |
+      The events page displays the log output of Envoy as it process changes from Pomerium and applies updates to the underlying services.
+
+      ![The Events page in Pomerium Enterprise](./img/events-fullpage.png)
+
+      The most common updates are to Pomerium Proxy services, which are updated every time a Route or Policy is created or updated.
+
+      The value under **Resource ID** will usually match the resource ID of a [Policy][policy-reference], visible in the Policy under **Change History** or in the URL. A value of "Pomerium Restarted" refers to when services are reloaded, usually due to a system update.
+    uuid: 219f8dd6-38d4-4dc3-98a6-98cca314c49e
+  - name: Deployments
+    doc: |
+      From the **Deployment History** page administrators can review changes made to their Pomerium configuration.
+
+      The default view shows all changes made through Pomerium Enterprise. Use the **COMPARE** button next to an entry to filter to only changes that affected that resource. Select two versions of that resource, then **DIFF** to see what changed:
+
+      ![A screenshot showing the diff of a change to a route, adding a policy](./img/deployment-diff.png)
+    uuid: c812c87e-ec06-4091-b1fe-e206e43103d5
+  uuid: e15ae275-fa57-40d3-b2f7-ce24799ccf79
+- name: Manage
+  settings:
+  - name: Routes
+    doc: |
+      A [Route](/enterprise/concepts.md#routes) defines how to access a service running behind Pomerium. This includes authentication (both for Pomerium and passed through to the service), rewrites, header management, load balancing, etc.
+
+      When first installing Pomerium Enterprise, users may want to import existing routes from the open-source Pomerium core. The **Import Routes** button accepts the open-source `config.yaml` file and imports routes from it to Pomerium Enterprise.
+
+      From the main Routes page you can view and manage existing routes. From the table of routes you can:
+        - filter visible routes,
+        - delete one or more routes,
+        - move routes between Namespaces,
+        - export one or more route definitions to a CSV file,
+        - create a JSON-formatted policy report on one or more selected routes.
+
+      The sections below cover the options available when creating or editing a route.
     settings:
-      - name: "Settings"
+    - name: General
+      doc: |
+        The **General** tab defines the route path, both from the internet and to the internal service, and the policies attached. Note that policies enforced on a [Namespace][namespace-reference] the route resides in will also be applied.
+      settings:
+      - name: Name
+        doc: This value is only visible in the Console UI.
+        more: /enterprise/reference/manage.html#name
+        uuid: 3f59881a-24b4-41a0-b92f-1d36a69b76e8
+      - name: From
+        uuid: b9c54c4e-28ad-4a8b-aa65-3aa7f8b1f032
+      - name: Metrics Name
         doc: |
-          The **Settings** section holds global settings that affect how the Pomerium Enterprise Console runs, logs, and communicates. Values set here are applied globally, except for settings documented to override global options.
-        settings:
-          - name: "Global"
-            settings:
-              - name: "Debug"
-              - name: "HTTP Redirect Address"
-              - name: "DNS Lookup Family"
-              - name: "Log Level"
-              - name: "Proxy Log Level"
-          - name: "Cookies"
-            settings:
-              - name: "HTTPS Only"
-                keys: ["cookie_secure"]
-              - name: "Javascript Security"
-              - name: "Expires"
-                keys: ["cookie_expire"]
-          - name: "Timeouts"
-            doc: "Timeouts set the global server timeouts. Timeouts can also be set for individual routes."
-          - name: "GRPC"
-            settings:
-              - name: "GRPC Server Max Connection Age"
-                doc: |
-                  Set max connection age for GRPC servers. After this interval, servers ask clients to reconnect and perform any rediscovery for new/updated endpoints from DNS.
-
-                  See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> (opens new window) for details
-              - name: "GRPC Server Max Connection Age Grace"
-                doc: |
-                  Additive period with grpc_server_max_connection_age, after which servers will force connections to close.
-
-                  See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> (opens new window) for details
-          - name: "Tracing"
-            doc: |
-              Tracing tracks the progression of a single user request as it is handled by Pomerium.
-
-              Each unit of work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
-            settings:
-              - name: "Tracing Sample Rate"
-                doc: |
-                  Percentage of requests to sample. Default is .01%.
-
-                  Unlike the decimal value notion used for the `tracing_sample_rate` [key](/reference/readme.md#shared-tracing-settings) in open-source Pomerium, this value is a percentage, e.g. a value of `1` equates to 1%
-          - name: "Authenticate"
-          - name: "Proxy"
-            settings:
-              - name: "Certificate Authority"
-                keys: ["certificate_authority"]
-              - name: "Default Upstream Timeout"
-              - name: "JWT Claim Headers"
-              - name: "X-Forward-For HTTP Header"
-                keys: ["skip_xff_append"]
-              - name: "Response Headers"
-                keys: ["set_response_headers"]
-      - name: "Service Accounts"
+          Once a Route is created, the Metric Name field will populate. You can use this name to scrape the Prometheus service for metrics on this Route when making custom dashboards.
+        uuid: 7df15eef-3070-4353-822d-c2745386e0db
+      - name: To
+        uuid: 9c0201e0-b5fa-4027-a1e7-f115a3f70969
+      - name: Redirect
+        uuid: 72d885ce-8cd3-41a7-b7d0-0953ce49f8de
+      - name: Pass Identity Headers
+        uuid: 12e599f2-8bcc-4061-ba88-998c2671109c
+      - name: Policies
+        doc: Add or remove Policies to be applied to the Route. Note that Policies
+          enforced in the Route's Namespace will be applied automatically.
+        more: /enterprise/reference/manage.html#policies-2
+        uuid: c7340a01-2942-4ffe-bbf6-f97f0fec1e75
+      - name: Enable Google Cloud Serverless Authentication
+        uuid: 416405ec-74c3-47cb-899e-34bebaff26bf
+      uuid: fd86b6ea-fe73-4222-a675-5493c7dbd105
+    - name: Matchers
+      settings:
+      - name: Path
+        uuid: e5c805e5-4f7f-4fce-ba33-d3f1f47f5d35
+      - name: Prefix
+        uuid: 3a2bc400-d1bc-4249-a813-9777cfca7779
+      - name: Regex
+        uuid: 13dbfeb0-a8a0-4c97-9bb9-52aa3f22c7cc
+      uuid: 0bbff866-b7b9-4fdf-b8e5-b6d4f2475855
+    - name: Rewrite
+      settings:
+      - name: Prefix Rewrite
+        uuid: 3fb98409-89ae-47ae-b9ff-44f07f833492
+      - name: Regex Rewrite Pattern
+        keys: [regex_rewrite_pattern]
         doc: |
-          [Service accounts](/enterprise/concepts.md#service-accounts) offer a protected and standardized method of authenticating machine-to-machine communication between services protected by Pomerium.
-
-          ::: tip
-          Before you begin, confirm you are in the correct Namespace. A service account can only be used in the Namespace it was created in, including its children Namespaces.
-          :::
-
-          1. From the main menu, select **Service Accounts** under **CONFIGURE**. Click the **+ ADD SERVICE ACCOUNT** button:
-
-             ![The Service Accounts page](./img/console-service-account.png)
-
-          1. Service accounts can be unique and exist only for Pomerium, or impersonate directory users from your IdP.
-
-             Give the user a unique ID, or select an existing user to impersonate. Consider referencing the Namespace you're creating it under, for easier reference later. Optionally set an expiration date:
-
-             ![Adding a unique service account](./img/create-service-account.png)
-
-             The user ID set here corresponds to the `User` criteria when editing a policy.
-
-          1. After you click **Submit**, the modal presents the JSON web token (**JWT**) for the service account. Temporarily save it somewhere secure, as you will not be able to view it again:
-
-             ![Service Account Added](./img/service-account-jwt.png)
-
-             This JWT must be added to your application configuration to enable direct communication.
-
-          1. Edit or create policies to give the service account access to the internal service:
-
-            ![An example policy for a service account](./img/create-policy-1.png)
-
-            ---
-
-            ![An example policy for a service account](./img/create-policy-2.png)
-      - name: "Namespaces"
-        keys: ["namespace"]
+          The pattern to match before rewriting, ex: `^/service/([^/]+)(/.*)$`.
+        uuid: 5cd03f7c-b474-45fd-aef0-c1ee15f2eaf2
+      - name: Regex Rewrite Substitution
+        keys: [regex_rewrite_substitution]
         doc: |
-          A [Namespace][namespace-concept] is a collection of users, groups, routes, and policies that allows system administrators to organize, manage, and delegate permissions across their infrastructure.
+          The substitution for your regex pattern, ex: `\\2/instance/\\1`.
+        uuid: 71cdc7a9-d72e-407c-99f0-36e3a5ef1f41
+      uuid: b9ee5ae3-e90d-40f1-8df3-91d26ebe85cd
+    - name: Timeouts
+      settings:
+      - name: Allow Websockets
+        keys: [allow_websockets]
+        uuid: f42c273d-7c3d-471c-a28e-75b8c9e771f3
+      - name: Allow SPDY
+        keys: [allow_spdy]
+        uuid: ca7bf8ec-e123-4171-b22b-00c24a6a0d96
+      - name: Timeout
+        keys: [timeout]
+        uuid: 2b38fd23-24b0-4830-b924-0de802402191
+      - name: Idle Timeout
+        keys: [idle_timeout]
+        uuid: 25d0d973-9add-4efb-abaa-d526a41b3c4e
+      uuid: d93421db-ae13-4978-8d22-91561cc9eb61
+    - name: Headers
+      settings:
+      - name: Host Headers
+        keys: [host_rewrite]
+        uuid: 399e48ea-e6f3-4ab9-b007-714ed7428168
+      - name: Set Request Headers
+        uuid: 6acc6aa7-6cde-4849-b960-63103e3f00ee
+      - name: Remove Request Headers
+        uuid: c593bd77-b333-40c7-95bb-0ba41bf270e3
+      - name: Rewrite Response Headers
+        uuid: 1a9d6b6e-8d79-4ece-92c3-1d36d9c58af6
+      uuid: e8022486-c36d-4fad-970f-6412b7b156a2
+    - name: Load Balancer
+      settings:
+      - name: Load Balancing Policy
+        uuid: b4563876-813c-4eab-85e1-7c74efeb4412
+      uuid: ef865e68-a544-4482-b331-6acf5e723d3a
+    uuid: 99cab2ec-f8e6-4bcb-aa1d-2eba94948f49
+  - name: Policies
+    keys: [Policy]
+    doc: |
+      A [Policy](/enterprise/concepts.md#policies) defines what permissions a set of users or groups has. Policies are applied to Namespaces or Routes to associate the set of permissions with a service or set of service, completing the authentication model.
 
-          - Policies can be optional or enforced on a Namespace.
-             - Enforced policies are also enforced on child Namespaces, and optional policies are available to them as well.
-          - Users or groups can be granted permission to edit access to routes within a Namespace, allowing them self-serve access to the routes critical to their work.
+      Policies can be constructed three ways:
 
-          ::: tip
-          When using an IdP without directory sync or when working with non-domain users, they will not show up in the look-ahead search. See [Non-Domain Users](/enterprise/concepts.md#non-domain-users) for more information.
-          :::
+      ### Web UI
 
+      From the **BUILDER** tab, users can add allow or deny blocks to a policy, containing and/or/not/nor logic to allow or deny sets of users and groups.
+
+      ![A policy being constructed in Pomerium Enterprise allowing a single user access](./img/example-policy-single-user.png)
+
+      ### Pomerium Policy Language
+
+      From the **EDITOR** tab users can write policies in Pomerium Policy Language (**PPL**), a YAML-based notation.
+
+      ![A policy as viewed from the editor tab](./img/example-policy-editor.png)
+
+      PPL documents contain one or more rules. Each rule has a corresponding action and one or more logical operators.
+      Each logical operator contains criteria and each criterion has a name and corresponding data.
+
+      PPL documents are defined via YAML:
+
+      ```yaml
+      - allow:
+          or:
+            - email:
+                is: x@example.com
+            - email:
+                is: y@example.com
+      ```
+
+      The available rule actions are:
+
+      - `allow`
+      - `deny`
+
+      The available logical operators are:
+
+      - `and`
+      - `or`
+      - `not`
+      - `nor`
+
+      The available criteria types are:
+
+      - `accept`
+      - `authenticated_user`
+      - `claim`
+      - `date`
+      - `day_of_week`
+      - `domain`
+      - `email`
+      - `groups`
+      - `http_method`
+      - `http_path`
+      - `reject`
+      - `time_of_day`
+      - `user`
+
+      Some criteria also support a sub-path as part of the criterion name:
+
+      ```yaml
+      - allow:
+          or:
+            - claim/family_name: Smith
+      ```
+
+      ### Rego
+
+      For those using [OPA](https://www.openpolicyagent.org/), the **REGO** tab will accept policies written in Rego.
+
+      ::: tip
+      A policy can only support PPL or Rego. Once one is set, the other tab is disabled.
+      :::
+
+      ### Overrides
+
+      - **Any Authenticated User**: This setting will allow access to a route with this policy attached to any user who can authenticate to your Identity Provider (**IdP**).
+      - **CORS Preflight**: Allow unauthenticated HTTP OPTIONS requests as per the CORS spec.
+      - **Public Access**: This setting allows complete, unrestricted access to an associated route. Use this setting with caution.
+    uuid: 1710a312-0562-4a18-b5a6-bedfc54873f6
+  - name: Certificates
+    uuid: bff9a877-7c35-4b9d-80d8-ca3b2d16a2fc
+  - name: Devices
+    doc: |
+      Introduced in v0.16.0, the **Manage Devices** page lets administrators manage user devices for policy-based authorization.
+    settings:
+    - name: Manage Devices
+      doc: |
+        From this page, administrators can manage new and existing device enrollments.
+        Device enrollment let's you create [policies](/docs/topics/ppl.md#device-matcher) that use [device identity](/docs/topics/device-identity.md).
+        - Users can [self-enroll](/guides/enroll-device.md) devices, which must then be approved in the **Devices List** for policies requiring approved devices.
+        - Administrators can use the **New Enrollment** button to create a link for the user to enroll a device as pre-approved. See our [Pre-Approved Device Enrollment](/guides/admin-enroll-device.md) guide for more information.
+      more: /enterprise/reference/manage.html#manage-devices
+      uuid: 742c64e4-9441-41b0-ac6e-677b6bfe6cbb
+    - name: Devices List
+      doc: |
+        Displays the currently enrolled devices for each user, along with their current approval status.
+        Administrators can inspect, approve, or delete registered devices from this table.
+
+        ![List of user devices](./img/console-devices.png)
+      uuid: dd10552e-c7f8-4cca-8c31-3ed01f31b478
+    - name: New Enrollment
+      doc: |
+        The **New Enrollment** button allows administrators to create a custom link for a specific user to use to register a new device, which will automatically be approved.
+        This scheme is known as [Trust on First Use (TOFU)](https://en.wikipedia.org/wiki/Trust_on_first_use).
+
+        ![Example device enrollment](./img/new-enrollment.png)
+      more: /guides/admin-enroll-device.html
+      settings:
+      - name: Search Users
+        doc: New Enrollment URLs are only valid for the specified user.
+        more: /guides/admin-enroll-device.html
+        uuid: 4d636f56-21e2-4c72-9a65-0fc9ff76823e
+      - name: Redirect URL
+        doc: '**Optional**: The URL the user will be taken to after device enrollment
+          is successful.'
+        more: /guides/admin-enroll-device.html
+        uuid: 79e3b000-79cd-4522-9336-cefb28906930
+      - name: Enrollment Type
+        doc: Specify if the user can enroll any device identity, or restrict it to
+          a [secure enclave](/docs/topics/device-identity.md#secure-enclaves).
+        more: /guides/admin-enroll-device.html
+        uuid: 69b7c84d-84aa-4a38-b830-55dfed8ad2a1
+      uuid: 4bdd0102-a593-420b-8999-51a461657dc4
+    uuid: d1eb6b9e-ab93-4beb-ab91-d1de6aa76498
+  uuid: e0dbd749-1a83-4d28-8fb9-e067f2d6daa4
+- name: Configure
+  doc: |
+    The **Configure** section of the Pomerium Enterprise Console houses settings that affect the entirety of the Console environment, i.e. across all Namespaces. Adjust these settings with care.
+  settings:
+  - name: Settings
+    doc: |
+      The **Settings** section holds global settings that affect how the Pomerium Enterprise Console runs, logs, and communicates. Values set here are applied globally, except for settings documented to override global options.
+    settings:
+    - name: Global
+      settings:
+      - name: Debug
+        uuid: 6c058151-b21b-4b65-9abc-6ab884f946c0
+      - name: HTTP Redirect Address
+        uuid: 42459dde-ebb7-4e31-9cd1-1dbf01d7a440
+      - name: DNS Lookup Family
+        uuid: 206d37b5-9a6b-4043-8dae-68ca89640e2d
+      - name: Log Level
+        uuid: 1c13dfc6-6718-412a-8091-904f703c3014
+      - name: Proxy Log Level
+        uuid: c1f29676-7bf9-4feb-bb3b-246debd9c64b
+      uuid: 77e4a8cb-447e-4f79-b6b9-e752dcc53249
+    - name: Cookies
+      settings:
+      - name: HTTPS Only
+        keys: [cookie_secure]
+        uuid: 43d28fb7-69c3-4923-b095-b0f97ec88ed4
+      - name: Javascript Security
+        uuid: 9597b118-6fa1-4dd2-bf07-68b9f582f519
+      - name: Expires
+        keys: [cookie_expire]
+        uuid: e28156d0-5175-4cdc-8a39-dcb3735d1438
+      uuid: 378293b9-6068-4a97-9fa5-75a0fa155538
+    - name: Timeouts
+      doc: Timeouts set the global server timeouts. Timeouts can also be set for individual
+        routes.
+      uuid: 58a18216-744f-4ffc-aab5-aeabd74851f1
+    - name: GRPC
+      settings:
+      - name: GRPC Server Max Connection Age
+        doc: |
+          Set max connection age for GRPC servers. After this interval, servers ask clients to reconnect and perform any rediscovery for new/updated endpoints from DNS.
+
+          See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> (opens new window) for details
+        uuid: 02d307d3-415f-4c0c-8d64-5f2fb96198cc
+      - name: GRPC Server Max Connection Age Grace
+        doc: |
+          Additive period with grpc_server_max_connection_age, after which servers will force connections to close.
+
+          See <https://godoc.org/google.golang.org/grpc/keepalive#ServerParameters> (opens new window) for details
+        uuid: b49ffe89-5006-4f8e-841a-d6a12d00dbb3
+      uuid: f744ee07-7d41-4016-8621-3ead4e330a95
+    - name: Tracing
+      doc: |
+        Tracing tracks the progression of a single user request as it is handled by Pomerium.
+
+        Each unit of work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
+      settings:
+      - name: Tracing Sample Rate
+        doc: |
+          Percentage of requests to sample. Default is .01%.
+
+          Unlike the decimal value notion used for the `tracing_sample_rate` [key](/reference/readme.md#shared-tracing-settings) in open-source Pomerium, this value is a percentage, e.g. a value of `1` equates to 1%
+        uuid: a214565d-9b77-4994-9c07-531bd9610dd0
+      uuid: bd62365e-1e08-4c45-9b3f-0eccbb0f8d80
+    - name: Authenticate
+      uuid: 5ce0bdf1-c73b-4994-988c-74a3c1743514
+    - name: Proxy
+      settings:
+      - name: Certificate Authority
+        keys: [certificate_authority]
+        uuid: 8b2127cd-b876-4296-b724-80101825be10
+      - name: Default Upstream Timeout
+        uuid: 11689429-03f1-4a75-9432-8c070c468ad7
+      - name: JWT Claim Headers
+        uuid: 01b24ad4-96dc-4885-b837-96ec1a5e826e
+      - name: X-Forward-For HTTP Header
+        keys: [skip_xff_append]
+        uuid: b1427fa5-4ddb-468b-a6c6-527634b374f6
+      - name: Response Headers
+        keys: [set_response_headers]
+        uuid: fe27b075-e5f0-40fe-8561-748b7ff9dae3
+      uuid: 9334d44c-919c-45af-8405-6acf19be1085
+    uuid: b0e3a449-e743-4cc2-a820-d5d470b752ab
+  - name: Service Accounts
+    doc: |
+      [Service accounts](/enterprise/concepts.md#service-accounts) offer a protected and standardized method of authenticating machine-to-machine communication between services protected by Pomerium.
+
+      ::: tip
+      Before you begin, confirm you are in the correct Namespace. A service account can only be used in the Namespace it was created in, including its children Namespaces.
+      :::
+
+      1. From the main menu, select **Service Accounts** under **CONFIGURE**. Click the **+ ADD SERVICE ACCOUNT** button:
+
+         ![The Service Accounts page](./img/console-service-account.png)
+
+      1. Service accounts can be unique and exist only for Pomerium, or impersonate directory users from your IdP.
+
+         Give the user a unique ID, or select an existing user to impersonate. Consider referencing the Namespace you're creating it under, for easier reference later. Optionally set an expiration date:
+
+         ![Adding a unique service account](./img/create-service-account.png)
+
+         The user ID set here corresponds to the `User` criteria when editing a policy.
+
+      1. After you click **Submit**, the modal presents the JSON web token (**JWT**) for the service account. Temporarily save it somewhere secure, as you will not be able to view it again:
+
+         ![Service Account Added](./img/service-account-jwt.png)
+
+         This JWT must be added to your application configuration to enable direct communication.
+
+      1. Edit or create policies to give the service account access to the internal service:
+
+        ![An example policy for a service account](./img/create-policy-1.png)
+
+        ---
+
+        ![An example policy for a service account](./img/create-policy-2.png)
+    uuid: f2a12f52-ea7a-4b44-8308-3500d653c122
+  - name: Namespaces
+    keys: [namespace]
+    doc: |
+      A [Namespace][namespace-concept] is a collection of users, groups, routes, and policies that allows system administrators to organize, manage, and delegate permissions across their infrastructure.
+
+      - Policies can be optional or enforced on a Namespace.
+         - Enforced policies are also enforced on child Namespaces, and optional policies are available to them as well.
+      - Users or groups can be granted permission to edit access to routes within a Namespace, allowing them self-serve access to the routes critical to their work.
+
+      ::: tip
+      When using an IdP without directory sync or when working with non-domain users, they will not show up in the look-ahead search. See [Non-Domain Users](/enterprise/concepts.md#non-domain-users) for more information.
+      :::
+
+    uuid: 3ffcbb2a-4c02-4c3f-b11e-0eef5c30f1bd
+  uuid: b1688ca0-aea8-4296-bc67-8c397ef969a6
 postamble: |
   [route-concept]: /enterprise/concepts.md#routes
   [route-reference]: /enterprise/reference/manage.md#routes

--- a/docs/enterprise/reference/configure.md
+++ b/docs/enterprise/reference/configure.md
@@ -151,7 +151,9 @@ Default Upstream Timeout is the default timeout applied to a proxied route when 
 
 The JWT Claim Headers setting allows you to pass specific user session data to upstream applications as HTTP request headers. Note, unlike the header `x-pomerium-jwt-assertion` these values are not signed by the authorization service.
 
-Any claim in the pomerium session JWT can be placed into a corresponding header for upstream consumption. This claim information is sourced from your Identity Provider (IdP) and Pomerium's own session metadata. The header will have the following format:
+Additionally, this will add the claim to the `X-Pomerium-Jwt-Assertion` header provided by [`pass_identity_headers`](/reference/readme.md#pass-identity-headers), if not already present.
+
+Any claim in the pomerium session JWT can be placed into a corresponding header and the JWT payload for upstream consumption. This claim information is sourced from your Identity Provider (IdP) and Pomerium's own session metadata. The header will have the following format:
 
 `X-Pomerium-Claim-{Name}` where `{Name}` is the name of the claim requested. Underscores will be replaced with dashes; e.g. `X-Pomerium-Claim-Given-Name`.
 

--- a/docs/reference/settings.yaml
+++ b/docs/reference/settings.yaml
@@ -48,1985 +48,2066 @@ postamble: |
   [yaml]: https://en.wikipedia.org/wiki/YAML
 
 settings:
-  - name: "Shared Settings"
-    doc: |
-      These configuration variables are shared by all services, in all service modes.
-    settings:
-      - name: "Address"
-        keys: ["address"]
-        attributes: |
-          - Environmental Variable: `ADDRESS`
-          - Config File Key: `address`
-          - Type: `string`
-          - Example: `:443`, `:8443`
-          - Default: `:443`
-          - Required
-        doc: |
-          Address specifies the host and port to serve HTTP requests from. If empty, `:443` is used. Note, in all-in-one deployments, gRPC traffic will be served on loopback on port `:5443`.
-        shortdoc: |
-          Address specifies the host and port to serve HTTP requests from.
-      - name: "Authenticate Service URL"
-        keys: ["authenticate_service_url"]
-        attributes: |
-          - Environmental Variable: `AUTHENTICATE_SERVICE_URL`
-          - Config File Key: `authenticate_service_url`
-          - Type: `URL`
-          - Required
-          - Example: `https://authenticate.corp.example.com`
-        doc: |
-          Authenticate Service URL is the externally accessible URL for the authenticate service. In split service mode, this key is required by all services other than Databroker.
-        shortdoc: |
-          Authenticate Service URL is the externally accessible URL for the authenticate service.
-      - name: "Autocert"
-        keys: ["autocert"]
-        attributes: |
-          - Environmental Variable: `AUTOCERT`
-          - Config File Key: `autocert`
-          - Type: `bool`
-          - Optional
-        doc: |
-          Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from [Let's Encrypt][letsencrypt] which includes managed routes and the authenticate service.  [Autocert Directory](#autocert-directory) must be used with Autocert must have a place to persist, and share certificate data between services. Note that autocert also provides [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling).
-
-          This setting can be useful in situations where you may not have Pomerium behind a TLS terminating ingress or proxy that is already handling your public certificates on your behalf.
-
-          :::warning
-
-          By using autocert, you agree to the [Let's Encrypt Subscriber Agreement](https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf). There are [_strict_ usage limits](https://letsencrypt.org/docs/rate-limits/) per domain you should be aware of. Consider testing with `autocert_use_staging` first.
-
-          :::
-
-          :::warning
-
-          Autocert requires that ports `80`/`443` be accessible from the internet in order to complete a [TLS-ALPN-01 challenge](https://letsencrypt.org/docs/challenge-types/#tls-alpn-01).
-
-          :::
-        shortdoc: |
-          Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from Lets Encrypt.
-      - name: "Autocert CA"
-        keys: ["autocert_ca"]
-        attributes: |
-          - Environmental Variable: `AUTOCERT_CA`
-          - Config File Key: `autocert_ca`
-          - Type: `string` containing the directory URL of an ACME CA (e.g. `https://acme.zerossl.com/v2/DV90` for ZeroSSL)
-          - Optional
-        doc: |
-          Autocert CA is the directory URL of the ACME CA to use when requesting certificates.
-
-          :::tip
-
-          This will overrule the "Autocert Use Staging" setting if set.
-
-          :::
-        shortdoc: |
-          Autocert CA is the directory URL of the ACME CA to use when requesting certificates.
-      - name: "Autocert Email"
-        keys: ["autocert_email"]
-        attributes: |
-          - Environmental Variable: `AUTOCERT_EMAIL`
-          - Config File Key: `autocert_email`
-          - Type: `string` containing the email address to use when registering an account
-          - Optional
-        doc: |
-          Autocert Email is the email address to use when requesting certificates from an ACME CA.
-
-          :::tip
-
-          The CA may contact you at this address, for example when a certificate expires.
-
-          :::
-        shortdoc: |
-          Autocert Email is the email address to use when requesting certificates from an ACME CA.
-      - name: "Autocert Must-Staple"
-        keys: ["autocert_must_staple"]
-        attributes: |
-          - Environmental Variable: `AUTOCERT_MUST_STAPLE`
-          - Config File Key: `autocert_must_staple`
-          - Type: `bool`
-          - Optional
-        doc: |
-          If true, force autocert to request a certificate with the `status_request` extension (commonly called `Must-Staple`). This allows the TLS client (_id est_ the browser) to fail immediately if the TLS handshake doesn't include OCSP stapling information. This setting is only used when [Autocert](#autocert) is true.
-
-          :::tip
-
-          This setting will only take effect when you request or renew your certificates.
-
-          :::
-
-          For more details, please see [RFC7633](https://tools.ietf.org/html/rfc7633) .
-      - name: "Autocert Directory"
-        keys: ["autocert_dir"]
-        attributes: |
-          - Environmental Variable: either `AUTOCERT_DIR`
-          - Config File Key: `autocert_dir`
-          - Type: `string` pointing to the path of the directory
-          - Required if using [Autocert](#autocert) setting
-          - Default:
-
-            - `/data/autocert` in published Pomerium docker images
-            - [$XDG_DATA_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
-            - `$HOME/.local/share/pomerium`
-        doc: |
-          Autocert directory is the path which autocert will store x509 certificate data.
-        shortdoc: |
-          Autocert directory is the path which autocert will store x509 certificate data.
-      - name: "Autocert Use Staging"
-        keys: ["autocert_use_staging"]
-        attributes: |
-          - Environmental Variable: `AUTOCERT_USE_STAGING`
-          - Config File Key: `autocert_use_staging`
-          - Type: `bool`
-          - Optional
-        doc: |
-          Let's Encrypt has strict [usage limits](https://letsencrypt.org/docs/rate-limits/). Enabling this setting allows you to use Let's Encrypt's [staging environment](https://letsencrypt.org/docs/staging-environment/) which has much more lax usage limits.
-        shortdoc: |
-          Let's Encrypt has strict usage limits. Enabling this setting allows you to use Let's Encrypt's staging environment which has much more lax usage limits.
-      - name: "Autocert EAB Key ID"
-        keys: ["autocert_eab_key_id"]
-        attributes: |
-          - Environmental Variable: `AUTOCERT_EAB_KEY_ID`
-          - Config File Key: `autocert_eab_key_id`
-          - Type: `string` containing the identifier for an ACME EAB key to use
-          - Optional
-        doc: |
-          Autocert EAB Key ID is the key identifier when requesting a certificate from a CA with External Account Binding enabled.
-
-          For more information, please see [RFC8555-#7.3.4](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4).
-        shortdoc: |
-          Autocert EAB Key ID is the key identifier when requesting a certificate from a CA with External Account Binding enabled.
-      - name: "Autocert EAB MAC Key"
-        keys: ["autocert_eab_mac_key"]
-        attributes: |
-          - Environmental Variable: `AUTOCERT_EAB_MAC_KEY`
-          - Config File Key: `autocert_eab_mac_key`
-          - Type: `string` containing a base64url-encoded secret key
-          - Optional
-        doc: |
-          Autocert EAB MAC Key is the base64url-encoded secret key corresponding to the Autocert EAB Key ID.
-
-          This setting is required when Autocert EAB Key ID is set.
-        shortdoc: |
-          Autocert EAB MAC Key is the base64url-encoded secret key corresponding to the Autocert EAB Key ID.
-      - name: "Autocert Trusted Certificate Authority"
-        keys: ["autocert_trusted_ca", "autocert_trusted_ca_file"]
-        attributes: |
-          - Environment Variable: `AUTOCERT_TRUSTED_CA` / `AUTOCERT_TRUSTED_CA_FILE`
-          - Config File Key: `autocert_trusted_ca` / `autocert_trusted_ca_file`
-          - Type: [base64 encoded] `string` or relative file location
-          - Optional
-        doc: |
-          The Autocert Trusted Certificate Authority is the x509 CA (bundle) used when communicating with a CA supporting the ACME protocol. If not set, the system trusted roots will be used to verify TLS connections to the ACME CA.
-      - name: "Certificates"
-        keys:
-          [
-            "certificates",
-            "certificate",
-            "certificate_key",
-            "certificate_file",
-            "certificate_key_file",
-          ]
-        attributes: |
-          - Config File Key: `certificates` (not yet settable using environmental variables)
-          - Config File Key: `certificate` / `certificate_key`
-          - Config File Key: `certificate_file` / `certificate_key_file`
-          - Environmental Variable: `CERTIFICATE` / `CERTIFICATE_KEY`
-          - Environmental Variable: `CERTIFICATE_FILE` / `CERTIFICATE_KEY_FILE`
-          - Type: array of relative file locations `string`
-          - Type: [base64 encoded] `string`
-          - Type: certificate relative file location `string`
-          - Required (if insecure not set)
-        doc: |
-          Certificates are the x509 _public-key_ and _private-key_ used to establish secure HTTP and gRPC connections. Any combination of the above can be used together, and are additive. You can also use any of these settings in conjunction with `Autocert` to get OCSP stapling.
-
-          Certificates loaded into Pomerium from these config values are used to attempt secure connections between end users and services, between Pomerium services, and to upstream endpoints.
-
-          For example, if specifying multiple certificates at once:
-
-          ```yaml
-          certificates:
-            - cert: "$HOME/.acme.sh/authenticate.example.com_ecc/fullchain.cer"
-              key: "$HOME/.acme.sh/authenticate.example.com_ecc/authenticate.example.com.key"
-            - cert: "$HOME/.acme.sh/verify.example.com_ecc/fullchain.cer"
-              key: "$HOME/.acme.sh/verify.example.com_ecc/verify.example.com.key"
-            - cert: "$HOME/.acme.sh/prometheus.example.com_ecc/fullchain.cer"
-              key: "$HOME/.acme.sh/prometheus.example.com_ecc/prometheus.example.com.key"
-          ```
-
-          Or to set a single certificate and key covering multiple domains and/or a wildcard subdomain:
-
-          ```yaml
-          certificate_file: "$HOME/.acme.sh/*.example.com/fullchain.crt"
-          certificate_key:  "$HOME/.acme.sh/*.example.com/*.example.com.key"
-          ```
-
-          **Note:** Pomerium will check your system's trust/key store for valid certificates first. If your certificate solution imports into the system store, you don't need to also specify them with these configuration keys.
-      - name: "Client Certificate Authority"
-        keys: ["client_ca", "client_ca_file"]
-        attributes: |
-          - Environment Variable: `CLIENT_CA` / `CLIENT_CA_FILE`
-          - Config File Key: `client_ca` / `client_ca_file`
-          - Type: [base64 encoded] `string` or relative file location
-          - Optional
-        doc: |
-          The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) client certificates. If not set, no client certificate will be required.
-      - name: "Client CRL"
-        keys: ["client_crl", "client_crl_file"]
-        attributes: |
-          - Environment Variable: `CLIENT_CRL` / `CLIENT_CRL_FILE`
-          - Config File Key: `client_crl` / `client_crl_file`
-          - Type: [base64 encoded] `string` or relative file location
-          - Optional
-        doc: |
-          The Client CRL is the [certificate revocation list](https://en.wikipedia.org/wiki/Certificate_revocation_list)
-          (in PEM format) for client certificates. If not set, no CRL will be used.
-      - name: "Cookie Options"
-        settings:
-          - name: "Cookie Name"
-            keys: ["cookie_name"]
-            attributes: |
-              - Environmental Variable: `COOKIE_NAME`
-              - Config File Key: `cookie_name`
-              - Type: `string`
-              - Default: `_pomerium`
-            doc: |
-              The name of the session cookie sent to clients.
-            shortdoc: |
-              The name of the session cookie sent to clients.
-          - name: "Cookie Secret"
-            keys: ["cookie_secret"]
-            attributes: |
-              - Environmental Variable: `COOKIE_SECRET`
-              - Config File Key: `cookie_secret`
-              - Type: [base64 encoded] `string`
-              - Required for Proxy service
-            doc: |
-              Secret used to encrypt and sign session cookies. You can generate a random key with `head -c32 /dev/urandom | base64`.
-            shortdoc: |
-              Secret used to encrypt and sign session cookies.
-          - name: "Cookie Domain"
-            keys: ["cookie_domain"]
-            attributes: |
-              - Environmental Variable: `COOKIE_DOMAIN`
-              - Config File Key: `cookie_domain`
-              - Type: `string`
-              - Example: `localhost.pomerium.io`
-              - Optional
-            doc: |
-              The scope of session cookies issued by Pomerium.
-            shortdoc: |
-              The scope of session cookies issued by Pomerium.
-          - name: "HTTPS only"
-            keys: ["cookie_secure"]
-            attributes: |
-              - Environmental Variable: `COOKIE_SECURE`
-              - Config File Key: `cookie_secure`
-              - Type: `bool`
-              - Default: `true`
-            doc: |
-              If true, instructs browsers to only send user session cookies over HTTPS.
-
-              :::warning
-
-              Setting this to false may result in session cookies being sent in cleartext.
-
-              :::
-            shortdoc: |
-              If true, instructs browsers to only send user session cookies over HTTPS.
-          - name: "Javascript Security"
-            keys: ["cookie_http_only"]
-            attributes: |
-              - Environmental Variable: `COOKIE_HTTP_ONLY`
-              - Config File Key: `cookie_http_only`
-              - Type: `bool`
-              - Default: `true`
-            doc: |
-              If true, prevents javascript in browsers from reading user session cookies.
-
-              :::warning
-
-              Setting this to false enables hostile javascript to steal session cookies and impersonate users.
-
-              :::
-            shortdoc: |
-              If true, prevents javascript in browsers from reading user session cookies.
-          - name: "Expiration"
-            keys: ["cookie_expire"]
-            attributes: |
-              - Environmental Variable: `COOKIE_EXPIRE`
-              - Config File Key: `cookie_expire`
-              - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
-              - Default: `14h`
-            doc: |
-              Sets the lifetime of session cookies. After this interval, users must reauthenticate.
-            shortdoc: |
-              Sets the lifetime of session cookies. After this interval, users must reauthenticate.
-      - name: "Data Broker Service URL"
-        keys: ["databroker_service_url"]
-        attributes: |
-          - Environmental Variable: `DATABROKER_SERVICE_URL` or `DATABROKER_SERVICE_URLS`
-          - Config File Key: `databroker_service_url` or `databroker_service_urls`
-          - Type: `URL`
-          - Example: `https://databroker.corp.example.com`
-          - Default: in all-in-one mode, `http://localhost:5443`
-        doc: |
-          The data broker service URL points to a data broker which is responsible for storing associated authorization context (e.g. sessions, users and user groups). Multiple URLs can be specified with `databroker_service_urls`.
-      - name: "Debug"
-        keys: ["pomerium_debug"]
-        attributes: |
-          - Environmental Variable: `POMERIUM_DEBUG`
-          - Config File Key: `pomerium_debug`
-          - Type: `bool`
-          - Default: `false`
-        doc: |
-          ::: danger
-
-          Enabling the debug flag could result in sensitive information being logged!!!
-
-          :::
-
-          By default, JSON encoded logs are produced. Debug enables colored, human-readable logs to be streamed to [standard out](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)>>>). In production, it is recommended to be set to `false`.
-
-          For example, if `true`
-
-          ```
-          10:37AM INF cmd/pomerium version=v0.0.1-dirty+ede4124
-          10:37AM INF proxy: new route from=verify.localhost.pomerium.io to=https://verify.pomerium.com
-          10:37AM INF proxy: new route from=ssl.localhost.pomerium.io to=http://neverssl.com
-          10:37AM INF proxy/authenticator: grpc connection OverrideCertificateName= addr=auth.localhost.pomerium.io:443
-          ```
-
-          If `false`
-
-          ```
-          {"level":"info","version":"v0.0.1-dirty+ede4124","time":"2019-02-18T10:41:03-08:00","message":"cmd/pomerium"}
-          {"level":"info","from":"verify.localhost.pomerium.io","to":"https://verify.pomerium.com","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
-          {"level":"info","from":"ssl.localhost.pomerium.io","to":"http://neverssl.com","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
-          {"level":"info","OverrideCertificateName":"","addr":"auth.localhost.pomerium.io:443","time":"2019-02-18T10:41:03-08:00","message":"proxy/authenticator: grpc connection"}
-          ```
-        shortdoc: |
-          Debug enables colored, human-readable logs to be streamed to standard out.
-      - name: "Forward Auth"
-        keys: ["forward_auth_url"]
-        attributes: |
-          - Environmental Variable: `FORWARD_AUTH_URL`
-          - Config File Key: `forward_auth_url`
-          - Type: `URL` (must contain a scheme and hostname)
-          - Example: `https://forwardauth.corp.example.com`
-          - Resulting Verification URL: `https://forwardauth.corp.example.com/?uri={URL-TO-VERIFY}`
-          - Optional
-        doc: |
-          Forward authentication creates an endpoint that can be used with third-party proxies that do not have rich access control capabilities ([nginx](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html), [nginx-ingress](https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/), [ambassador](https://www.getambassador.io/reference/services/auth-service/), [traefik](https://docs.traefik.io/middlewares/forwardauth/)). Forward authentication allows you to delegate authentication and authorization for each request to Pomerium.
-
-          #### Request flow
-
-          ![pomerium forward auth request flow](./img/auth-flow-diagram.svg)
-
-          #### Examples
-
-          ##### NGINX Ingress
-
-          Some reverse-proxies, such as nginx split access control flow into two parts: verification and sign-in redirection. Notice the additional path `/verify` used for `auth-url` indicating to Pomerium that it should return a `401` instead of redirecting and starting the sign-in process.
-
-          ```yaml
-          apiVersion: extensions/v1beta1
-          kind: Ingress
-          metadata:
-            name: verify
-            annotations:
-              kubernetes.io/ingress.class: "nginx"
-              certmanager.k8s.io/issuer: "letsencrypt-prod"
-              nginx.ingress.kubernetes.io/auth-url: https://forwardauth.corp.example.com/verify?uri=$scheme://$host$request_uri
-              nginx.ingress.kubernetes.io/auth-signin: "https://forwardauth.corp.example.com/?uri=$scheme://$host$request_uri"
-          spec:
-            tls:
-              - hosts:
-                  - verify.corp.example.com
-                secretName: quickstart-example-tls
-            rules:
-              - host: verify.corp.example.com
-                http:
-                  paths:
-                    - path: /
-                      backend:
-                        serviceName: verify
-                        servicePort: 80
-          ```
-
-          #### Traefik docker-compose
-
-          If the `forward_auth_url` is also handled by Traefik, you will need to configure Traefik to trust the `X-Forwarded-*` headers as described in [the documentation](https://docs.traefik.io/v2.2/routing/entrypoints/#forwarded-headers).
-
-          ```yml
-          version: "3"
-
-          services:
-            traefik:
-              # The official v2.2 Traefik docker image
-              image: traefik:v2.2
-              # Enables the web UI and tells Traefik to listen to docker
-              command:
-                - "--api.insecure=true"
-                - "--providers.docker=true"
-                - "--entrypoints.web.address=:80"
-                - "--entrypoints.web.forwardedheaders.insecure=true"
-              ports:
-                # The HTTP port
-                - "80:80"
-                # The Web UI (enabled by --api.insecure=true)
-                - "8080:8080"
-              volumes:
-                # So that Traefik can listen to the Docker events
-                - /var/run/docker.sock:/var/run/docker.sock
-            verify:
-              # A container that exposes an API to show its IP address
-              image: pomerium/verify:latest
-              labels:
-                - "traefik.http.routers.verify.rule=Host(`verify.corp.example.com`)"
-                # Create a middleware named `foo-add-prefix`
-                - "traefik.http.middlewares.test-auth.forwardauth.authResponseHeaders=x-pomerium-claim-email,x-pomerium-claim-id,x-pomerium-claim-groups,x-pomerium-jwt-assertion"
-                - "traefik.http.middlewares.test-auth.forwardauth.address=http://forwardauth.corp.example.com/?uri=https://verify.corp.example.com"
-                - "traefik.http.routers.verify.middlewares=test-auth@docker"
-          ```
-        shortdoc: |
-          Forward authentication creates an endpoint that can be used with third-party proxies.
-      - name: "Global Timeouts"
-        keys: ["timeout_read", "timeout_write", "timeout_idle"]
-        attributes: |
-          - Environmental Variables: `TIMEOUT_READ` `TIMEOUT_WRITE` `TIMEOUT_IDLE`
-          - Config File Key: `timeout_read` `timeout_write` `timeout_idle`
-          - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
-          - Example: `TIMEOUT_READ=30s`
-          - Defaults: `TIMEOUT_READ=30s` `TIMEOUT_WRITE=0` `TIMEOUT_IDLE=5m`
-        doc: |
-          Timeouts set the global server timeouts. Timeouts can also be set for individual [routes](#routes).
-
-          - `idle_timeout`: The idle timeout is the time at which a downstream or upstream connection will be terminated if there are no active streams.
-          - `write_timeout`: The max stream duration is the maximum time that a stream’s lifetime will span. An HTTP request/response exchange fully consumes a single stream.
-            Therefore, this value must be greater than read_timeout as it covers both request and response time.
-          - `read_timeout`: The amount of time for the entire request stream to be received from the client.
-        shortdoc: |
-          Timeouts set the global server timeouts. Timeouts can also be set for individual routes.
-      - name: "GRPC Options"
-        settings:
-          - name: "GRPC Address"
-            keys: ["grpc_address"]
-            attributes: |
-              - Environmental Variable: `GRPC_ADDRESS`
-              - Config File Key: `grpc_address`
-              - Type: `string`
-              - Example: `:443`, `:8443`
-              - Default: `:443` or `:5443` if in all-in-one mode
-            doc: |
-              gRPC Address specifies the host and port to serve gRPC requests from.
-            shortdoc: |
-              Address specifies the host and port to serve GRPC requests from.
-          - name: "GRPC Insecure"
-            keys: ["grpc_insecure"]
-            attributes: |
-              - Environmental Variable: `GRPC_INSECURE`
-              - Config File Key: `grpc_insecure`
-              - Type: `bool`
-            doc: |
-              This setting disables transport security for gRPC communication. If running in all-in-one mode, defaults to true as communication will run over localhost's own socket.
-            shortdoc: |
-              If set, GRPC Insecure disables transport security for communication between the proxy and authorize components.
-          - name: "GRPC Client Timeout"
-            keys: ["grpc_client_timeout"]
-            attributes: |
-              - Environmental Variable: `GRPC_CLIENT_TIMEOUT`
-              - Config File Key: `grpc_client_timeout`
-              - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
-              - Default: `10s`
-            doc: |
-              Maximum time before canceling an upstream gRPC request. During transient failures, the proxy will retry upstreams for this duration. You should leave this high enough to handle backend service restart and rediscovery so that client requests do not fail.
-          - name: "GRPC Client DNS RoundRobin"
-            keys: ["grpc_client_dns_roundrobin"]
-            attributes: |
-              - Environmental Variable: `GRPC_CLIENT_DNS_ROUNDROBIN`
-              - Config File Key: `grpc_client_dns_roundrobin`
-              - Type: `bool`
-              - Default: `true`
-            doc: |
-              Enable gRPC DNS based round robin load balancing. This method uses DNS to resolve endpoints and does client side load balancing of _all_ addresses returned by the DNS record. Do not disable unless you have a specific use case.
-      - name: "HTTP Redirect Address"
-        keys: ["http_redirect_addr"]
-        attributes: |
-          - Environmental Variable: `HTTP_REDIRECT_ADDR`
-          - Config File Key: `http_redirect_addr`
-          - Type: `string`
-          - Example: `:80`, `:8080`
-          - Optional
-        doc: |
-          If set, the HTTP Redirect Address specifies the host and port to redirect http to https traffic on. If unset, no redirect server is started.
-        shortdoc: |
-          If set, the HTTP Redirect Address specifies the host and port to redirect http to https traffic on.
-      - name: "Insecure Server"
-        keys: ["insecure_server"]
-        attributes: |
-          - Environmental Variable: `INSECURE_SERVER`
-          - Config File Key: `insecure_server`
-          - Type: `bool`
-          - Required if certificates unset
-        doc: |
-          Turning on insecure server mode will result in pomerium starting, and operating without any protocol encryption in transit.
-
-          This setting can be useful in a situation where you have Pomerium behind a TLS terminating ingress or proxy. However, even in that case, it is highly recommended to use TLS to protect the confidentiality and integrity of service communication even behind the ingress using self-signed certificates or an internal CA. Please see our helm-chart for an example of just that.
-
-          :::warning
-
-          Pomerium should _never_ be exposed to the internet without TLS encryption.
-
-          :::
-        shortdoc: |
-          Turning on insecure server mode will result in pomerium starting, and operating without any protocol encryption in transit.
-      - name: "DNS Lookup Family"
-        keys: ["dns_lookup_family"]
-        attributes: |
-          - Environmental Variable: `DNS_LOOKUP_FAMILY`
-          - Config File Key: `dns_lookup_family`
-          - Type: `string`
-          - Options: `V4_ONLY` `V6_ONLY` `AUTO`
-          - Optional
-        doc: |
-          The DNS IP address resolution policy. If not specified, the value defaults to `AUTO`.
-        shortdoc: |
-          The DNS IP address resolution policy.
-      - name: "Log Level"
-        keys: ["log_level"]
-        attributes: |
-          - Environmental Variable: `LOG_LEVEL`
-          - Config File Key: `log_level`
-          - Type: `string`
-          - Options: `debug` `info` `warn` `error`
-          - Default: `debug`
-        doc: |
-          Log level sets the global logging level for pomerium. Only logs of the desired level and above will be logged.
-        shortdoc: |
-          Log level sets the global logging level for pomerium.
-      - name: "Metrics Address"
-        keys: ["metrics_address"]
-        attributes: |
-          - Environmental Variable: `METRICS_ADDRESS`
-          - Config File Key: `metrics_address`
-          - Type: `string`
-          - Example: `:9090`, `127.0.0.1:9090`
-          - Default: `disabled`
-          - Optional
-        doc: |
-          Expose a prometheus endpoint on the specified port.
-
-          :::warning
-
-          **Use with caution:** the endpoint can expose frontend and backend server names or addresses. Do not externally expose the metrics if this is sensitive information.
-
-          :::
-
-          #### Pomerium Metrics Tracked
-
-          Each metric exposed by Pomerium has a `pomerium` prefix, which is omitted in the table below for brevity.
-
-          Name                                          | Type      | Description
-          --------------------------------------------- | --------- | -----------------------------------------------------------------------
-          build_info                                    | Gauge     | Pomerium build metadata by git revision, service, version and goversion
-          config_checksum_int64                         | Gauge     | Currently loaded configuration checksum by service
-          config_last_reload_success                    | Gauge     | Whether the last configuration reload succeeded by service
-          config_last_reload_success_timestamp          | Gauge     | The timestamp of the last successful configuration reload by service
-          grpc_client_request_duration_ms               | Histogram | GRPC client request duration by service
-          grpc_client_request_size_bytes                | Histogram | GRPC client request size by service
-          grpc_client_requests_total                    | Counter   | Total GRPC client requests made by service
-          grpc_client_response_size_bytes               | Histogram | GRPC client response size by service
-          grpc_server_request_duration_ms               | Histogram | GRPC server request duration by service
-          grpc_server_request_size_bytes                | Histogram | GRPC server request size by service
-          grpc_server_requests_total                    | Counter   | Total GRPC server requests made by service
-          grpc_server_response_size_bytes               | Histogram | GRPC server response size by service
-          http_client_request_duration_ms               | Histogram | HTTP client request duration by service
-          http_client_request_size_bytes                | Histogram | HTTP client request size by service
-          http_client_requests_total                    | Counter   | Total HTTP client requests made by service
-          http_client_response_size_bytes               | Histogram | HTTP client response size by service
-          http_server_request_duration_ms               | Histogram | HTTP server request duration by service
-          http_server_request_size_bytes                | Histogram | HTTP server request size by service
-          http_server_requests_total                    | Counter   | Total HTTP server requests handled by service
-          http_server_response_size_bytes               | Histogram | HTTP server response size by service
-          redis_conns                                   | Gauge     | Number of total connections in the pool
-          redis_idle_conns                              | Gauge     | Total number of times free connection was found in the pool
-          redis_wait_count_total                        | Counter   | Total number of connections waited for
-          redis_wait_duration_ms_total                  | Counter   | Total time spent waiting for connections
-          storage_operation_duration_ms                 | Histogram | Storage operation duration by operation, result, backend and service
-
-          #### Identity Manager
-
-          Identity manager metrics have `pomerium_identity_manager` prefix.
-
-          Name                                          | Type      | Description
-          --------------------------------------------- | --------- | -----------------------------------------------------------------------
-          last_refresh_timestamp                        | Gauge     | Timestamp of last directory refresh operation.
-          session_refresh_error_timestamp               | Gauge     | Timestamp of last session refresh ended in an error.
-          session_refresh_errors                        | Counter   | Session refresh error counter.
-          session_refresh_success                       | Counter   | Session refresh success counter.
-          session_refresh_success_timestamp             | Gauge     | Timestamp of last successful session refresh.
-          user_group_refresh_error_timestamp            | Gauge     | Timestamp of last user group refresh ended in an error.
-          user_group_refresh_errors                     | Counter   | User group refresh error counter.
-          user_group_refresh_success                    | Counter   | User group refresh success counter.
-          user_group_refresh_success_timestamp          | Gauge     | Timestamp of last group successful user refresh.
-          user_refresh_error_timestamp                  | Gauge     | Timestamp of last user refresh ended in an error.
-          user_refresh_errors                           | Counter   | User refresh error counter.
-          user_refresh_success                          | Counter   | User refresh success counter.
-          user_refresh_success_timestamp                | Gauge     | Timestamp of last successful user refresh.
-
-          #### Envoy Proxy Metrics
-
-          As of `v0.9`, Pomerium uses [envoy](https://www.envoyproxy.io/) for the data plane. As such, proxy related metrics are sourced from envoy, and use envoy's internal [stats data model](https://www.envoyproxy.io/docs/envoy/latest/operations/stats_overview). Please see Envoy's documentation for information about specific metrics.
-
-          All metrics coming from envoy will be labeled with `service="pomerium"` or `service="pomerium-proxy"`, depending if you're running all-in-one or distributed service mode and have `pomerium` prefix added to the standard envoy metric name.
-        shortdoc: |
-          Expose a prometheus format HTTP endpoint on the specified port.
-      - name: "Metrics Basic Authentication"
-        keys: ["metrics_basic_auth"]
-        attributes: |
-          - Environmental Variable: `METRICS_BASIC_AUTH`
-          - Config File Key: `metrics_basic_auth`
-          - Type: base64 encoded `string` of `username:password`
-          - Example: `eDp5` (for username: x, and password: y)
-          - Default: ``
-          - Optional
-        doc: |
-          Require [Basic HTTP Authentication](https://tools.ietf.org/html/rfc7617) to access the metrics endpoint.
-
-          To support this in Prometheus, consult the `basic_auth` option in the [`scrape_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)
-          documentation.
-      - name: "Metrics Certificate"
-        keys:
-          [
-            "metrics_certificate",
-            "metrics_certificate_key",
-            "metrics_certificate_file",
-            "metrics_certificate_key_file",
-          ]
-        attributes: |
-          - Config File Key: `metrics_certificate` / `metrics_certificate_key`
-          - Config File Key: `metrics_certificate_file` / `metrics_certificate_key_file`
-          - Environmental Variable: `METRICS_CERTIFICATE` / `METRICS_CERTIFICATE_KEY`
-          - Environmental Variable: `METRICS_CERTIFICATE_FILE` / `METRICS_CERTIFICATE_KEY_FILE`
-          - Type: [base64 encoded] `string`
-          - Type: certificate relative file location `string`
-          - Optional
-        doc: |
-          Certificates are the x509 _public-key_ and _private-key_ used to secure the metrics endpoint.
-      - name: "Metrics Client Certificate Authority"
-        keys: ["metrics_client_ca", "metrics_client_ca_file"]
-        attributes: |
-          - Environment Variable: `METRICS_CLIENT_CA` / `METRICS_CLIENT_CA_FILE`
-          - Config File Key: `metrics_client_ca` / `metrics_client_ca_file`
-          - Type: [base64 encoded] `string` or relative file location
-          - Optional
-        doc: |
-          The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) client certificates for the metrics endpoint. If not set, no client certificate will be required.
-      - name: "Proxy Log Level"
-        keys: ["proxy_log_level"]
-        attributes: |
-          - Environmental Variable: `PROXY_LOG_LEVEL`
-          - Config File Key: `proxy_log_level`
-          - Type: `string`
-          - Options: `debug` `info` `warn` `error`
-          - Default: value of `log_level` or `debug` if both are unset
-        doc: |
-          Proxy log level sets the logging level for the Pomerium Proxy service access logs. Only logs of the desired level and above will be logged.
-        shortdoc: |
-          Log level sets the logging level for the Pomerium Proxy service.
-      - name: "Service Mode"
-        keys: ["services"]
-        attributes: |
-          - Environmental Variable: `SERVICES`
-          - Config File Key: `services`
-          - Type: `string`
-          - Default: `all`
-          - Options: `all` `authenticate` `authorize` `databroker` or `proxy`
-        doc: |
-          Service mode sets which service(s) to run. If testing, you may want to set to `all` and run pomerium in "all-in-one mode." In production, you'll likely want to spin up several instances of each service mode for high availability.
-        shortdoc: |
-          Service mode sets the pomerium service(s) to run.
-      - name: "Shared Secret"
-        keys: ["shared_secret"]
-        attributes: |
-          - Environmental Variable: `SHARED_SECRET`
-          - Config File Key: `shared_secret`
-          - Type: [base64 encoded] `string`
-          - Required
-        doc: |
-          Shared Secret is the base64 encoded 256-bit key used to mutually authenticate requests between services. It's critical that secret keys are random, and stored safely. Use a key management system or `/dev/urandom` to generate a key. For example:
-
-          ```
-          head -c32 /dev/urandom | base64
-          ```
-        shortdoc: |
-          Shared Secret is the base64 encoded 256-bit key used to mutually authenticate requests between services.
-      - name: "Tracing"
-        keys:
-          [
-            "tracing_provider",
-            "tracing_sample_rate",
-            "tracing_datadog_address",
-            "tracing_jaeger_collector_endpoint",
-            "tracing_jaeger_agent_endpoint",
-            "tracing_zipkin_endpoint",
-          ]
-        doc: |
-          Tracing tracks the progression of a single user request as it is handled by Pomerium.
-
-          Each unit of work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
-
-          #### Shared Tracing Settings
-
-          Config Key          | Description                                                                          | Required
-          :------------------ | :----------------------------------------------------------------------------------- | --------
-          tracing_provider    | The name of the tracing provider. (e.g. jaeger, zipkin)                              | ✅
-          tracing_sample_rate | Percentage of requests to sample in decimal notation. Default is `0.0001`, or .01%   | ❌
-
-          #### Datadog
-
-          Datadog is a real-time monitoring system that supports distributed tracing and monitoring.
-
-          Config Key              | Description                                                                  | Required
-          :---------------------- | :--------------------------------------------------------------------------- | --------
-          tracing_datadog_address | `host:port` address of the Datadog Trace Agent. Defaults to `localhost:8126` | ❌
-
-          #### Jaeger (partial)
-
-          **Warning** At this time, Jaeger protocol does not capture spans inside the Proxy service. Please use Zipkin protocol with Jaeger for full support.
-
-          [Jaeger](https://www.jaegertracing.io/) is a distributed tracing system released as open source by Uber Technologies. It is used for monitoring and troubleshooting microservices-based distributed systems, including:
-
-          - Distributed context propagation
-          - Distributed transaction monitoring
-          - Root cause analysis
-          - Service dependency analysis
-          - Performance / latency optimization
-
-          Config Key                        | Description                                 | Required
-          :-------------------------------- | :------------------------------------------ | --------
-          tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅
-          tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅
-
-          #### Zipkin
-
-          Zipkin is an open source distributed tracing system and protocol.
-
-          Many tracing backends support zipkin either directly or through intermediary agents, including Jaeger. For full tracing support, we recommend using the Zipkin tracing protocol.
-
-          Config Key              | Description                      | Required
-          :---------------------- | :------------------------------- | --------
-          tracing_zipkin_endpoint | Url to the Zipkin HTTP endpoint. | ✅
-
-          #### Example
-
-          ![jaeger example trace](./img/jaeger.png)
-      - name: "Use Proxy Protocol"
-        keys: ["use_proxy_protocol"]
-        attributes: |
-          - Environment Variable: `USE_PROXY_PROTOCOL`
-          - Config File Key: `use_proxy_protocol`
-          - Type: `bool`
-          - Optional
-        doc: |
-          Setting `use_proxy_protocol` will configure Pomerium to require the [HAProxy proxy protocol](https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt) on incoming connections. Versions 1 and 2 of the protocol are supported.
-      - name: "Envoy Bootstrap Options"
-        keys:
-          [
-            "envoy_admin_address",
-            "envoy_admin_access_log_path",
-            "envoy_admin_profile_path",
-            "envoy_bind_config_freebind",
-            "envoy_bind_config_source_address",
-          ]
-        attributes: |
-          - Environment Variable: `ENVOY_ADMIN_ADDRESS`, `ENVOY_ADMIN_ACCESS_LOG_PATH`, `ENVOY_ADMIN_PROFILE_PATH`, `ENVOY_BIND_CONFIG_FREEBIND`, `ENVOY_BIND_CONFIG_SOURCE_ADDRESS`
-          - Config File Keys: `envoy_admin_address`, `envoy_admin_access_log_path`, `envoy_admin_profile_path`, `envoy_bind_config_freebind`, `envoy_bind_config_source_address`
-          - Type: `string`
-          - Optional
-        doc: |
-          The `envoy_admin` keys customize Envoy's [bootstrap configuration](https://www.envoyproxy.io/docs/envoy/latest/operations/admin#operations-admin-interface). The `envoy_bind_config` keys modify the [ClusterManager](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/bootstrap/v3/bootstrap.proto.html#config-bootstrap-v3-clustermanager) configuration. These options cannot be modified at runtime.
-  - name: "Authenticate Service"
-    settings:
-      - name: "Authenticate Callback Path"
-        keys: ["authenticate_callback_path"]
-        attributes: |
-          - Environmental Variable: `AUTHENTICATE_CALLBACK_PATH`
-          - Config File Key: `authenticate_callback_path`
-          - Type: `string`
-          - Default: `/oauth2/callback`
-          - Optional
-        doc: |
-          Authenticate callback path sets the path at which the authenticate service receives callback responses from your identity provider. The value must exactly match one of the authorized redirect URIs for the OAuth 2.0 client.
-
-          This value is referred to as the `redirect_url` in the [OpenIDConnect][oidc rfc] and OAuth2 specs.
-
-          See also:
-
-          - [OAuth2 RFC 6749](https://tools.ietf.org/html/rfc6749#section-3.1.2)
-          - [OIDC Spec][oidc rfc]
-          - [Google - Setting Redirect URI](https://developers.google.com/identity/protocols/OpenIDConnect#setredirecturi)
-        shortdoc: |
-          The authenticate callback path is the path/url from the authenticate service that will receive the response from your identity provider.
-      - name: "Authenticate Internal Service URL"
-        keys: ["authenticate_internal_service_url"]
-        attributes: |
-          - Environmental Variable: `AUTHENTICATE_INTERNAL_SERVICE_URL`
-          - Config File Key: `authenticate_internal_service_url`
-          - Type: `URL`
-          - Required
-          - Example: `https://authenticate.internal`
-        short: |
-          Authenticate Service URL is the internally accessible URL for the authenticate service.
-        doc: |
-          Authenticate Internal Service URL overrides `authenticate_service_url` when determining the TLS certificate and hostname for the authenticate service to listen with.
-      - name: "Identity Provider Client ID"
-        keys: ["idp_client_id"]
-        attributes: |
-          - Environmental Variable: `IDP_CLIENT_ID`
-          - Config File Key: `idp_client_id`
-          - Type: `string`
-          - Required
-        doc: |
-          Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider] docs for details.
-        shortdoc: |
-          Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provider.
-      - name: "Identity Provider Client Secret"
-        keys: ["idp_client_secret"]
-        attributes: |
-          - Environmental Variable: `IDP_CLIENT_SECRET`
-          - Config File Key: `idp_client_secret`
-          - Type: `string`
-          - Required
-        doc: |
-          Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider] docs for details.
-        shortdoc: |
-          Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity provider.
-      - name: "Identity Provider Name"
-        keys: ["idp_provider"]
-        attributes: |
-          - Environmental Variable: `IDP_PROVIDER`
-          - Config File Key: `idp_provider`
-          - Type: `string`
-          - Required
-          - Options: `auth0` `azure` `google` `okta` `onelogin` or `oidc`
-        doc: |
-          Provider is the short-hand name of a built-in OpenID Connect (oidc) identity provider to be used for authentication. To use a generic provider,set to `oidc`.
-
-          See [identity provider] for details.
-        shortdoc: |
-          Provider is the short-hand name of a built-in OpenID Connect (oidc) identity provider to be used for authentication.
-      - name: "Identity Provider Scopes"
-        keys: ["idp_scopes"]
-        attributes: |
-          - Environmental Variable: `IDP_SCOPES`
-          - Config File Key: `idp_scopes`
-          - Type: list of `string`
-          - Default: `oidc`,`profile`, `email`, `offline_access` (typically)
-          - Optional for built-in identity providers.
-        doc: |
-          Identity provider scopes correspond to access privilege scopes as defined in Section 3.3 of OAuth 2.0 RFC6749\. The scopes associated with Access Tokens determine what resources will be available when they are used to access OAuth 2.0 protected endpoints.
-
-          :::warning
-
-          If you are using a built-in provider, you probably don't want to set customized scopes.
-
-          :::
-
-          :::warning
-
-          Some providers, like Amazon Cognito, _do not_ support the `offline_access` scope.
-
-          :::
-
-        shortdoc: |
-          Identity provider scopes correspond to access privilege scopes as defined in Section 33 of OAuth 20 RFC6749.
-      - name: "Identity Provider Service Account"
-        keys: ["idp_service_account"]
-        attributes: |
-          - Environmental Variable: `IDP_SERVICE_ACCOUNT`
-          - Config File Key: `idp_service_account`
-          - Type: `string`
-          - **Required** for group based policies (most configurations)
-        doc: |
-          The identity provider service account setting is used to query associated identity information from your identity provider.  This is a provider specific value and is not required for all providers.  For example, when using Okta this value will be an Okta API key, and for an OIDC provider that provides groups as a claim, this value will be empty.
-
-          :::warning
-
-          If you plan to write authorization policies using groups, or any other data that exists in your identity provider's directory service, this setting is **mandatory**.
-
-          :::
-        shortdoc: |
-          Identity Provider Service Account is field used to configure any additional user account or access-token that may be required for querying additional user information during authentication.
-      - name: "Identity Provider URL"
-        keys: ["idp_provider_url"]
-        attributes: |
-          - Environmental Variable: `IDP_PROVIDER_URL`
-          - Config File Key: `idp_provider_url`
-          - Type: `string`
-          - Required, depending on provider (Do not use with Google).
-        doc: |
-          Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). An example Azure URL would be `https://login.microsoftonline.com/common/v2.0` for [their discover document](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration).
-
-          "Base path" is defined as the section of the URL to the discovery document up to (but not including) `/.well-known/openid-configuration`.
-        shortdoc: |
-          Provider URL is the base path to an identity provider's OpenID connect discovery document.
-      - name: "Identity Provider Request Params"
-        keys: ["idp_request_params"]
-        attributes: |
-          - Environmental Variable: `IDP_REQUEST_PARAMS`
-          - Config File Key: `idp_request_params`
-          - Type: map of `strings` key value pairs
-          - Optional
-        doc: |
-          Request parameters to be added as part of a signin request using OAuth2 code flow.
-
-          For more information see:
-
-          - [OIDC Request Parameters](https://openid.net/specs/openid-connect-basic-1_0.html#RequestParameters)
-          - [IANA OAuth Parameters](https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml)
-          - [Microsoft Azure Request params](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code)
-          - [Google Authentication URI parameters](https://developers.google.com/identity/protocols/oauth2/openid-connect)
-        shortdoc: |
-          Headers specifies a mapping of HTTP Header to be added to proxied  requests. Nota bene Downstream application headers will be overwritten by Pomerium's headers on conflict.
-      - name: "Identity Provider Refresh Directory Settings"
-        keys:
-          ["idp_refresh_directory_interval", "idp_refresh_directory_timeout"]
-        attributes: |
-          - Environmental Variables: `IDP_REFRESH_DIRECTORY_INTERVAL` `IDP_REFRESH_DIRECTORY_TIMEOUT`
-          - Config File Key: `idp_refresh_directory_interval` `idp_refresh_directory_timeout`
-          - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
-          - Example: `IDP_REFRESH_DIRECTORY_INTERVAL=30m`
-          - Defaults: `IDP_REFRESH_DIRECTORY_INTERVAL=10m` `IDP_REFRESH_DIRECTORY_TIMEOUT=1m`
-        doc: |
-          Refresh directory interval is the time that pomerium will sync your IDP diretory, while refresh directory timeout is the maximum time allowed each run.
-
-          :::warning
-
-          Use it at your own risk, if you set a too low value, you may reach IDP API rate limit.
-
-          :::
-  - name: "Proxy Service"
-    settings:
-      - name: "Authorize Service URL"
-        keys: ["authorize_service_url"]
-        attributes: |
-          - Environmental Variable: `AUTHORIZE_SERVICE_URL or `AUTHORIZE_SERVICE_URLS`
-          - Config File Key: `authorize_service_url` or `authorize_service_urls`
-          - Type: `URL`
-          - Required; inferred in all-in-one mode to be localhost.
-          - Example: `https://pomerium-authorize-service.default.svc.cluster.local`, `https://localhost:5443`, `https://authorize.corp.example.com`
-        doc: |
-          Authorize Service URL is the location of the internally accessible Authorize service. NOTE: Unlike authenticate, authorize has no publicly accessible http handlers so this setting is purely for gRPC communication.
-
-          Multiple URLs can be specified with `authorize_service_urls`.
-
-          If your load balancer does not support gRPC pass-through you'll need to set this value to an internally routable location (`https://pomerium-authorize-service.default.svc.cluster.local`) instead of an externally routable one (`https://authorize.corp.example.com`).
-        shortdoc: |
-          Authorize Service URL is the location of the internally accessible Authorize service.
-      - name: "Authorize Internal Service URL"
-        keys: ["authorize_internal_service_url"]
-        attributes: |
-          - Environmental Variable: `AUTHORIZE_INTERNAL_SERVICE_URL`
-          - Config File Key: `authorize_internal_service_url`
-          - Type: `URL`
-          - Required; inferred in all-in-one mode to be localhost.
-          - Example: `https://pomerium-authorize-service.default.svc.cluster.local` or `https://localhost:5443`
-        doc: |
-          Authorize Internal Service URL overrides `authorize_service_url` when determining the TLS certificate for the authorize service to listen with.
-      - name: "Certificate Authority"
-        keys: ["certificate_authority", "certificate_authority_file"]
-        attributes: |
-          - Environmental Variable: `CERTIFICATE_AUTHORITY` or `CERTIFICATE_AUTHORITY_FILE`
-          - Config File Key: `certificate_authority` or `certificate_authority_file`
-          - Type: [base64 encoded] `string` or relative file location
-          - Optional
-        doc: |
-          This defines a set of root certificate authorities that Pomerium uses when communicating with other TLS-protected services.
-
-          **Note**: Unlike route-specific certificate authority settings, this setting augments (rather than replaces) the system's trust store. But routes that specify a CA will ignore those provided here.
-
-          :::warning
-
-          Be sure to include the intermediary certificate.
-
-          :::
-        shortdoc: |
-          Certificate Authority is set when behind-the-ingress service communication uses self-signed certificates.
-      - name: "Default Upstream Timeout"
-        keys: ["default_upstream_timeout"]
-        attributes: |
-          - Environmental Variable: `DEFAULT_UPSTREAM_TIMEOUT`
-          - Config File Key: `default_upstream_timeout`
-          - Type: [Duration](https://golang.org/pkg/time/#Duration) `string`
-          - Example: `10m`, `1h45m`
-          - Default: `30s`
-        doc: |
-          Default Upstream Timeout is the default timeout applied to a proxied route when no `timeout` key is specified by the policy.
-        shortdoc: |
-          Default Upstream Timeout is the default timeout applied to a proxied route when no timeout key is specified by the policy.
-      - name: "Set Response Headers"
-        keys: ["set_response_headers"]
-        attributes: |
-          - Environmental Variable: `SET_RESPONSE_HEADERS`
-          - Config File Key: `set_response_headers`
-          - Type: map of `strings` key value pairs
-          - Examples:
-
-            - Comma Separated: `X-Content-Type-Options:nosniff,X-Frame-Options:SAMEORIGIN`
-            - JSON: `'{"X-Test": "X-Value"}'`
-            - YAML:
-
-              ```yaml
-              set_response_headers:
-                X-Test: X-Value
-              ```
-
-          - To disable: `disable:true`
-
-          - Default :
-
-            ```javascript
-            X-Content-Type-Options : nosniff,
-            X-Frame-Options:SAMEORIGIN,
-            X-XSS-Protection:1; mode=block,
-            Strict-Transport-Security:max-age=31536000; includeSubDomains; preload,
-            ```
-        doc: |
-          Set Response Headers specifies a mapping of [HTTP Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers) to be added globally to all managed routes and pomerium's authenticate service.
-
-          By default, conservative [secure HTTP headers](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project) are set:
-
-            - `max-age=31536000` instructs the browser to pin the certificate for a domain for a year. This helps prevent man-in-the-middle attacks, but can create issues when developing new environments with temporary certificates. See [Troubleshooting - HSTS](/docs/troubleshooting.md#http-strict-transport-security-hsts) for more information.
-            - `includeSubDomains` applies these rules to subdomains, which is how individual routes are defined.
-            - `preload` instructs the browser to preload the certificate from an HSTS preload service if available. This means that the certificate can be loaded from an already-trusted secure connection, and the user never needs to connect to your domain without TLS.
-
-          ![pomerium security headers](./img/security-headers.png)
-
-          See [MDN Web Docs - Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) for more information.
-
-          :::tip
-
-          Several security-related headers are not set by default since doing so might break legacy sites. These include:
-          `Cross-Origin Resource Policy`, `Cross-Origin Opener Policy` and `Cross-Origin Embedder Policy`. If possible
-          users are encouraged to add these to `set_response_headers` or their downstream applications.
-
-          :::
-      - name: "JWT Claim Headers"
-        keys: ["jwt_claims_headers"]
-        attributes: |
-          - Environmental Variable: `JWT_CLAIMS_HEADERS`
-          - Config File Key: `jwt_claims_headers`
-          - Type: slice of `string`
-          - Example: `email`, `groups`, `user`, `given_name`
-          - Optional
-        doc: |
-          The JWT Claim Headers setting allows you to pass specific user session data to upstream applications as HTTP request headers. Note, unlike the header `x-pomerium-jwt-assertion` these values are not signed by the authorization service.
-
-          Additionally, this will add the claim to the `X-Pomerium-Jwt-Assertion` header provided by [`pass_identity_headers`](#pass-identity-headers), if not already present.
-
-          Any claim in the pomerium session JWT can be placed into a corresponding header and the JWT payload for upstream consumption. This claim information is sourced from your Identity Provider (IdP) and Pomerium's own session metadata. The header will have the following format:
-
-          `X-Pomerium-Claim-{Name}` where `{Name}` is the name of the claim requested. Underscores will be replaced with dashes; e.g. `X-Pomerium-Claim-Given-Name`.
-
-          This option also supports a nested object to customize the header name. For example:
-
-          ```yaml
-          jwt_claims_headers:
-            X-Email: email
-          ```
-
-          Will add an `X-Email` header with a value of the `email` claim.
-
-          Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}`.
-        shortdoc: |
-          The JWT Claim Headers setting allows you to pass specific user session data to upstream applications as HTTP request headers and additional JWT claims.
-      - name: "Override Certificate Name"
-        keys: ["override_certificate_name"]
-        attributes: |
-          - Environmental Variable: `OVERRIDE_CERTIFICATE_NAME`
-          - Config File Key: `override_certificate_name`
-          - Type: `string`
-          - Optional
-          - Example: `*.corp.example.com` if wild card or `authenticate.corp.example.com`/`authorize.corp.example.com`
-        doc: |
-          Secure service communication can fail if the external certificate does not match the internally routed service hostname/[SNI](https://en.wikipedia.org/wiki/Server_Name_Indication). This setting allows you to override that value.
-        shortdoc: |
-          Secure service communication can fail if the external certificate does not match the internally routed service hostname/SNI.
-      - name: "Programmatic Redirect Domain Whitelist"
-        keys: ["programmatic_redirect_domain_whitelist"]
-        attributes: |
-          - Config File Key: `programmatic_redirect_domain_whitelist`
-          - Type: array of `string`
-          - Optional
-          - Default: `localhost`
-        doc: |
-          The programmatic redirect domain whitelist is used to restrict the allowed redirect URLs when using programmatic login. By default only `localhost` URLs are allowed.
-      - name: "X-Forwarded-For HTTP Header"
-        keys: ["skip_xff_append"]
-        attributes: |
-          - Environmental Variable: `SKIP_XFF_APPEND`
-          - Config File Key: `skip_xff_append`
-          - Type: `bool`
-          - Default: `false`
-        doc: |
-          Do not append proxy IP address to `x-forwarded-for` HTTP header. See [Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=skip_xff_append#x-forwarded-for) docs for more detail.
-        shortdoc: |
-          Do not append proxy IP address to [x-forwarded-for](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=skip_xff_append#x-forwarded-for).
-      - name: "The number of trusted hops"
-        keys: ["xff_num_trusted_hops"]
-        attributes: |
-          - Environmental Variable: `XFF_NUM_TRUSTED_HOPS`
-          - Config File Key: `xff_num_trusted_hops`
-          - Type: `uint32`
-          - Default: `0`
-        doc: |
-          The number of trusted reverse proxies in front of pomerium. This affects `x-forwarded-proto` header and [`x-envoy-external-address` header](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-envoy-external-address), which reports tursted client address. [Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=xff_num_trusted_hops#x-forwarded-for) docs for more detail.
-        shortdoc: |
-          The number of trusted reverse proxies in front of pomerium.
-      - name: "Codec Type"
-        keys: ["codec_type"]
-        attributes: |
-          - Environment Variable: `CODEC_TYPE`
-          - Config File Key: `codec_type`
-          - Type: `string`
-          - Default: `auto` (`http1` in all-in-one mode)
-        doc: |
-          Specifies the codec to use for downstream connections. Either `auto`, `http1` or `http2`.
-
-          When `auto` is specified the codec will be determined via TLS ALPN or protocol inference.
-
-          :::warning
-
-          With HTTP/2, browsers typically coalesce connections for the same IP address that use the same
-          TLS certificate. For example, you may have `authenticate.localhost.pomerium.io` and
-          `example.localhost.pomerium.io` using the same wildcard certificate (`*.localhost.pomerium.io`)
-          and both pointing to `127.0.0.1`. Your browser sees this and re-uses the initial connection
-          it makes to `example` for `authenticate`. But unfortunately the routes necessary to handle
-          `authenticate` don't exist on `example` so the proxy cannot handle the request.
-
-          If this happens Pomerium will respond with a `421 Misdirected Request` status. Most browsers will attempt to
-          make the request on a new HTTP/2 connection. However not all browsers implement this behavior
-          (notably Safari), and users may end up seeing a blank page instead.
-
-          If you see this happen, there are several ways to mitigate the problem:
-
-          1. Don't re-use TLS certificates for shared IP domains.
-          2. Don't re-use IP addresses for shared TLS certificates.
-          3. Don't use HTTP/2.
-
-          More details on this problem are available in [Github Issue #2150](https://github.com/pomerium/pomerium/issues/2150).
-
-          :::
-  - name: "Data Broker Service"
-    doc: |
-      The databroker service is used for storing user session data.
-
-      By default, the `databroker` service uses an in-memory databroker.
-
-      To create your own data broker, implement the following gRPC interface:
-
-      - [pkg/grpc/databroker/databroker.proto](https://github.com/pomerium/pomerium/blob/main/pkg/grpc/databroker/databroker.proto)
-
-      For an example implementation, the in-memory database used by the databroker service can be found here:
-
-      - [pkg/databroker/memory](https://github.com/pomerium/pomerium/tree/main/pkg/databroker/memory)
-    settings:
-      - name: "Data Broker Internal Service URL"
-        keys: ["databroker_internal_service_url"]
-        attributes: |
-          - Environmental Variable: `DATABROKER_INTERNAL_SERVICE_URL` or `DATABROKER_INTERNAL_SERVICE_URLS`
-          - Config File Key: `databroker_internal_service_url` or `databroker_internal_service_urls`
-          - Type: `URL`
-          - Example: `https://databroker.corp.example.com`
-          - Default: in all-in-one mode, `http://localhost:5443`
-        doc: |
-          Data Broker Internal URL overrides `databroker_service_url` when determining the TLS certificate for the databroker service to listen with.
-      - name: "Data Broker Storage Type"
-        keys: ["databroker_storage_type"]
-        attributes: |
-          - Environmental Variable: `DATABROKER_STORAGE_TYPE`
-          - Config File Key: `databroker_storage_type`
-          - Type: `string`
-          - Optional
-          - Example: `redis`,`memory`
-          - Default: `memory`
-        doc: |
-          The backend storage that databroker server will use.
-      - name: "Data Broker Storage Connection String"
-        keys: ["databroker_storage_connection_string"]
-        attributes: |
-          - Environmental Variable: `DATABROKER_STORAGE_CONNECTION_STRING`
-          - Config File Key: `databroker_storage_connection_string`
-          - Type: `string`
-          - **Required** when storage type is `redis`
-          - Example: `"redis://localhost:6379/0"`, `"rediss://localhost:6379/0"`
-        doc: |
-          The connection string that the databroker service will use to connect to storage backend.
-
-          For `redis`, the following URL types are supported:
-
-          - simple: `redis://[username:password@]host:port/[db]`
-          - sentinel: `redis+sentinel://[:password@]host:port[,host2:port2,...]/[master_name[/db]][?param1=value1[&param2=value2&...]]`
-          - cluster: `redis+cluster://[username:password@]host:port[,host2:port2,...]/[?param1=value1[&param2=value=2&...]]`
-
-          You can also enable TLS with `rediss://`, `rediss+sentinel://` and `rediss+cluster://`.
-      - name: "Data Broker Storage Certificate File"
-        keys: ["databroker_storage_cert_file"]
-        attributes: |
-          - Environment Variable: `DATABROKER_STORAGE_CERT_FILE`
-          - Config File Key: `databroker_storage_cert_file`
-          - Type: relative file location
-          - Optional
-        doc: |
-          The certificate used to connect to a storage backend.
-      - name: "Data Broker Storage Certificate Key File"
-        keys: ["databroker_storage_key_file"]
-        attributes: |
-          - Environment Variable: `DATABROKER_STORAGE_KEY_FILE`
-          - Config File Key: `databroker_storage_key_file`
-          - Type: relative file location
-          - Optional
-        doc: |
-          The certificate key used to connect to a storage backend.
-      - name: "Data Broker Storage Certificate Authority"
-        keys: ["databroker_storage_ca_file"]
-        attributes: |
-          - Environment Variable: `DATABROKER_STORAGE_CA_FILE`
-          - Config File Key: `databroker_storage_ca_file`
-          - Type: relative file location
-          - Optional
-        doc: |
-          This setting defines the set of root certificates used when verifying storage server connections.
-      - name: "Data Broker Storage TLS Skip Verify"
-        keys: ["databroker_storage_tls_skip_verify"]
-        attributes: |
-          - Environment Variable: `DATABROKER_STORAGE_TLS_SKIP_VERIFY`
-          - Config File Key: `databroker_storage_tls_skip_verify`
-          - Type: relative file location
-          - Optional
-        doc: |
-          If set, the TLS connection to the storage backend will not be verified.
-  - name: "Policy"
-    keys: ["policy"]
+- name: Shared Settings
+  doc: |
+    These configuration variables are shared by all services, in all service modes.
+  settings:
+  - name: Address
+    keys: [address]
     attributes: |
-      - Environmental Variable: `POLICY`
-      - Config File Key: `policy`
-      - Type: [base64 encoded] `string` or inline policy structure in config file
-      - **Deprecated**: This key has been replaced with `route`.
+      - Environmental Variable: `ADDRESS`
+      - Config File Key: `address`
+      - Type: `string`
+      - Example: `:443`, `:8443`
+      - Default: `:443`
+      - Required
     doc: |
+      Address specifies the host and port to serve HTTP requests from. If empty, `:443` is used. Note, in all-in-one deployments, gRPC traffic will be served on loopback on port `:5443`.
+    shortdoc: |
+      Address specifies the host and port to serve HTTP requests from.
+    uuid: 0ed5bb0a-74e3-4db5-85c9-45129aeccee3
+  - name: Authenticate Service URL
+    keys: [authenticate_service_url]
+    attributes: |
+      - Environmental Variable: `AUTHENTICATE_SERVICE_URL`
+      - Config File Key: `authenticate_service_url`
+      - Type: `URL`
+      - Required
+      - Example: `https://authenticate.corp.example.com`
+    doc: |
+      Authenticate Service URL is the externally accessible URL for the authenticate service. In split service mode, this key is required by all services other than Databroker.
+    shortdoc: |
+      Authenticate Service URL is the externally accessible URL for the authenticate service.
+    uuid: 5e698d84-bc2b-4851-81b0-237651f9ed74
+  - name: Autocert
+    keys: [autocert]
+    attributes: |
+      - Environmental Variable: `AUTOCERT`
+      - Config File Key: `autocert`
+      - Type: `bool`
+      - Optional
+    doc: |
+      Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from [Let's Encrypt][letsencrypt] which includes managed routes and the authenticate service.  [Autocert Directory](#autocert-directory) must be used with Autocert must have a place to persist, and share certificate data between services. Note that autocert also provides [OCSP stapling](https://en.wikipedia.org/wiki/OCSP_stapling).
 
-      ::: warning
-      The `policy` field as a top-level configuration key has been replaced with [`routes`](/reference/readme.md#routes). Moving forward, define policies within each defined route.
+      This setting can be useful in situations where you may not have Pomerium behind a TLS terminating ingress or proxy that is already handling your public certificates on your behalf.
 
-      Existing policy definitions will currently behave as expected, but are deprecated and will be removed in a future version of Pomerium.
+      :::warning
+
+      By using autocert, you agree to the [Let's Encrypt Subscriber Agreement](https://letsencrypt.org/documents/LE-SA-v1.2-November-15-2017.pdf). There are [_strict_ usage limits](https://letsencrypt.org/docs/rate-limits/) per domain you should be aware of. Consider testing with `autocert_use_staging` first.
+
       :::
 
-      Policy contains route specific settings, and access control details. If you are configuring via POLICY environment variable, just the contents of the policy needs to be passed. If you are configuring via file, the policy should be present under the policy key. For example,
+      :::warning
 
-      <<< @/examples/config/policy.example.yaml
+      Autocert requires that ports `80`/`443` be accessible from the internet in order to complete a [TLS-ALPN-01 challenge](https://letsencrypt.org/docs/challenge-types/#tls-alpn-01).
 
-      Policy routes are checked in the order they appear in the policy, so more specific routes should appear before less specific routes. For example:
+      :::
+    shortdoc: |
+      Turning on autocert allows Pomerium to automatically retrieve, manage, and renew public facing TLS certificates from Lets Encrypt.
+    uuid: d6743ca2-4feb-497f-b901-b154a8c248e0
+  - name: Autocert CA
+    keys: [autocert_ca]
+    attributes: |
+      - Environmental Variable: `AUTOCERT_CA`
+      - Config File Key: `autocert_ca`
+      - Type: `string` containing the directory URL of an ACME CA (e.g. `https://acme.zerossl.com/v2/DV90` for ZeroSSL)
+      - Optional
+    doc: |
+      Autocert CA is the directory URL of the ACME CA to use when requesting certificates.
+
+      :::tip
+
+      This will overrule the "Autocert Use Staging" setting if set.
+
+      :::
+    shortdoc: |
+      Autocert CA is the directory URL of the ACME CA to use when requesting certificates.
+    uuid: 9a92d22d-de09-4707-bf02-f6867e312977
+  - name: Autocert Email
+    keys: [autocert_email]
+    attributes: |
+      - Environmental Variable: `AUTOCERT_EMAIL`
+      - Config File Key: `autocert_email`
+      - Type: `string` containing the email address to use when registering an account
+      - Optional
+    doc: |
+      Autocert Email is the email address to use when requesting certificates from an ACME CA.
+
+      :::tip
+
+      The CA may contact you at this address, for example when a certificate expires.
+
+      :::
+    shortdoc: |
+      Autocert Email is the email address to use when requesting certificates from an ACME CA.
+    uuid: ecc8774e-2b7e-4e9a-b87d-185f63b76102
+  - name: Autocert Must-Staple
+    keys: [autocert_must_staple]
+    attributes: |
+      - Environmental Variable: `AUTOCERT_MUST_STAPLE`
+      - Config File Key: `autocert_must_staple`
+      - Type: `bool`
+      - Optional
+    doc: |
+      If true, force autocert to request a certificate with the `status_request` extension (commonly called `Must-Staple`). This allows the TLS client (_id est_ the browser) to fail immediately if the TLS handshake doesn't include OCSP stapling information. This setting is only used when [Autocert](#autocert) is true.
+
+      :::tip
+
+      This setting will only take effect when you request or renew your certificates.
+
+      :::
+
+      For more details, please see [RFC7633](https://tools.ietf.org/html/rfc7633) .
+    uuid: 93f84bc9-c13c-4c89-a501-2f6bd87c6ef6
+  - name: Autocert Directory
+    keys: [autocert_dir]
+    attributes: |
+      - Environmental Variable: either `AUTOCERT_DIR`
+      - Config File Key: `autocert_dir`
+      - Type: `string` pointing to the path of the directory
+      - Required if using [Autocert](#autocert) setting
+      - Default:
+
+        - `/data/autocert` in published Pomerium docker images
+        - [$XDG_DATA_HOME](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)
+        - `$HOME/.local/share/pomerium`
+    doc: |
+      Autocert directory is the path which autocert will store x509 certificate data.
+    shortdoc: |
+      Autocert directory is the path which autocert will store x509 certificate data.
+    uuid: b33862da-0d87-4ca3-a515-b34e2c4f1789
+  - name: Autocert Use Staging
+    keys: [autocert_use_staging]
+    attributes: |
+      - Environmental Variable: `AUTOCERT_USE_STAGING`
+      - Config File Key: `autocert_use_staging`
+      - Type: `bool`
+      - Optional
+    doc: |
+      Let's Encrypt has strict [usage limits](https://letsencrypt.org/docs/rate-limits/). Enabling this setting allows you to use Let's Encrypt's [staging environment](https://letsencrypt.org/docs/staging-environment/) which has much more lax usage limits.
+    shortdoc: |
+      Let's Encrypt has strict usage limits. Enabling this setting allows you to use Let's Encrypt's staging environment which has much more lax usage limits.
+    uuid: d280b0e3-631f-4376-9abe-3813ed7f8f7a
+  - name: Autocert EAB Key ID
+    keys: [autocert_eab_key_id]
+    attributes: |
+      - Environmental Variable: `AUTOCERT_EAB_KEY_ID`
+      - Config File Key: `autocert_eab_key_id`
+      - Type: `string` containing the identifier for an ACME EAB key to use
+      - Optional
+    doc: |
+      Autocert EAB Key ID is the key identifier when requesting a certificate from a CA with External Account Binding enabled.
+
+      For more information, please see [RFC8555-#7.3.4](https://datatracker.ietf.org/doc/html/rfc8555#section-7.3.4).
+    shortdoc: |
+      Autocert EAB Key ID is the key identifier when requesting a certificate from a CA with External Account Binding enabled.
+    uuid: 9a42babb-4225-457e-8f01-1b4a729582b8
+  - name: Autocert EAB MAC Key
+    keys: [autocert_eab_mac_key]
+    attributes: |
+      - Environmental Variable: `AUTOCERT_EAB_MAC_KEY`
+      - Config File Key: `autocert_eab_mac_key`
+      - Type: `string` containing a base64url-encoded secret key
+      - Optional
+    doc: |
+      Autocert EAB MAC Key is the base64url-encoded secret key corresponding to the Autocert EAB Key ID.
+
+      This setting is required when Autocert EAB Key ID is set.
+    shortdoc: |
+      Autocert EAB MAC Key is the base64url-encoded secret key corresponding to the Autocert EAB Key ID.
+    uuid: edba2860-8db6-457f-8b8a-ce3fc9681534
+  - name: Autocert Trusted Certificate Authority
+    keys: [autocert_trusted_ca, autocert_trusted_ca_file]
+    attributes: |
+      - Environment Variable: `AUTOCERT_TRUSTED_CA` / `AUTOCERT_TRUSTED_CA_FILE`
+      - Config File Key: `autocert_trusted_ca` / `autocert_trusted_ca_file`
+      - Type: [base64 encoded] `string` or relative file location
+      - Optional
+    doc: |
+      The Autocert Trusted Certificate Authority is the x509 CA (bundle) used when communicating with a CA supporting the ACME protocol. If not set, the system trusted roots will be used to verify TLS connections to the ACME CA.
+    uuid: ba1fa5e2-e8a2-400f-aa42-aecf9acc4a1b
+  - name: Certificates
+    keys: [certificates, certificate, certificate_key, certificate_file, certificate_key_file]
+    attributes: |
+      - Config File Key: `certificates` (not yet settable using environmental variables)
+      - Config File Key: `certificate` / `certificate_key`
+      - Config File Key: `certificate_file` / `certificate_key_file`
+      - Environmental Variable: `CERTIFICATE` / `CERTIFICATE_KEY`
+      - Environmental Variable: `CERTIFICATE_FILE` / `CERTIFICATE_KEY_FILE`
+      - Type: array of relative file locations `string`
+      - Type: [base64 encoded] `string`
+      - Type: certificate relative file location `string`
+      - Required (if insecure not set)
+    doc: |
+      Certificates are the x509 _public-key_ and _private-key_ used to establish secure HTTP and gRPC connections. Any combination of the above can be used together, and are additive. You can also use any of these settings in conjunction with `Autocert` to get OCSP stapling.
+
+      Certificates loaded into Pomerium from these config values are used to attempt secure connections between end users and services, between Pomerium services, and to upstream endpoints.
+
+      For example, if specifying multiple certificates at once:
 
       ```yaml
-      policy:
-        - from: http://from.example.com
-          to: http://to.example.com
-          prefix: /admin
-          allowed_groups: ["superuser"]
-        - from: http://from.example.com
-          to: http://to.example.com
-          allow_public_unauthenticated_access: true
+      certificates:
+        - cert: "$HOME/.acme.sh/authenticate.example.com_ecc/fullchain.cer"
+          key: "$HOME/.acme.sh/authenticate.example.com_ecc/authenticate.example.com.key"
+        - cert: "$HOME/.acme.sh/verify.example.com_ecc/fullchain.cer"
+          key: "$HOME/.acme.sh/verify.example.com_ecc/verify.example.com.key"
+        - cert: "$HOME/.acme.sh/prometheus.example.com_ecc/fullchain.cer"
+          key: "$HOME/.acme.sh/prometheus.example.com_ecc/prometheus.example.com.key"
       ```
 
-      In this example, an incoming request with a path prefix of `/admin` would be handled by the first route (which is restricted to superusers). All other requests for `from.example.com` would be handled by the second route (which is open to the public).
+      Or to set a single certificate and key covering multiple domains and/or a wildcard subdomain:
 
-      A list of configuration variables specific to `policy` follows Note that this also shares all configuration variables listed under [routes](/reference/readme.md#routes), excluding `policy` and its child variables.
-    settings:
-      - name: "Allowed Domains"
-        keys: ["allowed_domains"]
-        attributes: |
-          - `yaml`/`json` setting: `allowed_domains`
-          - Type: list of `string`
-          - Required
-          - Example: `pomerium.io` , `gmail.com`
-        doc: |
-          Allowed domains is a collection of whitelisted domains to authorize for a given route.
-      - name: "Allowed Groups"
-        keys: ["allowed_groups"]
-        attributes: |
-          - `yaml`/`json` setting: `allowed_groups`
-          - Type: list of `string`
-          - Required
-          - Example: `admins` , `support@company.com`
-        doc: |
-          Allowed groups is a collection of whitelisted groups to authorize for a given route.
-      - name: "Allowed IdP Claims"
-        keys: ["allowed_idp_claims"]
-        attributes: |
-          - `yaml`/`json` setting: `allowed_idp_claims`
-          - Type: map of `strings` lists
-          - Required
-        shortdoc: |
-          Authorize users by matching claims attached to a user's identity token by their identity provider
-        doc: |
-          Allowed IdP Claims is a collection of whitelisted claim key-value pairs to authorize for a given route.
+      ```yaml
+      certificate_file: "$HOME/.acme.sh/*.example.com/fullchain.crt"
+      certificate_key:  "$HOME/.acme.sh/*.example.com/*.example.com.key"
+      ```
 
-          This is useful if your identity provider has extra information about a user that is not in the directory.  It can also be useful if you wish to use groups with the generic OIDC provider.
-
-          Example:
-
-          ```yaml
-            - from: http://from.example.com
-              to: http://to.example.com
-              allowed_idp_claims:
-                family_name:
-                  - Doe
-                  - Smith
-          ```
-
-          This policy would match users with the `family_name` claim containing `Smith` or `Doe`.
-
-          Claims are represented as a map of strings to a list of values:
-
-          ```json
-          {
-            "family_name": ["Doe"],
-            "given_name": ["John"]
-          }
-          ```
-
-          - Nested maps are flattened: `{ "a": { "b": ["c"] } }` becomes `{ "a.b": ["c"] }`
-          - Values are always a list: `{ "a": "b" }` becomes `{ "a": ["b"] }`
-      - name: "Allowed Users"
-        keys: ["allowed_users"]
-        attributes: |
-          - `yaml`/`json` setting: `allowed_users`
-          - Type: list of `string`
-          - Required
-          - Example: `alice@pomerium.io` , `bob@contractor.co`
-        doc: |
-          Allowed users is a collection of whitelisted users to authorize for a given route.
-  - name: "Routes"
-    keys: ["routes"]
+      **Note:** Pomerium will check your system's trust/key store for valid certificates first. If your certificate solution imports into the system store, you don't need to also specify them with these configuration keys.
+    uuid: 97d1aeeb-72f5-4b78-998c-9408b97f5f54
+  - name: Client Certificate Authority
+    keys: [client_ca, client_ca_file]
     attributes: |
-      - Environment Variable: `ROUTES`
-      - Config File Key: `routes`
-      - Type: [base64 encoded] `string` or inline policy structure in config file
-      - **Required** - While Pomerium will start without a route configured, it will not authorize or proxy any traffic until a route is defined. If configuring Pomerium for the Enterprise Console, define a route for the Console itself in Pomerium.
+      - Environment Variable: `CLIENT_CA` / `CLIENT_CA_FILE`
+      - Config File Key: `client_ca` / `client_ca_file`
+      - Type: [base64 encoded] `string` or relative file location
+      - Optional
     doc: |
-      A route contains specific access and control definitions for a back-end service. Each route is a list item under the `routes` key.
-
-      Each route defines at minimum a `from` and `to` field, and a `policy` key defining authorization logic. Policies are defined using [Pomerium Policy Language](/enterprise/reference/manage.md#pomerium-policy-language) (**PPL**). Additional options are listed below.
-
-      <<< @/examples/config/route.example.yaml
+      The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) client certificates. If not set, no client certificate will be required.
+    uuid: eda58b12-b5f6-4937-a0d5-9c059937d471
+  - name: Client CRL
+    keys: [client_crl, client_crl_file]
+    attributes: |
+      - Environment Variable: `CLIENT_CRL` / `CLIENT_CRL_FILE`
+      - Config File Key: `client_crl` / `client_crl_file`
+      - Type: [base64 encoded] `string` or relative file location
+      - Optional
+    doc: |
+      The Client CRL is the [certificate revocation list](https://en.wikipedia.org/wiki/Certificate_revocation_list)
+      (in PEM format) for client certificates. If not set, no CRL will be used.
+    uuid: 5839be2a-919b-4be6-bc4d-c95d60002606
+  - name: Cookie Options
     settings:
-      - name: "Allow Any Authenticated User"
-        keys: ["allow_any_authenticated_user"]
-        attributes: |
-          - `yaml`/`json` setting: `allow_any_authenticated_user`
-          - Type: `bool`
-          - Optional
-          - Default: `false`
-        doc: |
-          **Use with caution:** This setting will allow all requests for any user which is able to authenticate with our given identity provider. For instance, if you are using a corporate GSuite account, an unrelated gmail user will be able to access the underlying upstream.
+    - name: Cookie Name
+      keys: [cookie_name]
+      attributes: |
+        - Environmental Variable: `COOKIE_NAME`
+        - Config File Key: `cookie_name`
+        - Type: `string`
+        - Default: `_pomerium`
+      doc: |
+        The name of the session cookie sent to clients.
+      shortdoc: |
+        The name of the session cookie sent to clients.
+      uuid: 5d1b9f7d-0378-4969-b95a-c80ffce641f4
+    - name: Cookie Secret
+      keys: [cookie_secret]
+      attributes: |
+        - Environmental Variable: `COOKIE_SECRET`
+        - Config File Key: `cookie_secret`
+        - Type: [base64 encoded] `string`
+        - Required for Proxy service
+      doc: |
+        Secret used to encrypt and sign session cookies. You can generate a random key with `head -c32 /dev/urandom | base64`.
+      shortdoc: |
+        Secret used to encrypt and sign session cookies.
+      uuid: 1f96ae07-2d02-4010-9c5b-dc3b641e1b97
+    - name: Cookie Domain
+      keys: [cookie_domain]
+      attributes: |
+        - Environmental Variable: `COOKIE_DOMAIN`
+        - Config File Key: `cookie_domain`
+        - Type: `string`
+        - Example: `localhost.pomerium.io`
+        - Optional
+      doc: |
+        The scope of session cookies issued by Pomerium.
+      shortdoc: |
+        The scope of session cookies issued by Pomerium.
+      uuid: 090e1333-e489-4bf5-b652-721e7682c5ab
+    - name: HTTPS only
+      keys: [cookie_secure]
+      attributes: |
+        - Environmental Variable: `COOKIE_SECURE`
+        - Config File Key: `cookie_secure`
+        - Type: `bool`
+        - Default: `true`
+      doc: |
+        If true, instructs browsers to only send user session cookies over HTTPS.
 
-          Use of this setting means Pomerium **will not enforce centralized authorization policy** for this route. The upstream is responsible for handling any authorization.
-      - name: "Cluster Name"
-        keys: ["name"]
-        attributes: |
-          - Config File Key: `name`
-          - Type: `string`
-          - Optional
-        doc: |
-          Runtime metrics for this policy would be available under `envoy_cluster_`*`name`* prefix.
-      - name: "CORS Preflight"
-        keys: ["cors_allow_preflight"]
-        attributes: |
-          - `yaml`/`json` setting: `cors_allow_preflight`
-          - Type: `bool`
-          - Optional
-          - Default: `false`
-        doc: |
-          Allow unauthenticated HTTP OPTIONS requests as [per the CORS spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests).
-      - name: "Enable Google Cloud Serverless Authentication"
-        keys: ["enable_google_cloud_serverless_authentication"]
-        attributes: |
-          - Environmental Variable: `ENABLE_GOOGLE_CLOUD_SERVERLESS_AUTHENTICATION`
-          - Config File Key: `enable_google_cloud_serverless_authentication`
-          - Type: `bool`
-          - Default: `false`
-        doc: |
-          Enable sending a signed [Authorization Header](https://cloud.google.com/run/docs/authenticating/service-to-service) to upstream GCP services.
+        :::warning
 
-          Requires setting [Google Cloud Serverless Authentication Service Account](#google-cloud-serverless-authentication-service-account) or running Pomerium in an environment with a GCP service account present in default locations.
-      - name: "From"
-        keys: ["from"]
-        attributes: |
-          - `yaml`/`json` setting: `from`
-          - Type: `URL` (must contain a scheme and hostname, must not contain a path)
-          - Schemes: `https`, `tcp+https`
-          - Required
-          - Example: `https://verify.corp.example.com`, `tcp+https://ssh.corp.example.com:22`
-        doc: |
-          `From` is the externally accessible URL for the proxied request.
+        Setting this to false may result in session cookies being sent in cleartext.
 
-          Specifying `tcp+https` for the scheme enables [TCP proxying](/docs/tcp/readme.md) support for the route. You may map more than one port through the same hostname by specifying a different `:port` in the URL.
+        :::
+      shortdoc: |
+        If true, instructs browsers to only send user session cookies over HTTPS.
+      uuid: 8d90e462-1853-48bc-a7bf-3a45509bfef7
+    - name: Javascript Security
+      keys: [cookie_http_only]
+      attributes: |
+        - Environmental Variable: `COOKIE_HTTP_ONLY`
+        - Config File Key: `cookie_http_only`
+        - Type: `bool`
+        - Default: `true`
+      doc: |
+        If true, prevents javascript in browsers from reading user session cookies.
 
-          :::warning
+        :::warning
 
-          Only secure schemes (`https` and `tcp+https`) are supported.
+        Setting this to false enables hostile javascript to steal session cookies and impersonate users.
 
-          :::
-      - name: "Health Checks"
-        keys: ["health_checks"]
-        attributes: |
-          - Config File Key: `health_checks`
-          - Type: `array of objects`
-          - Optional
-        doc: |
-          When defined, will issue periodic health check requests to upstream servers. When health checks are defined, unhealthy upstream servers would not serve traffic.
-          See also `outlier_detection` for automatic upstream server health detection.
-          In presence of multiple upstream servers, it is recommended to set up either `health_checks` or `outlier_detection` or both.
+        :::
+      shortdoc: |
+        If true, prevents javascript in browsers from reading user session cookies.
+      uuid: 1ab6ff2e-e162-47f4-adeb-6d3b289f2966
+    - name: Expiration
+      keys: [cookie_expire]
+      attributes: |
+        - Environmental Variable: `COOKIE_EXPIRE`
+        - Config File Key: `cookie_expire`
+        - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
+        - Default: `14h`
+      doc: |
+        Sets the lifetime of session cookies. After this interval, users must reauthenticate.
+      shortdoc: |
+        Sets the lifetime of session cookies. After this interval, users must reauthenticate.
+      uuid: 4e69fd9b-fc3d-401d-8aae-b467192bec9d
+    uuid: 589c264c-670a-4f69-9ad1-e580fc476999
+  - name: Data Broker Service URL
+    keys: [databroker_service_url]
+    attributes: |
+      - Environmental Variable: `DATABROKER_SERVICE_URL` or `DATABROKER_SERVICE_URLS`
+      - Config File Key: `databroker_service_url` or `databroker_service_urls`
+      - Type: `URL`
+      - Example: `https://databroker.corp.example.com`
+      - Default: in all-in-one mode, `http://localhost:5443`
+    doc: |
+      The data broker service URL points to a data broker which is responsible for storing associated authorization context (e.g. sessions, users and user groups). Multiple URLs can be specified with `databroker_service_urls`.
+    uuid: 7cb15ca2-503e-4510-8c1d-9ed47b8e547e
+  - name: Debug
+    keys: [pomerium_debug]
+    attributes: |
+      - Environmental Variable: `POMERIUM_DEBUG`
+      - Config File Key: `pomerium_debug`
+      - Type: `bool`
+      - Default: `false`
+    doc: |
+      ::: danger
 
-          See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a list of [supported parameters](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-msg-config-core-v3-healthcheck).
+      Enabling the debug flag could result in sensitive information being logged!!!
 
-          Only one of `http_health_check`, `tcp_health_check`, or `grpc_health_check` may be configured per health_check object definition.
+      :::
 
-          - [TCP](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-msg-config-core-v3-healthcheck-tcphealthcheck)
-          - [HTTP](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-msg-config-core-v3-healthcheck-httphealthcheck)
-          - [GRPC](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-msg-config-core-v3-healthcheck-grpchealthcheck)
+      By default, JSON encoded logs are produced. Debug enables colored, human-readable logs to be streamed to [standard out](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout)>>>). In production, it is recommended to be set to `false`.
 
-          See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.md#active-health-checks).
-      - name: "Host Rewrite"
-        keys:
-          [
-            "host_rewrite",
-            "host_rewrite_header",
-            "host_path_regex_rewrite_pattern",
-            "host_path_regex_rewrite_substitution",
-            "preserve_host_header",
-          ]
-        attributes: |
-          - `yaml`/`json` settings: `host_rewrite`, `host_rewrite_header`, `host_path_regex_rewrite_pattern`, `host_path_regex_rewrite_substitution`
-          - Type: `string`
-          - Optional
-          - Example: `host_rewrite: "example.com"`
-        doc: |
-          The `host` header can be preserved via the `preserve_host_header` setting or customized via three mutually exclusive options:
+      For example, if `true`
 
-          1. `preserve_host_header` will, when enabled, this option will pass the host header from the incoming request to the proxied host, instead of the destination hostname. It's an optional parameter of type `bool` that defaults to `false`.
+      ```
+      10:37AM INF cmd/pomerium version=v0.0.1-dirty+ede4124
+      10:37AM INF proxy: new route from=verify.localhost.pomerium.io to=https://verify.pomerium.com
+      10:37AM INF proxy: new route from=ssl.localhost.pomerium.io to=http://neverssl.com
+      10:37AM INF proxy/authenticator: grpc connection OverrideCertificateName= addr=auth.localhost.pomerium.io:443
+      ```
 
-              See [ProxyPreserveHost](http://httpd.apache.org/docs/2.0/mod/mod_proxy.html#proxypreservehost).
-          2. `host_rewrite`, which will rewrite the host to a new literal value.
-          3. `host_rewrite_header`, which will rewrite the host to match an incoming header value.
-          4. `host_path_regex_rewrite_pattern` & `host_path_regex_rewrite_substitution`, which will rewrite the host according to a regex matching the path. For example with the following config:
+      If `false`
 
-              ```yaml
-              host_path_regex_rewrite_pattern: "^/(.+)/.+$"
-              host_path_regex_rewrite_substitution: \1
-              ```
+      ```
+      {"level":"info","version":"v0.0.1-dirty+ede4124","time":"2019-02-18T10:41:03-08:00","message":"cmd/pomerium"}
+      {"level":"info","from":"verify.localhost.pomerium.io","to":"https://verify.pomerium.com","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
+      {"level":"info","from":"ssl.localhost.pomerium.io","to":"http://neverssl.com","time":"2019-02-18T10:41:03-08:00","message":"proxy: new route"}
+      {"level":"info","OverrideCertificateName":"","addr":"auth.localhost.pomerium.io:443","time":"2019-02-18T10:41:03-08:00","message":"proxy/authenticator: grpc connection"}
+      ```
+    shortdoc: |
+      Debug enables colored, human-readable logs to be streamed to standard out.
+    uuid: 1b7bd6a8-b204-4e5d-a6c3-a6287e080330
+  - name: Forward Auth
+    keys: [forward_auth_url]
+    attributes: |
+      - Environmental Variable: `FORWARD_AUTH_URL`
+      - Config File Key: `forward_auth_url`
+      - Type: `URL` (must contain a scheme and hostname)
+      - Example: `https://forwardauth.corp.example.com`
+      - Resulting Verification URL: `https://forwardauth.corp.example.com/?uri={URL-TO-VERIFY}`
+      - Optional
+    doc: |
+      Forward authentication creates an endpoint that can be used with third-party proxies that do not have rich access control capabilities ([nginx](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html), [nginx-ingress](https://kubernetes.github.io/ingress-nginx/examples/auth/oauth-external-auth/), [ambassador](https://www.getambassador.io/reference/services/auth-service/), [traefik](https://docs.traefik.io/middlewares/forwardauth/)). Forward authentication allows you to delegate authentication and authorization for each request to Pomerium.
 
-              Would rewrite the host header to `example.com` given the path `/example.com/some/path`.
+      #### Request flow
 
-          The 2nd, 3rd and 4th options correspond to the Envoy route action host related options, which can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html#config-route-v3-routeaction).
-      - name: "Idle Timeout"
-        keys: ["idle_timeout"]
-        attributes: |
-          - `yaml`/`json` setting: `idle_timeout`
-          - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
-          - Optional
-          - Default: `5m`
-        doc: |
-          If you are proxying long-lived requests that employ streaming calls such as websockets or gRPC,
-          set this to either a maximum value there may be no data exchange over a connection (recommended),
-          or set it to unlimited (`0s`). If `idle_timeout` is specified, and `timeout` is not
-          explicitly set, then `timeout` would be unlimited (`0s`). You still may specify maximum lifetime
-          of the connection using `timeout` value (i.e. to 1 day).
-      - name: "Identity Provider Client ID (per route)"
-        keys: ["routes.idp_client_id"]
-        attributes: |
-          - `yaml`/`json` setting: `idp_client_id`
-          - Type: `string`
-          - Optional
-        doc: |
-          When set, this overrides the value of [idp_client_id](#identity-provider-client-id) set globally for this route.
-      - name: "Identity Provider Client Secret (per route)"
-        keys: ["routes.idp_client_id"]
-        attributes: |
-          - `yaml`/`json` setting: `idp_client_secret`
-          - Type: `string`
-          - Optional
-        doc: |
-          When set, this overrides the value of [idp_client_secret](#identity-provider-client-secret) set globally for this route.
-      - name: "Kubernetes Service Account Token"
-        keys:
-          [
-            "kubernetes_service_account_token",
-            "kubernetes_service_account_token_file",
-          ]
-        attributes: |
-          - `yaml`/`json` setting: `kubernetes_service_account_token` / `kubernetes_service_account_token_file`
-          - Type: `string` or relative file location containing a Kubernetes bearer token
-          - Optional
-          - Example: `eyJ0eXAiOiJKV1QiLCJhbGciOiJ...` or `/var/run/secrets/kubernetes.io/serviceaccount/token`
-        doc: |
-          Use this token to authenticate requests to a Kubernetes API server.
+      ![pomerium forward auth request flow](./img/auth-flow-diagram.svg)
 
-          Pomerium will [impersonate](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation) the Pomerium user's identity, and Kubernetes RBAC can be applied to IdP user and groups.
-      - name: "Load Balancing Policy"
-        keys: ["lb_policy"]
-        attributes: |
-          - Config File Key: `lb_policy`
-          - Type: `enum`
-          - Optional
-        doc: |
-          In presence of multiple upstreams, defines load balancing strategy between them.
+      #### Examples
 
-          See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-enum-config-cluster-v3-cluster-lbpolicy) for more details.
+      ##### NGINX Ingress
 
-          - [`ROUND_ROBIN`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-round-robin) (default)
-          - [`LEAST_REQUEST`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-least-request) and may be further configured using [`least_request_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-leastrequestlbconfig)
-          - [`RING_HASH`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#ring-hash) and may be further configured using [`ring_hash_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-ringhashlbconfig) option
-          - [`RANDOM`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#random)
-          - [`MAGLEV`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#maglev) and may be further configured using [`maglev_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig) option
+      Some reverse-proxies, such as nginx split access control flow into two parts: verification and sign-in redirection. Notice the additional path `/verify` used for `auth-url` indicating to Pomerium that it should return a `401` instead of redirecting and starting the sign-in process.
 
-          Some policy types support additional [configuration](#load-balancing-policy-config).
-      - name: "Load Balancing Policy Config"
-        keys:
-          ["least_request_lb_config", "ring_hash_lb_config", "maglev_lb_config"]
-        attributes: |
-          - Config File Key: `least_request_lb_config`, `ring_hash_lb_config`, `maglev_lb_config`
-          - Type: `object`
-          - Optional
-        doc: |
-          When [`lb_policy`](#load-balancing-policy) is configured, you may further customize policy settings for `LEAST_REQUEST`, `RING_HASH`, AND `MAGLEV` using one of the following options.
+      ```yaml
+      apiVersion: extensions/v1beta1
+      kind: Ingress
+      metadata:
+        name: verify
+        annotations:
+          kubernetes.io/ingress.class: "nginx"
+          certmanager.k8s.io/issuer: "letsencrypt-prod"
+          nginx.ingress.kubernetes.io/auth-url: https://forwardauth.corp.example.com/verify?uri=$scheme://$host$request_uri
+          nginx.ingress.kubernetes.io/auth-signin: "https://forwardauth.corp.example.com/?uri=$scheme://$host$request_uri"
+      spec:
+        tls:
+          - hosts:
+              - verify.corp.example.com
+            secretName: quickstart-example-tls
+        rules:
+          - host: verify.corp.example.com
+            http:
+              paths:
+                - path: /
+                  backend:
+                    serviceName: verify
+                    servicePort: 80
+      ```
 
-          - [`least_request_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-leastrequestlbconfig)
-          - [`ring_hash_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-ringhashlbconfig)
-          - [`maglev_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig)
+      #### Traefik docker-compose
 
-          See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.md#load-balancing-method)
-      - name: "Outlier Detection"
-        keys: ["outlier_detection"]
-        attributes: |
-          - `yaml`/`json` setting: `outlier_detection`
-          - Type: `object`
-          - Optional
-          - Example: `{ "consecutive_5xx": 12 }`
-        doc: |
-          Outlier detection and ejection is the process of dynamically determining whether some number of hosts in an upstream cluster are performing unlike the others and removing them from the healthy load balancing set.
+      If the `forward_auth_url` is also handled by Traefik, you will need to configure Traefik to trust the `X-Forwarded-*` headers as described in [the documentation](https://docs.traefik.io/v2.2/routing/entrypoints/#forwarded-headers).
 
-          See Envoy [documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier#arch-overview-outlier-detection) and [API](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/outlier_detection.proto#envoy-v3-api-msg-config-cluster-v3-outlierdetection) for more details.
-      - name: "Pass Identity Headers"
-        keys: ["pass_identity_headers"]
-        attributes: |
-          - `yaml`/`json` setting: `pass_identity_headers`
-          - Type: `bool`
-          - Optional
-          - Default: `false`
-        doc: |
-          When enabled, this option will pass identity headers to upstream applications. These headers include:
+      ```yml
+      version: "3"
 
-          - X-Pomerium-Jwt-Assertion
-          - X-Pomerium-Claim-*
-      - name: "Path"
-        keys: ["path"]
-        attributes: |
-          - `yaml`/`json` setting: `path`
-          - Type: `string`
-          - Optional
-          - Example: `/admin/some/exact/path`
-        doc: |
-          If set, the route will only match incoming requests with a path that is an exact match for the specified path.
-      - name: "Prefix"
-        keys: ["prefix"]
-        attributes: |
-          - `yaml`/`json` setting: `prefix`
-          - Type: `string`
-          - Optional
-          - Example: `/admin`
-        doc: |
-          If set, the route will only match incoming requests with a path that begins with the specified prefix.
-      - name: "Prefix Rewrite"
-        keys: ["prefix_rewrite"]
-        attributes: |
-          - `yaml`/`json` setting: `prefix_rewrite`
-          - Type: `string`
-          - Optional
-          - Example: `/subpath`
-        doc: |
-          If set, indicates that during forwarding, the matched prefix (or path) should be swapped with this value.
-          For example, given this policy:
+      services:
+        traefik:
+          # The official v2.2 Traefik docker image
+          image: traefik:v2.2
+          # Enables the web UI and tells Traefik to listen to docker
+          command:
+            - "--api.insecure=true"
+            - "--providers.docker=true"
+            - "--entrypoints.web.address=:80"
+            - "--entrypoints.web.forwardedheaders.insecure=true"
+          ports:
+            # The HTTP port
+            - "80:80"
+            # The Web UI (enabled by --api.insecure=true)
+            - "8080:8080"
+          volumes:
+            # So that Traefik can listen to the Docker events
+            - /var/run/docker.sock:/var/run/docker.sock
+        verify:
+          # A container that exposes an API to show its IP address
+          image: pomerium/verify:latest
+          labels:
+            - "traefik.http.routers.verify.rule=Host(`verify.corp.example.com`)"
+            # Create a middleware named `foo-add-prefix`
+            - "traefik.http.middlewares.test-auth.forwardauth.authResponseHeaders=x-pomerium-claim-email,x-pomerium-claim-id,x-pomerium-claim-groups,x-pomerium-jwt-assertion"
+            - "traefik.http.middlewares.test-auth.forwardauth.address=http://forwardauth.corp.example.com/?uri=https://verify.corp.example.com"
+            - "traefik.http.routers.verify.middlewares=test-auth@docker"
+      ```
+    shortdoc: |
+      Forward authentication creates an endpoint that can be used with third-party proxies.
+    uuid: 8ace2fb5-c457-4ca6-bfb2-e59cd8b03f89
+  - name: Global Timeouts
+    keys: [timeout_read, timeout_write, timeout_idle]
+    attributes: |
+      - Environmental Variables: `TIMEOUT_READ` `TIMEOUT_WRITE` `TIMEOUT_IDLE`
+      - Config File Key: `timeout_read` `timeout_write` `timeout_idle`
+      - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
+      - Example: `TIMEOUT_READ=30s`
+      - Defaults: `TIMEOUT_READ=30s` `TIMEOUT_WRITE=0` `TIMEOUT_IDLE=5m`
+    doc: |
+      Timeouts set the global server timeouts. Timeouts can also be set for individual [routes](#routes).
 
-          ```yaml
-          from: https://from.example.com
-          to: https://to.example.com
-          prefix: /admin
-          prefix_rewrite: /
-          ```
-
-          A request to `https://from.example.com/admin` would be forwarded to `https://to.example.com/`.
-      - name: "Public Access"
-        keys: ["allow_public_unauthenticated_access"]
-        attributes: |
-          - `yaml`/`json` setting: `allow_public_unauthenticated_access`
-          - Type: `bool`
-          - Optional
-          - Default: `false`
-        doc: |
-          **Use with caution:** Allow all requests for a given route, bypassing authentication and authorization. Suitable for publicly exposed web services.
-
-          If this setting is enabled, no whitelists (e.g. Allowed Users) should be provided in this route.
-      - name: "Redirect"
-        keys: ["redirect"]
-        attributes: |
-          - `yaml`/`json` setting: 'redirect'
-          - Type: object
-          - Optional
-          - Example: `{ "host_redirect": "example.com" }`
-        doc: |
-          `Redirect` is used to redirect incoming requests to a new URL. The `redirect` field is an object with several possible
-          options:
-
-          - `https_redirect` (boolean): the incoming scheme will be swapped with "https".
-          - `scheme_redirect` (string): the incoming scheme will be swapped with the given value.
-          - `host_redirect` (string): the incoming host will be swapped with the given value.
-          - `port_redirect` (integer): the incoming port will be swapped with the given value.
-          - `path_redirect` (string): the incoming path portion of the URL will be swapped with the given value.
-          - `prefix_rewrite` (string): the incoming matched prefix will be swapped with the given value.
-          - `response_code` (integer): the response code to use for the redirect. Defaults to 301.
-          - `strip_query` (boolean): indicates that during redirection, the query portion of the URL will be removed. Defaults to false.
-
-          Either `redirect` or `to` must be set.
-      - name: "Regex"
-        keys: ["regex"]
-        attributes: |
-          - `yaml`/`json` setting: `regex`
-          - Type: `string` (containing a regular expression)
-          - Optional
-          - Example: `^/(admin|superuser)/.*$`
-        doc: |
-          If set, the route will only match incoming requests with a path that matches the specified regular expression. The supported syntax is the same as the Go [regexp package](https://golang.org/pkg/regexp/) which is based on [re2](https://github.com/google/re2/wiki/Syntax).
-      - name: "Regex Rewrite"
-        keys: ["regex_rewrite_pattern", "regex_rewrite_substitution"]
-        attributes: |
-          - `yaml`/`json` setting: `regex_rewrite_pattern`, `regex_rewrite_substitution`
-          - Type: `string`
-          - Optional
-          - Example: `{ "regex_rewrite_pattern":"^/service/([^/]+)(/.*)$", "regex_rewrite_substitution": "\\2/instance/\\1" }`
-        doc: |
-          If set, the URL path will be rewritten according to the pattern and substitution, similar to `prefix_rewrite`.
-      - name: "Remove Request Headers"
-        keys: ["remove_request_headers"]
-        attributes: |
-          - Config File Key: `remove_request_headers`
-          - Type: array of `strings`
-          - Optional
-        doc: |
-          Remove Request Headers allows you to remove given request headers. This can be useful if you want to prevent privacy information from being passed to downstream applications. For example:
-
-          ```yaml
-          - from: https://verify.corp.example.com
-            to: https://verify.pomerium.com
-            policy:
-              - allow:
-                  or:
-                    - email:
-                        is: user@example.com
-            remove_request_headers:
-              - X-Email
-              - X-Username
-          ```
-      - name: "Rewrite Response Headers"
-        keys: ["rewrite_response_headers"]
-        attributes: |
-          - Config File Key: `rewrite_response_headers`
-          - Type: `object`
-          - Optional
-          - Example: `[{ "header": "Location", "prefix": "http://localhost:8000/two/", "value": "http://frontend/one/" }]`
-        doc: |
-          Rewrite Response Headers allows you to modify response headers before they are returned to the client. The `header` field will match the HTTP header name, and `prefix` will be replaced with `value`. For example, if the downstream server returns a header:
-
-          ```text
-          Location: http://localhost:8000/two/some/path/
-          ```
-
-          And the policy has this config:
-
-          ```yaml
-          rewrite_response_headers:
-            - header: Location
-              prefix: http://localhost:8000/two/
-              value: http://frontend/one/
-          ```
-
-          The browser would be redirected to: `http://frontend/one/some/path/`. This is similar to nginx's [`proxy_redirect` option](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect), but can be used for any header.
-      - name: "Route Timeout"
-        keys: ["timeout"]
-        attributes: |
-          - `yaml`/`json` setting: `timeout`
-          - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
-          - Optional
-          - Default: `30s`
-        doc: |
-          Policy timeout establishes the per-route timeout value. Cannot exceed global timeout values.
-      - name: "Set Authorization Header"
-        keys: ["set_authorization_header"]
-        attributes: |
-          - `yaml`/`json` setting: `set_authorization_header`
-          - Type: `string` (`pass_through`, `access_token` or `id_token`)
-          - Optional
-          - Default: `pass_through`
-        doc: |
-          `set_authorization_header` allows you to send a user's identity token through as a bearer token in the Authorization header.
-
-          Use `access_token` to send the OAuth access token, `id_token` to send the OIDC ID token, or `pass_through` (the default) to leave the Authorization header unchanged
-          from the client when it's not used for Pomerium authentication.
-      - name: "Set Response Headers"
-        keys: ["set_response_headers"]
-        attributes: |
-          - Config File Key: `set_response_headers`
-          - Type: map of `strings` key value pairs
-          - Optional
-        doc: |
-          Set Response Headers allows you to set static values for the given response headers. These headers will take precedence over the global `set_response_headers`.
-      - name: "Set Request Headers"
-        keys: ["set_request_headers"]
-        attributes: |
-          - Config File Key: `set_request_headers`
-          - Type: map of `strings` key value pairs
-          - Optional
-        doc: |
-          Set Request Headers allows you to set static values for given request headers. This can be useful if you want to pass along additional information to downstream applications as headers, or set authentication header to the request. For example:
-
-          ```yaml
-          - from: https://verify.corp.example.com
-            to: https://verify.pomerium.com
-            policy:
-              - allow:
-                  or:
-                    - email:
-                        is: user@example.com
-            set_request_headers:
-              # works auto-magically!
-              # https://verify.corp.example.com/basic-auth/root/hunter42
-              Authorization: Basic cm9vdDpodW50ZXI0Mg==
-              X-Your-favorite-authenticating-Proxy: "Pomerium"
-          ```
-          :::warning
-
-          Neither `:-prefixed` pseudo-headers nor the `Host:` header may be modified via this mechanism. Those headers may instead be modified via mechanisms such as `prefix_rewrite`, `regex_rewrite`, and `host_rewrite`.
-
-          :::
-      - name: "Signout Redirect URL"
-        keys: ["signout_redirect_url"]
-        attributes: |
-          - Environmental Variable: `SIGNOUT_REDIRECT_URL`
-          - Config File Key: `signout_redirect_url`
-          - Type: `URL`
-          - Required
-          - Example: `https://signout-redirect-url.corp.example.com`
-        doc: |
-          Signout redirect url is the url user will be redirected to after signing out.
-
-          You can overwrite this behavior by passing the query param `pomerium_redirect_uri` or post value `pomerium_redirect_uri`
-          to the `/.pomerium/signout/` endpoint.
-      - name: "TLS Client Certificate"
-        keys:
-          [
-            "tls_client_cert",
-            "tls_client_key",
-            "tls_client_cert_file",
-            "tls_client_key_file",
-          ]
-        attributes: |
-          - Config File Key: `tls_client_cert` and `tls_client_key` or `tls_client_cert_file` and `tls_client_key_file`
-          - Type: [base64 encoded] `string` or relative file location
-          - Optional
-        doc: |
-          If specified, Pomerium will present this client certificate to upstream services when requested to enforce [mutual authentication](https://en.wikipedia.org/wiki/Mutual_authentication) (mTLS).
-
-          For more details, see our [mTLS example repository](https://github.com/pomerium/pomerium/tree/main/examples/mutual-tls) and the [Upstream mTLS With Pomerium](/guides/upstream-mtls.md) guide.
-      - name: "TLS Custom Certificate Authority"
-        keys: ["tls_custom_ca", "tls_custom_ca_file"]
-        attributes: |
-          - Config File Key: `tls_custom_ca` or `tls_custom_ca_file`
-          - Type: [base64 encoded] `string` or relative file location
-          - Optional
-        doc: |
-          TLS Custom Certificate Authority defines a set of root certificate authorities that the Pomerium Proxy Service uses when verifying upstream server certificates.
-
-          **Note**: This setting will replace (not append) the system's trust store for a given route.
-      - name: "TLS Downstream Client Certificate Authority"
-        keys: ["tls_downstream_client_ca", "tls_downstream_client_ca_file"]
-        attributes: |
-          - Config File Key: `tls_downstream_client_ca` or `tls_downstream_client_ca_file`
-          - Type: [base64 encoded] `string` or relative file location
-          - Optional
-        doc: |
-          If specified, downstream clients (eg a user's browser) will be required to provide a valid client TLS
-          certificate. This overrides the global `client_ca` option for this route.
-
-          See [Client-Side mTLS With Pomerium](/guides/mtls.md) for more information.
-      - name: "TLS Skip Verification"
-        keys: ["tls_skip_verify"]
-        attributes: |
-          - Config File Key: `tls_skip_verify`
-          - Type: `bool`
-          - Default: `false`
-        doc: |
-          TLS Skip Verification controls whether the Pomerium Proxy Service verifies the upstream server's certificate chain and host name. If enabled, Pomerium accepts any certificate presented by the upstream server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks. This should be used only for testing.
-      - name: "TLS Server Name"
-        keys: ["tls_server_name"]
-        attributes: |
-          - Config File Key: `tls_server_name`
-          - Type: `string`
-          - Optional
-        doc: |
-          **Deprecated**: this key has been replaced with `tls_upstream_server_name`.
-      - name: "TLS Upstream Server Name"
-        keys: ["tls_upstream_server_name"]
-        attributes: |
-          - Config File Key: `tls_upstream_server_name`
-          - Type: `string`
-          - Optional
-        doc: |
-          TLS Upstream Server Name overrides the hostname specified in the `to` field. If set, this server name will be used to verify the certificate name. This is useful when the backend of your service is a TLS server with a valid certificate, but mismatched name.
-      - name: "TLS Downstream Server Name"
-        keys: ["tls_downstream_server_name"]
-        attributes: |
-          - Config File Key: `tls_downstream_server_name`
-          - Type: `string`
-          - Optional
-        doc: |
-          TLS Downstream Server Name overrides the hostname specified in the `from` field. When a connection to Pomerium is made via TLS the `tls_downstream_server_name` will be used as the expected Server Name Indication, whereas the host part of the `from` field, will be expected to match the `Host` or `:authority` headers of the HTTP request.
-      - name: "To"
-        keys: ["to"]
-        attributes: |
-          - `yaml`/`json` setting: `to`
-          - Type: `URL` or list of `URL`s (must contain a scheme and hostname) with an optional weight
-          - Schemes: `http`, `https`, `tcp`
-          - Optional
-          - Example: `http://verify` , `https://192.1.20.12:8080`, `http://neverssl.com`, `https://verify.pomerium.com/anything/`, `["http://a", "http://b"]`, `["http://a,10", "http://b,20"]`
-        doc: |
-          `To` is the destination(s) of a proxied request. It can be an internal resource, or an external resource. Multiple upstream resources can be targeted by using a list instead of a single URL:
-
-          ```yaml
-          - from: https://example.com
-            to:
-            - https://a.example.com
-            - https://b.example.com
-          ```
-
-          A load balancing weight may be associated with a particular upstream by appending `,[weight]` to the URL.  The exact behavior depends on your [`lb_policy`](#load-balancing-policy) setting.  See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.md#load-balancing-weight).
-
-          Must be `tcp` if `from` is `tcp+https`.
-
-          :::warning
-
-          Be careful with trailing slash.
-
-          With rule:
-
-          ```yaml
-          - from: https://verify.corp.example.com
-            to: https://verify.pomerium.com/anything
-          ```
-
-          Requests to `https://verify.corp.example.com` will be forwarded to `https://verify.pomerium.com/anything`, while requests to `https://verify.corp.example.com/foo` will be forwarded to `https://verify.pomerium.com/anythingfoo`.To make the request forwarded to `https://httbin.org/anything/foo`, you can use double slashes in your request `https://httbin.corp.example.com//foo`.
-
-          While the rule:
-
-          ```yaml
-          - from: https://verify.corp.example.com
-            to: https://verify.pomerium.com/anything/
-          ```
-
-          All requests to `https://verify.corp.example.com/*` will be forwarded to `https://verify.pomerium.com/anything/*`. That means accessing to `https://verify.corp.example.com` will be forwarded to `https://verify.pomerium.com/anything/`. That said, if your application does not handle trailing slash, the request will end up with 404 not found.
-
-          Either `redirect` or `to` must be set.
-
-          :::
-      - name: "SPDY"
-        keys: ["allow_spdy"]
-        attributes: |
-          - Config File Key: `allow_spdy`
-          - Type: `bool`
-          - Default: `false`
-        doc: |
-          If set, enables proxying of SPDY protocol upgrades.
-      - name: "Websocket Connections"
-        keys: ["allow_websockets"]
-        attributes: |
-          - Config File Key: `allow_websockets`
-          - Type: `bool`
-          - Default: `false`
-        doc: |
-          If set, enables proxying of websocket connections.
-
-          :::warning
-
-          **Use with caution:** websockets are long-lived connections, so [global timeouts](#global-timeouts) are not enforced (though the policy-specific `timeout` is enforced). Allowing websocket connections to the proxy could result in abuse via [DOS attacks](https://www.cloudflare.com/learning/ddos/ddos-attack-tools/slowloris/).
-
-          :::
-  - name: "Authorize Service"
+      - `idle_timeout`: The idle timeout is the time at which a downstream or upstream connection will be terminated if there are no active streams.
+      - `write_timeout`: The max stream duration is the maximum time that a stream’s lifetime will span. An HTTP request/response exchange fully consumes a single stream.
+        Therefore, this value must be greater than read_timeout as it covers both request and response time.
+      - `read_timeout`: The amount of time for the entire request stream to be received from the client.
+    shortdoc: |
+      Timeouts set the global server timeouts. Timeouts can also be set for individual routes.
+    uuid: 580fc2c4-3c1c-4def-b0b2-ef8387bc2362
+  - name: GRPC Options
     settings:
-      - name: "Google Cloud Serverless Authentication Service Account"
-        keys: ["google_cloud_serverless_authentication_service_account"]
-        attributes: |
-          - Environmental Variable: `GOOGLE_CLOUD_SERVERLESS_AUTHENTICATION_SERVICE_ACCOUNT`
-          - Config File Key: `google_cloud_serverless_authentication_service_account`
-          - Type: [base64 encoded] `string`
-          - Optional
-        doc: |
-          Manually specify the service account credentials to support GCP's [Authorization Header](https://cloud.google.com/run/docs/authenticating/service-to-service) format.
+    - name: GRPC Address
+      keys: [grpc_address]
+      attributes: |
+        - Environmental Variable: `GRPC_ADDRESS`
+        - Config File Key: `grpc_address`
+        - Type: `string`
+        - Example: `:443`, `:8443`
+        - Default: `:443` or `:5443` if in all-in-one mode
+      doc: |
+        gRPC Address specifies the host and port to serve gRPC requests from.
+      shortdoc: |
+        Address specifies the host and port to serve GRPC requests from.
+      uuid: b37f3393-bc18-4f91-bf19-94d00dcfd1dc
+    - name: GRPC Insecure
+      keys: [grpc_insecure]
+      attributes: |
+        - Environmental Variable: `GRPC_INSECURE`
+        - Config File Key: `grpc_insecure`
+        - Type: `bool`
+      doc: |
+        This setting disables transport security for gRPC communication. If running in all-in-one mode, defaults to true as communication will run over localhost's own socket.
+      shortdoc: |
+        If set, GRPC Insecure disables transport security for communication between the proxy and authorize components.
+      uuid: c3cf821f-f2d6-4f8a-b7d5-242ab2bd3e64
+    - name: GRPC Client Timeout
+      keys: [grpc_client_timeout]
+      attributes: |
+        - Environmental Variable: `GRPC_CLIENT_TIMEOUT`
+        - Config File Key: `grpc_client_timeout`
+        - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
+        - Default: `10s`
+      doc: |
+        Maximum time before canceling an upstream gRPC request. During transient failures, the proxy will retry upstreams for this duration. You should leave this high enough to handle backend service restart and rediscovery so that client requests do not fail.
+      uuid: 1525571a-ea43-4b96-9c77-f73d9c8858f6
+    - name: GRPC Client DNS RoundRobin
+      keys: [grpc_client_dns_roundrobin]
+      attributes: |
+        - Environmental Variable: `GRPC_CLIENT_DNS_ROUNDROBIN`
+        - Config File Key: `grpc_client_dns_roundrobin`
+        - Type: `bool`
+        - Default: `true`
+      doc: |
+        Enable gRPC DNS based round robin load balancing. This method uses DNS to resolve endpoints and does client side load balancing of _all_ addresses returned by the DNS record. Do not disable unless you have a specific use case.
+      uuid: 9d0fa560-39c6-4bff-a3ae-68236dcf36e0
+    uuid: 0c83057d-9925-4686-9f6b-73a082eb8ea3
+  - name: HTTP Redirect Address
+    keys: [http_redirect_addr]
+    attributes: |
+      - Environmental Variable: `HTTP_REDIRECT_ADDR`
+      - Config File Key: `http_redirect_addr`
+      - Type: `string`
+      - Example: `:80`, `:8080`
+      - Optional
+    doc: |
+      If set, the HTTP Redirect Address specifies the host and port to redirect http to https traffic on. If unset, no redirect server is started.
+    shortdoc: |
+      If set, the HTTP Redirect Address specifies the host and port to redirect http to https traffic on.
+    uuid: d5739f39-cce4-4df9-9354-c000d0105f5f
+  - name: Insecure Server
+    keys: [insecure_server]
+    attributes: |
+      - Environmental Variable: `INSECURE_SERVER`
+      - Config File Key: `insecure_server`
+      - Type: `bool`
+      - Required if certificates unset
+    doc: |
+      Turning on insecure server mode will result in pomerium starting, and operating without any protocol encryption in transit.
 
-          If unspecified:
+      This setting can be useful in a situation where you have Pomerium behind a TLS terminating ingress or proxy. However, even in that case, it is highly recommended to use TLS to protect the confidentiality and integrity of service communication even behind the ingress using self-signed certificates or an internal CA. Please see our helm-chart for an example of just that.
 
-          - If [Identity Provider Name](#identity-provider-name) is set to `google`, will default to [Identity Provider Service Account](#identity-provider-service-account)
-          - Otherwise, will default to ambient credentials in the default locations searched by the Google SDK. This includes GCE metadata server tokens.
-      - name: "Signing Key"
-        keys: ["signing_key"]
-        attributes: |
-          - Environmental Variable: `SIGNING_KEY`
-          - Config File Key: `signing_key`
-          - Type: [base64 encoded] `string`
-          - Optional
-        doc: |
-          Signing Key is the private key used to sign a user's attestation JWT which can be consumed by upstream applications to pass along identifying user information like username, id, and groups.
+      :::warning
 
-          If set, the signing key's public key will can retrieved by hitting Pomerium's `/.well-known/pomerium/jwks.json` endpoint which lives on the authenticate service. Otherwise, the endpoint will return an empty keyset.
+      Pomerium should _never_ be exposed to the internet without TLS encryption.
 
-          For example, assuming you have [generated an ES256 key](https://github.com/pomerium/pomerium/blob/main/scripts/generate_self_signed_signing_key.sh) as follows.
+      :::
+    shortdoc: |
+      Turning on insecure server mode will result in pomerium starting, and operating without any protocol encryption in transit.
+    uuid: c8bc545c-49a1-4a62-a13b-d4fdadf0f136
+  - name: DNS Lookup Family
+    keys: [dns_lookup_family]
+    attributes: |
+      - Environmental Variable: `DNS_LOOKUP_FAMILY`
+      - Config File Key: `dns_lookup_family`
+      - Type: `string`
+      - Options: `V4_ONLY` `V6_ONLY` `AUTO`
+      - Optional
+    doc: |
+      The DNS IP address resolution policy. If not specified, the value defaults to `AUTO`.
+    shortdoc: |
+      The DNS IP address resolution policy.
+    uuid: c1ac06cd-da27-4920-b482-3de69b1736a2
+  - name: Log Level
+    keys: [log_level]
+    attributes: |
+      - Environmental Variable: `LOG_LEVEL`
+      - Config File Key: `log_level`
+      - Type: `string`
+      - Options: `debug` `info` `warn` `error`
+      - Default: `debug`
+    doc: |
+      Log level sets the global logging level for pomerium. Only logs of the desired level and above will be logged.
+    shortdoc: |
+      Log level sets the global logging level for pomerium.
+    uuid: 5a13be8f-5526-4bac-88b3-d018925e2569
+  - name: Metrics Address
+    keys: [metrics_address]
+    attributes: |
+      - Environmental Variable: `METRICS_ADDRESS`
+      - Config File Key: `metrics_address`
+      - Type: `string`
+      - Example: `:9090`, `127.0.0.1:9090`
+      - Default: `disabled`
+      - Optional
+    doc: |
+      Expose a prometheus endpoint on the specified port.
 
-          ```bash
-          # Generates an P-256 (ES256) signing key
-          openssl ecparam  -genkey  -name prime256v1  -noout  -out ec_private.pem
-          # careful! this will output your private key in terminal
-          cat ec_private.pem | base64
+      :::warning
+
+      **Use with caution:** the endpoint can expose frontend and backend server names or addresses. Do not externally expose the metrics if this is sensitive information.
+
+      :::
+
+      #### Pomerium Metrics Tracked
+
+      Each metric exposed by Pomerium has a `pomerium` prefix, which is omitted in the table below for brevity.
+
+      Name                                          | Type      | Description
+      --------------------------------------------- | --------- | -----------------------------------------------------------------------
+      build_info                                    | Gauge     | Pomerium build metadata by git revision, service, version and goversion
+      config_checksum_int64                         | Gauge     | Currently loaded configuration checksum by service
+      config_last_reload_success                    | Gauge     | Whether the last configuration reload succeeded by service
+      config_last_reload_success_timestamp          | Gauge     | The timestamp of the last successful configuration reload by service
+      grpc_client_request_duration_ms               | Histogram | GRPC client request duration by service
+      grpc_client_request_size_bytes                | Histogram | GRPC client request size by service
+      grpc_client_requests_total                    | Counter   | Total GRPC client requests made by service
+      grpc_client_response_size_bytes               | Histogram | GRPC client response size by service
+      grpc_server_request_duration_ms               | Histogram | GRPC server request duration by service
+      grpc_server_request_size_bytes                | Histogram | GRPC server request size by service
+      grpc_server_requests_total                    | Counter   | Total GRPC server requests made by service
+      grpc_server_response_size_bytes               | Histogram | GRPC server response size by service
+      http_client_request_duration_ms               | Histogram | HTTP client request duration by service
+      http_client_request_size_bytes                | Histogram | HTTP client request size by service
+      http_client_requests_total                    | Counter   | Total HTTP client requests made by service
+      http_client_response_size_bytes               | Histogram | HTTP client response size by service
+      http_server_request_duration_ms               | Histogram | HTTP server request duration by service
+      http_server_request_size_bytes                | Histogram | HTTP server request size by service
+      http_server_requests_total                    | Counter   | Total HTTP server requests handled by service
+      http_server_response_size_bytes               | Histogram | HTTP server response size by service
+      redis_conns                                   | Gauge     | Number of total connections in the pool
+      redis_idle_conns                              | Gauge     | Total number of times free connection was found in the pool
+      redis_wait_count_total                        | Counter   | Total number of connections waited for
+      redis_wait_duration_ms_total                  | Counter   | Total time spent waiting for connections
+      storage_operation_duration_ms                 | Histogram | Storage operation duration by operation, result, backend and service
+
+      #### Identity Manager
+
+      Identity manager metrics have `pomerium_identity_manager` prefix.
+
+      Name                                          | Type      | Description
+      --------------------------------------------- | --------- | -----------------------------------------------------------------------
+      last_refresh_timestamp                        | Gauge     | Timestamp of last directory refresh operation.
+      session_refresh_error_timestamp               | Gauge     | Timestamp of last session refresh ended in an error.
+      session_refresh_errors                        | Counter   | Session refresh error counter.
+      session_refresh_success                       | Counter   | Session refresh success counter.
+      session_refresh_success_timestamp             | Gauge     | Timestamp of last successful session refresh.
+      user_group_refresh_error_timestamp            | Gauge     | Timestamp of last user group refresh ended in an error.
+      user_group_refresh_errors                     | Counter   | User group refresh error counter.
+      user_group_refresh_success                    | Counter   | User group refresh success counter.
+      user_group_refresh_success_timestamp          | Gauge     | Timestamp of last group successful user refresh.
+      user_refresh_error_timestamp                  | Gauge     | Timestamp of last user refresh ended in an error.
+      user_refresh_errors                           | Counter   | User refresh error counter.
+      user_refresh_success                          | Counter   | User refresh success counter.
+      user_refresh_success_timestamp                | Gauge     | Timestamp of last successful user refresh.
+
+      #### Envoy Proxy Metrics
+
+      As of `v0.9`, Pomerium uses [envoy](https://www.envoyproxy.io/) for the data plane. As such, proxy related metrics are sourced from envoy, and use envoy's internal [stats data model](https://www.envoyproxy.io/docs/envoy/latest/operations/stats_overview). Please see Envoy's documentation for information about specific metrics.
+
+      All metrics coming from envoy will be labeled with `service="pomerium"` or `service="pomerium-proxy"`, depending if you're running all-in-one or distributed service mode and have `pomerium` prefix added to the standard envoy metric name.
+    shortdoc: |
+      Expose a prometheus format HTTP endpoint on the specified port.
+    uuid: c3d87004-af01-4667-9aaa-b5e0d4ae08ac
+  - name: Metrics Basic Authentication
+    keys: [metrics_basic_auth]
+    attributes: |
+      - Environmental Variable: `METRICS_BASIC_AUTH`
+      - Config File Key: `metrics_basic_auth`
+      - Type: base64 encoded `string` of `username:password`
+      - Example: `eDp5` (for username: x, and password: y)
+      - Default: ``
+      - Optional
+    doc: |
+      Require [Basic HTTP Authentication](https://tools.ietf.org/html/rfc7617) to access the metrics endpoint.
+
+      To support this in Prometheus, consult the `basic_auth` option in the [`scrape_config`](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config)
+      documentation.
+    uuid: 5f33f57f-74ae-4374-95e3-aff0200438d3
+  - name: Metrics Certificate
+    keys: [metrics_certificate, metrics_certificate_key, metrics_certificate_file,
+      metrics_certificate_key_file]
+    attributes: |
+      - Config File Key: `metrics_certificate` / `metrics_certificate_key`
+      - Config File Key: `metrics_certificate_file` / `metrics_certificate_key_file`
+      - Environmental Variable: `METRICS_CERTIFICATE` / `METRICS_CERTIFICATE_KEY`
+      - Environmental Variable: `METRICS_CERTIFICATE_FILE` / `METRICS_CERTIFICATE_KEY_FILE`
+      - Type: [base64 encoded] `string`
+      - Type: certificate relative file location `string`
+      - Optional
+    doc: |
+      Certificates are the x509 _public-key_ and _private-key_ used to secure the metrics endpoint.
+    uuid: 207cdd33-372a-434c-896f-1bb54bebfffc
+  - name: Metrics Client Certificate Authority
+    keys: [metrics_client_ca, metrics_client_ca_file]
+    attributes: |
+      - Environment Variable: `METRICS_CLIENT_CA` / `METRICS_CLIENT_CA_FILE`
+      - Config File Key: `metrics_client_ca` / `metrics_client_ca_file`
+      - Type: [base64 encoded] `string` or relative file location
+      - Optional
+    doc: |
+      The Client Certificate Authority is the x509 _public-key_ used to validate [mTLS](https://en.wikipedia.org/wiki/Mutual_authentication) client certificates for the metrics endpoint. If not set, no client certificate will be required.
+    uuid: 3088ec5a-87d7-4d03-8a16-d53989ec8e92
+  - name: Proxy Log Level
+    keys: [proxy_log_level]
+    attributes: |
+      - Environmental Variable: `PROXY_LOG_LEVEL`
+      - Config File Key: `proxy_log_level`
+      - Type: `string`
+      - Options: `debug` `info` `warn` `error`
+      - Default: value of `log_level` or `debug` if both are unset
+    doc: |
+      Proxy log level sets the logging level for the Pomerium Proxy service access logs. Only logs of the desired level and above will be logged.
+    shortdoc: |
+      Log level sets the logging level for the Pomerium Proxy service.
+    uuid: 04682198-1236-46eb-bd0e-762e26ff5714
+  - name: Service Mode
+    keys: [services]
+    attributes: |
+      - Environmental Variable: `SERVICES`
+      - Config File Key: `services`
+      - Type: `string`
+      - Default: `all`
+      - Options: `all` `authenticate` `authorize` `databroker` or `proxy`
+    doc: |
+      Service mode sets which service(s) to run. If testing, you may want to set to `all` and run pomerium in "all-in-one mode." In production, you'll likely want to spin up several instances of each service mode for high availability.
+    shortdoc: |
+      Service mode sets the pomerium service(s) to run.
+    uuid: 7b82ddb0-5076-4c6d-9150-fb727551b43c
+  - name: Shared Secret
+    keys: [shared_secret]
+    attributes: |
+      - Environmental Variable: `SHARED_SECRET`
+      - Config File Key: `shared_secret`
+      - Type: [base64 encoded] `string`
+      - Required
+    doc: |
+      Shared Secret is the base64 encoded 256-bit key used to mutually authenticate requests between services. It's critical that secret keys are random, and stored safely. Use a key management system or `/dev/urandom` to generate a key. For example:
+
+      ```
+      head -c32 /dev/urandom | base64
+      ```
+    shortdoc: |
+      Shared Secret is the base64 encoded 256-bit key used to mutually authenticate requests between services.
+    uuid: fb7b8426-ad1d-4ee7-b0fe-b00652764f2e
+  - name: Tracing
+    keys: [tracing_provider, tracing_sample_rate, tracing_datadog_address, tracing_jaeger_collector_endpoint,
+      tracing_jaeger_agent_endpoint, tracing_zipkin_endpoint]
+    doc: |
+      Tracing tracks the progression of a single user request as it is handled by Pomerium.
+
+      Each unit of work is called a Span in a trace. Spans include metadata about the work, including the time spent in the step (latency), status, time events, attributes, links. You can use tracing to debug errors and latency issues in your applications, including in downstream connections.
+
+      #### Shared Tracing Settings
+
+      Config Key          | Description                                                                          | Required
+      :------------------ | :----------------------------------------------------------------------------------- | --------
+      tracing_provider    | The name of the tracing provider. (e.g. jaeger, zipkin)                              | ✅
+      tracing_sample_rate | Percentage of requests to sample in decimal notation. Default is `0.0001`, or .01%   | ❌
+
+      #### Datadog
+
+      Datadog is a real-time monitoring system that supports distributed tracing and monitoring.
+
+      Config Key              | Description                                                                  | Required
+      :---------------------- | :--------------------------------------------------------------------------- | --------
+      tracing_datadog_address | `host:port` address of the Datadog Trace Agent. Defaults to `localhost:8126` | ❌
+
+      #### Jaeger (partial)
+
+      **Warning** At this time, Jaeger protocol does not capture spans inside the Proxy service. Please use Zipkin protocol with Jaeger for full support.
+
+      [Jaeger](https://www.jaegertracing.io/) is a distributed tracing system released as open source by Uber Technologies. It is used for monitoring and troubleshooting microservices-based distributed systems, including:
+
+      - Distributed context propagation
+      - Distributed transaction monitoring
+      - Root cause analysis
+      - Service dependency analysis
+      - Performance / latency optimization
+
+      Config Key                        | Description                                 | Required
+      :-------------------------------- | :------------------------------------------ | --------
+      tracing_jaeger_collector_endpoint | Url to the Jaeger HTTP Thrift collector.    | ✅
+      tracing_jaeger_agent_endpoint     | Send spans to jaeger-agent at this address. | ✅
+
+      #### Zipkin
+
+      Zipkin is an open source distributed tracing system and protocol.
+
+      Many tracing backends support zipkin either directly or through intermediary agents, including Jaeger. For full tracing support, we recommend using the Zipkin tracing protocol.
+
+      Config Key              | Description                      | Required
+      :---------------------- | :------------------------------- | --------
+      tracing_zipkin_endpoint | Url to the Zipkin HTTP endpoint. | ✅
+
+      #### Example
+
+      ![jaeger example trace](./img/jaeger.png)
+    uuid: 04f2244d-8b30-497c-a380-93a60cefded5
+  - name: Use Proxy Protocol
+    keys: [use_proxy_protocol]
+    attributes: |
+      - Environment Variable: `USE_PROXY_PROTOCOL`
+      - Config File Key: `use_proxy_protocol`
+      - Type: `bool`
+      - Optional
+    doc: |
+      Setting `use_proxy_protocol` will configure Pomerium to require the [HAProxy proxy protocol](https://www.haproxy.org/download/1.9/doc/proxy-protocol.txt) on incoming connections. Versions 1 and 2 of the protocol are supported.
+    uuid: 02e05cf0-ee81-4710-9266-1db26bf1a04d
+  - name: Envoy Bootstrap Options
+    keys: [envoy_admin_address, envoy_admin_access_log_path, envoy_admin_profile_path,
+      envoy_bind_config_freebind, envoy_bind_config_source_address]
+    attributes: |
+      - Environment Variable: `ENVOY_ADMIN_ADDRESS`, `ENVOY_ADMIN_ACCESS_LOG_PATH`, `ENVOY_ADMIN_PROFILE_PATH`, `ENVOY_BIND_CONFIG_FREEBIND`, `ENVOY_BIND_CONFIG_SOURCE_ADDRESS`
+      - Config File Keys: `envoy_admin_address`, `envoy_admin_access_log_path`, `envoy_admin_profile_path`, `envoy_bind_config_freebind`, `envoy_bind_config_source_address`
+      - Type: `string`
+      - Optional
+    doc: |
+      The `envoy_admin` keys customize Envoy's [bootstrap configuration](https://www.envoyproxy.io/docs/envoy/latest/operations/admin#operations-admin-interface). The `envoy_bind_config` keys modify the [ClusterManager](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/bootstrap/v3/bootstrap.proto.html#config-bootstrap-v3-clustermanager) configuration. These options cannot be modified at runtime.
+    uuid: 0894dd9b-1e9b-4f0e-9a39-ae0971cd621e
+  uuid: f7807d34-b268-4c7c-8a7f-f579993385ec
+- name: Authenticate Service
+  settings:
+  - name: Authenticate Callback Path
+    keys: [authenticate_callback_path]
+    attributes: |
+      - Environmental Variable: `AUTHENTICATE_CALLBACK_PATH`
+      - Config File Key: `authenticate_callback_path`
+      - Type: `string`
+      - Default: `/oauth2/callback`
+      - Optional
+    doc: |
+      Authenticate callback path sets the path at which the authenticate service receives callback responses from your identity provider. The value must exactly match one of the authorized redirect URIs for the OAuth 2.0 client.
+
+      This value is referred to as the `redirect_url` in the [OpenIDConnect][oidc rfc] and OAuth2 specs.
+
+      See also:
+
+      - [OAuth2 RFC 6749](https://tools.ietf.org/html/rfc6749#section-3.1.2)
+      - [OIDC Spec][oidc rfc]
+      - [Google - Setting Redirect URI](https://developers.google.com/identity/protocols/OpenIDConnect#setredirecturi)
+    shortdoc: |
+      The authenticate callback path is the path/url from the authenticate service that will receive the response from your identity provider.
+    uuid: 5043c2c6-6241-4557-8474-3547448f3e07
+  - name: Authenticate Internal Service URL
+    keys: [authenticate_internal_service_url]
+    attributes: |
+      - Environmental Variable: `AUTHENTICATE_INTERNAL_SERVICE_URL`
+      - Config File Key: `authenticate_internal_service_url`
+      - Type: `URL`
+      - Required
+      - Example: `https://authenticate.internal`
+    short: |
+      Authenticate Service URL is the internally accessible URL for the authenticate service.
+    doc: |
+      Authenticate Internal Service URL overrides `authenticate_service_url` when determining the TLS certificate and hostname for the authenticate service to listen with.
+    uuid: 5cd8376e-20f3-42b0-a7ab-e9bd28d6d766
+  - name: Identity Provider Client ID
+    keys: [idp_client_id]
+    attributes: |
+      - Environmental Variable: `IDP_CLIENT_ID`
+      - Config File Key: `idp_client_id`
+      - Type: `string`
+      - Required
+    doc: |
+      Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider] docs for details.
+    shortdoc: |
+      Client ID is the OAuth 2.0 Client Identifier retrieved from your identity provider.
+    uuid: 35410d07-be0e-482e-a131-22ec7908a41b
+  - name: Identity Provider Client Secret
+    keys: [idp_client_secret]
+    attributes: |
+      - Environmental Variable: `IDP_CLIENT_SECRET`
+      - Config File Key: `idp_client_secret`
+      - Type: `string`
+      - Required
+    doc: |
+      Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity provider. See your identity provider's documentation, and our [identity provider] docs for details.
+    shortdoc: |
+      Client Secret is the OAuth 2.0 Secret Identifier retrieved from your identity provider.
+    uuid: e3c0b866-e26e-4b93-b1ed-a6d99217f06c
+  - name: Identity Provider Name
+    keys: [idp_provider]
+    attributes: |
+      - Environmental Variable: `IDP_PROVIDER`
+      - Config File Key: `idp_provider`
+      - Type: `string`
+      - Required
+      - Options: `auth0` `azure` `google` `okta` `onelogin` or `oidc`
+    doc: |
+      Provider is the short-hand name of a built-in OpenID Connect (oidc) identity provider to be used for authentication. To use a generic provider,set to `oidc`.
+
+      See [identity provider] for details.
+    shortdoc: |
+      Provider is the short-hand name of a built-in OpenID Connect (oidc) identity provider to be used for authentication.
+    uuid: dc2e3398-6073-406e-a631-25f5a9ce2540
+  - name: Identity Provider Scopes
+    keys: [idp_scopes]
+    attributes: |
+      - Environmental Variable: `IDP_SCOPES`
+      - Config File Key: `idp_scopes`
+      - Type: list of `string`
+      - Default: `oidc`,`profile`, `email`, `offline_access` (typically)
+      - Optional for built-in identity providers.
+    doc: |
+      Identity provider scopes correspond to access privilege scopes as defined in Section 3.3 of OAuth 2.0 RFC6749\. The scopes associated with Access Tokens determine what resources will be available when they are used to access OAuth 2.0 protected endpoints.
+
+      :::warning
+
+      If you are using a built-in provider, you probably don't want to set customized scopes.
+
+      :::
+
+      :::warning
+
+      Some providers, like Amazon Cognito, _do not_ support the `offline_access` scope.
+
+      :::
+
+    shortdoc: |
+      Identity provider scopes correspond to access privilege scopes as defined in Section 33 of OAuth 20 RFC6749.
+    uuid: 376226b7-439c-47e7-84a2-4ec0ccf39300
+  - name: Identity Provider Service Account
+    keys: [idp_service_account]
+    attributes: |
+      - Environmental Variable: `IDP_SERVICE_ACCOUNT`
+      - Config File Key: `idp_service_account`
+      - Type: `string`
+      - **Required** for group based policies (most configurations)
+    doc: |
+      The identity provider service account setting is used to query associated identity information from your identity provider.  This is a provider specific value and is not required for all providers.  For example, when using Okta this value will be an Okta API key, and for an OIDC provider that provides groups as a claim, this value will be empty.
+
+      :::warning
+
+      If you plan to write authorization policies using groups, or any other data that exists in your identity provider's directory service, this setting is **mandatory**.
+
+      :::
+    shortdoc: |
+      Identity Provider Service Account is field used to configure any additional user account or access-token that may be required for querying additional user information during authentication.
+    uuid: 3e6abe90-87e1-4da7-8d73-5c6d4b6d62e2
+  - name: Identity Provider URL
+    keys: [idp_provider_url]
+    attributes: |
+      - Environmental Variable: `IDP_PROVIDER_URL`
+      - Config File Key: `idp_provider_url`
+      - Type: `string`
+      - Required, depending on provider (Do not use with Google).
+    doc: |
+      Provider URL is the base path to an identity provider's [OpenID connect discovery document](https://openid.net/specs/openid-connect-discovery-1_0.html). An example Azure URL would be `https://login.microsoftonline.com/common/v2.0` for [their discover document](https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration).
+
+      "Base path" is defined as the section of the URL to the discovery document up to (but not including) `/.well-known/openid-configuration`.
+    shortdoc: |
+      Provider URL is the base path to an identity provider's OpenID connect discovery document.
+    uuid: c0323ebb-b70c-481d-aba4-b6790fd0ef02
+  - name: Identity Provider Request Params
+    keys: [idp_request_params]
+    attributes: |
+      - Environmental Variable: `IDP_REQUEST_PARAMS`
+      - Config File Key: `idp_request_params`
+      - Type: map of `strings` key value pairs
+      - Optional
+    doc: |
+      Request parameters to be added as part of a signin request using OAuth2 code flow.
+
+      For more information see:
+
+      - [OIDC Request Parameters](https://openid.net/specs/openid-connect-basic-1_0.html#RequestParameters)
+      - [IANA OAuth Parameters](https://www.iana.org/assignments/oauth-parameters/oauth-parameters.xhtml)
+      - [Microsoft Azure Request params](https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow#request-an-authorization-code)
+      - [Google Authentication URI parameters](https://developers.google.com/identity/protocols/oauth2/openid-connect)
+    shortdoc: |
+      Headers specifies a mapping of HTTP Header to be added to proxied  requests. Nota bene Downstream application headers will be overwritten by Pomerium's headers on conflict.
+    uuid: 7644a1bc-7d83-43e6-a13c-e89c21f24937
+  - name: Identity Provider Refresh Directory Settings
+    keys: [idp_refresh_directory_interval, idp_refresh_directory_timeout]
+    attributes: |
+      - Environmental Variables: `IDP_REFRESH_DIRECTORY_INTERVAL` `IDP_REFRESH_DIRECTORY_TIMEOUT`
+      - Config File Key: `idp_refresh_directory_interval` `idp_refresh_directory_timeout`
+      - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
+      - Example: `IDP_REFRESH_DIRECTORY_INTERVAL=30m`
+      - Defaults: `IDP_REFRESH_DIRECTORY_INTERVAL=10m` `IDP_REFRESH_DIRECTORY_TIMEOUT=1m`
+    doc: |
+      Refresh directory interval is the time that pomerium will sync your IDP diretory, while refresh directory timeout is the maximum time allowed each run.
+
+      :::warning
+
+      Use it at your own risk, if you set a too low value, you may reach IDP API rate limit.
+
+      :::
+    uuid: 5894092d-b5de-4f42-83c1-961c6592b39f
+  uuid: dac3da93-b5f2-4bd7-9bfd-9985818005d5
+- name: Proxy Service
+  settings:
+  - name: Authorize Service URL
+    keys: [authorize_service_url]
+    attributes: |
+      - Environmental Variable: `AUTHORIZE_SERVICE_URL or `AUTHORIZE_SERVICE_URLS`
+      - Config File Key: `authorize_service_url` or `authorize_service_urls`
+      - Type: `URL`
+      - Required; inferred in all-in-one mode to be localhost.
+      - Example: `https://pomerium-authorize-service.default.svc.cluster.local`, `https://localhost:5443`, `https://authorize.corp.example.com`
+    doc: |
+      Authorize Service URL is the location of the internally accessible Authorize service. NOTE: Unlike authenticate, authorize has no publicly accessible http handlers so this setting is purely for gRPC communication.
+
+      Multiple URLs can be specified with `authorize_service_urls`.
+
+      If your load balancer does not support gRPC pass-through you'll need to set this value to an internally routable location (`https://pomerium-authorize-service.default.svc.cluster.local`) instead of an externally routable one (`https://authorize.corp.example.com`).
+    shortdoc: |
+      Authorize Service URL is the location of the internally accessible Authorize service.
+    uuid: 18f38ae1-9684-4841-8f80-5fef188fc347
+  - name: Authorize Internal Service URL
+    keys: [authorize_internal_service_url]
+    attributes: |
+      - Environmental Variable: `AUTHORIZE_INTERNAL_SERVICE_URL`
+      - Config File Key: `authorize_internal_service_url`
+      - Type: `URL`
+      - Required; inferred in all-in-one mode to be localhost.
+      - Example: `https://pomerium-authorize-service.default.svc.cluster.local` or `https://localhost:5443`
+    doc: |
+      Authorize Internal Service URL overrides `authorize_service_url` when determining the TLS certificate for the authorize service to listen with.
+    uuid: 5a59ac40-928c-4aee-b50b-f5d476f1fae8
+  - name: Certificate Authority
+    keys: [certificate_authority, certificate_authority_file]
+    attributes: |
+      - Environmental Variable: `CERTIFICATE_AUTHORITY` or `CERTIFICATE_AUTHORITY_FILE`
+      - Config File Key: `certificate_authority` or `certificate_authority_file`
+      - Type: [base64 encoded] `string` or relative file location
+      - Optional
+    doc: |
+      This defines a set of root certificate authorities that Pomerium uses when communicating with other TLS-protected services.
+
+      **Note**: Unlike route-specific certificate authority settings, this setting augments (rather than replaces) the system's trust store. But routes that specify a CA will ignore those provided here.
+
+      :::warning
+
+      Be sure to include the intermediary certificate.
+
+      :::
+    shortdoc: |
+      Certificate Authority is set when behind-the-ingress service communication uses self-signed certificates.
+    uuid: 07590e71-5ece-4977-834c-e0cdfa884e71
+  - name: Default Upstream Timeout
+    keys: [default_upstream_timeout]
+    attributes: |
+      - Environmental Variable: `DEFAULT_UPSTREAM_TIMEOUT`
+      - Config File Key: `default_upstream_timeout`
+      - Type: [Duration](https://golang.org/pkg/time/#Duration) `string`
+      - Example: `10m`, `1h45m`
+      - Default: `30s`
+    doc: |
+      Default Upstream Timeout is the default timeout applied to a proxied route when no `timeout` key is specified by the policy.
+    shortdoc: |
+      Default Upstream Timeout is the default timeout applied to a proxied route when no timeout key is specified by the policy.
+    uuid: 252505b1-ab9e-44f0-aecb-589c07ebc36b
+  - name: Set Response Headers
+    keys: [set_response_headers]
+    attributes: |
+      - Environmental Variable: `SET_RESPONSE_HEADERS`
+      - Config File Key: `set_response_headers`
+      - Type: map of `strings` key value pairs
+      - Examples:
+
+        - Comma Separated: `X-Content-Type-Options:nosniff,X-Frame-Options:SAMEORIGIN`
+        - JSON: `'{"X-Test": "X-Value"}'`
+        - YAML:
+
+          ```yaml
+          set_response_headers:
+            X-Test: X-Value
           ```
 
-          That signing key can be accessed via the well-known jwks endpoint.
+      - To disable: `disable:true`
 
-          ```bash
-          $ curl https://authenticate.int.example.com/.well-known/pomerium/jwks.json | jq
+      - Default :
+
+        ```javascript
+        X-Content-Type-Options : nosniff,
+        X-Frame-Options:SAMEORIGIN,
+        X-XSS-Protection:1; mode=block,
+        Strict-Transport-Security:max-age=31536000; includeSubDomains; preload,
+        ```
+    doc: |
+      Set Response Headers specifies a mapping of [HTTP Header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers) to be added globally to all managed routes and pomerium's authenticate service.
+
+      By default, conservative [secure HTTP headers](https://www.owasp.org/index.php/OWASP_Secure_Headers_Project) are set:
+
+        - `max-age=31536000` instructs the browser to pin the certificate for a domain for a year. This helps prevent man-in-the-middle attacks, but can create issues when developing new environments with temporary certificates. See [Troubleshooting - HSTS](/docs/troubleshooting.md#http-strict-transport-security-hsts) for more information.
+        - `includeSubDomains` applies these rules to subdomains, which is how individual routes are defined.
+        - `preload` instructs the browser to preload the certificate from an HSTS preload service if available. This means that the certificate can be loaded from an already-trusted secure connection, and the user never needs to connect to your domain without TLS.
+
+      ![pomerium security headers](./img/security-headers.png)
+
+      See [MDN Web Docs - Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) for more information.
+
+      :::tip
+
+      Several security-related headers are not set by default since doing so might break legacy sites. These include:
+      `Cross-Origin Resource Policy`, `Cross-Origin Opener Policy` and `Cross-Origin Embedder Policy`. If possible
+      users are encouraged to add these to `set_response_headers` or their downstream applications.
+
+      :::
+    uuid: e98deb26-5ec0-4cda-8ec9-664c43cc446c
+  - name: JWT Claim Headers
+    keys: [jwt_claims_headers]
+    attributes: |
+      - Environmental Variable: `JWT_CLAIMS_HEADERS`
+      - Config File Key: `jwt_claims_headers`
+      - Type: slice of `string`
+      - Example: `email`, `groups`, `user`, `given_name`
+      - Optional
+    doc: |
+      The JWT Claim Headers setting allows you to pass specific user session data to upstream applications as HTTP request headers. Note, unlike the header `x-pomerium-jwt-assertion` these values are not signed by the authorization service.
+
+      Additionally, this will add the claim to the `X-Pomerium-Jwt-Assertion` header provided by [`pass_identity_headers`](#pass-identity-headers), if not already present.
+
+      Any claim in the pomerium session JWT can be placed into a corresponding header and the JWT payload for upstream consumption. This claim information is sourced from your Identity Provider (IdP) and Pomerium's own session metadata. The header will have the following format:
+
+      `X-Pomerium-Claim-{Name}` where `{Name}` is the name of the claim requested. Underscores will be replaced with dashes; e.g. `X-Pomerium-Claim-Given-Name`.
+
+      This option also supports a nested object to customize the header name. For example:
+
+      ```yaml
+      jwt_claims_headers:
+        X-Email: email
+      ```
+
+      Will add an `X-Email` header with a value of the `email` claim.
+
+      Use this option if you previously relied on `x-pomerium-authenticated-user-{email|user-id|groups}`.
+    shortdoc: |
+      The JWT Claim Headers setting allows you to pass specific user session data to upstream applications as HTTP request headers and additional JWT claims.
+    uuid: 94ab5d2d-039f-44cc-87c5-716541d54d33
+  - name: Override Certificate Name
+    keys: [override_certificate_name]
+    attributes: |
+      - Environmental Variable: `OVERRIDE_CERTIFICATE_NAME`
+      - Config File Key: `override_certificate_name`
+      - Type: `string`
+      - Optional
+      - Example: `*.corp.example.com` if wild card or `authenticate.corp.example.com`/`authorize.corp.example.com`
+    doc: |
+      Secure service communication can fail if the external certificate does not match the internally routed service hostname/[SNI](https://en.wikipedia.org/wiki/Server_Name_Indication). This setting allows you to override that value.
+    shortdoc: |
+      Secure service communication can fail if the external certificate does not match the internally routed service hostname/SNI.
+    uuid: e2dd1961-9fce-4634-ad59-d15b5fa62a54
+  - name: Programmatic Redirect Domain Whitelist
+    keys: [programmatic_redirect_domain_whitelist]
+    attributes: |
+      - Config File Key: `programmatic_redirect_domain_whitelist`
+      - Type: array of `string`
+      - Optional
+      - Default: `localhost`
+    doc: |
+      The programmatic redirect domain whitelist is used to restrict the allowed redirect URLs when using programmatic login. By default only `localhost` URLs are allowed.
+    uuid: cd309c37-3f93-4099-91f2-724e6a2778cc
+  - name: X-Forwarded-For HTTP Header
+    keys: [skip_xff_append]
+    attributes: |
+      - Environmental Variable: `SKIP_XFF_APPEND`
+      - Config File Key: `skip_xff_append`
+      - Type: `bool`
+      - Default: `false`
+    doc: |
+      Do not append proxy IP address to `x-forwarded-for` HTTP header. See [Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=skip_xff_append#x-forwarded-for) docs for more detail.
+    shortdoc: |
+      Do not append proxy IP address to [x-forwarded-for](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=skip_xff_append#x-forwarded-for).
+    uuid: 25234763-f88d-446b-ba78-03d33a9c6535
+  - name: The number of trusted hops
+    keys: [xff_num_trusted_hops]
+    attributes: |
+      - Environmental Variable: `XFF_NUM_TRUSTED_HOPS`
+      - Config File Key: `xff_num_trusted_hops`
+      - Type: `uint32`
+      - Default: `0`
+    doc: |
+      The number of trusted reverse proxies in front of pomerium. This affects `x-forwarded-proto` header and [`x-envoy-external-address` header](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-envoy-external-address), which reports tursted client address. [Envoy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=xff_num_trusted_hops#x-forwarded-for) docs for more detail.
+    shortdoc: |
+      The number of trusted reverse proxies in front of pomerium.
+    uuid: 69545469-88dc-4f3e-a8f7-829958b41bf4
+  - name: Codec Type
+    keys: [codec_type]
+    attributes: |
+      - Environment Variable: `CODEC_TYPE`
+      - Config File Key: `codec_type`
+      - Type: `string`
+      - Default: `auto` (`http1` in all-in-one mode)
+    doc: |
+      Specifies the codec to use for downstream connections. Either `auto`, `http1` or `http2`.
+
+      When `auto` is specified the codec will be determined via TLS ALPN or protocol inference.
+
+      :::warning
+
+      With HTTP/2, browsers typically coalesce connections for the same IP address that use the same
+      TLS certificate. For example, you may have `authenticate.localhost.pomerium.io` and
+      `example.localhost.pomerium.io` using the same wildcard certificate (`*.localhost.pomerium.io`)
+      and both pointing to `127.0.0.1`. Your browser sees this and re-uses the initial connection
+      it makes to `example` for `authenticate`. But unfortunately the routes necessary to handle
+      `authenticate` don't exist on `example` so the proxy cannot handle the request.
+
+      If this happens Pomerium will respond with a `421 Misdirected Request` status. Most browsers will attempt to
+      make the request on a new HTTP/2 connection. However not all browsers implement this behavior
+      (notably Safari), and users may end up seeing a blank page instead.
+
+      If you see this happen, there are several ways to mitigate the problem:
+
+      1. Don't re-use TLS certificates for shared IP domains.
+      2. Don't re-use IP addresses for shared TLS certificates.
+      3. Don't use HTTP/2.
+
+      More details on this problem are available in [Github Issue #2150](https://github.com/pomerium/pomerium/issues/2150).
+
+      :::
+    uuid: c4f89bdc-85a3-47df-b8c6-a31d5855206e
+  uuid: fc61dc8d-dad9-4920-a446-d8cd4a7d6e3a
+- name: Data Broker Service
+  doc: |
+    The databroker service is used for storing user session data.
+
+    By default, the `databroker` service uses an in-memory databroker.
+
+    To create your own data broker, implement the following gRPC interface:
+
+    - [pkg/grpc/databroker/databroker.proto](https://github.com/pomerium/pomerium/blob/main/pkg/grpc/databroker/databroker.proto)
+
+    For an example implementation, the in-memory database used by the databroker service can be found here:
+
+    - [pkg/databroker/memory](https://github.com/pomerium/pomerium/tree/main/pkg/databroker/memory)
+  settings:
+  - name: Data Broker Internal Service URL
+    keys: [databroker_internal_service_url]
+    attributes: |
+      - Environmental Variable: `DATABROKER_INTERNAL_SERVICE_URL` or `DATABROKER_INTERNAL_SERVICE_URLS`
+      - Config File Key: `databroker_internal_service_url` or `databroker_internal_service_urls`
+      - Type: `URL`
+      - Example: `https://databroker.corp.example.com`
+      - Default: in all-in-one mode, `http://localhost:5443`
+    doc: |
+      Data Broker Internal URL overrides `databroker_service_url` when determining the TLS certificate for the databroker service to listen with.
+    uuid: a4b69326-2c69-4a24-bf54-da6b3da55ee0
+  - name: Data Broker Storage Type
+    keys: [databroker_storage_type]
+    attributes: |
+      - Environmental Variable: `DATABROKER_STORAGE_TYPE`
+      - Config File Key: `databroker_storage_type`
+      - Type: `string`
+      - Optional
+      - Example: `redis`,`memory`
+      - Default: `memory`
+    doc: |
+      The backend storage that databroker server will use.
+    uuid: e6ba2ee8-4292-41a0-858a-99ccaf76dfcb
+  - name: Data Broker Storage Connection String
+    keys: [databroker_storage_connection_string]
+    attributes: |
+      - Environmental Variable: `DATABROKER_STORAGE_CONNECTION_STRING`
+      - Config File Key: `databroker_storage_connection_string`
+      - Type: `string`
+      - **Required** when storage type is `redis`
+      - Example: `"redis://localhost:6379/0"`, `"rediss://localhost:6379/0"`
+    doc: |
+      The connection string that the databroker service will use to connect to storage backend.
+
+      For `redis`, the following URL types are supported:
+
+      - simple: `redis://[username:password@]host:port/[db]`
+      - sentinel: `redis+sentinel://[:password@]host:port[,host2:port2,...]/[master_name[/db]][?param1=value1[&param2=value2&...]]`
+      - cluster: `redis+cluster://[username:password@]host:port[,host2:port2,...]/[?param1=value1[&param2=value=2&...]]`
+
+      You can also enable TLS with `rediss://`, `rediss+sentinel://` and `rediss+cluster://`.
+    uuid: 09fb5787-a8bb-4b81-a1ba-b9da70a66fcf
+  - name: Data Broker Storage Certificate File
+    keys: [databroker_storage_cert_file]
+    attributes: |
+      - Environment Variable: `DATABROKER_STORAGE_CERT_FILE`
+      - Config File Key: `databroker_storage_cert_file`
+      - Type: relative file location
+      - Optional
+    doc: |
+      The certificate used to connect to a storage backend.
+    uuid: b2cafddd-148d-4529-a4e0-175e00e387a5
+  - name: Data Broker Storage Certificate Key File
+    keys: [databroker_storage_key_file]
+    attributes: |
+      - Environment Variable: `DATABROKER_STORAGE_KEY_FILE`
+      - Config File Key: `databroker_storage_key_file`
+      - Type: relative file location
+      - Optional
+    doc: |
+      The certificate key used to connect to a storage backend.
+    uuid: fe8b7782-1d4f-4a91-a124-c4c8a26627c1
+  - name: Data Broker Storage Certificate Authority
+    keys: [databroker_storage_ca_file]
+    attributes: |
+      - Environment Variable: `DATABROKER_STORAGE_CA_FILE`
+      - Config File Key: `databroker_storage_ca_file`
+      - Type: relative file location
+      - Optional
+    doc: |
+      This setting defines the set of root certificates used when verifying storage server connections.
+    uuid: 85674afe-20ba-4c0f-9b19-c5f652dfd537
+  - name: Data Broker Storage TLS Skip Verify
+    keys: [databroker_storage_tls_skip_verify]
+    attributes: |
+      - Environment Variable: `DATABROKER_STORAGE_TLS_SKIP_VERIFY`
+      - Config File Key: `databroker_storage_tls_skip_verify`
+      - Type: relative file location
+      - Optional
+    doc: |
+      If set, the TLS connection to the storage backend will not be verified.
+    uuid: e55c6398-10c5-42f7-aa81-a87943472ece
+  uuid: 455d56c7-8979-4e02-9a56-e4b37448d523
+- name: Policy
+  keys: [policy]
+  attributes: |
+    - Environmental Variable: `POLICY`
+    - Config File Key: `policy`
+    - Type: [base64 encoded] `string` or inline policy structure in config file
+    - **Deprecated**: This key has been replaced with `route`.
+  doc: |2
+
+    ::: warning
+    The `policy` field as a top-level configuration key has been replaced with [`routes`](/reference/readme.md#routes). Moving forward, define policies within each defined route.
+
+    Existing policy definitions will currently behave as expected, but are deprecated and will be removed in a future version of Pomerium.
+    :::
+
+    Policy contains route specific settings, and access control details. If you are configuring via POLICY environment variable, just the contents of the policy needs to be passed. If you are configuring via file, the policy should be present under the policy key. For example,
+
+    <<< @/examples/config/policy.example.yaml
+
+    Policy routes are checked in the order they appear in the policy, so more specific routes should appear before less specific routes. For example:
+
+    ```yaml
+    policy:
+      - from: http://from.example.com
+        to: http://to.example.com
+        prefix: /admin
+        allowed_groups: ["superuser"]
+      - from: http://from.example.com
+        to: http://to.example.com
+        allow_public_unauthenticated_access: true
+    ```
+
+    In this example, an incoming request with a path prefix of `/admin` would be handled by the first route (which is restricted to superusers). All other requests for `from.example.com` would be handled by the second route (which is open to the public).
+
+    A list of configuration variables specific to `policy` follows Note that this also shares all configuration variables listed under [routes](/reference/readme.md#routes), excluding `policy` and its child variables.
+  settings:
+  - name: Allowed Domains
+    keys: [allowed_domains]
+    attributes: |
+      - `yaml`/`json` setting: `allowed_domains`
+      - Type: list of `string`
+      - Required
+      - Example: `pomerium.io` , `gmail.com`
+    doc: |
+      Allowed domains is a collection of whitelisted domains to authorize for a given route.
+    uuid: 60b8a658-ca87-4139-b1b1-f7c12d593353
+  - name: Allowed Groups
+    keys: [allowed_groups]
+    attributes: |
+      - `yaml`/`json` setting: `allowed_groups`
+      - Type: list of `string`
+      - Required
+      - Example: `admins` , `support@company.com`
+    doc: |
+      Allowed groups is a collection of whitelisted groups to authorize for a given route.
+    uuid: 49a0ff2b-f1ed-47a2-a350-88c95cd6d988
+  - name: Allowed IdP Claims
+    keys: [allowed_idp_claims]
+    attributes: |
+      - `yaml`/`json` setting: `allowed_idp_claims`
+      - Type: map of `strings` lists
+      - Required
+    shortdoc: |
+      Authorize users by matching claims attached to a user's identity token by their identity provider
+    doc: |
+      Allowed IdP Claims is a collection of whitelisted claim key-value pairs to authorize for a given route.
+
+      This is useful if your identity provider has extra information about a user that is not in the directory.  It can also be useful if you wish to use groups with the generic OIDC provider.
+
+      Example:
+
+      ```yaml
+        - from: http://from.example.com
+          to: http://to.example.com
+          allowed_idp_claims:
+            family_name:
+              - Doe
+              - Smith
+      ```
+
+      This policy would match users with the `family_name` claim containing `Smith` or `Doe`.
+
+      Claims are represented as a map of strings to a list of values:
+
+      ```json
+      {
+        "family_name": ["Doe"],
+        "given_name": ["John"]
+      }
+      ```
+
+      - Nested maps are flattened: `{ "a": { "b": ["c"] } }` becomes `{ "a.b": ["c"] }`
+      - Values are always a list: `{ "a": "b" }` becomes `{ "a": ["b"] }`
+    uuid: ae182cee-e95d-4efe-b3aa-d560bcc1dfc2
+  - name: Allowed Users
+    keys: [allowed_users]
+    attributes: |
+      - `yaml`/`json` setting: `allowed_users`
+      - Type: list of `string`
+      - Required
+      - Example: `alice@pomerium.io` , `bob@contractor.co`
+    doc: |
+      Allowed users is a collection of whitelisted users to authorize for a given route.
+    uuid: 138fe1c0-9e30-4fd8-82c4-779626268ba2
+  uuid: b22aa4e3-5508-4154-afdf-2e459c58b70d
+- name: Routes
+  keys: [routes]
+  attributes: |
+    - Environment Variable: `ROUTES`
+    - Config File Key: `routes`
+    - Type: [base64 encoded] `string` or inline policy structure in config file
+    - **Required** - While Pomerium will start without a route configured, it will not authorize or proxy any traffic until a route is defined. If configuring Pomerium for the Enterprise Console, define a route for the Console itself in Pomerium.
+  doc: |
+    A route contains specific access and control definitions for a back-end service. Each route is a list item under the `routes` key.
+
+    Each route defines at minimum a `from` and `to` field, and a `policy` key defining authorization logic. Policies are defined using [Pomerium Policy Language](/enterprise/reference/manage.md#pomerium-policy-language) (**PPL**). Additional options are listed below.
+
+    <<< @/examples/config/route.example.yaml
+  settings:
+  - name: Allow Any Authenticated User
+    keys: [allow_any_authenticated_user]
+    attributes: |
+      - `yaml`/`json` setting: `allow_any_authenticated_user`
+      - Type: `bool`
+      - Optional
+      - Default: `false`
+    doc: |
+      **Use with caution:** This setting will allow all requests for any user which is able to authenticate with our given identity provider. For instance, if you are using a corporate GSuite account, an unrelated gmail user will be able to access the underlying upstream.
+
+      Use of this setting means Pomerium **will not enforce centralized authorization policy** for this route. The upstream is responsible for handling any authorization.
+    uuid: 9ff77257-3d17-476e-95f8-76edc6e9284b
+  - name: Cluster Name
+    keys: [name]
+    attributes: |
+      - Config File Key: `name`
+      - Type: `string`
+      - Optional
+    doc: |
+      Runtime metrics for this policy would be available under `envoy_cluster_`*`name`* prefix.
+    uuid: f78ea784-1b96-4091-b937-e2778bce9b26
+  - name: CORS Preflight
+    keys: [cors_allow_preflight]
+    attributes: |
+      - `yaml`/`json` setting: `cors_allow_preflight`
+      - Type: `bool`
+      - Optional
+      - Default: `false`
+    doc: |
+      Allow unauthenticated HTTP OPTIONS requests as [per the CORS spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#Preflighted_requests).
+    uuid: d507b005-cf08-4844-8d0f-969992b7e7ad
+  - name: Enable Google Cloud Serverless Authentication
+    keys: [enable_google_cloud_serverless_authentication]
+    attributes: |
+      - Environmental Variable: `ENABLE_GOOGLE_CLOUD_SERVERLESS_AUTHENTICATION`
+      - Config File Key: `enable_google_cloud_serverless_authentication`
+      - Type: `bool`
+      - Default: `false`
+    doc: |
+      Enable sending a signed [Authorization Header](https://cloud.google.com/run/docs/authenticating/service-to-service) to upstream GCP services.
+
+      Requires setting [Google Cloud Serverless Authentication Service Account](#google-cloud-serverless-authentication-service-account) or running Pomerium in an environment with a GCP service account present in default locations.
+    uuid: 7ac61aea-fdf3-4060-b0fb-f9024a330af4
+  - name: From
+    keys: [from]
+    attributes: |
+      - `yaml`/`json` setting: `from`
+      - Type: `URL` (must contain a scheme and hostname, must not contain a path)
+      - Schemes: `https`, `tcp+https`
+      - Required
+      - Example: `https://verify.corp.example.com`, `tcp+https://ssh.corp.example.com:22`
+    doc: |
+      `From` is the externally accessible URL for the proxied request.
+
+      Specifying `tcp+https` for the scheme enables [TCP proxying](/docs/tcp/readme.md) support for the route. You may map more than one port through the same hostname by specifying a different `:port` in the URL.
+
+      :::warning
+
+      Only secure schemes (`https` and `tcp+https`) are supported.
+
+      :::
+    uuid: ad15b3c4-deda-47c3-bf72-9f59c6ca6de6
+  - name: Health Checks
+    keys: [health_checks]
+    attributes: |
+      - Config File Key: `health_checks`
+      - Type: `array of objects`
+      - Optional
+    doc: |
+      When defined, will issue periodic health check requests to upstream servers. When health checks are defined, unhealthy upstream servers would not serve traffic.
+      See also `outlier_detection` for automatic upstream server health detection.
+      In presence of multiple upstream servers, it is recommended to set up either `health_checks` or `outlier_detection` or both.
+
+      See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/health_checking) for a list of [supported parameters](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-msg-config-core-v3-healthcheck).
+
+      Only one of `http_health_check`, `tcp_health_check`, or `grpc_health_check` may be configured per health_check object definition.
+
+      - [TCP](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-msg-config-core-v3-healthcheck-tcphealthcheck)
+      - [HTTP](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-msg-config-core-v3-healthcheck-httphealthcheck)
+      - [GRPC](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/health_check.proto#envoy-v3-api-msg-config-core-v3-healthcheck-grpchealthcheck)
+
+      See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.md#active-health-checks).
+    uuid: 95326984-7e5f-49fb-bce7-fcc246ce8fb3
+  - name: Host Rewrite
+    keys: [host_rewrite, host_rewrite_header, host_path_regex_rewrite_pattern, host_path_regex_rewrite_substitution,
+      preserve_host_header]
+    attributes: |
+      - `yaml`/`json` settings: `host_rewrite`, `host_rewrite_header`, `host_path_regex_rewrite_pattern`, `host_path_regex_rewrite_substitution`
+      - Type: `string`
+      - Optional
+      - Example: `host_rewrite: "example.com"`
+    doc: |
+      The `host` header can be preserved via the `preserve_host_header` setting or customized via three mutually exclusive options:
+
+      1. `preserve_host_header` will, when enabled, this option will pass the host header from the incoming request to the proxied host, instead of the destination hostname. It's an optional parameter of type `bool` that defaults to `false`.
+
+          See [ProxyPreserveHost](http://httpd.apache.org/docs/2.0/mod/mod_proxy.html#proxypreservehost).
+      2. `host_rewrite`, which will rewrite the host to a new literal value.
+      3. `host_rewrite_header`, which will rewrite the host to match an incoming header value.
+      4. `host_path_regex_rewrite_pattern` & `host_path_regex_rewrite_substitution`, which will rewrite the host according to a regex matching the path. For example with the following config:
+
+          ```yaml
+          host_path_regex_rewrite_pattern: "^/(.+)/.+$"
+          host_path_regex_rewrite_substitution: \1
           ```
 
-          ```json
+          Would rewrite the host header to `example.com` given the path `/example.com/some/path`.
+
+      The 2nd, 3rd and 4th options correspond to the Envoy route action host related options, which can be found [here](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto.html#config-route-v3-routeaction).
+    uuid: e32a53ce-eaad-4a5e-9666-25667df606c1
+  - name: Idle Timeout
+    keys: [idle_timeout]
+    attributes: |
+      - `yaml`/`json` setting: `idle_timeout`
+      - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
+      - Optional
+      - Default: `5m`
+    doc: |
+      If you are proxying long-lived requests that employ streaming calls such as websockets or gRPC,
+      set this to either a maximum value there may be no data exchange over a connection (recommended),
+      or set it to unlimited (`0s`). If `idle_timeout` is specified, and `timeout` is not
+      explicitly set, then `timeout` would be unlimited (`0s`). You still may specify maximum lifetime
+      of the connection using `timeout` value (i.e. to 1 day).
+    uuid: 47c9ab2a-a9b1-48c2-ba92-101ecc65211e
+  - name: Identity Provider Client ID (per route)
+    keys: [routes.idp_client_id]
+    attributes: |
+      - `yaml`/`json` setting: `idp_client_id`
+      - Type: `string`
+      - Optional
+    doc: |
+      When set, this overrides the value of [idp_client_id](#identity-provider-client-id) set globally for this route.
+    uuid: d4b13155-bacc-4a62-ab1b-0305da89dc5d
+  - name: Identity Provider Client Secret (per route)
+    keys: [routes.idp_client_id]
+    attributes: |
+      - `yaml`/`json` setting: `idp_client_secret`
+      - Type: `string`
+      - Optional
+    doc: |
+      When set, this overrides the value of [idp_client_secret](#identity-provider-client-secret) set globally for this route.
+    uuid: 1b906278-45b6-4ec4-a45a-39404f835a0b
+  - name: Kubernetes Service Account Token
+    keys: [kubernetes_service_account_token, kubernetes_service_account_token_file]
+    attributes: |
+      - `yaml`/`json` setting: `kubernetes_service_account_token` / `kubernetes_service_account_token_file`
+      - Type: `string` or relative file location containing a Kubernetes bearer token
+      - Optional
+      - Example: `eyJ0eXAiOiJKV1QiLCJhbGciOiJ...` or `/var/run/secrets/kubernetes.io/serviceaccount/token`
+    doc: |
+      Use this token to authenticate requests to a Kubernetes API server.
+
+      Pomerium will [impersonate](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation) the Pomerium user's identity, and Kubernetes RBAC can be applied to IdP user and groups.
+    uuid: 479adae8-e0e9-4754-8fb6-a01a2132cbb8
+  - name: Load Balancing Policy
+    keys: [lb_policy]
+    attributes: |
+      - Config File Key: `lb_policy`
+      - Type: `enum`
+      - Optional
+    doc: |
+      In presence of multiple upstreams, defines load balancing strategy between them.
+
+      See [Envoy documentation](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-enum-config-cluster-v3-cluster-lbpolicy) for more details.
+
+      - [`ROUND_ROBIN`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-round-robin) (default)
+      - [`LEAST_REQUEST`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#weighted-least-request) and may be further configured using [`least_request_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-leastrequestlbconfig)
+      - [`RING_HASH`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#ring-hash) and may be further configured using [`ring_hash_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-ringhashlbconfig) option
+      - [`RANDOM`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#random)
+      - [`MAGLEV`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/load_balancing/load_balancers#maglev) and may be further configured using [`maglev_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig) option
+
+      Some policy types support additional [configuration](#load-balancing-policy-config).
+    uuid: e5593396-f01f-4ad5-8fe7-0052dab1e7a2
+  - name: Load Balancing Policy Config
+    keys: [least_request_lb_config, ring_hash_lb_config, maglev_lb_config]
+    attributes: |
+      - Config File Key: `least_request_lb_config`, `ring_hash_lb_config`, `maglev_lb_config`
+      - Type: `object`
+      - Optional
+    doc: |
+      When [`lb_policy`](#load-balancing-policy) is configured, you may further customize policy settings for `LEAST_REQUEST`, `RING_HASH`, AND `MAGLEV` using one of the following options.
+
+      - [`least_request_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-leastrequestlbconfig)
+      - [`ring_hash_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#config-cluster-v3-cluster-ringhashlbconfig)
+      - [`maglev_lb_config`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto#envoy-v3-api-msg-config-cluster-v3-cluster-maglevlbconfig)
+
+      See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.md#load-balancing-method)
+    uuid: f81e94b5-868a-4d4f-8fe1-d0636c7c181b
+  - name: Outlier Detection
+    keys: [outlier_detection]
+    attributes: |
+      - `yaml`/`json` setting: `outlier_detection`
+      - Type: `object`
+      - Optional
+      - Example: `{ "consecutive_5xx": 12 }`
+    doc: |
+      Outlier detection and ejection is the process of dynamically determining whether some number of hosts in an upstream cluster are performing unlike the others and removing them from the healthy load balancing set.
+
+      See Envoy [documentation](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/outlier#arch-overview-outlier-detection) and [API](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/outlier_detection.proto#envoy-v3-api-msg-config-cluster-v3-outlierdetection) for more details.
+    uuid: c5175518-b323-4eb9-a2dc-829d55f06402
+  - name: Pass Identity Headers
+    keys: [pass_identity_headers]
+    attributes: |
+      - `yaml`/`json` setting: `pass_identity_headers`
+      - Type: `bool`
+      - Optional
+      - Default: `false`
+    doc: |
+      When enabled, this option will pass identity headers to upstream applications. These headers include:
+
+      - X-Pomerium-Jwt-Assertion
+      - X-Pomerium-Claim-*
+    uuid: 4ec87c58-0228-44f8-b3ec-0a1fa8c352db
+  - name: Path
+    keys: [path]
+    attributes: |
+      - `yaml`/`json` setting: `path`
+      - Type: `string`
+      - Optional
+      - Example: `/admin/some/exact/path`
+    doc: |
+      If set, the route will only match incoming requests with a path that is an exact match for the specified path.
+    uuid: d8141411-ac7f-4e75-9280-b11035bbbdb2
+  - name: Prefix
+    keys: [prefix]
+    attributes: |
+      - `yaml`/`json` setting: `prefix`
+      - Type: `string`
+      - Optional
+      - Example: `/admin`
+    doc: |
+      If set, the route will only match incoming requests with a path that begins with the specified prefix.
+    uuid: 2c73dffb-cad7-4475-8103-72be21378e47
+  - name: Prefix Rewrite
+    keys: [prefix_rewrite]
+    attributes: |
+      - `yaml`/`json` setting: `prefix_rewrite`
+      - Type: `string`
+      - Optional
+      - Example: `/subpath`
+    doc: |
+      If set, indicates that during forwarding, the matched prefix (or path) should be swapped with this value.
+      For example, given this policy:
+
+      ```yaml
+      from: https://from.example.com
+      to: https://to.example.com
+      prefix: /admin
+      prefix_rewrite: /
+      ```
+
+      A request to `https://from.example.com/admin` would be forwarded to `https://to.example.com/`.
+    uuid: da7605f9-a0dd-4e03-a03d-4832c62fe88f
+  - name: Public Access
+    keys: [allow_public_unauthenticated_access]
+    attributes: |
+      - `yaml`/`json` setting: `allow_public_unauthenticated_access`
+      - Type: `bool`
+      - Optional
+      - Default: `false`
+    doc: |
+      **Use with caution:** Allow all requests for a given route, bypassing authentication and authorization. Suitable for publicly exposed web services.
+
+      If this setting is enabled, no whitelists (e.g. Allowed Users) should be provided in this route.
+    uuid: 3b36d80d-5806-4529-9027-0fdbaab790fe
+  - name: Redirect
+    keys: [redirect]
+    attributes: |
+      - `yaml`/`json` setting: 'redirect'
+      - Type: object
+      - Optional
+      - Example: `{ "host_redirect": "example.com" }`
+    doc: |
+      `Redirect` is used to redirect incoming requests to a new URL. The `redirect` field is an object with several possible
+      options:
+
+      - `https_redirect` (boolean): the incoming scheme will be swapped with "https".
+      - `scheme_redirect` (string): the incoming scheme will be swapped with the given value.
+      - `host_redirect` (string): the incoming host will be swapped with the given value.
+      - `port_redirect` (integer): the incoming port will be swapped with the given value.
+      - `path_redirect` (string): the incoming path portion of the URL will be swapped with the given value.
+      - `prefix_rewrite` (string): the incoming matched prefix will be swapped with the given value.
+      - `response_code` (integer): the response code to use for the redirect. Defaults to 301.
+      - `strip_query` (boolean): indicates that during redirection, the query portion of the URL will be removed. Defaults to false.
+
+      Either `redirect` or `to` must be set.
+    uuid: 0fa1872b-3757-4fcc-b645-900c768107dd
+  - name: Regex
+    keys: [regex]
+    attributes: |
+      - `yaml`/`json` setting: `regex`
+      - Type: `string` (containing a regular expression)
+      - Optional
+      - Example: `^/(admin|superuser)/.*$`
+    doc: |
+      If set, the route will only match incoming requests with a path that matches the specified regular expression. The supported syntax is the same as the Go [regexp package](https://golang.org/pkg/regexp/) which is based on [re2](https://github.com/google/re2/wiki/Syntax).
+    uuid: 61210771-a4f8-4ddc-ba7f-61739d85bd23
+  - name: Regex Rewrite
+    keys: [regex_rewrite_pattern, regex_rewrite_substitution]
+    attributes: |
+      - `yaml`/`json` setting: `regex_rewrite_pattern`, `regex_rewrite_substitution`
+      - Type: `string`
+      - Optional
+      - Example: `{ "regex_rewrite_pattern":"^/service/([^/]+)(/.*)$", "regex_rewrite_substitution": "\\2/instance/\\1" }`
+    doc: |
+      If set, the URL path will be rewritten according to the pattern and substitution, similar to `prefix_rewrite`.
+    uuid: 530d5de2-743e-4600-80fb-c5357bac1951
+  - name: Remove Request Headers
+    keys: [remove_request_headers]
+    attributes: |
+      - Config File Key: `remove_request_headers`
+      - Type: array of `strings`
+      - Optional
+    doc: |
+      Remove Request Headers allows you to remove given request headers. This can be useful if you want to prevent privacy information from being passed to downstream applications. For example:
+
+      ```yaml
+      - from: https://verify.corp.example.com
+        to: https://verify.pomerium.com
+        policy:
+          - allow:
+              or:
+                - email:
+                    is: user@example.com
+        remove_request_headers:
+          - X-Email
+          - X-Username
+      ```
+    uuid: 5cc4dd96-f9a9-4089-b1bb-6e15f3595ae7
+  - name: Rewrite Response Headers
+    keys: [rewrite_response_headers]
+    attributes: |
+      - Config File Key: `rewrite_response_headers`
+      - Type: `object`
+      - Optional
+      - Example: `[{ "header": "Location", "prefix": "http://localhost:8000/two/", "value": "http://frontend/one/" }]`
+    doc: |
+      Rewrite Response Headers allows you to modify response headers before they are returned to the client. The `header` field will match the HTTP header name, and `prefix` will be replaced with `value`. For example, if the downstream server returns a header:
+
+      ```text
+      Location: http://localhost:8000/two/some/path/
+      ```
+
+      And the policy has this config:
+
+      ```yaml
+      rewrite_response_headers:
+        - header: Location
+          prefix: http://localhost:8000/two/
+          value: http://frontend/one/
+      ```
+
+      The browser would be redirected to: `http://frontend/one/some/path/`. This is similar to nginx's [`proxy_redirect` option](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_redirect), but can be used for any header.
+    uuid: 66845eb7-10a6-4620-9a9e-eea5b78fae87
+  - name: Route Timeout
+    keys: [timeout]
+    attributes: |
+      - `yaml`/`json` setting: `timeout`
+      - Type: [Go Duration](https://golang.org/pkg/time/#Duration.String) `string`
+      - Optional
+      - Default: `30s`
+    doc: |
+      Policy timeout establishes the per-route timeout value. Cannot exceed global timeout values.
+    uuid: 7ec1eebb-f3a9-4415-b0bf-6ab8f02a8be2
+  - name: Set Authorization Header
+    keys: [set_authorization_header]
+    attributes: |
+      - `yaml`/`json` setting: `set_authorization_header`
+      - Type: `string` (`pass_through`, `access_token` or `id_token`)
+      - Optional
+      - Default: `pass_through`
+    doc: |
+      `set_authorization_header` allows you to send a user's identity token through as a bearer token in the Authorization header.
+
+      Use `access_token` to send the OAuth access token, `id_token` to send the OIDC ID token, or `pass_through` (the default) to leave the Authorization header unchanged
+      from the client when it's not used for Pomerium authentication.
+    uuid: 73c39eef-724a-48bb-920b-337805ceef8b
+  - name: Set Response Headers
+    keys: [set_response_headers]
+    attributes: |
+      - Config File Key: `set_response_headers`
+      - Type: map of `strings` key value pairs
+      - Optional
+    doc: |
+      Set Response Headers allows you to set static values for the given response headers. These headers will take precedence over the global `set_response_headers`.
+    uuid: 4df6b96b-f02b-4918-8214-259648f55f85
+  - name: Set Request Headers
+    keys: [set_request_headers]
+    attributes: |
+      - Config File Key: `set_request_headers`
+      - Type: map of `strings` key value pairs
+      - Optional
+    doc: |
+      Set Request Headers allows you to set static values for given request headers. This can be useful if you want to pass along additional information to downstream applications as headers, or set authentication header to the request. For example:
+
+      ```yaml
+      - from: https://verify.corp.example.com
+        to: https://verify.pomerium.com
+        policy:
+          - allow:
+              or:
+                - email:
+                    is: user@example.com
+        set_request_headers:
+          # works auto-magically!
+          # https://verify.corp.example.com/basic-auth/root/hunter42
+          Authorization: Basic cm9vdDpodW50ZXI0Mg==
+          X-Your-favorite-authenticating-Proxy: "Pomerium"
+      ```
+      :::warning
+
+      Neither `:-prefixed` pseudo-headers nor the `Host:` header may be modified via this mechanism. Those headers may instead be modified via mechanisms such as `prefix_rewrite`, `regex_rewrite`, and `host_rewrite`.
+
+      :::
+    uuid: 6731c491-3dc5-4cc0-a882-eee2c5f90905
+  - name: Signout Redirect URL
+    keys: [signout_redirect_url]
+    attributes: |
+      - Environmental Variable: `SIGNOUT_REDIRECT_URL`
+      - Config File Key: `signout_redirect_url`
+      - Type: `URL`
+      - Required
+      - Example: `https://signout-redirect-url.corp.example.com`
+    doc: |
+      Signout redirect url is the url user will be redirected to after signing out.
+
+      You can overwrite this behavior by passing the query param `pomerium_redirect_uri` or post value `pomerium_redirect_uri`
+      to the `/.pomerium/signout/` endpoint.
+    uuid: f37009dc-b027-47be-b8e5-7a0bc9640edf
+  - name: TLS Client Certificate
+    keys: [tls_client_cert, tls_client_key, tls_client_cert_file, tls_client_key_file]
+    attributes: |
+      - Config File Key: `tls_client_cert` and `tls_client_key` or `tls_client_cert_file` and `tls_client_key_file`
+      - Type: [base64 encoded] `string` or relative file location
+      - Optional
+    doc: |
+      If specified, Pomerium will present this client certificate to upstream services when requested to enforce [mutual authentication](https://en.wikipedia.org/wiki/Mutual_authentication) (mTLS).
+
+      For more details, see our [mTLS example repository](https://github.com/pomerium/pomerium/tree/main/examples/mutual-tls) and the [Upstream mTLS With Pomerium](/guides/upstream-mtls.md) guide.
+    uuid: fdf0036b-068a-46ca-b429-e8ca29d056e8
+  - name: TLS Custom Certificate Authority
+    keys: [tls_custom_ca, tls_custom_ca_file]
+    attributes: |
+      - Config File Key: `tls_custom_ca` or `tls_custom_ca_file`
+      - Type: [base64 encoded] `string` or relative file location
+      - Optional
+    doc: |
+      TLS Custom Certificate Authority defines a set of root certificate authorities that the Pomerium Proxy Service uses when verifying upstream server certificates.
+
+      **Note**: This setting will replace (not append) the system's trust store for a given route.
+    uuid: 186e167c-80cb-4af5-a1a8-ca8b8ef00c26
+  - name: TLS Downstream Client Certificate Authority
+    keys: [tls_downstream_client_ca, tls_downstream_client_ca_file]
+    attributes: |
+      - Config File Key: `tls_downstream_client_ca` or `tls_downstream_client_ca_file`
+      - Type: [base64 encoded] `string` or relative file location
+      - Optional
+    doc: |
+      If specified, downstream clients (eg a user's browser) will be required to provide a valid client TLS
+      certificate. This overrides the global `client_ca` option for this route.
+
+      See [Client-Side mTLS With Pomerium](/guides/mtls.md) for more information.
+    uuid: b5c8abb8-cf51-49a7-870f-d0203383735a
+  - name: TLS Skip Verification
+    keys: [tls_skip_verify]
+    attributes: |
+      - Config File Key: `tls_skip_verify`
+      - Type: `bool`
+      - Default: `false`
+    doc: |
+      TLS Skip Verification controls whether the Pomerium Proxy Service verifies the upstream server's certificate chain and host name. If enabled, Pomerium accepts any certificate presented by the upstream server and any host name in that certificate. In this mode, TLS is susceptible to man-in-the-middle attacks. This should be used only for testing.
+    uuid: 66ac5047-2db6-40c8-82c5-4cc3e100e819
+  - name: TLS Server Name
+    keys: [tls_server_name]
+    attributes: |
+      - Config File Key: `tls_server_name`
+      - Type: `string`
+      - Optional
+    doc: |
+      **Deprecated**: this key has been replaced with `tls_upstream_server_name`.
+    uuid: a7e6b27f-c62c-4e93-94f1-6410422214a1
+  - name: TLS Upstream Server Name
+    keys: [tls_upstream_server_name]
+    attributes: |
+      - Config File Key: `tls_upstream_server_name`
+      - Type: `string`
+      - Optional
+    doc: |
+      TLS Upstream Server Name overrides the hostname specified in the `to` field. If set, this server name will be used to verify the certificate name. This is useful when the backend of your service is a TLS server with a valid certificate, but mismatched name.
+    uuid: fba5f2ca-eafe-4495-bcdb-510858149c2d
+  - name: TLS Downstream Server Name
+    keys: [tls_downstream_server_name]
+    attributes: |
+      - Config File Key: `tls_downstream_server_name`
+      - Type: `string`
+      - Optional
+    doc: |
+      TLS Downstream Server Name overrides the hostname specified in the `from` field. When a connection to Pomerium is made via TLS the `tls_downstream_server_name` will be used as the expected Server Name Indication, whereas the host part of the `from` field, will be expected to match the `Host` or `:authority` headers of the HTTP request.
+    uuid: ae84a7ff-24c0-4cbc-aef9-4222ab6f70b4
+  - name: To
+    keys: [to]
+    attributes: |
+      - `yaml`/`json` setting: `to`
+      - Type: `URL` or list of `URL`s (must contain a scheme and hostname) with an optional weight
+      - Schemes: `http`, `https`, `tcp`
+      - Optional
+      - Example: `http://verify` , `https://192.1.20.12:8080`, `http://neverssl.com`, `https://verify.pomerium.com/anything/`, `["http://a", "http://b"]`, `["http://a,10", "http://b,20"]`
+    doc: |
+      `To` is the destination(s) of a proxied request. It can be an internal resource, or an external resource. Multiple upstream resources can be targeted by using a list instead of a single URL:
+
+      ```yaml
+      - from: https://example.com
+        to:
+        - https://a.example.com
+        - https://b.example.com
+      ```
+
+      A load balancing weight may be associated with a particular upstream by appending `,[weight]` to the URL.  The exact behavior depends on your [`lb_policy`](#load-balancing-policy) setting.  See [Load Balancing](/docs/topics/load-balancing) for example [configurations](/docs/topics/load-balancing.md#load-balancing-weight).
+
+      Must be `tcp` if `from` is `tcp+https`.
+
+      :::warning
+
+      Be careful with trailing slash.
+
+      With rule:
+
+      ```yaml
+      - from: https://verify.corp.example.com
+        to: https://verify.pomerium.com/anything
+      ```
+
+      Requests to `https://verify.corp.example.com` will be forwarded to `https://verify.pomerium.com/anything`, while requests to `https://verify.corp.example.com/foo` will be forwarded to `https://verify.pomerium.com/anythingfoo`.To make the request forwarded to `https://httbin.org/anything/foo`, you can use double slashes in your request `https://httbin.corp.example.com//foo`.
+
+      While the rule:
+
+      ```yaml
+      - from: https://verify.corp.example.com
+        to: https://verify.pomerium.com/anything/
+      ```
+
+      All requests to `https://verify.corp.example.com/*` will be forwarded to `https://verify.pomerium.com/anything/*`. That means accessing to `https://verify.corp.example.com` will be forwarded to `https://verify.pomerium.com/anything/`. That said, if your application does not handle trailing slash, the request will end up with 404 not found.
+
+      Either `redirect` or `to` must be set.
+
+      :::
+    uuid: a3cb9ed1-8a92-4516-b328-e70751efe84f
+  - name: SPDY
+    keys: [allow_spdy]
+    attributes: |
+      - Config File Key: `allow_spdy`
+      - Type: `bool`
+      - Default: `false`
+    doc: |
+      If set, enables proxying of SPDY protocol upgrades.
+    uuid: 0daccff6-ce6d-4b0d-8946-2ad00e83c791
+  - name: Websocket Connections
+    keys: [allow_websockets]
+    attributes: |
+      - Config File Key: `allow_websockets`
+      - Type: `bool`
+      - Default: `false`
+    doc: |
+      If set, enables proxying of websocket connections.
+
+      :::warning
+
+      **Use with caution:** websockets are long-lived connections, so [global timeouts](#global-timeouts) are not enforced (though the policy-specific `timeout` is enforced). Allowing websocket connections to the proxy could result in abuse via [DOS attacks](https://www.cloudflare.com/learning/ddos/ddos-attack-tools/slowloris/).
+
+      :::
+    uuid: 6506106b-4b3d-4946-b4d8-efe7e2e1b708
+  uuid: c7057578-26f3-49f7-a19b-ebddb1d14af6
+- name: Authorize Service
+  settings:
+  - name: Google Cloud Serverless Authentication Service Account
+    keys: [google_cloud_serverless_authentication_service_account]
+    attributes: |
+      - Environmental Variable: `GOOGLE_CLOUD_SERVERLESS_AUTHENTICATION_SERVICE_ACCOUNT`
+      - Config File Key: `google_cloud_serverless_authentication_service_account`
+      - Type: [base64 encoded] `string`
+      - Optional
+    doc: |
+      Manually specify the service account credentials to support GCP's [Authorization Header](https://cloud.google.com/run/docs/authenticating/service-to-service) format.
+
+      If unspecified:
+
+      - If [Identity Provider Name](#identity-provider-name) is set to `google`, will default to [Identity Provider Service Account](#identity-provider-service-account)
+      - Otherwise, will default to ambient credentials in the default locations searched by the Google SDK. This includes GCE metadata server tokens.
+    uuid: bd94a8ee-2351-4edd-b10a-88107ab8ea0d
+  - name: Signing Key
+    keys: [signing_key]
+    attributes: |
+      - Environmental Variable: `SIGNING_KEY`
+      - Config File Key: `signing_key`
+      - Type: [base64 encoded] `string`
+      - Optional
+    doc: |
+      Signing Key is the private key used to sign a user's attestation JWT which can be consumed by upstream applications to pass along identifying user information like username, id, and groups.
+
+      If set, the signing key's public key will can retrieved by hitting Pomerium's `/.well-known/pomerium/jwks.json` endpoint which lives on the authenticate service. Otherwise, the endpoint will return an empty keyset.
+
+      For example, assuming you have [generated an ES256 key](https://github.com/pomerium/pomerium/blob/main/scripts/generate_self_signed_signing_key.sh) as follows.
+
+      ```bash
+      # Generates an P-256 (ES256) signing key
+      openssl ecparam  -genkey  -name prime256v1  -noout  -out ec_private.pem
+      # careful! this will output your private key in terminal
+      cat ec_private.pem | base64
+      ```
+
+      That signing key can be accessed via the well-known jwks endpoint.
+
+      ```bash
+      $ curl https://authenticate.int.example.com/.well-known/pomerium/jwks.json | jq
+      ```
+
+      ```json
+      {
+        "keys": [
           {
-            "keys": [
-              {
-                "use": "sig",
-                "kty": "EC",
-                "kid": "ccc5bc9d835ff3c8f7075ed4a7510159cf440fd7bf7b517b5caeb1fa419ee6a1",
-                "crv": "P-256",
-                "alg": "ES256",
-                "x": "QCN7adG2AmIK3UdHJvVJkldsUc6XeBRz83Z4rXX8Va4",
-                "y": "PI95b-ary66nrvA55TpaiWADq8b3O1CYIbvjqIHpXCY"
-              }
-            ]
+            "use": "sig",
+            "kty": "EC",
+            "kid": "ccc5bc9d835ff3c8f7075ed4a7510159cf440fd7bf7b517b5caeb1fa419ee6a1",
+            "crv": "P-256",
+            "alg": "ES256",
+            "x": "QCN7adG2AmIK3UdHJvVJkldsUc6XeBRz83Z4rXX8Va4",
+            "y": "PI95b-ary66nrvA55TpaiWADq8b3O1CYIbvjqIHpXCY"
           }
-          ```
+        ]
+      }
+      ```
 
-          If no certificate is specified, one will be generated and the base64'd public key will be added to the logs. Note, however, that this key be unique to each service, ephemeral, and will not be accessible via the authenticate service's `jwks_uri` endpoint.
-        shortdoc: |
-          Signing Key is the key used to sign a user's attestation JWT which can be consumed by upstream applications to pass along identifying user information like username, id, and groups.
+      If no certificate is specified, one will be generated and the base64'd public key will be added to the logs. Note, however, that this key be unique to each service, ephemeral, and will not be accessible via the authenticate service's `jwks_uri` endpoint.
+    shortdoc: |
+      Signing Key is the key used to sign a user's attestation JWT which can be consumed by upstream applications to pass along identifying user information like username, id, and groups.
+    uuid: 69774434-2a43-4896-a574-0fbd38aaa4d4
+  uuid: aa44f409-3de6-42bc-80ce-e0a67f7693e5

--- a/scripts/generate-settings-docs.py
+++ b/scripts/generate-settings-docs.py
@@ -33,9 +33,6 @@ def main():
 
 
 def rewrite_settings_yaml(path):
-    path = os.path.normpath(os.path.join(os.path.dirname(__file__), '..',
-                                         'docs', 'enterprise', 'console-settings.yaml'))
-
     with open(path) as f:
         doc = yaml.load(f)
 


### PR DESCRIPTION
## Summary

To make it easier for downstream consumers of the yaml reference docs, this PR automatically adds a section UUID for each block of content.  It also adds a `make gen-docs` command to help with re-running the script.

The script changes should keep the yaml consistent in future edits, but the first pass reformats things a bit.  

## Related issues

https://github.com/pomerium/internal/issues/806

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
