### PR TITLE
pin to a debian:latest image for casource base image

### DIFF
--- a/.github/Dockerfile-release
+++ b/.github/Dockerfile-release
@@ -1,6 +1,6 @@
 # build our own root trust store from current stable
-FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:latest@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 as casource
+RUN apt-get update && apt-get install -y ca-certificates=20210119
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 

--- a/.github/Dockerfile-release-debug
+++ b/.github/Dockerfile-release-debug
@@ -1,6 +1,6 @@
 # build our own root trust store from current stable
-FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:latest@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 as casource
+RUN apt-get update && apt-get install -y ca-certificates=20210119
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 

--- a/.github/Dockerfile-release-debug-nonroot
+++ b/.github/Dockerfile-release-debug-nonroot
@@ -1,6 +1,6 @@
 # build our own root trust store from current stable
-FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:latest@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 as casource
+RUN apt-get update && apt-get install -y ca-certificates=20210119
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 

--- a/.github/Dockerfile-release-nonroot
+++ b/.github/Dockerfile-release-nonroot
@@ -1,6 +1,6 @@
 # build our own root trust store from current stable
-FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:latest@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 as casource
+RUN apt-get update && apt-get install -y ca-certificates=20210119
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN make build-go NAME=pomerium
 RUN touch /config.yaml
 
 # build our own root trust store from current stable
-FROM debian:stable@sha256:cd9b6e7c992d48721c780696c93e1d65ebb3a3d6121e31353a6a16d78baf5386 as casource
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:latest@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 as casource
+RUN apt-get update && apt-get install -y ca-certificates=20210119
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 


### PR DESCRIPTION
The debian 'stable' images configure apt to install from the rolling 'stable' repository, rather than a specific Debian release. Thus even though we pin to a specific Docker image digest, the packages installed by 'apt-get' can change when a new Debian release is promoted to stable.

Instead, pin to an image where apt is configured to install from repositories for a specific Debian release (in this case, bullseye).