### PR TITLE
envoyconfig: disable validation context when no client certificates are required

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -531,6 +531,19 @@ func (b *Builder) buildDownstreamValidationContext(
 	ctx context.Context,
 	cfg *config.Config,
 ) *envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext {
+	needsClientCert := false
+	if ca, _ := cfg.Options.GetClientCA(); len(ca) > 0 {
+		needsClientCert = true
+	}
+	for _, p := range cfg.Options.GetAllPolicies() {
+		if p.TLSDownstreamClientCA != "" || p.TLSDownstreamClientCAFile != "" {
+			needsClientCert = true
+		}
+	}
+	if !needsClientCert {
+		return nil
+	}
+
 	// trusted_ca is left blank because we verify the client certificate in the authorize service
 	vc := &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{
 		ValidationContext: &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -89,10 +89,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 					],
 					"tlsMinimumProtocolVersion": "TLSv1_2"
 				},
-				"alpnProtocols": ["h2", "http/1.1"],
-				"validationContext": {
-					"trustChainVerification": "ACCEPT_UNTRUSTED"
-				}
+				"alpnProtocols": ["h2", "http/1.1"]
 			}
 		}`, downstreamTLSContext)
 	})
@@ -173,10 +170,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 					],
 					"tlsMinimumProtocolVersion": "TLSv1_2"
 				},
-				"alpnProtocols": ["http/1.1"],
-				"validationContext": {
-					"trustChainVerification": "ACCEPT_UNTRUSTED"
-				}
+				"alpnProtocols": ["http/1.1"]
 			}
 		}`, downstreamTLSContext)
 	})
@@ -201,10 +195,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 					],
 					"tlsMinimumProtocolVersion": "TLSv1_2"
 				},
-				"alpnProtocols": ["h2"],
-				"validationContext": {
-					"trustChainVerification": "ACCEPT_UNTRUSTED"
-				}
+				"alpnProtocols": ["h2"]
 			}
 		}`, downstreamTLSContext)
 	})


### PR DESCRIPTION
## Summary
If a `ValidationContextType` is set for downstream TLS contexts, it will result in the server sending a client certificate request during the TLS handshake. This may prompt the user to choose a client certificate (though it doesn't always result in this behavior).

## Related issues
Fixes #4150 
 

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
