### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/config/config_source_test.go
+++ b/config/config_source_test.go
@@ -8,20 +8,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestFileWatcherSource(t *testing.T) {
 	ctx := context.Background()
 
-	tmpdir := filepath.Join(os.TempDir(), uuid.New().String())
-	err := os.MkdirAll(tmpdir, 0o755)
-	if !assert.NoError(t, err) {
-		return
-	}
+	tmpdir := t.TempDir()
 
-	err = os.WriteFile(filepath.Join(tmpdir, "example.txt"), []byte{1, 2, 3, 4}, 0o600)
+	err := os.WriteFile(filepath.Join(tmpdir, "example.txt"), []byte{1, 2, 3, 4}, 0o600)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/config/envoyconfig/filemgr/filemgr_test.go
+++ b/config/envoyconfig/filemgr/filemgr_test.go
@@ -6,19 +6,11 @@ import (
 	"testing"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test(t *testing.T) {
-	dir := filepath.Join(os.TempDir(), uuid.New().String())
-	err := os.MkdirAll(dir, 0o755)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer func() {
-		_ = os.RemoveAll(dir)
-	}()
+	dir := t.TempDir()
 
 	t.Run("bytes", func(t *testing.T) {
 		mgr := NewManager(WithCacheDir(dir))

--- a/databroker/cache_test.go
+++ b/databroker/cache_test.go
@@ -1,8 +1,6 @@
 package databroker
 
 import (
-	"log"
-	"os"
 	"testing"
 
 	"github.com/pomerium/pomerium/config"
@@ -11,12 +9,6 @@ import (
 )
 
 func TestNew(t *testing.T) {
-	dir, err := os.MkdirTemp("", "example")
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
-
 	tests := []struct {
 		name    string
 		opts    config.Options

--- a/internal/autocert/manager_test.go
+++ b/internal/autocert/manager_test.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -27,7 +26,6 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/google/uuid"
 	"github.com/mholt/acmez/acme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -217,9 +215,7 @@ func TestConfig(t *testing.T) {
 
 	mockACME = newMockACME(ca, srv)
 
-	tmpdir := filepath.Join(os.TempDir(), uuid.New().String())
-	_ = os.MkdirAll(tmpdir, 0o755)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	li, err := net.Listen("tcp", "127.0.0.1:0")
 	if !assert.NoError(t, err) {

--- a/internal/fileutil/watcher_test.go
+++ b/internal/fileutil/watcher_test.go
@@ -6,18 +6,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWatcher(t *testing.T) {
-	tmpdir := filepath.Join(os.TempDir(), uuid.New().String())
-	err := os.MkdirAll(tmpdir, 0o755)
-	if !assert.NoError(t, err) {
-		return
-	}
+	tmpdir := t.TempDir()
 
-	err = os.WriteFile(filepath.Join(tmpdir, "test1.txt"), []byte{1, 2, 3, 4}, 0o666)
+	err := os.WriteFile(filepath.Join(tmpdir, "test1.txt"), []byte{1, 2, 3, 4}, 0o666)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -44,14 +39,9 @@ func TestWatcher(t *testing.T) {
 func TestWatcherSymlink(t *testing.T) {
 	t.Parallel()
 
-	tmpdir := filepath.Join(os.TempDir(), uuid.New().String())
-	err := os.MkdirAll(tmpdir, 0o755)
-	if !assert.NoError(t, err) {
-		return
-	}
-	t.Cleanup(func() { os.RemoveAll(tmpdir) })
+	tmpdir := t.TempDir()
 
-	err = os.WriteFile(filepath.Join(tmpdir, "test1.txt"), []byte{1, 2, 3, 4}, 0o666)
+	err := os.WriteFile(filepath.Join(tmpdir, "test1.txt"), []byte{1, 2, 3, 4}, 0o666)
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

The existing temporary directories in tests were created using `filepath.Join` and `os.MkdirAll`.

This PR replaces `filepath.Join` and `os.MkdirAll` with `t.TempDir` in tests. The directory created by `t.TempDir` is automatically removed when the test and all its subtests complete.

Reference: https://pkg.go.dev/testing#T.TempDir

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag
- [x] ready for review
