### PR TITLE
autocert: use atomic pointer to allow nil

### DIFF
--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"sort"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/caddyserver/certmagic"
@@ -19,7 +20,6 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/atomicutil"
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
@@ -48,7 +48,7 @@ type Manager struct {
 	mu                  sync.RWMutex
 	config              *config.Config
 	certmagic           *certmagic.Config
-	acmeMgr             *atomicutil.Value[*certmagic.ACMEIssuer]
+	acmeMgr             atomic.Pointer[certmagic.ACMEIssuer]
 	srv                 *http.Server
 	acmeTLSALPNListener net.Listener
 
@@ -91,7 +91,6 @@ func newManager(ctx context.Context,
 	mgr := &Manager{
 		src:          src,
 		acmeTemplate: acmeTemplate,
-		acmeMgr:      atomicutil.NewValue(new(certmagic.ACMEIssuer)),
 		certmagic:    certmagicConfig,
 		ocspCache:    ocspRespCache,
 	}
@@ -270,6 +269,7 @@ func (mgr *Manager) renewCert(ctx context.Context, domain string, cert certmagic
 
 func (mgr *Manager) updateAutocert(ctx context.Context, cfg *config.Config) error {
 	if !cfg.Options.AutocertOptions.Enable {
+		mgr.acmeMgr.Store(nil)
 		return nil
 	}
 


### PR DESCRIPTION
## Summary
We currently use the `atomicutil.Value` to store the acme issuer with a zero-value acme issuer. This acme issuer will panic if accessed. Instead we should store nil, which exits early:

```
func (am *ACMEIssuer) HandleHTTPChallenge(w http.ResponseWriter, r *http.Request) bool {
	if am == nil {
		return false
	}
```

However `atomic.Value` doesn't support a nil value, so we can use `atomic.Pointer` which is a generic type that supports nil pointers.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3806

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
