### PR TITLE
authorize: fix x-forwarded-uri

### DIFF
--- a/internal/urlutil/forward.go
+++ b/internal/urlutil/forward.go
@@ -30,10 +30,10 @@ func GetForwardAuthURL(r *http.Request) *url.URL {
 		}
 		rawPath := r.Header.Get(HeaderForwardedURI)
 		if idx := strings.Index(rawPath, "?"); idx >= 0 {
-			u.RawPath = rawPath[:idx]
+			u.Path = rawPath[:idx]
 			u.RawQuery = rawPath[idx+1:]
 		} else {
-			u.RawPath = rawPath
+			u.Path = rawPath
 		}
 	}
 	originalURL := r.Header.Get(HeaderOriginalURL)

--- a/internal/urlutil/forward.go
+++ b/internal/urlutil/forward.go
@@ -1,0 +1,47 @@
+package urlutil
+
+import (
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// Forward headers contains information from the client-facing side of proxy
+// servers that is altered or lost when a proxy is involved in the path of the
+// request.
+//
+// https://tools.ietf.org/html/rfc7239
+// https://en.wikipedia.org/wiki/X-Forwarded-For
+const (
+	HeaderForwardedHost  = "X-Forwarded-Host"
+	HeaderForwardedProto = "X-Forwarded-Proto"
+	HeaderForwardedURI   = "X-Forwarded-Uri" // traefik
+	HeaderOriginalURL    = "X-Original-Url"  // nginx
+)
+
+// GetForwardAuthURL gets the forward-auth URL for the given request.
+func GetForwardAuthURL(r *http.Request) *url.URL {
+	urqQuery := r.URL.Query().Get("uri")
+	u, _ := ParseAndValidateURL(urqQuery)
+	if u == nil {
+		u = &url.URL{
+			Scheme: r.Header.Get(HeaderForwardedProto),
+			Host:   r.Header.Get(HeaderForwardedHost),
+		}
+		rawPath := r.Header.Get(HeaderForwardedURI)
+		if idx := strings.Index(rawPath, "?"); idx >= 0 {
+			u.RawPath = rawPath[:idx]
+			u.RawQuery = rawPath[idx+1:]
+		} else {
+			u.RawPath = rawPath
+		}
+	}
+	originalURL := r.Header.Get(HeaderOriginalURL)
+	if originalURL != "" {
+		k, _ := ParseAndValidateURL(originalURL)
+		if k != nil {
+			u = k
+		}
+	}
+	return u
+}

--- a/internal/urlutil/forward_test.go
+++ b/internal/urlutil/forward_test.go
@@ -17,6 +17,6 @@ func TestGetForwardAuthURL(t *testing.T) {
 		req.Header.Set("X-Forwarded-Uri", "/example?a=b&c=d")
 
 		u := GetForwardAuthURL(req)
-		assert.Equal(t, "https://protected-host.tld?a=b&c=d", u.String())
+		assert.Equal(t, "https://protected-host.tld/example?a=b&c=d", u.String())
 	})
 }

--- a/internal/urlutil/forward_test.go
+++ b/internal/urlutil/forward_test.go
@@ -1,0 +1,22 @@
+package urlutil
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetForwardAuthURL(t *testing.T) {
+	t.Run("double-escaping", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "https://example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set("X-Forwarded-Proto", "https")
+		req.Header.Set("X-Forwarded-Host", "protected-host.tld")
+		req.Header.Set("X-Forwarded-Uri", "/example?a=b&c=d")
+
+		u := GetForwardAuthURL(req)
+		assert.Equal(t, "https://protected-host.tld?a=b&c=d", u.String())
+	})
+}


### PR DESCRIPTION
## Summary
Traefik sends the path and query string for the original URL as a header named `X-Forwarded-Uri`. Previously we were setting this as the path, but we should've been parsing out the `?` and setting that as the RawQuery.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3299

## User Explanation
Fixes an escaping bug with Traefik.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
