### PR TITLE
autocert: continue on error

### DIFF
--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -270,14 +270,8 @@ func (mgr *Manager) updateAutocert(ctx context.Context, cfg *config.Config) erro
 
 	for _, domain := range sourceHostnames(cfg) {
 		cert, err := mgr.obtainCert(ctx, domain, cm)
-		if err != nil && errors.Is(err, errObtainCertFailed) {
-			return fmt.Errorf("autocert: failed to obtain client certificate: %w", err)
-		}
 		if err == nil && cert.NeedsRenewal(cm) {
 			cert, err = mgr.renewCert(ctx, domain, cert, cm)
-		}
-		if err != nil && errors.Is(err, errRenewCertFailed) {
-			return fmt.Errorf("autocert: failed to renew client certificate: %w", err)
 		}
 		if err != nil {
 			log.Error(ctx).Err(err).Msg("autocert: failed to obtain client certificate")


### PR DESCRIPTION
## Summary
Continue on certmagic errors instead of returning them. Returning them causes the process to crash.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3371

## User Explanation
Continue on certmagic errors instead of returning them. Returning them causes the process to crash.

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
