### PR TITLE
authenticate: save session for bare webauthn redirects, consider external service URL to be a pomerium url

### DIFF
--- a/authenticate/handlers/webauthn/webauthn.go
+++ b/authenticate/handlers/webauthn/webauthn.go
@@ -407,12 +407,6 @@ func (h *Handler) handleView(w http.ResponseWriter, r *http.Request, state *Stat
 }
 
 func (h *Handler) saveSessionAndRedirect(w http.ResponseWriter, r *http.Request, state *State, rawRedirectURI string) error {
-	// if the redirect URL is for a URL we don't control, just do a plain redirect
-	if !isURLForPomerium(state.PomeriumDomains, rawRedirectURI) {
-		httputil.Redirect(w, r, rawRedirectURI, http.StatusFound)
-		return nil
-	}
-
 	// save the session to the databroker
 	res, err := session.Put(r.Context(), state.Client, state.Session)
 	if err != nil {
@@ -425,6 +419,12 @@ func (h *Handler) saveSessionAndRedirect(w http.ResponseWriter, r *http.Request,
 	err = state.SessionStore.SaveSession(w, r, state.SessionState)
 	if err != nil {
 		return err
+	}
+
+	// if the redirect URL is for a URL we don't control, just do a plain redirect
+	if !isURLForPomerium(state.PomeriumDomains, rawRedirectURI) {
+		httputil.Redirect(w, r, rawRedirectURI, http.StatusFound)
+		return nil
 	}
 
 	// sign+encrypt the session JWT

--- a/config/options.go
+++ b/config/options.go
@@ -1130,6 +1130,16 @@ func (o *Options) GetAllRouteableHTTPDomainsForTLSServerName(tlsServerName strin
 				domains.Add(h)
 			}
 		}
+
+		authenticateURL, err = o.GetAuthenticateURL()
+		if err != nil {
+			return nil, err
+		}
+		for _, h := range urlutil.GetDomainsForURL(*authenticateURL) {
+			if tlsServerName == "" || urlutil.StripPort(h) == tlsServerName {
+				domains.Add(h)
+			}
+		}
 	}
 
 	// policy urls


### PR DESCRIPTION
## Summary
We support redirects to non-pomerium URLs for webauthn. Unfortunately the way the code was written, when we did this we failed to save the device credential to the session.

The reason a URL in authenticate wasn't considered a pomerium domain was because we weren't adding both the external and internal service URLs to the list.

## Related issues
- https://github.com/pomerium/internal/issues/830


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
