### PR TITLE
hpke: move published public keys to a new endpoint

### DIFF
--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -30,13 +30,10 @@ func TestAuthorize_handleResult(t *testing.T) {
 	opt.DataBrokerURLString = "https://databroker.example.com"
 	opt.SharedKey = "E8wWIMnihUx+AUfRegAQDNs8eRb3UrB5G3zlJW9XJDM="
 
-	htpkePrivateKey, err := opt.GetHPKEPrivateKey()
+	hpkePrivateKey, err := opt.GetHPKEPrivateKey()
 	require.NoError(t, err)
 
-	signingKey, err := opt.GetSigningKey()
-	require.NoError(t, err)
-
-	authnSrv := httptest.NewServer(handlers.JWKSHandler(signingKey, htpkePrivateKey.PublicKey()))
+	authnSrv := httptest.NewServer(handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
 	t.Cleanup(authnSrv.Close)
 	opt.AuthenticateURLString = authnSrv.URL
 
@@ -228,13 +225,10 @@ func TestRequireLogin(t *testing.T) {
 	opt.SharedKey = "E8wWIMnihUx+AUfRegAQDNs8eRb3UrB5G3zlJW9XJDM="
 	opt.SigningKey = "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUJlMFRxbXJkSXBZWE03c3pSRERWYndXOS83RWJHVWhTdFFJalhsVHNXM1BvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFb0xaRDI2bEdYREhRQmhhZkdlbEVmRDdlNmYzaURjWVJPVjdUbFlIdHF1Y1BFL2hId2dmYQpNY3FBUEZsRmpueUpySXJhYTFlQ2xZRTJ6UktTQk5kNXBRPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
 
-	htpkePrivateKey, err := opt.GetHPKEPrivateKey()
+	hpkePrivateKey, err := opt.GetHPKEPrivateKey()
 	require.NoError(t, err)
 
-	signingKey, err := opt.GetSigningKey()
-	require.NoError(t, err)
-
-	authnSrv := httptest.NewServer(handlers.JWKSHandler(signingKey, htpkePrivateKey.PublicKey()))
+	authnSrv := httptest.NewServer(handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
 	t.Cleanup(authnSrv.Close)
 	opt.AuthenticateURLString = authnSrv.URL
 

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
+	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/derivecert"
 	"github.com/pomerium/pomerium/pkg/hpke"
@@ -253,7 +254,7 @@ func (cfg *Config) GetAuthenticateKeyFetcher() (hpke.KeyFetcher, error) {
 		return nil, err
 	}
 	jwksURL := authenticateURL.ResolveReference(&url.URL{
-		Path: "/.well-known/pomerium/jwks.json",
+		Path: urlutil.HPKEPublicKeyPath,
 	}).String()
 	return hpke.NewKeyFetcher(jwksURL, transport), nil
 }

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pomerium/pomerium/internal/middleware"
 	"github.com/pomerium/pomerium/internal/telemetry"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
+	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
 func (srv *Server) addHTTPMiddleware(root *mux.Router, cfg *config.Config) {
@@ -68,6 +69,7 @@ func (srv *Server) mountCommonEndpoints(root *mux.Router, cfg *config.Config) er
 	root.HandleFunc("/ping", handlers.HealthCheck)
 	root.Handle("/.well-known/pomerium", handlers.WellKnownPomerium(authenticateURL))
 	root.Handle("/.well-known/pomerium/", handlers.WellKnownPomerium(authenticateURL))
-	root.Path("/.well-known/pomerium/jwks.json").Methods(http.MethodGet).Handler(handlers.JWKSHandler(signingKey, hpkePublicKey))
+	root.Path("/.well-known/pomerium/jwks.json").Methods(http.MethodGet).Handler(handlers.JWKSHandler(signingKey))
+	root.Path(urlutil.HPKEPublicKeyPath).Methods(http.MethodGet).Handler(handlers.HPKEPublicKeyHandler(hpkePublicKey))
 	return nil
 }

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"testing"
 
@@ -77,14 +78,22 @@ func TestServerHTTP(t *testing.T) {
 					"x":   "UG5xCP0JTT1H6Iol8jKuTIPVLM04CgW9PlEypNRmWlo",
 					"y":   "KChF0fR09zm884ymInM29PtSsFdnzExNfLsP-ta1AgQ",
 				},
-				map[string]any{
-					"kty": "OKP",
-					"kid": "pomerium/hpke",
-					"crv": "X25519",
-					"x":   "T0cbNrJbO9in-FgowKAP-HX6Ci8q50gopOt52sdheHg",
-				},
 			},
 		}
 		assert.Equal(t, expect, actual)
+	})
+	t.Run("hpke-public-key", func(t *testing.T) {
+		res, err := http.Get(fmt.Sprintf("http://localhost:%s/.well-known/pomerium/hpke-public-key", src.GetConfig().HTTPPort))
+		require.NoError(t, err)
+		defer res.Body.Close()
+
+		bs, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		assert.Equal(t, []byte{
+			0x4f, 0x47, 0x1b, 0x36, 0xb2, 0x5b, 0x3b, 0xd8,
+			0xa7, 0xf8, 0x58, 0x28, 0xc0, 0xa0, 0x0f, 0xf8,
+			0x75, 0xfa, 0x0a, 0x2f, 0x2a, 0xe7, 0x48, 0x28,
+			0xa4, 0xeb, 0x79, 0xda, 0xc7, 0x61, 0x78, 0x78,
+		}, bs)
 	})
 }

--- a/internal/handlers/hpke_public_key.go
+++ b/internal/handlers/hpke_public_key.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"bytes"
+	"fmt"
+	"hash/fnv"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/rs/cors"
+
+	"github.com/pomerium/pomerium/internal/httputil"
+	"github.com/pomerium/pomerium/pkg/hpke"
+)
+
+// HPKEPublicKeyHandler returns a handler which returns the HPKE public key.
+func HPKEPublicKeyHandler(publicKey *hpke.PublicKey) http.Handler {
+	return cors.AllowAll().Handler(httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		bs := publicKey.Bytes()
+
+		hasher := fnv.New64()
+		_, _ = hasher.Write(bs)
+		h := hasher.Sum64()
+
+		w.Header().Set("Cache-Control", "max-age=60")
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", strconv.Itoa(len(bs)))
+		w.Header().Set("ETag", fmt.Sprintf(`"%x"`, h))
+		http.ServeContent(w, r, "hpke-public-key", time.Time{}, bytes.NewReader(bs))
+		return nil
+	}))
+}

--- a/internal/handlers/hpke_public_key_test.go
+++ b/internal/handlers/hpke_public_key_test.go
@@ -1,0 +1,34 @@
+package handlers_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/internal/handlers"
+	"github.com/pomerium/pomerium/pkg/hpke"
+)
+
+func TestHPKEPublicKeyHandler(t *testing.T) {
+	t.Parallel()
+
+	k1 := hpke.DerivePrivateKey([]byte("TEST"))
+
+	t.Run("cors", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodOptions, "/", nil)
+		r.Header.Set("Origin", "https://www.example.com")
+		r.Header.Set("Access-Control-Request-Method", "GET")
+		handlers.HPKEPublicKeyHandler(k1.PublicKey()).ServeHTTP(w, r)
+		assert.Equal(t, http.StatusNoContent, w.Result().StatusCode)
+	})
+	t.Run("keys", func(t *testing.T) {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/", nil)
+		handlers.HPKEPublicKeyHandler(k1.PublicKey()).ServeHTTP(w, r)
+
+		assert.Equal(t, k1.PublicKey().Bytes(), w.Body.Bytes())
+	})
+}

--- a/internal/handlers/jwks.go
+++ b/internal/handlers/jwks.go
@@ -17,10 +17,7 @@ import (
 )
 
 // JWKSHandler returns the /.well-known/pomerium/jwks.json handler.
-func JWKSHandler(
-	signingKey []byte,
-	additionalKeys ...any,
-) http.Handler {
+func JWKSHandler(signingKey []byte) http.Handler {
 	return cors.AllowAll().Handler(httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		var jwks struct {
 			Keys []any `json:"keys"`
@@ -34,7 +31,6 @@ func JWKSHandler(
 				jwks.Keys = append(jwks.Keys, *k)
 			}
 		}
-		jwks.Keys = append(jwks.Keys, additionalKeys...)
 
 		bs, err := json.Marshal(jwks)
 		if err != nil {

--- a/internal/urlutil/known.go
+++ b/internal/urlutil/known.go
@@ -13,6 +13,9 @@ import (
 	"github.com/pomerium/pomerium/pkg/hpke"
 )
 
+// HPKEPublicKeyPath is the well-known path to the HPKE public key
+const HPKEPublicKeyPath = "/.well-known/pomerium/hpke-public-key"
+
 // DefaultDeviceType is the default device type when none is specified.
 const DefaultDeviceType = "any"
 

--- a/pkg/hpke/hpke.go
+++ b/pkg/hpke/hpke.go
@@ -97,6 +97,16 @@ type PublicKey struct {
 	key kem.PublicKey
 }
 
+// PublicKeyFromBytes converts raw bytes into a public key.
+func PublicKeyFromBytes(raw []byte) (*PublicKey, error) {
+	key, err := kemID.Scheme().UnmarshalBinaryPublicKey(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PublicKey{key: key}, nil
+}
+
 // PublicKeyFromString converts a string into a public key.
 func PublicKeyFromString(raw string) (*PublicKey, error) {
 	bs, err := decode(raw)
@@ -126,6 +136,20 @@ func (key *PublicKey) Equals(other *PublicKey) bool {
 		return false
 	}
 	return key.key.Equal(other.key)
+}
+
+// Bytes returns the public key as raw bytes.
+func (key *PublicKey) Bytes() []byte {
+	if key == nil || key.key == nil {
+		return nil
+	}
+
+	bs, err := key.key.MarshalBinary()
+	if err != nil {
+		// this should not happen
+		panic(fmt.Sprintf("failed to marshal public HPKE key: %v", err))
+	}
+	return bs
 }
 
 // MarshalJSON returns the JSON Web Key representation of the public key.

--- a/pkg/hpke/http_test.go
+++ b/pkg/hpke/http_test.go
@@ -24,11 +24,11 @@ func TestFetchPublicKeyFromJWKS(t *testing.T) {
 	require.NoError(t, err)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handlers.JWKSHandler(nil, hpkePrivateKey.PublicKey()).ServeHTTP(w, r)
+		handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()).ServeHTTP(w, r)
 	}))
 	t.Cleanup(srv.Close)
 
-	publicKey, err := hpke.FetchPublicKeyFromJWKS(ctx, http.DefaultClient, srv.URL)
+	publicKey, err := hpke.FetchPublicKey(ctx, http.DefaultClient, srv.URL)
 	assert.NoError(t, err)
 	assert.Equal(t, hpkePrivateKey.PublicKey().String(), publicKey.String())
 }

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -30,13 +30,10 @@ func testOptions(t *testing.T) *config.Options {
 	opts.SharedKey = "80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ="
 	opts.CookieSecret = "OromP1gurwGWjQPYb1nNgSxtbVB5NnLzX6z5WOKr0Yw="
 
-	htpkePrivateKey, err := opts.GetHPKEPrivateKey()
+	hpkePrivateKey, err := opts.GetHPKEPrivateKey()
 	require.NoError(t, err)
 
-	signingKey, err := opts.GetSigningKey()
-	require.NoError(t, err)
-
-	authnSrv := httptest.NewServer(handlers.JWKSHandler(signingKey, htpkePrivateKey.PublicKey()))
+	authnSrv := httptest.NewServer(handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
 	t.Cleanup(authnSrv.Close)
 	opts.AuthenticateURLString = authnSrv.URL
 


### PR DESCRIPTION
## Summary
Publishing the HPKE public key to the jwks endpoint caused problems. This PR moves it to a separate endpoint.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/4029
 

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
