### PR TITLE
config: add support for extended TCP route URLs

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -151,7 +151,7 @@ func getCheckRequestURL(req *envoy_service_auth_v3.CheckRequest) url.URL {
 		Scheme: h.GetScheme(),
 		Host:   h.GetHost(),
 	}
-	u.Host = urlutil.GetDomainsForURL(u)[0]
+	u.Host = urlutil.GetDomainsForURL(&u)[0]
 	// envoy sends the query string as part of the path
 	path := h.GetPath()
 	if idx := strings.Index(path, "?"); idx != -1 {

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -620,25 +620,35 @@ func getAllServerNames(cfg *config.Config, addr string) ([]string, error) {
 	serverNames := sets.NewSorted[string]()
 	serverNames.Add("*")
 
-	routeableHosts, err := getAllRouteableHosts(cfg.Options, addr)
-	if err != nil {
-		return nil, err
-	}
-	for _, hp := range routeableHosts {
-		if h, _, err := net.SplitHostPort(hp); err == nil {
-			serverNames.Add(h)
-		} else {
-			serverNames.Add(hp)
-		}
-	}
-
 	certs, err := cfg.AllCertificates()
 	if err != nil {
 		return nil, err
 	}
 	for i := range certs {
-		for _, domain := range cryptutil.GetCertificateServerNames(&certs[i]) {
-			serverNames.Add(domain)
+		serverNames.Add(cryptutil.GetCertificateServerNames(&certs[i])...)
+	}
+
+	if addr == cfg.Options.Addr {
+		sns, err := cfg.Options.GetAllRouteableHTTPServerNames()
+		if err != nil {
+			return nil, err
+		}
+		for _, sn := range sns {
+			if !cryptutil.HasCertificateForServerName(certs, sn) {
+				serverNames.Add(sn)
+			}
+		}
+	}
+
+	if addr == cfg.Options.GetGRPCAddr() {
+		sns, err := cfg.Options.GetAllRouteableGRPCServerNames()
+		if err != nil {
+			return nil, err
+		}
+		for _, sn := range sns {
+			if !cryptutil.HasCertificateForServerName(certs, sn) {
+				serverNames.Add(sn)
+			}
 		}
 	}
 
@@ -655,30 +665,12 @@ func urlsMatchHost(urls []*url.URL, host string) bool {
 }
 
 func urlMatchesHost(u *url.URL, host string) bool {
-	if u == nil {
-		return false
+	for _, h := range urlutil.GetDomainsForURL(u) {
+		if h == host {
+			return true
+		}
 	}
-
-	var defaultPort string
-	if u.Scheme == "http" {
-		defaultPort = "80"
-	} else {
-		defaultPort = "443"
-	}
-
-	h1, p1, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		h1 = u.Host
-		p1 = defaultPort
-	}
-
-	h2, p2, err := net.SplitHostPort(host)
-	if err != nil {
-		h2 = host
-		p2 = defaultPort
-	}
-
-	return h1 == h2 && p1 == p2
+	return false
 }
 
 func getPoliciesForServerName(options *config.Options, serverName string) []config.Policy {

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -633,11 +633,7 @@ func getAllServerNames(cfg *config.Config, addr string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		for _, sn := range sns {
-			if !cryptutil.HasCertificateForServerName(certs, sn) {
-				serverNames.Add(sn)
-			}
-		}
+		serverNames.Add(sns...)
 	}
 
 	if addr == cfg.Options.GetGRPCAddr() {
@@ -645,11 +641,7 @@ func getAllServerNames(cfg *config.Config, addr string) ([]string, error) {
 		if err != nil {
 			return nil, err
 		}
-		for _, sn := range sns {
-			if !cryptutil.HasCertificateForServerName(certs, sn) {
-				serverNames.Add(sn)
-			}
-		}
+		serverNames.Add(sns...)
 	}
 
 	return serverNames.ToSlice(), nil

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -984,6 +984,7 @@ func Test_getAllDomains(t *testing.T) {
 			{Source: &config.StringURL{URL: mustParseURL(t, "http://a.example.com")}},
 			{Source: &config.StringURL{URL: mustParseURL(t, "https://b.example.com")}},
 			{Source: &config.StringURL{URL: mustParseURL(t, "https://c.example.com")}},
+			{Source: &config.StringURL{URL: mustParseURL(t, "https://d.unknown.example.com")}},
 		},
 		Cert: base64.StdEncoding.EncodeToString(certPEM),
 		Key:  base64.StdEncoding.EncodeToString(keyPEM),
@@ -1001,6 +1002,8 @@ func Test_getAllDomains(t *testing.T) {
 				"b.example.com:443",
 				"c.example.com",
 				"c.example.com:443",
+				"d.unknown.example.com",
+				"d.unknown.example.com:443",
 			}
 			assert.Equal(t, expect, actual)
 		})
@@ -1029,6 +1032,8 @@ func Test_getAllDomains(t *testing.T) {
 				"c.example.com",
 				"c.example.com:443",
 				"cache.example.com:9001",
+				"d.unknown.example.com",
+				"d.unknown.example.com:443",
 			}
 			assert.Equal(t, expect, actual)
 		})

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -1049,6 +1049,7 @@ func Test_getAllDomains(t *testing.T) {
 				"authenticate.example.com",
 				"b.example.com",
 				"c.example.com",
+				"d.unknown.example.com",
 			}
 			assert.Equal(t, expect, actual)
 		})

--- a/config/policy.go
+++ b/config/policy.go
@@ -599,7 +599,12 @@ func (p *Policy) Matches(requestURL url.URL) bool {
 		return false
 	}
 
-	if p.Source.Host != requestURL.Host {
+	// make sure one of the host domains matches the incoming url
+	found := false
+	for _, host := range urlutil.GetDomainsForURL(p.Source.URL) {
+		found = found || host == requestURL.Host
+	}
+	if !found {
 		return false
 	}
 

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -269,4 +269,13 @@ func TestPolicy_Matches(t *testing.T) {
 		assert.True(t, p.Matches(urlutil.MustParseAndValidateURL(`https://www.example.com/admin/foo`)))
 		assert.True(t, p.Matches(urlutil.MustParseAndValidateURL(`https://www.example.com/admin/bar`)))
 	})
+	t.Run("tcp", func(t *testing.T) {
+		p := &Policy{
+			From: "tcp+https://proxy.example.com/redis.example.com:6379",
+			To:   mustParseWeightedURLs(t, "tcp://localhost:6379"),
+		}
+		assert.NoError(t, p.Validate())
+
+		assert.True(t, p.Matches(urlutil.MustParseAndValidateURL(`https://redis.example.com:6379`)))
+	})
 }

--- a/internal/urlutil/url_test.go
+++ b/internal/urlutil/url_test.go
@@ -136,6 +136,31 @@ func TestGetAbsoluteURL(t *testing.T) {
 	}
 }
 
+func TestGetServerNamesForURL(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name string
+		u    *url.URL
+		want []string
+	}{
+		{"http", &url.URL{Scheme: "http", Host: "example.com"}, []string{"example.com"}},
+		{"http scheme with host contain 443", &url.URL{Scheme: "http", Host: "example.com:443"}, []string{"example.com"}},
+		{"https", &url.URL{Scheme: "https", Host: "example.com"}, []string{"example.com"}},
+		{"Host contains other port", &url.URL{Scheme: "https", Host: "example.com:1234"}, []string{"example.com"}},
+		{"tcp", &url.URL{Scheme: "tcp+https", Host: "example.com:1234"}, []string{"example.com"}},
+		{"tcp with path", &url.URL{Scheme: "tcp+https", Host: "proxy.example.com", Path: "/ssh.example.com:1234"}, []string{"proxy.example.com"}},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := GetServerNamesForURL(tc.u)
+			if diff := cmp.Diff(got, tc.want); diff != "" {
+				t.Errorf("GetServerNamesForURL() = %v", diff)
+			}
+		})
+	}
+}
+
 func TestGetDomainsForURL(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -147,12 +172,14 @@ func TestGetDomainsForURL(t *testing.T) {
 		{"http scheme with host contain 443", &url.URL{Scheme: "http", Host: "example.com:443"}, []string{"example.com:443"}},
 		{"https", &url.URL{Scheme: "https", Host: "example.com"}, []string{"example.com", "example.com:443"}},
 		{"Host contains other port", &url.URL{Scheme: "https", Host: "example.com:1234"}, []string{"example.com:1234"}},
+		{"tcp", &url.URL{Scheme: "tcp+https", Host: "example.com:1234"}, []string{"example.com:1234"}},
+		{"tcp with path", &url.URL{Scheme: "tcp+https", Host: "proxy.example.com", Path: "/ssh.example.com:1234"}, []string{"ssh.example.com:1234"}},
 	}
 	for _, tc := range tests {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := GetDomainsForURL(*tc.u)
+			got := GetDomainsForURL(tc.u)
 			if diff := cmp.Diff(got, tc.want); diff != "" {
 				t.Errorf("GetDomainsForURL() = %v", diff)
 			}


### PR DESCRIPTION
## Summary
Add support for an extended TCP route definition syntax. Currently we support:

```
tcp+https://redis.example.com:6379
```

This adds support for:

```
tcp+https://proxy.example.com/redis.example.com:6379
```

What this does is add a TLS server name for `proxy.example.com`, with a virtual host for `redis.example.com:6379`. This way if connections from the CLI have a custom Pomerium URL set they will be routed properly.

~~This PR also updates the code so that if you have a certificate for `*.example.com`, only one filter chain will be added for all the routes instead of `*.example.com` and `authenticate.example.com`, ...~~

## Related issues
Fixes https://github.com/pomerium/internal/issues/1199

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
