### PR TITLE
DOCS: add twitter meta tags

### DIFF
--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -40,6 +40,17 @@ module.exports = {
         ga: "UA-129872447-2",
       },
     ],
+    [
+      '@limdongjin/vuepress-plugin-simple-seo',
+      {
+      root_url: 'https://www.pomerium.com/',
+      default_site_name: 'Pomerium Documentation',
+      default_twitter_site: '@pomerium_io',
+      default_twitter_creator: '@pomerium_io',
+      default_image: 'img/logo-round.png',
+      default_twitter_card: 'summary',
+      },
+    ],
   ],
   markdown: {
     externalLinkSymbol: false,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": {
+    "@limdongjin/vuepress-plugin-simple-seo": "https://github.com/pomerium/vuepress-plugin-simple-seo",
     "@vuepress/plugin-google-analytics": "1.8.2",
     "js-yaml": "^4.1.0",
     "vuepress": "1.8.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -908,6 +908,10 @@
   resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-3.1.0.tgz#8ff71d51053cd5ee4981e5a501d80a536244f7fd"
   integrity sha512-GcIY79elgB+azP74j8vqkiXz8xLFfIzbQJdlwOPisgbKT00tviJQuEghOXSMVxJ00HoYJbGswr4kcllUc4xCcg==
 
+"@limdongjin/vuepress-plugin-simple-seo@https://github.com/pomerium/vuepress-plugin-simple-seo":
+  version "1.0.4-alpha.5"
+  resolved "https://github.com/pomerium/vuepress-plugin-simple-seo#b8898006d4a6f446dd378e0967e8bb60ee827d44"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
## Summary

Adds ~my~ our fork of the plugin `@limdongjin/vuepress-plugin-simple-seo`, which has some minor JS logic fixes, to the Docs site. This plugin gives us the meta tags required to generate Twitter cards.

## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
