### PR TITLE
move hpke public key handler out of internal

### DIFF
--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -20,8 +20,8 @@ import (
 	"github.com/pomerium/pomerium/authorize/internal/store"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/atomicutil"
-	"github.com/pomerium/pomerium/internal/handlers"
 	"github.com/pomerium/pomerium/internal/testutil"
+	hpke_handlers "github.com/pomerium/pomerium/pkg/hpke/handlers"
 	"github.com/pomerium/pomerium/pkg/policy/criteria"
 )
 
@@ -33,7 +33,7 @@ func TestAuthorize_handleResult(t *testing.T) {
 	hpkePrivateKey, err := opt.GetHPKEPrivateKey()
 	require.NoError(t, err)
 
-	authnSrv := httptest.NewServer(handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
+	authnSrv := httptest.NewServer(hpke_handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
 	t.Cleanup(authnSrv.Close)
 	opt.AuthenticateURLString = authnSrv.URL
 
@@ -228,7 +228,7 @@ func TestRequireLogin(t *testing.T) {
 	hpkePrivateKey, err := opt.GetHPKEPrivateKey()
 	require.NoError(t, err)
 
-	authnSrv := httptest.NewServer(handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
+	authnSrv := httptest.NewServer(hpke_handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
 	t.Cleanup(authnSrv.Close)
 	opt.AuthenticateURLString = authnSrv.URL
 

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pomerium/pomerium/internal/telemetry"
 	"github.com/pomerium/pomerium/internal/telemetry/requestid"
 	"github.com/pomerium/pomerium/internal/urlutil"
+	hpke_handlers "github.com/pomerium/pomerium/pkg/hpke/handlers"
 )
 
 func (srv *Server) addHTTPMiddleware(root *mux.Router, cfg *config.Config) {
@@ -70,6 +71,6 @@ func (srv *Server) mountCommonEndpoints(root *mux.Router, cfg *config.Config) er
 	root.Handle("/.well-known/pomerium", handlers.WellKnownPomerium(authenticateURL))
 	root.Handle("/.well-known/pomerium/", handlers.WellKnownPomerium(authenticateURL))
 	root.Path("/.well-known/pomerium/jwks.json").Methods(http.MethodGet).Handler(handlers.JWKSHandler(signingKey))
-	root.Path(urlutil.HPKEPublicKeyPath).Methods(http.MethodGet).Handler(handlers.HPKEPublicKeyHandler(hpkePublicKey))
+	root.Path(urlutil.HPKEPublicKeyPath).Methods(http.MethodGet).Handler(hpke_handlers.HPKEPublicKeyHandler(hpkePublicKey))
 	return nil
 }

--- a/pkg/hpke/handlers/hpke_public_key.go
+++ b/pkg/hpke/handlers/hpke_public_key.go
@@ -1,3 +1,4 @@
+// Package handlers provides http handlers for HPKE.
 package handlers
 
 import (
@@ -11,8 +12,12 @@ import (
 	"github.com/rs/cors"
 
 	"github.com/pomerium/pomerium/internal/httputil"
+	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/hpke"
 )
+
+// HPKEPublicKeyPath is the path to the HPKE public key.
+const HPKEPublicKeyPath = urlutil.HPKEPublicKeyPath
 
 // HPKEPublicKeyHandler returns a handler which returns the HPKE public key.
 func HPKEPublicKeyHandler(publicKey *hpke.PublicKey) http.Handler {

--- a/pkg/hpke/handlers/hpke_public_key_test.go
+++ b/pkg/hpke/handlers/hpke_public_key_test.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/pomerium/pomerium/internal/handlers"
 	"github.com/pomerium/pomerium/pkg/hpke"
+	"github.com/pomerium/pomerium/pkg/hpke/handlers"
 )
 
 func TestHPKEPublicKeyHandler(t *testing.T) {

--- a/pkg/hpke/http_test.go
+++ b/pkg/hpke/http_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/pomerium/pomerium/internal/handlers"
 	"github.com/pomerium/pomerium/pkg/hpke"
+	hpke_handlers "github.com/pomerium/pomerium/pkg/hpke/handlers"
 )
 
 func TestFetchPublicKeyFromJWKS(t *testing.T) {
@@ -24,7 +24,7 @@ func TestFetchPublicKeyFromJWKS(t *testing.T) {
 	require.NoError(t, err)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()).ServeHTTP(w, r)
+		hpke_handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()).ServeHTTP(w, r)
 	}))
 	t.Cleanup(srv.Close)
 

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/handlers"
+	hpke_handlers "github.com/pomerium/pomerium/pkg/hpke/handlers"
 
 	"github.com/stretchr/testify/require"
 )
@@ -33,7 +33,7 @@ func testOptions(t *testing.T) *config.Options {
 	hpkePrivateKey, err := opts.GetHPKEPrivateKey()
 	require.NoError(t, err)
 
-	authnSrv := httptest.NewServer(handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
+	authnSrv := httptest.NewServer(hpke_handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
 	t.Cleanup(authnSrv.Close)
 	opts.AuthenticateURLString = authnSrv.URL
 


### PR DESCRIPTION
## Summary

Moves HPKE Public Key handler out of `internal` so that it could be referenced from other repos.

## Related issues

Related: https://github.com/pomerium/internal/issues/1310

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
