### PR TITLE
envoyconfig: prevent nil reproxy handler

### DIFF
--- a/config/envoyconfig/builder.go
+++ b/config/envoyconfig/builder.go
@@ -22,6 +22,9 @@ func New(
 	fileManager *filemgr.Manager,
 	reproxyHandler *reproxy.Handler,
 ) *Builder {
+	if reproxyHandler == nil {
+		reproxyHandler = reproxy.New()
+	}
 	return &Builder{
 		localGRPCAddress:    localGRPCAddress,
 		localHTTPAddress:    localHTTPAddress,


### PR DESCRIPTION
## Summary

Reproxy handler is set to nil during config validation in the console and ingress controller, 
that would result in SIGSEGV if `kubernetes_service_account_token` config option is set. 

as `reproxy` package is internal, a fix is to prevent a nil reproxy.

## Related issues

https://github.com/pomerium/ingress-controller/issues/205

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
