### PR TITLE
authenticate: save the session cookie with a different name

### DIFF
--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -96,7 +96,7 @@ func newAuthenticateStateFromConfig(cfg *config.Config) (*authenticateState, err
 
 	cookieStore, err := cookie.NewStore(func() cookie.Options {
 		return cookie.Options{
-			Name:     cfg.Options.CookieName,
+			Name:     cfg.Options.CookieName + "_authenticate",
 			Domain:   cfg.Options.CookieDomain,
 			Secure:   cfg.Options.CookieSecure,
 			HTTPOnly: cfg.Options.CookieHTTPOnly,


### PR DESCRIPTION
## Summary
Save the session cookie with a different name so that it doesn't collide with the proxy session cookie.

## Related issues
- https://github.com/pomerium/internal/issues/1278
 

## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
