### PR TITLE
envoyconfig: clean up filter chain construction

### DIFF
--- a/config/envoyconfig/http_connection_manager.go
+++ b/config/envoyconfig/http_connection_manager.go
@@ -12,16 +12,16 @@ import (
 func (b *Builder) buildVirtualHost(
 	options *config.Options,
 	name string,
-	domain string,
+	host string,
 	requireStrictTransportSecurity bool,
 ) (*envoy_config_route_v3.VirtualHost, error) {
 	vh := &envoy_config_route_v3.VirtualHost{
 		Name:    name,
-		Domains: []string{domain},
+		Domains: []string{host},
 	}
 
 	// these routes match /.pomerium/... and similar paths
-	rs, err := b.buildPomeriumHTTPRoutes(options, domain)
+	rs, err := b.buildPomeriumHTTPRoutes(options, host)
 	if err != nil {
 		return nil, err
 	}

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -129,7 +129,7 @@ func (b *Builder) buildMainListener(ctx context.Context, cfg *config.Config) (*e
 		}
 
 		for _, serverName := range serverNames {
-			requireStrictTransportSecurity := cryptutil.HasCertificateForDomain(allCertificates, serverName)
+			requireStrictTransportSecurity := cryptutil.HasCertificateForServerName(allCertificates, serverName)
 			filter, err := b.buildMainHTTPConnectionManagerFilter(cfg.Options, requireStrictTransportSecurity)
 			if err != nil {
 				return nil, err
@@ -517,7 +517,7 @@ func (b *Builder) buildDownstreamTLSContext(ctx context.Context,
 		return nil
 	}
 
-	cert, err := cryptutil.GetCertificateForDomain(certs, domain)
+	cert, err := cryptutil.GetCertificateForServerName(certs, domain)
 	if err != nil {
 		log.Warn(ctx).Str("domain", domain).Err(err).Msg("failed to get certificate for domain")
 		return nil
@@ -636,7 +636,7 @@ func getAllServerNames(cfg *config.Config, addr string) ([]string, error) {
 		return nil, err
 	}
 	for i := range certs {
-		for _, domain := range cryptutil.GetCertificateDomains(&certs[i]) {
+		for _, domain := range cryptutil.GetCertificateServerNames(&certs[i]) {
 			serverNames.Add(domain)
 		}
 	}

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -265,8 +265,8 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 
 		if options.Addr == options.GetGRPCAddr() {
 			// if this is a gRPC service domain and we're supposed to handle that, add those routes
-			if (config.IsAuthorize(options.Services) && hostsMatchDomain(authorizeURLs, host)) ||
-				(config.IsDataBroker(options.Services) && hostsMatchDomain(dataBrokerURLs, host)) {
+			if (config.IsAuthorize(options.Services) && urlsMatchHost(authorizeURLs, host)) ||
+				(config.IsDataBroker(options.Services) && urlsMatchHost(dataBrokerURLs, host)) {
 				rs, err := b.buildGRPCRoutes()
 				if err != nil {
 					return nil, err
@@ -644,16 +644,16 @@ func getAllServerNames(cfg *config.Config, addr string) ([]string, error) {
 	return serverNames.ToSlice(), nil
 }
 
-func hostsMatchDomain(urls []*url.URL, host string) bool {
+func urlsMatchHost(urls []*url.URL, host string) bool {
 	for _, u := range urls {
-		if hostMatchesDomain(u, host) {
+		if urlMatchesHost(u, host) {
 			return true
 		}
 	}
 	return false
 }
 
-func hostMatchesDomain(u *url.URL, host string) bool {
+func urlMatchesHost(u *url.URL, host string) bool {
 	if u == nil {
 		return false
 	}

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -990,7 +990,7 @@ func Test_getAllDomains(t *testing.T) {
 	}
 	t.Run("routable", func(t *testing.T) {
 		t.Run("http", func(t *testing.T) {
-			actual, err := getAllRouteableDomains(options, "127.0.0.1:9000")
+			actual, err := getAllRouteableHosts(options, "127.0.0.1:9000")
 			require.NoError(t, err)
 			expect := []string{
 				"a.example.com",
@@ -1005,7 +1005,7 @@ func Test_getAllDomains(t *testing.T) {
 			assert.Equal(t, expect, actual)
 		})
 		t.Run("grpc", func(t *testing.T) {
-			actual, err := getAllRouteableDomains(options, "127.0.0.1:9001")
+			actual, err := getAllRouteableHosts(options, "127.0.0.1:9001")
 			require.NoError(t, err)
 			expect := []string{
 				"authorize.example.com:9001",
@@ -1016,7 +1016,7 @@ func Test_getAllDomains(t *testing.T) {
 		t.Run("both", func(t *testing.T) {
 			newOptions := *options
 			newOptions.GRPCAddr = newOptions.Addr
-			actual, err := getAllRouteableDomains(&newOptions, "127.0.0.1:9000")
+			actual, err := getAllRouteableHosts(&newOptions, "127.0.0.1:9000")
 			require.NoError(t, err)
 			expect := []string{
 				"a.example.com",

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -1061,14 +1061,31 @@ func Test_getAllDomains(t *testing.T) {
 	})
 }
 
-func Test_hostMatchesDomain(t *testing.T) {
-	assert.True(t, hostMatchesDomain(mustParseURL(t, "http://example.com"), "example.com"))
-	assert.True(t, hostMatchesDomain(mustParseURL(t, "http://example.com"), "example.com:80"))
-	assert.True(t, hostMatchesDomain(mustParseURL(t, "https://example.com"), "example.com:443"))
-	assert.True(t, hostMatchesDomain(mustParseURL(t, "https://example.com:443"), "example.com:443"))
-	assert.True(t, hostMatchesDomain(mustParseURL(t, "https://example.com:443"), "example.com"))
-	assert.False(t, hostMatchesDomain(mustParseURL(t, "http://example.com:81"), "example.com"))
-	assert.False(t, hostMatchesDomain(mustParseURL(t, "http://example.com:81"), "example.com:80"))
+func Test_urlMatchesHost(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		sourceURL string
+		host      string
+		matches   bool
+	}{
+		{"no port", "http://example.com", "example.com", true},
+		{"host http port", "http://example.com", "example.com:80", true},
+		{"host https port", "https://example.com", "example.com:443", true},
+		{"with port", "https://example.com:443", "example.com:443", true},
+		{"url port", "https://example.com:443", "example.com", true},
+		{"non standard port", "http://example.com:81", "example.com", false},
+		{"non standard host port", "http://example.com:81", "example.com:80", false},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tc.matches, urlMatchesHost(mustParseURL(t, tc.sourceURL), tc.host),
+				"urlMatchesHost(%s,%s)", tc.sourceURL, tc.host)
+		})
+	}
 }
 
 func Test_buildRouteConfiguration(t *testing.T) {

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -79,7 +79,7 @@ func (b *Builder) buildPomeriumHTTPRoutes(options *config.Options, host string) 
 	if err != nil {
 		return nil, err
 	}
-	if config.IsAuthenticate(options.Services) && hostMatchesDomain(authenticateURL, host) {
+	if config.IsAuthenticate(options.Services) && urlMatchesHost(authenticateURL, host) {
 		routes = append(routes,
 			b.buildControlPlanePathRoute(options.AuthenticateCallbackPath, false),
 			b.buildControlPlanePathRoute("/", false),
@@ -151,12 +151,12 @@ func getClusterStatsName(policy *config.Policy) string {
 	return ""
 }
 
-func (b *Builder) buildPolicyRoutes(options *config.Options, domain string) ([]*envoy_config_route_v3.Route, error) {
+func (b *Builder) buildPolicyRoutes(options *config.Options, host string) ([]*envoy_config_route_v3.Route, error) {
 	var routes []*envoy_config_route_v3.Route
 
 	for i, p := range options.GetAllPolicies() {
 		policy := p
-		if !hostMatchesDomain(policy.Source.URL, domain) {
+		if !urlMatchesHost(policy.Source.URL, host) {
 			continue
 		}
 
@@ -188,7 +188,7 @@ func (b *Builder) buildPolicyRoutes(options *config.Options, domain string) ([]*
 		}
 
 		// disable authentication entirely when the proxy is fronting authenticate
-		isFrontingAuthenticate, err := isProxyFrontingAuthenticate(options, domain)
+		isFrontingAuthenticate, err := isProxyFrontingAuthenticate(options, host)
 		if err != nil {
 			return nil, err
 		}
@@ -497,13 +497,13 @@ func hasPublicPolicyMatchingURL(options *config.Options, requestURL url.URL) boo
 	return false
 }
 
-func isProxyFrontingAuthenticate(options *config.Options, domain string) (bool, error) {
+func isProxyFrontingAuthenticate(options *config.Options, host string) (bool, error) {
 	authenticateURL, err := options.GetAuthenticateURL()
 	if err != nil {
 		return false, err
 	}
 
-	if !config.IsAuthenticate(options.Services) && hostMatchesDomain(authenticateURL, domain) {
+	if !config.IsAuthenticate(options.Services) && urlMatchesHost(authenticateURL, host) {
 		return true, nil
 	}
 

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -47,12 +47,12 @@ func (b *Builder) buildGRPCRoutes() ([]*envoy_config_route_v3.Route, error) {
 	}}, nil
 }
 
-func (b *Builder) buildPomeriumHTTPRoutes(options *config.Options, domain string) ([]*envoy_config_route_v3.Route, error) {
+func (b *Builder) buildPomeriumHTTPRoutes(options *config.Options, host string) ([]*envoy_config_route_v3.Route, error) {
 	var routes []*envoy_config_route_v3.Route
 
 	// if this is the pomerium proxy in front of the the authenticate service, don't add
 	// these routes since they will be handled by authenticate
-	isFrontingAuthenticate, err := isProxyFrontingAuthenticate(options, domain)
+	isFrontingAuthenticate, err := isProxyFrontingAuthenticate(options, host)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (b *Builder) buildPomeriumHTTPRoutes(options *config.Options, domain string
 			b.buildControlPlanePrefixRoute("/.well-known/pomerium/", false),
 		)
 		// per #837, only add robots.txt if there are no unauthenticated routes
-		if !hasPublicPolicyMatchingURL(options, url.URL{Scheme: "https", Host: domain, Path: "/robots.txt"}) {
+		if !hasPublicPolicyMatchingURL(options, url.URL{Scheme: "https", Host: host, Path: "/robots.txt"}) {
 			routes = append(routes, b.buildControlPlanePathRoute("/robots.txt", false))
 		}
 	}
@@ -79,7 +79,7 @@ func (b *Builder) buildPomeriumHTTPRoutes(options *config.Options, domain string
 	if err != nil {
 		return nil, err
 	}
-	if config.IsAuthenticate(options.Services) && hostMatchesDomain(authenticateURL, domain) {
+	if config.IsAuthenticate(options.Services) && hostMatchesDomain(authenticateURL, host) {
 		routes = append(routes,
 			b.buildControlPlanePathRoute(options.AuthenticateCallbackPath, false),
 			b.buildControlPlanePathRoute("/", false),

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -666,14 +666,14 @@ func TestOptions_GetOauthOptions(t *testing.T) {
 	assert.Equal(t, u.Hostname(), oauthOptions.RedirectURL.Hostname())
 }
 
-func TestOptions_GetAllRouteableGRPCDomains(t *testing.T) {
+func TestOptions_GetAllRouteableGRPCHosts(t *testing.T) {
 	opts := &Options{
 		AuthenticateURLString: "https://authenticate.example.com",
 		AuthorizeURLString:    "https://authorize.example.com",
 		DataBrokerURLString:   "https://databroker.example.com",
 		Services:              "all",
 	}
-	domains, err := opts.GetAllRouteableGRPCDomains()
+	hosts, err := opts.GetAllRouteableGRPCHosts()
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{
@@ -681,10 +681,10 @@ func TestOptions_GetAllRouteableGRPCDomains(t *testing.T) {
 		"authorize.example.com:443",
 		"databroker.example.com",
 		"databroker.example.com:443",
-	}, domains)
+	}, hosts)
 }
 
-func TestOptions_GetAllRouteableHTTPDomains(t *testing.T) {
+func TestOptions_GetAllRouteableHTTPHosts(t *testing.T) {
 	p1 := Policy{From: "https://from1.example.com"}
 	p1.Validate()
 	p2 := Policy{From: "https://from2.example.com"}
@@ -699,7 +699,7 @@ func TestOptions_GetAllRouteableHTTPDomains(t *testing.T) {
 		Policies:              []Policy{p1, p2, p3},
 		Services:              "all",
 	}
-	domains, err := opts.GetAllRouteableHTTPDomains()
+	hosts, err := opts.GetAllRouteableHTTPHosts()
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{
@@ -713,7 +713,7 @@ func TestOptions_GetAllRouteableHTTPDomains(t *testing.T) {
 		"from2.example.com:443",
 		"from3.example.com",
 		"from3.example.com:443",
-	}, domains)
+	}, hosts)
 }
 
 func TestOptions_ApplySettings(t *testing.T) {

--- a/internal/urlutil/url.go
+++ b/internal/urlutil/url.go
@@ -8,6 +8,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/caddyserver/certmagic"
 )
 
 const (
@@ -159,4 +161,9 @@ func GetExternalRequest(internalURL, externalURL *url.URL, r *http.Request) *htt
 		er.Host = externalURL.Host
 	}
 	return er
+}
+
+// MatchesServerName returnes true if the url's host matches the given server name.
+func MatchesServerName(u url.URL, serverName string) bool {
+	return certmagic.MatchWildcard(u.Hostname(), serverName)
 }

--- a/internal/urlutil/url_test.go
+++ b/internal/urlutil/url_test.go
@@ -166,3 +166,9 @@ func TestJoin(t *testing.T) {
 	assert.Equal(t, "/x/y/z/", Join("/x", "/y/z/"))
 	assert.Equal(t, "/x/y/z/", Join("/x/", "/y/z/"))
 }
+
+func TestMatchesServerName(t *testing.T) {
+	t.Run("wildcard", func(t *testing.T) {
+		assert.True(t, MatchesServerName(MustParseAndValidateURL("https://domain.example.com"), "*.example.com"))
+	})
+}

--- a/pkg/cryptutil/tls.go
+++ b/pkg/cryptutil/tls.go
@@ -44,36 +44,36 @@ func GetCertPool(ca, caFile string) (*x509.CertPool, error) {
 	return rootCAs, nil
 }
 
-// GetCertificateForDomain returns the tls Certificate which matches the given domain name.
+// GetCertificateForServerName returns the tls Certificate which matches the given server name.
 // It should handle both exact matches and wildcard matches. If none of those match, the first certificate will be used.
 // Finally if there are no matching certificates one will be generated.
-func GetCertificateForDomain(certificates []tls.Certificate, domain string) (*tls.Certificate, error) {
+func GetCertificateForServerName(certificates []tls.Certificate, serverName string) (*tls.Certificate, error) {
 	// first try a direct name match
 	for i := range certificates {
-		if matchesDomain(&certificates[i], domain) {
+		if matchesServerName(&certificates[i], serverName) {
 			return &certificates[i], nil
 		}
 	}
 
-	log.WarnNoTLSCertificate(domain)
+	log.WarnNoTLSCertificate(serverName)
 
 	// finally fall back to a generated, self-signed certificate
-	return GenerateSelfSignedCertificate(domain)
+	return GenerateSelfSignedCertificate(serverName)
 }
 
-// HasCertificateForDomain returns true if a TLS certificate matches the given domain.
-func HasCertificateForDomain(certificates []tls.Certificate, domain string) bool {
+// HasCertificateForServerName returns true if a TLS certificate matches the given server name.
+func HasCertificateForServerName(certificates []tls.Certificate, serverName string) bool {
 	for i := range certificates {
-		if matchesDomain(&certificates[i], domain) {
+		if matchesServerName(&certificates[i], serverName) {
 			return true
 		}
 	}
 	return false
 }
 
-// GetCertificateDomains gets all the certificate's matching domain names.
+// GetCertificateServerNames gets all the certificate's server names.
 // Will return an empty slice if certificate is nil, empty, or x509 parsing fails.
-func GetCertificateDomains(cert *tls.Certificate) []string {
+func GetCertificateServerNames(cert *tls.Certificate) []string {
 	if cert == nil || len(cert.Certificate) == 0 {
 		return nil
 	}
@@ -83,19 +83,19 @@ func GetCertificateDomains(cert *tls.Certificate) []string {
 		return nil
 	}
 
-	var domains []string
+	var serverNames []string
 	if xcert.Subject.CommonName != "" {
-		domains = append(domains, xcert.Subject.CommonName)
+		serverNames = append(serverNames, xcert.Subject.CommonName)
 	}
 	for _, dnsName := range xcert.DNSNames {
 		if dnsName != "" {
-			domains = append(domains, dnsName)
+			serverNames = append(serverNames, dnsName)
 		}
 	}
-	return domains
+	return serverNames
 }
 
-func matchesDomain(cert *tls.Certificate, domain string) bool {
+func matchesServerName(cert *tls.Certificate, serverName string) bool {
 	if cert == nil || len(cert.Certificate) == 0 {
 		return false
 	}
@@ -105,12 +105,12 @@ func matchesDomain(cert *tls.Certificate, domain string) bool {
 		return false
 	}
 
-	if certmagic.MatchWildcard(domain, xcert.Subject.CommonName) {
+	if certmagic.MatchWildcard(serverName, xcert.Subject.CommonName) {
 		return true
 	}
 
 	for _, san := range xcert.DNSNames {
-		if certmagic.MatchWildcard(domain, san) {
+		if certmagic.MatchWildcard(serverName, san) {
 			return true
 		}
 	}

--- a/pkg/cryptutil/tls_test.go
+++ b/pkg/cryptutil/tls_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetCertificateForDomain(t *testing.T) {
-	gen := func(t *testing.T, domain string) *tls.Certificate {
-		cert, err := GenerateSelfSignedCertificate(domain)
-		if !assert.NoError(t, err, "error generating certificate for: %s", domain) {
+func TestGetCertificateForServerName(t *testing.T) {
+	gen := func(t *testing.T, serverName string) *tls.Certificate {
+		cert, err := GenerateSelfSignedCertificate(serverName)
+		if !assert.NoError(t, err, "error generating certificate for: %s", serverName) {
 			t.FailNow()
 		}
 		return cert
@@ -23,7 +23,7 @@ func TestGetCertificateForDomain(t *testing.T) {
 			*gen(t, "b.example.com"),
 		}
 
-		found, err := GetCertificateForDomain(certs, "b.example.com")
+		found, err := GetCertificateForServerName(certs, "b.example.com")
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -35,7 +35,7 @@ func TestGetCertificateForDomain(t *testing.T) {
 			*gen(t, "*.example.com"),
 		}
 
-		found, err := GetCertificateForDomain(certs, "b.example.com")
+		found, err := GetCertificateForServerName(certs, "b.example.com")
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -46,7 +46,7 @@ func TestGetCertificateForDomain(t *testing.T) {
 			*gen(t, "a.example.com"),
 		}
 
-		found, err := GetCertificateForDomain(certs, "b.example.com")
+		found, err := GetCertificateForServerName(certs, "b.example.com")
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -56,7 +56,7 @@ func TestGetCertificateForDomain(t *testing.T) {
 	t.Run("generate", func(t *testing.T) {
 		certs := []tls.Certificate{}
 
-		found, err := GetCertificateForDomain(certs, "b.example.com")
+		found, err := GetCertificateForServerName(certs, "b.example.com")
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -64,8 +64,8 @@ func TestGetCertificateForDomain(t *testing.T) {
 	})
 }
 
-func TestGetCertificateDomains(t *testing.T) {
+func TestGetCertificateServerNames(t *testing.T) {
 	cert, err := GenerateSelfSignedCertificate("www.example.com")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"www.example.com"}, GetCertificateDomains(cert))
+	assert.Equal(t, []string{"www.example.com"}, GetCertificateServerNames(cert))
 }


### PR DESCRIPTION
## Summary
The `buildFilterChains` method doesn't make sense anymore. We now add all virtual hosts to all filter chains.

## Related issues
- https://github.com/pomerium/internal/issues/1199

 

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
