### PR TITLE
authorize: rework token substitution in headers

### DIFF
--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -80,6 +80,9 @@ var variableSubstitutionFunctionRegoOption = rego.Function2(&rego.Function{
 
 	var err error
 	output := os.Expand(string(inputString), func(key string) string {
+		if key == "$" {
+			return "$" // allow a dollar sign to be escaped using $$
+		}
 		r := replacements.Get(ast.StringTerm(key))
 		if r == nil {
 			return ""

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -196,6 +196,7 @@ func TestHeadersEvaluator(t *testing.T) {
 					"X-ID-Token":              "${pomerium.id_token}",
 					"X-Access-Token":          "${pomerium.access_token}",
 					"Client-Cert-Fingerprint": "${pomerium.client_cert_fingerprint}",
+					"Foo":                     "escaped $$dollar sign",
 				},
 				ClientCertificate: ClientCertificateInfo{Leaf: testValidCert},
 			})
@@ -206,6 +207,7 @@ func TestHeadersEvaluator(t *testing.T) {
 		assert.Equal(t, "ACCESS_TOKEN", output.Headers.Get("X-Access-Token"))
 		assert.Equal(t, "f0c7dc2ca5e4b792935bcdb61a8b8f31b6521c686ffd8a6edb414a1e64ab8eb5",
 			output.Headers.Get("Client-Cert-Fingerprint"))
+		assert.Equal(t, "escaped $dollar sign", output.Headers.Get("Foo"))
 	})
 
 	t.Run("set_request_headers no repeated substitution", func(t *testing.T) {

--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -219,13 +219,15 @@ client_cert_fingerprint = v {
 } else = ""
 
 set_request_headers = h {
+    replacements := {
+        "pomerium.id_token": session_id_token,
+        "pomerium.access_token": session_access_token,
+		"pomerium.client_cert_fingerprint": client_cert_fingerprint,
+    }
 	h := [[header_name, header_value] |
 		some header_name
-		v1 := input.set_request_headers[header_name]
-		v2 := replace(v1, "$pomerium.id_token", session_id_token)
-		v3 := replace(v2, "$pomerium.access_token", session_access_token)
-		v4 := replace(v3, "$pomerium.client_cert_fingerprint", client_cert_fingerprint)
-		header_value := v4
+		v := input.set_request_headers[header_name]
+		header_value := pomerium.variable_substitution(v, replacements)
 	]
 } else = []
 

--- a/config/policy.go
+++ b/config/policy.go
@@ -544,7 +544,7 @@ func (p *Policy) Validate() error {
 
 	if p.SetAuthorizationHeader != "" {
 		log.Warn(context.Background()).Msg("config: set_authorization_header is deprecated, " +
-			"use $pomerium.id_token or $pomerium.access_token in set_request_headers instead")
+			"use ${pomerium.id_token} or ${pomerium.access_token} in set_request_headers instead")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Currently Pomerium replaces dynamic `set_request_headers` tokens sequentially. As a result, if a replacement value itself contained a supported "$pomerium" token, Pomerium may treat that as another replacement, resulting in incorrect output.

This is unlikely to be a problem given the current set of dynamic tokens, but if we continue to add additional tokens, this will likely become more of a concern.

To forestall any issues, let's perform all replacements in one pass, using the `os.Expand()` method. This does require a slight change to the syntax, as tokens containing a '.' (i.e. all of them) will need to be wrapped in curly braces, like `${pomerium.id_token}`.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Resolves https://github.com/pomerium/internal/issues/1501.

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
