### PR TITLE
authorize: check CRLs only for leaf certificates

### DIFF
--- a/authorize/evaluator/functions_test.go
+++ b/authorize/evaluator/functions_test.go
@@ -238,16 +238,6 @@ func Test_isValidClientCertificate(t *testing.T) {
 		assert.NoError(t, err, "should not return an error")
 		assert.True(t, valid, "should return true")
 	})
-	t.Run("missing CRL", func(t *testing.T) {
-		// If a CRL is provided for any CA, it must be provided for all CAs.
-		valid, err := isValidClientCertificate(testCA, testCRL, ClientCertificateInfo{
-			Presented:     true,
-			Leaf:          testValidIntermediateCert,
-			Intermediates: testIntermediateCA,
-		}, noConstraints)
-		assert.NoError(t, err, "should not return an error")
-		assert.False(t, valid, "should return false")
-	})
 	t.Run("chain too deep", func(t *testing.T) {
 		valid, err := isValidClientCertificate(testCA, "", ClientCertificateInfo{
 			Presented:     true,

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -553,6 +553,7 @@ func (b *Builder) buildDownstreamValidationContext(
 		TrustedCa: b.filemgr.BytesDataSource("client-ca.pem", clientCA),
 		MatchTypedSubjectAltNames: make([]*envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher,
 			0, len(cfg.Options.DownstreamMTLS.MatchSubjectAltNames)),
+		OnlyVerifyLeafCertCrl: true,
 	}
 	for i := range cfg.Options.DownstreamMTLS.MatchSubjectAltNames {
 		vc.MatchTypedSubjectAltNames = append(vc.MatchTypedSubjectAltNames,

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -119,6 +119,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 				"alpnProtocols": ["h2", "http/1.1"],
 				"validationContext": {
 					"maxVerifyDepth": 1,
+					"onlyVerifyLeafCertCrl": true,
 					"trustChainVerification": "ACCEPT_UNTRUSTED",
 					"trustedCa": {
 						"filename": "`+clientCAFileName+`"
@@ -151,6 +152,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 				"alpnProtocols": ["h2", "http/1.1"],
 				"validationContext": {
 					"maxVerifyDepth": 1,
+					"onlyVerifyLeafCertCrl": true,
 					"trustedCa": {
 						"filename": "`+clientCAFileName+`"
 					}
@@ -186,6 +188,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 				"alpnProtocols": ["h2", "http/1.1"],
 				"validationContext": {
 					"maxVerifyDepth": 1,
+					"onlyVerifyLeafCertCrl": true,
 					"trustChainVerification": "ACCEPT_UNTRUSTED",
 					"trustedCa": {
 						"filename": "`+clientCAFileName+`"
@@ -209,6 +212,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 		require.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `{
 			"maxVerifyDepth": 10,
+			"onlyVerifyLeafCertCrl": true,
 			"trustChainVerification": "ACCEPT_UNTRUSTED",
 			"trustedCa": {
 				"filename": "`+clientCAFileName+`"
@@ -220,6 +224,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 			b.buildDownstreamTLSContextMulti(context.Background(), config, nil)
 		require.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `{
+			"onlyVerifyLeafCertCrl": true,
 			"trustChainVerification": "ACCEPT_UNTRUSTED",
 			"trustedCa": {
 				"filename": "`+clientCAFileName+`"
@@ -281,6 +286,7 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 					"sanType": "URI"
 				}
 			],
+			"onlyVerifyLeafCertCrl": true,
 			"trustChainVerification": "ACCEPT_UNTRUSTED",
 			"trustedCa": {
 				"filename": "`+clientCAFileName+`"


### PR DESCRIPTION
## Summary

Set the Envoy option `only_verify_leaf_cert_crl`, to avoid a bug where CRLs cannot be used in combination with an intermediate CA trust root. Update the client certificate validation logic in the authorize service to match this behavior.

## Related issues

https://github.com/pomerium/pomerium/issues/4471

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
