### PR TITLE
authorize: pass idp id for webauthn url, allow unauthenticated access to static files

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -54,7 +54,7 @@ func (a *Authorize) handleResultDenied(
 	case reasons.Has(criteria.ReasonDeviceUnauthenticated):
 		// when the user's device is unauthenticated it means they haven't
 		// registered a webauthn device yet, so redirect to the webauthn flow
-		return a.requireWebAuthnResponse(ctx, in, result, isForwardAuthVerify)
+		return a.requireWebAuthnResponse(ctx, in, request, result, isForwardAuthVerify)
 	case reasons.Has(criteria.ReasonDeviceUnauthorized):
 		denyStatusCode = httputil.StatusDeviceUnauthorized
 		denyStatusText = httputil.DetailsText(httputil.StatusDeviceUnauthorized)
@@ -178,6 +178,7 @@ func (a *Authorize) requireLoginResponse(
 func (a *Authorize) requireWebAuthnResponse(
 	ctx context.Context,
 	in *envoy_service_auth_v3.CheckRequest,
+	request *evaluator.Request,
 	result *evaluator.Result,
 	isForwardAuthVerify bool,
 ) (*envoy_service_auth_v3.CheckResponse, error) {
@@ -209,6 +210,7 @@ func (a *Authorize) requireWebAuthnResponse(
 		q.Set(urlutil.QueryDeviceType, webauthnutil.DefaultDeviceType)
 	}
 	q.Set(urlutil.QueryRedirectURI, checkRequestURL.String())
+	q.Set(urlutil.QueryIdentityProviderID, opts.GetIdentityProviderForPolicy(request.Policy).GetId())
 	signinURL.RawQuery = q.Encode()
 	redirectTo := urlutil.NewSignedURL(state.sharedKey, signinURL).String()
 

--- a/internal/httputil/router.go
+++ b/internal/httputil/router.go
@@ -39,5 +39,6 @@ func DashboardSubrouter(parent *mux.Router) *mux.Router {
 			return ui.ServeFile(w, r, fileName)
 		}))
 	}
-	return r
+	// return a new subrouter so any middleware doesn't get added to the static files
+	return r.NewRoute().Subrouter()
 }


### PR DESCRIPTION
## Summary
We need to pass the idp id for webauthn registration so the proper session gets updated. Also update the dashboard subrouter on the authenticate service so that static files don't have middleware added to them (they were redirecting to the auth flow when not logged in leading to a blank screen)

## Related issues
- https://github.com/pomerium/internal/issues/830


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
