### PR TITLE
add front end support for optional first paragraph of markdown on err…

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -30,6 +30,7 @@
     "@mui/icons-material": "^5.3.1",
     "@mui/material": "^5.4.0",
     "luxon": "^2.3.0",
+    "markdown-to-jsx": "^7.1.7",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-feather": "^2.0.9"

--- a/ui/src/components/ErrorPage.tsx
+++ b/ui/src/components/ErrorPage.tsx
@@ -8,6 +8,7 @@ import Paper from "@mui/material/Paper";
 import Stack from "@mui/material/Stack";
 import Typography from "@mui/material/Typography";
 import React, { FC } from "react";
+import Markdown from "markdown-to-jsx";
 
 export type ErrorPageProps = {
   data: ErrorPageData;
@@ -26,6 +27,13 @@ export const ErrorPage: FC<ErrorPageProps> = ({ data }) => {
               {data?.error || "Internal Server Error"}
             </Alert>
           </Box>
+          {!!data?.errorMessageFirstParagraph && (
+            <Box sx={{p: 4}}>
+              <Markdown>
+                {data.errorMessageFirstParagraph}
+              </Markdown>
+            </Box>
+          )}
           {data?.requestId ? (
             <SectionFooter>
               <Typography variant="caption">

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -96,6 +96,7 @@ export type ErrorPageData = BasePageData & {
   requestId?: string;
   status?: number;
   statusText?: string;
+  errorMessageFirstParagraph?: string;
 };
 
 export type UserInfoData = {

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1873,6 +1873,11 @@ make-error@^1.1.1:
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
 
+markdown-to-jsx@^7.1.7:
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz#a5f22102fb12241c8cea1ca6a4050bb76b23a25d"
+  integrity sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==
+
 merge2@^1.3.0, merge2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"


### PR DESCRIPTION
add front end support for optional default first paragraph for all error messages

## Related issues

Fixes https://github.com/pomerium/internal/issues/948

## User Explanation
Useful with Enterprise Console

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
