### PR TITLE
databroker: support rotating shared secret

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,7 +50,6 @@ jobs:
         if: runner.os == 'Linux'
         run: make lint
       - name: test
-        if: runner.os != 'Linux'
         run: make test
 
   cover:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,28 +16,30 @@ jobs:
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # pin@v2
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
           go-version: ${{ matrix.go-version }}
 
-      - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # pin@v3
+      - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: set env vars
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
+
       - name: cache go binaries
-        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129
         id: cache-go-bin
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-${{ hashFiles('**/go.mod') }}
           restore-keys: ${{ runner.os }}-go-bin
 
-      - uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+      - uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129
         with:
           path: |
             ~/go/pkg/mod
@@ -45,6 +47,7 @@ jobs:
             ~/Library/Caches/go-build
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: ${{ runner.os }}-go-
+
       - run: make deps-build
       - name: Lint
         if: runner.os == 'Linux'
@@ -59,15 +62,15 @@ jobs:
         go-version: [1.18.x]
         node-version: [16.x]
     steps:
-      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # pin@v2
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
           go-version: ${{ matrix.go-version }}
 
-      - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # pin@v3
+      - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
 
@@ -75,14 +78,14 @@ jobs:
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: cache go binaries
-        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+        uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129
         id: cache-go-bin
         with:
           path: ~/go/bin
           key: ${{ runner.os }}-${{ hashFiles('**/go.mod') }}
           restore-keys: ${{ runner.os }}-go-bin
 
-      - uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+      - uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129
         with:
           path: |
             ~/go/pkg/mod
@@ -94,14 +97,14 @@ jobs:
       - name: cover
         run: make cover
 
-      - uses: jandelgado/gcov2lcov-action@c680c0f7c7442485f1749eb2a13e54a686e76eb5 # pin@v1.0.8
+      - uses: jandelgado/gcov2lcov-action@c680c0f7c7442485f1749eb2a13e54a686e76eb5  .0.8
         name: convert coverage to lcov
         with:
           infile: coverage.txt
           outfile: coverage.lcov
 
       - name: upload to coveralls
-        uses: coverallsapp/github-action@9ba913c152ae4be1327bfb9085dc806cedb44057 # pin@1.1.3
+        uses: coverallsapp/github-action@9ba913c152ae4be1327bfb9085dc806cedb44057
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.lcov
@@ -117,20 +120,20 @@ jobs:
         idp: [auth0, azure, github, gitlab, google, oidc, okta, onelogin, ping]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # pin@v2
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
           go-version: ${{ matrix.go-version }}
 
-      - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # pin@v3
+      - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: set env vars
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
-      - uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+      - uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129
         with:
           path: |
             ~/go/pkg
@@ -163,18 +166,18 @@ jobs:
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # pin@v2
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
           go-version: ${{ matrix.go-version }}
 
-      - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93 # pin@v3
+      - uses: actions/setup-node@2fddd8803e2f5c9604345a0b591c3020ee971a93
         with:
           node-version: ${{ matrix.node-version }}
 
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
-      - uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129 # pin@v3
+      - uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129
         with:
           path: |
             ~/go/pkg/mod
@@ -190,7 +193,7 @@ jobs:
           make build
 
       - name: save binary
-        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # pin@v2
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
         with:
           path: bin/pomerium*
           name: pomerium ${{ github.run_id }} ${{ matrix.platform }}
@@ -199,15 +202,15 @@ jobs:
   build-docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6 # pin@v1
+        uses: docker/setup-buildx-action@dc7b9719a96d48369863986a06765841d7ea23f6
 
       - name: Docker Build
-        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8 # pin@v2
+        uses: docker/build-push-action@e551b19e49efd4e98792db7592c17c09b89db8d8
         with:
           context: .
           file: ./Dockerfile
@@ -217,16 +220,16 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # pin@v2
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
           go-version: 1.18.x
-      - uses: actions/setup-python@c4e89fac7e8767b327bbad6cb4d859eda999cf08 # pin@v3
+      - uses: actions/setup-python@c4e89fac7e8767b327bbad6cb4d859eda999cf08
         with:
           python-version: "3.x"
-      - uses: pre-commit/action@876132a3c26aa072b09eab6c5395b4749eeb2435 # pin@release
+      - uses: pre-commit/action@876132a3c26aa072b09eab6c5395b4749eeb2435
         with:
           extra_args: --show-diff-on-failure --from-ref ${{
             github.event.pull_request.base.sha }} --to-ref ${{
@@ -243,14 +246,14 @@ jobs:
     needs:
       - build
     steps:
-      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a # pin@v2
+      - uses: actions/setup-go@84cbf8094393cdc5fe1fe1671ff2647332956b1a
         with:
           go-version: 1.18.x
 
-      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
 
       - name: retrieve binary
-        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741 # pin@v2
+        uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
         with:
           name: pomerium ${{ github.run_id }} ${{ matrix.platform }}
           path: bin/
@@ -259,6 +262,6 @@ jobs:
         run: make get-envoy
 
       - name: FOSSA Scan
-        uses: fossa-contrib/fossa-action@6cffaa064112e1cf9b5798c6224f9487dc1ec316 # pin@v1
+        uses: fossa-contrib/fossa-action@6cffaa064112e1cf9b5798c6224f9487dc1ec316
         with:
           fossa-api-key: 18f4ef488f514d06874b75f5809cea93

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -97,7 +97,7 @@ jobs:
       - name: cover
         run: make cover
 
-      - uses: jandelgado/gcov2lcov-action@c680c0f7c7442485f1749eb2a13e54a686e76eb5  .0.8
+      - uses: jandelgado/gcov2lcov-action@c680c0f7c7442485f1749eb2a13e54a686e76eb5
         name: convert coverage to lcov
         with:
           infile: coverage.txt

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ test: get-envoy ## Runs the go tests.
 .PHONY: cover
 cover: get-envoy ## Runs go test with coverage
 	@echo "==> $@"
-	$(GO) test -race -coverprofile=coverage.txt -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration | grep -v github.com/pomerium/pomerium/pkg/storage/postgres)
+	$(GO) test -race -coverprofile=coverage.txt -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration)
 	@sed -i.bak '/\.pb\.go\:/d' coverage.txt
 	@sed -i.bak '/\/mock\.go\:/d' coverage.txt
 	@sort -o coverage.txt coverage.txt

--- a/databroker/cache_test.go
+++ b/databroker/cache_test.go
@@ -24,7 +24,6 @@ func TestNew(t *testing.T) {
 	}{
 		{"good", config.Options{SharedKey: cryptutil.NewBase64Key(), DataBrokerURLString: "http://example"}, false},
 		{"bad shared secret", config.Options{SharedKey: string([]byte(cryptutil.NewBase64Key())[:31]), DataBrokerURLString: "http://example"}, true},
-		{"bad databroker url", config.Options{SharedKey: cryptutil.NewBase64Key(), DataBrokerURLString: "BAD"}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/atomicutil/value.go
+++ b/internal/atomicutil/value.go
@@ -1,0 +1,26 @@
+// Package atomicutil contains functions for working with the atomic package.
+package atomicutil
+
+import "sync/atomic"
+
+// Value is a generic atomic.Value.
+type Value[T any] struct {
+	value atomic.Value
+}
+
+// NewValue creates a new Value.
+func NewValue[T any](init T) *Value[T] {
+	v := new(Value[T])
+	v.value.Store(init)
+	return v
+}
+
+// Load loads the value atomically.
+func (v *Value[T]) Load() T {
+	return v.value.Load().(T)
+}
+
+// Store stores the value atomically.
+func (v *Value[T]) Store(val T) {
+	v.value.Store(val)
+}

--- a/internal/testutil/redis.go
+++ b/internal/testutil/redis.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
-const maxWait = time.Minute
+const maxWait = 20 * time.Minute
 
 // WithTestRedis creates a test a test redis instance using docker.
 func WithTestRedis(useTLS bool, handler func(rawURL string) error) error {

--- a/pkg/grpc/client.go
+++ b/pkg/grpc/client.go
@@ -43,8 +43,8 @@ func NewGRPCClientConn(ctx context.Context, opts *Options, other ...grpc.DialOpt
 		requestid.StreamClientInterceptor(),
 	}
 	if opts.SignedJWTKey != nil {
-		unaryClientInterceptors = append(unaryClientInterceptors, grpcutil.WithUnarySignedJWT(opts.SignedJWTKey))
-		streamClientInterceptors = append(streamClientInterceptors, grpcutil.WithStreamSignedJWT(opts.SignedJWTKey))
+		unaryClientInterceptors = append(unaryClientInterceptors, grpcutil.WithUnarySignedJWT(func() []byte { return opts.SignedJWTKey }))
+		streamClientInterceptors = append(streamClientInterceptors, grpcutil.WithStreamSignedJWT(func() []byte { return opts.SignedJWTKey }))
 	}
 
 	dialOptions := []grpc.DialOption{

--- a/pkg/grpcutil/client.go
+++ b/pkg/grpcutil/client.go
@@ -63,8 +63,8 @@ func NewGRPCClientConn(ctx context.Context, opts *Options, other ...grpc.DialOpt
 	}
 	streamClientInterceptors := []grpc.StreamClientInterceptor{}
 	if opts.SignedJWTKey != nil {
-		unaryClientInterceptors = append(unaryClientInterceptors, WithUnarySignedJWT(opts.SignedJWTKey))
-		streamClientInterceptors = append(streamClientInterceptors, WithStreamSignedJWT(opts.SignedJWTKey))
+		unaryClientInterceptors = append(unaryClientInterceptors, WithUnarySignedJWT(func() []byte { return opts.SignedJWTKey }))
+		streamClientInterceptors = append(streamClientInterceptors, WithStreamSignedJWT(func() []byte { return opts.SignedJWTKey }))
 	}
 
 	dialOptions := []grpc.DialOption{

--- a/pkg/grpcutil/options.go
+++ b/pkg/grpcutil/options.go
@@ -13,7 +13,7 @@ import (
 )
 
 // WithStreamSignedJWT returns a StreamClientInterceptor that adds a JWT to requests.
-func WithStreamSignedJWT(key []byte) grpc.StreamClientInterceptor {
+func WithStreamSignedJWT(getKey func() []byte) grpc.StreamClientInterceptor {
 	return func(
 		ctx context.Context,
 		desc *grpc.StreamDesc,
@@ -21,7 +21,7 @@ func WithStreamSignedJWT(key []byte) grpc.StreamClientInterceptor {
 		method string, streamer grpc.Streamer,
 		opts ...grpc.CallOption,
 	) (grpc.ClientStream, error) {
-		ctx, err := withSignedJWT(ctx, key)
+		ctx, err := withSignedJWT(ctx, getKey())
 		if err != nil {
 			return nil, err
 		}
@@ -31,9 +31,9 @@ func WithStreamSignedJWT(key []byte) grpc.StreamClientInterceptor {
 }
 
 // WithUnarySignedJWT returns a UnaryClientInterceptor that adds a JWT to requests.
-func WithUnarySignedJWT(key []byte) grpc.UnaryClientInterceptor {
+func WithUnarySignedJWT(getKey func() []byte) grpc.UnaryClientInterceptor {
 	return func(ctx context.Context, method string, req, reply interface{}, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
-		ctx, err := withSignedJWT(ctx, key)
+		ctx, err := withSignedJWT(ctx, getKey())
 		if err != nil {
 			return err
 		}

--- a/pkg/grpcutil/options_test.go
+++ b/pkg/grpcutil/options_test.go
@@ -74,8 +74,8 @@ func TestSignedJWT(t *testing.T) {
 	})
 	t.Run("authenticated", func(t *testing.T) {
 		cc, err := grpc.Dial(li.Addr().String(),
-			grpc.WithUnaryInterceptor(WithUnarySignedJWT(key)),
-			grpc.WithStreamInterceptor(WithStreamSignedJWT(key)),
+			grpc.WithUnaryInterceptor(WithUnarySignedJWT(func() []byte { return key })),
+			grpc.WithStreamInterceptor(WithStreamSignedJWT(func() []byte { return key })),
 			grpc.WithInsecure())
 		if !assert.NoError(t, err) {
 			return

--- a/pkg/storage/postgres/backend_test.go
+++ b/pkg/storage/postgres/backend_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/pomerium/pomerium/pkg/storage"
 )
 
+const maxWait = time.Minute * 10
+
 func TestBackend(t *testing.T) {
 	if os.Getenv("GITHUB_ACTION") != "" && runtime.GOOS == "darwin" {
 		t.Skip("Github action can not run docker on MacOS")
@@ -27,7 +29,7 @@ func TestBackend(t *testing.T) {
 
 	t.Parallel()
 
-	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, clearTimeout := context.WithTimeout(context.Background(), maxWait)
 	defer clearTimeout()
 
 	require.NoError(t, testutil.WithTestPostgres(func(dsn string) error {

--- a/pkg/storage/postgres/backend_test.go
+++ b/pkg/storage/postgres/backend_test.go
@@ -25,6 +25,8 @@ func TestBackend(t *testing.T) {
 		t.Skip("Github action can not run docker on MacOS")
 	}
 
+	t.Parallel()
+
 	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
 	defer clearTimeout()
 

--- a/pkg/storage/postgres/registry_test.go
+++ b/pkg/storage/postgres/registry_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"runtime"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -38,7 +37,7 @@ func TestRegistry(t *testing.T) {
 
 	t.Parallel()
 
-	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, clearTimeout := context.WithTimeout(context.Background(), maxWait)
 	defer clearTimeout()
 
 	require.NoError(t, testutil.WithTestPostgres(func(dsn string) error {

--- a/pkg/storage/postgres/registry_test.go
+++ b/pkg/storage/postgres/registry_test.go
@@ -36,6 +36,8 @@ func TestRegistry(t *testing.T) {
 		t.Skip("Github action can not run docker on MacOS")
 	}
 
+	t.Parallel()
+
 	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
 	defer clearTimeout()
 

--- a/pkg/storage/redis/redis_test.go
+++ b/pkg/storage/redis/redis_test.go
@@ -79,12 +79,14 @@ func TestBackend(t *testing.T) {
 	}
 
 	t.Run("no-tls", func(t *testing.T) {
+		t.Parallel()
 		require.NoError(t, testutil.WithTestRedis(false, func(rawURL string) error {
 			return handler(t, false, rawURL)
 		}))
 	})
 
 	t.Run("tls", func(t *testing.T) {
+		t.Parallel()
 		require.NoError(t, testutil.WithTestRedis(true, func(rawURL string) error {
 			return handler(t, true, rawURL)
 		}))
@@ -92,12 +94,14 @@ func TestBackend(t *testing.T) {
 
 	if runtime.GOOS == "linux" {
 		t.Run("cluster", func(t *testing.T) {
+			t.Parallel()
 			require.NoError(t, testutil.WithTestRedisCluster(func(rawURL string) error {
 				return handler(t, false, rawURL)
 			}))
 		})
 
 		t.Run("sentinel", func(t *testing.T) {
+			t.Parallel()
 			require.NoError(t, testutil.WithTestRedisSentinel(func(rawURL string) error {
 				return handler(t, false, rawURL)
 			}))
@@ -109,6 +113,8 @@ func TestChangeSignal(t *testing.T) {
 	if os.Getenv("GITHUB_ACTION") != "" && runtime.GOOS == "darwin" {
 		t.Skip("Github action can not run docker on MacOS")
 	}
+
+	t.Parallel()
 
 	ctx := context.Background()
 	require.NoError(t, testutil.WithTestRedis(false, func(rawURL string) error {
@@ -174,6 +180,8 @@ func TestExpiry(t *testing.T) {
 		t.Skip("Github action can not run docker on MacOS")
 	}
 
+	t.Parallel()
+
 	ctx := context.Background()
 	require.NoError(t, testutil.WithTestRedis(false, func(rawURL string) error {
 		backend, err := New(rawURL, WithExpiry(0))
@@ -219,6 +227,8 @@ func TestCapacity(t *testing.T) {
 		t.Skip("Github action can not run docker on MacOS")
 	}
 
+	t.Parallel()
+
 	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
 	defer clearTimeout()
 
@@ -262,6 +272,8 @@ func TestLease(t *testing.T) {
 	if os.Getenv("GITHUB_ACTION") != "" && runtime.GOOS == "darwin" {
 		t.Skip("Github action can not run docker on MacOS")
 	}
+
+	t.Parallel()
 
 	ctx := context.Background()
 	require.NoError(t, testutil.WithTestRedis(false, func(rawURL string) error {


### PR DESCRIPTION
## Summary
Support rotating the shared secret in the databroker by using a function to load the current shared key from the options instead of only doing so on first boot.

## Related issues
Fixes https://github.com/pomerium/internal/issues/928

## User Explanation
Support reloading more configuration options without a restart of the process.

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
