### PR TITLE
authenticate: always trust the passed in idp

### DIFF
--- a/authenticate/identity_profile.go
+++ b/authenticate/identity_profile.go
@@ -31,12 +31,9 @@ func (a *Authenticate) buildIdentityProfile(
 	oauthToken *oauth2.Token,
 ) (*identitypb.Profile, error) {
 	options := a.options.Load()
-	idp, err := options.GetIdentityProviderForID(r.FormValue(urlutil.QueryIdentityProviderID))
-	if err != nil {
-		return nil, fmt.Errorf("authenticate: error getting identity provider for id: %w", err)
-	}
+	idpID := r.FormValue(urlutil.QueryIdentityProviderID)
 
-	authenticator, err := a.cfg.getIdentityProvider(options, idp.GetId())
+	authenticator, err := a.cfg.getIdentityProvider(options, idpID)
 	if err != nil {
 		return nil, fmt.Errorf("authenticate: error getting identity provider authenticator: %w", err)
 	}
@@ -57,7 +54,7 @@ func (a *Authenticate) buildIdentityProfile(
 	}
 
 	return &identitypb.Profile{
-		ProviderId: idp.GetId(),
+		ProviderId: idpID,
 		IdToken:    rawIDToken,
 		OauthToken: rawOAuthToken,
 		Claims:     rawClaims,


### PR DESCRIPTION
## Summary
When using the authenticate service, always associate the login with the identity provider id chosen by the proxy. This way the authenticate service idp credentials don't have to match the proxy idp credentials. 

## Related issues
Fixes https://github.com/pomerium/internal/issues/1256


## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
