### PR TITLE
Allow clearing default Azure and Google auth code options

### DIFF
--- a/config/options_test.go
+++ b/config/options_test.go
@@ -977,6 +977,28 @@ func TestOptions_GetCSRFSameSite(t *testing.T) {
 	}
 }
 
+func TestOptions_RequestParams(t *testing.T) {
+	cases := []struct {
+		label    string
+		config   string
+		expected map[string]string
+	}{
+		{"not present", "", nil},
+		{"explicitly empty", "idp_request_params: {}", map[string]string{}},
+	}
+	cfg := filepath.Join(t.TempDir(), "config.yaml")
+	for i := range cases {
+		c := &cases[i]
+		t.Run(c.label, func(t *testing.T) {
+			err := os.WriteFile(cfg, []byte(c.config), 0644)
+			require.NoError(t, err)
+			o, err := newOptionsFromConfig(cfg)
+			require.NoError(t, err)
+			assert.Equal(t, c.expected, o.RequestParams)
+		})
+	}
+}
+
 func encodeCert(cert *tls.Certificate) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
 }

--- a/internal/identity/oidc/azure/microsoft.go
+++ b/internal/identity/oidc/azure/microsoft.go
@@ -61,7 +61,7 @@ func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
 	p.Provider = genericOidc
 
 	p.AuthCodeOptions = defaultAuthCodeOptions
-	if len(o.AuthCodeOptions) != 0 {
+	if o.AuthCodeOptions != nil {
 		p.AuthCodeOptions = o.AuthCodeOptions
 	}
 

--- a/internal/identity/oidc/azure/microsoft_test.go
+++ b/internal/identity/oidc/azure/microsoft_test.go
@@ -1,0 +1,23 @@
+package azure
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/internal/identity/oauth"
+)
+
+func TestAuthCodeOptions(t *testing.T) {
+	var options oauth.Options
+	p, err := New(context.Background(), &options)
+	require.NoError(t, err)
+	assert.Equal(t, defaultAuthCodeOptions, p.AuthCodeOptions)
+
+	options.AuthCodeOptions = map[string]string{}
+	p, err = New(context.Background(), &options)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{}, p.AuthCodeOptions)
+}

--- a/internal/identity/oidc/google/google.go
+++ b/internal/identity/oidc/google/google.go
@@ -55,7 +55,7 @@ func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
 	p.Provider = genericOidc
 
 	p.AuthCodeOptions = defaultAuthCodeOptions
-	if len(o.AuthCodeOptions) != 0 {
+	if o.AuthCodeOptions != nil {
 		p.AuthCodeOptions = o.AuthCodeOptions
 	}
 	return &p, nil

--- a/internal/identity/oidc/google/google_test.go
+++ b/internal/identity/oidc/google/google_test.go
@@ -1,0 +1,23 @@
+package google
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/internal/identity/oauth"
+)
+
+func TestAuthCodeOptions(t *testing.T) {
+	var options oauth.Options
+	p, err := New(context.Background(), &options)
+	require.NoError(t, err)
+	assert.Equal(t, defaultAuthCodeOptions, p.AuthCodeOptions)
+
+	options.AuthCodeOptions = map[string]string{}
+	p, err = New(context.Background(), &options)
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{}, p.AuthCodeOptions)
+}


### PR DESCRIPTION
## Summary

Allow users to clear the default Azure and Google auth code options, by explicitly setting an empty idp_request_params map.

To do this in a YAML config file, set:

    idp_request_params: {}

## Related issues

This is the idea suggested in https://github.com/pomerium/pomerium/pull/4251#issuecomment-1595115320.

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

Allow default IdP request params to be removed, by explicitly setting an empty `id_request_params` map.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review

## Note

There is also a default Apple auth code option, but the behavior there is different — it's always applied, being merged with any additional `idp_request_params`: https://github.com/pomerium/pomerium/blob/1f839554c9ed0016a4168224bd850e6acf8e36ff/internal/identity/oauth/apple/apple.go#L60-L62

I'm not sure we should change the behavior there without further discussion, as that would be a breaking change.