### PR TITLE
pin to a debian:latest image for casource base image (#4250)

### DIFF
--- a/.github/Dockerfile-release
+++ b/.github/Dockerfile-release
@@ -1,6 +1,6 @@
 # build our own root trust store from current stable
-FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:latest@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 as casource
+RUN apt-get update && apt-get install -y ca-certificates=20210119
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 

--- a/.github/Dockerfile-release-debug
+++ b/.github/Dockerfile-release-debug
@@ -1,6 +1,6 @@
 # build our own root trust store from current stable
-FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:latest@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 as casource
+RUN apt-get update && apt-get install -y ca-certificates=20210119
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 

--- a/.github/Dockerfile-release-debug-nonroot
+++ b/.github/Dockerfile-release-debug-nonroot
@@ -1,6 +1,6 @@
 # build our own root trust store from current stable
-FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:latest@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 as casource
+RUN apt-get update && apt-get install -y ca-certificates=20210119
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 

--- a/.github/Dockerfile-release-nonroot
+++ b/.github/Dockerfile-release-nonroot
@@ -1,6 +1,6 @@
 # build our own root trust store from current stable
-FROM debian:stable@sha256:1c3446475ac28a9f42a4627d8945d7bed88b8128b5850b61c5890ff47f317681 as casource
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:latest@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 as casource
+RUN apt-get update && apt-get install -y ca-certificates=20210119
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN make build-go NAME=pomerium
 RUN touch /config.yaml
 
 # build our own root trust store from current stable
-FROM debian:stable@sha256:1fbdbcfb07b174d245e5f26191aa0401294ae5612a406cdb407f1f6fa6e29e23 as casource
-RUN apt-get update && apt-get install -y ca-certificates
+FROM debian:latest@sha256:432f545c6ba13b79e2681f4cc4858788b0ab099fc1cca799cc0fae4687c69070 as casource
+RUN apt-get update && apt-get install -y ca-certificates=20210119
 # Remove expired root (https://github.com/pomerium/pomerium/issues/2653)
 RUN rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt && update-ca-certificates
 


### PR DESCRIPTION
Backport d96ca0611afbb9d1358dad35aee73e1cdcca0716 from #4250.