### PR TITLE
dependencies: upgrade go and envoy

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         node-version: [16.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
 
       - name: Set up Docker
         run: docker run --rm --privileged multiarch/qemu-user-static --reset -p yes

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         node-version: [16.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         node-version: [16.x]
     steps:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         node-version: [16.x]
         platform: [ubuntu-latest]
         deployment: [multi, single]
@@ -160,7 +160,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         node-version: [16.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
@@ -224,7 +224,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
       - uses: actions/setup-python@d27e3f3d7c64b4bbf8e4abfb9b63b83e846e0435
         with:
           python-version: "3.x"
@@ -240,14 +240,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.20.x]
         platform: [ubuntu-latest]
     needs:
       - build
     steps:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
-          go-version: 1.19.x
+          go-version: 1.20.x
 
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.19.2
+golang 1.20.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pomerium/pomerium
 
-go 1.19
+go 1.20
 
 require (
 	contrib.go.opencensus.io/exporter/jaeger v0.2.1

--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -5,7 +5,7 @@ PATH="$PATH:$(go env GOPATH)/bin"
 export PATH
 
 _project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/.."
-_envoy_version=1.25.0
+_envoy_version=1.25.5
 _dir="$_project_root/pkg/envoy/files"
 
 for _target in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do


### PR DESCRIPTION
## Summary
Upgrade go to 1.20.3. Upgrade envoy to 1.25.5.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1335
 

## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
