### PR TITLE
make hpke key fetcher consider authenticate internal service url

### DIFF
--- a/authorize/state.go
+++ b/authorize/state.go
@@ -78,7 +78,7 @@ func newAuthorizeStateFromConfig(cfg *config.Config, store *store.Store) (*autho
 		return nil, fmt.Errorf("authorize: invalid session store: %w", err)
 	}
 
-	authenticateURL, err := cfg.Options.GetAuthenticateURL()
+	authenticateURL, err := cfg.Options.GetInternalAuthenticateURL()
 	if err != nil {
 		return nil, fmt.Errorf("authorize: invalid authenticate service url: %w", err)
 	}

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -48,7 +48,7 @@ func newProxyStateFromConfig(cfg *config.Config) (*proxyState, error) {
 
 	state := new(proxyState)
 
-	authenticateURL, err := cfg.Options.GetAuthenticateURL()
+	authenticateURL, err := cfg.Options.GetInternalAuthenticateURL()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Authorize and Proxy now need have ability to access the authenticate endpoint to fetch HPKE Public Key.

In some environments (i.e. docker-compose in split mode using `authenticate.localhost.pomerium.io`) it is impossible. 

We have an `authenticate_internal_service_url` setting for such cases, that need be used instead. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Fixes https://github.com/pomerium/internal/issues/1209

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
