### PR TITLE
add google cloud creds to ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,5 @@ pkg/envoy/files/envoy-*-?????.sha256
 pkg/envoy/files/envoy-*-?????.version
 
 yarn-error.log
+
+gha-creds-*.json


### PR DESCRIPTION
## Summary

`gcloud authenticate` action creates `ghe-creds-*.json` file that need be added to exclusions for `goreleaser` to proceed. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
