### PR TITLE
autocert: support storing certificates in the databroker

### DIFF
--- a/internal/autocert/locker.go
+++ b/internal/autocert/locker.go
@@ -1,0 +1,137 @@
+package autocert
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+
+	"github.com/pomerium/pomerium/internal/atomicutil"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+const (
+	leaseDuration      = time.Minute
+	leaseRenewInterval = leaseDuration / 4
+)
+
+type dataBrokerLocker struct {
+	name        string
+	client      *atomicutil.Value[databroker.DataBrokerServiceClient]
+	localLocker *channelLocker
+	id          string
+
+	renewCtx    context.Context
+	renewCancel context.CancelFunc
+}
+
+func newDataBrokerLocker(name string, client *atomicutil.Value[databroker.DataBrokerServiceClient]) *dataBrokerLocker {
+	return &dataBrokerLocker{
+		name:        name,
+		client:      client,
+		localLocker: newChannelLocker(),
+		renewCancel: func() {},
+	}
+}
+
+func (locker *dataBrokerLocker) Lock(ctx context.Context) error {
+	// acquire the local lock
+	if err := locker.localLocker.Lock(ctx); err != nil {
+		return err
+	}
+	defer locker.localLocker.Unlock()
+
+	for {
+		// attempt to acquire the lease
+		res, err := locker.client.Load().AcquireLease(ctx, &databroker.AcquireLeaseRequest{
+			Name:     locker.name,
+			Duration: durationpb.New(leaseDuration),
+		})
+
+		// if the lease is already taken, wait and retry
+		if status.Code(err) == codes.AlreadyExists {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second):
+			}
+			continue
+		}
+
+		// any other error is unexpected, so return it
+		if err != nil {
+			return err
+		}
+
+		// start a background goroutine to renew the lease periodically
+		locker.renewCtx, locker.renewCancel = context.WithCancel(context.Background())
+		go locker.periodicallyRenewLease(locker.renewCtx, res.GetId())
+
+		// store the id for later release
+		locker.id = res.GetId()
+
+		return nil
+	}
+}
+
+func (locker *dataBrokerLocker) Unlock(ctx context.Context) error {
+	// acquire the local lock
+	if err := locker.localLocker.Lock(ctx); err != nil {
+		return err
+	}
+	defer locker.localLocker.Unlock()
+
+	// cancel the lease renewal loop
+	locker.renewCancel()
+
+	// release the lease
+	_, err := locker.client.Load().ReleaseLease(ctx, &databroker.ReleaseLeaseRequest{
+		Name: locker.name,
+		Id:   locker.id,
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (locker *dataBrokerLocker) periodicallyRenewLease(ctx context.Context, id string) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(leaseRenewInterval):
+		}
+
+		_, _ = locker.client.Load().RenewLease(ctx, &databroker.RenewLeaseRequest{
+			Name: locker.name,
+			Id:   id,
+		})
+	}
+}
+
+type channelLocker struct {
+	ch chan struct{}
+}
+
+func newChannelLocker() *channelLocker {
+	return &channelLocker{ch: make(chan struct{}, 1)}
+}
+
+func (locker *channelLocker) Lock(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case locker.ch <- struct{}{}:
+		return nil
+	}
+}
+
+func (locker *channelLocker) Unlock() {
+	select {
+	case <-locker.ch:
+	default:
+	}
+}

--- a/internal/autocert/storage.go
+++ b/internal/autocert/storage.go
@@ -1,0 +1,163 @@
+package autocert
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/caddyserver/certmagic"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/pomerium/pomerium/internal/atomicutil"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+const certMagicStorageRecordType = "pomerium.io/CertMagicStorageRecord"
+
+type dataBrokerStorage struct {
+	client *atomicutil.Value[databroker.DataBrokerServiceClient]
+
+	lockersMu sync.Mutex
+	lockers   map[string]*dataBrokerLocker
+}
+
+func newDataBrokerStorage(client *atomicutil.Value[databroker.DataBrokerServiceClient]) *dataBrokerStorage {
+	return &dataBrokerStorage{
+		client:  client,
+		lockers: make(map[string]*dataBrokerLocker),
+	}
+}
+
+func (s *dataBrokerStorage) Lock(ctx context.Context, name string) error {
+	name = fmt.Sprintf("autocert/%s", name)
+
+	s.lockersMu.Lock()
+	l, ok := s.lockers[name]
+	if !ok {
+		l = newDataBrokerLocker(name, s.client)
+		s.lockers[name] = l
+	}
+	s.lockersMu.Unlock()
+
+	return l.Lock(ctx)
+}
+
+func (s *dataBrokerStorage) Unlock(ctx context.Context, name string) error {
+	name = fmt.Sprintf("autocert/%s", name)
+
+	s.lockersMu.Lock()
+	l, ok := s.lockers[name]
+	delete(s.lockers, name)
+	s.lockersMu.Unlock()
+
+	if !ok {
+		return nil
+	}
+	return l.Unlock(ctx)
+}
+
+func (s *dataBrokerStorage) Store(ctx context.Context, key string, value []byte) error {
+	_, err := s.client.Load().Put(ctx, &databroker.PutRequest{
+		Records: []*databroker.Record{
+			{Type: certMagicStorageRecordType, Id: key, Data: protoutil.NewAny(wrapperspb.Bytes(value))},
+		},
+	})
+	return err
+}
+
+func (s *dataBrokerStorage) Load(ctx context.Context, key string) ([]byte, error) {
+	value, _, err := s.load(ctx, key)
+	return value, err
+}
+
+func (s *dataBrokerStorage) Delete(ctx context.Context, key string) error {
+	res, err := s.client.Load().Get(ctx, &databroker.GetRequest{
+		Type: certMagicStorageRecordType,
+		Id:   key,
+	})
+	if storage.IsNotFound(err) {
+		// delete should not return an error if the key is already deleted
+		return nil
+	} else if err != nil {
+		return err
+	}
+
+	record := res.GetRecord()
+	record.DeletedAt = timestamppb.Now()
+
+	_, err = s.client.Load().Put(ctx, &databroker.PutRequest{
+		Records: []*databroker.Record{record},
+	})
+	return err
+}
+
+func (s *dataBrokerStorage) Exists(ctx context.Context, key string) bool {
+	_, _, err := s.load(ctx, key)
+	return err == nil
+}
+
+func (s *dataBrokerStorage) List(ctx context.Context, prefix string, recursive bool) ([]string, error) {
+	records, _, _, err := databroker.InitialSync(ctx, s.client.Load(), &databroker.SyncLatestRequest{
+		Type: certMagicStorageRecordType,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var keys []string
+	for _, record := range records {
+		key := record.GetId()
+
+		if !strings.HasPrefix(key, prefix) {
+			continue
+		}
+
+		if !recursive && strings.Contains(key[len(prefix):], "/") {
+			continue
+		}
+
+		keys = append(keys, key)
+	}
+	return keys, nil
+}
+
+func (s *dataBrokerStorage) Stat(ctx context.Context, key string) (certmagic.KeyInfo, error) {
+	value, modifiedAt, err := s.load(ctx, key)
+	if err != nil {
+		return certmagic.KeyInfo{}, err
+	}
+
+	return certmagic.KeyInfo{
+		Key:        key,
+		Modified:   modifiedAt,
+		Size:       int64(len(value)),
+		IsTerminal: true,
+	}, nil
+}
+
+func (s *dataBrokerStorage) load(ctx context.Context, key string) (value []byte, modifiedAt time.Time, err error) {
+	res, err := s.client.Load().Get(ctx, &databroker.GetRequest{
+		Type: certMagicStorageRecordType,
+		Id:   key,
+	})
+	if storage.IsNotFound(err) {
+		return nil, time.Time{}, fs.ErrNotExist
+	} else if err != nil {
+		return nil, time.Time{}, err
+	}
+
+	var data wrapperspb.BytesValue
+	err = res.GetRecord().GetData().UnmarshalTo(&data)
+	if err != nil {
+		// if the stored value isn't what we expect, just treat it like it doesn't exist
+		return nil, time.Time{}, fs.ErrNotExist
+	}
+
+	return data.GetValue(), res.GetRecord().GetModifiedAt().AsTime(), nil
+}

--- a/internal/autocert/storage_test.go
+++ b/internal/autocert/storage_test.go
@@ -1,0 +1,103 @@
+package autocert
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/pomerium/pomerium/internal/atomicutil"
+	"github.com/pomerium/pomerium/internal/databroker"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+func TestStorage(t *testing.T) {
+	t.Parallel()
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Minute)
+	defer clearTimeout()
+
+	li, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = li.Close() }()
+
+	srv := grpc.NewServer()
+	databrokerpb.RegisterDataBrokerServiceServer(srv, databroker.New())
+	go func() { _ = srv.Serve(li) }()
+
+	cc, err := grpc.Dial(li.Addr().String(), grpc.WithInsecure())
+	require.NoError(t, err)
+
+	s := newDataBrokerStorage(atomicutil.NewValue(databrokerpb.NewDataBrokerServiceClient(cc)))
+
+	assert.False(t, s.Exists(ctx, "example/1"))
+
+	for _, r := range []struct {
+		key   string
+		value []byte
+	}{
+		{"example/1", []byte{1, 2, 3}},
+		{"example/2", []byte{4, 5, 6}},
+		{"example/3", []byte{7, 8, 9}},
+		{"example/3/1", []byte{11, 12, 13}},
+		{"example/3/2", []byte{14, 15, 16}},
+		{"example/3/3", []byte{17, 18, 19}},
+	} {
+		assert.NoError(t, s.Store(ctx, r.key, r.value))
+		assert.True(t, s.Exists(ctx, r.key))
+		v, err := s.Load(ctx, r.key)
+		assert.NoError(t, err)
+		assert.Equal(t, r.value, v)
+
+		fi, err := s.Stat(ctx, r.key)
+		assert.NoError(t, err)
+		assert.Equal(t, r.key, fi.Key)
+		assert.True(t, fi.IsTerminal)
+		assert.NotZero(t, fi.Modified)
+		assert.Equal(t, int64(len(r.value)), fi.Size)
+	}
+
+	keys, err := s.List(ctx, "example/3", true)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"example/3", "example/3/1", "example/3/2", "example/3/3"}, keys)
+
+	keys, err = s.List(ctx, "example/3", false)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"example/3"}, keys)
+
+	assert.NoError(t, s.Delete(ctx, "example/3/2"))
+
+	keys, err = s.List(ctx, "example/3", true)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"example/3", "example/3/1", "example/3/3"}, keys)
+}
+
+func TestStorageLocker(t *testing.T) {
+	t.Parallel()
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Minute)
+	defer clearTimeout()
+
+	li, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { _ = li.Close() }()
+
+	srv := grpc.NewServer()
+	databrokerpb.RegisterDataBrokerServiceServer(srv, databroker.New())
+	go func() { _ = srv.Serve(li) }()
+
+	cc, err := grpc.Dial(li.Addr().String(), grpc.WithInsecure())
+	require.NoError(t, err)
+
+	s := newDataBrokerStorage(atomicutil.NewValue(databrokerpb.NewDataBrokerServiceClient(cc)))
+
+	err = s.Lock(ctx, "example")
+	assert.NoError(t, err)
+
+	err = s.Unlock(ctx, "example")
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
Add support for using the databroker as an autocert backend.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1058
 

## Checklist

- [x] reference any related issues 
- [x] updated unit tests 
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
