### PR TITLE
netutil: improve port allocation

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"crypto/tls"
+	"strconv"
 
 	"github.com/pomerium/pomerium/internal/hashutil"
 	"github.com/pomerium/pomerium/internal/netutil"
@@ -67,11 +68,11 @@ func (cfg *Config) AllocatePorts() error {
 		return err
 	}
 
-	cfg.GRPCPort = ports[0]
-	cfg.HTTPPort = ports[1]
-	cfg.OutboundPort = ports[2]
-	cfg.MetricsPort = ports[3]
-	cfg.DebugPort = ports[4]
+	cfg.GRPCPort = strconv.Itoa(ports[0])
+	cfg.HTTPPort = strconv.Itoa(ports[1])
+	cfg.OutboundPort = strconv.Itoa(ports[2])
+	cfg.MetricsPort = strconv.Itoa(ports[3])
+	cfg.DebugPort = strconv.Itoa(ports[4])
 
 	return nil
 }

--- a/internal/netutil/netutil.go
+++ b/internal/netutil/netutil.go
@@ -11,12 +11,12 @@ func AllocatePorts(count int) ([]int, error) {
 	for k := range ports {
 		addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 		if err != nil {
-			return ports, err
+			return nil, err
 		}
 
 		l, err := net.ListenTCP("tcp", addr)
 		if err != nil {
-			return ports, err
+			return nil, err
 		}
 		// This is done on purpose - we want to keep ports
 		// busy to avoid collisions when getting the next one


### PR DESCRIPTION
## Summary
Sometimes we seem to allocate an invalid port which causes tests to fail: https://github.com/pomerium/pomerium/runs/6923304146?check_suite_focus=true

This PR updates the port allocation code to hopefully use a more reliable approach.

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
