### PR TITLE
postgres: fix CIDR query

### DIFF
--- a/pkg/storage/postgres/filter_test.go
+++ b/pkg/storage/postgres/filter_test.go
@@ -21,12 +21,16 @@ func TestAddFilterExpressionToQuery(t *testing.T) {
 				Fields: []string{"$index"},
 				Value:  "v2",
 			},
+			storage.EqualsFilterExpression{
+				Fields: []string{"$index"},
+				Value:  "10.0.0.0/8",
+			},
 		},
 		storage.EqualsFilterExpression{
 			Fields: []string{"type"},
 			Value:  "v3",
 		},
 	})
-	assert.Equal(t, "( ( pomerium.records.id = $1 OR pomerium.records.index_cidr >>= $2 ) AND pomerium.records.type = $3 )", query)
-	assert.Equal(t, []any{"v1", "v2", "v3"}, args)
+	assert.Equal(t, "( ( pomerium.records.id = $1 OR  false  OR pomerium.records.index_cidr >>= $2 ) AND pomerium.records.type = $3 )", query)
+	assert.Equal(t, []any{"v1", "10.0.0.0/8", "v3"}, args)
 }


### PR DESCRIPTION
## Summary
Currently when we try to use an `$index: ...` query, we don't check the value to make sure that it's a valid CIDR before attempting to use the GIST index. This results in an error: 

```
{"level":"error","error":"rpc error: code = Unknown desc = ERROR: invalid input syntax for type inet: \"\" (SQLSTATE 22P02)","time":"2022-06-02T16:23:07Z","message":"authorize/store: error retrieving record"}
```

This PR changes the code so that we only use the CIDR index when `$index` is set to a valid IP address or prefix.

## Related issues
Fixes https://github.com/pomerium/internal/issues/872


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
