### PR TITLE
authenticate: fix identity provider id in encrypted query string

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -128,7 +128,7 @@ func (a *Authenticate) VerifySession(next http.Handler) http.Handler {
 		defer span.End()
 
 		state := a.state.Load()
-		idpID := r.FormValue(urlutil.QueryIdentityProviderID)
+		idpID := a.getIdentityProviderIDForRequest(r)
 
 		sessionState, err := a.getSessionFromCtx(ctx)
 		if err != nil {
@@ -242,7 +242,7 @@ func (a *Authenticate) signOutRedirect(w http.ResponseWriter, r *http.Request) e
 	defer span.End()
 
 	options := a.options.Load()
-	idpID := r.FormValue(urlutil.QueryIdentityProviderID)
+	idpID := a.getIdentityProviderIDForRequest(r)
 
 	authenticator, err := a.cfg.getIdentityProvider(options, idpID)
 	if err != nil {
@@ -299,7 +299,7 @@ func (a *Authenticate) reauthenticateOrFail(w http.ResponseWriter, r *http.Reque
 
 	state := a.state.Load()
 	options := a.options.Load()
-	idpID := r.FormValue(urlutil.QueryIdentityProviderID)
+	idpID := a.getIdentityProviderIDForRequest(r)
 
 	authenticator, err := a.cfg.getIdentityProvider(options, idpID)
 	if err != nil {
@@ -403,7 +403,7 @@ Or contact your administrator.
 `, redirectURL.String(), redirectURL.String()))
 	}
 
-	idpID := redirectURL.Query().Get(urlutil.QueryIdentityProviderID)
+	idpID := a.getIdentityProviderIDForURLValues(redirectURL.Query())
 
 	authenticator, err := a.cfg.getIdentityProvider(options, idpID)
 	if err != nil {
@@ -582,4 +582,25 @@ func (a *Authenticate) saveCallbackSession(w http.ResponseWriter, r *http.Reques
 		return nil, fmt.Errorf("proxy: callback session save failure: %w", err)
 	}
 	return rawJWT, nil
+}
+
+func (a *Authenticate) getIdentityProviderIDForRequest(r *http.Request) string {
+	if err := r.ParseForm(); err != nil {
+		return ""
+	}
+	return a.getIdentityProviderIDForURLValues(r.Form)
+}
+
+func (a *Authenticate) getIdentityProviderIDForURLValues(vs url.Values) string {
+	state := a.state.Load()
+	idpID := ""
+	if _, requestParams, err := hpke.DecryptURLValues(state.hpkePrivateKey, vs); err == nil {
+		if idpID == "" {
+			idpID = requestParams.Get(urlutil.QueryIdentityProviderID)
+		}
+	}
+	if idpID == "" {
+		idpID = vs.Get(urlutil.QueryIdentityProviderID)
+	}
+	return idpID
 }


### PR DESCRIPTION
## Summary
Per-route IDP credentials use a `pomerium_idp_id` query string parameter to indicate which credentials they need. The current code is not working because the `pomerium_idp_id` is inside an HPKE encrypted query string. This updates the code to decrypted the URL parameters to find it.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/3976

## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
