### PR TITLE
config: use insecure skip verify if derived certificates are not used

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -189,6 +189,23 @@ func (cfg *Config) GetCertificateForServerName(serverName string) (*tls.Certific
 	return cryptutil.GenerateSelfSignedCertificate(serverName)
 }
 
+// WillHaveCertificateForServerName returns true if there will be a certificate for the given server name.
+func (cfg *Config) WillHaveCertificateForServerName(serverName string) (bool, error) {
+	certificates, err := cfg.AllCertificates()
+	if err != nil {
+		return false, err
+	}
+
+	// first try a direct name match
+	for i := range certificates {
+		if cryptutil.MatchesServerName(&certificates[i], serverName) {
+			return true, nil
+		}
+	}
+
+	return cfg.Options.DeriveInternalDomainCert != nil, nil
+}
+
 // GetCertificatePool gets the certificate pool for the config.
 func (cfg *Config) GetCertificatePool() (*x509.CertPool, error) {
 	pool, err := cryptutil.GetCertPool(cfg.Options.CA, cfg.Options.CAFile)

--- a/internal/httputil/transport.go
+++ b/internal/httputil/transport.go
@@ -1,0 +1,15 @@
+package httputil
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+// GetInsecureTransport gets an insecure HTTP transport.
+func GetInsecureTransport() *http.Transport {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialTLS = nil
+	transport.DialTLSContext = nil
+	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	return transport
+}

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/encoding"
 	"github.com/pomerium/pomerium/internal/encoding/jws"
+	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/sessions"
 	"github.com/pomerium/pomerium/internal/sessions/cookie"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
@@ -66,9 +67,16 @@ func newProxyStateFromConfig(cfg *config.Config) (*proxyState, error) {
 	jwksURL := authenticateURL.ResolveReference(&url.URL{
 		Path: "/.well-known/pomerium/jwks.json",
 	}).String()
-	transport, err := config.GetTLSClientTransport(cfg)
+	transport := httputil.GetInsecureTransport()
+	ok, err := cfg.WillHaveCertificateForServerName(authenticateURL.Hostname())
 	if err != nil {
-		return nil, fmt.Errorf("authorize: get tls client config: %w", err)
+		return nil, fmt.Errorf("proxy: error determining if authenticate service will have a certificate name: %w", err)
+	}
+	if ok {
+		transport, err = config.GetTLSClientTransport(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("proxy: get tls client config: %w", err)
+		}
 	}
 	state.authenticateKeyFetcher = hpke.NewKeyFetcher(jwksURL, transport)
 


### PR DESCRIPTION
## Summary
If we aren't using derived certificates, disable TLS verification because the resulting certificate used by the authenticate service will be self-signed.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1062

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
