### PR TITLE
ppl: support . in object_get paths

### DIFF
--- a/config/policy_ppl_test.go
+++ b/config/policy_ppl_test.go
@@ -751,14 +751,14 @@ else = [] {
 }
 
 object_get(obj, key, def) = value {
-	segments := split(key, "/")
+	segments := split(replace(key, ".", "/"), "/")
 	count(segments) == 2
 	o1 := object.get(obj, segments[0], {})
 	value = object.get(o1, segments[1], def)
 }
 
 else = value {
-	segments := split(key, "/")
+	segments := split(replace(key, ".", "/"), "/")
 	count(segments) == 3
 	o1 := object.get(obj, segments[0], {})
 	o2 := object.get(o1, segments[1], {})
@@ -766,7 +766,7 @@ else = value {
 }
 
 else = value {
-	segments := split(key, "/")
+	segments := split(replace(key, ".", "/"), "/")
 	count(segments) == 4
 	o1 := object.get(obj, segments[0], {})
 	o2 := object.get(o1, segments[1], {})
@@ -775,7 +775,7 @@ else = value {
 }
 
 else = value {
-	segments := split(key, "/")
+	segments := split(replace(key, ".", "/"), "/")
 	count(segments) == 5
 	o1 := object.get(obj, segments[0], {})
 	o2 := object.get(o1, segments[1], {})

--- a/pkg/policy/rules/rules.go
+++ b/pkg/policy/rules/rules.go
@@ -177,25 +177,25 @@ func ObjectGet() *ast.Rule {
 # object_get is like object.get, but supports converting "/" in keys to separate lookups
 # rego doesn't support recursion, so we hard code a limited number of /'s
 object_get(obj, key, def) = value {
-	segments := split(key, "/")
+	segments := split(replace(key, ".", "/"), "/")
 	count(segments) == 2
 	o1 := object.get(obj, segments[0], {})
 	value = object.get(o1, segments[1], def)
 } else = value {
-	segments := split(key, "/")
+	segments := split(replace(key, ".", "/"), "/")
 	count(segments) == 3
 	o1 := object.get(obj, segments[0], {})
 	o2 := object.get(o1, segments[1], {})
 	value = object.get(o2, segments[2], def)
 } else = value {
-	segments := split(key, "/")
+	segments := split(replace(key, ".", "/"), "/")
 	count(segments) == 4
 	o1 := object.get(obj, segments[0], {})
 	o2 := object.get(o1, segments[1], {})
 	o3 := object.get(o2, segments[2], {})
 	value = object.get(o3, segments[3], def)
 } else = value {
-	segments := split(key, "/")
+	segments := split(replace(key, ".", "/"), "/")
 	count(segments) == 5
 	o1 := object.get(obj, segments[0], {})
 	o2 := object.get(o1, segments[1], {})


### PR DESCRIPTION
## Summary
Our custom `object_get` function in rego is used to handle nested path look ups for JSON objects. Currently it uses `/` to indicate we should look inside an object. This PR also adds support for `.`.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/2501


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
