### PR TITLE
adds success colors for statuses in the 200 range

### DIFF
--- a/ui/src/components/ErrorPage.tsx
+++ b/ui/src/components/ErrorPage.tsx
@@ -20,8 +20,7 @@ type PolicyEvaluationTraceDetailsProps = {
   trace: PolicyEvaluationTrace;
 } & ListItemProps;
 const PolicyEvaluationTraceDetails: FC<PolicyEvaluationTraceDetailsProps> = ({
-  trace,
-  ...props
+  trace
 }) => {
   return (
     <TableRow>
@@ -52,14 +51,16 @@ export type ErrorPageProps = {
 export const ErrorPage: FC<ErrorPageProps> = ({ data }) => {
   const traces =
     data?.policyEvaluationTraces?.filter((trace) => !!trace.id) || [];
+  const status = data?.status || 500;
+
   return (
     <Container maxWidth={false}>
       <Paper sx={{ overflow: "hidden" }}>
         <Stack>
           <Box sx={{ padding: "16px" }}>
-            <Alert severity="error">
+            <Alert severity={status < 200 || status >= 300 ? "error" : "success"}>
               <AlertTitle>
-                {data?.status || 500}{" "}
+                {status}{" "}
                 {data?.statusText || "Internal Server Error"}
               </AlertTitle>
               {data?.description ? (


### PR DESCRIPTION
## Summary
Adds success colors when the status is a 200

## Related issues
https://app.zenhub.com/workspaces/pomerium-5f0d1eec340a620025c4dfa0/issues/gh/pomerium/pomerium-console/3214

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
