### PR TITLE
config: add support for wildcard from addresses

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -38,6 +38,7 @@ type Request struct {
 // RequestHTTP is the HTTP field in the request.
 type RequestHTTP struct {
 	Method            string            `json:"method"`
+	Hostname          string            `json:"hostname"`
 	Path              string            `json:"path"`
 	URL               string            `json:"url"`
 	Headers           map[string]string `json:"headers"`
@@ -55,6 +56,7 @@ func NewRequestHTTP(
 ) RequestHTTP {
 	return RequestHTTP{
 		Method:            method,
+		Hostname:          requestURL.Hostname(),
 		Path:              requestURL.Path,
 		URL:               requestURL.String(),
 		Headers:           headers,
@@ -162,7 +164,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, req *Request) (*Result, error)
 
 	var headersOutput *HeadersResponse
 	eg.Go(func() error {
-		headersReq := NewHeadersRequestFromPolicy(req.Policy)
+		headersReq := NewHeadersRequestFromPolicy(req.Policy, req.HTTP.Hostname)
 		headersReq.Session = req.Session
 		var err error
 		headersOutput, err = e.headersEvaluators.Evaluate(ectx, headersReq)

--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pomerium/pomerium/authorize/internal/store"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
-	"github.com/pomerium/pomerium/internal/urlutil"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 )
 
@@ -29,14 +28,12 @@ type HeadersRequest struct {
 }
 
 // NewHeadersRequestFromPolicy creates a new HeadersRequest from a policy.
-func NewHeadersRequestFromPolicy(policy *config.Policy) *HeadersRequest {
+func NewHeadersRequestFromPolicy(policy *config.Policy, hostname string) *HeadersRequest {
 	input := new(HeadersRequest)
 	input.EnableGoogleCloudServerlessAuthentication = policy.EnableGoogleCloudServerlessAuthentication
 	input.EnableRoutingKey = policy.EnvoyOpts.GetLbPolicy() == envoy_config_cluster_v3.Cluster_RING_HASH ||
 		policy.EnvoyOpts.GetLbPolicy() == envoy_config_cluster_v3.Cluster_MAGLEV
-	if u, err := urlutil.ParseAndValidateURL(policy.From); err == nil {
-		input.Issuer = u.Hostname()
-	}
+	input.Issuer = hostname
 	input.KubernetesServiceAccountToken = policy.KubernetesServiceAccountToken
 	for _, wu := range policy.To {
 		input.ToAudience = "https://" + wu.URL.Hostname()

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -22,13 +22,13 @@ import (
 func TestNewHeadersRequestFromPolicy(t *testing.T) {
 	req := NewHeadersRequestFromPolicy(&config.Policy{
 		EnableGoogleCloudServerlessAuthentication: true,
-		From: "https://from.example.com",
+		From: "https://*.example.com",
 		To: config.WeightedURLs{
 			{
 				URL: *mustParseURL("http://to.example.com"),
 			},
 		},
-	})
+	}, "from.example.com")
 	assert.Equal(t, &HeadersRequest{
 		EnableGoogleCloudServerlessAuthentication: true,
 		Issuer:     "from.example.com",

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"strings"
 	"time"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -570,7 +571,13 @@ func getAllRouteableHosts(options *config.Options, addr string) ([]string, error
 		allHosts.Add(hosts...)
 	}
 
-	return allHosts.ToSlice(), nil
+	var filtered []string
+	for _, host := range allHosts.ToSlice() {
+		if !strings.Contains(host, "*") {
+			filtered = append(filtered, host)
+		}
+	}
+	return filtered, nil
 }
 
 func urlsMatchHost(urls []*url.URL, host string) bool {

--- a/config/envoyconfig/route_configurations.go
+++ b/config/envoyconfig/route_configurations.go
@@ -78,7 +78,7 @@ func (b *Builder) buildMainRouteConfiguration(
 
 		// if we're the proxy, add all the policy routes
 		if config.IsProxy(cfg.Options.Services) {
-			rs, err := b.buildPolicyRoutes(cfg.Options, host, requireStrictTransportSecurity)
+			rs, err := b.buildRoutesForPoliciesWithHost(cfg, host)
 			if err != nil {
 				return nil, err
 			}
@@ -94,6 +94,14 @@ func (b *Builder) buildMainRouteConfiguration(
 	if err != nil {
 		return nil, err
 	}
+	if config.IsProxy(cfg.Options.Services) {
+		rs, err := b.buildRoutesForPoliciesWithCatchAll(cfg)
+		if err != nil {
+			return nil, err
+		}
+		vh.Routes = append(vh.Routes, rs...)
+	}
+
 	virtualHosts = append(virtualHosts, vh)
 
 	rc, err := b.buildRouteConfiguration("main", virtualHosts)

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -53,7 +53,7 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 						"name": "policy-0",
 						"match": {
 							"headers": [
-								{ "name": ":authority", "stringMatch": { "safeRegex": { "googleRe2": {}, "regex": "(.*)\\.example\\.com" } }}
+								{ "name": ":authority", "stringMatch": { "safeRegex": { "regex": "^(.*)\\.example\\.com$" } }}
 							],
 							"prefix": "/"
 						},
@@ -95,7 +95,7 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 						"name": "policy-0",
 						"match": {
 							"headers": [
-								{ "name": ":authority", "stringMatch": { "safeRegex": { "googleRe2": {}, "regex": "(.*)\\.example\\.com:443" } }}
+								{ "name": ":authority", "stringMatch": { "safeRegex": { "regex": "^(.*)\\.example\\.com:443$" } }}
 							],
 							"prefix": "/"
 						},

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -1,0 +1,141 @@
+package envoyconfig
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/encoding/protojson"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
+	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+)
+
+func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := &config.Config{Options: &config.Options{
+		CookieName:             "pomerium",
+		DefaultUpstreamTimeout: time.Second * 3,
+		SharedKey:              cryptutil.NewBase64Key(),
+		Services:               "proxy",
+		Policies: []config.Policy{
+			{
+				From: "https://*.example.com",
+			},
+		},
+	}}
+	b := New("grpc", "http", "metrics", filemgr.NewManager(), nil)
+	routeConfiguration, err := b.buildMainRouteConfiguration(ctx, cfg)
+	assert.NoError(t, err)
+	testutil.AssertProtoJSONEqual(t, `{
+		"name": "main",
+		"validateClusters": false,
+		"virtualHosts": [
+			{
+				"name": "catch-all",
+				"domains": ["*"],
+				"routes": [
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium/jwt", true, false))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium/webauthn", true, false))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/ping", false, false))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/healthz", false, false))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium", false, false))+`,
+					`+protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.pomerium/", false, false))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.well-known/pomerium", false, false))+`,
+					`+protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.well-known/pomerium/", false, false))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/robots.txt", false, false))+`,
+					{
+						"name": "policy-0",
+						"match": {
+							"headers": [
+								{ "name": ":authority", "stringMatch": { "safeRegex": { "googleRe2": {}, "regex": "(.*)\\.example\\.com" } }}
+							],
+							"prefix": "/"
+						},
+						"metadata": {
+							"filterMetadata": {
+								"envoy.filters.http.lua": {
+									"remove_impersonate_headers": false,
+									"remove_pomerium_authorization": true,
+									"remove_pomerium_cookie": "pomerium",
+									"rewrite_response_headers": []
+								}
+							}
+						},
+						"requestHeadersToRemove": [
+							"x-pomerium-jwt-assertion",
+							"x-pomerium-jwt-assertion-for",
+							"x-pomerium-reproxy-policy",
+							"x-pomerium-reproxy-policy-hmac"
+						],
+						"responseHeadersToAdd": [
+							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-Frame-Options", "value": "SAMEORIGIN" } },
+							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-XSS-Protection", "value": "1; mode=block" } }
+						],
+						"route": {
+							"autoHostRewrite": true,
+							"cluster": "route-0",
+							"hashPolicy": [
+								{ "header": { "headerName": "x-pomerium-routing-key" }, "terminal": true },
+								{ "connectionProperties": { "sourceIp": true }, "terminal": true }
+							],
+							"timeout": "3s",
+							"upgradeConfigs": [
+								{ "enabled": false, "upgradeType": "websocket" },
+								{ "enabled": false, "upgradeType": "spdy/3.1" }
+							]
+						}
+					},
+					{
+						"name": "policy-0",
+						"match": {
+							"headers": [
+								{ "name": ":authority", "stringMatch": { "safeRegex": { "googleRe2": {}, "regex": "(.*)\\.example\\.com:443" } }}
+							],
+							"prefix": "/"
+						},
+						"metadata": {
+							"filterMetadata": {
+								"envoy.filters.http.lua": {
+									"remove_impersonate_headers": false,
+									"remove_pomerium_authorization": true,
+									"remove_pomerium_cookie": "pomerium",
+									"rewrite_response_headers": []
+								}
+							}
+						},
+						"requestHeadersToRemove": [
+							"x-pomerium-jwt-assertion",
+							"x-pomerium-jwt-assertion-for",
+							"x-pomerium-reproxy-policy",
+							"x-pomerium-reproxy-policy-hmac"
+						],
+						"responseHeadersToAdd": [
+							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-Frame-Options", "value": "SAMEORIGIN" } },
+							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-XSS-Protection", "value": "1; mode=block" } }
+						],
+						"route": {
+							"autoHostRewrite": true,
+							"cluster": "route-0",
+							"hashPolicy": [
+								{ "header": { "headerName": "x-pomerium-routing-key" }, "terminal": true },
+								{ "connectionProperties": { "sourceIp": true }, "terminal": true }
+							],
+							"timeout": "3s",
+							"upgradeConfigs": [
+								{ "enabled": false, "upgradeType": "websocket" },
+								{ "enabled": false, "upgradeType": "spdy/3.1" }
+							]
+						}
+					}
+				]
+			}
+		]
+
+	}`, routeConfiguration)
+}

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"regexp"
 	"sort"
 	"strings"
 
@@ -530,7 +529,7 @@ func mkRouteMatchForHost(
 						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
 							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
 						},
-						Regex: wildcardToRegex(host),
+						Regex: config.WildcardToRegex(host),
 					},
 				},
 			},
@@ -674,20 +673,4 @@ func getRewriteHeadersMetadata(headers []config.RewriteHeader) *structpb.Value {
 	_ = json.Unmarshal(bs, &obj)
 	v, _ := structpb.NewValue(obj)
 	return v
-}
-
-// wildcardToRegex converts a wildcard string into a regular expression
-func wildcardToRegex(wildcard string) string {
-	var b strings.Builder
-	for {
-		idx := strings.IndexByte(wildcard, '*')
-		if idx < 0 {
-			break
-		}
-		b.WriteString(regexp.QuoteMeta(wildcard[:idx]))
-		b.WriteString("(.*)")
-		wildcard = wildcard[idx+1:]
-	}
-	b.WriteString(regexp.QuoteMeta(wildcard))
-	return b.String()
 }

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -499,9 +499,6 @@ func mkRouteMatch(policy *config.Policy) *envoy_config_route_v3.RouteMatch {
 	case policy.Regex != "":
 		match.PathSpecifier = &envoy_config_route_v3.RouteMatch_SafeRegex{
 			SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-				EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-					GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-				},
 				Regex: policy.Regex,
 			},
 		}
@@ -526,9 +523,6 @@ func mkRouteMatchForHost(
 			StringMatch: &envoy_type_matcher_v3.StringMatcher{
 				MatchPattern: &envoy_type_matcher_v3.StringMatcher_SafeRegex{
 					SafeRegex: &envoy_type_matcher_v3.RegexMatcher{
-						EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-							GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-						},
 						Regex: config.WildcardToRegex(host),
 					},
 				},
@@ -591,9 +585,6 @@ func getRewriteOptions(policy *config.Policy) (prefixRewrite string, regexRewrit
 	} else if policy.RegexRewritePattern != "" {
 		regexRewrite = &envoy_type_matcher_v3.RegexMatchAndSubstitute{
 			Pattern: &envoy_type_matcher_v3.RegexMatcher{
-				EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-					GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-				},
 				Regex: policy.RegexRewritePattern,
 			},
 			Substitution: policy.RegexRewriteSubstitution,
@@ -619,9 +610,6 @@ func setHostRewriteOptions(policy *config.Policy, action *envoy_config_route_v3.
 		action.HostRewriteSpecifier = &envoy_config_route_v3.RouteAction_HostRewritePathRegex{
 			HostRewritePathRegex: &envoy_type_matcher_v3.RegexMatchAndSubstitute{
 				Pattern: &envoy_type_matcher_v3.RegexMatcher{
-					EngineType: &envoy_type_matcher_v3.RegexMatcher_GoogleRe2{
-						GoogleRe2: &envoy_type_matcher_v3.RegexMatcher_GoogleRE2{},
-					},
 					Regex: policy.HostPathRegexRewritePattern,
 				},
 				Substitution: policy.HostPathRegexRewriteSubstitution,

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -606,7 +606,6 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				"name": "policy-4",
 				"match": {
 					"safeRegex": {
-						"googleRe2": {},
 						"regex": "^/[a]+$"
 					}
 				},
@@ -1417,7 +1416,6 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 					"autoHostRewrite": true,
 					"regexRewrite": {
 						"pattern": {
-							"googleRe2": {},
 							"regex": "^/service/([^/]+)(/.*)$"
 						},
 						"substitution": "\\2/instance/\\1"
@@ -1602,7 +1600,6 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 				"route": {
 					"hostRewritePathRegex": {
 						"pattern": {
-							"googleRe2": {},
 							"regex": "^/(.+)/.+$"
 						},
 						"substitution": "\\1"

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
 	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/internal/urlutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
 func policyNameFunc() func(*config.Policy) string {
@@ -293,9 +294,10 @@ func TestTimeouts(t *testing.T) {
 
 	for _, tc := range testCases {
 		b := &Builder{filemgr: filemgr.NewManager()}
-		routes, err := b.buildPolicyRoutes(&config.Options{
+		routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
 			CookieName:             "pomerium",
 			DefaultUpstreamTimeout: time.Second * 3,
+			SharedKey:              cryptutil.NewBase64Key(),
 			Policies: []config.Policy{
 				{
 					From:            "https://example.com",
@@ -305,7 +307,7 @@ func TestTimeouts(t *testing.T) {
 					AllowWebsockets: tc.allowWebsockets,
 				},
 			},
-		}, "example.com", false)
+		}}, "example.com")
 		if !assert.NoError(t, err, "%v", tc) || !assert.Len(t, routes, 1, tc) || !assert.NotNil(t, routes[0].GetRoute(), "%v", tc) {
 			continue
 		}
@@ -347,9 +349,10 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	ten := time.Second * 10
 
 	b := &Builder{filemgr: filemgr.NewManager()}
-	routes, err := b.buildPolicyRoutes(&config.Options{
+	routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
 		CookieName:             "pomerium",
 		DefaultUpstreamTimeout: time.Second * 3,
+		SharedKey:              cryptutil.NewBase64Key(),
 		Policies: []config.Policy{
 			{
 				From:                "https://ignore.example.com",
@@ -409,7 +412,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				UpstreamTimeout:     &ten,
 			},
 		},
-	}, "example.com", false)
+	}}, "example.com")
 	require.NoError(t, err)
 
 	testutil.AssertProtoJSONEqual(t, `
@@ -904,18 +907,19 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	`, routes)
 
 	t.Run("fronting-authenticate", func(t *testing.T) {
-		routes, err := b.buildPolicyRoutes(&config.Options{
+		routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
 			AuthenticateURLString:  "https://authenticate.example.com",
 			Services:               "proxy",
 			CookieName:             "pomerium",
 			DefaultUpstreamTimeout: time.Second * 3,
+			SharedKey:              cryptutil.NewBase64Key(),
 			Policies: []config.Policy{
 				{
 					From:                "https://authenticate.example.com",
 					PassIdentityHeaders: true,
 				},
 			},
-		}, "authenticate.example.com", false)
+		}}, "authenticate.example.com")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `
@@ -987,9 +991,10 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	})
 
 	t.Run("tcp", func(t *testing.T) {
-		routes, err := b.buildPolicyRoutes(&config.Options{
+		routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
 			CookieName:             "pomerium",
 			DefaultUpstreamTimeout: time.Second * 3,
+			SharedKey:              cryptutil.NewBase64Key(),
 			Policies: []config.Policy{
 				{
 					From:                "tcp+https://example.com:22",
@@ -1001,7 +1006,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					UpstreamTimeout:     &ten,
 				},
 			},
-		}, "example.com:22", false)
+		}}, "example.com:22")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `
@@ -1133,11 +1138,12 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	})
 
 	t.Run("remove-pomerium-headers", func(t *testing.T) {
-		routes, err := b.buildPolicyRoutes(&config.Options{
+		routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
 			AuthenticateURLString:  "https://authenticate.example.com",
 			Services:               "proxy",
 			CookieName:             "pomerium",
 			DefaultUpstreamTimeout: time.Second * 3,
+			SharedKey:              cryptutil.NewBase64Key(),
 			JWTClaimsHeaders: map[string]string{
 				"x-email": "email",
 			},
@@ -1146,7 +1152,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					From: "https://from.example.com",
 				},
 			},
-		}, "from.example.com", false)
+		}}, "from.example.com")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `
@@ -1224,9 +1230,10 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 	}(getClusterID)
 	getClusterID = policyNameFunc()
 	b := &Builder{filemgr: filemgr.NewManager()}
-	routes, err := b.buildPolicyRoutes(&config.Options{
+	routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
 		CookieName:             "pomerium",
 		DefaultUpstreamTimeout: time.Second * 3,
+		SharedKey:              cryptutil.NewBase64Key(),
 		Policies: []config.Policy{
 			{
 				From:                "https://example.com",
@@ -1266,7 +1273,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 				HostPathRegexRewriteSubstitution: "\\1",
 			},
 		},
-	}, "example.com", false)
+	}}, "example.com")
 	require.NoError(t, err)
 
 	testutil.AssertProtoJSONEqual(t, `

--- a/config/from.go
+++ b/config/from.go
@@ -1,0 +1,47 @@
+package config
+
+import (
+	"net/url"
+	"regexp"
+	"strings"
+
+	"github.com/pomerium/pomerium/internal/urlutil"
+)
+
+// FromURLMatchesRequestURL returns true if the from URL matches the request URL.
+func FromURLMatchesRequestURL(fromURL, requestURL *url.URL) bool {
+	for _, domain := range urlutil.GetDomainsForURL(fromURL) {
+		if domain == requestURL.Host {
+			return true
+		}
+
+		if !strings.Contains(domain, "*") {
+			continue
+		}
+
+		reStr := WildcardToRegex(domain)
+		re := regexp.MustCompile(reStr)
+		if re.MatchString(requestURL.Host) {
+			return true
+		}
+	}
+	return false
+}
+
+// WildcardToRegex converts a wildcard string to a regular expression.
+func WildcardToRegex(wildcard string) string {
+	var b strings.Builder
+	b.WriteByte('^')
+	for {
+		idx := strings.IndexByte(wildcard, '*')
+		if idx < 0 {
+			break
+		}
+		b.WriteString(regexp.QuoteMeta(wildcard[:idx]))
+		b.WriteString("(.*)")
+		wildcard = wildcard[idx+1:]
+	}
+	b.WriteString(regexp.QuoteMeta(wildcard))
+	b.WriteByte('$')
+	return b.String()
+}

--- a/config/from_test.go
+++ b/config/from_test.go
@@ -1,0 +1,38 @@
+package config
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/internal/urlutil"
+)
+
+func TestFromURLMatchesRequestURL(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		pattern string
+		input   string
+		matches bool
+	}{
+		{"https://from.example.com", "https://from.example.com/some/path", true},
+		{"https://from.example.com", "https://to.example.com/some/path", false},
+		{"https://*.example.com", "https://from.example.com/some/path", true},
+		{"https://*.example.com", "https://example.com/some/path", false},
+	} {
+		fromURL := urlutil.MustParseAndValidateURL(tc.pattern)
+		requestURL := urlutil.MustParseAndValidateURL(tc.input)
+		assert.Equal(t, tc.matches, FromURLMatchesRequestURL(&fromURL, &requestURL),
+			"from-url: %s\nrequest-url: %s", tc.pattern, tc.input)
+	}
+}
+
+func TestWildcardToRegex(t *testing.T) {
+	t.Parallel()
+
+	re, err := regexp.Compile(WildcardToRegex("*.internal.*.example.com"))
+	assert.NoError(t, err)
+	assert.True(t, re.MatchString("a.internal.b.example.com"))
+}

--- a/config/policy.go
+++ b/config/policy.go
@@ -595,12 +595,7 @@ func (p *Policy) Matches(requestURL url.URL) bool {
 		return false
 	}
 
-	// make sure one of the host domains matches the incoming url
-	found := false
-	for _, host := range urlutil.GetDomainsForURL(fromURL) {
-		found = found || host == requestURL.Host
-	}
-	if !found {
+	if !FromURLMatchesRequestURL(fromURL, &requestURL) {
 		return false
 	}
 

--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"net/http"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -439,7 +440,7 @@ func sourceHostnames(cfg *config.Config) []string {
 
 	dedupe := map[string]struct{}{}
 	for _, p := range policies {
-		if u, _ := urlutil.ParseAndValidateURL(p.From); u != nil {
+		if u, _ := urlutil.ParseAndValidateURL(p.From); u != nil && !strings.Contains(u.Host, "*") {
 			dedupe[u.Hostname()] = struct{}{}
 		}
 	}


### PR DESCRIPTION
## Summary
Adds support for from addresses like `https://*.example.com`.

## Related issues
- https://github.com/pomerium/internal/issues/1329

## User Explanation
Adds support for `*` in from addresses that will match 0 or more characters. This can occur anywhere inside the host part of the URL.

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
