### PR TITLE
authorize: allow access to /.pomerium/webauthn when policy denies access

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -226,13 +226,19 @@ func (a *Authorize) requireWebAuthnResponse(
 	opts := a.currentOptions.Load()
 	state := a.state.Load()
 
-	if !a.shouldRedirect(in) {
-		return a.deniedResponse(ctx, in, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), nil)
-	}
-
 	// always assume https scheme
 	checkRequestURL := getCheckRequestURL(in)
 	checkRequestURL.Scheme = "https"
+
+	// If we're already on a webauthn route, return OK.
+	// https://github.com/pomerium/pomerium-console/issues/3210
+	if checkRequestURL.Path == urlutil.WebAuthnURLPath || checkRequestURL.Path == urlutil.DeviceEnrolledPath {
+		return a.okResponse(result.Headers), nil
+	}
+
+	if !a.shouldRedirect(in) {
+		return a.deniedResponse(ctx, in, http.StatusUnauthorized, http.StatusText(http.StatusUnauthorized), nil)
+	}
 
 	q := url.Values{}
 	if deviceType, ok := result.Allow.AdditionalData["device_type"].(string); ok {

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -60,7 +60,7 @@ func (b *Builder) buildPomeriumHTTPRoutes(options *config.Options, host string) 
 		routes = append(routes,
 			// enable ext_authz
 			b.buildControlPlanePathRoute("/.pomerium/jwt", true),
-			b.buildControlPlanePathRoute("/.pomerium/webauthn", true),
+			b.buildControlPlanePathRoute(urlutil.WebAuthnURLPath, true),
 			// disable ext_authz and passthrough to proxy handlers
 			b.buildControlPlanePathRoute("/ping", false),
 			b.buildControlPlanePathRoute("/healthz", false),

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
 	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
 func policyNameFunc() func(*config.Policy) string {
@@ -88,7 +89,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 
 		testutil.AssertProtoJSONEqual(t, `[
 			`+routeString("path", "/.pomerium/jwt", true)+`,
-			`+routeString("path", "/.pomerium/webauthn", true)+`,
+			`+routeString("path", urlutil.WebAuthnURLPath, true)+`,
 			`+routeString("path", "/ping", false)+`,
 			`+routeString("path", "/healthz", false)+`,
 			`+routeString("path", "/.pomerium", false)+`,
@@ -127,7 +128,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 
 		testutil.AssertProtoJSONEqual(t, `[
 			`+routeString("path", "/.pomerium/jwt", true)+`,
-			`+routeString("path", "/.pomerium/webauthn", true)+`,
+			`+routeString("path", urlutil.WebAuthnURLPath, true)+`,
 			`+routeString("path", "/ping", false)+`,
 			`+routeString("path", "/healthz", false)+`,
 			`+routeString("path", "/.pomerium", false)+`,
@@ -155,7 +156,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 
 		testutil.AssertProtoJSONEqual(t, `[
 			`+routeString("path", "/.pomerium/jwt", true)+`,
-			`+routeString("path", "/.pomerium/webauthn", true)+`,
+			`+routeString("path", urlutil.WebAuthnURLPath, true)+`,
 			`+routeString("path", "/ping", false)+`,
 			`+routeString("path", "/healthz", false)+`,
 			`+routeString("path", "/.pomerium", false)+`,

--- a/internal/urlutil/known.go
+++ b/internal/urlutil/known.go
@@ -34,15 +34,21 @@ func SignOutURL(r *http.Request, authenticateURL *url.URL, key []byte) string {
 	return NewSignedURL(key, u).Sign().String()
 }
 
+// Device paths
+const (
+	WebAuthnURLPath    = "/.pomerium/webauthn"
+	DeviceEnrolledPath = "/.pomerium/device-enrolled"
+)
+
 // WebAuthnURL returns the /.pomerium/webauthn URL.
 func WebAuthnURL(r *http.Request, authenticateURL *url.URL, key []byte, values url.Values) string {
 	u := authenticateURL.ResolveReference(&url.URL{
-		Path: "/.pomerium/webauthn",
+		Path: WebAuthnURLPath,
 		RawQuery: buildURLValues(values, url.Values{
 			QueryDeviceType:      {DefaultDeviceType},
 			QueryEnrollmentToken: nil,
 			QueryRedirectURI: {authenticateURL.ResolveReference(&url.URL{
-				Path: "/.pomerium/device-enrolled",
+				Path: DeviceEnrolledPath,
 			}).String()},
 		}).Encode(),
 	})

--- a/pkg/policy/criteria/pomerium_routes.go
+++ b/pkg/policy/criteria/pomerium_routes.go
@@ -3,6 +3,7 @@ package criteria
 import (
 	"github.com/open-policy-agent/opa/ast"
 
+	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/policy/generator"
 	"github.com/pomerium/pomerium/pkg/policy/parser"
 	"github.com/pomerium/pomerium/pkg/policy/rules"
@@ -34,7 +35,7 @@ func (c pomeriumRoutesCriterion) GenerateRule(_ string, _ parser.Value) (*ast.Ru
 	r2.Body = ast.Body{
 		ast.MustParseExpr(`contains(input.http.url, "/.pomerium/")`),
 		ast.MustParseExpr(`not contains(input.http.url, "/.pomerium/jwt")`),
-		ast.MustParseExpr(`not contains(input.http.url, "/.pomerium/webauthn")`),
+		ast.MustParseExpr(`not contains(input.http.url, "` + urlutil.WebAuthnURLPath + `")`),
 	}
 	r1.Else = r2
 


### PR DESCRIPTION
## Summary
The route `/.pomerium/webauthn`, is granted access via the special `pomerium` policy criterion. However when a policy defines a `deny` rule, that rule will take precedent over the `allow` rule. As a result, if there's a device `deny` rule on a route, it will cause an infinite redirect loop to the `/.pomerium/webauthn` path.

This PR updates the `requireWebauthnResponse` so that it always allows access to `/.pomerium/webauthn`.

## Related issues
Fixes https://github.com/pomerium/pomerium-console/issues/3210

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
