### PR TITLE
Allow basic-auth for programmatic access

### DIFF
--- a/internal/sessions/header/header_store_test.go
+++ b/internal/sessions/header/header_store_test.go
@@ -26,4 +26,10 @@ func TestTokenFromHeader(t *testing.T) {
 		v := TokenFromHeaders(r)
 		assert.Equal(t, "JWT", v)
 	})
+	t.Run("basic auth", func(t *testing.T) {
+		r, _ := http.NewRequest("GET", "http://localhost/some/url", nil)
+		r.SetBasicAuth("pomerium", "JWT")
+		v := TokenFromHeaders(r)
+		assert.Equal(t, "JWT", v)
+	})
 }


### PR DESCRIPTION
## Summary

Allow basic-auth for a more feasible way to authenticate for a wide range of web apps

## Related issues

Fixes #3687

## User Explanation

Check if basic-auth headers are available and if so use them to authenticate your app in a programmatic way, using `pomerium` as default user name and the JWT as password.

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
