### PR TITLE
authenticate: allow changing the authenticate service URL at runtime

### DIFF
--- a/config/config_source.go
+++ b/config/config_source.go
@@ -139,9 +139,6 @@ func NewFileOrEnvironmentSource(
 		config:     cfg,
 	}
 	src.watcher.Add(configFile)
-	options.viper.OnConfigChange(src.onConfigChange(ctx))
-	go options.viper.WatchConfig()
-
 	ch := src.watcher.Bind()
 	go func() {
 		for range ch {
@@ -174,6 +171,7 @@ func (src *FileOrEnvironmentSource) check(ctx context.Context) {
 		log.Error(ctx).Err(err).Msg("config: error updating config")
 		metrics.SetConfigInfo(ctx, cfg.Options.Services, "local", cfg.Checksum(), false)
 	}
+	src.config = cfg
 	src.mu.Unlock()
 
 	src.Trigger(ctx, cfg)

--- a/config/config_source.go
+++ b/config/config_source.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"sync"
 
-	"github.com/fsnotify/fsnotify"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 
@@ -147,12 +146,6 @@ func NewFileOrEnvironmentSource(
 	}()
 
 	return src, nil
-}
-
-func (src *FileOrEnvironmentSource) onConfigChange(ctx context.Context) func(fsnotify.Event) {
-	return func(evt fsnotify.Event) {
-		src.check(ctx)
-	}
 }
 
 func (src *FileOrEnvironmentSource) check(ctx context.Context) {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/docker/docker v20.10.16+incompatible
 	github.com/envoyproxy/go-control-plane v0.10.2-0.20220325020618-49ff273808a1
 	github.com/envoyproxy/protoc-gen-validate v0.6.7
-	github.com/fsnotify/fsnotify v1.5.4
+	github.com/fsnotify/fsnotify v1.5.4 // indirect
 	github.com/go-chi/chi/v5 v5.0.7
 	github.com/go-jose/go-jose/v3 v3.0.0
 	github.com/go-redis/redis/v8 v8.11.5

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -73,6 +73,7 @@ func New(cfg *config.Config) (*Proxy, error) {
 	return p, nil
 }
 
+// Mount mounts the http handler to a mux router.
 func (p *Proxy) Mount(r *mux.Router) {
 	r.PathPrefix("/").Handler(p)
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -73,6 +73,10 @@ func New(cfg *config.Config) (*Proxy, error) {
 	return p, nil
 }
 
+func (p *Proxy) Mount(r *mux.Router) {
+	r.PathPrefix("/").Handler(p)
+}
+
 // OnConfigChange updates internal structures based on config.Options
 func (p *Proxy) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	if p == nil {


### PR DESCRIPTION
## Summary
Update the way HTTP handlers are added to the control plane so that the authenticate service URL can be changed at runtime.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3355 


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
