### PR TITLE
hpke: fix hpke key fetcher when using self-signed certificates

### DIFF
--- a/authorize/state.go
+++ b/authorize/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pomerium/pomerium/authorize/evaluator"
 	"github.com/pomerium/pomerium/authorize/internal/store"
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/pkg/grpc"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/hpke"
@@ -88,11 +89,7 @@ func newAuthorizeStateFromConfig(cfg *config.Config, store *store.Store) (*autho
 	jwksURL := authenticateURL.ResolveReference(&url.URL{
 		Path: "/.well-known/pomerium/jwks.json",
 	}).String()
-	transport, err := config.GetTLSClientTransport(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("authorize: get tls client config: %w", err)
-	}
-	state.authenticateKeyFetcher = hpke.NewKeyFetcher(jwksURL, transport)
+	state.authenticateKeyFetcher = hpke.NewKeyFetcher(jwksURL, httputil.GetInsecureTransport())
 
 	return state, nil
 }

--- a/internal/httputil/transport.go
+++ b/internal/httputil/transport.go
@@ -1,0 +1,19 @@
+package httputil
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+// GetInsecureTransport returns an HTTP transport which skips TLS verification.
+func GetInsecureTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.Dial = nil
+	transport.DialContext = nil
+	transport.DialTLS = nil
+	transport.DialTLSContext = nil
+	transport.TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+	return transport
+}

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -3,12 +3,12 @@ package proxy
 import (
 	"context"
 	"crypto/cipher"
-	"fmt"
 	"net/url"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/encoding"
 	"github.com/pomerium/pomerium/internal/encoding/jws"
+	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/sessions"
 	"github.com/pomerium/pomerium/internal/sessions/cookie"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
@@ -66,11 +66,7 @@ func newProxyStateFromConfig(cfg *config.Config) (*proxyState, error) {
 	jwksURL := authenticateURL.ResolveReference(&url.URL{
 		Path: "/.well-known/pomerium/jwks.json",
 	}).String()
-	transport, err := config.GetTLSClientTransport(cfg)
-	if err != nil {
-		return nil, fmt.Errorf("authorize: get tls client config: %w", err)
-	}
-	state.authenticateKeyFetcher = hpke.NewKeyFetcher(jwksURL, transport)
+	state.authenticateKeyFetcher = hpke.NewKeyFetcher(jwksURL, httputil.GetInsecureTransport())
 
 	state.sharedCipher, err = cryptutil.NewAEADCipher(state.sharedKey)
 	if err != nil {


### PR DESCRIPTION
## Summary
When certificates are generated by pomerium the JWKS endpoint currently can't be fetched, resulting in 500s when trying to go through the authorization flow. 

## Related issues
Fixes https://github.com/pomerium/internal/issues/1062


## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
