### PR TITLE
authenticate: add CORS headers to jwks endpoint

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -113,7 +113,7 @@ func (a *Authenticate) mountDashboard(r *mux.Router) {
 }
 
 func (a *Authenticate) mountWellKnown(r *mux.Router) {
-	r.Path("/.well-known/pomerium/jwks.json").Handler(httputil.HandlerFunc(a.jwks)).Methods(http.MethodGet)
+	r.Path("/.well-known/pomerium/jwks.json").Handler(cors.AllowAll().Handler(httputil.HandlerFunc(a.jwks))).Methods(http.MethodGet)
 }
 
 // jwks returns the signing key(s) the client can use to validate signatures


### PR DESCRIPTION
## Summary
To give any javascript application the ability to query this endpoint, we should add CORS headers.


## Related issues

- https://github.com/pomerium/documentation/issues/101
 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
