### PR TITLE
publish to any-distro

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -84,7 +84,7 @@ jobs:
 
           DEBS="pomerium_${VERSION}-1_amd64.deb pomerium_${VERSION}-1_arm64.deb"
           for pkg in $(echo $DEBS); do
-            cloudsmith push deb pomerium/pomerium/debian/any-version $pkg
+            cloudsmith push deb pomerium/pomerium/any-distro/any-version $pkg
           done
 
       - name: Find latest tag


### PR DESCRIPTION
## Summary
Update the cloudsmith step to publish to any distro instead of just debian.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/2716
 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
