### PR TITLE
authorize: incorporate mTLS validation from Envoy

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -215,8 +215,7 @@ func (e *Evaluator) evaluatePolicy(ctx context.Context, req *Request) (*PolicyRe
 		return nil, err
 	}
 
-	isValidClientCertificate, err :=
-		isValidClientCertificate(clientCA, req.HTTP.ClientCertificate)
+	isValidClientCertificate, err := isValidClientCertificate(clientCA, req.HTTP.ClientCertificate)
 	if err != nil {
 		return nil, fmt.Errorf("authorize: error validating client certificate: %w", err)
 	}

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -32,13 +32,13 @@ type Request struct {
 
 // RequestHTTP is the HTTP field in the request.
 type RequestHTTP struct {
-	Method            string            `json:"method"`
-	Hostname          string            `json:"hostname"`
-	Path              string            `json:"path"`
-	URL               string            `json:"url"`
-	Headers           map[string]string `json:"headers"`
-	ClientCertificate string            `json:"client_certificate"`
-	IP                string            `json:"ip"`
+	Method            string                `json:"method"`
+	Hostname          string                `json:"hostname"`
+	Path              string                `json:"path"`
+	URL               string                `json:"url"`
+	Headers           map[string]string     `json:"headers"`
+	ClientCertificate ClientCertificateInfo `json:"client_certificate"`
+	IP                string                `json:"ip"`
 }
 
 // NewRequestHTTP creates a new RequestHTTP.
@@ -46,7 +46,7 @@ func NewRequestHTTP(
 	method string,
 	requestURL url.URL,
 	headers map[string]string,
-	rawClientCertificate string,
+	clientCertificate ClientCertificateInfo,
 	ip string,
 ) RequestHTTP {
 	return RequestHTTP{
@@ -55,9 +55,31 @@ func NewRequestHTTP(
 		Path:              requestURL.Path,
 		URL:               requestURL.String(),
 		Headers:           headers,
-		ClientCertificate: rawClientCertificate,
+		ClientCertificate: clientCertificate,
 		IP:                ip,
 	}
+}
+
+// ClientCertificateInfo contains information about the certificate presented
+// by the client (if any).
+type ClientCertificateInfo struct {
+	// Presented is true if the client presented any certificate at all.
+	Presented bool `json:"presented"`
+
+	// Validated is true if the client presented a valid certificate with a
+	// trust chain rooted at any of the CAs configured within the Envoy
+	// listener. If any routes define a tls_downstream_client_ca, additional
+	// validation is required (for all routes).
+	Validated bool `json:"validated"`
+
+	// Leaf contains the leaf client certificate, provided that the certificate
+	// validated successfully.
+	Leaf string `json:"leaf,omitempty"`
+
+	// Intermediates contains the remainder of the client certificate chain as
+	// it was originally presented by the client, provided that the client
+	// certificate validated successfully.
+	Intermediates string `json:"intermediates,omitempty"`
 }
 
 // RequestSession is the session field in the request.
@@ -193,7 +215,8 @@ func (e *Evaluator) evaluatePolicy(ctx context.Context, req *Request) (*PolicyRe
 		return nil, err
 	}
 
-	isValidClientCertificate, err := isValidClientCertificate(clientCA, req.HTTP.ClientCertificate)
+	isValidClientCertificate, err :=
+		isValidClientCertificate(clientCA, req.HTTP.ClientCertificate)
 	if err != nil {
 		return nil, fmt.Errorf("authorize: error validating client certificate: %w", err)
 	}

--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -116,6 +116,12 @@ func TestEvaluator(t *testing.T) {
 		WithPolicies(policies),
 	}
 
+	validCertInfo := ClientCertificateInfo{
+		Presented: true,
+		Validated: true,
+		Leaf:      testValidCert,
+	}
+
 	t.Run("client certificate", func(t *testing.T) {
 		t.Run("invalid", func(t *testing.T) {
 			res, err := eval(t, options, nil, &Request{
@@ -128,7 +134,7 @@ func TestEvaluator(t *testing.T) {
 			res, err := eval(t, options, nil, &Request{
 				Policy: &policies[0],
 				HTTP: RequestHTTP{
-					ClientCertificate: testValidCert,
+					ClientCertificate: validCertInfo,
 				},
 			})
 			require.NoError(t, err)
@@ -154,7 +160,7 @@ func TestEvaluator(t *testing.T) {
 				HTTP: RequestHTTP{
 					Method:            http.MethodGet,
 					URL:               "https://from.example.com",
-					ClientCertificate: testValidCert,
+					ClientCertificate: validCertInfo,
 				},
 			})
 			require.NoError(t, err)
@@ -179,7 +185,7 @@ func TestEvaluator(t *testing.T) {
 					HTTP: RequestHTTP{
 						Method:            http.MethodGet,
 						URL:               "https://from.example.com",
-						ClientCertificate: testValidCert,
+						ClientCertificate: validCertInfo,
 					},
 				})
 				require.NoError(t, err)
@@ -206,7 +212,7 @@ func TestEvaluator(t *testing.T) {
 				HTTP: RequestHTTP{
 					Method:            http.MethodGet,
 					URL:               "https://from.example.com",
-					ClientCertificate: testValidCert,
+					ClientCertificate: validCertInfo,
 				},
 			})
 			require.NoError(t, err)
@@ -230,7 +236,7 @@ func TestEvaluator(t *testing.T) {
 				HTTP: RequestHTTP{
 					Method:            http.MethodGet,
 					URL:               "https://from.example.com",
-					ClientCertificate: testValidCert,
+					ClientCertificate: validCertInfo,
 				},
 			})
 			require.NoError(t, err)
@@ -254,7 +260,7 @@ func TestEvaluator(t *testing.T) {
 				HTTP: RequestHTTP{
 					Method:            http.MethodGet,
 					URL:               "https://from.example.com",
-					ClientCertificate: testValidCert,
+					ClientCertificate: validCertInfo,
 				},
 			})
 			require.NoError(t, err)
@@ -285,7 +291,7 @@ func TestEvaluator(t *testing.T) {
 				HTTP: RequestHTTP{
 					Method:            http.MethodGet,
 					URL:               "https://from.example.com",
-					ClientCertificate: testValidCert,
+					ClientCertificate: validCertInfo,
 				},
 			})
 			require.NoError(t, err)
@@ -310,7 +316,7 @@ func TestEvaluator(t *testing.T) {
 			HTTP: RequestHTTP{
 				Method:            http.MethodGet,
 				URL:               "https://from.example.com",
-				ClientCertificate: testValidCert,
+				ClientCertificate: validCertInfo,
 			},
 		})
 		require.NoError(t, err)
@@ -334,7 +340,7 @@ func TestEvaluator(t *testing.T) {
 			HTTP: RequestHTTP{
 				Method:            http.MethodGet,
 				URL:               "https://from.example.com",
-				ClientCertificate: testValidCert,
+				ClientCertificate: validCertInfo,
 			},
 		})
 		require.NoError(t, err)
@@ -363,7 +369,7 @@ func TestEvaluator(t *testing.T) {
 			HTTP: RequestHTTP{
 				Method:            http.MethodGet,
 				URL:               "https://from.example.com",
-				ClientCertificate: testValidCert,
+				ClientCertificate: validCertInfo,
 			},
 		})
 		require.NoError(t, err)
@@ -386,7 +392,7 @@ func TestEvaluator(t *testing.T) {
 			HTTP: RequestHTTP{
 				Method:            http.MethodGet,
 				URL:               "https://from.example.com",
-				ClientCertificate: testValidCert,
+				ClientCertificate: validCertInfo,
 			},
 		})
 		require.NoError(t, err)
@@ -423,7 +429,7 @@ func TestEvaluator(t *testing.T) {
 				HTTP: RequestHTTP{
 					Method:            http.MethodGet,
 					URL:               "https://from.example.com",
-					ClientCertificate: testValidCert,
+					ClientCertificate: validCertInfo,
 					Headers:           tc.src,
 				},
 			})
@@ -439,7 +445,7 @@ func TestEvaluator(t *testing.T) {
 				http.MethodGet,
 				*mustParseURL("https://from.example.com/"),
 				nil,
-				testValidCert,
+				validCertInfo,
 				"",
 			),
 		})
@@ -453,7 +459,7 @@ func TestEvaluator(t *testing.T) {
 				"POST",
 				*mustParseURL("https://from.example.com/test"),
 				nil,
-				testValidCert,
+				validCertInfo,
 				"",
 			),
 		})

--- a/authorize/evaluator/functions.go
+++ b/authorize/evaluator/functions.go
@@ -13,14 +13,15 @@ import (
 
 var isValidClientCertificateCache, _ = lru.New2Q[[2]string, bool](100)
 
-func isValidClientCertificate(ca, cert string) (bool, error) {
-	// when ca is the empty string, client certificates are always accepted
+func isValidClientCertificate(ca string, certInfo ClientCertificateInfo) (bool, error) {
+	// when ca is the empty string, client certificates are not required
 	if ca == "" {
 		return true, nil
 	}
 
-	// when cert is the empty string, no client certificate was supplied
-	if cert == "" {
+	cert := certInfo.Leaf
+
+	if !certInfo.Validated || cert == "" {
 		return false, nil
 	}
 

--- a/authorize/evaluator/functions_test.go
+++ b/authorize/evaluator/functions_test.go
@@ -95,27 +95,48 @@ Y+E5W+FKfIBv9yvdNBYZsL6IZ0Yh1ctKwB5gnajO8+swx5BeaCIbBrCtOBSB
 
 func Test_isValidClientCertificate(t *testing.T) {
 	t.Run("no ca", func(t *testing.T) {
-		valid, err := isValidClientCertificate("", "WHATEVER!")
+		valid, err := isValidClientCertificate("", ClientCertificateInfo{Leaf: "WHATEVER!"})
 		assert.NoError(t, err, "should not return an error")
 		assert.True(t, valid, "should return true")
 	})
 	t.Run("no cert", func(t *testing.T) {
-		valid, err := isValidClientCertificate(testCA, "")
+		valid, err := isValidClientCertificate(testCA, ClientCertificateInfo{})
 		assert.NoError(t, err, "should not return an error")
 		assert.False(t, valid, "should return false")
 	})
 	t.Run("valid cert", func(t *testing.T) {
-		valid, err := isValidClientCertificate(testCA, testValidCert)
+		valid, err := isValidClientCertificate(testCA, ClientCertificateInfo{
+			Presented: true,
+			Validated: true,
+			Leaf:      testValidCert,
+		})
 		assert.NoError(t, err, "should not return an error")
 		assert.True(t, valid, "should return true")
 	})
+	t.Run("cert not externally validated", func(t *testing.T) {
+		valid, err := isValidClientCertificate(testCA, ClientCertificateInfo{
+			Presented: true,
+			Validated: false,
+			Leaf:      testValidCert,
+		})
+		assert.NoError(t, err, "should not return an error")
+		assert.False(t, valid, "should return false")
+	})
 	t.Run("unsigned cert", func(t *testing.T) {
-		valid, err := isValidClientCertificate(testCA, testUnsignedCert)
+		valid, err := isValidClientCertificate(testCA, ClientCertificateInfo{
+			Presented: true,
+			Validated: true,
+			Leaf:      testUnsignedCert,
+		})
 		assert.NoError(t, err, "should not return an error")
 		assert.False(t, valid, "should return false")
 	})
 	t.Run("not a cert", func(t *testing.T) {
-		valid, err := isValidClientCertificate(testCA, "WHATEVER!")
+		valid, err := isValidClientCertificate(testCA, ClientCertificateInfo{
+			Presented: true,
+			Validated: true,
+			Leaf:      "WHATEVER!",
+		})
 		assert.Error(t, err, "should return an error")
 		assert.False(t, valid, "should return false")
 	})

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -1,20 +1,25 @@
 package authorize
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"net/url"
 	"testing"
 
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pomerium/pomerium/authorize/evaluator"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/atomicutil"
 	"github.com/pomerium/pomerium/internal/sessions"
+	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
@@ -53,12 +58,9 @@ func Test_getEvaluatorRequest(t *testing.T) {
 		}},
 	})
 
-	actual, err := a.getEvaluatorRequestFromCheckRequest(
+	actual, err := a.getEvaluatorRequestFromCheckRequest(context.Background(),
 		&envoy_service_auth_v3.CheckRequest{
 			Attributes: &envoy_service_auth_v3.AttributeContext{
-				Source: &envoy_service_auth_v3.AttributeContext_Peer{
-					Certificate: url.QueryEscape(certPEM),
-				},
 				Request: &envoy_service_auth_v3.AttributeContext_Request{
 					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 						Id:     "id-1234",
@@ -71,6 +73,17 @@ func Test_getEvaluatorRequest(t *testing.T) {
 						Host:   "example.com",
 						Scheme: "http",
 						Body:   "BODY",
+					},
+				},
+				MetadataContext: &envoy_config_core_v3.Metadata{
+					FilterMetadata: map[string]*structpb.Struct{
+						"com.pomerium.client-certificate-info": &structpb.Struct{
+							Fields: map[string]*structpb.Value{
+								"presented": structpb.NewBoolValue(true),
+								"validated": structpb.NewBoolValue(true),
+								"chain":     structpb.NewStringValue(url.QueryEscape(certPEM)),
+							},
+						},
 					},
 				},
 			},
@@ -92,7 +105,12 @@ func Test_getEvaluatorRequest(t *testing.T) {
 				"Accept":            "text/html",
 				"X-Forwarded-Proto": "https",
 			},
-			certPEM,
+			evaluator.ClientCertificateInfo{
+				Presented:     true,
+				Validated:     true,
+				Leaf:          certPEM[1:] + "\n",
+				Intermediates: "",
+			},
 			"",
 		),
 	}
@@ -110,27 +128,25 @@ func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 		}},
 	})
 
-	actual, err := a.getEvaluatorRequestFromCheckRequest(&envoy_service_auth_v3.CheckRequest{
-		Attributes: &envoy_service_auth_v3.AttributeContext{
-			Source: &envoy_service_auth_v3.AttributeContext_Peer{
-				Certificate: url.QueryEscape(certPEM),
-			},
-			Request: &envoy_service_auth_v3.AttributeContext_Request{
-				Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
-					Id:     "id-1234",
-					Method: http.MethodGet,
-					Headers: map[string]string{
-						"accept":            "text/html",
-						"x-forwarded-proto": "https",
+	actual, err := a.getEvaluatorRequestFromCheckRequest(context.Background(),
+		&envoy_service_auth_v3.CheckRequest{
+			Attributes: &envoy_service_auth_v3.AttributeContext{
+				Request: &envoy_service_auth_v3.AttributeContext_Request{
+					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
+						Id:     "id-1234",
+						Method: http.MethodGet,
+						Headers: map[string]string{
+							"accept":            "text/html",
+							"x-forwarded-proto": "https",
+						},
+						Path:   "/some/path?qs=1",
+						Host:   "example.com:80",
+						Scheme: "http",
+						Body:   "BODY",
 					},
-					Path:   "/some/path?qs=1",
-					Host:   "example.com:80",
-					Scheme: "http",
-					Body:   "BODY",
 				},
 			},
-		},
-	}, nil)
+		}, nil)
 	require.NoError(t, err)
 	expect := &evaluator.Request{
 		Policy:  &a.currentOptions.Load().Policies[0],
@@ -142,11 +158,142 @@ func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 				"Accept":            "text/html",
 				"X-Forwarded-Proto": "https",
 			},
-			certPEM,
+			evaluator.ClientCertificateInfo{},
 			"",
 		),
 	}
 	assert.Equal(t, expect, actual)
+}
+
+func Test_getClientCertificateInfo(t *testing.T) {
+	const leafPEM = `-----BEGIN CERTIFICATE-----
+MIIBZTCCAQugAwIBAgICEAEwCgYIKoZIzj0EAwIwGjEYMBYGA1UEAxMPSW50ZXJt
+ZWRpYXRlIENBMCIYDzAwMDEwMTAxMDAwMDAwWhgPMDAwMTAxMDEwMDAwMDBaMB8x
+HTAbBgNVBAMTFENsaWVudCBjZXJ0aWZpY2F0ZSAxMFkwEwYHKoZIzj0CAQYIKoZI
+zj0DAQcDQgAESly1cwEbcxaJBl6qAhrX1k7vejTFNE2dEbrTMpUYMl86GEWdsDYN
+KSa/1wZCowPy82gPGjfAU90odkqJOusCQqM4MDYwEwYDVR0lBAwwCgYIKwYBBQUH
+AwIwHwYDVR0jBBgwFoAU6Qb7nEl2XHKpf/QLL6PENsHFqbowCgYIKoZIzj0EAwID
+SAAwRQIgXREMUz81pYwJCMLGcV0ApaXIUap1V5n1N4VhyAGxGLYCIQC8p/LwoSgu
+71H3/nCi5MxsECsvVtsmHIfwXt0wulQ1TA==
+-----END CERTIFICATE-----
+`
+	const intermediatePEM = `-----BEGIN CERTIFICATE-----
+MIIBYzCCAQigAwIBAgICEAEwCgYIKoZIzj0EAwIwEjEQMA4GA1UEAxMHUm9vdCBD
+QTAiGA8wMDAxMDEwMTAwMDAwMFoYDzAwMDEwMTAxMDAwMDAwWjAaMRgwFgYDVQQD
+Ew9JbnRlcm1lZGlhdGUgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAATYaTr9
+uH4LpEp541/2SlKrdQZwNns+NHY/ftm++NhMDUn+izzNbPZ5aPT6VBs4Q6vbgfkK
+kDaBpaKzb+uOT+o1o0IwQDAdBgNVHQ4EFgQU6Qb7nEl2XHKpf/QLL6PENsHFqbow
+HwYDVR0jBBgwFoAUiQ3r61y+vxDn6PMWZrpISr67HiQwCgYIKoZIzj0EAwIDSQAw
+RgIhAMvdURs28uib2QwSMnqJjKasMb30yrSJvTiSU+lcg97/AiEA+6GpioM0c221
+n/XNKVYEkPmeXHRoz9ZuVDnSfXKJoHE=
+-----END CERTIFICATE-----
+`
+	const rootPEM = `-----BEGIN CERTIFICATE-----
+MIIBNzCB36ADAgECAgIQADAKBggqhkjOPQQDAjASMRAwDgYDVQQDEwdSb290IENB
+MCIYDzAwMDEwMTAxMDAwMDAwWhgPMDAwMTAxMDEwMDAwMDBaMBIxEDAOBgNVBAMT
+B1Jvb3QgQ0EwWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAAS6q0mTvm29xasq7Lwk
+aRGb2S/LkQFsAwaCXohSNvonCQHRMCRvA1IrQGk/oyBS5qrDoD9/7xkcVYHuTv5D
+CbtuoyEwHzAdBgNVHQ4EFgQUiQ3r61y+vxDn6PMWZrpISr67HiQwCgYIKoZIzj0E
+AwIDRwAwRAIgF1ux0ridbN+bo0E3TTcNY8Xfva7yquYRMmEkfbGvSb0CIDqK80B+
+fYCZHo3CID0gRSemaQ/jYMgyeBFrHIr6icZh
+-----END CERTIFICATE-----
+`
+
+	cases := []struct {
+		label       string
+		presented   bool
+		validated   bool
+		chain       string
+		expected    evaluator.ClientCertificateInfo
+		expectedLog string
+	}{
+		{
+			"not presented",
+			false,
+			false,
+			"",
+			evaluator.ClientCertificateInfo{},
+			"",
+		},
+		{
+			"presented but invalid",
+			true,
+			false,
+			"",
+			evaluator.ClientCertificateInfo{
+				Presented: true,
+			},
+			"",
+		},
+		{
+			"validated",
+			true,
+			true,
+			url.QueryEscape(leafPEM),
+			evaluator.ClientCertificateInfo{
+				Presented: true,
+				Validated: true,
+				Leaf:      leafPEM,
+			},
+			"",
+		},
+		{
+			"validated with intermediates",
+			true,
+			true,
+			url.QueryEscape(leafPEM + intermediatePEM + rootPEM),
+			evaluator.ClientCertificateInfo{
+				Presented:     true,
+				Validated:     true,
+				Leaf:          leafPEM,
+				Intermediates: intermediatePEM + rootPEM,
+			},
+			"",
+		},
+		{
+			"invalid chain URL encoding",
+			false,
+			false,
+			"invalid%URL%encoding",
+			evaluator.ClientCertificateInfo{},
+			`{"level":"warn","chain":"invalid%URL%encoding","error":"invalid URL escape \"%UR\"","message":"received unexpected client certificate \"chain\" value"}
+`,
+		},
+		{
+			"invalid chain PEM encoding",
+			true,
+			true,
+			"not valid PEM data",
+			evaluator.ClientCertificateInfo{
+				Presented: true,
+				Validated: true,
+			},
+			`{"level":"warn","chain":"not valid PEM data","message":"received unexpected client certificate \"chain\" value (no PEM block found)"}
+`,
+		},
+	}
+
+	var logOutput bytes.Buffer
+	zl := zerolog.New(&logOutput)
+	testutil.SetLogger(t, &zl)
+
+	ctx := context.Background()
+	for i := range cases {
+		c := &cases[i]
+		logOutput.Reset()
+		t.Run(c.label, func(t *testing.T) {
+			metadata := &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"presented": structpb.NewBoolValue(c.presented),
+					"validated": structpb.NewBoolValue(c.validated),
+					"chain":     structpb.NewStringValue(c.chain),
+				},
+			}
+			info := getClientCertificateInfo(ctx, metadata)
+			assert.Equal(t, c.expected, info)
+			assert.Equal(t, c.expectedLog, logOutput.String())
+		})
+	}
 }
 
 type mockDataBrokerServiceClient struct {

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -77,7 +77,7 @@ func Test_getEvaluatorRequest(t *testing.T) {
 				},
 				MetadataContext: &envoy_config_core_v3.Metadata{
 					FilterMetadata: map[string]*structpb.Struct{
-						"com.pomerium.client-certificate-info": &structpb.Struct{
+						"com.pomerium.client-certificate-info": {
 							Fields: map[string]*structpb.Value{
 								"presented": structpb.NewBoolValue(true),
 								"validated": structpb.NewBoolValue(true),

--- a/config/envoyconfig/filters.go
+++ b/config/envoyconfig/filters.go
@@ -35,8 +35,8 @@ func ExtAuthzFilter(grpcClientTimeout *durationpb.Duration) *envoy_extensions_fi
 						},
 					},
 				},
-				IncludePeerCertificate: true,
-				TransportApiVersion:    envoy_config_core_v3.ApiVersion_V3,
+				MetadataContextNamespaces: []string{"com.pomerium.client-certificate-info"},
+				TransportApiVersion:       envoy_config_core_v3.ApiVersion_V3,
 			}),
 		},
 	}

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -577,6 +577,9 @@ func clientCABundle(ctx context.Context, cfg *config.Config) []byte {
 	allPolicies := cfg.Options.GetAllPolicies()
 	for i := range allPolicies {
 		p := &allPolicies[i]
+		// We don't need to check TLSDownstreamClientCAFile here because
+		// Policy.Validate() will populate TLSDownstreamClientCA when
+		// TLSDownstreamClientCAFile is set.
 		if p.TLSDownstreamClientCA == "" {
 			continue
 		}

--- a/config/envoyconfig/testdata/main_http_connection_manager_filter.json
+++ b/config/envoyconfig/testdata/main_http_connection_manager_filter.json
@@ -34,6 +34,15 @@
         }
       },
       {
+        "name": "envoy.filters.http.lua",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
+          "defaultSourceCode": {
+            "inlineString": "function envoy_on_request(request_handle)\n    local metadata = request_handle:streamInfo():dynamicMetadata()\n    local ssl = request_handle:streamInfo():downstreamSslConnection()\n    metadata:set(\"com.pomerium.client-certificate-info\", \"presented\",\n                 ssl:peerCertificatePresented())\n    local validated = ssl:peerCertificateValidated()\n    metadata:set(\"com.pomerium.client-certificate-info\", \"validated\", validated)\n    if validated then\n        metadata:set(\"com.pomerium.client-certificate-info\", \"chain\",\n                     ssl:urlEncodedPemEncodedPeerCertificateChain())\n    end\nend\n\nfunction envoy_on_response(response_handle) end\n"
+          }
+        }
+      },
+      {
         "name": "envoy.filters.http.ext_authz",
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz",
@@ -43,7 +52,9 @@
             },
             "timeout": "10s"
           },
-          "includePeerCertificate": true,
+          "metadataContextNamespaces": [
+            "com.pomerium.client-certificate-info"
+          ],
           "statusOnError": {
             "code": "InternalServerError"
           },

--- a/internal/testutil/log.go
+++ b/internal/testutil/log.go
@@ -1,0 +1,18 @@
+package testutil
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+// SetLogger sets the given logger as the global logger for the remainder of
+// the current test. Because the logger is global, this must not be called from
+// parallel tests.
+func SetLogger(t *testing.T, logger *zerolog.Logger) {
+	originalLogger := log.Logger()
+	t.Cleanup(func() { log.SetLogger(originalLogger) })
+	log.SetLogger(logger)
+}


### PR DESCRIPTION
## Summary

Configure Envoy to validate client certificates, using the union of all relevant client CA bundles (that is, a bundle of the main client CA setting together with all per-route client CAs). Pass the validation status from Envoy through to the authorize service, by configuring Envoy to use the newly-added SetClientCertificateMetadata filter, and by also adding the relevant metadata namespace to the ExtAuthz configuration.

Remove the existing 'include_peer_certificate' setting from the ExtAuthz configuration, as the metadata from the Lua filter will include the full certificate chain (when it validates successfully by Envoy).

Update policy evaluation to consider the validation status from Envoy, in addition to its own certificate chain validation. (Policy evaluation cannot rely solely on the Envoy validation status while we still support the per-route client CA setting.)

## Related issues

Resolves #4352. Possibly #4257 as well (still need to add a test for that one).

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] ~~updated docs~~ [n/a]
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
