### PR TITLE
store authenticate state on creation

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -51,6 +51,8 @@ func New(cfg *config.Config, options ...Option) (*Authenticate, error) {
 		state:   atomicutil.NewValue(newAuthenticateState()),
 	}
 
+	a.options.Store(cfg.Options)
+
 	state, err := newAuthenticateStateFromConfig(cfg)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

The config was not stored on authenticate initialization, and was only applied on config change. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
