### PR TITLE
grpc: wait for connect to be ready before making calls

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/pomerium/pomerium/authorize/evaluator"
 	"github.com/pomerium/pomerium/config"
@@ -13,6 +14,7 @@ import (
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/grpc"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
@@ -57,6 +59,7 @@ func (a *Authorize) GetDataBrokerServiceClient() databroker.DataBrokerServiceCli
 // Run runs the authorize service.
 func (a *Authorize) Run(ctx context.Context) error {
 	go a.accessTracker.Run(ctx)
+	_ = grpc.WaitForReady(ctx, a.state.Load().dataBrokerClientConnection, time.Second*10)
 	return newDataBrokerSyncer(a).Run(ctx)
 }
 

--- a/internal/controlplane/events.go
+++ b/internal/controlplane/events.go
@@ -80,6 +80,7 @@ func (srv *Server) getDataBrokerClient(ctx context.Context) (databrokerpb.DataBr
 	if err != nil {
 		return nil, fmt.Errorf("controlplane: error creating databroker connection: %w", err)
 	}
+	_ = grpc.WaitForReady(ctx, cc, time.Second*10)
 	client := databrokerpb.NewDataBrokerServiceClient(cc)
 	return client, nil
 }

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -3,6 +3,7 @@ package databroker
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/hashutil"
@@ -208,6 +209,7 @@ func (src *ConfigSource) runUpdater(cfg *config.Config) {
 			Str("outbound_port", cfg.OutboundPort).
 			Strs("databroker_urls", databrokerURLs).
 			Msg("config: starting databroker config source syncer")
+		_ = grpc.WaitForReady(ctx, cc, time.Second*10)
 		_ = syncer.Run(ctx)
 	}()
 }


### PR DESCRIPTION
## Summary
Currently our logs are a bit noisy when it comes to gRPC errors. We have no guarantees about process order and usually we'll start syncing before the databroker is up yet.

Although gRPC has a built-in `WaitForReady` option, the behavior of this option isn't quite what we're looking for. It could result in pomerium starting and sitting seemingly idle without much feedback if there were connection problems. This PR adds a `WaitForReady` function which does much the same thing, but only for the first 10 seconds, then we should start seeing the same sorts of errors we did before.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
