### PR TITLE
config: default to http2

### DIFF
--- a/config/codec_type_test.go
+++ b/config/codec_type_test.go
@@ -8,10 +8,5 @@ import (
 
 func TestOptions_GetCodecType(t *testing.T) {
 	options := NewDefaultOptions()
-	assert.Equal(t, CodecTypeHTTP1, options.GetCodecType())
-	options.Services = "proxy"
-	assert.Equal(t, CodecTypeAuto, options.GetCodecType())
-	options.Services = "all"
-	options.CodecType = CodecTypeAuto
 	assert.Equal(t, CodecTypeAuto, options.GetCodecType())
 }

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -139,7 +139,6 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 				}
 			}],
 			"alwaysSetRequestIdInResponse": true,
-			"codecType": "HTTP1",
 			"commonHttpProtocolOptions": {
 				"idleTimeout": "300s"
 			},

--- a/config/options.go
+++ b/config/options.go
@@ -1049,9 +1049,6 @@ func (o *Options) GetQPS() float64 {
 // GetCodecType gets a codec type.
 func (o *Options) GetCodecType() CodecType {
 	if o.CodecType == CodecTypeUnset {
-		if IsAll(o.Services) {
-			return CodecTypeHTTP1
-		}
 		return CodecTypeAuto
 	}
 	return o.CodecType


### PR DESCRIPTION
## Summary
Previously we defaulted to `http1` when in all-in-one mode. This PR updates the code so that we default to `http2` instead.

The original behavior was because we did not add routes to all virtual hosts resulting in 421s when requests were coalesced on the same HTTP/2 connection. We now can handle these routes, so there's no need to return the 421s anymore.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1010

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
