### PR TITLE
postgres: remove not null constraint on data column of record changes table

### DIFF
--- a/pkg/storage/postgres/migrate.go
+++ b/pkg/storage/postgres/migrate.go
@@ -130,6 +130,17 @@ var migrations = []func(context.Context, pgx.Tx) error{
 
 		return nil
 	},
+	4: func(ctx context.Context, tx pgx.Tx) error {
+		_, err := tx.Exec(ctx, `
+			ALTER TABLE `+schemaName+`.`+recordChangesTableName+`
+			ALTER data DROP NOT NULL
+		`)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
 }
 
 func migrate(ctx context.Context, tx pgx.Tx) (serverVersion uint64, err error) {


### PR DESCRIPTION
## Summary
Remove the not null constraint on the data column of the record changes table. I don't know why data would be null, but apparently it happens.
 
## Related issues
Fixes https://github.com/pomerium/pomerium-console/issues/2753
 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
