### PR TITLE
webauthn: only return known device credentials that match the given type

### DIFF
--- a/pkg/webauthnutil/options.go
+++ b/pkg/webauthnutil/options.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/device"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/slices"
 )
 
 const (
@@ -156,7 +157,10 @@ func newRequestOptions(
 		options,
 		deviceType.GetWebauthn().GetOptions().GetAuthenticatorSelection().UserVerification,
 	)
-	for _, knownDeviceCredential := range knownDeviceCredentials {
+	knownDeviceCredentialsForType := slices.Filter(knownDeviceCredentials, func(c *device.Credential) bool {
+		return c.GetTypeId() == deviceType.GetId()
+	})
+	for _, knownDeviceCredential := range knownDeviceCredentialsForType {
 		if publicKey := knownDeviceCredential.GetWebauthn(); publicKey != nil {
 			options.AllowCredentials = append(options.AllowCredentials, webauthn.PublicKeyCredentialDescriptor{
 				Type: webauthn.PublicKeyCredentialTypePublicKey,

--- a/pkg/webauthnutil/options_test.go
+++ b/pkg/webauthnutil/options_test.go
@@ -81,8 +81,11 @@ func TestGenerateRequestOptions(t *testing.T) {
 	t.Run(DefaultDeviceType, func(t *testing.T) {
 		key := []byte{1, 2, 3}
 		options := GenerateRequestOptions(r, key, predefinedDeviceTypes[DefaultDeviceType], []*device.Credential{
-			{Id: "device1", Specifier: &device.Credential_Webauthn{Webauthn: &device.Credential_WebAuthn{
+			{Id: "device1", TypeId: DefaultDeviceType, Specifier: &device.Credential_Webauthn{Webauthn: &device.Credential_WebAuthn{
 				Id: []byte{4, 5, 6},
+			}}},
+			{Id: "device2", TypeId: "some-other-type", Specifier: &device.Credential_Webauthn{Webauthn: &device.Credential_WebAuthn{
+				Id: []byte{7, 8, 9},
 			}}},
 		})
 		options.Challenge = nil


### PR DESCRIPTION
## Summary
Currently we return all the known device credentials when generating the request options. This filters the list of device credentials to only those for the given type.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3909


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
