### PR TITLE
envoy: check for nil ssl() in client cert script

### DIFF
--- a/config/envoyconfig/luascripts/set-client-certificate-metadata.lua
+++ b/config/envoyconfig/luascripts/set-client-certificate-metadata.lua
@@ -1,6 +1,9 @@
 function envoy_on_request(request_handle)
     local metadata = request_handle:streamInfo():dynamicMetadata()
     local ssl = request_handle:streamInfo():downstreamSslConnection()
+    if ssl == nil then
+        return
+    end
     metadata:set("com.pomerium.client-certificate-info", "presented",
                  ssl:peerCertificatePresented())
     metadata:set("com.pomerium.client-certificate-info", "chain",

--- a/config/envoyconfig/testdata/main_http_connection_manager_filter.json
+++ b/config/envoyconfig/testdata/main_http_connection_manager_filter.json
@@ -38,7 +38,7 @@
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
           "defaultSourceCode": {
-            "inlineString": "function envoy_on_request(request_handle)\n    local metadata = request_handle:streamInfo():dynamicMetadata()\n    local ssl = request_handle:streamInfo():downstreamSslConnection()\n    metadata:set(\"com.pomerium.client-certificate-info\", \"presented\",\n                 ssl:peerCertificatePresented())\n    metadata:set(\"com.pomerium.client-certificate-info\", \"chain\",\n                 ssl:urlEncodedPemEncodedPeerCertificateChain())\nend\n\nfunction envoy_on_response(response_handle) end\n"
+            "inlineString": "function envoy_on_request(request_handle)\n    local metadata = request_handle:streamInfo():dynamicMetadata()\n    local ssl = request_handle:streamInfo():downstreamSslConnection()\n    if ssl == nil then\n        return\n    end\n    metadata:set(\"com.pomerium.client-certificate-info\", \"presented\",\n                 ssl:peerCertificatePresented())\n    metadata:set(\"com.pomerium.client-certificate-info\", \"chain\",\n                 ssl:urlEncodedPemEncodedPeerCertificateChain())\nend\n\nfunction envoy_on_response(response_handle) end\n"
           }
         }
       },


### PR DESCRIPTION
## Summary

If Pomerium is operating in the `insecure_server` mode (e.g. if there is another reverse proxy in front of Pomerium), then the `ssl()` Lua method will return nil.

Add a check for this case to the set-client-certificate-metadata.lua script, in order to avoid an error when attempting to store the client certificate info.

## Related issues

Fixes #4465.

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
