### PR TITLE
autocert: fix certmagic cache logging

### DIFF
--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -77,24 +77,31 @@ func newManager(ctx context.Context,
 		return nil, err
 	}
 
-	certmagicConfig := certmagic.NewDefault()
-	// set certmagic default storage cache, otherwise cert renewal loop will be based off
-	// certmagic's own default location
-	certmagicConfig.Storage, err = GetCertMagicStorage(ctx, src.GetConfig().Options.AutocertOptions.Folder)
-	if err != nil {
-		return nil, err
-	}
-
 	logger := log.ZapLogger().With(zap.String("service", "autocert"))
-	certmagicConfig.Logger = logger
 	acmeTemplate.Logger = logger
 
 	mgr := &Manager{
 		src:          src,
 		acmeTemplate: acmeTemplate,
-		certmagic:    certmagicConfig,
 		ocspCache:    ocspRespCache,
 	}
+
+	// set certmagic default storage cache, otherwise cert renewal loop will be based off
+	// certmagic's own default location
+	certmagicStorage, err := GetCertMagicStorage(ctx, src.GetConfig().Options.AutocertOptions.Folder)
+	if err != nil {
+		return nil, err
+	}
+	mgr.certmagic = certmagic.New(certmagic.NewCache(certmagic.CacheOptions{
+		GetConfigForCert: func(c certmagic.Certificate) (*certmagic.Config, error) {
+			return mgr.certmagic, nil
+		},
+		Logger: logger,
+	}), certmagic.Config{
+		Logger:  logger,
+		Storage: certmagicStorage,
+	})
+
 	err = mgr.update(ctx, src.GetConfig())
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
The certmagic cache starts by using the `certmagic.Default` config, which uses a default logger, so when we set it on our `certmagic.Config` it doesn't use the right logger. This updates the code so we don't use `NewDefault` but set the cache ourselves.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/4133
 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
