### PR TITLE
tls: wildcard catch-all cert must be at the end of cert list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .*.yaml
 .*.json
 .*.rego
+*.jq
 pem
 env
 coverage.txt

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -114,9 +114,7 @@ func getAllCertificates(cfg *config.Config) ([]tls.Certificate, error) {
 		return nil, fmt.Errorf("error getting wildcard certificate: %w", err)
 	}
 
-	// wildcard certificate must be first so that it is used as the default certificate
-	// when no SNI matches
-	return append([]tls.Certificate{*wc}, allCertificates...), nil
+	return append(allCertificates, *wc), nil
 }
 
 func (b *Builder) buildTLSSocket(ctx context.Context, cfg *config.Config, certs []tls.Certificate) (*envoy_config_core_v3.TransportSocket, error) {


### PR DESCRIPTION
## Summary

Wildcard catch-all "*" cert must be at the very bottom of cert list so that it'll get matched last. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
