### PR TITLE
authorize: fix not found check

### DIFF
--- a/authorize/databroker.go
+++ b/authorize/databroker.go
@@ -3,11 +3,10 @@ package authorize
 import (
 	"context"
 
-	"github.com/open-policy-agent/opa/storage"
-
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/storage"
 )
 
 type sessionOrServiceAccount interface {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -113,3 +113,8 @@ func matchProtoMapValue(fd protoreflect.FieldDescriptor, m protoreflect.Map, que
 	})
 	return matches
 }
+
+// IsNotFound returns true if the error is because a record was not found.
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrNotFound) || status.Code(err) == codes.NotFound
+}


### PR DESCRIPTION
## Summary
We were mistakenly using the OPA storage not found error check when retrieving a session or service account. We should've been using our storage not found error check.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/2590


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
