### PR TITLE
authorize: populate issuer even when policy is nil

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -33,6 +33,7 @@ type Request struct {
 // RequestHTTP is the HTTP field in the request.
 type RequestHTTP struct {
 	Method            string            `json:"method"`
+	Hostname          string            `json:"hostname"`
 	Path              string            `json:"path"`
 	URL               string            `json:"url"`
 	Headers           map[string]string `json:"headers"`
@@ -50,6 +51,7 @@ func NewRequestHTTP(
 ) RequestHTTP {
 	return RequestHTTP{
 		Method:            method,
+		Hostname:          requestURL.Hostname(),
 		Path:              requestURL.Path,
 		URL:               requestURL.String(),
 		Headers:           headers,
@@ -203,7 +205,7 @@ func (e *Evaluator) evaluatePolicy(ctx context.Context, req *Request) (*PolicyRe
 }
 
 func (e *Evaluator) evaluateHeaders(ctx context.Context, req *Request) (*HeadersResponse, error) {
-	headersReq := NewHeadersRequestFromPolicy(req.Policy)
+	headersReq := NewHeadersRequestFromPolicy(req.Policy, req.HTTP.Hostname)
 	headersReq.Session = req.Session
 	res, err := e.headersEvaluators.Evaluate(ctx, headersReq)
 	if err != nil {

--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -12,7 +12,6 @@ import (
 	"github.com/pomerium/pomerium/authorize/internal/store"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
-	"github.com/pomerium/pomerium/internal/urlutil"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 )
 
@@ -29,15 +28,13 @@ type HeadersRequest struct {
 }
 
 // NewHeadersRequestFromPolicy creates a new HeadersRequest from a policy.
-func NewHeadersRequestFromPolicy(policy *config.Policy) *HeadersRequest {
+func NewHeadersRequestFromPolicy(policy *config.Policy, hostname string) *HeadersRequest {
 	input := new(HeadersRequest)
+	input.Issuer = hostname
 	if policy != nil {
 		input.EnableGoogleCloudServerlessAuthentication = policy.EnableGoogleCloudServerlessAuthentication
 		input.EnableRoutingKey = policy.EnvoyOpts.GetLbPolicy() == envoy_config_cluster_v3.Cluster_RING_HASH ||
 			policy.EnvoyOpts.GetLbPolicy() == envoy_config_cluster_v3.Cluster_MAGLEV
-		if u, err := urlutil.ParseAndValidateURL(policy.From); err == nil {
-			input.Issuer = u.Hostname()
-		}
 		input.KubernetesServiceAccountToken = policy.KubernetesServiceAccountToken
 		for _, wu := range policy.To {
 			input.ToAudience = "https://" + wu.URL.Hostname()

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -28,11 +28,18 @@ func TestNewHeadersRequestFromPolicy(t *testing.T) {
 				URL: *mustParseURL("http://to.example.com"),
 			},
 		},
-	})
+	}, "from.example.com")
 	assert.Equal(t, &HeadersRequest{
 		EnableGoogleCloudServerlessAuthentication: true,
 		Issuer:     "from.example.com",
 		ToAudience: "https://to.example.com",
+	}, req)
+}
+
+func TestNewHeadersRequestFromPolicy_nil(t *testing.T) {
+	req := NewHeadersRequestFromPolicy(nil, "from.example.com")
+	assert.Equal(t, &HeadersRequest{
+		Issuer: "from.example.com",
 	}, req)
 }
 


### PR DESCRIPTION
Backport https://github.com/pomerium/pomerium/commit/6df4fba83236c8401fa487c0575453b0fd759d63 from https://github.com/pomerium/pomerium/pull/4211

This also backports the change from commit 18bc86d63284c64cd9c2d1e257b1c53198cb5d39 to add a `hostname` parameter to the `NewHeadersRequestFromPolicy()` method, in order to determine the issuer.