### PR TITLE
databroker: fix in-memory backend deadlock

### DIFF
--- a/pkg/storage/inmemory/backend.go
+++ b/pkg/storage/inmemory/backend.go
@@ -188,6 +188,10 @@ func (backend *Backend) Lease(_ context.Context, leaseName, leaseID string, ttl 
 
 // Put puts a record into the in-memory store.
 func (backend *Backend) Put(ctx context.Context, records []*databroker.Record) (serverVersion uint64, err error) {
+	backend.mu.Lock()
+	defer backend.mu.Unlock()
+	defer backend.onChange.Broadcast(ctx)
+
 	recordTypes := map[string]struct{}{}
 	for _, record := range records {
 		if record == nil {
@@ -199,10 +203,6 @@ func (backend *Backend) Put(ctx context.Context, records []*databroker.Record) (
 				Str("db_id", record.Id).
 				Str("db_type", record.Type)
 		})
-
-		backend.mu.Lock()
-		defer backend.mu.Unlock()
-		defer backend.onChange.Broadcast(ctx)
 
 		backend.recordChange(record)
 

--- a/pkg/storage/inmemory/backend_test.go
+++ b/pkg/storage/inmemory/backend_test.go
@@ -28,22 +28,36 @@ func TestBackend(t *testing.T) {
 	})
 	t.Run("get record", func(t *testing.T) {
 		data := new(anypb.Any)
-		sv, err := backend.Put(ctx, []*databroker.Record{{
-			Type: "TYPE",
-			Id:   "abcd",
-			Data: data,
-		}})
+		sv, err := backend.Put(ctx, []*databroker.Record{
+			{
+				Type: "TYPE",
+				Id:   "a",
+				Data: data,
+			},
+			{
+				Type: "TYPE",
+				Id:   "b",
+				Data: data,
+			},
+			{
+				Type: "TYPE",
+				Id:   "c",
+				Data: data,
+			},
+		})
 		assert.NoError(t, err)
 		assert.Equal(t, backend.serverVersion, sv)
-		record, err := backend.Get(ctx, "TYPE", "abcd")
-		require.NoError(t, err)
-		if assert.NotNil(t, record) {
-			assert.Equal(t, data, record.Data)
-			assert.Nil(t, record.DeletedAt)
-			assert.Equal(t, "abcd", record.Id)
-			assert.NotNil(t, record.ModifiedAt)
-			assert.Equal(t, "TYPE", record.Type)
-			assert.Equal(t, uint64(1), record.Version)
+		for i, id := range []string{"a", "b", "c"} {
+			record, err := backend.Get(ctx, "TYPE", id)
+			require.NoError(t, err)
+			if assert.NotNil(t, record) {
+				assert.Equal(t, data, record.Data)
+				assert.Nil(t, record.DeletedAt)
+				assert.Equal(t, id, record.Id)
+				assert.NotNil(t, record.ModifiedAt)
+				assert.Equal(t, "TYPE", record.Type)
+				assert.Equal(t, uint64(i+1), record.Version)
+			}
 		}
 	})
 	t.Run("delete record", func(t *testing.T) {


### PR DESCRIPTION
## Summary
The in-memory storage backend will deadlock if multiple records are updated in a single call because we call `.Lock` multiple times. This PR fixes that and adds a test so it doesn't happen again.

## Related issues


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
