### PR TITLE
authorize: do not redirect if invalid client cert

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -32,6 +32,12 @@ func (a *Authorize) handleResult(
 	request *evaluator.Request,
 	result *evaluator.Result,
 ) (*envoy_service_auth_v3.CheckResponse, error) {
+	// If a client certificate is required, but the client did not provide a
+	// valid certificate, deny right away. Do not redirect to authenticate.
+	if result.Deny.Reasons.Has(criteria.ReasonInvalidClientCertificate) {
+		return a.handleResultDenied(ctx, in, request, result, result.Deny.Reasons)
+	}
+
 	// when the user is unauthenticated it means they haven't
 	// logged in yet, so redirect to authenticate
 	if result.Allow.Reasons.Has(criteria.ReasonUserUnauthenticated) ||

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -88,6 +88,19 @@ func TestAuthorize_handleResult(t *testing.T) {
 			assert.NotNil(t, res.GetOkResponse())
 		})
 	})
+	t.Run("invalid-client-certificate", func(t *testing.T) {
+		// Even if the user is unauthenticated, if a client certificate was required and no valid
+		// certificate was provided, access should be denied (no login redirect).
+		res, err := a.handleResult(context.Background(),
+			&envoy_service_auth_v3.CheckRequest{},
+			&evaluator.Request{},
+			&evaluator.Result{
+				Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+				Deny:  evaluator.NewRuleResult(true, criteria.ReasonInvalidClientCertificate),
+			})
+		assert.NoError(t, err)
+		assert.Equal(t, 495, int(res.GetDeniedResponse().GetStatus().GetCode()))
+	})
 }
 
 func TestAuthorize_okResponse(t *testing.T) {


### PR DESCRIPTION
## Summary

If an authorization policy requires a client certificate, but an incoming request does not include a valid certificate, we should serve a deny error page right away, regardless of whether the user is authenticated via the identity provider or not. Do not redirect to the identity provider login page in this case.

Update the existing integration tests accordingly.

## Related issues

 - #4347 

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
