### PR TITLE
hpke: add HPKE key to JWKS endpoint

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/config"
+	"github.com/pomerium/pomerium/pkg/hpke"
 )
 
 // DisableHeaderKey is the key used to check whether to disable setting header
@@ -995,6 +996,16 @@ func (o *Options) GetSharedKey() ([]byte, error) {
 		return nil, errors.New("shared secret contains whitespace")
 	}
 	return base64.StdEncoding.DecodeString(sharedKey)
+}
+
+// GetHPKEPrivateKey gets the hpke.PrivateKey dervived from the shared key.
+func (o *Options) GetHPKEPrivateKey() (hpke.PrivateKey, error) {
+	sharedKey, err := o.GetSharedKey()
+	if err != nil {
+		return hpke.PrivateKey{}, err
+	}
+
+	return hpke.DerivePrivateKey(sharedKey), nil
 }
 
 // GetGoogleCloudServerlessAuthenticationServiceAccount gets the GoogleCloudServerlessAuthenticationServiceAccount.

--- a/config/options.go
+++ b/config/options.go
@@ -999,10 +999,10 @@ func (o *Options) GetSharedKey() ([]byte, error) {
 }
 
 // GetHPKEPrivateKey gets the hpke.PrivateKey dervived from the shared key.
-func (o *Options) GetHPKEPrivateKey() (hpke.PrivateKey, error) {
+func (o *Options) GetHPKEPrivateKey() (*hpke.PrivateKey, error) {
 	sharedKey, err := o.GetSharedKey()
 	if err != nil {
-		return hpke.PrivateKey{}, err
+		return nil, err
 	}
 
 	return hpke.DerivePrivateKey(sharedKey), nil

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
+	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/jackc/pgconn v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -507,6 +507,8 @@ github.com/gostaticanalysis/nilerr v0.1.1 h1:ThE+hJP0fEp4zWLkWHWcRyI2Od0p7DlgYG3
 github.com/gostaticanalysis/nilerr v0.1.1/go.mod h1:wZYb6YI5YAxxq0i1+VJbY0s2YONW0HU0GPE3+5PWN4A=
 github.com/gostaticanalysis/testutil v0.3.1-0.20210208050101-bfb5c8eec0e4/go.mod h1:D+FIZ+7OahH3ePw/izIEeH5I06eKs1IKI4Xr64/Am3M=
 github.com/gostaticanalysis/testutil v0.4.0 h1:nhdCmubdmDF6VEatUNjgUZBJKWRqugoISdUv3PPQgHY=
+github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 h1:+ngKgrYPPJrOjhax5N+uePQ0Fh1Z7PheYoUI/0nzkPA=
+github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -34,6 +34,7 @@ func TestServerHTTP(t *testing.T) {
 	}
 	cfg.Options.AuthenticateURLString = "https://authenticate.localhost.pomerium.io"
 	cfg.Options.SigningKey = "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUpCMFZkbko1VjEvbVlpYUlIWHhnd2Q0Yzd5YWRTeXMxb3Y0bzA1b0F3ekdvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFVUc1eENQMEpUVDFINklvbDhqS3VUSVBWTE0wNENnVzlQbEV5cE5SbVdsb29LRVhSOUhUMwpPYnp6aktZaWN6YjArMUt3VjJmTVRFMTh1dy82MXJVQ0JBPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
+	cfg.Options.SharedKey = "JDNjY2ITDlARvNaQXjc2Djk+GA6xeCy4KiozmZfdbTs="
 
 	src := config.NewStaticSource(cfg)
 	srv, err := NewServer(cfg, config.NewMetricsManager(ctx, src), events.New())
@@ -66,15 +67,23 @@ func TestServerHTTP(t *testing.T) {
 		require.NoError(t, err)
 
 		expect := map[string]any{
-			"keys": []any{map[string]any{
-				"alg": "ES256",
-				"crv": "P-256",
-				"kid": "5b419ade1895fec2d2def6cd33b1b9a018df60db231dc5ecb85cbed6d942813c",
-				"kty": "EC",
-				"use": "sig",
-				"x":   "UG5xCP0JTT1H6Iol8jKuTIPVLM04CgW9PlEypNRmWlo",
-				"y":   "KChF0fR09zm884ymInM29PtSsFdnzExNfLsP-ta1AgQ",
-			}},
+			"keys": []any{
+				map[string]any{
+					"alg": "ES256",
+					"crv": "P-256",
+					"kid": "5b419ade1895fec2d2def6cd33b1b9a018df60db231dc5ecb85cbed6d942813c",
+					"kty": "EC",
+					"use": "sig",
+					"x":   "UG5xCP0JTT1H6Iol8jKuTIPVLM04CgW9PlEypNRmWlo",
+					"y":   "KChF0fR09zm884ymInM29PtSsFdnzExNfLsP-ta1AgQ",
+				},
+				map[string]any{
+					"kty": "OKP",
+					"kid": "pomerium/hpke",
+					"crv": "X25519",
+					"x":   "T0cbNrJbO9in-FgowKAP-HX6Ci8q50gopOt52sdheHg",
+				},
+			},
 		}
 		assert.Equal(t, expect, actual)
 	})

--- a/internal/handlers/jwks_test.go
+++ b/internal/handlers/jwks_test.go
@@ -1,22 +1,71 @@
-package handlers
+package handlers_test
 
 import (
+	"crypto/ecdsa"
+	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/internal/handlers"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/hpke"
 )
 
 func TestJWKSHandler(t *testing.T) {
 	t.Parallel()
+
+	signingKey, err := cryptutil.NewSigningKey()
+	require.NoError(t, err)
+
+	rawSigningKey, err := cryptutil.EncodePrivateKey(signingKey)
+	require.NoError(t, err)
+
+	jwkSigningKey, err := cryptutil.PublicJWKFromBytes(rawSigningKey)
+	require.NoError(t, err)
+
+	hpkePrivateKey, err := hpke.GeneratePrivateKey()
+	require.NoError(t, err)
 
 	t.Run("cors", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodOptions, "/", nil)
 		r.Header.Set("Origin", "https://www.example.com")
 		r.Header.Set("Access-Control-Request-Method", "GET")
-		JWKSHandler("").ServeHTTP(w, r)
+		handlers.JWKSHandler("", hpkePrivateKey.PublicKey()).ServeHTTP(w, r)
 		assert.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+	})
+	t.Run("keys", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		handlers.JWKSHandler(base64.StdEncoding.EncodeToString(rawSigningKey), hpkePrivateKey.PublicKey()).ServeHTTP(w, r)
+
+		var expect any = map[string]any{
+			"keys": []any{
+				map[string]any{
+					"kty": "EC",
+					"kid": jwkSigningKey.KeyID,
+					"crv": "P-256",
+					"alg": "ES256",
+					"use": "sig",
+					"x":   base64.RawURLEncoding.EncodeToString(jwkSigningKey.Key.(*ecdsa.PublicKey).X.Bytes()),
+					"y":   base64.RawURLEncoding.EncodeToString(jwkSigningKey.Key.(*ecdsa.PublicKey).Y.Bytes()),
+				},
+				map[string]any{
+					"kty": "OKP",
+					"kid": "pomerium/hpke",
+					"crv": "X25519",
+					"x":   hpkePrivateKey.PublicKey().String(),
+				},
+			},
+		}
+		var actual any
+		err := json.Unmarshal(w.Body.Bytes(), &actual)
+		assert.NoError(t, err)
+		assert.Equal(t, expect, actual)
 	})
 }

--- a/pkg/hpke/jwks.go
+++ b/pkg/hpke/jwks.go
@@ -1,0 +1,89 @@
+package hpke
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/gregjones/httpcache"
+)
+
+const (
+	defaultMaxBodySize = 1024 * 1024 * 4
+
+	jwkType  = "OKP"
+	jwkID    = "pomerium/hpke"
+	jwkCurve = "X25519"
+)
+
+// JWK is the JSON Web Key representation of an HPKE key.
+// Defined in RFC8037.
+type JWK struct {
+	Type  string `json:"kty"`
+	ID    string `json:"kid"`
+	Curve string `json:"crv"`
+	X     string `json:"x"`
+	D     string `json:"d,omitempty"`
+}
+
+// FetchPublicKeyFromJWKS fetches the HPKE public key from the JWKS endpoint.
+func FetchPublicKeyFromJWKS(ctx context.Context, client *http.Client, endpoint string) (PublicKey, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return PublicKey{}, fmt.Errorf("hpke: error building jwks http request: %w", err)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return PublicKey{}, fmt.Errorf("hpke: error requesting jwks endpoint: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode/100 != 2 {
+		return PublicKey{}, fmt.Errorf("hpke: error requesting jwks endpoint, invalid status code: %d", res.StatusCode)
+	}
+
+	bs, err := io.ReadAll(io.LimitReader(res.Body, defaultMaxBodySize))
+	if err != nil {
+		return PublicKey{}, fmt.Errorf("hpke: error reading jwks endpoint: %d", res.StatusCode)
+	}
+
+	var jwks struct {
+		Keys []JWK `json:"keys"`
+	}
+	err = json.Unmarshal(bs, &jwks)
+	if err != nil {
+		return PublicKey{}, fmt.Errorf("hpke: error unmarshaling jwks endpoint: %w", err)
+	}
+
+	for _, key := range jwks.Keys {
+		if key.ID == jwkID && key.Type == jwkType && key.Curve == jwkCurve {
+			return PublicKeyFromString(key.X)
+		}
+	}
+	return PublicKey{}, fmt.Errorf("hpke key not found in JWKS endpoint")
+}
+
+// A KeyFetcher fetches public keys.
+type KeyFetcher interface {
+	FetchPublicKey(ctx context.Context) (PublicKey, error)
+}
+
+type jwksKeyFetcher struct {
+	client   *http.Client
+	endpoint string
+}
+
+func (fetcher *jwksKeyFetcher) FetchPublicKey(ctx context.Context) (PublicKey, error) {
+	return FetchPublicKeyFromJWKS(ctx, fetcher.client, fetcher.endpoint)
+}
+
+// NewKeyFetcher returns a new KeyFetcher which fetches keys using an in-memory HTTP cache.
+func NewKeyFetcher(endpoint string) KeyFetcher {
+	return &jwksKeyFetcher{
+		client:   httpcache.NewMemoryCacheTransport().Client(),
+		endpoint: endpoint,
+	}
+}

--- a/pkg/hpke/jwks.go
+++ b/pkg/hpke/jwks.go
@@ -47,7 +47,7 @@ func FetchPublicKeyFromJWKS(ctx context.Context, client *http.Client, endpoint s
 
 	bs, err := io.ReadAll(io.LimitReader(res.Body, defaultMaxBodySize))
 	if err != nil {
-		return PublicKey{}, fmt.Errorf("hpke: error reading jwks endpoint: %d", res.StatusCode)
+		return PublicKey{}, fmt.Errorf("hpke: error reading jwks endpoint: %w", err)
 	}
 
 	var jwks struct {

--- a/pkg/hpke/jwks_test.go
+++ b/pkg/hpke/jwks_test.go
@@ -1,0 +1,33 @@
+package hpke
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/internal/handlers"
+)
+
+func TestFetchPublicKeyFromJWKS(t *testing.T) {
+	t.Parallel()
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	t.Cleanup(clearTimeout)
+
+	hpkePrivateKey, err := GeneratePrivateKey()
+	require.NoError(t, err)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		handlers.JWKSHandler("", hpkePrivateKey.PublicKey()).ServeHTTP(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	publicKey, err := FetchPublicKeyFromJWKS(ctx, http.DefaultClient, srv.URL)
+	assert.NoError(t, err)
+	assert.Equal(t, hpkePrivateKey.PublicKey().String(), publicKey.String())
+}


### PR DESCRIPTION
## Summary
Add the HPKE public key to the JWKS endpoint and add code to fetch the HPKE public key from a JWKS endpoint. The format of an X25519 key is defined in [RFC8037](https://www.rfc-editor.org/rfc/rfc8037).

## Related issues
- https://github.com/pomerium/internal/issues/1015

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
