### PR TITLE
fix: rename rego rule function param name from in to ins

### DIFF
--- a/config/policy_ppl_test.go
+++ b/config/policy_ppl_test.go
@@ -623,14 +623,14 @@ deny = v {
 	v := merge_with_or(normalized)
 }
 
-invert_criterion_result(in) = out {
-	in[0]
-	out = array.concat([false], array.slice(in, 1, count(in)))
+invert_criterion_result(ins) = out {
+	ins[0]
+	out = array.concat([false], array.slice(ins, 1, count(ins)))
 }
 
 else = out {
-	not in[0]
-	out = array.concat([true], array.slice(in, 1, count(in)))
+	not ins[0]
+	out = array.concat([true], array.slice(ins, 1, count(ins)))
 }
 
 normalize_criterion_result(result) = v {

--- a/pkg/policy/generator/generator_test.go
+++ b/pkg/policy/generator/generator_test.go
@@ -178,14 +178,14 @@ deny = v {
 	v := merge_with_or(normalized)
 }
 
-invert_criterion_result(in) = out {
-	in[0]
-	out = array.concat([false], array.slice(in, 1, count(in)))
+invert_criterion_result(ins) = out {
+	ins[0]
+	out = array.concat([false], array.slice(ins, 1, count(ins)))
 }
 
 else = out {
-	not in[0]
-	out = array.concat([true], array.slice(in, 1, count(in)))
+	not ins[0]
+	out = array.concat([true], array.slice(ins, 1, count(ins)))
 }
 
 normalize_criterion_result(result) = v {

--- a/pkg/policy/rules/rules.go
+++ b/pkg/policy/rules/rules.go
@@ -146,12 +146,12 @@ merge_with_or(results) = [true, reasons, additional_data] {
 // true, or vice-versa.
 func InvertCriterionResult() *ast.Rule {
 	return ast.MustParseRule(`
-invert_criterion_result(in) = out {
-	in[0]
-	out = array.concat([false], array.slice(in, 1, count(in)))
+invert_criterion_result(ins) = out {
+	ins[0]
+	out = array.concat([false], array.slice(ins, 1, count(ins)))
 } else = out {
-	not in[0]
-	out = array.concat([true], array.slice(in, 1, count(in)))
+	not ins[0]
+	out = array.concat([true], array.slice(ins, 1, count(ins)))
 }
 `)
 }


### PR DESCRIPTION
when call rego function `ast.Member.Expr()` occur conflict


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
