### PR TITLE
goreleaser: remove ignore

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -28,9 +28,6 @@ builds:
     goos:
       - linux
       - darwin
-    ignore:
-      - goos: darwin
-        goarch: arm64
 
     ldflags:
       - -s -w
@@ -45,7 +42,6 @@ builds:
         - cmd: ./scripts/get-envoy.bash
           env:
             - TARGET={{ .Os }}-{{ .Arch }}
-
 
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
@@ -124,7 +120,6 @@ dockers:
       - "--label=org.opencontainers.image.source={{.GitURL}}"
       - "--label=repository=http://github.com/pomerium/pomerium"
       - "--label=homepage=http://www.pomerium.io"
-
 
   - image_templates:
       - "gcr.io/pomerium-io/pomerium:{{ .Tag }}-cloudrun"


### PR DESCRIPTION
## Summary
Remove the ignore block from goreleaser to build for darwin/arm64.

## Related issues
Fixes #3414 


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
