### PR TITLE
config: use config.Config instead of config.Options everywhere

### DIFF
--- a/authenticate/authenticate_test.go
+++ b/authenticate/authenticate_test.go
@@ -113,7 +113,7 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := New(&config.Config{Options: tt.opts})
+			_, err := New(config.New(tt.opts))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/authenticate/config.go
+++ b/authenticate/config.go
@@ -6,7 +6,7 @@ import (
 )
 
 type authenticateConfig struct {
-	getIdentityProvider func(options *config.Options, idpID string) (identity.Authenticator, error)
+	getIdentityProvider func(cfg *config.Config, idpID string) (identity.Authenticator, error)
 }
 
 // An Option customizes the Authenticate config.
@@ -22,7 +22,7 @@ func getAuthenticateConfig(options ...Option) *authenticateConfig {
 }
 
 // WithGetIdentityProvider sets the getIdentityProvider function in the config.
-func WithGetIdentityProvider(getIdentityProvider func(options *config.Options, idpID string) (identity.Authenticator, error)) Option {
+func WithGetIdentityProvider(getIdentityProvider func(cfg *config.Config, idpID string) (identity.Authenticator, error)) Option {
 	return func(cfg *authenticateConfig) {
 		cfg.getIdentityProvider = getIdentityProvider
 	}

--- a/authenticate/identity.go
+++ b/authenticate/identity.go
@@ -7,8 +7,8 @@ import (
 	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
-func defaultGetIdentityProvider(options *config.Options, idpID string) (identity.Authenticator, error) {
-	authenticateURL, err := options.GetAuthenticateURL()
+func defaultGetIdentityProvider(cfg *config.Config, idpID string) (identity.Authenticator, error) {
+	authenticateURL, err := cfg.Options.GetAuthenticateURL()
 	if err != nil {
 		return nil, err
 	}
@@ -17,9 +17,9 @@ func defaultGetIdentityProvider(options *config.Options, idpID string) (identity
 	if err != nil {
 		return nil, err
 	}
-	redirectURL.Path = options.AuthenticateCallbackPath
+	redirectURL.Path = cfg.Options.AuthenticateCallbackPath
 
-	idp, err := options.GetIdentityProviderForID(idpID)
+	idp, err := cfg.Options.GetIdentityProviderForID(idpID)
 	if err != nil {
 		return nil, err
 	}

--- a/authenticate/middleware.go
+++ b/authenticate/middleware.go
@@ -34,14 +34,14 @@ func (a *Authenticate) requireValidSignature(next httputil.HandlerFunc) http.Han
 }
 
 func (a *Authenticate) getExternalRequest(r *http.Request) *http.Request {
-	options := a.options.Load()
+	cfg := a.currentConfig.Load()
 
-	externalURL, err := options.GetAuthenticateURL()
+	externalURL, err := cfg.Options.GetAuthenticateURL()
 	if err != nil {
 		return r
 	}
 
-	internalURL, err := options.GetInternalAuthenticateURL()
+	internalURL, err := cfg.Options.GetInternalAuthenticateURL()
 	if err != nil {
 		return r
 	}

--- a/authorize/authorize_test.go
+++ b/authorize/authorize_test.go
@@ -74,7 +74,7 @@ func TestNew(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := New(&config.Config{Options: &tt.config})
+			_, err := New(config.New(&tt.config))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -105,12 +105,12 @@ func TestAuthorize_OnConfigChange(t *testing.T) {
 				SharedKey:             tc.SharedKey,
 				Policies:              tc.Policies,
 			}
-			a, err := New(&config.Config{Options: o})
+			a, err := New(config.New(o))
 			require.NoError(t, err)
 			require.NotNil(t, a)
 
 			oldPe := a.state.Load().evaluator
-			cfg := &config.Config{Options: o}
+			cfg := config.New(o)
 			assertFunc := assert.True
 			o.SigningKey = "bad-share-key"
 			if tc.expectedChange {

--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -125,7 +125,7 @@ func (a *Authorize) deniedResponse(
 	respBody := []byte(reason)
 	respHeader := []*envoy_config_core_v3.HeaderValueOption{}
 
-	forwardAuthURL, _ := a.currentOptions.Load().GetForwardAuthURL()
+	forwardAuthURL, _ := a.currentConfig.Load().Options.GetForwardAuthURL()
 	if forwardAuthURL == nil {
 		// create a http response writer recorder
 		w := httptest.NewRecorder()
@@ -140,7 +140,7 @@ func (a *Authorize) deniedResponse(
 			Err:             errors.New(reason),
 			DebugURL:        debugEndpoint,
 			RequestID:       requestid.FromContext(ctx),
-			BrandingOptions: a.currentOptions.Load().BrandingOptions,
+			BrandingOptions: a.currentConfig.Load().Options.BrandingOptions,
 		}
 		httpErr.ErrorResponse(ctx, w, r)
 
@@ -184,7 +184,7 @@ func (a *Authorize) requireLoginResponse(
 	request *evaluator.Request,
 	isForwardAuthVerify bool,
 ) (*envoy_service_auth_v3.CheckResponse, error) {
-	opts := a.currentOptions.Load()
+	opts := a.currentConfig.Load().Options
 	state := a.state.Load()
 	authenticateURL, err := opts.GetAuthenticateURL()
 	if err != nil {
@@ -225,7 +225,7 @@ func (a *Authorize) requireWebAuthnResponse(
 	result *evaluator.Result,
 	isForwardAuthVerify bool,
 ) (*envoy_service_auth_v3.CheckResponse, error) {
-	opts := a.currentOptions.Load()
+	opts := a.currentConfig.Load().Options
 	state := a.state.Load()
 	authenticateURL, err := opts.GetAuthenticateURL()
 	if err != nil {
@@ -295,7 +295,7 @@ func toEnvoyHeaders(headers http.Header) []*envoy_config_core_v3.HeaderValueOpti
 // userInfoEndpointURL returns the user info endpoint url which can be used to debug the user's
 // session that lives on the authenticate service.
 func (a *Authorize) userInfoEndpointURL(in *envoy_service_auth_v3.CheckRequest) (*url.URL, error) {
-	opts := a.currentOptions.Load()
+	opts := a.currentConfig.Load().Options
 	authenticateURL, err := opts.GetAuthenticateURL()
 	if err != nil {
 		return nil, err

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -55,7 +55,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 		}
 	}
 
-	rawJWT, _ := loadRawSession(hreq, a.currentOptions.Load(), state.encoder)
+	rawJWT, _ := loadRawSession(hreq, a.currentConfig.Load(), state.encoder)
 	sessionState, _ := loadSession(state.encoder, rawJWT)
 
 	var s sessionOrServiceAccount
@@ -100,9 +100,9 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 
 // isForwardAuth returns if the current request is a forward auth route.
 func (a *Authorize) isForwardAuth(req *envoy_service_auth_v3.CheckRequest) bool {
-	opts := a.currentOptions.Load()
+	cfg := a.currentConfig.Load()
 
-	forwardAuthURL, err := opts.GetForwardAuthURL()
+	forwardAuthURL, err := cfg.Options.GetForwardAuthURL()
 	if err != nil || forwardAuthURL == nil {
 		return false
 	}
@@ -136,9 +136,9 @@ func (a *Authorize) getEvaluatorRequestFromCheckRequest(
 }
 
 func (a *Authorize) getMatchingPolicy(requestURL url.URL) *config.Policy {
-	options := a.currentOptions.Load()
+	cfg := a.currentConfig.Load()
 
-	for _, p := range options.GetAllPolicies() {
+	for _, p := range cfg.Options.GetAllPolicies() {
 		if p.Matches(requestURL) {
 			return &p
 		}

--- a/authorize/session.go
+++ b/authorize/session.go
@@ -13,9 +13,13 @@ import (
 	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
-func loadRawSession(req *http.Request, options *config.Options, encoder encoding.MarshalUnmarshaler) ([]byte, error) {
+func loadRawSession(
+	req *http.Request,
+	cfg *config.Config,
+	encoder encoding.MarshalUnmarshaler,
+) ([]byte, error) {
 	var loaders []sessions.SessionLoader
-	cookieStore, err := getCookieStore(options, encoder)
+	cookieStore, err := getCookieStore(cfg, encoder)
 	if err != nil {
 		return nil, err
 	}
@@ -37,7 +41,10 @@ func loadRawSession(req *http.Request, options *config.Options, encoder encoding
 	return nil, sessions.ErrNoSessionFound
 }
 
-func loadSession(encoder encoding.MarshalUnmarshaler, rawJWT []byte) (*sessions.State, error) {
+func loadSession(
+	encoder encoding.MarshalUnmarshaler,
+	rawJWT []byte,
+) (*sessions.State, error) {
 	var s sessions.State
 	err := encoder.Unmarshal(rawJWT, &s)
 	if err != nil {
@@ -46,14 +53,17 @@ func loadSession(encoder encoding.MarshalUnmarshaler, rawJWT []byte) (*sessions.
 	return &s, nil
 }
 
-func getCookieStore(options *config.Options, encoder encoding.MarshalUnmarshaler) (sessions.SessionStore, error) {
+func getCookieStore(
+	cfg *config.Config,
+	encoder encoding.MarshalUnmarshaler,
+) (sessions.SessionStore, error) {
 	cookieStore, err := cookie.NewStore(func() cookie.Options {
 		return cookie.Options{
-			Name:     options.CookieName,
-			Domain:   options.CookieDomain,
-			Secure:   options.CookieSecure,
-			HTTPOnly: options.CookieHTTPOnly,
-			Expire:   options.CookieExpire,
+			Name:     cfg.Options.CookieName,
+			Domain:   cfg.Options.CookieDomain,
+			Secure:   cfg.Options.CookieSecure,
+			HTTPOnly: cfg.Options.CookieHTTPOnly,
+			Expire:   cfg.Options.CookieExpire,
 		}
 	}, encoder)
 	if err != nil {

--- a/authorize/session_test.go
+++ b/authorize/session_test.go
@@ -32,7 +32,7 @@ func TestLoadSession(t *testing.T) {
 				},
 			},
 		})
-		raw, err := loadRawSession(req, opts, encoder)
+		raw, err := loadRawSession(req, config.New(opts), encoder)
 		if err != nil {
 			return nil, err
 		}

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -36,7 +36,7 @@ func newAuthorizeStateFromConfig(cfg *config.Config, store *store.Store) (*autho
 
 	var err error
 
-	state.evaluator, err = newPolicyEvaluator(cfg.Options, store)
+	state.evaluator, err = newPolicyEvaluator(cfg, store)
 	if err != nil {
 		return nil, fmt.Errorf("authorize: failed to update policy with options: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,16 @@ type Config struct {
 	MetricsScrapeEndpoints []MetricsScrapeEndpoint
 }
 
+// New creates a new Config.
+func New(options *Options) *Config {
+	if options == nil {
+		options = NewDefaultOptions()
+	}
+	return &Config{
+		Options: options,
+	}
+}
+
 // Clone creates a clone of the config.
 func (cfg *Config) Clone() *Config {
 	newOptions := new(Options)

--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -13,11 +13,9 @@ import (
 func TestBuilder_BuildBootstrapAdmin(t *testing.T) {
 	b := New("local-grpc", "local-http", "local-metrics", filemgr.NewManager(), nil)
 	t.Run("valid", func(t *testing.T) {
-		adminCfg, err := b.BuildBootstrapAdmin(&config.Config{
-			Options: &config.Options{
-				EnvoyAdminAddress: "localhost:9901",
-			},
-		})
+		adminCfg, err := b.BuildBootstrapAdmin(config.New(&config.Options{
+			EnvoyAdminAddress: "localhost:9901",
+		}))
 		assert.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -31,11 +29,9 @@ func TestBuilder_BuildBootstrapAdmin(t *testing.T) {
 		`, adminCfg)
 	})
 	t.Run("bad address", func(t *testing.T) {
-		_, err := b.BuildBootstrapAdmin(&config.Config{
-			Options: &config.Options{
-				EnvoyAdminAddress: "xyz1234:zyx4321",
-			},
-		})
+		_, err := b.BuildBootstrapAdmin(config.New(&config.Options{
+			EnvoyAdminAddress: "xyz1234:zyx4321",
+		}))
 		assert.Error(t, err)
 	})
 }
@@ -111,11 +107,9 @@ func TestBuilder_BuildBootstrapStaticResources(t *testing.T) {
 func TestBuilder_BuildBootstrapStatsConfig(t *testing.T) {
 	b := New("local-grpc", "local-http", "local-metrics", filemgr.NewManager(), nil)
 	t.Run("valid", func(t *testing.T) {
-		statsCfg, err := b.BuildBootstrapStatsConfig(&config.Config{
-			Options: &config.Options{
-				Services: "all",
-			},
-		})
+		statsCfg, err := b.BuildBootstrapStatsConfig(config.New(&config.Options{
+			Services: "all",
+		}))
 		assert.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -37,14 +37,14 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 	combinedCA := b.filemgr.BytesDataSource("ca.pem", combinedCABytes).GetFilename()
 
 	t.Run("insecure", func(t *testing.T) {
-		ts, err := b.buildPolicyTransportSocket(ctx, o1, &config.Policy{
+		ts, err := b.buildPolicyTransportSocket(ctx, config.New(o1), &config.Policy{
 			To: mustParseWeightedURLs(t, "http://example.com"),
 		}, *mustParseURL(t, "http://example.com"))
 		require.NoError(t, err)
 		assert.Nil(t, ts)
 	})
 	t.Run("host as sni", func(t *testing.T) {
-		ts, err := b.buildPolicyTransportSocket(ctx, o1, &config.Policy{
+		ts, err := b.buildPolicyTransportSocket(ctx, config.New(o1), &config.Policy{
 			To: mustParseWeightedURLs(t, "https://example.com"),
 		}, *mustParseURL(t, "https://example.com"))
 		require.NoError(t, err)
@@ -97,7 +97,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 		`, ts)
 	})
 	t.Run("tls_server_name as sni", func(t *testing.T) {
-		ts, err := b.buildPolicyTransportSocket(ctx, o1, &config.Policy{
+		ts, err := b.buildPolicyTransportSocket(ctx, config.New(o1), &config.Policy{
 			To:            mustParseWeightedURLs(t, "https://example.com"),
 			TLSServerName: "use-this-name.example.com",
 		}, *mustParseURL(t, "https://example.com"))
@@ -151,7 +151,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 		`, ts)
 	})
 	t.Run("tls_upstream_server_name as sni", func(t *testing.T) {
-		ts, err := b.buildPolicyTransportSocket(ctx, o1, &config.Policy{
+		ts, err := b.buildPolicyTransportSocket(ctx, config.New(o1), &config.Policy{
 			To:                    mustParseWeightedURLs(t, "https://example.com"),
 			TLSUpstreamServerName: "use-this-name.example.com",
 		}, *mustParseURL(t, "https://example.com"))
@@ -205,7 +205,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 		`, ts)
 	})
 	t.Run("tls_skip_verify", func(t *testing.T) {
-		ts, err := b.buildPolicyTransportSocket(ctx, o1, &config.Policy{
+		ts, err := b.buildPolicyTransportSocket(ctx, config.New(o1), &config.Policy{
 			To:            mustParseWeightedURLs(t, "https://example.com"),
 			TLSSkipVerify: true,
 		}, *mustParseURL(t, "https://example.com"))
@@ -260,7 +260,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 		`, ts)
 	})
 	t.Run("custom ca", func(t *testing.T) {
-		ts, err := b.buildPolicyTransportSocket(ctx, o1, &config.Policy{
+		ts, err := b.buildPolicyTransportSocket(ctx, config.New(o1), &config.Policy{
 			To:          mustParseWeightedURLs(t, "https://example.com"),
 			TLSCustomCA: base64.StdEncoding.EncodeToString([]byte{0, 0, 0, 0}),
 		}, *mustParseURL(t, "https://example.com"))
@@ -314,7 +314,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 		`, ts)
 	})
 	t.Run("options custom ca", func(t *testing.T) {
-		ts, err := b.buildPolicyTransportSocket(ctx, o2, &config.Policy{
+		ts, err := b.buildPolicyTransportSocket(ctx, config.New(o2), &config.Policy{
 			To: mustParseWeightedURLs(t, "https://example.com"),
 		}, *mustParseURL(t, "https://example.com"))
 		require.NoError(t, err)
@@ -368,7 +368,7 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 	})
 	t.Run("client certificate", func(t *testing.T) {
 		clientCert, _ := cryptutil.CertificateFromBase64(aExampleComCert, aExampleComKey)
-		ts, err := b.buildPolicyTransportSocket(ctx, o1, &config.Policy{
+		ts, err := b.buildPolicyTransportSocket(ctx, config.New(o1), &config.Policy{
 			To:                mustParseWeightedURLs(t, "https://example.com"),
 			ClientCertificate: clientCert,
 		}, *mustParseURL(t, "https://example.com"))
@@ -438,7 +438,7 @@ func Test_buildCluster(t *testing.T) {
 	rootCA := b.filemgr.BytesDataSource("ca.pem", rootCABytes).GetFilename()
 	o1 := config.NewDefaultOptions()
 	t.Run("insecure", func(t *testing.T) {
-		endpoints, err := b.buildPolicyEndpoints(ctx, o1, &config.Policy{
+		endpoints, err := b.buildPolicyEndpoints(ctx, config.New(o1), &config.Policy{
 			To: mustParseWeightedURLs(t, "http://example.com", "http://1.2.3.4"),
 		})
 		require.NoError(t, err)
@@ -495,7 +495,7 @@ func Test_buildCluster(t *testing.T) {
 		`, cluster)
 	})
 	t.Run("secure", func(t *testing.T) {
-		endpoints, err := b.buildPolicyEndpoints(ctx, o1, &config.Policy{
+		endpoints, err := b.buildPolicyEndpoints(ctx, config.New(o1), &config.Policy{
 			To: mustParseWeightedURLs(t,
 				"https://example.com",
 				"https://example.com",
@@ -663,7 +663,7 @@ func Test_buildCluster(t *testing.T) {
 		`, cluster)
 	})
 	t.Run("ip addresses", func(t *testing.T) {
-		endpoints, err := b.buildPolicyEndpoints(ctx, o1, &config.Policy{
+		endpoints, err := b.buildPolicyEndpoints(ctx, config.New(o1), &config.Policy{
 			To: mustParseWeightedURLs(t, "http://127.0.0.1", "http://127.0.0.2"),
 		})
 		require.NoError(t, err)
@@ -718,7 +718,7 @@ func Test_buildCluster(t *testing.T) {
 		`, cluster)
 	})
 	t.Run("weights", func(t *testing.T) {
-		endpoints, err := b.buildPolicyEndpoints(ctx, o1, &config.Policy{
+		endpoints, err := b.buildPolicyEndpoints(ctx, config.New(o1), &config.Policy{
 			To: mustParseWeightedURLs(t, "http://127.0.0.1:8080,1", "http://127.0.0.2,2"),
 		})
 		require.NoError(t, err)
@@ -775,7 +775,7 @@ func Test_buildCluster(t *testing.T) {
 		`, cluster)
 	})
 	t.Run("localhost", func(t *testing.T) {
-		endpoints, err := b.buildPolicyEndpoints(ctx, o1, &config.Policy{
+		endpoints, err := b.buildPolicyEndpoints(ctx, config.New(o1), &config.Policy{
 			To: mustParseWeightedURLs(t, "http://localhost"),
 		})
 		require.NoError(t, err)
@@ -821,7 +821,7 @@ func Test_buildCluster(t *testing.T) {
 		`, cluster)
 	})
 	t.Run("outlier", func(t *testing.T) {
-		endpoints, err := b.buildPolicyEndpoints(ctx, o1, &config.Policy{
+		endpoints, err := b.buildPolicyEndpoints(ctx, config.New(o1), &config.Policy{
 			To: mustParseWeightedURLs(t, "http://example.com"),
 		})
 		require.NoError(t, err)
@@ -904,7 +904,7 @@ func Test_bindConfig(t *testing.T) {
 
 	b := New("local-grpc", "local-http", "local-metrics", filemgr.NewManager(), nil)
 	t.Run("no bind config", func(t *testing.T) {
-		cluster, err := b.buildPolicyCluster(ctx, &config.Options{}, &config.Policy{
+		cluster, err := b.buildPolicyCluster(ctx, config.New(nil), &config.Policy{
 			From: "https://from.example.com",
 			To:   mustParseWeightedURLs(t, "https://to.example.com"),
 		})
@@ -912,9 +912,9 @@ func Test_bindConfig(t *testing.T) {
 		assert.Nil(t, cluster.UpstreamBindConfig)
 	})
 	t.Run("freebind", func(t *testing.T) {
-		cluster, err := b.buildPolicyCluster(ctx, &config.Options{
+		cluster, err := b.buildPolicyCluster(ctx, config.New(&config.Options{
 			EnvoyBindConfigFreebind: null.BoolFrom(true),
-		}, &config.Policy{
+		}), &config.Policy{
 			From: "https://from.example.com",
 			To:   mustParseWeightedURLs(t, "https://to.example.com"),
 		})
@@ -930,9 +930,9 @@ func Test_bindConfig(t *testing.T) {
 		`, cluster.UpstreamBindConfig)
 	})
 	t.Run("source address", func(t *testing.T) {
-		cluster, err := b.buildPolicyCluster(ctx, &config.Options{
+		cluster, err := b.buildPolicyCluster(ctx, config.New(&config.Options{
 			EnvoyBindConfigSourceAddress: "192.168.0.1",
-		}, &config.Policy{
+		}), &config.Policy{
 			From: "https://from.example.com",
 			To:   mustParseWeightedURLs(t, "https://to.example.com"),
 		})

--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -76,10 +76,10 @@ func newDefaultEnvoyClusterConfig() *envoy_config_cluster_v3.Cluster {
 	}
 }
 
-func buildAccessLogs(options *config.Options) []*envoy_config_accesslog_v3.AccessLog {
-	lvl := options.ProxyLogLevel
+func buildAccessLogs(cfg *config.Config) []*envoy_config_accesslog_v3.AccessLog {
+	lvl := cfg.Options.ProxyLogLevel
 	if lvl == "" {
-		lvl = options.LogLevel
+		lvl = cfg.Options.LogLevel
 	}
 	if lvl == "" {
 		lvl = "debug"

--- a/config/envoyconfig/http_connection_manager.go
+++ b/config/envoyconfig/http_connection_manager.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (b *Builder) buildVirtualHost(
-	options *config.Options,
+	cfg *config.Config,
 	name string,
 	domain string,
 ) (*envoy_config_route_v3.VirtualHost, error) {
@@ -20,15 +20,15 @@ func (b *Builder) buildVirtualHost(
 	}
 
 	// these routes match /.pomerium/... and similar paths
-	rs, err := b.buildPomeriumHTTPRoutes(options, domain)
+	rs, err := b.buildPomeriumHTTPRoutes(cfg, domain)
 	if err != nil {
 		return nil, err
 	}
 	vh.Routes = append(vh.Routes, rs...)
 
 	// if we're the proxy or authenticate service, add our global headers
-	if config.IsProxy(options.Services) || config.IsAuthenticate(options.Services) {
-		vh.ResponseHeadersToAdd = toEnvoyHeaders(options.GetSetResponseHeaders())
+	if config.IsProxy(cfg.Options.Services) || config.IsAuthenticate(cfg.Options.Services) {
+		vh.ResponseHeadersToAdd = toEnvoyHeaders(cfg.Options.GetSetResponseHeaders())
 	}
 
 	return vh, nil
@@ -37,13 +37,13 @@ func (b *Builder) buildVirtualHost(
 // buildLocalReplyConfig builds the local reply config: the config used to modify "local" replies, that is replies
 // coming directly from envoy
 func (b *Builder) buildLocalReplyConfig(
-	options *config.Options,
+	cfg *config.Config,
 ) *envoy_http_connection_manager.LocalReplyConfig {
 	// add global headers for HSTS headers (#2110)
 	var headers []*envoy_config_core_v3.HeaderValueOption
 	// if we're the proxy or authenticate service, add our global headers
-	if config.IsProxy(options.Services) || config.IsAuthenticate(options.Services) {
-		headers = toEnvoyHeaders(options.GetSetResponseHeaders())
+	if config.IsProxy(cfg.Options.Services) || config.IsAuthenticate(cfg.Options.Services) {
+		headers = toEnvoyHeaders(cfg.Options.GetSetResponseHeaders())
 	}
 
 	return &envoy_http_connection_manager.LocalReplyConfig{

--- a/config/envoyconfig/outbound.go
+++ b/config/envoyconfig/outbound.go
@@ -14,7 +14,9 @@ import (
 	"github.com/pomerium/pomerium/config"
 )
 
-func (b *Builder) buildOutboundListener(cfg *config.Config) (*envoy_config_listener_v3.Listener, error) {
+func (b *Builder) buildOutboundListener(
+	cfg *config.Config,
+) (*envoy_config_listener_v3.Listener, error) {
 	outboundPort, err := strconv.Atoi(cfg.OutboundPort)
 	if err != nil {
 		return nil, fmt.Errorf("invalid outbound port %v: %w", cfg.OutboundPort, err)

--- a/config/envoyconfig/tracing.go
+++ b/config/envoyconfig/tracing.go
@@ -14,8 +14,10 @@ import (
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
-func buildTracingCluster(options *config.Options) (*envoy_config_cluster_v3.Cluster, error) {
-	tracingOptions, err := config.NewTracingOptions(options)
+func buildTracingCluster(
+	cfg *config.Config,
+) (*envoy_config_cluster_v3.Cluster, error) {
+	tracingOptions, err := config.NewTracingOptions(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("envoyconfig: invalid tracing config: %w", err)
 	}
@@ -24,8 +26,8 @@ func buildTracingCluster(options *config.Options) (*envoy_config_cluster_v3.Clus
 	case trace.DatadogTracingProviderName:
 		addr, _ := parseAddress("127.0.0.1:8126")
 
-		if options.TracingDatadogAddress != "" {
-			addr, err = parseAddress(options.TracingDatadogAddress)
+		if cfg.Options.TracingDatadogAddress != "" {
+			addr, err = parseAddress(cfg.Options.TracingDatadogAddress)
 			if err != nil {
 				return nil, fmt.Errorf("envoyconfig: invalid tracing datadog address: %w", err)
 			}
@@ -94,8 +96,10 @@ func buildTracingCluster(options *config.Options) (*envoy_config_cluster_v3.Clus
 	}
 }
 
-func buildTracingHTTP(options *config.Options) (*envoy_config_trace_v3.Tracing_Http, error) {
-	tracingOptions, err := config.NewTracingOptions(options)
+func buildTracingHTTP(
+	cfg *config.Config,
+) (*envoy_config_trace_v3.Tracing_Http, error) {
+	tracingOptions, err := config.NewTracingOptions(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("invalid tracing config: %w", err)
 	}

--- a/config/envoyconfig/tracing_test.go
+++ b/config/envoyconfig/tracing_test.go
@@ -11,9 +11,9 @@ import (
 
 func TestBuildTracingCluster(t *testing.T) {
 	t.Run("datadog", func(t *testing.T) {
-		c, err := buildTracingCluster(&config.Options{
+		c, err := buildTracingCluster(config.New(&config.Options{
 			TracingProvider: "datadog",
-		})
+		}))
 		require.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -38,10 +38,10 @@ func TestBuildTracingCluster(t *testing.T) {
 			}
 		`, c)
 
-		c, err = buildTracingCluster(&config.Options{
+		c, err = buildTracingCluster(config.New(&config.Options{
 			TracingProvider:       "datadog",
 			TracingDatadogAddress: "example.com:8126",
-		})
+		}))
 		require.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -67,10 +67,10 @@ func TestBuildTracingCluster(t *testing.T) {
 		`, c)
 	})
 	t.Run("zipkin", func(t *testing.T) {
-		c, err := buildTracingCluster(&config.Options{
+		c, err := buildTracingCluster(config.New(&config.Options{
 			TracingProvider: "zipkin",
 			ZipkinEndpoint:  "https://example.com/api/v2/spans",
-		})
+		}))
 		require.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -99,9 +99,9 @@ func TestBuildTracingCluster(t *testing.T) {
 
 func TestBuildTracingHTTP(t *testing.T) {
 	t.Run("datadog", func(t *testing.T) {
-		h, err := buildTracingHTTP(&config.Options{
+		h, err := buildTracingHTTP(config.New(&config.Options{
 			TracingProvider: "datadog",
-		})
+		}))
 		require.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -115,10 +115,10 @@ func TestBuildTracingHTTP(t *testing.T) {
 		`, h)
 	})
 	t.Run("zipkin", func(t *testing.T) {
-		h, err := buildTracingHTTP(&config.Options{
+		h, err := buildTracingHTTP(config.New(&config.Options{
 			TracingProvider: "zipkin",
 			ZipkinEndpoint:  "https://example.com/api/v2/spans",
-		})
+		}))
 		require.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{

--- a/config/trace_test.go
+++ b/config/trace_test.go
@@ -68,7 +68,7 @@ func Test_NewTracingOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := NewTracingOptions(tt.opts)
+			got, err := NewTracingOptions(&Config{Options: tt.opts})
 			assert.NotEqual(t, err == nil, tt.wantErr, "unexpected error value")
 			assert.Empty(t, cmp.Diff(tt.want, got))
 		})

--- a/databroker/cache_test.go
+++ b/databroker/cache_test.go
@@ -28,7 +28,7 @@ func TestNew(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.opts.Provider = "google"
-			_, err := New(&config.Config{Options: &tt.opts}, events.New())
+			_, err := New(config.New(&tt.opts), events.New())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/internal/autocert/manager_test.go
+++ b/internal/autocert/manager_test.go
@@ -236,8 +236,8 @@ func TestConfig(t *testing.T) {
 	}
 	_ = p1.Validate()
 
-	mgr, err := newManager(ctx, config.NewStaticSource(&config.Config{
-		Options: &config.Options{
+	mgr, err := newManager(ctx,
+		config.NewStaticSource(config.New(&config.Options{
 			AutocertOptions: config.AutocertOptions{
 				Enable:     true,
 				UseStaging: true,
@@ -247,11 +247,11 @@ func TestConfig(t *testing.T) {
 			},
 			HTTPRedirectAddr: addr,
 			Policies:         []config.Policy{p1},
-		},
-	}), certmagic.ACMEIssuer{
-		CA:     srv.URL + "/acme/directory",
-		TestCA: srv.URL + "/acme/directory",
-	}, time.Millisecond*100)
+		})),
+		certmagic.ACMEIssuer{
+			CA:     srv.URL + "/acme/directory",
+			TestCA: srv.URL + "/acme/directory",
+		}, time.Millisecond*100)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -304,16 +304,14 @@ func TestRedirect(t *testing.T) {
 	addr := li.Addr().String()
 	_ = li.Close()
 
-	src := config.NewStaticSource(&config.Config{
-		Options: &config.Options{
-			HTTPRedirectAddr: addr,
-			SetResponseHeaders: map[string]string{
-				"X-Frame-Options":           "SAMEORIGIN",
-				"X-XSS-Protection":          "1; mode=block",
-				"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
-			},
+	src := config.NewStaticSource(config.New(&config.Options{
+		HTTPRedirectAddr: addr,
+		SetResponseHeaders: map[string]string{
+			"X-Frame-Options":           "SAMEORIGIN",
+			"X-XSS-Protection":          "1; mode=block",
+			"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
 		},
-	})
+	}))
 	_, err = New(src)
 	if !assert.NoError(t, err) {
 		return

--- a/internal/httputil/reproxy/reproxy.go
+++ b/internal/httputil/reproxy/reproxy.go
@@ -28,7 +28,7 @@ import (
 type Handler struct {
 	mu       sync.RWMutex
 	key      []byte
-	options  *config.Options
+	cfg      *config.Config
 	policies map[uint64]config.Policy
 }
 
@@ -83,7 +83,7 @@ func (h *Handler) Middleware(next http.Handler) http.Handler {
 		}
 
 		h.mu.RLock()
-		options := h.options
+		options := h.cfg.Options
 		policy, ok := h.policies[policyID]
 		h.mu.RUnlock()
 
@@ -132,7 +132,7 @@ func (h *Handler) Update(ctx context.Context, cfg *config.Config) {
 	defer h.mu.Unlock()
 
 	h.key, _ = cfg.Options.GetSharedKey()
-	h.options = cfg.Options
+	h.cfg = cfg
 	h.policies = make(map[uint64]config.Policy)
 	for _, p := range cfg.Options.GetAllPolicies() {
 		id, err := p.RouteID()

--- a/internal/httputil/reproxy/reproxy_test.go
+++ b/internal/httputil/reproxy/reproxy_test.go
@@ -49,15 +49,13 @@ func TestMiddleware(t *testing.T) {
 		srv2 := httptest.NewServer(h.Middleware(next))
 		defer srv2.Close()
 
-		cfg := &config.Config{
-			Options: &config.Options{
-				SharedKey: cryptutil.NewBase64Key(),
-				Policies: []config.Policy{{
-					To:                            config.WeightedURLs{{URL: *u}},
-					KubernetesServiceAccountToken: "ABCD",
-				}},
-			},
-		}
+		cfg := config.New(&config.Options{
+			SharedKey: cryptutil.NewBase64Key(),
+			Policies: []config.Policy{{
+				To:                            config.WeightedURLs{{URL: *u}},
+				KubernetesServiceAccountToken: "ABCD",
+			}},
+		})
 		h.Update(context.Background(), cfg)
 
 		policyID, _ := cfg.Options.Policies[0].RouteID()

--- a/proxy/forward_auth_test.go
+++ b/proxy/forward_auth_test.go
@@ -80,11 +80,11 @@ func TestProxy_ForwardAuth(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := New(&config.Config{Options: tt.options})
+			p, err := New(config.New(tt.options))
 			if err != nil {
 				t.Fatal(err)
 			}
-			p.OnConfigChange(ctx, &config.Config{Options: tt.options})
+			p.OnConfigChange(ctx, config.New(tt.options))
 			state := p.state.Load()
 			state.sessionStore = tt.sessionStore
 			signer, err := jws.NewHS256Signer(nil)

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -58,7 +58,7 @@ func (p *Proxy) SignOut(w http.ResponseWriter, r *http.Request) error {
 	state := p.state.Load()
 
 	var redirectURL *url.URL
-	signOutURL, err := p.currentOptions.Load().GetSignOutRedirectURL()
+	signOutURL, err := p.currentConfig.Load().Options.GetSignOutRedirectURL()
 	if err != nil {
 		return httputil.NewError(http.StatusInternalServerError, err)
 	}

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -47,7 +47,7 @@ func TestProxy_Signout(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	proxy, err := New(&config.Config{Options: opts})
+	proxy, err := New(config.New(opts))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +70,7 @@ func TestProxy_userInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	proxy, err := New(&config.Config{Options: opts})
+	proxy, err := New(config.New(opts))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +102,7 @@ func TestProxy_SignOut(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := testOptions(t)
-			p, err := New(&config.Config{Options: opts})
+			p, err := New(config.New(opts))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -236,11 +236,11 @@ func TestProxy_Callback(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := New(&config.Config{Options: tt.options})
+			p, err := New(config.New(tt.options))
 			if err != nil {
 				t.Fatal(err)
 			}
-			p.OnConfigChange(context.Background(), &config.Config{Options: tt.options})
+			p.OnConfigChange(context.Background(), config.New(tt.options))
 			state := p.state.Load()
 			state.encoder = tt.cipher
 			state.sessionStore = tt.sessionStore
@@ -350,7 +350,7 @@ func TestProxy_ProgrammaticLogin(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := New(&config.Config{Options: tt.options})
+			p, err := New(config.New(tt.options))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -482,11 +482,11 @@ func TestProxy_ProgrammaticCallback(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := New(&config.Config{Options: tt.options})
+			p, err := New(config.New(tt.options))
 			if err != nil {
 				t.Fatal(err)
 			}
-			p.OnConfigChange(context.Background(), &config.Config{Options: tt.options})
+			p.OnConfigChange(context.Background(), config.New(tt.options))
 			state := p.state.Load()
 			state.encoder = tt.cipher
 			state.sessionStore = tt.sessionStore

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -99,7 +99,7 @@ func TestNew(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := New(&config.Config{Options: tt.opts})
+			got, err := New(config.New(tt.opts))
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -194,12 +194,12 @@ func Test_UpdateOptions(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := New(&config.Config{Options: tt.originalOptions})
+			p, err := New(config.New(tt.originalOptions))
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			p.OnConfigChange(context.Background(), &config.Config{Options: tt.updatedOptions})
+			p.OnConfigChange(context.Background(), config.New(tt.updatedOptions))
 			r := httptest.NewRequest("GET", tt.host, nil)
 			w := httptest.NewRecorder()
 			p.ServeHTTP(w, r)
@@ -212,5 +212,5 @@ func Test_UpdateOptions(t *testing.T) {
 
 	// Test nil
 	var p *Proxy
-	p.OnConfigChange(context.Background(), &config.Config{})
+	p.OnConfigChange(context.Background(), config.New(nil))
 }


### PR DESCRIPTION
## Summary
As a first step towards deprecating `config.Options`, update the code so we use `config.Config` everywhere.

## Related issues
-  https://github.com/pomerium/internal/issues/953

 

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
