### PR TITLE
docs: fix a typo in auth0 config example

### DIFF
--- a/docs/docs/identity-providers/auth0.md
+++ b/docs/docs/identity-providers/auth0.md
@@ -87,7 +87,7 @@ idp_provider: "auth0"
 idp_provider_url: "https://awesome-company.auth0.com"
 idp_client_id: "REPLACE_ME" # from the web application
 idp_client_secret: "REPLACE_ME" # from the web application
-idp_service_acount: "REPLACE_ME" # built from the machine-to-machine application, base64-encoded
+idp_service_account: "REPLACE_ME" # built from the machine-to-machine application, base64-encoded
 ```
 :::
 ::: tab Environment Variables


### PR DESCRIPTION
## Summary

There is a typo in the Auth0 config example, misleading people to configure IDP.

## Related issues

Fixes #3331

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
