### PR TITLE
autocert: suppress OCSP stapling errors

### DIFF
--- a/internal/autocert/certmagic_logger.go
+++ b/internal/autocert/certmagic_logger.go
@@ -1,0 +1,50 @@
+package autocert
+
+import (
+	"strings"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+type certMagicLoggerCore struct {
+	core   zapcore.Core
+	fields []zapcore.Field
+}
+
+func (c certMagicLoggerCore) Enabled(lvl zapcore.Level) bool {
+	return c.core.Enabled(lvl)
+}
+
+func (c certMagicLoggerCore) With(fs []zapcore.Field) zapcore.Core {
+	return certMagicLoggerCore{core: c.core, fields: append(c.fields, fs...)}
+}
+
+func (c certMagicLoggerCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	return ce.AddCore(e, c)
+}
+
+func (c certMagicLoggerCore) Write(e zapcore.Entry, fs []zapcore.Field) error {
+	fs = append(c.fields, fs...)
+	for _, f := range fs {
+		if f.Type == zapcore.ErrorType && strings.Contains(f.Interface.(error).Error(), "no OCSP server specified in certificate") {
+			// ignore this error message (#4245)
+			return nil
+		}
+	}
+	return c.core.Write(e, fs)
+}
+
+func (c certMagicLoggerCore) Sync() error {
+	return c.core.Sync()
+}
+
+func getCertMagicLogger() *zap.Logger {
+	logger := log.ZapLogger().With(zap.String("service", "autocert"))
+	logger = logger.WithOptions(zap.WrapCore(func(c zapcore.Core) zapcore.Core {
+		return certMagicLoggerCore{core: c}
+	}))
+	return logger
+}

--- a/internal/autocert/certmagic_logger.go
+++ b/internal/autocert/certmagic_logger.go
@@ -23,6 +23,9 @@ func (c certMagicLoggerCore) With(fs []zapcore.Field) zapcore.Core {
 }
 
 func (c certMagicLoggerCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if !c.Enabled(e.Level) {
+		return ce
+	}
 	return ce.AddCore(e, c)
 }
 

--- a/internal/autocert/certmagic_logger_test.go
+++ b/internal/autocert/certmagic_logger_test.go
@@ -1,0 +1,28 @@
+package autocert
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestCertMagicLogger(t *testing.T) {
+	t.Parallel()
+
+	encoder := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+	var buf bytes.Buffer
+	core := zapcore.NewCore(encoder, zapcore.AddSync(&buf), zapcore.DebugLevel)
+	core = certMagicLoggerCore{core: core}
+
+	logger := zap.New(core)
+
+	logger.Info("TEST", zap.Error(errors.New("no OCSP server specified in certificate")))
+	assert.Empty(t, buf.Bytes())
+
+	logger.Info("TEST")
+	assert.NotEmpty(t, buf.Bytes())
+}

--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/caddyserver/certmagic"
 	"github.com/mholt/acmez/acme"
 	"github.com/rs/zerolog"
-	"go.uber.org/zap"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/httputil"
@@ -78,7 +77,7 @@ func newManager(ctx context.Context,
 		return nil, err
 	}
 
-	logger := log.ZapLogger().With(zap.String("service", "autocert"))
+	logger := getCertMagicLogger()
 	acmeTemplate.Logger = logger
 
 	mgr := &Manager{


### PR DESCRIPTION
## Summary
Suppress "no OCSP server specified in certificate" errors. These errors are generated in the certmagic package and logged with a zap logger, so we need to implement a custom zap core to remove them.

## Related issues
Fixes #4245 
 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
