### PR TITLE
envoyconfig: add authority header to outbound gRPC requests

### DIFF
--- a/config/envoyconfig/outbound.go
+++ b/config/envoyconfig/outbound.go
@@ -9,6 +9,7 @@ import (
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/pomerium/pomerium/config"
 )
@@ -121,6 +122,10 @@ func (b *Builder) buildOutboundRoutes() []*envoy_config_route_v3.Route {
 					Route: &envoy_config_route_v3.RouteAction{
 						ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
 							Cluster: def.Cluster,
+						},
+						// rewrite the host header
+						HostRewriteSpecifier: &envoy_config_route_v3.RouteAction_AutoHostRewrite{
+							AutoHostRewrite: wrapperspb.Bool(true),
 						},
 						// disable the timeout to support grpc streaming
 						Timeout:     durationpb.New(0),

--- a/config/envoyconfig/outbound_test.go
+++ b/config/envoyconfig/outbound_test.go
@@ -1,0 +1,79 @@
+package envoyconfig
+
+import (
+	"testing"
+
+	"github.com/pomerium/pomerium/internal/testutil"
+)
+
+func Test_buildOutboundRoutes(t *testing.T) {
+	b := New("local-grpc", "local-http", "local-metrics", nil, nil)
+	routes := b.buildOutboundRoutes()
+	testutil.AssertProtoJSONEqual(t, `[
+		{
+			"match": {
+				"grpc": {},
+				"prefix": "/envoy.service.auth.v3.Authorization/"
+			},
+			"name": "pomerium-authorize",
+			"route": {
+				"autoHostRewrite": true,
+				"cluster": "pomerium-authorize",
+				"idleTimeout": "0s",
+				"timeout": "0s"
+			}
+		},
+		{
+			"match": {
+				"grpc": {},
+				"prefix": "/databroker.DataBrokerService/"
+			},
+			"name": "pomerium-databroker",
+			"route": {
+				"autoHostRewrite": true,
+				"cluster": "pomerium-databroker",
+				"idleTimeout": "0s",
+				"timeout": "0s"
+			}
+		},
+		{
+			"match": {
+				"grpc": {},
+				"prefix": "/directory.DirectoryService/"
+			},
+			"name": "pomerium-databroker",
+			"route": {
+				"autoHostRewrite": true,
+				"cluster": "pomerium-databroker",
+				"idleTimeout": "0s",
+				"timeout": "0s"
+			}
+		},
+		{
+			"match": {
+				"grpc": {},
+				"prefix": "/registry.Registry/"
+			},
+			"name": "pomerium-databroker",
+			"route": {
+				"autoHostRewrite": true,
+				"cluster": "pomerium-databroker",
+				"idleTimeout": "0s",
+				"timeout": "0s"
+			}
+		},
+		{
+			"match": {
+				"grpc": {},
+				"prefix": "/"
+			},
+			"name": "pomerium-control-plane-grpc",
+			"route": {
+				"autoHostRewrite": true,
+				"cluster": "pomerium-control-plane-grpc",
+				"idleTimeout": "0s",
+				"timeout": "0s"
+			}
+		}
+	]`, routes)
+}


### PR DESCRIPTION
## Summary
Update the envoy config for outbound gRPC requests so that the authority header gets rewritten to match the cluster's destination address.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3505

## User Explanation
Fixes an issue with route matching for Istio.

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
