### PR TITLE
config: add additional dns lookup families, default to V4_PREFERRED

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -190,10 +190,7 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 		return nil, err
 	}
 
-	if cluster.DnsLookupFamily == envoy_config_cluster_v3.Cluster_AUTO {
-		cluster.DnsLookupFamily = config.GetEnvoyDNSLookupFamily(options.DNSLookupFamily)
-	}
-
+	cluster.DnsLookupFamily = config.GetEnvoyDNSLookupFamily(options.DNSLookupFamily)
 	if policy.EnableGoogleCloudServerlessAuthentication {
 		cluster.DnsLookupFamily = envoy_config_cluster_v3.Cluster_V4_ONLY
 	}

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -676,6 +676,7 @@ func Test_buildCluster(t *testing.T) {
 						}
 					}
 				},
+				"dnsLookupFamily": "V4_PREFERRED",
 				"loadAssignment": {
 					"clusterName": "example",
 					"endpoints": [{
@@ -745,6 +746,7 @@ func Test_buildCluster(t *testing.T) {
 						}
 					}
 				},
+				"dnsLookupFamily": "V4_PREFERRED",
 				"loadAssignment": {
 					"clusterName": "example",
 					"endpoints": [{
@@ -800,6 +802,7 @@ func Test_buildCluster(t *testing.T) {
 						}
 					}
 				},
+				"dnsLookupFamily": "V4_PREFERRED",
 				"loadAssignment": {
 					"clusterName": "example",
 					"endpoints": [{
@@ -857,6 +860,7 @@ func Test_buildCluster(t *testing.T) {
 						}
 					}
 				},
+				"dnsLookupFamily": "V4_PREFERRED",
 				"loadAssignment": {
 					"clusterName": "example",
 					"endpoints": [{

--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -71,7 +71,7 @@ func newDefaultEnvoyClusterConfig() *envoy_config_cluster_v3.Cluster {
 	return &envoy_config_cluster_v3.Cluster{
 		ConnectTimeout:                defaultConnectionTimeout,
 		RespectDnsTtl:                 true,
-		DnsLookupFamily:               envoy_config_cluster_v3.Cluster_AUTO,
+		DnsLookupFamily:               envoy_config_cluster_v3.Cluster_V4_PREFERRED,
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(connectionBufferLimit),
 	}
 }

--- a/config/options.go
+++ b/config/options.go
@@ -83,7 +83,7 @@ type Options struct {
 	InsecureServer bool `mapstructure:"insecure_server" yaml:"insecure_server,omitempty"`
 
 	// DNSLookupFamily is the DNS IP address resolution policy.
-	// If this setting is not specified, the value defaults to AUTO.
+	// If this setting is not specified, the value defaults to V4_PREFERRED.
 	DNSLookupFamily string `mapstructure:"dns_lookup_family" yaml:"dns_lookup_family,omitempty"`
 
 	CertificateFiles []certificateFilePair `mapstructure:"certificates" yaml:"certificates,omitempty"`

--- a/config/validate.go
+++ b/config/validate.go
@@ -11,18 +11,31 @@ import (
 
 // DNSLookupFamily values.
 const (
-	DNSLookupFamilyAuto   = "AUTO"
-	DNSLookupFamilyV4Only = "V4_ONLY"
-	DNSLookupFamilyV6Only = "V6_ONLY"
+	DNSLookupFamilyAuto        = "AUTO"
+	DNSLookupFamilyV4Only      = "V4_ONLY"
+	DNSLookupFamilyV6Only      = "V6_ONLY"
+	DNSLookupFamilyV4Preferred = "V4_PREFERRED"
+	DNSLookupFamilyAll         = "ALL"
 )
 
 // AllDNSLookupFamilies are all the available DNSLookupFamily values.
-var AllDNSLookupFamilies = []string{DNSLookupFamilyV6Only, DNSLookupFamilyV4Only, DNSLookupFamilyAuto}
+var AllDNSLookupFamilies = []string{
+	DNSLookupFamilyAuto,
+	DNSLookupFamilyV4Only,
+	DNSLookupFamilyV6Only,
+	DNSLookupFamilyV4Preferred,
+	DNSLookupFamilyAll,
+}
 
 // ValidateDNSLookupFamily validates the value to confirm its one of the available DNS lookup families.
 func ValidateDNSLookupFamily(value string) error {
 	switch value {
-	case "", DNSLookupFamilyAuto, DNSLookupFamilyV4Only, DNSLookupFamilyV6Only:
+	case "",
+		DNSLookupFamilyAuto,
+		DNSLookupFamilyV4Only,
+		DNSLookupFamilyV6Only,
+		DNSLookupFamilyV4Preferred,
+		DNSLookupFamilyAll:
 		return nil
 	}
 
@@ -32,12 +45,20 @@ func ValidateDNSLookupFamily(value string) error {
 // GetEnvoyDNSLookupFamily gets the envoy DNS lookup family.
 func GetEnvoyDNSLookupFamily(value string) envoy_config_cluster_v3.Cluster_DnsLookupFamily {
 	switch value {
+	case DNSLookupFamilyAuto:
+		return envoy_config_cluster_v3.Cluster_AUTO
 	case DNSLookupFamilyV4Only:
 		return envoy_config_cluster_v3.Cluster_V4_ONLY
 	case DNSLookupFamilyV6Only:
 		return envoy_config_cluster_v3.Cluster_V6_ONLY
+	case DNSLookupFamilyV4Preferred:
+		return envoy_config_cluster_v3.Cluster_V4_PREFERRED
+	case DNSLookupFamilyAll:
+		return envoy_config_cluster_v3.Cluster_ALL
 	}
-	return envoy_config_cluster_v3.Cluster_AUTO
+
+	// default
+	return envoy_config_cluster_v3.Cluster_V4_PREFERRED
 }
 
 // ValidateMetricsAddress validates address for the metrics


### PR DESCRIPTION
## Summary
Add additional DNS lookup family options. Default to V4_PREFERRED.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3954
 

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
