### PR TITLE
postgres: return an empty list of addresses on dns errors

### DIFF
--- a/pkg/storage/postgres/backend_test.go
+++ b/pkg/storage/postgres/backend_test.go
@@ -184,3 +184,17 @@ func TestBackend(t *testing.T) {
 		return nil
 	}))
 }
+
+func TestLookup(t *testing.T) {
+	t.Parallel()
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	t.Cleanup(clearTimeout)
+
+	cfg, err := ParseConfig("host=localhost")
+	assert.NoError(t, err)
+
+	addrs, err := cfg.ConnConfig.LookupFunc(ctx, "test.unknown")
+	assert.NoError(t, err)
+	assert.Empty(t, addrs)
+}


### PR DESCRIPTION
## Summary
The underlying postgres driver supports multiple failover hosts, but only if the DNS address used for the host resolves to an IP address. This PR changes the lookup function so that it does not return an error if a host doesn't resolve and instead returns an empty list of IP addresses. This in turn allows the multiple host capability to work properly.

## Related issues
Fixes #3634 

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
