### PR TITLE
config: separate wildcard hosts where possible

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"strings"
 	"time"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -585,9 +584,11 @@ func getAllRouteableHosts(options *config.Options, addr string) ([]string, error
 		allHosts.Add(hosts...)
 	}
 
+	// Filter out any "special" wildcard domains (those that can't be
+	// implemented as an Envoy virtual host).
 	var filtered []string
 	for _, host := range allHosts.ToSlice() {
-		if !strings.Contains(host, "*") {
+		if !isSpecialWildcardHost(host) {
 			filtered = append(filtered, host)
 		}
 	}

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -2,6 +2,7 @@ package envoyconfig
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,115 +28,131 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 			{
 				From: "https://*.example.com",
 			},
+			{
+				From: "https://foo.*.example.com",
+			},
 		},
 	}}
 	b := New("grpc", "http", "metrics", filemgr.NewManager(), nil)
 	routeConfiguration, err := b.buildMainRouteConfiguration(ctx, cfg)
 	assert.NoError(t, err)
+	commonRoutes := strings.Join([]string{
+		protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium/jwt", true, false)),
+		protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium/webauthn", true, false)),
+		protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/ping", false, false)),
+		protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/healthz", false, false)),
+		protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium", false, false)),
+		protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.pomerium/", false, false)),
+		protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.well-known/pomerium", false, false)),
+		protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.well-known/pomerium/", false, false)),
+		protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/robots.txt", false, false)),
+	}, ",\n")
+	const commonRouteConfig = `"metadata": {
+							"filterMetadata": {
+								"envoy.filters.http.lua": {
+									"remove_impersonate_headers": false,
+									"remove_pomerium_authorization": true,
+									"remove_pomerium_cookie": "pomerium",
+									"rewrite_response_headers": []
+								}
+							}
+						},
+						"requestHeadersToRemove": [
+							"x-pomerium-jwt-assertion",
+							"x-pomerium-jwt-assertion-for",
+							"x-pomerium-reproxy-policy",
+							"x-pomerium-reproxy-policy-hmac"
+						],
+						"responseHeadersToAdd": [
+							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-Frame-Options", "value": "SAMEORIGIN" } },
+							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-XSS-Protection", "value": "1; mode=block" } }
+						],
+						"route": {
+							"autoHostRewrite": true,
+							"cluster": "route-0",
+							"hashPolicy": [
+								{ "header": { "headerName": "x-pomerium-routing-key" }, "terminal": true },
+								{ "connectionProperties": { "sourceIp": true }, "terminal": true }
+							],
+							"timeout": "3s",
+							"upgradeConfigs": [
+								{ "enabled": false, "upgradeType": "websocket" },
+								{ "enabled": false, "upgradeType": "spdy/3.1" }
+							]
+						}`
 	testutil.AssertProtoJSONEqual(t, `{
 		"name": "main",
 		"validateClusters": false,
 		"virtualHosts": [
 			{
+				"name": "*.example.com",
+				"domains": ["*.example.com"],
+				"routes": [
+					`+commonRoutes+`,
+					{
+						"name": "policy-0",
+						"match": {
+							"prefix": "/"
+						},
+						`+commonRouteConfig+`
+					}
+				]
+			},
+			{
+				"name": "*.example.com:443",
+				"domains": ["*.example.com:443"],
+				"routes": [
+					`+commonRoutes+`,
+					{
+						"name": "policy-0",
+						"match": {
+							"prefix": "/"
+						},
+						`+commonRouteConfig+`
+					}
+				]
+			},
+			{
 				"name": "catch-all",
 				"domains": ["*"],
 				"routes": [
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium/jwt", true, false))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium/webauthn", true, false))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/ping", false, false))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/healthz", false, false))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium", false, false))+`,
-					`+protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.pomerium/", false, false))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.well-known/pomerium", false, false))+`,
-					`+protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.well-known/pomerium/", false, false))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/robots.txt", false, false))+`,
+					`+commonRoutes+`,
 					{
-						"name": "policy-0",
+						"name": "policy-1",
 						"match": {
 							"headers": [
-								{ "name": ":authority", "stringMatch": { "safeRegex": { "regex": "^(.*)\\.example\\.com$" } }}
+								{
+									"name": ":authority",
+									"stringMatch": {
+										"safeRegex": {
+											"regex": "^foo\\.(.*)\\.example\\.com$"
+										}
+									}
+								}
 							],
 							"prefix": "/"
 						},
-						"metadata": {
-							"filterMetadata": {
-								"envoy.filters.http.lua": {
-									"remove_impersonate_headers": false,
-									"remove_pomerium_authorization": true,
-									"remove_pomerium_cookie": "pomerium",
-									"rewrite_response_headers": []
-								}
-							}
-						},
-						"requestHeadersToRemove": [
-							"x-pomerium-jwt-assertion",
-							"x-pomerium-jwt-assertion-for",
-							"x-pomerium-reproxy-policy",
-							"x-pomerium-reproxy-policy-hmac"
-						],
-						"responseHeadersToAdd": [
-							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-Frame-Options", "value": "SAMEORIGIN" } },
-							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-XSS-Protection", "value": "1; mode=block" } }
-						],
-						"route": {
-							"autoHostRewrite": true,
-							"cluster": "route-0",
-							"hashPolicy": [
-								{ "header": { "headerName": "x-pomerium-routing-key" }, "terminal": true },
-								{ "connectionProperties": { "sourceIp": true }, "terminal": true }
-							],
-							"timeout": "3s",
-							"upgradeConfigs": [
-								{ "enabled": false, "upgradeType": "websocket" },
-								{ "enabled": false, "upgradeType": "spdy/3.1" }
-							]
-						}
+						`+commonRouteConfig+`
 					},
 					{
-						"name": "policy-0",
+						"name": "policy-1",
 						"match": {
 							"headers": [
-								{ "name": ":authority", "stringMatch": { "safeRegex": { "regex": "^(.*)\\.example\\.com:443$" } }}
+								{
+									"name": ":authority",
+									"stringMatch": {
+										"safeRegex": {
+											"regex": "^foo\\.(.*)\\.example\\.com:443$"
+										}
+									}
+								}
 							],
 							"prefix": "/"
 						},
-						"metadata": {
-							"filterMetadata": {
-								"envoy.filters.http.lua": {
-									"remove_impersonate_headers": false,
-									"remove_pomerium_authorization": true,
-									"remove_pomerium_cookie": "pomerium",
-									"rewrite_response_headers": []
-								}
-							}
-						},
-						"requestHeadersToRemove": [
-							"x-pomerium-jwt-assertion",
-							"x-pomerium-jwt-assertion-for",
-							"x-pomerium-reproxy-policy",
-							"x-pomerium-reproxy-policy-hmac"
-						],
-						"responseHeadersToAdd": [
-							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-Frame-Options", "value": "SAMEORIGIN" } },
-							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-XSS-Protection", "value": "1; mode=block" } }
-						],
-						"route": {
-							"autoHostRewrite": true,
-							"cluster": "route-0",
-							"hashPolicy": [
-								{ "header": { "headerName": "x-pomerium-routing-key" }, "terminal": true },
-								{ "connectionProperties": { "sourceIp": true }, "terminal": true }
-							],
-							"timeout": "3s",
-							"upgradeConfigs": [
-								{ "enabled": false, "upgradeType": "websocket" },
-								{ "enabled": false, "upgradeType": "spdy/3.1" }
-							]
-						}
+						`+commonRouteConfig+`
 					}
 				]
 			}
 		]
-
 	}`, routeConfiguration)
 }

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"sort"
-	"strings"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
@@ -231,7 +230,7 @@ func (b *Builder) buildRoutesForPoliciesWithCatchAll(
 			return nil, err
 		}
 
-		if !strings.Contains(fromURL.Host, "*") {
+		if !isSpecialWildcardHost(fromURL.Host) {
 			continue
 		}
 
@@ -257,7 +256,7 @@ func (b *Builder) buildRoutesForPolicy(
 	}
 
 	var routes []*envoy_config_route_v3.Route
-	if strings.Contains(fromURL.Host, "*") {
+	if isSpecialWildcardHost(fromURL.Host) {
 		// we have to match '*.example.com' and '*.example.com:443', so there are two routes
 		for _, host := range urlutil.GetDomainsForURL(fromURL) {
 			route, err := b.buildRouteForPolicyAndMatch(cfg, certs, policy, name, mkRouteMatchForHost(policy, host))

--- a/config/envoyconfig/wildcard.go
+++ b/config/envoyconfig/wildcard.go
@@ -1,0 +1,13 @@
+package envoyconfig
+
+import "strings"
+
+// Returns true if the given host contains a wildcard token and the wildcard
+// token does not appear at the beginning nor the end of the host.
+func isSpecialWildcardHost(host string) bool {
+	l := len(host)
+	if l <= 2 {
+		return false
+	}
+	return strings.Contains(host[1:l-1], "*")
+}

--- a/config/envoyconfig/wildcard_test.go
+++ b/config/envoyconfig/wildcard_test.go
@@ -1,0 +1,36 @@
+package envoyconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsSpecialWildcardHost(t *testing.T) {
+	cases := []struct {
+		host     string
+		expected bool
+	}{
+		{"", false},
+		{"*", false},
+		{"a*", false},
+		{"ab", false},
+		{"*b", false},
+		{"abc", false},
+		{"*.foo.example.com", false},
+		{"*-bar.example.com", false},
+		{"foo.*", false},
+		{"foo-*", false},
+		{"foo.*.bar.example.com", true},
+		{"foo.bar-*.example.com", true},
+		{"a*b", true},
+	}
+
+	for i := range cases {
+		c := &cases[i]
+		t.Run(c.host, func(t *testing.T) {
+			actual := isSpecialWildcardHost(c.host)
+			assert.Equal(t, c.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Envoy supports virtual hosts with wildcard domains, as long as the wildcard token appears at the very beginning or the end of the domain (that is, Envoy supports suffix and prefix domain wildcards). Update the configuration builder logic to take advantage of this support whenever possible, using the current regex route matching as a fallback.

This may improve routing performance in some cases, by reducing the size of the routing table for the catch-all virtual host.

Add a utility method isSpecialWildcardHost() to determine whether a host has a wildcard token that is not at the very beginning or end. Update the existing route configuration test to add one of these special wildcard hosts.

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

Improve routing performance when many routes have `*` at the beginning or end of the from address.

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
