### PR TITLE
eliminate global events manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ lint: ## Verifies `golint` passes.
 .PHONY: test
 test: get-envoy ## Runs the go tests.
 	@echo "==> $@"
-	@$(GO) test -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration)
+	@$(GO) test -race -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration)
 
 .PHONY: spellcheck
 spellcheck: # Spellcheck docs

--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/directory"
 	"github.com/pomerium/pomerium/internal/envoy/files"
+	"github.com/pomerium/pomerium/internal/events"
 	"github.com/pomerium/pomerium/internal/identity"
 	"github.com/pomerium/pomerium/internal/identity/manager"
 	"github.com/pomerium/pomerium/internal/log"
@@ -33,6 +34,7 @@ import (
 type DataBroker struct {
 	dataBrokerServer *dataBrokerServer
 	manager          *manager.Manager
+	eventsMgr        *events.Manager
 
 	localListener                net.Listener
 	localGRPCServer              *grpc.Server
@@ -45,7 +47,7 @@ type DataBroker struct {
 }
 
 // New creates a new databroker service.
-func New(cfg *config.Config) (*DataBroker, error) {
+func New(cfg *config.Config, eventsMgr *events.Manager) (*DataBroker, error) {
 	localListener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		return nil, err
@@ -100,6 +102,7 @@ func New(cfg *config.Config) (*DataBroker, error) {
 		localGRPCConnection:          localGRPCConnection,
 		deprecatedCacheClusterDomain: dataBrokerURLs[0].Hostname(),
 		dataBrokerStorageType:        cfg.Options.DataBrokerStorageType,
+		eventsMgr:                    eventsMgr,
 	}
 	c.Register(c.localGRPCServer)
 

--- a/databroker/cache_test.go
+++ b/databroker/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/events"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
@@ -28,7 +29,7 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.opts.Provider = "google"
-			_, err := New(&config.Config{Options: &tt.opts})
+			_, err := New(&config.Config{Options: &tt.opts}, events.New())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/controlplane/xdsmgr/xdsmgr_test.go
+++ b/internal/controlplane/xdsmgr/xdsmgr_test.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/test/bufconn"
 
+	"github.com/pomerium/pomerium/internal/events"
 	"github.com/pomerium/pomerium/internal/signal"
 )
 
@@ -36,7 +37,7 @@ func TestManager(t *testing.T) {
 		typeURL: {
 			{Name: "r1", Version: "1"},
 		},
-	})
+	}, events.New())
 	envoy_service_discovery_v3.RegisterAggregatedDiscoveryServiceServer(srv, mgr)
 
 	li := bufconn.Listen(bufSize)

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -21,21 +21,6 @@ type EventSink func(Event)
 // An EventSinkHandle is a reference to a registered EventSink so that it can be unregistered.
 type EventSinkHandle string
 
-// Dispatch dispatches an event to any event sinks.
-func Dispatch(evt Event) {
-	defaultManager.Dispatch(evt)
-}
-
-// Register registers a new sink to receive events.
-func Register(sink EventSink) EventSinkHandle {
-	return defaultManager.Register(sink)
-}
-
-// Unregister unregisters a sink so it will no longer receive events.
-func Unregister(sinkHandle EventSinkHandle) {
-	defaultManager.Unregister(sinkHandle)
-}
-
 type (
 	// EnvoyConfigurationEvent re-exports events.EnvoyConfigurationEvent.
 	EnvoyConfigurationEvent = events.EnvoyConfigurationEvent

--- a/internal/events/manager.go
+++ b/internal/events/manager.go
@@ -9,8 +9,6 @@ import (
 	"github.com/pomerium/pomerium/internal/log"
 )
 
-var defaultManager = New()
-
 // A Manager manages the dispatching of events to event sinks.
 type Manager struct {
 	mu    sync.RWMutex

--- a/internal/identity/manager/config.go
+++ b/internal/identity/manager/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/pomerium/pomerium/internal/directory"
+	"github.com/pomerium/pomerium/internal/events"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
@@ -24,6 +25,7 @@ type config struct {
 	sessionRefreshGracePeriod     time.Duration
 	sessionRefreshCoolOffDuration time.Duration
 	now                           func() time.Time
+	eventMgr                      *events.Manager
 }
 
 func newConfig(options ...Option) *config {
@@ -95,6 +97,13 @@ func WithSessionRefreshCoolOffDuration(dur time.Duration) Option {
 func WithNow(now func() time.Time) Option {
 	return func(cfg *config) {
 		cfg.now = now
+	}
+}
+
+// WithEventManager passes an event manager to record events
+func WithEventManager(mgr *events.Manager) Option {
+	return func(c *config) {
+		c.eventMgr = mgr
 	}
 }
 

--- a/internal/identity/manager/manager.go
+++ b/internal/identity/manager/manager.go
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/internal/directory"
+	"github.com/pomerium/pomerium/internal/events"
 	"github.com/pomerium/pomerium/internal/identity/identity"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/scheduler"
@@ -23,6 +24,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
+	metrics_ids "github.com/pomerium/pomerium/pkg/metrics"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
@@ -208,6 +210,7 @@ func (mgr *Manager) refreshDirectoryUserGroups(ctx context.Context) (nextRefresh
 
 	directoryGroups, directoryUsers, err := mgr.cfg.Load().directory.UserGroups(ctx)
 	metrics.RecordIdentityManagerUserGroupRefresh(ctx, err)
+	mgr.recordLastError(metrics_ids.IdentityManagerLastUserGroupRefreshError, err)
 	if err != nil {
 		msg := "failed to refresh directory users and groups"
 		if ctx.Err() != nil {
@@ -356,6 +359,7 @@ func (mgr *Manager) refreshSession(ctx context.Context, userID, sessionID string
 
 	newToken, err := mgr.cfg.Load().authenticator.Refresh(ctx, FromOAuthToken(s.OauthToken), &s)
 	metrics.RecordIdentityManagerSessionRefresh(ctx, err)
+	mgr.recordLastError(metrics_ids.IdentityManagerLastSessionRefreshError, err)
 	if isTemporaryError(err) {
 		log.Error(ctx).Err(err).
 			Str("user_id", s.GetUserId()).
@@ -374,6 +378,7 @@ func (mgr *Manager) refreshSession(ctx context.Context, userID, sessionID string
 
 	err = mgr.cfg.Load().authenticator.UpdateUserInfo(ctx, FromOAuthToken(s.OauthToken), &s)
 	metrics.RecordIdentityManagerUserRefresh(ctx, err)
+	mgr.recordLastError(metrics_ids.IdentityManagerLastUserRefreshError, err)
 	if isTemporaryError(err) {
 		log.Error(ctx).Err(err).
 			Str("user_id", s.GetUserId()).
@@ -426,6 +431,7 @@ func (mgr *Manager) refreshUser(ctx context.Context, userID string) {
 
 		err := mgr.cfg.Load().authenticator.UpdateUserInfo(ctx, FromOAuthToken(s.OauthToken), &u)
 		metrics.RecordIdentityManagerUserRefresh(ctx, err)
+		mgr.recordLastError(metrics_ids.IdentityManagerLastUserRefreshError, err)
 		if isTemporaryError(err) {
 			log.Error(ctx).Err(err).
 				Str("user_id", s.GetUserId()).
@@ -550,6 +556,21 @@ func (mgr *Manager) reset() {
 	mgr.directoryUsers = make(map[string]*directory.User)
 	mgr.sessions = sessionCollection{BTree: btree.New(8)}
 	mgr.users = userCollection{BTree: btree.New(8)}
+}
+
+func (mgr *Manager) recordLastError(id string, err error) {
+	if err == nil {
+		return
+	}
+	evtMgr := mgr.cfg.Load().eventMgr
+	if evtMgr == nil {
+		return
+	}
+	evtMgr.Dispatch(&events.LastError{
+		Time:    timestamppb.Now(),
+		Message: err.Error(),
+		Id:      id,
+	})
 }
 
 func isTemporaryError(err error) bool {

--- a/internal/telemetry/metrics/info.go
+++ b/internal/telemetry/metrics/info.go
@@ -9,9 +9,7 @@ import (
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
-	"google.golang.org/protobuf/types/known/timestamppb"
 
-	"github.com/pomerium/pomerium/internal/events"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/metrics"
 )
@@ -277,7 +275,6 @@ func RecordIdentityManagerUserRefresh(ctx context.Context, err error) {
 	if err != nil {
 		counter = identityManagerLastUserRefreshError
 		ts = identityManagerLastUserRefreshErrorTimestamp
-		storeLastErrorEvent(counter.Name(), err)
 	}
 	stats.Record(ctx,
 		ts.M(time.Now().Unix()),
@@ -292,7 +289,6 @@ func RecordIdentityManagerUserGroupRefresh(ctx context.Context, err error) {
 	if err != nil {
 		counter = identityManagerLastUserGroupRefreshError
 		ts = identityManagerLastUserGroupRefreshErrorTimestamp
-		storeLastErrorEvent(counter.Name(), err)
 	}
 	stats.Record(ctx,
 		ts.M(time.Now().Unix()),
@@ -307,20 +303,11 @@ func RecordIdentityManagerSessionRefresh(ctx context.Context, err error) {
 	if err != nil {
 		counter = identityManagerLastSessionRefreshError
 		ts = identityManagerLastSessionRefreshErrorTimestamp
-		storeLastErrorEvent(counter.Name(), err)
 	}
 	stats.Record(ctx,
 		ts.M(time.Now().Unix()),
 		counter.M(1),
 	)
-}
-
-func storeLastErrorEvent(id string, err error) {
-	events.Dispatch(&events.LastError{
-		Time:    timestamppb.Now(),
-		Message: err.Error(),
-		Id:      id,
-	})
 }
 
 // SetDBConfigInfo records status, databroker version and error count while parsing


### PR DESCRIPTION
## Summary

Remove global events manager and pass it as argument to New()
According to race detector, it caused `cover` test flakiness in the 
`internal/cmd/pomerium` package. 

Make tests run with `-race` by default. 

## Related issues


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
