### PR TITLE
fix lint warning in pkg/envoy

### DIFF
--- a/pkg/envoy/envoy_darwin.go
+++ b/pkg/envoy/envoy_darwin.go
@@ -14,7 +14,7 @@ var sysProcAttr = &syscall.SysProcAttr{
 	Setpgid: true,
 }
 
-func (srv *Server) runProcessCollector(ctx context.Context) {}
+func (srv *Server) runProcessCollector(_ context.Context) {}
 
 func (srv *Server) prepareRunEnvoyCommand(ctx context.Context, sharedArgs []string) (exePath string, args []string) {
 	if srv.cmd != nil && srv.cmd.Process != nil {


### PR DESCRIPTION
## Summary

Rename unused 'ctx' parameter to '_'.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

n/a

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
