### PR TITLE
logs: add ip address to access logs

### DIFF
--- a/internal/controlplane/grpc_accesslog.go
+++ b/internal/controlplane/grpc_accesslog.go
@@ -62,6 +62,8 @@ func populateLogEvent(
 		return evt.Dur(string(field), dur)
 	case log.AccessLogFieldForwardedFor:
 		return evt.Str(string(field), entry.GetRequest().GetForwardedFor())
+	case log.AccessLogFieldIP:
+		return evt.Str(string(field), entry.GetCommonProperties().GetDownstreamRemoteAddress().GetSocketAddress().GetAddress())
 	case log.AccessLogFieldMethod:
 		return evt.Str(string(field), entry.GetRequest().GetRequestMethod().String())
 	case log.AccessLogFieldPath:

--- a/internal/controlplane/grpc_accesslog_test.go
+++ b/internal/controlplane/grpc_accesslog_test.go
@@ -21,6 +21,13 @@ func Test_populateLogEvent(t *testing.T) {
 
 	entry := &envoy_data_accesslog_v3.HTTPAccessLogEntry{
 		CommonProperties: &envoy_data_accesslog_v3.AccessLogCommon{
+			DownstreamRemoteAddress: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Address: "127.0.0.1",
+					},
+				},
+			},
 			TimeToLastDownstreamTxByte: durationpb.New(time.Second * 3),
 			UpstreamCluster:            "UPSTREAM-CLUSTER",
 		},
@@ -47,6 +54,7 @@ func Test_populateLogEvent(t *testing.T) {
 		{log.AccessLogFieldAuthority, `{"authority":"AUTHORITY"}`},
 		{log.AccessLogFieldDuration, `{"duration":3000}`},
 		{log.AccessLogFieldForwardedFor, `{"forwarded-for":"FORWARDED-FOR"}`},
+		{log.AccessLogFieldIP, `{"ip":"127.0.0.1"}`},
 		{log.AccessLogFieldMethod, `{"method":"GET"}`},
 		{log.AccessLogFieldPath, `{"path":"https://www.example.com/some/path"}`},
 		{log.AccessLogFieldQuery, `{"query":"a=b"}`},

--- a/internal/log/access.go
+++ b/internal/log/access.go
@@ -13,6 +13,7 @@ const (
 	AccessLogFieldAuthority           AccessLogField = "authority"
 	AccessLogFieldDuration            AccessLogField = "duration"
 	AccessLogFieldForwardedFor        AccessLogField = "forwarded-for"
+	AccessLogFieldIP                  AccessLogField = "ip"
 	AccessLogFieldMethod              AccessLogField = "method"
 	AccessLogFieldPath                AccessLogField = "path"
 	AccessLogFieldQuery               AccessLogField = "query"
@@ -52,6 +53,7 @@ var accessLogFieldLookup = map[AccessLogField]struct{}{
 	AccessLogFieldAuthority:           {},
 	AccessLogFieldDuration:            {},
 	AccessLogFieldForwardedFor:        {},
+	AccessLogFieldIP:                  {},
 	AccessLogFieldMethod:              {},
 	AccessLogFieldPath:                {},
 	AccessLogFieldQuery:               {},


### PR DESCRIPTION
## Summary
Add an `ip` address field for access logs.

## Related issues
- https://github.com/pomerium/pomerium/issues/4377
 

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
