### PR TITLE
cryptutil: generate certificates from deriveca

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -185,8 +185,13 @@ func (cfg *Config) GetCertificateForServerName(serverName string) (*tls.Certific
 		return &cert, nil
 	}
 
+	sharedKey, err := cfg.Options.GetSharedKey()
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate cert, invalid shared key: %w", err)
+	}
+
 	// finally fall back to a generated, self-signed certificate
-	return cryptutil.GenerateSelfSignedCertificate(serverName)
+	return cryptutil.GenerateCertificate(sharedKey, serverName)
 }
 
 // WillHaveCertificateForServerName returns true if there will be a certificate for the given server name.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestConfig_GetCertificateForServerName(t *testing.T) {
 	gen := func(t *testing.T, serverName string) *tls.Certificate {
-		cert, err := cryptutil.GenerateSelfSignedCertificate(serverName)
+		cert, err := cryptutil.GenerateCertificate(nil, serverName)
 		if !assert.NoError(t, err, "error generating certificate for: %s", serverName) {
 			t.FailNow()
 		}

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -211,7 +211,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 }
 
 func Test_getAllDomains(t *testing.T) {
-	cert, err := cryptutil.GenerateSelfSignedCertificate("*.unknown.example.com")
+	cert, err := cryptutil.GenerateCertificate(nil, "*.unknown.example.com")
 	require.NoError(t, err)
 	certPEM, keyPEM, err := cryptutil.EncodeCertificate(cert)
 	require.NoError(t, err)

--- a/config/envoyconfig/tls_test.go
+++ b/config/envoyconfig/tls_test.go
@@ -46,7 +46,7 @@ func TestBuildSubjectNameIndication(t *testing.T) {
 }
 
 func TestValidateCertificate(t *testing.T) {
-	cert, err := cryptutil.GenerateSelfSignedCertificate("example.com", func(tpl *x509.Certificate) {
+	cert, err := cryptutil.GenerateCertificate(nil, "example.com", func(tpl *x509.Certificate) {
 		// set the must staple flag on the cert
 		tpl.ExtraExtensions = append(tpl.ExtraExtensions, pkix.Extension{
 			Id: oidMustStaple,

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -722,14 +722,14 @@ func TestOptions_ApplySettings(t *testing.T) {
 
 	t.Run("certificates", func(t *testing.T) {
 		options := NewDefaultOptions()
-		cert1, err := cryptutil.GenerateSelfSignedCertificate("example.com")
+		cert1, err := cryptutil.GenerateCertificate(nil, "example.com")
 		require.NoError(t, err)
 		options.CertificateFiles = append(options.CertificateFiles, certificateFilePair{
 			CertFile: base64.StdEncoding.EncodeToString(encodeCert(cert1)),
 		})
-		cert2, err := cryptutil.GenerateSelfSignedCertificate("example.com")
+		cert2, err := cryptutil.GenerateCertificate(nil, "example.com")
 		require.NoError(t, err)
-		cert3, err := cryptutil.GenerateSelfSignedCertificate("not.example.com")
+		cert3, err := cryptutil.GenerateCertificate(nil, "not.example.com")
 		require.NoError(t, err)
 
 		settings := &config.Settings{

--- a/pkg/cryptutil/tls_test.go
+++ b/pkg/cryptutil/tls_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGetCertificateServerNames(t *testing.T) {
-	cert, err := GenerateSelfSignedCertificate("www.example.com")
+	cert, err := GenerateCertificate(nil, "www.example.com")
 	require.NoError(t, err)
 	assert.Equal(t, []string{"www.example.com"}, GetCertificateServerNames(cert))
 }

--- a/pkg/derivecert/ca.go
+++ b/pkg/derivecert/ca.go
@@ -83,7 +83,7 @@ func CAFromPEM(p PEM) (*CA, string, error) {
 }
 
 // NewServerCert generates certificate for the given domain name(s)
-func (ca *CA) NewServerCert(domains []string) (*PEM, error) {
+func (ca *CA) NewServerCert(domains []string, configure ...func(*x509.Certificate)) (*PEM, error) {
 	key, err := deriveKey(newReader(readerTypeServerPrivateKey, ca.psk, domains...))
 	if err != nil {
 		return nil, fmt.Errorf("derive key: %w", err)
@@ -92,6 +92,9 @@ func (ca *CA) NewServerCert(domains []string) (*PEM, error) {
 	tmpl, err := serverCertTemplate(ca.psk, domains)
 	if err != nil {
 		return nil, fmt.Errorf("cert template: %w", err)
+	}
+	for _, f := range configure {
+		f(tmpl)
 	}
 
 	cert, err := x509.CreateCertificate(


### PR DESCRIPTION
## Summary
Generate certificates from the `deriveca` package instead of self-signed random ones. This will make it so that certificates are always the same for the same shared key.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3985


## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
