### PR TITLE
remove log message when no provider defined

### DIFF
--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -164,11 +164,13 @@ func (c *DataBroker) update(ctx context.Context, cfg *config.Config) error {
 		manager.WithEventManager(c.eventsMgr),
 	}
 
-	authenticator, err := identity.NewAuthenticator(oauthOptions)
-	if err != nil {
-		log.Error(ctx).Err(err).Msg("databroker: failed to create authenticator")
-	} else {
-		options = append(options, manager.WithAuthenticator(authenticator))
+	if cfg.Options.Provider != "" {
+		authenticator, err := identity.NewAuthenticator(oauthOptions)
+		if err != nil {
+			log.Error(ctx).Err(err).Msg("databroker: failed to create authenticator")
+		} else {
+			options = append(options, manager.WithAuthenticator(authenticator))
+		}
 	}
 
 	if c.manager == nil {


### PR DESCRIPTION
## Summary
When no provider is defined there's a log message about how the databroker failed. This PR removes that message.

## Checklist
- [ ] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
