### PR TITLE
postgres: return unknown records instead of skipping them

### DIFF
--- a/pkg/storage/postgres/backend_test.go
+++ b/pkg/storage/postgres/backend_test.go
@@ -173,10 +173,11 @@ func TestBackend(t *testing.T) {
 			_, err = backend.Get(ctx, "unknown", "1")
 			assert.ErrorIs(t, err, storage.ErrNotFound)
 
-			_, _, stream, err := backend.SyncLatest(ctx, "unknown-test", nil)
+			_, _, stream, err := backend.SyncLatest(ctx, "unknown", nil)
 			if assert.NoError(t, err) {
-				_, err := storage.RecordStreamToList(stream)
+				records, err := storage.RecordStreamToList(stream)
 				assert.NoError(t, err)
+				assert.Len(t, records, 1)
 				stream.Close()
 			}
 		})


### PR DESCRIPTION
## Summary
Instead of skipping unknown records, return them with a struct any of `{"id": "ID"}`.

Previously when we skipped these records we inadvertently stopped a stream early if too many unknown records were returned, because the `stream.pending` list would be empty, so the code would think the stream was complete when in fact there were many more records available that would be returned by subsequent SQL calls.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1207


## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
