### PR TITLE
config: extra CA and CRL validation

### DIFF
--- a/config/mtls.go
+++ b/config/mtls.go
@@ -116,10 +116,15 @@ func (s *DownstreamMTLSSettings) GetMaxVerifyDepth() uint32 {
 }
 
 func (s *DownstreamMTLSSettings) validate() error {
-	if _, err := s.GetCA(); err != nil {
+	if s.CA != "" && s.CAFile != "" {
+		return errors.New("cannot set both ca and ca_file")
+	} else if _, err := s.GetCA(); err != nil {
 		return err
 	}
 
+	if s.CRL != "" && s.CRLFile != "" {
+		return errors.New("cannot set both crl and crl_file")
+	}
 	crl, err := s.GetCRL()
 	if err != nil {
 		return err

--- a/config/mtls_test.go
+++ b/config/mtls_test.go
@@ -122,10 +122,14 @@ func TestDownstreamMTLSSettingsValidate(t *testing.T) {
 		errorMsg string
 	}{
 		{"not set", DownstreamMTLSSettings{}, ""},
+		{"both CA and CA file", DownstreamMTLSSettings{CA: "CA", CAFile: "CAFile"},
+			"cannot set both ca and ca_file"},
 		{"bad CA", DownstreamMTLSSettings{CA: "not%valid%base64%data"},
 			"CA: illegal base64 data at input byte 3"},
 		{"bad CA file", DownstreamMTLSSettings{CAFile: "-"},
 			"CA file: open -: no such file or directory"},
+		{"both CRL and CRL file", DownstreamMTLSSettings{CRL: "CRL", CRLFile: "CRLFile"},
+			"cannot set both crl and crl_file"},
 		{"bad CRL", DownstreamMTLSSettings{CRL: "dGhpc2lzZmluZQo="},
 			"CRL: cryptutil: invalid crl, no X509 CRL block found"},
 		{"bad CRL file", DownstreamMTLSSettings{CRLFile: "-"},

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -705,18 +705,37 @@ func TestDeprecatedClientCAOptions(t *testing.T) {
 	zl := zerolog.New(&logOutput)
 	testutil.SetLogger(t, &zl)
 
-	o := NewDefaultOptions()
-	o.ClientCA = "LS0tIEZBS0UgQ0EgQ0VSVCAtLS0="
-	o.ClientCAFile = caFile
-	o.AutocertOptions.Enable = true // suppress an unrelated warning
+	t.Run("CA", func(t *testing.T) {
+		logOutput.Reset()
 
-	err := o.Validate()
-	require.NoError(t, err)
-	assert.Equal(t, "LS0tIEZBS0UgQ0EgQ0VSVCAtLS0=", o.DownstreamMTLS.CA)
-	assert.Equal(t, caFile, o.DownstreamMTLS.CAFile)
-	assert.Equal(t, `{"level":"warn","message":"config: client_ca is deprecated, set downstream_mtls.ca instead"}
-{"level":"warn","message":"config: client_ca_file is deprecated, set downstream_mtls.ca_file instead"}
-`, logOutput.String())
+		o := NewDefaultOptions()
+		o.AutocertOptions.Enable = true // suppress an unrelated warning
+		o.ClientCA = "LS0tIEZBS0UgQ0EgQ0VSVCAtLS0="
+
+		err := o.Validate()
+
+		require.NoError(t, err)
+		assert.Equal(t, "LS0tIEZBS0UgQ0EgQ0VSVCAtLS0=", o.DownstreamMTLS.CA)
+		assert.Equal(t, `{"level":"warn","message":"config: client_ca is deprecated, set downstream_mtls.ca instead"}
+`,
+			logOutput.String())
+	})
+
+	t.Run("CAFile", func(t *testing.T) {
+		logOutput.Reset()
+
+		o := NewDefaultOptions()
+		o.AutocertOptions.Enable = true // suppress an unrelated warning
+		o.ClientCAFile = caFile
+
+		err := o.Validate()
+
+		require.NoError(t, err)
+		assert.Equal(t, caFile, o.DownstreamMTLS.CAFile)
+		assert.Equal(t, `{"level":"warn","message":"config: client_ca_file is deprecated, set downstream_mtls.ca_file instead"}
+`,
+			logOutput.String())
+	})
 }
 
 func TestOptions_DefaultURL(t *testing.T) {


### PR DESCRIPTION
## Summary

Return an error from DownstreamMTLSSettings.validate() if both CA and CAFile are populated, or if both CRL and CRLFile are populated.

## Related issues

https://github.com/pomerium/internal/issues/1485

## User Explanation

Pomerium will now consider it an error if both `downstream_mtls.ca` and `downstream_mtls.ca_file` are set. Likewise, Pomerium will now consider it an error if both `downstream_mtls.crl` and `downstream_mtls.crl_file` are set.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
