### PR TITLE
apple: fix userinfo

### DIFF
--- a/internal/sessions/cookie/cookie_store.go
+++ b/internal/sessions/cookie/cookie_store.go
@@ -121,16 +121,16 @@ func (cs *Store) LoadSession(r *http.Request) (string, error) {
 	if len(cookies) == 0 {
 		return "", sessions.ErrNoSessionFound
 	}
+	var err error
 	for _, cookie := range cookies {
 		jwt := loadChunkedCookie(r, cookie)
-
 		session := &sessions.State{}
-		err := cs.decoder.Unmarshal([]byte(jwt), session)
+		err = cs.decoder.Unmarshal([]byte(jwt), session)
 		if err == nil {
 			return jwt, nil
 		}
 	}
-	return "", sessions.ErrMalformed
+	return "", fmt.Errorf("%w: %s", sessions.ErrMalformed, err)
 }
 
 // SaveSession saves a session state to a request's cookie store.


### PR DESCRIPTION
## Summary
Fix the `UpdateUserInfo` call so that refreshing sessions doesn't kill the session anymore.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3973

## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
