### PR TITLE
authenticate: remove databroker dependency

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/atomicutil"
-	"github.com/pomerium/pomerium/internal/handlers/webauthn"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
@@ -39,10 +38,9 @@ func ValidateOptions(o *config.Options) error {
 
 // Authenticate contains data required to run the authenticate service.
 type Authenticate struct {
-	cfg      *authenticateConfig
-	options  *atomicutil.Value[*config.Options]
-	state    *atomicutil.Value[*authenticateState]
-	webauthn *webauthn.Handler
+	cfg     *authenticateConfig
+	options *atomicutil.Value[*config.Options]
+	state   *atomicutil.Value[*authenticateState]
 }
 
 // New validates and creates a new authenticate service from a set of Options.
@@ -52,7 +50,6 @@ func New(cfg *config.Config, options ...Option) (*Authenticate, error) {
 		options: config.NewAtomicOptions(),
 		state:   atomicutil.NewValue(newAuthenticateState()),
 	}
-	a.webauthn = webauthn.New(a.getWebauthnState)
 
 	state, err := newAuthenticateStateFromConfig(cfg)
 	if err != nil {


### PR DESCRIPTION
## Summary
Remove the databroker dependency from the authenticate service.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1070

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
