### PR TITLE
Update docs for supported Ingress annotations

### DIFF
--- a/docs/docs/k8s/ingress.md
+++ b/docs/docs/k8s/ingress.md
@@ -159,7 +159,10 @@ Most configuration keys in non-Kubernetes deployments can be specified as annota
 - [`ingress.pomerium.io/outlier_detection`]
 - [`ingress.pomerium.io/pass_identity_headers`]
 - [`ingress.pomerium.io/policy`]
+- [`ingress.pomerium.io/prefix_rewrite`]
 - [`ingress.pomerium.io/preserve_host_header`]
+- [`ingress.pomerium.io/regex_rewrite_pattern`]
+- [`ingress.pomerium.io/regex_rewrite_substitution`]
 - [`ingress.pomerium.io/remove_request_headers`]
 - [`ingress.pomerium.io/rewrite_response_headers`]
 - [`ingress.pomerium.io/set_request_headers`]
@@ -405,7 +408,10 @@ For more information on the Pomerium Ingress Controller or the Kubernetes concep
 [`ingress.pomerium.io/outlier_detection`]: /reference/readme.md#outlier-detection
 [`ingress.pomerium.io/pass_identity_headers`]: /reference/readme.md#pass-identity-headers
 [`ingress.pomerium.io/policy`]: /reference/readme.md#policy
+[`ingress.pomerium.io/prefix_rewrite`]: /reference/readme.md#prefix-rewrite
 [`ingress.pomerium.io/preserve_host_header`]: /reference/readme.md#host-rewrite
+[`ingress.pomerium.io/regex_rewrite_pattern`]: /reference/readme.md#regex-rewrite
+[`ingress.pomerium.io/regex_rewrite_substitution`]: /reference/readme.md#regex-rewrite
 [`ingress.pomerium.io/remove_request_headers`]: /reference/readme.md#remove-request-headers
 [`ingress.pomerium.io/rewrite_response_headers`]: /reference/readme.md#rewrite-response-headers
 [`ingress.pomerium.io/set_request_headers`]: /reference/readme.md#set-request-headers


### PR DESCRIPTION
Signed-off-by: TJ Wesolowski <wojoinc@pm.me>

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

Adds docs for supported annotations introduced by pomerium/ingress-controller#183

## Related issues

<!-- For example...
Fixes #159
-->
pomerium/ingress-controller#183
#2979 

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
