### PR TITLE
postgres: fix record deletion

### DIFF
--- a/pkg/storage/postgres/backend_test.go
+++ b/pkg/storage/postgres/backend_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
@@ -39,6 +40,21 @@ func TestBackend(t *testing.T) {
 				{Type: "test-1", Id: "r2", Data: protoutil.NewAny(protoutil.NewStructMap(map[string]*structpb.Value{
 					"k2": protoutil.NewStructString("v2"),
 				}))},
+			})
+			assert.NotEqual(t, 0, serverVersion)
+			assert.NoError(t, err)
+		})
+
+		t.Run("delete", func(t *testing.T) {
+			serverVersion, err := backend.Put(ctx, []*databroker.Record{
+				{
+					Type: "test-1",
+					Id:   "r3",
+					Data: protoutil.NewAny(protoutil.NewStructMap(map[string]*structpb.Value{
+						"k1": protoutil.NewStructString("v1"),
+					})),
+					DeletedAt: timestamppb.Now(),
+				},
 			})
 			assert.NotEqual(t, 0, serverVersion)
 			assert.NoError(t, err)


### PR DESCRIPTION
## Summary
Record deletion was failing because we were passing an argument (`indexCIDR`) that was never used.

## Related issues
Fixes #3445 

## User Explanation
Delete records in the databroker was broken. This PR fixes it.

## Checklist
- [x] reference any related issues
- [x] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
