### PR TITLE
envoy: use typed extension protocol options for static bootstrap cluster

### DIFF
--- a/config/envoyconfig/bootstrap.go
+++ b/config/envoyconfig/bootstrap.go
@@ -7,7 +7,6 @@ import (
 	envoy_config_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	envoy_config_bootstrap_v3 "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
-	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_config_metrics_v3 "github.com/envoyproxy/go-control-plane/envoy/config/metrics/v3"
 	envoy_extensions_access_loggers_file_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
@@ -100,7 +99,7 @@ func (b *Builder) BuildBootstrapStaticResources() (*envoy_config_bootstrap_v3.Bo
 				},
 			},
 		},
-		Http2ProtocolOptions: &envoy_config_core_v3.Http2ProtocolOptions{},
+		TypedExtensionProtocolOptions: buildTypedExtensionProtocolOptions(nil, upstreamProtocolHTTP2),
 	}
 
 	staticCfg := &envoy_config_bootstrap_v3.Bootstrap_StaticResources{

--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -68,7 +68,6 @@ func TestBuilder_BuildBootstrapStaticResources(t *testing.T) {
 						"name": "pomerium-control-plane-grpc",
 						"type": "STATIC",
 						"connectTimeout": "5s",
-						"http2ProtocolOptions": {},
 						"loadAssignment": {
 							"clusterName": "pomerium-control-plane-grpc",
 							"endpoints": [{
@@ -83,6 +82,19 @@ func TestBuilder_BuildBootstrapStaticResources(t *testing.T) {
 									}
 								}]
 							}]
+						},
+						"typedExtensionProtocolOptions": {
+							"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+								"@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+								"explicitHttpConfig": {
+									"http2ProtocolOptions": {
+										"allowConnect": true,
+										"initialConnectionWindowSize": 1048576,
+										"initialStreamWindowSize": 65536,
+										"maxConcurrentStreams": 100
+									}
+								}
+							}
 						}
 					}
 				]

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -14,7 +14,6 @@ import (
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"google.golang.org/protobuf/proto"
-	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -394,10 +393,7 @@ func (b *Builder) buildCluster(
 		cluster.TransportSocket = cluster.TransportSocketMatches[0].TransportSocket
 	}
 
-	cluster.TypedExtensionProtocolOptions = map[string]*anypb.Any{
-		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": marshalAny(buildUpstreamProtocolOptions(endpoints, upstreamProtocol)),
-	}
-
+	cluster.TypedExtensionProtocolOptions = buildTypedExtensionProtocolOptions(endpoints, upstreamProtocol)
 	cluster.ClusterDiscoveryType = getClusterDiscoveryType(lbEndpoints)
 
 	return cluster.Validate()

--- a/config/envoyconfig/protocols.go
+++ b/config/envoyconfig/protocols.go
@@ -5,6 +5,7 @@ import (
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_extensions_upstreams_http_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/pomerium/pomerium/config"
@@ -32,6 +33,12 @@ var http2ProtocolOptions = &envoy_config_core_v3.Http2ProtocolOptions{
 	MaxConcurrentStreams:        wrapperspb.UInt32(maxConcurrentStreams),
 	InitialStreamWindowSize:     wrapperspb.UInt32(initialStreamWindowSizeLimit),
 	InitialConnectionWindowSize: wrapperspb.UInt32(initialConnectionWindowSizeLimit),
+}
+
+func buildTypedExtensionProtocolOptions(endpoints []Endpoint, upstreamProtocol upstreamProtocolConfig) map[string]*anypb.Any {
+	return map[string]*anypb.Any{
+		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": marshalAny(buildUpstreamProtocolOptions(endpoints, upstreamProtocol)),
+	}
 }
 
 func buildUpstreamProtocolOptions(endpoints []Endpoint, upstreamProtocol upstreamProtocolConfig) *envoy_extensions_upstreams_http_v3.HttpProtocolOptions {


### PR DESCRIPTION
## Summary
Envoy deprecated the original `http2ProtocolOptions`, this PR updates the bootstrap code to use the newer configuration format, which we already using for policy clusters.

## Related issues
Fixes #819


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
