### PR TITLE
authorize: add "client-certificate-required" reason

### DIFF
--- a/pkg/policy/criteria/criteria_test.go
+++ b/pkg/policy/criteria/criteria_test.go
@@ -29,16 +29,21 @@ var testingNow = time.Date(2021, 5, 11, 13, 43, 0, 0, time.Local)
 
 type (
 	Input struct {
-		HTTP    InputHTTP    `json:"http"`
-		Session InputSession `json:"session"`
+		HTTP                     InputHTTP    `json:"http"`
+		Session                  InputSession `json:"session"`
+		IsValidClientCertificate bool         `json:"is_valid_client_certificate"`
 	}
 	InputHTTP struct {
-		Method  string              `json:"method"`
-		Path    string              `json:"path"`
-		Headers map[string][]string `json:"headers"`
+		Method            string                `json:"method"`
+		Path              string                `json:"path"`
+		Headers           map[string][]string   `json:"headers"`
+		ClientCertificate ClientCertificateInfo `json:"client_certificate"`
 	}
 	InputSession struct {
 		ID string `json:"id"`
+	}
+	ClientCertificateInfo struct {
+		Presented bool `json:"presented"`
 	}
 )
 

--- a/pkg/policy/criteria/invalid_client_certificate_test.go
+++ b/pkg/policy/criteria/invalid_client_certificate_test.go
@@ -1,0 +1,60 @@
+package criteria
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInvalidClientCertificate(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		label    string
+		input    Input
+		expected A
+	}{
+		{
+			"not presented",
+			Input{},
+			A{true, A{ReasonClientCertificateRequired}, M{}},
+		},
+		{
+			"invalid",
+			Input{
+				HTTP: InputHTTP{
+					ClientCertificate: ClientCertificateInfo{Presented: true},
+				},
+			},
+			A{true, A{ReasonInvalidClientCertificate}, M{}},
+		},
+		{
+			"valid",
+			Input{
+				HTTP: InputHTTP{
+					ClientCertificate: ClientCertificateInfo{Presented: true},
+				},
+				IsValidClientCertificate: true,
+			},
+			A{false, A{ReasonValidClientCertificate}, M{}},
+		},
+	}
+
+	const policy = `
+deny:
+  or:
+    - invalid_client_certificate: true`
+
+	for i := range cases {
+		c := cases[i]
+		t.Run(c.label, func(t *testing.T) {
+			t.Parallel()
+
+			res, err := evaluate(t, policy, []dataBrokerRecord{}, c.input)
+			require.NoError(t, err)
+			assert.Equal(t, A{false, A{}}, res["allow"])
+			assert.Equal(t, c.expected, res["deny"])
+		})
+	}
+}

--- a/pkg/policy/criteria/reasons.go
+++ b/pkg/policy/criteria/reasons.go
@@ -7,31 +7,32 @@ type Reason string
 
 // Well-known reasons.
 const (
-	ReasonAccept                   = "accept"
-	ReasonClaimOK                  = "claim-ok"
-	ReasonClaimUnauthorized        = "claim-unauthorized"
-	ReasonCORSRequest              = "cors-request"
-	ReasonDeviceOK                 = "device-ok"
-	ReasonDeviceUnauthenticated    = "device-unauthenticated"
-	ReasonDeviceUnauthorized       = "device-unauthorized"
-	ReasonDomainOK                 = "domain-ok"
-	ReasonDomainUnauthorized       = "domain-unauthorized"
-	ReasonEmailOK                  = "email-ok"
-	ReasonEmailUnauthorized        = "email-unauthorized"
-	ReasonHTTPMethodOK             = "http-method-ok"
-	ReasonHTTPMethodUnauthorized   = "http-method-unauthorized"
-	ReasonHTTPPathOK               = "http-path-ok"
-	ReasonHTTPPathUnauthorized     = "http-path-unauthorized"
-	ReasonInvalidClientCertificate = "invalid-client-certificate"
-	ReasonNonCORSRequest           = "non-cors-request"
-	ReasonNonPomeriumRoute         = "non-pomerium-route"
-	ReasonPomeriumRoute            = "pomerium-route"
-	ReasonReject                   = "reject"
-	ReasonRouteNotFound            = "route-not-found"
-	ReasonUserOK                   = "user-ok"
-	ReasonUserUnauthenticated      = "user-unauthenticated" // user needs to log in
-	ReasonUserUnauthorized         = "user-unauthorized"    // user does not have access
-	ReasonValidClientCertificate   = "valid-client-certificate"
+	ReasonAccept                    = "accept"
+	ReasonClaimOK                   = "claim-ok"
+	ReasonClaimUnauthorized         = "claim-unauthorized"
+	ReasonClientCertificateRequired = "client-certificate-required"
+	ReasonCORSRequest               = "cors-request"
+	ReasonDeviceOK                  = "device-ok"
+	ReasonDeviceUnauthenticated     = "device-unauthenticated"
+	ReasonDeviceUnauthorized        = "device-unauthorized"
+	ReasonDomainOK                  = "domain-ok"
+	ReasonDomainUnauthorized        = "domain-unauthorized"
+	ReasonEmailOK                   = "email-ok"
+	ReasonEmailUnauthorized         = "email-unauthorized"
+	ReasonHTTPMethodOK              = "http-method-ok"
+	ReasonHTTPMethodUnauthorized    = "http-method-unauthorized"
+	ReasonHTTPPathOK                = "http-path-ok"
+	ReasonHTTPPathUnauthorized      = "http-path-unauthorized"
+	ReasonInvalidClientCertificate  = "invalid-client-certificate"
+	ReasonNonCORSRequest            = "non-cors-request"
+	ReasonNonPomeriumRoute          = "non-pomerium-route"
+	ReasonPomeriumRoute             = "pomerium-route"
+	ReasonReject                    = "reject"
+	ReasonRouteNotFound             = "route-not-found"
+	ReasonUserOK                    = "user-ok"
+	ReasonUserUnauthenticated       = "user-unauthenticated" // user needs to log in
+	ReasonUserUnauthorized          = "user-unauthorized"    // user does not have access
+	ReasonValidClientCertificate    = "valid-client-certificate"
 )
 
 // Reasons is a collection of reasons.


### PR DESCRIPTION
## Summary

Add a new reason "client-certificate-required" that will be returned by the invalid_client_certificate criterion in the case that no client certificate was provided. Determine this using the new 'presented' field populated from the Envoy metadata.

## Related issues

- https://github.com/pomerium/pomerium/issues/4355

## User Explanation

Change the "deny" reason logged by the authorize service from "invalid-client-certificate" to "client-certificate-required" in the case that a client certificate was required but no certificate was presented.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
