### PR TITLE
tls_derive: rename for consistency

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -166,7 +166,7 @@ type Options struct {
 
 	// DeriveInternalDomainCert is an option that would derive certificate authority
 	// and domain certificates from the shared key and use them for internal communication
-	DeriveInternalDomainCert *string `mapstructure:"derive_tls" yaml:"derive_tls,omitempty"`
+	DeriveInternalDomainCert *string `mapstructure:"tls_derive" yaml:"tls_derive,omitempty"`
 
 	// SigningKey is the private key used to add a JWT-signature to upstream requests.
 	// https://www.pomerium.com/docs/topics/getting-users-identity.html


### PR DESCRIPTION
## Summary

Rename auto TLS option to `tls_derive` for consistency with other options prefixes and console.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
