### PR TITLE
ci: disable kubernetes integration test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -116,7 +116,7 @@ jobs:
         go-version: [1.19.x]
         node-version: [16.x]
         platform: [ubuntu-latest]
-        deployment: [kubernetes, multi, single]
+        deployment: [multi, single]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/setup-go@c4a742cab115ed795e34d4513e2cf7d472deb55f


### PR DESCRIPTION
## Summary
This test currently always fails and needs to be updated. We don't have an easy way of doing that, so for now disable the test so PRs don't look broken.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/3027


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
