### PR TITLE
DOCS: use https to download python api lib

### DIFF
--- a/docs/enterprise/api.md
+++ b/docs/enterprise/api.md
@@ -54,7 +54,7 @@ Service accounts created in any Namespace other than **Global** will include a r
 :::: tabs
 ::: tab Python
 ```bash
-pip3 install git+ssh://git@github.com/pomerium/enterprise-client-python.git
+pip3 install git+https://git@github.com/pomerium/enterprise-client-python
 ```
 :::
 ::: tab Go


### PR DESCRIPTION
## Summary

Updates the `pip3` example command to use HTTPS instead of SSH, which requires a key.

## Related issues

Slack Discussion

## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
