### PR TITLE
authorize: handle user-unauthenticated response for deny blocks

### DIFF
--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -41,7 +41,7 @@ func TestAuthorize_handleResult(t *testing.T) {
 			},
 			false)
 		assert.NoError(t, err)
-		assert.Equal(t, 302, res.GetDeniedResponse().GetStatus().GetCode())
+		assert.Equal(t, 302, int(res.GetDeniedResponse().GetStatus().GetCode()))
 
 		res, err = a.handleResult(context.Background(),
 			&envoy_service_auth_v3.CheckRequest{},
@@ -51,7 +51,7 @@ func TestAuthorize_handleResult(t *testing.T) {
 			},
 			false)
 		assert.NoError(t, err)
-		assert.Equal(t, 302, res.GetDeniedResponse().GetStatus().GetCode())
+		assert.Equal(t, 302, int(res.GetDeniedResponse().GetStatus().GetCode()))
 	})
 }
 

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -95,19 +95,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 	}
 
 	isForwardAuthVerify := isForwardAuth && hreq.URL.Path == "/verify"
-
-	// if there's a deny, the result is denied using the deny reasons.
-	if res.Deny.Value {
-		return a.handleResultDenied(ctx, in, req, res, isForwardAuthVerify, res.Deny.Reasons)
-	}
-
-	// if there's an allow, the result is allowed.
-	if res.Allow.Value {
-		return a.handleResultAllowed(ctx, in, res)
-	}
-
-	// otherwise, the result is denied using the allow reasons.
-	return a.handleResultDenied(ctx, in, req, res, isForwardAuthVerify, res.Allow.Reasons)
+	return a.handleResult(ctx, in, req, res, isForwardAuthVerify)
 }
 
 // isForwardAuth returns if the current request is a forward auth route.


### PR DESCRIPTION
## Summary
Handle `user-unauthenticated` response for deny blocks.

Currently if a policy had an allow block that allowed public access and a deny block that denied a specific user, that policy would not enforce the deny rule and the user would have access. This is because it would not initiate the user authentication process. (Basically it would be treating the user as if they were not logged in)

This PR updates the code so that if `unauthenticated` appears in either the allow or the deny block user authentication will be initiated.

## Related issues
Fixes https://github.com/pomerium/internal/issues/963


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
