### PR TITLE
databroker: fix fast forward

### DIFF
--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -2,8 +2,11 @@ package databroker
 
 import (
 	"context"
+	"sort"
 	"sync"
 	"time"
+
+	"golang.org/x/exp/maps"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/hashutil"
@@ -92,8 +95,13 @@ func (src *ConfigSource) rebuild(ctx context.Context, firstTime firstTime) {
 
 	var additionalPolicies []config.Policy
 
+	ids := maps.Keys(src.dbConfigs)
+	sort.Strings(ids)
+
 	// add all the config policies to the list
-	for id, cfgpb := range src.dbConfigs {
+	for _, id := range ids {
+		cfgpb := src.dbConfigs[id]
+
 		cfg.Options.ApplySettings(ctx, cfgpb.Settings)
 		var errCount uint64
 

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -81,7 +81,7 @@ func (src *ConfigSource) rebuild(ctx context.Context, firstTime firstTime) {
 	// start the updater
 	src.runUpdater(cfg)
 
-	seen := map[uint64]struct{}{}
+	seen := map[uint64]string{}
 	for _, policy := range cfg.Options.GetAllPolicies() {
 		id, err := policy.RouteID()
 		if err != nil {
@@ -90,7 +90,7 @@ func (src *ConfigSource) rebuild(ctx context.Context, firstTime firstTime) {
 				Msg("databroker: invalid policy config, ignoring")
 			return
 		}
-		seen[id] = struct{}{}
+		seen[id] = ""
 	}
 
 	var additionalPolicies []config.Policy
@@ -145,11 +145,12 @@ func (src *ConfigSource) rebuild(ctx context.Context, firstTime firstTime) {
 				errCount++
 				log.Warn(ctx).Err(err).
 					Str("db_config_id", id).
+					Str("seen-in", seen[routeID]).
 					Str("policy", policy.String()).
 					Msg("databroker: duplicate policy detected, ignoring")
 				continue
 			}
-			seen[routeID] = struct{}{}
+			seen[routeID] = id
 
 			additionalPolicies = append(additionalPolicies, *policy)
 		}

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -33,6 +33,13 @@ func Remove[S ~[]E, E comparable](s S, e E) S {
 	return ns
 }
 
+// Reverse reverses a slice's order.
+func Reverse[S ~[]E, E comparable](s S) {
+	for i := 0; i < len(s)/2; i++ {
+		s[i], s[len(s)-1-i] = s[len(s)-1-i], s[i]
+	}
+}
+
 // Unique returns the unique elements of s.
 func Unique[S ~[]E, E comparable](s S) S {
 	var ns S
@@ -40,6 +47,20 @@ func Unique[S ~[]E, E comparable](s S) S {
 	for _, el := range s {
 		if _, ok := h[el]; !ok {
 			h[el] = struct{}{}
+			ns = append(ns, el)
+		}
+	}
+	return ns
+}
+
+// UniqueBy returns the unique elements of s using a function to map elements.
+func UniqueBy[S ~[]E, E any, V comparable](s S, by func(E) V) S {
+	var ns S
+	h := map[V]struct{}{}
+	for _, el := range s {
+		v := by(el)
+		if _, ok := h[v]; !ok {
+			h[v] = struct{}{}
 			ns = append(ns, el)
 		}
 	}

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -1,0 +1,32 @@
+package slices
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReverse(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		in     []int
+		expect []int
+	}{
+		{in: []int{1, 2, 3}, expect: []int{3, 2, 1}},
+		{in: []int{1, 2}, expect: []int{2, 1}},
+		{in: []int{1}, expect: []int{1}},
+	} {
+		s := make([]int, len(tc.in))
+		copy(s, tc.in)
+		Reverse(s)
+		assert.Equal(t, tc.expect, s)
+	}
+}
+
+func TestUniqueBy(t *testing.T) {
+	t.Parallel()
+
+	s := UniqueBy([]int{1, 2, 3, 4, 3, 1, 1, 4, 2}, func(i int) int { return i % 3 })
+	assert.Equal(t, []int{1, 2, 3}, s)
+}


### PR DESCRIPTION
## Summary
Fix the fast forward option so that it combines record updates and drops duplicates. Otherwise updates may be lost.

## Related issues
- https://github.com/pomerium/pomerium-console/pull/3333
 

## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
