### PR TITLE
storage: ignore removed fields when deserializing the data

### DIFF
--- a/pkg/protoutil/any.go
+++ b/pkg/protoutil/any.go
@@ -1,6 +1,7 @@
 package protoutil
 
 import (
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -56,6 +57,19 @@ func NewAny(msg proto.Message) *anypb.Any {
 		return NewAnyNull()
 	}
 	return a
+}
+
+// UnmarshalAnyJSON unmarshals JSON data into Any
+func UnmarshalAnyJSON(data []byte) (*anypb.Any, error) {
+	opts := protojson.UnmarshalOptions{
+		AllowPartial:   true,
+		DiscardUnknown: true,
+	}
+	var val anypb.Any
+	if err := opts.Unmarshal(data, &val); err != nil {
+		return nil, err
+	}
+	return &val, nil
 }
 
 // NewAnyBool creates a new any type from a bool.

--- a/pkg/storage/postgres/registry_test.go
+++ b/pkg/storage/postgres/registry_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/pkg/grpc/registry"
+	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 type mockRegistryWatchServer struct {
@@ -111,4 +112,20 @@ func TestRegistry(t *testing.T) {
 
 		return nil
 	}))
+}
+
+func TestUnmarshalJSONUnknownFields(t *testing.T) {
+	any, err := protoutil.UnmarshalAnyJSON([]byte(`
+	{
+		"@type": "type.googleapis.com/registry.Service",
+		"kind": "AUTHENTICATE",
+		"endpoint": "endpoint",
+		"unknown_field": true
+	  }
+	`))
+	require.NoError(t, err)
+	var val registry.Service
+	require.NoError(t, any.UnmarshalTo(&val))
+	assert.Equal(t, registry.ServiceKind_AUTHENTICATE, val.Kind)
+	assert.Equal(t, "endpoint", val.Endpoint)
 }


### PR DESCRIPTION
## Summary

During upgrade, if some of the protobuf fields are removed, the record would fail to be loaded. 
This PR changes the postgres storage deserialization to ignore unknown JSON fields. 

## Related issues

Fixes https://github.com/pomerium/ingress-controller/issues/441

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
