### PR TITLE
config: simplify default set response headers

### DIFF
--- a/config/envoyconfig/http_connection_manager.go
+++ b/config/envoyconfig/http_connection_manager.go
@@ -13,7 +13,6 @@ func (b *Builder) buildVirtualHost(
 	options *config.Options,
 	name string,
 	host string,
-	requireStrictTransportSecurity bool,
 ) (*envoy_config_route_v3.VirtualHost, error) {
 	vh := &envoy_config_route_v3.VirtualHost{
 		Name:    name,
@@ -21,7 +20,7 @@ func (b *Builder) buildVirtualHost(
 	}
 
 	// these routes match /.pomerium/... and similar paths
-	rs, err := b.buildPomeriumHTTPRoutes(options, host, requireStrictTransportSecurity)
+	rs, err := b.buildPomeriumHTTPRoutes(options, host)
 	if err != nil {
 		return nil, err
 	}
@@ -34,13 +33,12 @@ func (b *Builder) buildVirtualHost(
 // coming directly from envoy
 func (b *Builder) buildLocalReplyConfig(
 	options *config.Options,
-	requireStrictTransportSecurity bool,
 ) *envoy_http_connection_manager.LocalReplyConfig {
 	// add global headers for HSTS headers (#2110)
 	var headers []*envoy_config_core_v3.HeaderValueOption
 	// if we're the proxy or authenticate service, add our global headers
 	if config.IsProxy(options.Services) || config.IsAuthenticate(options.Services) {
-		headers = toEnvoyHeaders(options.GetSetResponseHeaders(requireStrictTransportSecurity))
+		headers = toEnvoyHeaders(options.GetSetResponseHeaders())
 	}
 
 	return &envoy_http_connection_manager.LocalReplyConfig{

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -298,7 +298,7 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 		UseRemoteAddress:  &wrappers.BoolValue{Value: true},
 		SkipXffAppend:     cfg.Options.SkipXffAppend,
 		XffNumTrustedHops: cfg.Options.XffNumTrustedHops,
-		LocalReplyConfig:  b.buildLocalReplyConfig(cfg.Options, false),
+		LocalReplyConfig:  b.buildLocalReplyConfig(cfg.Options),
 		NormalizePath:     wrapperspb.Bool(true),
 	}
 

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -41,13 +41,13 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 				"name": "catch-all",
 				"domains": ["*"],
 				"routes": [
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/ping", false))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/healthz", false))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium", false))+`,
-					`+protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.pomerium/", false))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.well-known/pomerium", false))+`,
-					`+protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.well-known/pomerium/", false))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/robots.txt", false))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/ping"))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/healthz"))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium"))+`,
+					`+protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.pomerium/"))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.well-known/pomerium"))+`,
+					`+protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.well-known/pomerium/"))+`,
+					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/robots.txt"))+`,
 					{
 						"name": "policy-0",
 						"match": {

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -100,7 +100,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 			AuthenticateURLString:    "https://authenticate.example.com",
 			AuthenticateCallbackPath: "/oauth2/callback",
 		}
-		routes, err := b.buildPomeriumHTTPRoutes(options, "authenticate.example.com", false)
+		routes, err := b.buildPomeriumHTTPRoutes(options, "authenticate.example.com")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `[
@@ -121,7 +121,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 			AuthenticateURLString:    "https://authenticate.example.com",
 			AuthenticateCallbackPath: "/oauth2/callback",
 		}
-		routes, err := b.buildPomeriumHTTPRoutes(options, "authenticate.example.com", false)
+		routes, err := b.buildPomeriumHTTPRoutes(options, "authenticate.example.com")
 		require.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, "null", routes)
 	})
@@ -137,7 +137,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 			}},
 		}
 		_ = options.Policies[0].Validate()
-		routes, err := b.buildPomeriumHTTPRoutes(options, "from.example.com", false)
+		routes, err := b.buildPomeriumHTTPRoutes(options, "from.example.com")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `[
@@ -163,7 +163,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 			}},
 		}
 		_ = options.Policies[0].Validate()
-		routes, err := b.buildPomeriumHTTPRoutes(options, "from.example.com", false)
+		routes, err := b.buildPomeriumHTTPRoutes(options, "from.example.com")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `[
@@ -180,7 +180,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 func Test_buildControlPlanePathRoute(t *testing.T) {
 	options := config.NewDefaultOptions()
 	b := &Builder{filemgr: filemgr.NewManager()}
-	route := b.buildControlPlanePathRoute(options, "/hello/world", false)
+	route := b.buildControlPlanePathRoute(options, "/hello/world")
 	testutil.AssertProtoJSONEqual(t, `
 		{
 			"name": "pomerium-path-/hello/world",
@@ -224,7 +224,7 @@ func Test_buildControlPlanePathRoute(t *testing.T) {
 func Test_buildControlPlanePrefixRoute(t *testing.T) {
 	options := config.NewDefaultOptions()
 	b := &Builder{filemgr: filemgr.NewManager()}
-	route := b.buildControlPlanePrefixRoute(options, "/hello/world/", false)
+	route := b.buildControlPlanePrefixRoute(options, "/hello/world/")
 	testutil.AssertProtoJSONEqual(t, `
 		{
 			"name": "pomerium-prefix-/hello/world/",
@@ -311,7 +311,7 @@ func TestTimeouts(t *testing.T) {
 					AllowWebsockets: tc.allowWebsockets,
 				},
 			},
-		}}, nil, "example.com")
+		}}, "example.com")
 		if !assert.NoError(t, err, "%v", tc) || !assert.Len(t, routes, 1, tc) || !assert.NotNil(t, routes[0].GetRoute(), "%v", tc) {
 			continue
 		}
@@ -425,7 +425,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				UpstreamTimeout:     &ten,
 			},
 		},
-	}}, nil, "example.com")
+	}}, "example.com")
 	require.NoError(t, err)
 
 	testutil.AssertProtoJSONEqual(t, `
@@ -1020,7 +1020,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					PassIdentityHeaders: true,
 				},
 			},
-		}}, nil, "authenticate.example.com")
+		}}, "authenticate.example.com")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `
@@ -1109,7 +1109,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					UpstreamTimeout:     &ten,
 				},
 			},
-		}}, nil, "example.com:22")
+		}}, "example.com:22")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `
@@ -1278,7 +1278,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					To:   mustParseWeightedURLs(t, "https://to.example.com"),
 				},
 			},
-		}}, nil, "from.example.com")
+		}}, "from.example.com")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `
@@ -1410,7 +1410,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 				HostPathRegexRewriteSubstitution: "\\1",
 			},
 		},
-	}}, nil, "example.com")
+	}}, "example.com")
 	require.NoError(t, err)
 
 	testutil.AssertProtoJSONEqual(t, `

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -752,20 +752,21 @@ func TestOptions_GetSetResponseHeaders(t *testing.T) {
 		assert.Equal(t, map[string]string{
 			"X-Frame-Options":  "SAMEORIGIN",
 			"X-XSS-Protection": "1; mode=block",
-		}, options.GetSetResponseHeaders(false))
+		}, options.GetSetResponseHeaders())
 	})
 	t.Run("strict", func(t *testing.T) {
 		options := NewDefaultOptions()
+		options.Cert = "CERT"
 		assert.Equal(t, map[string]string{
 			"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
 			"X-Frame-Options":           "SAMEORIGIN",
 			"X-XSS-Protection":          "1; mode=block",
-		}, options.GetSetResponseHeaders(true))
+		}, options.GetSetResponseHeaders())
 	})
 	t.Run("disable", func(t *testing.T) {
 		options := NewDefaultOptions()
 		options.SetResponseHeaders = map[string]string{DisableHeaderKey: "1", "x-other": "xyz"}
-		assert.Equal(t, map[string]string{}, options.GetSetResponseHeaders(true))
+		assert.Equal(t, map[string]string{}, options.GetSetResponseHeaders())
 	})
 }
 
@@ -776,7 +777,7 @@ func TestOptions_GetSetResponseHeadersForPolicy(t *testing.T) {
 		policy := &Policy{
 			SetResponseHeaders: map[string]string{"x": "y"},
 		}
-		assert.Equal(t, map[string]string{"x": "y"}, options.GetSetResponseHeadersForPolicy(policy, true))
+		assert.Equal(t, map[string]string{"x": "y"}, options.GetSetResponseHeadersForPolicy(policy))
 	})
 }
 


### PR DESCRIPTION
## Summary
Currently we selectively remove the `Strict-Transport-Security` header for routes that use a generated certificate. This is done to help prevent the occurrence of an error page that requires users to manually type `thisisunsafe` to bypass.

We do this by searching the entire list of certificates for any that match the route. If there are none, we assume the certificate used will be a generated one and remove the `Strict-Transport-Security` header.

This PR updates the code to instead look for any certificates at all. If at least one certificate is supplied, we will assume the user would prefer to have this header added. If none are supplied, we will assume Pomerium is running in an entirely generated mode where the inclusion of this header is more annoying than helpful.

## Related issues
- https://github.com/pomerium/internal/issues/1375

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
