### PR TITLE
envoy: set re2 limits very high

### DIFF
--- a/config/envoyconfig/bootstrap.go
+++ b/config/envoyconfig/bootstrap.go
@@ -134,6 +134,12 @@ func (b *Builder) BuildBootstrapLayeredRuntime() (*envoy_config_bootstrap_v3.Lay
 		"overload": map[string]interface{}{
 			"global_downstream_max_connections": 50000,
 		},
+		"re2": map[string]any{
+			"max_program_size": map[string]any{
+				"error_level": 1024 * 1024,
+				"warn_level":  1024,
+			},
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("envoyconfig: failed to create layered runtime layer: %w", err)

--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -43,6 +43,10 @@ func TestBuilder_BuildBootstrapLayeredRuntime(t *testing.T) {
 			"staticLayer": {
 				"overload": {
 					"global_downstream_max_connections": 50000
+				},
+				"re2": {
+					"error_level": 1048576,
+					"warn_level": 1024
 				}
 			}
 		}] }


### PR DESCRIPTION
## Summary
Set the program size complexity for regular expressions in envoy to be very high.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1373


## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
