### PR TITLE
keep trace span context

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -91,7 +91,7 @@ func newPolicyEvaluator(opts *config.Options, store *store.Store) (*evaluator.Ev
 		return int64(len(opts.GetAllPolicies()))
 	})
 	ctx := context.Background()
-	_, span := trace.StartSpan(ctx, "authorize.newPolicyEvaluator")
+	ctx, span := trace.StartSpan(ctx, "authorize.newPolicyEvaluator")
 	defer span.End()
 
 	clientCA, err := opts.GetClientCA()

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -120,7 +120,7 @@ func New(ctx context.Context, store *store.Store, options ...Option) (*Evaluator
 
 // Evaluate evaluates the rego for the given policy and generates the identity headers.
 func (e *Evaluator) Evaluate(ctx context.Context, req *Request) (*Result, error) {
-	_, span := trace.StartSpan(ctx, "authorize.Evaluator.Evaluate")
+	ctx, span := trace.StartSpan(ctx, "authorize.Evaluator.Evaluate")
 	defer span.End()
 
 	if req.Policy == nil {

--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -78,7 +78,7 @@ func NewHeadersEvaluator(ctx context.Context, store *store.Store) (*HeadersEvalu
 
 // Evaluate evaluates the headers.rego script.
 func (e *HeadersEvaluator) Evaluate(ctx context.Context, req *HeadersRequest) (*HeadersResponse, error) {
-	_, span := trace.StartSpan(ctx, "authorize.HeadersEvaluator.Evaluate")
+	ctx, span := trace.StartSpan(ctx, "authorize.HeadersEvaluator.Evaluate")
 	defer span.End()
 	rs, err := safeEval(ctx, e.q, rego.EvalInput(req))
 	if err != nil {

--- a/authorize/evaluator/policy_evaluator.go
+++ b/authorize/evaluator/policy_evaluator.go
@@ -198,7 +198,7 @@ func (e *PolicyEvaluator) Evaluate(ctx context.Context, req *PolicyRequest) (*Po
 }
 
 func (e *PolicyEvaluator) evaluateQuery(ctx context.Context, req *PolicyRequest, query policyQuery) (*PolicyResponse, error) {
-	_, span := trace.StartSpan(ctx, "authorize.PolicyEvaluator.evaluateQuery")
+	ctx, span := trace.StartSpan(ctx, "authorize.PolicyEvaluator.evaluateQuery")
 	defer span.End()
 	span.AddAttributes(octrace.StringAttribute("script_checksum", query.checksum()))
 

--- a/internal/databroker/server.go
+++ b/internal/databroker/server.go
@@ -76,7 +76,7 @@ func (srv *Server) UpdateConfig(options ...ServerOption) {
 
 // AcquireLease acquires a lease.
 func (srv *Server) AcquireLease(ctx context.Context, req *databroker.AcquireLeaseRequest) (*databroker.AcquireLeaseResponse, error) {
-	_, span := trace.StartSpan(ctx, "databroker.grpc.AcquireLease")
+	ctx, span := trace.StartSpan(ctx, "databroker.grpc.AcquireLease")
 	defer span.End()
 	log.Info(ctx).
 		Str("name", req.GetName()).
@@ -103,7 +103,7 @@ func (srv *Server) AcquireLease(ctx context.Context, req *databroker.AcquireLeas
 
 // Get gets a record from the in-memory list.
 func (srv *Server) Get(ctx context.Context, req *databroker.GetRequest) (*databroker.GetResponse, error) {
-	_, span := trace.StartSpan(ctx, "databroker.grpc.Get")
+	ctx, span := trace.StartSpan(ctx, "databroker.grpc.Get")
 	defer span.End()
 	log.Info(ctx).
 		Str("type", req.GetType()).
@@ -130,7 +130,7 @@ func (srv *Server) Get(ctx context.Context, req *databroker.GetRequest) (*databr
 
 // Query queries for records.
 func (srv *Server) Query(ctx context.Context, req *databroker.QueryRequest) (*databroker.QueryResponse, error) {
-	_, span := trace.StartSpan(ctx, "databroker.grpc.Query")
+	ctx, span := trace.StartSpan(ctx, "databroker.grpc.Query")
 	defer span.End()
 	log.Info(ctx).
 		Str("type", req.GetType()).
@@ -183,7 +183,7 @@ func (srv *Server) Query(ctx context.Context, req *databroker.QueryRequest) (*da
 
 // Put updates an existing record or adds a new one.
 func (srv *Server) Put(ctx context.Context, req *databroker.PutRequest) (*databroker.PutResponse, error) {
-	_, span := trace.StartSpan(ctx, "databroker.grpc.Put")
+	ctx, span := trace.StartSpan(ctx, "databroker.grpc.Put")
 	defer span.End()
 
 	records := req.GetRecords()
@@ -222,7 +222,7 @@ func (srv *Server) Put(ctx context.Context, req *databroker.PutRequest) (*databr
 
 // ReleaseLease releases a lease.
 func (srv *Server) ReleaseLease(ctx context.Context, req *databroker.ReleaseLeaseRequest) (*emptypb.Empty, error) {
-	_, span := trace.StartSpan(ctx, "databroker.grpc.ReleaseLease")
+	ctx, span := trace.StartSpan(ctx, "databroker.grpc.ReleaseLease")
 	defer span.End()
 	log.Info(ctx).
 		Str("name", req.GetName()).
@@ -244,7 +244,7 @@ func (srv *Server) ReleaseLease(ctx context.Context, req *databroker.ReleaseLeas
 
 // RenewLease releases a lease.
 func (srv *Server) RenewLease(ctx context.Context, req *databroker.RenewLeaseRequest) (*emptypb.Empty, error) {
-	_, span := trace.StartSpan(ctx, "databroker.grpc.RenewLease")
+	ctx, span := trace.StartSpan(ctx, "databroker.grpc.RenewLease")
 	defer span.End()
 	log.Debug(ctx).
 		Str("name", req.GetName()).
@@ -269,7 +269,7 @@ func (srv *Server) RenewLease(ctx context.Context, req *databroker.RenewLeaseReq
 
 // SetOptions sets options for a type in the databroker.
 func (srv *Server) SetOptions(ctx context.Context, req *databroker.SetOptionsRequest) (*databroker.SetOptionsResponse, error) {
-	_, span := trace.StartSpan(ctx, "databroker.grpc.SetOptions")
+	ctx, span := trace.StartSpan(ctx, "databroker.grpc.SetOptions")
 	defer span.End()
 
 	backend, err := srv.getBackend()


### PR DESCRIPTION
## Summary

Do not discard context returned by `StartSpan` to properly see call hierarchy.

### Before
![image](https://user-images.githubusercontent.com/673131/200077131-6c332b68-2422-48a1-92c1-3f2266ff724c.png)

### After
![image](https://user-images.githubusercontent.com/673131/200077170-401e9bfd-8e48-4d80-800b-fd5926c61621.png)

## Related issues

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
