### PR TITLE
authorize: remove incorrect client-cert-valid reason

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -117,7 +117,7 @@ func newPolicyEvaluator(opts *config.Options, store *store.Store) (*evaluator.Ev
 	// It is important to add an invalid_client_certificate rule even when the
 	// mTLS enforcement behavior is set to reject connections at the listener
 	// level, because of the per-route TLSDownstreamClientCA setting.
-	addDefaultClientCertificateRule :=
+	addDefaultClientCertificateRule := opts.HasAnyDownstreamMTLSClientCA() &&
 		opts.DownstreamMTLS.GetEnforcement() != config.MTLSEnforcementPolicy
 
 	clientCertConstraints, err := evaluator.ClientCertConstraintsFromConfig(&opts.DownstreamMTLS)

--- a/config/options.go
+++ b/config/options.go
@@ -976,6 +976,26 @@ func (o *Options) GetMetricsBasicAuth() (username, password string, ok bool) {
 	return string(bs[:idx]), string(bs[idx+1:]), true
 }
 
+// HasAnyDownstreamMTLSClientCA returns true if there is a global downstream
+// client CA or there are any per-route downstream client CAs.
+func (o *Options) HasAnyDownstreamMTLSClientCA() bool {
+	// All the CA settings should already have been validated.
+	ca, _ := o.DownstreamMTLS.GetCA()
+	if len(ca) > 0 {
+		return true
+	}
+	allPolicies := o.GetAllPolicies()
+	for i := range allPolicies {
+		// We don't need to check TLSDownstreamClientCAFile here because
+		// Policy.Validate() will populate TLSDownstreamClientCA when
+		// TLSDownstreamClientCAFile is set.
+		if allPolicies[i].TLSDownstreamClientCA != "" {
+			return true
+		}
+	}
+	return false
+}
+
 // GetDataBrokerCertificate gets the optional databroker certificate. This method will return nil if no certificate is
 // specified.
 func (o *Options) GetDataBrokerCertificate() (*tls.Certificate, error) {


### PR DESCRIPTION
## Summary

Fix the logic around when to add the default invalid_client_certificate rule: this should only be added if mTLS is enabled and the enforcement mode is not set to "policy". Add a unit test for this logic.

## Related issues

Fixes #4469.

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
