### PR TITLE
databroker: support record type for sync latest in storage backend

### DIFF
--- a/authorize/sync.go
+++ b/authorize/sync.go
@@ -61,7 +61,6 @@ func (syncer *dataBrokerSyncer) UpdateRecords(ctx context.Context, serverVersion
 
 	// the first time we update records we signal the initial sync
 	syncer.signalOnce.Do(func() {
-		log.Info(ctx).Msg("initial sync from databroker complete")
 		close(syncer.authorize.dataBrokerInitialSync)
 	})
 }

--- a/pkg/storage/encrypted.go
+++ b/pkg/storage/encrypted.go
@@ -130,8 +130,8 @@ func (e *encryptedBackend) Sync(ctx context.Context, serverVersion, recordVersio
 	}, nil
 }
 
-func (e *encryptedBackend) SyncLatest(ctx context.Context) (serverVersion uint64, stream RecordStream, err error) {
-	serverVersion, stream, err = e.underlying.SyncLatest(ctx)
+func (e *encryptedBackend) SyncLatest(ctx context.Context, recordType string) (serverVersion uint64, stream RecordStream, err error) {
+	serverVersion, stream, err = e.underlying.SyncLatest(ctx, recordType)
 	if err != nil {
 		return serverVersion, nil, err
 	}

--- a/pkg/storage/inmemory/backend.go
+++ b/pkg/storage/inmemory/backend.go
@@ -255,12 +255,12 @@ func (backend *Backend) Sync(ctx context.Context, serverVersion, recordVersion u
 }
 
 // SyncLatest returns a record stream for all the records.
-func (backend *Backend) SyncLatest(ctx context.Context) (serverVersion uint64, stream storage.RecordStream, err error) {
+func (backend *Backend) SyncLatest(ctx context.Context, recordType string) (serverVersion uint64, stream storage.RecordStream, err error) {
 	backend.mu.RLock()
 	currentServerVersion := backend.serverVersion
 	backend.mu.RUnlock()
 
-	return currentServerVersion, newSyncLatestRecordStream(ctx, backend), nil
+	return currentServerVersion, newSyncLatestRecordStream(ctx, backend, recordType), nil
 }
 
 func (backend *Backend) recordChange(record *databroker.Record) {

--- a/pkg/storage/inmemory/backend_test.go
+++ b/pkg/storage/inmemory/backend_test.go
@@ -210,7 +210,7 @@ func TestCapacity(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	_, stream, err := backend.SyncLatest(ctx)
+	_, stream, err := backend.SyncLatest(ctx, "EXAMPLE")
 	require.NoError(t, err)
 
 	records, err := storage.RecordStreamToList(stream)

--- a/pkg/storage/inmemory/record_collection.go
+++ b/pkg/storage/inmemory/record_collection.go
@@ -38,6 +38,10 @@ func (c *RecordCollection) Delete(recordID string) {
 
 // Get gets a record from the collection.
 func (c *RecordCollection) Get(recordID string) *databroker.Record {
+	if c == nil {
+		return nil
+	}
+
 	node, ok := c.records[recordID]
 	if !ok {
 		return nil
@@ -47,11 +51,19 @@ func (c *RecordCollection) Get(recordID string) *databroker.Record {
 
 // Len returns the length of the collection.
 func (c *RecordCollection) Len() int {
+	if c == nil {
+		return 0
+	}
+
 	return len(c.records)
 }
 
 // List lists all the records in the collection in insertion order.
 func (c *RecordCollection) List() []*databroker.Record {
+	if c == nil {
+		return nil
+	}
+
 	var all []*databroker.Record
 	for el := c.insertionOrder.Front(); el != nil; el = el.Next() {
 		all = append(all, c.records[el.Value.(string)].Record)

--- a/pkg/storage/inmemory/stream.go
+++ b/pkg/storage/inmemory/stream.go
@@ -10,13 +10,18 @@ import (
 func newSyncLatestRecordStream(
 	ctx context.Context,
 	backend *Backend,
+	recordType string,
 ) storage.RecordStream {
 	var ready []*databroker.Record
 	return storage.NewRecordStream(ctx, backend.closed, []storage.RecordStreamGenerator{
 		func(ctx context.Context, block bool) (*databroker.Record, error) {
 			backend.mu.RLock()
-			for _, co := range backend.lookup {
-				ready = append(ready, co.List()...)
+			if recordType == "" {
+				for _, co := range backend.lookup {
+					ready = append(ready, co.List()...)
+				}
+			} else {
+				ready = append(ready, backend.lookup[recordType].List()...)
 			}
 			backend.mu.RUnlock()
 			return nil, storage.ErrStreamDone

--- a/pkg/storage/redis/redis.go
+++ b/pkg/storage/redis/redis.go
@@ -254,12 +254,12 @@ func (backend *Backend) Sync(ctx context.Context, serverVersion, recordVersion u
 
 // SyncLatest returns a record stream of all the records. Some records may be returned twice if the are updated while the
 // stream is streaming.
-func (backend *Backend) SyncLatest(ctx context.Context) (serverVersion uint64, stream storage.RecordStream, err error) {
+func (backend *Backend) SyncLatest(ctx context.Context, recordType string) (serverVersion uint64, stream storage.RecordStream, err error) {
 	serverVersion, err = backend.getOrCreateServerVersion(ctx)
 	if err != nil {
 		return 0, nil, err
 	}
-	return serverVersion, newSyncLatestRecordStream(ctx, backend), nil
+	return serverVersion, newSyncLatestRecordStream(ctx, backend, recordType), nil
 }
 
 func (backend *Backend) put(ctx context.Context, records []*databroker.Record) error {

--- a/pkg/storage/redis/redis_test.go
+++ b/pkg/storage/redis/redis_test.go
@@ -240,7 +240,7 @@ func TestCapacity(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		_, stream, err := backend.SyncLatest(ctx)
+		_, stream, err := backend.SyncLatest(ctx, "EXAMPLE")
 		require.NoError(t, err)
 		defer stream.Close()
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -40,7 +40,7 @@ type Backend interface {
 	// Sync syncs record changes after the specified version.
 	Sync(ctx context.Context, serverVersion, recordVersion uint64) (RecordStream, error)
 	// SyncLatest syncs all the records.
-	SyncLatest(ctx context.Context) (serverVersion uint64, stream RecordStream, err error)
+	SyncLatest(ctx context.Context, recordType string) (serverVersion uint64, stream RecordStream, err error)
 }
 
 // MatchAny searches any data with a query.


### PR DESCRIPTION
## Summary
Currently the `SyncLatest` storage backend call always returns all records and filters them in the server. This PR updates the code to support filtering by record type in the storage backend.

Basically this allows us to use the `MATCH xyz*` argument to `HSCAN` in redis, which is much faster than doing the filtering later.


## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
