### PR TITLE
replace docker publish action ::set-output usage

### DIFF
--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -38,11 +38,11 @@ jobs:
           TAGS=${TAGS},${IMAGE}:master
           TAGS=${TAGS},${IMAGE}:${SHA_TAG}
           TS=$(date +%Y%m%d%H%M%S)
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=timestamp::${TS}
-          echo ::set-output name=name::pomerium
-          echo ::set-output name=image::${IMAGE}
-          echo ::set-output name=sha-tag::${SHA_TAG}
+          echo "tags=${TAGS}" >> $GITHUB_OUTPUT
+          echo "timestamp=${TS}" >> $GITHUB_OUTPUT
+          echo "name=pomerium" >> $GITHUB_OUTPUT
+          echo "image=${IMAGE}" >> $GITHUB_OUTPUT
+          echo "sha-tag=${SHA_TAG}" >> $GITHUB_OUTPUT
 
       - name: Docker Publish - Main
         uses: docker/build-push-action@2eb1c1961a95fc15694676618e422e8ba1d63825


### PR DESCRIPTION
## Summary

Update the 'Docker Main' GitHub Action workflow to update the deprecated ::set-output command to use the newer environment file mechanism.

## Related issues

#4358

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
