### PR TITLE
explicitly list gRPC services accessible via the gRPC listener

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -454,13 +454,19 @@ func (b *Builder) buildGRPCListener(ctx context.Context, cfg *config.Config) (*e
 }
 
 func (b *Builder) buildGRPCHTTPConnectionManagerFilter() (*envoy_config_listener_v3.Filter, error) {
-	rc, err := b.buildRouteConfiguration("grpc", []*envoy_config_route_v3.VirtualHost{{
-		Name:    "grpc",
-		Domains: []string{"*"},
-		Routes: []*envoy_config_route_v3.Route{{
+	allow := []string{
+		"envoy.service.auth.v3.Authorization",
+		"databroker.DataBrokerService",
+		"registry.Registry",
+		"grpc.reflection.v1alpha.ServerReflection",
+		"grpc.health.v1.Health",
+	}
+	routes := make([]*envoy_config_route_v3.Route, 0, len(allow))
+	for _, svc := range allow {
+		routes = append(routes, &envoy_config_route_v3.Route{
 			Name: "grpc",
 			Match: &envoy_config_route_v3.RouteMatch{
-				PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{Prefix: "/"},
+				PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{Prefix: fmt.Sprintf("/%s/", svc)},
 				Grpc:          &envoy_config_route_v3.RouteMatch_GrpcRouteMatchOptions{},
 			},
 			Action: &envoy_config_route_v3.Route_Route{
@@ -477,7 +483,12 @@ func (b *Builder) buildGRPCHTTPConnectionManagerFilter() (*envoy_config_listener
 					},
 				},
 			},
-		}},
+		})
+	}
+	rc, err := b.buildRouteConfiguration("grpc", []*envoy_config_route_v3.VirtualHost{{
+		Name:    "grpc",
+		Domains: []string{"*"},
+		Routes:  routes,
 	}})
 	if err != nil {
 		return nil, err

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -458,7 +458,6 @@ func (b *Builder) buildGRPCHTTPConnectionManagerFilter() (*envoy_config_listener
 		"envoy.service.auth.v3.Authorization",
 		"databroker.DataBrokerService",
 		"registry.Registry",
-		"grpc.reflection.v1alpha.ServerReflection",
 		"grpc.health.v1.Health",
 	}
 	routes := make([]*envoy_config_route_v3.Route, 0, len(allow))

--- a/config/envoyconfig/outbound.go
+++ b/config/envoyconfig/outbound.go
@@ -98,7 +98,6 @@ func (b *Builder) buildOutboundRoutes() []*envoy_config_route_v3.Route {
 			Cluster: "pomerium-databroker",
 			Prefixes: []string{
 				"/databroker.DataBrokerService/",
-				"/directory.DirectoryService/",
 				"/registry.Registry/",
 			},
 		},

--- a/config/envoyconfig/outbound_test.go
+++ b/config/envoyconfig/outbound_test.go
@@ -39,19 +39,6 @@ func Test_buildOutboundRoutes(t *testing.T) {
 		{
 			"match": {
 				"grpc": {},
-				"prefix": "/directory.DirectoryService/"
-			},
-			"name": "pomerium-databroker",
-			"route": {
-				"autoHostRewrite": true,
-				"cluster": "pomerium-databroker",
-				"idleTimeout": "0s",
-				"timeout": "0s"
-			}
-		},
-		{
-			"match": {
-				"grpc": {},
 				"prefix": "/registry.Registry/"
 			},
 			"name": "pomerium-databroker",


### PR DESCRIPTION
## Summary

Previously, we matched all services available in the internal `grpc-control-plane` cluster for the external listener.
This PR changes that by limiting the available services explicitly.


<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Fixes https://github.com/pomerium/internal/issues/1063
Fixes https://github.com/pomerium/internal/issues/1064

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
