### PR TITLE
storage: add filtering to SyncLatest

### DIFF
--- a/internal/databroker/server.go
+++ b/internal/databroker/server.go
@@ -339,9 +339,6 @@ func (srv *Server) SyncLatest(req *databroker.SyncLatestRequest, stream databrok
 
 	for recordStream.Next(false) {
 		record := recordStream.Record()
-		if record.GetVersion() > recordVersion {
-			recordVersion = record.GetVersion()
-		}
 		if req.GetType() == "" || req.GetType() == record.GetType() {
 			err = stream.Send(&databroker.SyncLatestResponse{
 				Response: &databroker.SyncLatestResponse_Record{

--- a/internal/databroker/server.go
+++ b/internal/databroker/server.go
@@ -145,7 +145,7 @@ func (srv *Server) Query(ctx context.Context, req *databroker.QueryRequest) (*da
 		return nil, err
 	}
 
-	_, stream, err := db.SyncLatest(ctx)
+	_, _, stream, err := db.SyncLatest(ctx, req.GetType(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -332,11 +332,10 @@ func (srv *Server) SyncLatest(req *databroker.SyncLatestRequest, stream databrok
 		return err
 	}
 
-	serverVersion, recordStream, err := backend.SyncLatest(ctx)
+	serverVersion, recordVersion, recordStream, err := backend.SyncLatest(ctx, req.GetType(), nil)
 	if err != nil {
 		return err
 	}
-	recordVersion := uint64(0)
 
 	for recordStream.Next(false) {
 		record := recordStream.Record()

--- a/pkg/storage/encrypted.go
+++ b/pkg/storage/encrypted.go
@@ -130,7 +130,11 @@ func (e *encryptedBackend) Sync(ctx context.Context, serverVersion, recordVersio
 	}, nil
 }
 
-func (e *encryptedBackend) SyncLatest(ctx context.Context, recordType string, filter FilterExpression) (serverVersion, recordVersion uint64, stream RecordStream, err error) {
+func (e *encryptedBackend) SyncLatest(
+	ctx context.Context,
+	recordType string,
+	filter FilterExpression,
+) (serverVersion, recordVersion uint64, stream RecordStream, err error) {
 	serverVersion, recordVersion, stream, err = e.underlying.SyncLatest(ctx, recordType, filter)
 	if err != nil {
 		return serverVersion, recordVersion, nil, err

--- a/pkg/storage/encrypted.go
+++ b/pkg/storage/encrypted.go
@@ -130,12 +130,12 @@ func (e *encryptedBackend) Sync(ctx context.Context, serverVersion, recordVersio
 	}, nil
 }
 
-func (e *encryptedBackend) SyncLatest(ctx context.Context) (serverVersion uint64, stream RecordStream, err error) {
-	serverVersion, stream, err = e.underlying.SyncLatest(ctx)
+func (e *encryptedBackend) SyncLatest(ctx context.Context, recordType string, filter FilterExpression) (serverVersion, recordVersion uint64, stream RecordStream, err error) {
+	serverVersion, recordVersion, stream, err = e.underlying.SyncLatest(ctx, recordType, filter)
 	if err != nil {
-		return serverVersion, nil, err
+		return serverVersion, recordVersion, nil, err
 	}
-	return serverVersion, &encryptedRecordStream{
+	return serverVersion, recordVersion, &encryptedRecordStream{
 		underlying: stream,
 		backend:    e,
 	}, nil

--- a/pkg/storage/inmemory/backend.go
+++ b/pkg/storage/inmemory/backend.go
@@ -255,12 +255,17 @@ func (backend *Backend) Sync(ctx context.Context, serverVersion, recordVersion u
 }
 
 // SyncLatest returns a record stream for all the records.
-func (backend *Backend) SyncLatest(ctx context.Context) (serverVersion uint64, stream storage.RecordStream, err error) {
+func (backend *Backend) SyncLatest(
+	ctx context.Context,
+	recordType string,
+	filter storage.FilterExpression,
+) (serverVersion, recordVersion uint64, stream storage.RecordStream, err error) {
 	backend.mu.RLock()
-	currentServerVersion := backend.serverVersion
+	serverVersion = backend.serverVersion
+	recordVersion = backend.lastVersion
 	backend.mu.RUnlock()
 
-	return currentServerVersion, newSyncLatestRecordStream(ctx, backend), nil
+	return serverVersion, recordVersion, newSyncLatestRecordStream(ctx, backend), nil
 }
 
 func (backend *Backend) recordChange(record *databroker.Record) {

--- a/pkg/storage/inmemory/backend.go
+++ b/pkg/storage/inmemory/backend.go
@@ -258,14 +258,15 @@ func (backend *Backend) Sync(ctx context.Context, serverVersion, recordVersion u
 func (backend *Backend) SyncLatest(
 	ctx context.Context,
 	recordType string,
-	filter storage.FilterExpression,
+	expr storage.FilterExpression,
 ) (serverVersion, recordVersion uint64, stream storage.RecordStream, err error) {
 	backend.mu.RLock()
 	serverVersion = backend.serverVersion
 	recordVersion = backend.lastVersion
 	backend.mu.RUnlock()
 
-	return serverVersion, recordVersion, newSyncLatestRecordStream(ctx, backend), nil
+	stream, err = newSyncLatestRecordStream(ctx, backend, recordType, expr)
+	return serverVersion, recordVersion, stream, err
 }
 
 func (backend *Backend) recordChange(record *databroker.Record) {

--- a/pkg/storage/inmemory/backend_test.go
+++ b/pkg/storage/inmemory/backend_test.go
@@ -210,7 +210,7 @@ func TestCapacity(t *testing.T) {
 		require.NoError(t, err)
 	}
 
-	_, stream, err := backend.SyncLatest(ctx)
+	_, _, stream, err := backend.SyncLatest(ctx, "EXAMPLE", nil)
 	require.NoError(t, err)
 
 	records, err := storage.RecordStreamToList(stream)

--- a/pkg/storage/inmemory/stream.go
+++ b/pkg/storage/inmemory/stream.go
@@ -17,6 +17,11 @@ func newSyncLatestRecordStream(
 	if err != nil {
 		return nil, err
 	}
+	if recordType != "" {
+		filter = filter.And(func(record *databroker.Record) (keep bool) {
+			return record.GetType() == recordType
+		})
+	}
 
 	var ready []*databroker.Record
 	generator := storage.FilteredRecordStreamGenerator(

--- a/pkg/storage/redis/redis_test.go
+++ b/pkg/storage/redis/redis_test.go
@@ -240,7 +240,7 @@ func TestCapacity(t *testing.T) {
 			require.NoError(t, err)
 		}
 
-		_, stream, err := backend.SyncLatest(ctx)
+		_, _, stream, err := backend.SyncLatest(ctx, "EXAMPLE", nil)
 		require.NoError(t, err)
 		defer stream.Close()
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -40,7 +40,7 @@ type Backend interface {
 	// Sync syncs record changes after the specified version.
 	Sync(ctx context.Context, serverVersion, recordVersion uint64) (RecordStream, error)
 	// SyncLatest syncs all the records.
-	SyncLatest(ctx context.Context) (serverVersion uint64, stream RecordStream, err error)
+	SyncLatest(ctx context.Context, recordType string, filter FilterExpression) (serverVersion, recordVersion uint64, stream RecordStream, err error)
 }
 
 // MatchAny searches any data with a query.


### PR DESCRIPTION
## Summary
Add `recordType` and `FilterExpression` to the arguments for `SyncLatest`. Also updates the in-memory and redis backends to support filtering. Filtering is implemented via a function applied to all the results.

## Related issues
Fixes https://github.com/pomerium/internal/issues/854
Fixes https://github.com/pomerium/internal/issues/853


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
