### PR TITLE
config: add decode hook for the SANMatcher type

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -38,4 +38,5 @@ var ViperPolicyHooks = viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 	decodeJWTClaimHeadersHookFunc(),
 	decodeCodecTypeHookFunc(),
 	decodePPLPolicyHookFunc(),
+	decodeSANMatcherHookFunc(),
 ))

--- a/config/custom.go
+++ b/config/custom.go
@@ -508,6 +508,26 @@ func parseJSONPB(src map[string]interface{}, dst proto.Message, opts protojson.U
 	return opts.Unmarshal(data, dst)
 }
 
+// decodeSANMatcherHookFunc returns a decode hook for the SANMatcher type.
+func decodeSANMatcherHookFunc() mapstructure.DecodeHookFunc {
+	return func(f, t reflect.Type, data interface{}) (interface{}, error) {
+		if t != reflect.TypeOf(SANMatcher{}) {
+			return data, nil
+		}
+
+		b, err := json.Marshal(data)
+		if err != nil {
+			return nil, err
+		}
+
+		var m SANMatcher
+		if err := json.Unmarshal(b, &m); err != nil {
+			return nil, err
+		}
+		return m, nil
+	}
+}
+
 // serializable converts mapstructure nested map into map[string]interface{} that is serializable to JSON
 func serializable(in interface{}) (interface{}, error) {
 	switch typed := in.(type) {

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -341,6 +341,27 @@ func Test_parsePolicyFile(t *testing.T) {
 	}
 }
 
+func Test_decodeSANMatcher(t *testing.T) {
+	// Verify that config file parsing will decode the SANMatcher type.
+	const yaml = `
+downstream_mtls:
+  match_subject_alt_names:
+    - dns: 'example-1\..*'
+    - dns: '.*\.example-2'
+`
+	cfg := filepath.Join(t.TempDir(), "config.yaml")
+	err := os.WriteFile(cfg, []byte(yaml), 0644)
+	require.NoError(t, err)
+
+	o, err := optionsFromViper(cfg)
+	require.NoError(t, err)
+
+	assert.Equal(t, []SANMatcher{
+		{Type: SANTypeDNS, Pattern: `example-1\..*`},
+		{Type: SANTypeDNS, Pattern: `.*\.example-2`},
+	}, o.DownstreamMTLS.MatchSubjectAltNames)
+}
+
 func Test_Checksum(t *testing.T) {
 	o := NewDefaultOptions()
 


### PR DESCRIPTION
## Summary

Add a decode hook for the custom `SANMatcher` type. I had added an `UnmarshalJSON()` method for this type in 5568606f03023c1f936ed70b5a41fe3679ba6426 but I forgot that this needs a decode hook in order to be invoked.

## Related issues

Fixes #4463.

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
