### PR TITLE
config: validate cookie_secure option

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -767,6 +767,8 @@ func (o *Options) Validate() error {
 
 	if err := ValidateCookieSameSite(o.CookieSameSite); err != nil {
 		return fmt.Errorf("config: invalid cookie_same_site: %w", err)
+	} else if !o.CookieSecure && o.GetCookieSameSite() == http.SameSiteNoneMode {
+		return errors.New("config: cannot use cookie_same_site: none with cookie_secure: false")
 	}
 
 	if err := ValidateLogLevel(o.LogLevel); err != nil {

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -62,6 +62,9 @@ func Test_Validate(t *testing.T) {
 	missingStorageDSN.DataBrokerStorageType = "redis"
 	badSignoutRedirectURL := testOptions()
 	badSignoutRedirectURL.SignOutRedirectURLString = "--"
+	badCookieSettings := testOptions()
+	badCookieSettings.CookieSameSite = "none"
+	badCookieSettings.CookieSecure = false
 
 	tests := []struct {
 		name     string
@@ -76,6 +79,7 @@ func Test_Validate(t *testing.T) {
 		{"invalid databroker storage type", invalidStorageType, true},
 		{"missing databroker storage dsn", missingStorageDSN, true},
 		{"invalid signout redirect url", badSignoutRedirectURL, true},
+		{"CookieSameSite none with CookieSecure fale", badCookieSettings, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Do not allow the combination of 'cookie_same_site: none' and 'cookie_secure: false'.

Cookies with `SameSite=None` must also set the `Secure`option, see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie#none.

## Related issues

https://github.com/pomerium/pomerium/issues/4482

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
