### PR TITLE
postgres: increase record batch size

### DIFF
--- a/pkg/storage/postgres/stream.go
+++ b/pkg/storage/postgres/stream.go
@@ -11,7 +11,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/storage"
 )
 
-const recordBatchSize = 64
+const recordBatchSize = 4 * 1024
 
 type recordStream struct {
 	backend *Backend


### PR DESCRIPTION
## Summary
Increase the number of records we fetch from the database for 64 to 4096. This will increase memory usage but should also increase database memory efficiency.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/2921
 

## Checklist

- [x] reference any related issues 
- [x] updated unit tests 
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
