### PR TITLE
add x-request-id in responses

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -441,6 +441,8 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 		return nil, err
 	}
 	tc := marshalAny(&envoy_http_connection_manager.HttpConnectionManager{
+		AlwaysSetRequestIdInResponse: true,
+
 		CodecType:  options.GetCodecType().ToEnvoy(),
 		StatPrefix: "ingress",
 		RouteSpecifier: &envoy_http_connection_manager.HttpConnectionManager_RouteConfig{

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -134,6 +134,7 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 					}
 				}
 			}],
+			"alwaysSetRequestIdInResponse": true,
 			"codecType": "HTTP1",
 			"commonHttpProtocolOptions": {
 				"idleTimeout": "300s"


### PR DESCRIPTION
## Summary

Pomerium logs contain `request-id` fields, however it was not exposed in the actual response. 
This PR adds `x-request-id` to every response.

## Related issues

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
