### PR TITLE
device enrollment: fix ip address

### DIFF
--- a/authenticate/handlers/webauthn/webauthn.go
+++ b/authenticate/handlers/webauthn/webauthn.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 
@@ -523,9 +522,7 @@ func getOrCreateDeviceEnrollment(
 	deviceEnrollment.CredentialId = deviceCredentialID
 	deviceEnrollment.EnrolledAt = timestamppb.Now()
 	deviceEnrollment.UserAgent = r.UserAgent()
-	if ip, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
-		deviceEnrollment.IpAddress = ip
-	}
+	deviceEnrollment.IpAddress = httputil.GetClientIPAddress(r)
 
 	err := device.PutEnrollment(ctx, state.Client, deviceEnrollment)
 	if err != nil {

--- a/internal/httputil/httputil.go
+++ b/internal/httputil/httputil.go
@@ -1,6 +1,9 @@
 package httputil
 
-import "net/http"
+import (
+	"net"
+	"net/http"
+)
 
 const (
 	// StatusDeviceUnauthorized is the status code returned when a client's
@@ -38,4 +41,17 @@ func StatusText(code int) string {
 		return txt
 	}
 	return http.StatusText(code)
+}
+
+// GetClientIPAddress gets a client's IP address for an HTTP request.
+func GetClientIPAddress(r *http.Request) string {
+	if ip := r.Header.Get("X-Envoy-External-Address"); ip != "" {
+		return ip
+	}
+
+	if ip, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+		return ip
+	}
+
+	return "127.0.0.1"
 }

--- a/internal/httputil/httputil_test.go
+++ b/internal/httputil/httputil_test.go
@@ -1,0 +1,26 @@
+package httputil
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClientIPAddress(t *testing.T) {
+	r1, err := http.NewRequest("GET", "https://example.com", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "127.0.0.1", GetClientIPAddress(r1))
+
+	r2, err := http.NewRequest("GET", "https://example.com", nil)
+	require.NoError(t, err)
+	r2.RemoteAddr = "127.0.0.2:1234"
+	assert.Equal(t, "127.0.0.2", GetClientIPAddress(r2))
+
+	r3, err := http.NewRequest("GET", "https://example.com", nil)
+	require.NoError(t, err)
+	r3.RemoteAddr = "127.0.0.3:1234"
+	r3.Header.Set("X-Envoy-External-Address", "127.0.0.3")
+	assert.Equal(t, "127.0.0.3", GetClientIPAddress(r3))
+}


### PR DESCRIPTION
## Summary
Fix the device enrollment IP address.

## Related issues
Fixes https://github.com/pomerium/internal/issues/858

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
