### PR TITLE
options: fix overlapping certificate test

### DIFF
--- a/config/options_test.go
+++ b/config/options_test.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/base64"
+	"encoding/pem"
 	"fmt"
 	"net/url"
 	"os"
@@ -15,6 +17,9 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/grpc/config"
 )
 
 var cmpOptIgnoreUnexported = cmpopts.IgnoreUnexported(Options{}, Policy{})
@@ -732,6 +737,37 @@ func TestOptions_GetAllRouteableHTTPDomains(t *testing.T) {
 		"from3.example.com",
 		"from3.example.com:443",
 	}, domains)
+}
+
+func TestOptions_ApplySettings(t *testing.T) {
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second)
+	defer clearTimeout()
+
+	t.Run("certificates", func(t *testing.T) {
+		options := NewDefaultOptions()
+		cert1, err := cryptutil.GenerateSelfSignedCertificate("example.com")
+		require.NoError(t, err)
+		options.CertificateFiles = append(options.CertificateFiles, certificateFilePair{
+			CertFile: base64.StdEncoding.EncodeToString(encodeCert(cert1)),
+		})
+		cert2, err := cryptutil.GenerateSelfSignedCertificate("example.com")
+		require.NoError(t, err)
+		cert3, err := cryptutil.GenerateSelfSignedCertificate("not.example.com")
+		require.NoError(t, err)
+
+		settings := &config.Settings{
+			Certificates: []*config.Settings_Certificate{
+				{CertBytes: encodeCert(cert2)},
+				{CertBytes: encodeCert(cert3)},
+			},
+		}
+		options.ApplySettings(ctx, settings)
+		assert.Len(t, options.CertificateFiles, 2, "should prevent adding duplicate certificates")
+	})
+}
+
+func encodeCert(cert *tls.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
 }
 
 func mustParseWeightedURLs(t *testing.T, urls ...string) []WeightedURL {

--- a/pkg/cryptutil/certificates.go
+++ b/pkg/cryptutil/certificates.go
@@ -219,7 +219,7 @@ func GenerateSelfSignedCertificate(domain string, configure ...func(*x509.Certif
 	return &cert, nil
 }
 
-// ParsePEMCertificate parses PEM encoded certificate block
+// ParsePEMCertificate parses a PEM encoded certificate block.
 func ParsePEMCertificate(raw []byte) (*x509.Certificate, error) {
 	data := raw
 	for {
@@ -242,7 +242,16 @@ func ParsePEMCertificate(raw []byte) (*x509.Certificate, error) {
 	return nil, fmt.Errorf("no certificate block found")
 }
 
-// ParsePEMCertificateFromFile decodes PEM certificate from file
+// ParsePEMCertificateFromBase64 parses a PEM encoded certificate block from a base64 encoded string.
+func ParsePEMCertificateFromBase64(encoded string) (*x509.Certificate, error) {
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, err
+	}
+	return ParsePEMCertificate(raw)
+}
+
+// ParsePEMCertificateFromFile decodes a PEM certificate from a file.
 func ParsePEMCertificateFromFile(file string) (*x509.Certificate, error) {
 	fd, err := os.Open(file)
 	if err != nil {


### PR DESCRIPTION
## Summary
When testing for overlapping certificates we previously only supported testing files. We now support files or base64 encoded bytes.

## Related issues
Fixes https://github.com/pomerium/internal/issues/915

## User Explanation
I don't know how to explain this fix to a regular user. We fixed a bug in the internal machinations of pomerium.

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
