### PR TITLE
core/identity: fix slow restart

### DIFF
--- a/internal/identity/manager/manager.go
+++ b/internal/identity/manager/manager.go
@@ -117,6 +117,7 @@ func (mgr *Manager) refreshLoop(ctx context.Context, update <-chan updateRecords
 	}
 	select {
 	case <-ctx.Done():
+		return ctx.Err()
 	case msg := <-update:
 		mgr.onUpdateRecords(ctx, msg)
 	}
@@ -128,9 +129,9 @@ func (mgr *Manager) refreshLoop(ctx context.Context, update <-chan updateRecords
 
 	// start refreshing
 	maxWait := time.Minute * 10
-	nextTime := time.Now().Add(maxWait)
+	var nextTime time.Time
 
-	timer := time.NewTimer(time.Until(nextTime))
+	timer := time.NewTimer(0)
 	defer timer.Stop()
 
 	for {


### PR DESCRIPTION
## Summary
When we start the identity manager any existing sessions and users will not be refreshed until after 10 minutes, unless a session or user is updated.

In practice this issue will rarely happen because sessions are updated in the access tracker, so anyone using Pomerium would trigger the identity manager loop check.

## Checklist

- [x] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [x] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
