### PR TITLE
envoy: add a filter to store client cert info

### DIFF
--- a/config/envoyconfig/lua.go
+++ b/config/envoyconfig/lua.go
@@ -9,18 +9,20 @@ import (
 var luaFS embed.FS
 
 var luascripts struct {
-	ExtAuthzSetCookie        string
-	CleanUpstream            string
-	RemoveImpersonateHeaders string
-	RewriteHeaders           string
+	ExtAuthzSetCookie            string
+	CleanUpstream                string
+	RemoveImpersonateHeaders     string
+	RewriteHeaders               string
+	SetClientCertificateMetadata string
 }
 
 func init() {
 	fileToField := map[string]*string{
-		"luascripts/clean-upstream.lua":             &luascripts.CleanUpstream,
-		"luascripts/ext-authz-set-cookie.lua":       &luascripts.ExtAuthzSetCookie,
-		"luascripts/remove-impersonate-headers.lua": &luascripts.RemoveImpersonateHeaders,
-		"luascripts/rewrite-headers.lua":            &luascripts.RewriteHeaders,
+		"luascripts/clean-upstream.lua":                  &luascripts.CleanUpstream,
+		"luascripts/ext-authz-set-cookie.lua":            &luascripts.ExtAuthzSetCookie,
+		"luascripts/remove-impersonate-headers.lua":      &luascripts.RemoveImpersonateHeaders,
+		"luascripts/rewrite-headers.lua":                 &luascripts.RewriteHeaders,
+		"luascripts/set-client-certificate-metadata.lua": &luascripts.SetClientCertificateMetadata,
 	}
 
 	err := fs.WalkDir(luaFS, "luascripts", func(p string, d fs.DirEntry, err error) error {

--- a/config/envoyconfig/luascripts/set-client-certificate-metadata.lua
+++ b/config/envoyconfig/luascripts/set-client-certificate-metadata.lua
@@ -1,0 +1,14 @@
+function envoy_on_request(request_handle)
+    local metadata = request_handle:streamInfo():dynamicMetadata()
+    local ssl = request_handle:streamInfo():downstreamSslConnection()
+    metadata:set("com.pomerium.client-certificate-info", "presented",
+                 ssl:peerCertificatePresented())
+    local validated = ssl:peerCertificateValidated()
+    metadata:set("com.pomerium.client-certificate-info", "validated", validated)
+    if validated then
+        metadata:set("com.pomerium.client-certificate-info", "chain", 
+                     ssl:urlEncodedPemEncodedPeerCertificateChain())
+    end
+end
+
+function envoy_on_response(response_handle) end

--- a/config/envoyconfig/luascripts/set-client-certificate-metadata.lua
+++ b/config/envoyconfig/luascripts/set-client-certificate-metadata.lua
@@ -6,7 +6,7 @@ function envoy_on_request(request_handle)
     local validated = ssl:peerCertificateValidated()
     metadata:set("com.pomerium.client-certificate-info", "validated", validated)
     if validated then
-        metadata:set("com.pomerium.client-certificate-info", "chain", 
+        metadata:set("com.pomerium.client-certificate-info", "chain",
                      ssl:urlEncodedPemEncodedPeerCertificateChain())
     end
 end


### PR DESCRIPTION
## Summary

Add a new Lua filter that will store client certificate info as dynamic metadata. This will allow us to configure client certificate validation at the Envoy listener level, and then pass the results of that validation into our ExtAuthz service.

This also allows us to pass the entire client certificate chain (and not just the leaf certificate, which is how the 'include_peer_certificate' ExtAuthz setting behaves). This will allow us to add support for intermediate CA certificates supplied by the client.

However, if a client certificate does not validate successfully by Envoy, we will not store the certificate chain. (This should help guard against any possibility of making policy decisions based on unvalidated client certificate data.)

## Related issues

#4352 

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] ~~updated docs~~ [n/a]
- [x] ~~updated unit tests~~ [n/a]
- [x] ~~updated UPGRADING.md~~ [n/a]
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
