### PR TITLE
httputil/reproxy: fix policy transport

### DIFF
--- a/config/http.go
+++ b/config/http.go
@@ -62,6 +62,7 @@ func NewPolicyHTTPTransport(options *Options, policy *Policy, disableHTTP2 bool)
 	//
 	if disableHTTP2 {
 		transport.TLSNextProto = map[string]func(authority string, c *tls.Conn) http.RoundTripper{}
+		transport.ForceAttemptHTTP2 = false
 	}
 
 	var tlsClientConfig tls.Config
@@ -111,6 +112,7 @@ func NewPolicyHTTPTransport(options *Options, policy *Policy, disableHTTP2 bool)
 	// We avoid setting a custom client config unless we have to as
 	// if TLSClientConfig is nil, the default configuration is used.
 	if isCustomClientConfig {
+		transport.DialTLSContext = nil
 		transport.TLSClientConfig = &tlsClientConfig
 	}
 	return c.Then(transport)

--- a/config/http_test.go
+++ b/config/http_test.go
@@ -37,6 +37,13 @@ func TestHTTPTransport(t *testing.T) {
 }
 
 func TestPolicyHTTPTransport(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	defer func() {
+		http.DefaultTransport = originalTransport
+	}()
+	src := NewStaticSource(&Config{Options: &Options{}})
+	http.DefaultTransport = NewHTTPTransport(src)
+
 	s := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))


### PR DESCRIPTION
## Summary
Fix the reproxy policy transport so that it disables the custom TLS dialer. When the custom TLS dialer is set `transport.TLSClientConfig` is ignored. 

## Related issues
Fixes #3321 


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
