### PR TITLE
ci: fix lint workflow (#4229)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -18,9 +18,11 @@ jobs:
       - uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
         with:
           go-version: 1.20.x
+          cache: false
 
       - run: make deps-build
 
-      - uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
+      - uses: golangci/golangci-lint-action@5f1fec7010f6ae3b84ea4f7b2129beb8639b564f
         with:
+          version: v1.52
           args: --timeout=10m


### PR DESCRIPTION
Backport 334d4cd60d21e3c930d54f7bcafb2cb6d823e575 from #4229.