### PR TITLE
proxy: fix sign out redirect

### DIFF
--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -75,7 +75,9 @@ func (p *Proxy) SignOut(w http.ResponseWriter, r *http.Request) error {
 		redirectURL = uri
 	}
 
-	dashboardURL := *state.authenticateDashboardURL
+	dashboardURL := state.authenticateDashboardURL.ResolveReference(&url.URL{
+		Path: "/.pomerium/sign_out",
+	})
 	q := dashboardURL.Query()
 	if redirectURL != nil {
 		q.Set(urlutil.QueryRedirectURI, redirectURL.String())
@@ -83,7 +85,7 @@ func (p *Proxy) SignOut(w http.ResponseWriter, r *http.Request) error {
 	dashboardURL.RawQuery = q.Encode()
 
 	state.sessionStore.ClearSession(w, r)
-	httputil.Redirect(w, r, urlutil.NewSignedURL(state.sharedKey, &dashboardURL).String(), http.StatusFound)
+	httputil.Redirect(w, r, urlutil.NewSignedURL(state.sharedKey, dashboardURL).String(), http.StatusFound)
 	return nil
 }
 

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -67,6 +67,10 @@ func TestProxy_SignOut(t *testing.T) {
 			if status := w.Code; status != tt.wantStatus {
 				t.Errorf("status code: got %v want %v", status, tt.wantStatus)
 			}
+			u, err := urlutil.ParseAndValidateURL(w.HeaderMap.Get("Location"))
+			if assert.NoError(t, err) {
+				assert.Equal(t, "/.pomerium/sign_out", u.Path)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
Fix the sign out redirect URL. It was pointing the dashboard path, but should be pointing to the `/.pomerium/sign_out` path.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1051

## Checklist
- [x] reference any related issues
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
