### PR TITLE
config: fix DefaultTransport so it is still a *http.Transport

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -123,7 +123,6 @@ func (e *Evaluator) Evaluate(ctx context.Context, req *Request) (*Result, error)
 	defer span.End()
 
 	if req.Policy == nil {
-		fmt.Println(">>>NOT FOUND<<<")
 		return notFoundOutput, nil
 	}
 
@@ -134,7 +133,6 @@ func (e *Evaluator) Evaluate(ctx context.Context, req *Request) (*Result, error)
 
 	policyEvaluator, ok := e.policyEvaluators[id]
 	if !ok {
-		fmt.Println(">>>NOT DEFINED<<<")
 		return notFoundOutput, nil
 	}
 

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -123,6 +123,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, req *Request) (*Result, error)
 	defer span.End()
 
 	if req.Policy == nil {
+		fmt.Println(">>>NOT FOUND<<<")
 		return notFoundOutput, nil
 	}
 
@@ -133,6 +134,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, req *Request) (*Result, error)
 
 	policyEvaluator, ok := e.policyEvaluators[id]
 	if !ok {
+		fmt.Println(">>>NOT DEFINED<<<")
 		return notFoundOutput, nil
 	}
 

--- a/config/http.go
+++ b/config/http.go
@@ -20,22 +20,16 @@ func NewHTTPTransport(src Source) *http.Transport {
 		tlsConfig *tls.Config
 	)
 	update := func(ctx context.Context, cfg *Config) {
-		if cfg.Options.CA != "" || cfg.Options.CAFile != "" {
-			rootCAs, err := cryptutil.GetCertPool(cfg.Options.CA, cfg.Options.CAFile)
-			if err == nil {
-				lock.Lock()
-				tlsConfig = &tls.Config{
-					RootCAs:    rootCAs,
-					MinVersion: tls.VersionTLS12,
-				}
-				lock.Unlock()
-			} else {
-				log.Error(context.Background()).Err(err).Msg("config: error getting cert pool")
-			}
-		} else {
+		rootCAs, err := cryptutil.GetCertPool(cfg.Options.CA, cfg.Options.CAFile)
+		if err == nil {
 			lock.Lock()
-			tlsConfig = nil
+			tlsConfig = &tls.Config{
+				RootCAs:    rootCAs,
+				MinVersion: tls.VersionTLS12,
+			}
 			lock.Unlock()
+		} else {
+			log.Error(context.Background()).Err(err).Msg("config: error getting cert pool")
 		}
 	}
 	src.OnConfigChange(context.Background(), update)


### PR DESCRIPTION
## Summary
Some libraries (for example OPA) expect the `http.DefaultTransport` to be a `*http.Transport`. However when we override the `DefaultTransport` we replace it with a custom `RoundTripper`, so this interface conversion can't succeed.

This PR changes `NewHTTPTransport` so that it returns a `*http.Transport`. This is done by cloning the default transport and overriding the `DialTLSContext` function to use a custom `tls.Config` when necessary. We also set `ForceAttemptHTTP2` because the default behavior when the `DialTLSContext` is overridden is to disable http/2 entirely:

> ForceAttemptHTTP2 controls whether HTTP/2 is enabled when a non-zero Dial, DialTLS, or DialContext func or TLSClientConfig is provided. By default, use of any those fields conservatively disables HTTP/2. To use a custom dialer or TLS config and still attempt HTTP/2 upgrades, set this to true.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3256


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
