### PR TITLE
config: support files for shared_secret, client_secret, cookie_secret and signing_key

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -23,7 +23,11 @@ func ValidateOptions(o *config.Options) error {
 	if _, err := cryptutil.NewAEADCipher(sharedKey); err != nil {
 		return fmt.Errorf("authenticate: 'SHARED_SECRET' invalid: %w", err)
 	}
-	if _, err := cryptutil.NewAEADCipherFromBase64(o.CookieSecret); err != nil {
+	cookieSecret, err := o.GetCookieSecret()
+	if err != nil {
+		return fmt.Errorf("authenticate: 'COOKIE_SECRET' invalid: %w", err)
+	}
+	if _, err := cryptutil.NewAEADCipher(cookieSecret); err != nil {
 		return fmt.Errorf("authenticate: 'COOKIE_SECRET' invalid %w", err)
 	}
 	if o.AuthenticateCallbackPath == "" {

--- a/authenticate/identity.go
+++ b/authenticate/identity.go
@@ -19,7 +19,10 @@ func defaultGetIdentityProvider(options *config.Options, idpID string) (identity
 	}
 	redirectURL.Path = options.AuthenticateCallbackPath
 
-	idp := options.GetIdentityProviderForID(idpID)
+	idp, err := options.GetIdentityProviderForID(idpID)
+	if err != nil {
+		return nil, err
+	}
 	return identity.NewAuthenticator(oauth.Options{
 		RedirectURL:     redirectURL,
 		ProviderName:    idp.GetType(),

--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -101,7 +101,7 @@ func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, err
 	}
 
 	// private state encoder setup, used to encrypt oauth2 tokens
-	state.cookieSecret, err = base64.StdEncoding.DecodeString(cfg.Options.CookieSecret)
+	state.cookieSecret, err = cfg.Options.GetCookieSecret()
 	if err != nil {
 		return nil, err
 	}
@@ -131,7 +131,11 @@ func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, err
 	state.sessionStore = cookieStore
 	state.sessionLoaders = []sessions.SessionLoader{headerStore, cookieStore}
 	state.jwk = new(jose.JSONWebKeySet)
-	if cfg.Options.SigningKey != "" {
+	signingKey, err := cfg.Options.GetSigningKey()
+	if err != nil {
+		return nil, err
+	}
+	if signingKey != "" {
 		decodedCert, err := base64.StdEncoding.DecodeString(cfg.Options.SigningKey)
 		if err != nil {
 			return nil, fmt.Errorf("authenticate: failed to decode signing key: %w", err)

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -103,10 +103,15 @@ func newPolicyEvaluator(opts *config.Options, store *store.Store) (*evaluator.Ev
 		return nil, fmt.Errorf("authorize: invalid authenticate url: %w", err)
 	}
 
+	signingKey, err := opts.GetSigningKey()
+	if err != nil {
+		return nil, fmt.Errorf("authorize: invalid signing key: %w", err)
+	}
+
 	return evaluator.New(ctx, store,
 		evaluator.WithPolicies(opts.GetAllPolicies()),
 		evaluator.WithClientCA(clientCA),
-		evaluator.WithSigningKey(opts.SigningKey),
+		evaluator.WithSigningKey(signingKey),
 		evaluator.WithAuthenticateURL(authenticateURL.String()),
 		evaluator.WithGoogleCloudServerlessAuthenticationServiceAccount(opts.GetGoogleCloudServerlessAuthenticationServiceAccount()),
 		evaluator.WithJWTClaimsHeaders(opts.JWTClaimsHeaders),

--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -166,7 +166,11 @@ func (a *Authorize) requireLoginResponse(
 	checkRequestURL.Scheme = "https"
 
 	q.Set(urlutil.QueryRedirectURI, checkRequestURL.String())
-	q.Set(urlutil.QueryIdentityProviderID, opts.GetIdentityProviderForPolicy(request.Policy).GetId())
+	idp, err := opts.GetIdentityProviderForPolicy(request.Policy)
+	if err != nil {
+		return nil, err
+	}
+	q.Set(urlutil.QueryIdentityProviderID, idp.GetId())
 	signinURL.RawQuery = q.Encode()
 	redirectTo := urlutil.NewSignedURL(state.sharedKey, signinURL).String()
 
@@ -210,7 +214,11 @@ func (a *Authorize) requireWebAuthnResponse(
 		q.Set(urlutil.QueryDeviceType, webauthnutil.DefaultDeviceType)
 	}
 	q.Set(urlutil.QueryRedirectURI, checkRequestURL.String())
-	q.Set(urlutil.QueryIdentityProviderID, opts.GetIdentityProviderForPolicy(request.Policy).GetId())
+	idp, err := opts.GetIdentityProviderForPolicy(request.Policy)
+	if err != nil {
+		return nil, err
+	}
+	q.Set(urlutil.QueryIdentityProviderID, idp.GetId())
 	signinURL.RawQuery = q.Encode()
 	redirectTo := urlutil.NewSignedURL(state.sharedKey, signinURL).String()
 

--- a/config/config_source.go
+++ b/config/config_source.go
@@ -222,14 +222,18 @@ func (src *FileWatcherSource) check(ctx context.Context, cfg *Config) {
 		cfg.Options.CertFile,
 		cfg.Options.ClientCAFile,
 		cfg.Options.ClientCRLFile,
+		cfg.Options.ClientSecretFile,
+		cfg.Options.CookieSecretFile,
 		cfg.Options.DataBrokerStorageCAFile,
 		cfg.Options.DataBrokerStorageCertFile,
 		cfg.Options.DataBrokerStorageCertKeyFile,
 		cfg.Options.KeyFile,
-		cfg.Options.PolicyFile,
-		cfg.Options.MetricsClientCAFile,
 		cfg.Options.MetricsCertificateFile,
 		cfg.Options.MetricsCertificateKeyFile,
+		cfg.Options.MetricsClientCAFile,
+		cfg.Options.PolicyFile,
+		cfg.Options.SharedSecretFile,
+		cfg.Options.SigningKeyFile,
 	}
 
 	for _, pair := range cfg.Options.CertificateFiles {

--- a/config/identity.go
+++ b/config/identity.go
@@ -6,11 +6,14 @@ import (
 
 // GetIdentityProviderForID returns the identity provider associated with the given IDP id.
 // If none is found the default provider is returned.
-func (o *Options) GetIdentityProviderForID(idpID string) *identity.Provider {
+func (o *Options) GetIdentityProviderForID(idpID string) (*identity.Provider, error) {
 	for _, policy := range o.GetAllPolicies() {
-		idp := o.GetIdentityProviderForPolicy(&policy) //nolint
+		idp, err := o.GetIdentityProviderForPolicy(&policy) //nolint
+		if err != nil {
+			return nil, err
+		}
 		if idp.GetId() == idpID {
-			return idp
+			return idp, nil
 		}
 	}
 
@@ -19,10 +22,15 @@ func (o *Options) GetIdentityProviderForID(idpID string) *identity.Provider {
 
 // GetIdentityProviderForPolicy gets the identity provider associated with the given policy.
 // If policy is nil, or changes none of the default settings, the default provider is returned.
-func (o *Options) GetIdentityProviderForPolicy(policy *Policy) *identity.Provider {
+func (o *Options) GetIdentityProviderForPolicy(policy *Policy) (*identity.Provider, error) {
+	clientSecret, err := o.GetClientSecret()
+	if err != nil {
+		return nil, err
+	}
+
 	idp := &identity.Provider{
 		ClientId:       o.ClientID,
-		ClientSecret:   o.ClientSecret,
+		ClientSecret:   clientSecret,
 		Type:           o.Provider,
 		Scopes:         o.Scopes,
 		ServiceAccount: o.ServiceAccount,
@@ -38,5 +46,5 @@ func (o *Options) GetIdentityProviderForPolicy(policy *Policy) *identity.Provide
 		}
 	}
 	idp.Id = idp.Hash()
-	return idp
+	return idp, nil
 }

--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -158,13 +158,18 @@ func (c *DataBroker) update(ctx context.Context, cfg *config.Config) error {
 		return fmt.Errorf("databroker: invalid oauth options: %w", err)
 	}
 
+	clientSecret, err := cfg.Options.GetClientSecret()
+	if err != nil {
+		return fmt.Errorf("databroker: error retrieving IPD client secret: %w", err)
+	}
+
 	directoryProvider := directory.GetProvider(directory.Options{
 		ServiceAccount: cfg.Options.ServiceAccount,
 		Provider:       cfg.Options.Provider,
 		ProviderURL:    cfg.Options.ProviderURL,
 		QPS:            cfg.Options.GetQPS(),
 		ClientID:       cfg.Options.ClientID,
-		ClientSecret:   cfg.Options.ClientSecret,
+		ClientSecret:   clientSecret,
 	})
 	c.mu.Lock()
 	c.directoryProvider = directoryProvider

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -38,7 +38,11 @@ func ValidateOptions(o *config.Options) error {
 		return fmt.Errorf("proxy: invalid 'SHARED_SECRET': %w", err)
 	}
 
-	if _, err := cryptutil.NewAEADCipherFromBase64(o.CookieSecret); err != nil {
+	cookieSecret, err := o.GetCookieSecret()
+	if err != nil {
+		return fmt.Errorf("proxy: invalid 'COOKIE_SECRET': %w", err)
+	}
+	if _, err := cryptutil.NewAEADCipher(cookieSecret); err != nil {
 		return fmt.Errorf("proxy: invalid 'COOKIE_SECRET': %w", err)
 	}
 

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -2,7 +2,6 @@ package proxy
 
 import (
 	"crypto/cipher"
-	"encoding/base64"
 	"net/url"
 	"sync/atomic"
 
@@ -51,7 +50,7 @@ func newProxyStateFromConfig(cfg *config.Config) (*proxyState, error) {
 		return nil, err
 	}
 
-	state.cookieSecret, err = base64.StdEncoding.DecodeString(cfg.Options.CookieSecret)
+	state.cookieSecret, err = cfg.Options.GetCookieSecret()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Add support for loading values from files for these options.

## Related issues
- https://github.com/pomerium/pomerium/issues/3441

## User Explanation
Users can now load these options from a file instead of an environment variable.

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [x] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
