### PR TITLE
do not require idp set in the bootstrap config, as it may be later configured via the databroker

### DIFF
--- a/internal/directory/provider.go
+++ b/internal/directory/provider.go
@@ -172,6 +172,8 @@ func GetProvider(options Options) (provider Provider) {
 			Str("provider", options.Provider).
 			Err(err).
 			Msg("invalid service account for ping directory provider")
+	case "":
+		errSyncDisabled = fmt.Errorf("no directory provider configured")
 	default:
 		errSyncDisabled = fmt.Errorf("unknown directory provider %s", options.Provider)
 	}

--- a/internal/identity/providers.go
+++ b/internal/identity/providers.go
@@ -56,6 +56,8 @@ func NewAuthenticator(o oauth.Options) (a Authenticator, err error) {
 		a, err = onelogin.New(ctx, &o)
 	case ping.Name:
 		a, err = ping.New(ctx, &o)
+	case "":
+		return nil, fmt.Errorf("identity: provider is not defined")
 	default:
 		return nil, fmt.Errorf("identity: unknown provider: %s", o.ProviderName)
 	}


### PR DESCRIPTION
## Summary

Currently, IdP settings are required for Pomerium bootstrap config, and it would not 
start up without them. 

Allowing Pomerium to start without IdP configuration allows it to be later configured 
by external source, such as Ingress Controller.

## Related issues

Implements https://github.com/pomerium/internal/issues/862

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
