### PR TITLE
ci: fix lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,12 +15,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
+      - uses: actions/setup-go@v4
         with:
           go-version: 1.20.x
-
+          cache: false
+  
       - run: make deps-build
 
-      - uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
+      - uses: golangci/golangci-lint-action@v3.5.0
         with:
+          version: v1.52
           args: --timeout=10m

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,14 +15,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753
         with:
           go-version: 1.20.x
           cache: false
-  
+
       - run: make deps-build
 
-      - uses: golangci/golangci-lint-action@v3.5.0
+      - uses: golangci/golangci-lint-action@5f1fec7010f6ae3b84ea4f7b2129beb8639b564f
         with:
           version: v1.52
           args: --timeout=10m


### PR DESCRIPTION
## Summary

Fixes failing `lint` workflow by pinning specific compatible versions.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
