### PR TITLE
envoy: configure upstream IP SAN match as needed

### DIFF
--- a/config/envoyconfig/tls.go
+++ b/config/envoyconfig/tls.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"fmt"
+	"net"
 	"net/url"
 	"regexp"
 	"strings"
@@ -22,6 +23,17 @@ func (b *Builder) buildSubjectAltNameMatcher(
 	sni := dst.Hostname()
 	if overrideName != "" {
 		sni = overrideName
+	}
+
+	if net.ParseIP(sni) != nil {
+		return &envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher{
+			SanType: envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher_IP_ADDRESS,
+			Matcher: &envoy_type_matcher_v3.StringMatcher{
+				MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+					Exact: sni,
+				},
+			},
+		}
 	}
 
 	if strings.Contains(sni, "*") {

--- a/config/envoyconfig/tls_test.go
+++ b/config/envoyconfig/tls_test.go
@@ -34,6 +34,12 @@ func TestBuildSubjectAltNameMatcher(t *testing.T) {
 		}
 	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "[fd12:3456:789a:1::1]:1234"}, ""))
 	testutil.AssertProtoJSONEqual(t, `{
+		"sanType": "IP_ADDRESS",
+		"matcher": {
+			"exact": "fe80::1ff:fe23:4567:890a"
+		}
+	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "[fe80::1ff:fe23:4567:890a%eth2]:1234"}, ""))
+	testutil.AssertProtoJSONEqual(t, `{
 		"sanType": "DNS",
 		"matcher": {
 			"exact": "example.org"

--- a/config/envoyconfig/tls_test.go
+++ b/config/envoyconfig/tls_test.go
@@ -22,6 +22,18 @@ func TestBuildSubjectAltNameMatcher(t *testing.T) {
 		}
 	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "example.com:1234"}, ""))
 	testutil.AssertProtoJSONEqual(t, `{
+		"sanType": "IP_ADDRESS",
+		"matcher": {
+			"exact": "10.0.0.1"
+		}
+	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "10.0.0.1:1234"}, ""))
+	testutil.AssertProtoJSONEqual(t, `{
+		"sanType": "IP_ADDRESS",
+		"matcher": {
+			"exact": "fd12:3456:789a:1::1"
+		}
+	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "[fd12:3456:789a:1::1]:1234"}, ""))
+	testutil.AssertProtoJSONEqual(t, `{
 		"sanType": "DNS",
 		"matcher": {
 			"exact": "example.org"


### PR DESCRIPTION
## Summary

When building an upstream validation context for a particular URL, check whether the hostname is an IP address. If so, configure the SAN match to use type IP_ADDRESS rather than DNS.

## Related issues

Resolves #4379.

## User Explanation

Fix TLS certificate validation logic for routes where the `to` URL uses https with an IP address.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
