### PR TITLE
userinfo: embed assets as data URLs for forward auth

### DIFF
--- a/internal/urlutil/data.go
+++ b/internal/urlutil/data.go
@@ -1,0 +1,11 @@
+package urlutil
+
+import (
+	"encoding/base64"
+)
+
+// DataURL returns a data-url for the data.
+func DataURL(mediaType string, data []byte) string {
+	bs := base64.StdEncoding.EncodeToString(data)
+	return "data:" + mediaType + ";base64," + bs
+}


### PR DESCRIPTION
## Summary
When a user receives an authorization error page we have assets on the page pointing to `/.pomerium/` URLs. When in forward-auth mode, these assets are not loaded because `/.pomerium` ends up forwarded to the application server instead of pomerium. This PR embeds all the assets as data URLs, so only a single network request is needed to show an error page.

Unfortunately this results in an uncacheable 4MB response but I don't know how else to fix forward auth.

## Related issues
Fixes #3459 

## User Explanation
Fixes the display of errors when using forward auth.

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
