### PR TITLE
authenticate: have an option to trim the contents of the callback

### DIFF
--- a/authenticate/config.go
+++ b/authenticate/config.go
@@ -3,10 +3,12 @@ package authenticate
 import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/identity"
+	identitypb "github.com/pomerium/pomerium/pkg/grpc/identity"
 )
 
 type authenticateConfig struct {
 	getIdentityProvider func(options *config.Options, idpID string) (identity.Authenticator, error)
+	profileTrimFn       func(*identitypb.Profile)
 }
 
 // An Option customizes the Authenticate config.
@@ -25,5 +27,12 @@ func getAuthenticateConfig(options ...Option) *authenticateConfig {
 func WithGetIdentityProvider(getIdentityProvider func(options *config.Options, idpID string) (identity.Authenticator, error)) Option {
 	return func(cfg *authenticateConfig) {
 		cfg.getIdentityProvider = getIdentityProvider
+	}
+}
+
+// WithProfileTrimFn sets the profileTrimFn function in the config
+func WithProfileTrimFn(profileTrimFn func(*identitypb.Profile)) Option {
+	return func(cfg *authenticateConfig) {
+		cfg.profileTrimFn = profileTrimFn
 	}
 }

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -212,6 +212,10 @@ func (a *Authenticate) SignIn(w http.ResponseWriter, r *http.Request) error {
 		return httputil.NewError(http.StatusBadRequest, err)
 	}
 
+	if a.cfg.profileTrimFn != nil {
+		a.cfg.profileTrimFn(profile)
+	}
+
 	redirectTo, err := urlutil.CallbackURL(state.hpkePrivateKey, proxyPublicKey, requestParams, profile)
 	if err != nil {
 		return httputil.NewError(http.StatusInternalServerError, err)


### PR DESCRIPTION
## Summary

The user identity protobuf passed by the authenticate may need be stripped down from unnecessary information. Adds a hook to customize the behaviour. 

## Related issues

Related: https://github.com/pomerium/pomerium-zero/issues/35

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
