### PR TITLE
config: default to authenticate.pomerium.app when authenticate url is not specified

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -311,6 +311,7 @@ var defaultOptions = Options{
 	GRPCAddr:                 ":443",
 	GRPCClientTimeout:        10 * time.Second, // Try to withstand transient service failures for a single request
 	GRPCClientDNSRoundRobin:  true,
+	AuthenticateURLString:    "https://authenticate.pomerium.app",
 	AuthenticateCallbackPath: "/oauth2/callback",
 	TracingSampleRate:        0.0001,
 

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -297,6 +297,7 @@ func TestOptionsFromViper(t *testing.T) {
 				CookieSecure:             true,
 				InsecureServer:           true,
 				CookieHTTPOnly:           true,
+				AuthenticateURLString:    "https://authenticate.pomerium.app",
 				AuthenticateCallbackPath: "/oauth2/callback",
 				DataBrokerStorageType:    "memory",
 				EnvoyAdminAccessLogPath:  os.DevNull,
@@ -310,6 +311,7 @@ func TestOptionsFromViper(t *testing.T) {
 			&Options{
 				Policies:                 []Policy{{From: "https://from.example", To: mustParseWeightedURLs(t, "https://to.example")}},
 				CookieName:               "_pomerium",
+				AuthenticateURLString:    "https://authenticate.pomerium.app",
 				AuthenticateCallbackPath: "/oauth2/callback",
 				CookieSecure:             true,
 				CookieHTTPOnly:           true,

--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -449,6 +449,10 @@ func sourceHostnames(cfg *config.Config) []string {
 		}
 	}
 
+	// remove any hosted authenticate URLs
+	delete(dedupe, "authenticate.pomerium.app")
+	delete(dedupe, "authenticate.staging.pomerium.app")
+
 	var h []string
 	for k := range dedupe {
 		h = append(h, k)


### PR DESCRIPTION
## Summary
Default to `authenticate.pomerium.app` when the authenticate URL is not specified. This allows pomerium to run without needing to configure an identity provider.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1323

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
