### PR TITLE
configure Envoy to validate client certificates

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -1,6 +1,7 @@
 package envoyconfig
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
@@ -668,42 +669,54 @@ func (b *Builder) buildDownstreamTLSContext(ctx context.Context,
 	}
 
 	envoyCert := b.envoyTLSCertificateFromGoTLSCertificate(ctx, cert)
-	return &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{
+	dtc := &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
-			TlsParams:             tlsParams,
-			TlsCertificates:       []*envoy_extensions_transport_sockets_tls_v3.TlsCertificate{envoyCert},
-			AlpnProtocols:         alpnProtocols,
-			ValidationContextType: b.buildDownstreamValidationContext(ctx, cfg, domain),
+			TlsParams:       tlsParams,
+			TlsCertificates: []*envoy_extensions_transport_sockets_tls_v3.TlsCertificate{envoyCert},
+			AlpnProtocols:   alpnProtocols,
 		},
 	}
+	if clientCA := clientCAForDomain(ctx, cfg, domain); len(clientCA) > 0 {
+		dtc.CommonTlsContext.ValidationContextType = b.buildDownstreamValidationContext(ctx, cfg, clientCA)
+		dtc.RequireClientCertificate = wrapperspb.Bool(true)
+	}
+	return dtc
 }
 
-func (b *Builder) buildDownstreamValidationContext(ctx context.Context,
-	cfg *config.Config,
-	domain string,
-) *envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext {
-	needsClientCert := false
-
-	if ca, _ := cfg.Options.GetClientCA(); len(ca) > 0 {
-		needsClientCert = true
-	}
-	if !needsClientCert {
-		for _, p := range getPoliciesForDomain(cfg.Options, domain) {
-			if p.TLSDownstreamClientCA != "" {
-				needsClientCert = true
-				break
-			}
+// clientCAForDomain returns a bundle of all per-route client CAs configured
+// for the given domain, or else the globally configured client CA.
+func clientCAForDomain(ctx context.Context, cfg *config.Config, domain string) []byte {
+	var bundle bytes.Buffer
+	for _, p := range getPoliciesForDomain(cfg.Options, domain) {
+		if p.TLSDownstreamClientCA == "" {
+			continue
+		}
+		ca, err := base64.StdEncoding.DecodeString(p.TLSDownstreamClientCA)
+		if err != nil {
+			log.Error(ctx).Err(err).Msg("invalid client CA")
+			continue
+		}
+		bundle.Write(ca)
+		// In case there are multiple CAs, make sure they are separated by a newline.
+		if ca[len(ca)-1] != '\n' {
+			bundle.WriteByte('\n')
 		}
 	}
-
-	if !needsClientCert {
-		return nil
+	if bundle.Len() > 0 {
+		return bundle.Bytes()
 	}
+	ca, _ := cfg.Options.GetClientCA()
+	return ca
+}
 
-	// trusted_ca is left blank because we verify the client certificate in the authorize service
+func (b *Builder) buildDownstreamValidationContext(
+	ctx context.Context,
+	cfg *config.Config,
+	clientCA []byte,
+) *envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext {
 	vc := &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{
 		ValidationContext: &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
-			TrustChainVerification: envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext_ACCEPT_UNTRUSTED,
+			TrustedCa: b.filemgr.BytesDataSource("client-ca.pem", clientCA),
 		},
 	}
 

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -563,7 +563,7 @@ func Test_buildMainHTTPConnectionManagerFilter(t *testing.T) {
 	}`, filter)
 }
 
-func Test_buildDownstreamTLSContext(t *testing.T) {
+func Test_buildDownstreamTLSContextWithValidation(t *testing.T) {
 	b := New("local-grpc", "local-http", "local-metrics", filemgr.NewManager(), nil)
 
 	cacheDir, _ := os.UserCacheDir()
@@ -572,7 +572,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 	clientCAFileName := filepath.Join(cacheDir, "pomerium", "envoy", "files", "client-ca-3533485838304b593757424e3354425157494c4747433534384f474f3631364d5332554c3332485a483834334d50454c344a.pem")
 
 	t.Run("no-validation", func(t *testing.T) {
-		downstreamTLSContext := b.buildDownstreamTLSContext(context.Background(), &config.Config{Options: &config.Options{
+		downstreamTLSContext := b.buildDownstreamTLSContextWithValidation(context.Background(), &config.Config{Options: &config.Options{
 			Cert: aExampleComCert,
 			Key:  aExampleComKey,
 		}}, "a.example.com")
@@ -605,7 +605,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 		}`, downstreamTLSContext)
 	})
 	t.Run("client-ca", func(t *testing.T) {
-		downstreamTLSContext := b.buildDownstreamTLSContext(context.Background(), &config.Config{Options: &config.Options{
+		downstreamTLSContext := b.buildDownstreamTLSContextWithValidation(context.Background(), &config.Config{Options: &config.Options{
 			Cert:     aExampleComCert,
 			Key:      aExampleComKey,
 			ClientCA: "VEVTVAo=", // "TEST\n" (with a trailing newline)
@@ -645,7 +645,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 		}`, downstreamTLSContext)
 	})
 	t.Run("policy-client-ca", func(t *testing.T) {
-		downstreamTLSContext := b.buildDownstreamTLSContext(context.Background(), &config.Config{Options: &config.Options{
+		downstreamTLSContext := b.buildDownstreamTLSContextWithValidation(context.Background(), &config.Config{Options: &config.Options{
 			Cert: aExampleComCert,
 			Key:  aExampleComKey,
 			Policies: []config.Policy{
@@ -690,7 +690,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 		}`, downstreamTLSContext)
 	})
 	t.Run("http1", func(t *testing.T) {
-		downstreamTLSContext := b.buildDownstreamTLSContext(context.Background(), &config.Config{Options: &config.Options{
+		downstreamTLSContext := b.buildDownstreamTLSContextWithValidation(context.Background(), &config.Config{Options: &config.Options{
 			Cert:      aExampleComCert,
 			Key:       aExampleComKey,
 			CodecType: config.CodecTypeHTTP1,
@@ -724,7 +724,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 		}`, downstreamTLSContext)
 	})
 	t.Run("http2", func(t *testing.T) {
-		downstreamTLSContext := b.buildDownstreamTLSContext(context.Background(), &config.Config{Options: &config.Options{
+		downstreamTLSContext := b.buildDownstreamTLSContextWithValidation(context.Background(), &config.Config{Options: &config.Options{
 			Cert:      aExampleComCert,
 			Key:       aExampleComKey,
 			CodecType: config.CodecTypeHTTP2,

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -170,3 +170,14 @@ func mustParseURL(str string) *url.URL {
 	}
 	return u
 }
+
+func loadCertificate(t *testing.T, certName string) tls.Certificate {
+	t.Helper()
+	certFile := filepath.Join(".", "tpl", "files", certName+".pem")
+	keyFile := filepath.Join(".", "tpl", "files", certName+"-key.pem")
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cert
+}

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pomerium/pomerium/integration/flows"
+	"github.com/pomerium/pomerium/internal/httputil"
 )
 
 func TestCORS(t *testing.T) {
@@ -318,5 +319,192 @@ func TestLoadBalancer(t *testing.T) {
 		distribution := getDistribution(t, "maglev")
 		assert.Lenf(t, distribution, 1, "should distribute requests to a single backend, got: %v",
 			distribution)
+	})
+}
+
+func TestDownstreamClientCA(t *testing.T) {
+	if ClusterType == "traefik" || ClusterType == "nginx" {
+		t.Skip()
+		return
+	}
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Minute*10)
+	defer clearTimeout()
+
+	t.Run("no client cert", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, "GET",
+			"https://client-cert-required.localhost.pomerium.io/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, err := getClient().Do(req)
+		if assert.Error(t, err, "expected error when no certificate provided") {
+			assert.Contains(t, err.Error(), "remote error: tls: certificate required")
+		} else {
+			res.Body.Close()
+		}
+	})
+	t.Run("untrusted client cert", func(t *testing.T) {
+		// Configure an http.Client with an untrusted client certificate.
+		cert := loadCertificate(t, "downstream-2-client")
+		client := *getClient()
+		tr := client.Transport.(*http.Transport).Clone()
+		// We need to use the GetClientCertificate callback here in order to
+		// present a certificate that doesn't match the advertised CA.
+		tr.TLSClientConfig.GetClientCertificate =
+			func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) { return &cert, nil }
+		client.Transport = tr
+
+		req, err := http.NewRequestWithContext(ctx, "GET",
+			"https://client-cert-required.localhost.pomerium.io/", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, err := client.Do(req)
+		if assert.Error(t, err, "expected error for untrusted certificate") {
+			assert.Contains(t, err.Error(), "remote error: tls: unknown certificate authority")
+		} else {
+			res.Body.Close()
+		}
+	})
+	t.Run("valid client cert", func(t *testing.T) {
+		// Configure an http.Client with a trusted client certificate.
+		cert := loadCertificate(t, "downstream-1-client")
+		client := *getClient()
+		tr := client.Transport.(*http.Transport).Clone()
+		tr.TLSClientConfig.Certificates = []tls.Certificate{cert}
+		client.Transport = tr
+
+		res, err := flows.Authenticate(ctx, &client,
+			mustParseURL("https://client-cert-required.localhost.pomerium.io/"),
+			flows.WithEmail("user1@dogs.test"))
+		if !assert.NoError(t, err, "unexpected http error") {
+			return
+		}
+		defer res.Body.Close()
+
+		var result struct {
+			Path string `json:"path"`
+		}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, "/", result.Path)
+	})
+}
+
+func TestMultipleDownstreamClientCAs(t *testing.T) {
+	if ClusterType == "traefik" || ClusterType == "nginx" {
+		t.Skip()
+		return
+	}
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Minute*10)
+	defer clearTimeout()
+
+	// Initializes a new http.Client with the given certificate.
+	newClientWithCert := func(certName string) *http.Client {
+		cert := loadCertificate(t, certName)
+		client := *getClient()
+		tr := client.Transport.(*http.Transport).Clone()
+		tr.TLSClientConfig.Certificates = []tls.Certificate{cert}
+		client.Transport = tr
+		return &client
+	}
+
+	// Asserts that we get a successful JSON response from the httpdetails
+	// service, matching the given path.
+	assertOK := func(res *http.Response, err error, path string) {
+		if !assert.NoError(t, err, "unexpected http error") {
+			return
+		}
+		defer res.Body.Close()
+
+		var result struct {
+			Path string `json:"path"`
+		}
+		err = json.NewDecoder(res.Body).Decode(&result)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.Equal(t, path, result.Path)
+	}
+
+	t.Run("cert1", func(t *testing.T) {
+		client := newClientWithCert("downstream-1-client")
+
+		// With cert1, we should get a valid response for the /ca1 path.
+		res, err := flows.Authenticate(ctx, client,
+			mustParseURL("https://client-cert-overlap.localhost.pomerium.io/ca1"),
+			flows.WithEmail("user1@dogs.test"))
+		assertOK(res, err, "/ca1")
+
+		// With cert1, we should get an HTTP error response for the /ca2 path.
+		req, err := http.NewRequestWithContext(ctx, "GET",
+			"https://client-cert-overlap.localhost.pomerium.io/ca2", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, err = client.Do(req)
+		if !assert.NoError(t, err, "unexpected http error") {
+			return
+		}
+		defer res.Body.Close()
+		assert.Equal(t, httputil.StatusInvalidClientCertificate, res.StatusCode)
+	})
+	t.Run("cert2", func(t *testing.T) {
+		client := newClientWithCert("downstream-2-client")
+
+		// With cert2, we should get an HTTP error response for the /ca1 path.
+		req, err := http.NewRequestWithContext(ctx, "GET",
+			"https://client-cert-overlap.localhost.pomerium.io/ca1", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, err := client.Do(req)
+		if !assert.NoError(t, err, "unexpected http error") {
+			return
+		}
+		defer res.Body.Close()
+		assert.Equal(t, httputil.StatusInvalidClientCertificate, res.StatusCode)
+
+		// With cert2, we should get a valid response for the /ca2 path.
+		res, err = flows.Authenticate(ctx, client,
+			mustParseURL("https://client-cert-overlap.localhost.pomerium.io/ca2"),
+			flows.WithEmail("user1@dogs.test"))
+		assertOK(res, err, "/ca2")
+	})
+	t.Run("no cert", func(t *testing.T) {
+		// Without a client certificate, connections should be rejected
+		req, err := http.NewRequestWithContext(ctx, "GET",
+			"https://client-cert-overlap.localhost.pomerium.io/ca1", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, err := getClient().Do(req)
+		if assert.Error(t, err, "expected error when no certificate provided") {
+			assert.Contains(t, err.Error(), "remote error: tls: certificate required")
+		} else {
+			res.Body.Close()
+		}
+
+		req, err = http.NewRequestWithContext(ctx, "GET",
+			"https://client-cert-overlap.localhost.pomerium.io/ca2", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		res, err = getClient().Do(req)
+		if assert.Error(t, err, "expected error when no certificate provided") {
+			assert.Contains(t, err.Error(), "remote error: tls: certificate required")
+		} else {
+			res.Body.Close()
+		}
 	})
 }

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/integration/flows"
 	"github.com/pomerium/pomerium/internal/httputil"
@@ -334,9 +335,7 @@ func TestDownstreamClientCA(t *testing.T) {
 	t.Run("no client cert", func(t *testing.T) {
 		req, err := http.NewRequestWithContext(ctx, "GET",
 			"https://client-cert-required.localhost.pomerium.io/", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		res, err := getClient().Do(req)
 		if assert.Error(t, err, "expected error when no certificate provided") {
@@ -358,9 +357,7 @@ func TestDownstreamClientCA(t *testing.T) {
 
 		req, err := http.NewRequestWithContext(ctx, "GET",
 			"https://client-cert-required.localhost.pomerium.io/", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		res, err := client.Do(req)
 		if assert.Error(t, err, "expected error for untrusted certificate") {
@@ -380,18 +377,14 @@ func TestDownstreamClientCA(t *testing.T) {
 		res, err := flows.Authenticate(ctx, &client,
 			mustParseURL("https://client-cert-required.localhost.pomerium.io/"),
 			flows.WithEmail("user1@dogs.test"))
-		if !assert.NoError(t, err, "unexpected http error") {
-			return
-		}
+		require.NoError(t, err, "unexpected http error")
 		defer res.Body.Close()
 
 		var result struct {
 			Path string `json:"path"`
 		}
 		err = json.NewDecoder(res.Body).Decode(&result)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
 		assert.Equal(t, "/", result.Path)
 	})
 }
@@ -418,18 +411,14 @@ func TestMultipleDownstreamClientCAs(t *testing.T) {
 	// Asserts that we get a successful JSON response from the httpdetails
 	// service, matching the given path.
 	assertOK := func(res *http.Response, err error, path string) {
-		if !assert.NoError(t, err, "unexpected http error") {
-			return
-		}
+		require.NoError(t, err, "unexpected http error")
 		defer res.Body.Close()
 
 		var result struct {
 			Path string `json:"path"`
 		}
 		err = json.NewDecoder(res.Body).Decode(&result)
-		if !assert.NoError(t, err) {
-			return
-		}
+		require.NoError(t, err)
 		assert.Equal(t, path, result.Path)
 	}
 
@@ -445,14 +434,10 @@ func TestMultipleDownstreamClientCAs(t *testing.T) {
 		// With cert1, we should get an HTTP error response for the /ca2 path.
 		req, err := http.NewRequestWithContext(ctx, "GET",
 			"https://client-cert-overlap.localhost.pomerium.io/ca2", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		res, err = client.Do(req)
-		if !assert.NoError(t, err, "unexpected http error") {
-			return
-		}
+		require.NoError(t, err)
 		defer res.Body.Close()
 		assert.Equal(t, httputil.StatusInvalidClientCertificate, res.StatusCode)
 	})
@@ -462,14 +447,10 @@ func TestMultipleDownstreamClientCAs(t *testing.T) {
 		// With cert2, we should get an HTTP error response for the /ca1 path.
 		req, err := http.NewRequestWithContext(ctx, "GET",
 			"https://client-cert-overlap.localhost.pomerium.io/ca1", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		res, err := client.Do(req)
-		if !assert.NoError(t, err, "unexpected http error") {
-			return
-		}
+		require.NoError(t, err, "unexpected http error")
 		defer res.Body.Close()
 		assert.Equal(t, httputil.StatusInvalidClientCertificate, res.StatusCode)
 
@@ -480,12 +461,10 @@ func TestMultipleDownstreamClientCAs(t *testing.T) {
 		assertOK(res, err, "/ca2")
 	})
 	t.Run("no cert", func(t *testing.T) {
-		// Without a client certificate, connections should be rejected
+		// Without a client certificate, connections should be rejected.
 		req, err := http.NewRequestWithContext(ctx, "GET",
 			"https://client-cert-overlap.localhost.pomerium.io/ca1", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		res, err := getClient().Do(req)
 		if assert.Error(t, err, "expected error when no certificate provided") {
@@ -496,9 +475,7 @@ func TestMultipleDownstreamClientCAs(t *testing.T) {
 
 		req, err = http.NewRequestWithContext(ctx, "GET",
 			"https://client-cert-overlap.localhost.pomerium.io/ca2", nil)
-		if err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, err)
 
 		res, err = getClient().Do(req)
 		if assert.Error(t, err, "expected error when no certificate provided") {


### PR DESCRIPTION
Currently, client certificate validation is performed within the authorize service, after user login. Instead, configure Envoy to perform certificate validation itself, at the time of the initial connection.

When a client certificate authority is configured, Envoy will reject any connection attempts that do not present a valid client certificate corresponding with a trust chain rooted at the configured certificate authority.

For end users without a client certificate configured in their browser, after this change they will see a browser default error page, rather than an HTML error page served by Pomerium.

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
