### PR TITLE
ci: use labels to alert of recently updated issues

### DIFF
--- a/.github/workflows/needs-data.yaml
+++ b/.github/workflows/needs-data.yaml
@@ -1,0 +1,29 @@
+name: "Close Stale Issues and PRs"
+on:
+  schedule:
+    - cron: "30 1 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    permissions:
+      issues: write # for actions/stale to close stale issues
+      pull-requests: write # for actions/stale to close stale PRs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@3cc123766321e9f15a6676375c154ccffb12a358
+        with:
+          stale-issue-message: "This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days"
+          stale-pr-message: "This pull request is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 7 days"
+          days-before-stale: 30
+          days-before-close: 7
+          exempt-issue-labels: "NeedsDecision"
+          exempt-all-milestones: true
+          labels-to-remove-when-unstale: "NeedsMoreData,WaitingForInfo"
+          any-of-issue-labels: "NeedsMoreData,WaitingForInfo"
+          any-of-pr-labels: "NeedsMoreData,WaitingForInfo"
+          labels-to-add-when-unstale: "NeedsDiscussion"
+          stale-issue-label: "NeedsMoreData"
+          stale-pr-label: "NeedsMoreData"


### PR DESCRIPTION
## Summary

Currently, it's easy to miss issues that have been updated. This makes it so any "NeedsMoreData" labeled issue gets marked with "NeedsDiscussion" for triage. 

## Related issues

N/A

## Checklist

- [x] ready for review
