### PR TITLE
authorize: allow missing user for authorization

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -61,16 +61,12 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 	if sessionState != nil {
 		s, err = a.getDataBrokerSessionOrServiceAccount(ctx, sessionState.ID)
 		if err != nil {
-			log.Warn(ctx).Err(err).Msg("clearing session due to force sync failed")
+			log.Warn(ctx).Err(err).Msg("clearing session due to missing session or service account")
 			sessionState = nil
 		}
 	}
 	if s != nil {
-		u, err = a.getDataBrokerUser(ctx, s.GetUserId())
-		if err != nil {
-			log.Warn(ctx).Err(err).Msg("clearing session due to force sync failed")
-			sessionState = nil
-		}
+		u, _ = a.getDataBrokerUser(ctx, s.GetUserId()) // ignore any missing user error
 	}
 
 	req, err := a.getEvaluatorRequestFromCheckRequest(in, sessionState)


### PR DESCRIPTION
## Summary
The previous version of the code would not return an error if a user record did not exist:

```go
	s := a.forceSyncSession(ctx, ss.ID)
	if s == nil {
		return nil, nil, errors.New("session not found")
	}
	u := a.forceSyncUser(ctx, s.GetUserId())
	return s, u, nil
```

We inadvertently made this more strict when we switched to querying for the user on-demand. This PR restores the original behavior.

A `user.User` record will not exist unless that specific user logs in via Authenticate. If a service account is created for a user, and the user itself never logs in, then only a `directory.User` record will exist.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/2590

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
