### PR TITLE
authorize: add support for logging id token

### DIFF
--- a/authorize/log_test.go
+++ b/authorize/log_test.go
@@ -46,6 +46,9 @@ func Test_populateLogEvent(t *testing.T) {
 	headers := map[string]string{"X-Request-Id": "CHECK-REQUEST-ID"}
 	s := &session.Session{
 		Id: "SESSION-ID",
+		IdToken: &session.IDToken{
+			Raw: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2OTAzMTU4NjIsImV4cCI6MTcyMTg1MTg2MiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.AAojgaG0fjMFwMCAC6YALHHMFIZEedFSP_vMGhiHhso",
+		},
 	}
 	sa := &user.ServiceAccount{
 		Id: "SERVICE-ACCOUNT-ID",
@@ -68,6 +71,7 @@ func Test_populateLogEvent(t *testing.T) {
 		{log.AuthorizeLogFieldCheckRequestID, s, `{"check-request-id":"CHECK-REQUEST-ID"}`},
 		{log.AuthorizeLogFieldEmail, s, `{"email":"EMAIL"}`},
 		{log.AuthorizeLogFieldHost, s, `{"host":"HOST"}`},
+		{log.AuthorizeLogFieldIDToken, s, `{"id-token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2OTAzMTU4NjIsImV4cCI6MTcyMTg1MTg2MiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.AAojgaG0fjMFwMCAC6YALHHMFIZEedFSP_vMGhiHhso","id-token-claims":{"Email":"jrocket@example.com","GivenName":"Johnny","Role":["Manager","Project Administrator"],"Surname":"Rocket","aud":"www.example.com","exp":1721851862,"iat":1690315862,"iss":"Online JWT Builder","sub":"jrocket@example.com"}}`},
 		{log.AuthorizeLogFieldImpersonateEmail, s, `{"impersonate-email":"IMPERSONATE-EMAIL"}`},
 		{log.AuthorizeLogFieldImpersonateSessionID, s, `{"impersonate-session-id":"IMPERSONATE-SESSION-ID"}`},
 		{log.AuthorizeLogFieldImpersonateUserID, s, `{"impersonate-user-id":"IMPERSONATE-USER-ID"}`},

--- a/internal/log/authorize.go
+++ b/internal/log/authorize.go
@@ -16,6 +16,7 @@ const (
 	AuthorizeLogFieldEmail                AuthorizeLogField = "email"
 	AuthorizeLogFieldHeaders                                = AuthorizeLogField(headersFieldName)
 	AuthorizeLogFieldHost                 AuthorizeLogField = "host"
+	AuthorizeLogFieldIDToken              AuthorizeLogField = "id-token"
 	AuthorizeLogFieldImpersonateEmail     AuthorizeLogField = "impersonate-email"
 	AuthorizeLogFieldImpersonateSessionID AuthorizeLogField = "impersonate-session-id"
 	AuthorizeLogFieldImpersonateUserID    AuthorizeLogField = "impersonate-user-id"
@@ -63,6 +64,7 @@ var authorizeLogFieldLookup = map[AuthorizeLogField]struct{}{
 	AuthorizeLogFieldEmail:                {},
 	AuthorizeLogFieldHeaders:              {},
 	AuthorizeLogFieldHost:                 {},
+	AuthorizeLogFieldIDToken:              {},
 	AuthorizeLogFieldImpersonateEmail:     {},
 	AuthorizeLogFieldImpersonateSessionID: {},
 	AuthorizeLogFieldImpersonateUserID:    {},


### PR DESCRIPTION
## Summary
Add support for logging the id token. When this field is included in the logs the raw id token will be logged to `id-token` and the decoded claims to `id-token-claims`.

## Related issues
- https://github.com/pomerium/pomerium/issues/4376
 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
