### PR TITLE
authorize: populate issuer even when policy is nil

### DIFF
--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -30,11 +30,11 @@ type HeadersRequest struct {
 // NewHeadersRequestFromPolicy creates a new HeadersRequest from a policy.
 func NewHeadersRequestFromPolicy(policy *config.Policy, hostname string) *HeadersRequest {
 	input := new(HeadersRequest)
+	input.Issuer = hostname
 	if policy != nil {
 		input.EnableGoogleCloudServerlessAuthentication = policy.EnableGoogleCloudServerlessAuthentication
 		input.EnableRoutingKey = policy.EnvoyOpts.GetLbPolicy() == envoy_config_cluster_v3.Cluster_RING_HASH ||
 			policy.EnvoyOpts.GetLbPolicy() == envoy_config_cluster_v3.Cluster_MAGLEV
-		input.Issuer = hostname
 		input.KubernetesServiceAccountToken = policy.KubernetesServiceAccountToken
 		for _, wu := range policy.To {
 			input.ToAudience = "https://" + wu.URL.Hostname()

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -36,6 +36,13 @@ func TestNewHeadersRequestFromPolicy(t *testing.T) {
 	}, req)
 }
 
+func TestNewHeadersRequestFromPolicy_nil(t *testing.T) {
+	req := NewHeadersRequestFromPolicy(nil, "from.example.com")
+	assert.Equal(t, &HeadersRequest{
+		Issuer: "from.example.com",
+	}, req)
+}
+
 func TestHeadersEvaluator(t *testing.T) {
 	type A = []interface{}
 	type M = map[string]interface{}


### PR DESCRIPTION
## Summary

After the recent changes to internal policy evaluation, the /.pomerium/jwt endpoint was returning empty strings for the JWT `aud` and `iss` claims.

## Related issues

Fixes #4210

## User Explanation

Fix an issue where the /.pomerium/jwt endpoint returned a JWT missing the audience and issuer claims.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
