### PR TITLE
authenticate: fix internal service URL dashboard redirect

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -507,6 +507,7 @@ func (a *Authenticate) userInfo(w http.ResponseWriter, r *http.Request) error {
 	ctx, span := trace.StartSpan(r.Context(), "authenticate.userInfo")
 	defer span.End()
 	r = r.WithContext(ctx)
+	r = a.getExternalRequest(r)
 
 	// if we came in with a redirect URI, save it to a cookie so it doesn't expire with the HMAC
 	if redirectURI := r.FormValue(urlutil.QueryRedirectURI); redirectURI != "" {


### PR DESCRIPTION
## Summary
Fix the internal service URL dashboard redirect.

## Related issues
- https://github.com/pomerium/internal/issues/837

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
