### PR TITLE
autocert: use new OCSP error type

### DIFF
--- a/internal/autocert/certmagic_logger.go
+++ b/internal/autocert/certmagic_logger.go
@@ -1,8 +1,9 @@
 package autocert
 
 import (
-	"strings"
+	"errors"
 
+	"github.com/caddyserver/certmagic"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -32,7 +33,7 @@ func (c certMagicLoggerCore) Check(e zapcore.Entry, ce *zapcore.CheckedEntry) *z
 func (c certMagicLoggerCore) Write(e zapcore.Entry, fs []zapcore.Field) error {
 	fs = append(c.fields, fs...)
 	for _, f := range fs {
-		if f.Type == zapcore.ErrorType && strings.Contains(f.Interface.(error).Error(), "no OCSP server specified in certificate") {
+		if f.Type == zapcore.ErrorType && errors.Is(f.Interface.(error), certmagic.ErrNoOCSPServerSpecified) {
 			// ignore this error message (#4245)
 			return nil
 		}

--- a/internal/autocert/certmagic_logger_test.go
+++ b/internal/autocert/certmagic_logger_test.go
@@ -2,9 +2,10 @@ package autocert
 
 import (
 	"bytes"
-	"errors"
+	"fmt"
 	"testing"
 
+	"github.com/caddyserver/certmagic"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -20,7 +21,8 @@ func TestCertMagicLogger(t *testing.T) {
 
 	logger := zap.New(core)
 
-	logger.Info("TEST", zap.Error(errors.New("no OCSP server specified in certificate")))
+	ocspError := fmt.Errorf("ocsp error: %w", certmagic.ErrNoOCSPServerSpecified)
+	logger.Info("TEST", zap.Error(ocspError))
 	assert.Empty(t, buf.Bytes())
 
 	logger.Info("TEST")


### PR DESCRIPTION
## Summary

The certmagic package now exposes an `ErrNoOCSPServerSpecified` for the OCSP stapling error that we suppress. Let's check for this error using `errors.Is()` rather than performing a substring match on the error text.

## Related issues

Follow-up to https://github.com/pomerium/pomerium/issues/4245.

## User Explanation

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
