### PR TITLE
autocert: fix flaky test

### DIFF
--- a/internal/autocert/manager_test.go
+++ b/internal/autocert/manager_test.go
@@ -262,12 +262,15 @@ func TestConfig(t *testing.T) {
 	var initialOCSPStaple []byte
 	var certValidTime *time.Time
 	mgr.OnConfigChange(ctx, func(ctx context.Context, cfg *config.Config) {
-		log.Info(ctx).Msg("OnConfigChange")
+		if len(cfg.AutoCertificates) == 0 {
+			return
+		}
+
 		cert := cfg.AutoCertificates[0]
 		if initialOCSPStaple == nil {
 			initialOCSPStaple = cert.OCSPStaple
 		} else {
-			if bytes.Compare(initialOCSPStaple, cert.OCSPStaple) != 0 {
+			if !bytes.Equal(initialOCSPStaple, cert.OCSPStaple) {
 				log.Info(ctx).Msg("OCSP updated")
 				ocspUpdated <- true
 			}


### PR DESCRIPTION
## Summary
This test seems to fail in github actions sometimes. Wasn't able to reproduce locally, but hopefully this should prevent it from happening.

## Related issues
- https://github.com/pomerium/pomerium/pull/3590

 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
