### PR TITLE
use tlsClientConfig instead of custom dialer

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,7 +7,8 @@
       "request": "launch",
       "mode": "debug",
       "program": "${workspaceRoot}/cmd/pomerium",
-      "args": ["-config", "${workspaceRoot}/.config.yaml"]
+      "args": ["-config", "${workspaceRoot}/.config.yaml"],
+      "cwd": "${workspaceRoot}",
     },
     {
       "name": "Connect to server",

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -84,9 +84,15 @@ func newAuthorizeStateFromConfig(cfg *config.Config, store *store.Store) (*autho
 	}
 
 	state.hpkePrivateKey = hpke.DerivePrivateKey(sharedKey)
-	state.authenticateKeyFetcher = hpke.NewKeyFetcher(authenticateURL.ResolveReference(&url.URL{
+
+	jwksURL := authenticateURL.ResolveReference(&url.URL{
 		Path: "/.well-known/pomerium/jwks.json",
-	}).String())
+	}).String()
+	transport, err := config.GetTLSClientTransport(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("authorize: get tls client config: %w", err)
+	}
+	state.authenticateKeyFetcher = hpke.NewKeyFetcher(jwksURL, transport)
 
 	return state, nil
 }

--- a/config/config.go
+++ b/config/config.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/pomerium/pomerium/internal/hashutil"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
 // MetricsScrapeEndpoint defines additional metrics endpoints that would be scraped and exposed by pomerium
@@ -85,4 +86,16 @@ func (cfg *Config) AllocatePorts(ports [6]string) {
 	cfg.MetricsPort = ports[3]
 	cfg.DebugPort = ports[4]
 	cfg.ACMETLSALPNPort = ports[5]
+}
+
+// GetTLSClientConfig returns TLS configuration that accounts for additional CA entries
+func (cfg *Config) GetTLSClientConfig() (*tls.Config, error) {
+	roots, err := cryptutil.GetCertPool(cfg.Options.CA, cfg.Options.CAFile)
+	if err != nil {
+		return nil, err
+	}
+	return &tls.Config{
+		RootCAs:    roots,
+		MinVersion: tls.VersionTLS12,
+	}, nil
 }

--- a/config/http.go
+++ b/config/http.go
@@ -42,12 +42,7 @@ func NewHTTPTransport(src Source) *http.Transport {
 			Config: tlsConfig,
 		}
 		lock.Unlock()
-		log.Info(ctx).Str("network", network).Str("addr", addr).Msg("DIALING...")
-		conn, err := d.DialContext(ctx, network, addr)
-		if err != nil {
-			log.Error(ctx).Err(err).Str("network", network).Str("addr", addr).Msg("DIAL")
-		}
-		return conn, err
+		return d.DialContext(ctx, network, addr)
 	}
 	transport.ForceAttemptHTTP2 = true
 	return transport

--- a/pkg/hpke/jwks.go
+++ b/pkg/hpke/jwks.go
@@ -81,9 +81,12 @@ func (fetcher *jwksKeyFetcher) FetchPublicKey(ctx context.Context) (*PublicKey, 
 }
 
 // NewKeyFetcher returns a new KeyFetcher which fetches keys using an in-memory HTTP cache.
-func NewKeyFetcher(endpoint string) KeyFetcher {
+func NewKeyFetcher(endpoint string, transport http.RoundTripper) KeyFetcher {
 	return &jwksKeyFetcher{
-		client:   httpcache.NewMemoryCacheTransport().Client(),
+		client: (&httpcache.Transport{
+			Transport: transport,
+			Cache:     httpcache.NewMemoryCache(),
+		}).Client(),
 		endpoint: endpoint,
 	}
 }

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -3,7 +3,7 @@ package proxy
 import (
 	"context"
 	"crypto/cipher"
-	"net/http"
+	"fmt"
 	"net/url"
 
 	"github.com/pomerium/pomerium/config"
@@ -62,13 +62,15 @@ func newProxyStateFromConfig(cfg *config.Config) (*proxyState, error) {
 	if err != nil {
 		return nil, err
 	}
-	tlsConfig, err := cfg.GetTLSClientConfig()
-	if err != nil {
-		return nil, err
-	}
-	state.authenticateKeyFetcher = hpke.NewKeyFetcher(authenticateURL.ResolveReference(&url.URL{
+
+	jwksURL := authenticateURL.ResolveReference(&url.URL{
 		Path: "/.well-known/pomerium/jwks.json",
-	}).String(), &http.Transport{TLSClientConfig: tlsConfig, ForceAttemptHTTP2: true})
+	}).String()
+	transport, err := config.GetTLSClientTransport(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("authorize: get tls client config: %w", err)
+	}
+	state.authenticateKeyFetcher = hpke.NewKeyFetcher(jwksURL, transport)
 
 	state.sharedCipher, err = cryptutil.NewAEADCipher(state.sharedKey)
 	if err != nil {


### PR DESCRIPTION
## Summary

When using custom CA, either supplied via `certificate_authority`/`certificate_authority_file`, or a custom certificate added to a system store, i.e. `mkcert --install`, `authz_check` and `proxy` were not able to communicate to the authenticate endpoint in order to fetch the signing public key. 

Apparently, installing a custom `TLSDialer` is not sufficient, and all requests to the authenticate endpoint would end up with 
EOF. 

This behaviour was observed for both Linux and MacOS using Go 1.19. 

This PR changes the way JWKSKeyFetcher operates, and adds an http Transport option to it, that is customized using current Config.

## Related issues

Related https://github.com/pomerium/internal/issues/1062

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
