### PR TITLE
config: generate derived certificates instead of self-signed certificates

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,66 @@
+package config
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+)
+
+func TestConfig_GetCertificateForServerName(t *testing.T) {
+	gen := func(t *testing.T, serverName string) *tls.Certificate {
+		cert, err := cryptutil.GenerateSelfSignedCertificate(serverName)
+		if !assert.NoError(t, err, "error generating certificate for: %s", serverName) {
+			t.FailNow()
+		}
+		return cert
+	}
+
+	t.Run("exact match", func(t *testing.T) {
+		cfg := &Config{Options: NewDefaultOptions(), AutoCertificates: []tls.Certificate{
+			*gen(t, "a.example.com"),
+			*gen(t, "b.example.com"),
+		}}
+
+		found, err := cfg.GetCertificateForServerName("b.example.com")
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, &cfg.AutoCertificates[1], found)
+	})
+	t.Run("wildcard match", func(t *testing.T) {
+		cfg := &Config{Options: NewDefaultOptions(), AutoCertificates: []tls.Certificate{
+			*gen(t, "a.example.com"),
+			*gen(t, "*.example.com"),
+		}}
+
+		found, err := cfg.GetCertificateForServerName("b.example.com")
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, &cfg.AutoCertificates[1], found)
+	})
+	t.Run("no name match", func(t *testing.T) {
+		cfg := &Config{Options: NewDefaultOptions(), AutoCertificates: []tls.Certificate{
+			*gen(t, "a.example.com"),
+		}}
+
+		found, err := cfg.GetCertificateForServerName("b.example.com")
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, found)
+		assert.NotEqual(t, &cfg.AutoCertificates[0], found)
+	})
+	t.Run("generate", func(t *testing.T) {
+		cfg := &Config{Options: NewDefaultOptions()}
+
+		found, err := cfg.GetCertificateForServerName("b.example.com")
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.NotNil(t, found)
+	})
+}

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -512,13 +512,7 @@ func (b *Builder) buildDownstreamTLSContext(ctx context.Context,
 	cfg *config.Config,
 	serverName string,
 ) *envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext {
-	certs, err := cfg.AllCertificates()
-	if err != nil {
-		log.Warn(ctx).Str("domain", serverName).Err(err).Msg("failed to get all certificates from config")
-		return nil
-	}
-
-	cert, err := cryptutil.GetCertificateForServerName(certs, serverName)
+	cert, err := cfg.GetCertificateForServerName(serverName)
 	if err != nil {
 		log.Warn(ctx).Str("domain", serverName).Err(err).Msg("failed to get certificate for domain")
 		return nil

--- a/pkg/cryptutil/tls.go
+++ b/pkg/cryptutil/tls.go
@@ -44,27 +44,10 @@ func GetCertPool(ca, caFile string) (*x509.CertPool, error) {
 	return rootCAs, nil
 }
 
-// GetCertificateForServerName returns the tls Certificate which matches the given server name.
-// It should handle both exact matches and wildcard matches. If none of those match, the first certificate will be used.
-// Finally if there are no matching certificates one will be generated.
-func GetCertificateForServerName(certificates []tls.Certificate, serverName string) (*tls.Certificate, error) {
-	// first try a direct name match
-	for i := range certificates {
-		if matchesServerName(&certificates[i], serverName) {
-			return &certificates[i], nil
-		}
-	}
-
-	log.WarnNoTLSCertificate(serverName)
-
-	// finally fall back to a generated, self-signed certificate
-	return GenerateSelfSignedCertificate(serverName)
-}
-
 // HasCertificateForServerName returns true if a TLS certificate matches the given server name.
 func HasCertificateForServerName(certificates []tls.Certificate, serverName string) bool {
 	for i := range certificates {
-		if matchesServerName(&certificates[i], serverName) {
+		if MatchesServerName(&certificates[i], serverName) {
 			return true
 		}
 	}
@@ -95,7 +78,8 @@ func GetCertificateServerNames(cert *tls.Certificate) []string {
 	return serverNames
 }
 
-func matchesServerName(cert *tls.Certificate, serverName string) bool {
+// MatchesServerName returns true if the certificate matches the server name.
+func MatchesServerName(cert *tls.Certificate, serverName string) bool {
 	if cert == nil || len(cert.Certificate) == 0 {
 		return false
 	}

--- a/pkg/cryptutil/tls_test.go
+++ b/pkg/cryptutil/tls_test.go
@@ -1,68 +1,11 @@
 package cryptutil
 
 import (
-	"crypto/tls"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestGetCertificateForServerName(t *testing.T) {
-	gen := func(t *testing.T, serverName string) *tls.Certificate {
-		cert, err := GenerateSelfSignedCertificate(serverName)
-		if !assert.NoError(t, err, "error generating certificate for: %s", serverName) {
-			t.FailNow()
-		}
-		return cert
-	}
-
-	t.Run("exact match", func(t *testing.T) {
-		certs := []tls.Certificate{
-			*gen(t, "a.example.com"),
-			*gen(t, "b.example.com"),
-		}
-
-		found, err := GetCertificateForServerName(certs, "b.example.com")
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.Equal(t, &certs[1], found)
-	})
-	t.Run("wildcard match", func(t *testing.T) {
-		certs := []tls.Certificate{
-			*gen(t, "a.example.com"),
-			*gen(t, "*.example.com"),
-		}
-
-		found, err := GetCertificateForServerName(certs, "b.example.com")
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.Equal(t, &certs[1], found)
-	})
-	t.Run("no name match", func(t *testing.T) {
-		certs := []tls.Certificate{
-			*gen(t, "a.example.com"),
-		}
-
-		found, err := GetCertificateForServerName(certs, "b.example.com")
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.NotNil(t, found)
-		assert.NotEqual(t, &certs[0], found)
-	})
-	t.Run("generate", func(t *testing.T) {
-		certs := []tls.Certificate{}
-
-		found, err := GetCertificateForServerName(certs, "b.example.com")
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.NotNil(t, found)
-	})
-}
 
 func TestGetCertificateServerNames(t *testing.T) {
 	cert, err := GenerateSelfSignedCertificate("www.example.com")


### PR DESCRIPTION
## Summary
If deriving certificates is enabled, generate derived certificates instead of self-signed ones. Also add the derived CA to the certificate pool used for the JWKS key fetcher.

We will still see 500s when this option is not enabled, so it does not fix the associated issue.

## Related issues
- https://github.com/pomerium/internal/issues/1062

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
