### PR TITLE
chore: unnecessary use of fmt.Sprintf

### DIFF
--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -60,7 +60,7 @@ func TestAuthenticate_RobotsTxt(t *testing.T) {
 	if status := rr.Code; status != http.StatusOK {
 		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
 	}
-	expected := fmt.Sprintf("User-agent: *\nDisallow: /")
+	expected := "User-agent: *\nDisallow: /"
 	if rr.Body.String() != expected {
 		t.Errorf("handler returned wrong body: got %v want %v", rr.Body.String(), expected)
 	}
@@ -78,7 +78,7 @@ func TestAuthenticate_Handler(t *testing.T) {
 
 	rr := httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
-	expected := fmt.Sprintf("User-agent: *\nDisallow: /")
+	expected := "User-agent: *\nDisallow: /"
 
 	body := rr.Body.String()
 	if body != expected {
@@ -92,7 +92,7 @@ func TestAuthenticate_Handler(t *testing.T) {
 	req.Header.Set("Access-Control-Request-Headers", "X-Requested-With")
 	rr = httptest.NewRecorder()
 	h.ServeHTTP(rr, req)
-	expected = fmt.Sprintf("User-agent: *\nDisallow: /")
+	expected = "User-agent: *\nDisallow: /"
 	code := rr.Code
 	if code/100 != 2 {
 		t.Errorf("bad preflight code %v", code)

--- a/pkg/cryptutil/hmac_test.go
+++ b/pkg/cryptutil/hmac_test.go
@@ -56,8 +56,8 @@ func TestValidTimestamp(t *testing.T) {
 		{"good - now + 200ms", fmt.Sprint(time.Now().Add(200 * time.Millisecond).Unix()), false},
 		{"bad - now + 10m", fmt.Sprint(time.Now().Add(10 * time.Minute).Unix()), true},
 		{"bad - now - 10m", fmt.Sprint(time.Now().Add(-10 * time.Minute).Unix()), true},
-		{"malformed - non int", fmt.Sprint("pomerium"), true},
-		{"malformed - negative number", fmt.Sprint("-1"), true},
+		{"malformed - non int", "pomerium", true},
+		{"malformed - negative number", "-1", true},
 		{"malformed - huge number", fmt.Sprintf("%d", 10*10000000000), true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Remove fmt.Sprintf() calls where the format string contains no formatting verbs.
<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
