### PR TITLE
authenticate: jwks: use local bypass to fetch keys

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -6,13 +6,18 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"fmt"
+	"net"
+	"net/http"
+	"net/url"
 
 	"github.com/pomerium/pomerium/internal/fileutil"
 	"github.com/pomerium/pomerium/internal/hashutil"
+	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/derivecert"
+	"github.com/pomerium/pomerium/pkg/hpke"
 )
 
 // MetricsScrapeEndpoint defines additional metrics endpoints that would be scraped and exposed by pomerium
@@ -235,4 +240,44 @@ func (cfg *Config) GetCertificatePool() (*x509.CertPool, error) {
 	}
 
 	return pool, nil
+}
+
+// GetAuthenticateKeyFetcher returns a key fetcher for the authenticate service
+func (cfg *Config) GetAuthenticateKeyFetcher() (hpke.KeyFetcher, error) {
+	authenticateURL, transport, err := cfg.resolveAuthenticateURL()
+	if err != nil {
+		return nil, err
+	}
+	jwksURL := authenticateURL.ResolveReference(&url.URL{
+		Path: "/.well-known/pomerium/jwks.json",
+	}).String()
+	return hpke.NewKeyFetcher(jwksURL, transport), nil
+}
+
+func (cfg *Config) resolveAuthenticateURL() (*url.URL, *http.Transport, error) {
+	if IsAll(cfg.Options.Services) {
+		return &url.URL{
+			Scheme: "http",
+			Host:   net.JoinHostPort("127.0.0.1", cfg.HTTPPort),
+		}, httputil.GetInsecureTransport(), nil
+	}
+
+	authenticateURL, err := cfg.Options.GetAuthenticateURL()
+	if err != nil {
+		return nil, nil, fmt.Errorf("invalid authenticate service url: %w", err)
+	}
+	ok, err := cfg.WillHaveCertificateForServerName(authenticateURL.Hostname())
+	if err != nil {
+		return nil, nil, fmt.Errorf("error determining if authenticate service will have a certificate name: %w", err)
+	}
+	if !ok {
+		return authenticateURL, httputil.GetInsecureTransport(), nil
+	}
+
+	transport, err := GetTLSClientTransport(cfg)
+	if err != nil {
+		return nil, nil, fmt.Errorf("get tls client config: %w", err)
+	}
+
+	return authenticateURL, transport, nil
 }


### PR DESCRIPTION
## Summary

Both `authorize` and `proxy` services need access the `/.well-known/pomerium/jwks.json` endpoint of `authenticate`. 
When running all-in-one mode inside a non-root container with port mapping, it is not possible to reach that url. 

This PR changes to use a local control plane server to access it in that case. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
