### PR TITLE
controlplane: fix /.well-known/pomerium missing CORS headers

### DIFF
--- a/internal/httputil/handlers.go
+++ b/internal/httputil/handlers.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 
 	"github.com/go-jose/go-jose/v3"
+	"github.com/rs/cors"
 
 	"github.com/pomerium/csrf"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
@@ -74,7 +75,7 @@ func (f HandlerFunc) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // JWKSHandler returns the /.well-known/pomerium/jwks.json handler.
 func JWKSHandler(rawSigningKey string) http.Handler {
-	return HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+	return cors.AllowAll().Handler(HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		var jwks jose.JSONWebKeySet
 		if rawSigningKey != "" {
 			decodedCert, err := base64.StdEncoding.DecodeString(rawSigningKey)
@@ -89,12 +90,12 @@ func JWKSHandler(rawSigningKey string) http.Handler {
 		}
 		RenderJSON(w, http.StatusOK, jwks)
 		return nil
-	})
+	}))
 }
 
 // WellKnownPomeriumHandler returns the /.well-known/pomerium handler.
 func WellKnownPomeriumHandler(authenticateURL *url.URL) http.Handler {
-	return HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+	return cors.AllowAll().Handler(HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		wellKnownURLs := struct {
 			OAuth2Callback        string `json:"authentication_callback_endpoint"` // RFC6749
 			JSONWebKeySetURL      string `json:"jwks_uri"`                         // RFC7517
@@ -107,5 +108,5 @@ func WellKnownPomeriumHandler(authenticateURL *url.URL) http.Handler {
 		w.Header().Set("X-CSRF-Token", csrf.Token(r))
 		RenderJSON(w, http.StatusOK, wellKnownURLs)
 		return nil
-	})
+	}))
 }

--- a/internal/httputil/handlers_test.go
+++ b/internal/httputil/handlers_test.go
@@ -5,9 +5,11 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHealthCheck(t *testing.T) {
@@ -147,4 +149,31 @@ func TestRenderJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestJWKSHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cors", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodOptions, "/", nil)
+		r.Header.Set("Origin", "https://www.example.com")
+		r.Header.Set("Access-Control-Request-Method", "GET")
+		JWKSHandler("").ServeHTTP(w, r)
+		assert.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+	})
+}
+
+func TestWellKnownPomeriumHandler(t *testing.T) {
+	t.Parallel()
+
+	t.Run("cors", func(t *testing.T) {
+		authenticateURL, _ := url.Parse("https://authenticate.example.com")
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodOptions, "/", nil)
+		r.Header.Set("Origin", authenticateURL.String())
+		r.Header.Set("Access-Control-Request-Method", "GET")
+		WellKnownPomeriumHandler(authenticateURL).ServeHTTP(w, r)
+		assert.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+	})
 }


### PR DESCRIPTION
## Summary
These endpoints should be accessible from any frontend Javascript application, so should have CORS headers added. They accidentally got lost in #3691.

## Related issues


## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
