### PR TITLE
authenticate: get/set identity provider id for all sessions

### DIFF
--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -478,6 +478,8 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
+	idp, _ := new(config.Options).GetIdentityProviderForID("")
+
 	tests := []struct {
 		name    string
 		headers map[string]string
@@ -491,7 +493,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 		{
 			"good",
 			nil,
-			&mstore.Store{Session: &sessions.State{ID: "xyz"}},
+			&mstore.Store{Session: &sessions.State{IdentityProviderID: idp.GetId(), ID: "xyz"}},
 			nil,
 			identity.MockProvider{RefreshResponse: oauth2.Token{Expiry: time.Now().Add(10 * time.Minute)}},
 			http.StatusOK,
@@ -499,7 +501,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 		{
 			"invalid session",
 			nil,
-			&mstore.Store{Session: &sessions.State{ID: "xyz"}},
+			&mstore.Store{Session: &sessions.State{IdentityProviderID: idp.GetId(), ID: "xyz"}},
 			errors.New("hi"),
 			identity.MockProvider{},
 			http.StatusFound,
@@ -507,7 +509,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 		{
 			"good refresh expired",
 			nil,
-			&mstore.Store{Session: &sessions.State{ID: "xyz"}},
+			&mstore.Store{Session: &sessions.State{IdentityProviderID: idp.GetId(), ID: "xyz"}},
 			nil,
 			identity.MockProvider{RefreshResponse: oauth2.Token{Expiry: time.Now().Add(10 * time.Minute)}},
 			http.StatusOK,
@@ -515,7 +517,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 		{
 			"expired,refresh error",
 			nil,
-			&mstore.Store{Session: &sessions.State{ID: "xyz"}},
+			&mstore.Store{Session: &sessions.State{IdentityProviderID: idp.GetId(), ID: "xyz"}},
 			sessions.ErrExpired,
 			identity.MockProvider{RefreshError: errors.New("error")},
 			http.StatusFound,
@@ -523,7 +525,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 		{
 			"expired,save error",
 			nil,
-			&mstore.Store{SaveError: errors.New("error"), Session: &sessions.State{ID: "xyz"}},
+			&mstore.Store{SaveError: errors.New("error"), Session: &sessions.State{IdentityProviderID: idp.GetId(), ID: "xyz"}},
 			sessions.ErrExpired,
 			identity.MockProvider{RefreshResponse: oauth2.Token{Expiry: time.Now().Add(10 * time.Minute)}},
 			http.StatusFound,
@@ -531,7 +533,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 		{
 			"expired XHR,refresh error",
 			map[string]string{"X-Requested-With": "XmlHttpRequest"},
-			&mstore.Store{Session: &sessions.State{ID: "xyz"}},
+			&mstore.Store{Session: &sessions.State{IdentityProviderID: idp.GetId(), ID: "xyz"}},
 			sessions.ErrExpired,
 			identity.MockProvider{RefreshError: errors.New("error")},
 			http.StatusUnauthorized,


### PR DESCRIPTION
## Summary
Currently if you go to the authenticate service directly (`https://authenticate.localhost.pomerium.io`), we will create a session using an empty `IdentityProviderID`. However when you go to a route (`https://httpbin.localhost.pomerium.io`), the created session will have an `IdentityProviderID` set to an ID generated from a hash of the options. This change occurred when we introduced route-specific identity provider client ids and secrets. As a result of this behavior the sessions for `authenticate.localhost.pomerium.io` and `httpbin.localhost.pomerium.io` are not the same. So if you logout with `https://authenticate.localhost.pomerium.io/.pomerium/sign_out` it will delete the authenticate session but not the httpbin session. And if there is no authenticate session it will attempt to log you in.

The identity provider in question is the protobuf type:

```proto
message Provider {
  string id = 1;
  string client_id = 2;
  string client_secret = 3;
  string type = 4;
  repeated string scopes = 5;
  string service_account = 6;
  string url = 7;
  map<string, string> request_params = 8;
}
```

This PR updates the code so that everywhere we get `pomerium_idp_id` from the query string we use the options to get the associated identity provider and then use that ID instead. This way we will default to the global options identity provider's ID instead of the empty string when working with sessions on the authenticate service. So if `authenticate.localhost.pomerium.io` and `httpbin.localhost.pomerium.io` use the same client id and secret, they will share a session, and logging out directly from the authenticate service, will also log you out of the route.

(though if users logout directly from authenticate their session will persist for ~30s on the route because the route's cookie is not cleared and the databroker session persists in cache, the fix is to logout from the route itself which clears both cookies) 

## Related issues
- https://github.com/pomerium/pomerium/issues/3592

 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
