### PR TITLE
add JWT timestamp formatting workaround

### DIFF
--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -90,12 +90,20 @@ jwt_payload_exp = v {
 	v = five_minutes
 } else = null
 
+jwt_payload_exp_int = v {
+	v = to_number(format_int(jwt_payload_exp, 10))
+} else = null
+
 jwt_payload_iat = v {
 	# sessions store the issued_at on the id_token
 	v = round(session.id_token.issued_at.seconds)
 } else = v {
 	# service accounts store the issued at directly
 	v = round(session.issued_at.seconds)
+} else = null
+
+jwt_payload_iat_int = v {
+	v = to_number(format_int(jwt_payload_iat, 10))
 } else = null
 
 jwt_payload_sub = v {
@@ -133,8 +141,8 @@ base_jwt_claims := [
 	["iss", jwt_payload_iss],
 	["aud", jwt_payload_aud],
 	["jti", jwt_payload_jti],
-	["exp", jwt_payload_exp],
-	["iat", jwt_payload_iat],
+	["exp", jwt_payload_exp_int],
+	["iat", jwt_payload_iat_int],
 	["sub", jwt_payload_sub],
 	["user", jwt_payload_user],
 	["email", jwt_payload_email],


### PR DESCRIPTION
## Summary

Rego will sometimes serialize integers to JSON with a decimal point and exponent. I don't completely understand this behavior.

Add a workaround to headers.rego to convert the JWT "iat" and "exp" timestamps to a string and back to an integer. This appears to cause Rego to serialize these values as plain integers.

Add a unit test to verify this behavior. Also add a unit test that will fail if the Rego behavior changes, making this workaround unnecessary.

## Related issues

Fixes #4149.

## User Explanation

Simplify the Pomerium JWT timestamp format for better compatibility with some JWT parsing libraries.

## Checklist

- [x] reference any related issues
- [x] ~~updated docs~~ [shouldn't need any changes]
- [x] updated unit tests
- [x] ~~updated UPGRADING.md~~ [shouldn't need any changes]
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
