### PR TITLE
fix WillHaveCertificateForServerName check to be strict match for derived cert name

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -213,7 +213,7 @@ func (cfg *Config) WillHaveCertificateForServerName(serverName string) (bool, er
 		}
 	}
 
-	return cfg.Options.DeriveInternalDomainCert != nil, nil
+	return cfg.Options.GetDeriveInternalDomain() == serverName, nil
 }
 
 // GetCertificatePool gets the certificate pool for the config.

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -208,12 +208,13 @@ func Test_getAllDomains(t *testing.T) {
 	require.NoError(t, err)
 
 	options := &config.Options{
-		Addr:                  "127.0.0.1:9000",
-		GRPCAddr:              "127.0.0.1:9001",
-		Services:              "all",
-		AuthenticateURLString: "https://authenticate.example.com",
-		AuthorizeURLString:    "https://authorize.example.com:9001",
-		DataBrokerURLString:   "https://cache.example.com:9001",
+		Addr:                          "127.0.0.1:9000",
+		GRPCAddr:                      "127.0.0.1:9001",
+		Services:                      "all",
+		AuthenticateURLString:         "https://authenticate.example.com",
+		AuthenticateInternalURLString: "https://authenticate.int.example.com",
+		AuthorizeURLString:            "https://authorize.example.com:9001",
+		DataBrokerURLString:           "https://cache.example.com:9001",
 		Policies: []config.Policy{
 			{From: "http://a.example.com"},
 			{From: "https://b.example.com"},
@@ -232,6 +233,8 @@ func Test_getAllDomains(t *testing.T) {
 				"a.example.com:80",
 				"authenticate.example.com",
 				"authenticate.example.com:443",
+				"authenticate.int.example.com",
+				"authenticate.int.example.com:443",
 				"b.example.com",
 				"b.example.com:443",
 				"c.example.com",
@@ -260,6 +263,8 @@ func Test_getAllDomains(t *testing.T) {
 				"a.example.com:80",
 				"authenticate.example.com",
 				"authenticate.example.com:443",
+				"authenticate.int.example.com",
+				"authenticate.int.example.com:443",
 				"authorize.example.com:9001",
 				"b.example.com",
 				"b.example.com:443",

--- a/config/options.go
+++ b/config/options.go
@@ -748,7 +748,7 @@ func (o *Options) GetDeriveInternalDomain() string {
 	if o.DeriveInternalDomainCert == nil {
 		return ""
 	}
-	return *o.DeriveInternalDomainCert
+	return strings.ToLower(*o.DeriveInternalDomainCert)
 }
 
 // GetAuthenticateURL returns the AuthenticateURL in the options or 127.0.0.1.


### PR DESCRIPTION
## Summary

An Ingress Controller has the following runtime environment specifics: 
- port-mapped (8443:443) due to non-root container requirements,
- the authenticate service URL may not be accessible from _inside_ the cluster - one example is performing Quickstart with `https://authenticate.localhost.pomerium.io` in a popular Docker Desktop environment

The authenticate endpoint is essential as it hosts `/.well-known/pomerium/hpke-public-key` which is consumed by Proxy and Authorize components. 

In order to overcome that limitation, IC [sets](https://github.com/pomerium/ingress-controller/blob/120b0d9068947ace23bbbe2f2ba0df5341e81c76/pomerium/ctrl/bootstrap.go#L52-L65) `authenticate_internal_service_url` to `https://localhost:8443`.

There are two issues this PR addresses: 

Current implementation of the WillHaveCert assumed that it was sufficient just to check whether autoTLS is enabled, as in that case there would be a wildcard cert, signed by the derived CA. 

The wildcard CA is indeed installed, however, if there are other wildcard certs added to the config, they would be presented instead. I think it might be related to [`full_scan_certs_on_tls_mismatch`](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/security/ssl#arch-overview-ssl-cert-select:~:text=If%20no%20cert%20is%20selected%20from%20certs%20that%20matches%20wildcard%20name%2C%20the%20candidate%20cert%20is%20selected%20for%20handshake%20if%20it%20is%20present.%20If%20there%20is%20no%20candidate%2C%20check%20full_scan_certs_on_sni_mismatch%2C%20go%20to%20full%20scan%20all%20certificates%20if%20it%20is%20enabled%2C%20otherwise%20pick%20the%20first%20certificate%20for%20handshake.)

> If no cert is selected from certs that matches wildcard name, the candidate cert is selected for handshake if it is present. If there is no candidate, check [full_scan_certs_on_sni_mismatch](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/transport_sockets/tls/v3/tls.proto#envoy-v3-api-field-extensions-transport-sockets-tls-v3-downstreamtlscontext-full-scan-certs-on-sni-mismatch), go to full scan all certificates if it is enabled, otherwise pick the first certificate for handshake.

This PR changes the behaviour of the `WillHaveCertificateForServerName` (which is only currently used by HPKE Key Fetcher) to only promise the. 

Couple notes: 

1. Maybe we should return a full set of certificates via `cfg.AllCertificates()`, moving derived cert generation out of the Envoy Config Builder to Config, and making this function only check the certs returned by the `cfg.AllCertificates()` so that it would be deterministic. 
2. The `cryptutil.MatchesServerName` used by tests naturally cannot reflect how the actual Envoy would perform TLS matching. We may want to do something about it as well. 
3. This issue does not seem to be unit testable, requires an integration test. 

## Related issues

Fixes https://github.com/pomerium/ingress-controller/issues/629

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
