### PR TITLE
identity: batch directory updates

### DIFF
--- a/internal/identity/manager/manager.go
+++ b/internal/identity/manager/manager.go
@@ -264,10 +264,13 @@ func (mgr *Manager) mergeGroups(ctx context.Context, directoryGroups []*director
 		}
 	}
 
-	for _, batch := range databroker.OptimumPutRequestsFromRecords(records) {
+	for i, batch := range databroker.OptimumPutRequestsFromRecords(records) {
 		_, err := mgr.cfg.Load().dataBrokerClient.Put(ctx, batch)
 		if err != nil {
-			log.Warn(ctx).Err(err).Msg("manager: failed to update groups")
+			log.Warn(ctx).Err(err).
+				Int("batch", i).
+				Int("record-count", len(batch.GetRecords())).
+				Msg("manager: failed to update groups")
 		}
 	}
 }
@@ -307,10 +310,13 @@ func (mgr *Manager) mergeUsers(ctx context.Context, directoryUsers []*directory.
 		}
 	}
 
-	for _, batch := range databroker.OptimumPutRequestsFromRecords(records) {
+	for i, batch := range databroker.OptimumPutRequestsFromRecords(records) {
 		_, err := mgr.cfg.Load().dataBrokerClient.Put(ctx, batch)
 		if err != nil {
-			log.Warn(ctx).Err(err).Msg("manager: failed to update users")
+			log.Warn(ctx).Err(err).
+				Int("batch", i).
+				Int("record-count", len(batch.GetRecords())).
+				Msg("manager: failed to update users")
 		}
 	}
 }


### PR DESCRIPTION
## Summary
We now support batching Puts on the databroker. This PR updates the identity manager so that it updates the directory with batches instead of 10 at a time concurrently. This dramatically improves performance for large updates.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/2590


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
