### PR TITLE
scripts: update get-envoy script to download all binaries

### DIFF
--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -7,26 +7,27 @@ export PATH
 _project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/.."
 _envoy_version=1.24.0
 _dir="$_project_root/pkg/envoy/files"
-_target="${TARGET:-"$(go env GOOS)-$(go env GOARCH)"}"
 
-_url="https://github.com/pomerium/envoy-binaries/releases/download/v${_envoy_version}/envoy-${_target}"
+for _target in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do
+  _url="https://github.com/pomerium/envoy-binaries/releases/download/v${_envoy_version}/envoy-${_target}"
 
-curl \
-  --silent \
-  --fail \
-  --compressed \
-  --location \
-  --time-cond "$_dir/envoy-$_target" \
-  --output "$_dir/envoy-$_target" \
-  "$_url"
+  curl \
+    --silent \
+    --fail \
+    --compressed \
+    --location \
+    --time-cond "$_dir/envoy-$_target" \
+    --output "$_dir/envoy-$_target" \
+    "$_url"
 
-curl \
-  --silent \
-  --fail \
-  --compressed \
-  --location \
-  --time-cond "$_dir/envoy-$_target.sha256" \
-  --output "$_dir/envoy-$_target.sha256" \
-  "$_url.sha256"
+  curl \
+    --silent \
+    --fail \
+    --compressed \
+    --location \
+    --time-cond "$_dir/envoy-$_target.sha256" \
+    --output "$_dir/envoy-$_target.sha256" \
+    "$_url.sha256"
 
-echo "$_envoy_version" >"$_dir/envoy-$_target.version"
+  echo "$_envoy_version" >"$_dir/envoy-$_target.version"
+done

--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -18,7 +18,7 @@ for _target in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do
     --location \
     --time-cond "$_dir/envoy-$_target" \
     --output "$_dir/envoy-$_target" \
-    "$_url"
+    "$_url" &
 
   curl \
     --silent \
@@ -27,7 +27,9 @@ for _target in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do
     --location \
     --time-cond "$_dir/envoy-$_target.sha256" \
     --output "$_dir/envoy-$_target.sha256" \
-    "$_url.sha256"
+    "$_url.sha256" &
 
   echo "$_envoy_version" >"$_dir/envoy-$_target.version"
 done
+
+wait

--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -14,6 +14,7 @@ for _target in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do
   curl \
     --silent \
     --fail \
+    --show-error \
     --compressed \
     --location \
     --time-cond "$_dir/envoy-$_target" \
@@ -23,6 +24,7 @@ for _target in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do
   curl \
     --silent \
     --fail \
+    --show-error \
     --compressed \
     --location \
     --time-cond "$_dir/envoy-$_target.sha256" \


### PR DESCRIPTION
## Summary
When using macos and building a docker image the linux binary won't be available because we only download the envoy binary for the current os. This updates the script to download all the binaries. Only one envoy binary is included because we use build constraints:

```go
//go:build darwin && amd64 && !embed_pomerium
```

## Related issues

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
