### PR TITLE
feat: custom response header field "server" 

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -464,6 +464,8 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 		SkipXffAppend:     options.SkipXffAppend,
 		XffNumTrustedHops: options.XffNumTrustedHops,
 		LocalReplyConfig:  b.buildLocalReplyConfig(options),
+
+		ServerName: options.ServerName,
 	})
 
 	return &envoy_config_listener_v3.Filter{

--- a/config/options.go
+++ b/config/options.go
@@ -92,6 +92,10 @@ type Options struct {
 
 	CertificateFiles []certificateFilePair `mapstructure:"certificates" yaml:"certificates,omitempty"`
 
+	// An optional override that the connection manager will write to the server header in responses.
+	// If not set, the default is envoy.
+	ServerName string `mapstructure:"server_name" yaml:"server_name"`
+
 	// Cert and Key is the x509 certificate used to create the HTTPS server.
 	Cert string `mapstructure:"certificate" yaml:"certificate,omitempty"`
 	Key  string `mapstructure:"certificate_key" yaml:"certificate_key,omitempty"`


### PR DESCRIPTION
## Summary

allow user custom response header field "server" 


## Related issues

https://github.com/pomerium/pomerium/issues/2893


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
