### PR TITLE
jwt: require logged in user to return .pomerium/jwt

### DIFF
--- a/config/policy_ppl_test.go
+++ b/config/policy_ppl_test.go
@@ -59,6 +59,7 @@ default deny = [false, set()]
 
 pomerium_routes_0 = [true, {"pomerium-route"}] {
 	contains(input.http.url, "/.pomerium/")
+	not contains(input.http.url, "/.pomerium/jwt")
 }
 
 else = [false, {"non-pomerium-route"}]

--- a/pkg/policy/criteria/pomerium_routes.go
+++ b/pkg/policy/criteria/pomerium_routes.go
@@ -11,6 +11,9 @@ var pomeriumRoutesBody = ast.Body{
 	ast.MustParseExpr(`
 		contains(input.http.url, "/.pomerium/")
 	`),
+	ast.MustParseExpr(`
+		not contains(input.http.url, "/.pomerium/jwt")
+	`),
 }
 
 type pomeriumRoutesCriterion struct {

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/gorilla/mux"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -238,13 +239,26 @@ func (p *Proxy) ProgrammaticLogin(w http.ResponseWriter, r *http.Request) error 
 
 // jwtAssertion returns the current request's JWT assertion (rfc7519#section-10.3.1).
 func (p *Proxy) jwtAssertion(w http.ResponseWriter, r *http.Request) error {
-	assertionJWT := r.Header.Get(httputil.HeaderPomeriumJWTAssertion)
-	if assertionJWT == "" {
+	rawAssertionJWT := r.Header.Get(httputil.HeaderPomeriumJWTAssertion)
+	if rawAssertionJWT == "" {
 		return httputil.NewError(http.StatusNotFound, errors.New("jwt not found"))
 	}
+
+	assertionJWT, err := jwt.ParseSigned(rawAssertionJWT)
+	if err != nil {
+		return httputil.NewError(http.StatusNotFound, errors.New("jwt not found"))
+	}
+
+	var dst struct {
+		Subject string `json:"sub"`
+	}
+	if assertionJWT.UnsafeClaimsWithoutVerification(&dst) != nil || dst.Subject == "" {
+		return httputil.NewError(http.StatusUnauthorized, errors.New("jwt not found"))
+	}
+
 	w.Header().Set("Content-Type", "application/jwt")
 	w.WriteHeader(http.StatusOK)
-	_, _ = io.WriteString(w, assertionJWT)
+	_, _ = io.WriteString(w, rawAssertionJWT)
 	return nil
 }
 

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -182,13 +182,14 @@ func TestProxy_jwt(t *testing.T) {
 	}
 
 	// with upstream request headers being set
+	rawJWT := "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTY3MDg4OTI0MSwiZXhwIjoxNjcwODkyODQxfQ.YoROB12_-a8VxikPqrYOA576pLYoLFeGwXAOWCGpXgM"
 	req, _ = http.NewRequest("GET", "https://www.example.com/.pomerium/jwt", nil)
 	w = httptest.NewRecorder()
-	req.Header.Set(httputil.HeaderPomeriumJWTAssertion, "MOCK_JWT")
+	req.Header.Set(httputil.HeaderPomeriumJWTAssertion, rawJWT)
 	err = proxy.jwtAssertion(w, req)
 	if !assert.NoError(t, err) {
 		return
 	}
 	assert.Equal(t, "application/jwt", w.Header().Get("Content-Type"))
-	assert.Equal(t, w.Body.String(), "MOCK_JWT")
+	assert.Equal(t, w.Body.String(), rawJWT)
 }


### PR DESCRIPTION
## Summary
Require a logged in user to return the JWT.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3805

 

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
