### PR TITLE
httputil: ignore errors < 400

### DIFF
--- a/internal/httputil/errors.go
+++ b/internal/httputil/errors.go
@@ -69,12 +69,14 @@ func (e *HTTPError) ErrorResponse(ctx context.Context, w http.ResponseWriter, r 
 	// indicate to clients that the error originates from Pomerium, not the app
 	w.Header().Set(HeaderPomeriumResponse, "true")
 
-	log.Error(ctx).
-		Err(e.Err).
-		Int("status", e.Status).
-		Str("status-text", StatusText(e.Status)).
-		Str("request-id", reqID).
-		Msg("httputil: error")
+	if e.Status >= 400 {
+		log.Error(ctx).
+			Err(e.Err).
+			Int("status", e.Status).
+			Str("status-text", StatusText(e.Status)).
+			Str("request-id", reqID).
+			Msg("httputil: error")
+	}
 
 	if r.Header.Get("Accept") == "application/json" {
 		RenderJSON(w, e.Status, response)

--- a/internal/httputil/errors_test.go
+++ b/internal/httputil/errors_test.go
@@ -21,6 +21,7 @@ func TestHTTPError_ErrorResponse(t *testing.T) {
 	}{
 		{"404 json", http.StatusNotFound, errors.New("route not known"), "application/json", http.StatusNotFound, "{\"Status\":404}\n"},
 		{"404 html", http.StatusNotFound, errors.New("route not known"), "", http.StatusNotFound, ""},
+		{"302 found", http.StatusFound, errors.New("redirect"), "", http.StatusFound, ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
We shouldn't log `Found` or `OK` "errors".

## Related issues
Fixes #3780 

## Checklist
- [x] reference any related issues
- [x] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
