### PR TITLE
ppl: support special characters in claim keys

### DIFF
--- a/pkg/policy/criteria/claims_test.go
+++ b/pkg/policy/criteria/claims_test.go
@@ -86,4 +86,28 @@ allow:
 		require.Equal(t, A{true, A{ReasonClaimOK}, M{}}, res["allow"])
 		require.Equal(t, A{false, A{}}, res["deny"])
 	})
+	t.Run("special keys", func(t *testing.T) {
+		res, err := evaluate(t, `
+allow:
+  and:
+    - claim/example.com/key: value
+`,
+			[]dataBrokerRecord{
+				&session.Session{
+					Id:     "SESSION_ID",
+					UserId: "USER_ID",
+					Claims: map[string]*structpb.ListValue{
+						"example.com/key": {Values: []*structpb.Value{structpb.NewStringValue("value")}},
+					},
+				},
+				&user.User{
+					Id:    "USER_ID",
+					Email: "test@example.com",
+				},
+			},
+			Input{Session: InputSession{ID: "SESSION_ID"}})
+		require.NoError(t, err)
+		require.Equal(t, A{true, A{ReasonClaimOK}, M{}}, res["allow"])
+		require.Equal(t, A{false, A{}}, res["deny"])
+	})
 }

--- a/pkg/policy/rules/rules.go
+++ b/pkg/policy/rules/rules.go
@@ -176,7 +176,12 @@ func ObjectGet() *ast.Rule {
 	return ast.MustParseRule(`
 # object_get is like object.get, but supports converting "/" in keys to separate lookups
 # rego doesn't support recursion, so we hard code a limited number of /'s
+
 object_get(obj, key, def) = value {
+	undefined := "10a0fd35-0f1a-4e5b-97ce-631e89e1bafa"
+	value = object.get(obj, key, undefined)
+	value != undefined
+} else = value {
 	segments := split(replace(key, ".", "/"), "/")
 	count(segments) == 2
 	o1 := object.get(obj, segments[0], {})


### PR DESCRIPTION
## Summary
Claims can sometimes have special characters like `/` in them. Our custom `object_get` method in rego converts `/` into a sub-object lookup. This PR makes it first see if the key exists as-is, and then starts the recursive search.

## Related issues
- https://github.com/pomerium/internal/issues/996

## Checklist
- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
