### PR TITLE
authorize: client cert fingerprint in set_request_headers

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -225,7 +225,7 @@ func (e *Evaluator) evaluatePolicy(ctx context.Context, req *Request) (*PolicyRe
 }
 
 func (e *Evaluator) evaluateHeaders(ctx context.Context, req *Request) (*HeadersResponse, error) {
-	headersReq := NewHeadersRequestFromPolicy(req.Policy, req.HTTP.Hostname)
+	headersReq := NewHeadersRequestFromPolicy(req.Policy, req.HTTP)
 	headersReq.Session = req.Session
 	res, err := e.headersEvaluators.Evaluate(ctx, headersReq)
 	if err != nil {

--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -17,21 +17,22 @@ import (
 
 // HeadersRequest is the input to the headers.rego script.
 type HeadersRequest struct {
-	EnableGoogleCloudServerlessAuthentication bool              `json:"enable_google_cloud_serverless_authentication"`
-	EnableRoutingKey                          bool              `json:"enable_routing_key"`
-	Issuer                                    string            `json:"issuer"`
-	KubernetesServiceAccountToken             string            `json:"kubernetes_service_account_token"`
-	ToAudience                                string            `json:"to_audience"`
-	Session                                   RequestSession    `json:"session"`
-	PassAccessToken                           bool              `json:"pass_access_token"`
-	PassIDToken                               bool              `json:"pass_id_token"`
-	SetRequestHeaders                         map[string]string `json:"set_request_headers"`
+	EnableGoogleCloudServerlessAuthentication bool                  `json:"enable_google_cloud_serverless_authentication"`
+	EnableRoutingKey                          bool                  `json:"enable_routing_key"`
+	Issuer                                    string                `json:"issuer"`
+	KubernetesServiceAccountToken             string                `json:"kubernetes_service_account_token"`
+	ToAudience                                string                `json:"to_audience"`
+	Session                                   RequestSession        `json:"session"`
+	ClientCertificate                         ClientCertificateInfo `json:"client_certificate"`
+	PassAccessToken                           bool                  `json:"pass_access_token"`
+	PassIDToken                               bool                  `json:"pass_id_token"`
+	SetRequestHeaders                         map[string]string     `json:"set_request_headers"`
 }
 
 // NewHeadersRequestFromPolicy creates a new HeadersRequest from a policy.
-func NewHeadersRequestFromPolicy(policy *config.Policy, hostname string) *HeadersRequest {
+func NewHeadersRequestFromPolicy(policy *config.Policy, http RequestHTTP) *HeadersRequest {
 	input := new(HeadersRequest)
-	input.Issuer = hostname
+	input.Issuer = http.Hostname
 	if policy != nil {
 		input.EnableGoogleCloudServerlessAuthentication = policy.EnableGoogleCloudServerlessAuthentication
 		input.EnableRoutingKey = policy.EnvoyOpts.GetLbPolicy() == envoy_config_cluster_v3.Cluster_RING_HASH ||
@@ -42,6 +43,7 @@ func NewHeadersRequestFromPolicy(policy *config.Policy, hostname string) *Header
 		}
 		input.PassAccessToken = policy.GetSetAuthorizationHeader() == configpb.Route_ACCESS_TOKEN
 		input.PassIDToken = policy.GetSetAuthorizationHeader() == configpb.Route_ID_TOKEN
+		input.ClientCertificate = http.ClientCertificate
 		input.SetRequestHeaders = policy.SetRequestHeaders
 	}
 	return input

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -34,16 +34,24 @@ func TestNewHeadersRequestFromPolicy(t *testing.T) {
 				URL: *mustParseURL("http://to.example.com"),
 			},
 		},
-	}, "from.example.com")
+	}, RequestHTTP{
+		Hostname: "from.example.com",
+		ClientCertificate: ClientCertificateInfo{
+			Leaf: "--- FAKE CERTIFICATE ---",
+		},
+	})
 	assert.Equal(t, &HeadersRequest{
 		EnableGoogleCloudServerlessAuthentication: true,
 		Issuer:     "from.example.com",
 		ToAudience: "https://to.example.com",
+		ClientCertificate: ClientCertificateInfo{
+			Leaf: "--- FAKE CERTIFICATE ---",
+		},
 	}, req)
 }
 
 func TestNewHeadersRequestFromPolicy_nil(t *testing.T) {
-	req := NewHeadersRequestFromPolicy(nil, "from.example.com")
+	req := NewHeadersRequestFromPolicy(nil, RequestHTTP{Hostname: "from.example.com"})
 	assert.Equal(t, &HeadersRequest{
 		Issuer: "from.example.com",
 	}, req)
@@ -184,16 +192,20 @@ func TestHeadersEvaluator(t *testing.T) {
 				ToAudience: "to.example.com",
 				Session:    RequestSession{ID: "s1"},
 				SetRequestHeaders: map[string]string{
-					"X-Custom-Header": "CUSTOM_VALUE",
-					"X-ID-Token":      "$pomerium.id_token",
-					"X-Access-Token":  "$pomerium.access_token",
+					"X-Custom-Header":         "CUSTOM_VALUE",
+					"X-ID-Token":              "$pomerium.id_token",
+					"X-Access-Token":          "$pomerium.access_token",
+					"Client-Cert-Fingerprint": "$pomerium.client_cert_fingerprint",
 				},
+				ClientCertificate: ClientCertificateInfo{Leaf: testValidCert},
 			})
 		require.NoError(t, err)
 
 		assert.Equal(t, "CUSTOM_VALUE", output.Headers.Get("X-Custom-Header"))
 		assert.Equal(t, "ID_TOKEN", output.Headers.Get("X-ID-Token"))
 		assert.Equal(t, "ACCESS_TOKEN", output.Headers.Get("X-Access-Token"))
+		assert.Equal(t, "17859273e8a980631d367b2d5a6a6635412b0f22835f69e47b3f65624546a704",
+			output.Headers.Get("Client-Cert-Fingerprint"))
 	})
 
 	t.Run("set_request_headers original behavior", func(t *testing.T) {
@@ -216,6 +228,20 @@ func TestHeadersEvaluator(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, "Bearer ID_TOKEN", output.Headers.Get("Authorization"))
+	})
+
+	t.Run("set_request_headers no client cert", func(t *testing.T) {
+		output, err := eval(t, nil,
+			&HeadersRequest{
+				Issuer:     "from.example.com",
+				ToAudience: "to.example.com",
+				SetRequestHeaders: map[string]string{
+					"fingerprint": "$pomerium.client_cert_fingerprint",
+				},
+			})
+		require.NoError(t, err)
+
+		assert.Equal(t, "", output.Headers.Get("fingerprint"))
 	})
 }
 


### PR DESCRIPTION
## Summary

Add support for a new token `$pomerium.client_cert_fingerprint` in the set_request_headers option. This token will be replaced with the SHA-256 hash of the presented leaf client certificate.

## Related issues

Fixes #4259.

## User Explanation

Allow passing the client certificate fingerprint to upstream services, by adding support for the token `$pomerium.client_cert_fingerprint` in the [Set Request Headers](https://www.pomerium.com/docs/reference/routes/set-request-headers) option.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
