### PR TITLE
authorize: fix policy numbers in evaluator test

### DIFF
--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -76,11 +76,11 @@ func TestEvaluator(t *testing.T) {
 			AllowedDomains: []string{"example.com"},
 		},
 		{
-			To:                        config.WeightedURLs{{URL: *mustParseURL("https://to9.example.com")}},
+			To:                        config.WeightedURLs{{URL: *mustParseURL("https://to8.example.com")}},
 			AllowAnyAuthenticatedUser: true,
 		},
 		{
-			To: config.WeightedURLs{{URL: *mustParseURL("https://to10.example.com")}},
+			To: config.WeightedURLs{{URL: *mustParseURL("https://to9.example.com")}},
 			Policy: &config.PPLPolicy{
 				Policy: &parser.Policy{
 					Rules: []parser.Rule{{
@@ -95,7 +95,7 @@ func TestEvaluator(t *testing.T) {
 			},
 		},
 		{
-			To: config.WeightedURLs{{URL: *mustParseURL("https://to11.example.com")}},
+			To: config.WeightedURLs{{URL: *mustParseURL("https://to10.example.com")}},
 			Policy: &config.PPLPolicy{
 				Policy: &parser.Policy{
 					Rules: []parser.Rule{{
@@ -385,7 +385,7 @@ func TestEvaluator(t *testing.T) {
 				Id: "user1",
 			},
 		}, &Request{
-			Policy: &policies[8],
+			Policy: &policies[7],
 			Session: RequestSession{
 				ID: "session1",
 			},


### PR DESCRIPTION
## Summary

In authorize_test.go, the policy 'to' URLs are numbered from 1 to 11. However, there is no number 8 (it looks like it was removed in commit c178819). Update the URLs with numbers 9 through 11 to remove this gap. Update the "any authenticated user" test case to use the corresponding AllowAnyAuthenticatedUser policy (currently this case passes because it's using the policy that allows any GET request, but it's not testing what it says it should).

## Related issues

n/a

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
