### PR TITLE
postgres: only use serializable for record updates, retry serialization errors

### DIFF
--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -261,8 +261,8 @@ func putRecord(ctx context.Context, q querier, record *databroker.Record) error 
 	} else {
 		_, err = q.Exec(ctx, `
 			DELETE FROM `+schemaName+`.`+recordsTableName+`
-			WHERE type=$1 AND id=$2 AND version<$3
-		`, record.GetType(), record.GetId(), record.GetVersion())
+			WHERE type=$1 AND id=$2
+		`, record.GetType(), record.GetId())
 	}
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
We are occasionally seeing errors like:

> postgres_1                         | 2022-06-06 18:37:40.636 UTC [62] ERROR:  could not serialize access due to read/write dependencies among transactions
> postgres_1                         | 2022-06-06 18:37:40.636 UTC [62] DETAIL:  Reason code: Canceled on identification as a pivot, during write.
> postgres_1                         | 2022-06-06 18:37:40.636 UTC [62] HINT:  The transaction might succeed if retried.
> postgres_1                         | 2022-06-06 18:37:40.636 UTC [62] STATEMENT:  
> postgres_1                         | 			INSERT INTO pomerium.record_changes (type, id, version, data, modified_at, deleted_at)
> postgres_1                         | 			VALUES ($1, $2, $3, $4, $5, $6)
> postgres_1                         |

This PR makes it so we make less SQL queries in the serializable transaction to reduce the likelihood of a serialization error (previously we enforced type limits in the transaction, now we will do that after updating the records in a normal transaction). We will also retry up to 5 times.


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
