### PR TITLE
core/authorize: check for expired tokens

### DIFF
--- a/authorize/databroker.go
+++ b/authorize/databroker.go
@@ -13,6 +13,7 @@ import (
 
 type sessionOrServiceAccount interface {
 	GetUserId() string
+	Validate() error
 }
 
 func getDataBrokerRecord(
@@ -77,6 +78,9 @@ func (a *Authorize) getDataBrokerSessionOrServiceAccount(
 		return nil, err
 	}
 	s = msg.(sessionOrServiceAccount)
+	if err := s.Validate(); err != nil {
+		return nil, err
+	}
 
 	if _, ok := s.(*session.Session); ok {
 		a.accessTracker.TrackSessionAccess(sessionID)

--- a/authorize/databroker_test.go
+++ b/authorize/databroker_test.go
@@ -7,7 +7,10 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
 	"github.com/pomerium/pomerium/pkg/storage"
@@ -53,4 +56,21 @@ func Test_getDataBrokerRecord(t *testing.T) {
 				"should have %d traces to the cached querier", tc.cachedQueryCount)
 		})
 	}
+}
+
+func TestAuthorize_getDataBrokerSessionOrServiceAccount(t *testing.T) {
+	t.Parallel()
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	t.Cleanup(clearTimeout)
+
+	opt := config.NewDefaultOptions()
+	a, err := New(&config.Config{Options: opt})
+	require.NoError(t, err)
+
+	s1 := &session.Session{Id: "s1", ExpiresAt: timestamppb.New(time.Now().Add(-time.Second))}
+	sq := storage.NewStaticQuerier(s1)
+	qctx := storage.WithQuerier(ctx, sq)
+	_, err = a.getDataBrokerSessionOrServiceAccount(qctx, "s1", 0)
+	assert.ErrorIs(t, err, session.ErrSessionExpired)
 }

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -55,7 +55,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 	if sessionState != nil {
 		s, err = a.getDataBrokerSessionOrServiceAccount(ctx, sessionState.ID, sessionState.DatabrokerRecordVersion)
 		if err != nil {
-			log.Warn(ctx).Err(err).Msg("clearing session due to missing session or service account")
+			log.Warn(ctx).Err(err).Msg("clearing session due to missing or invalid session or service account")
 			sessionState = nil
 		}
 	}

--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -95,9 +95,9 @@ var ErrSessionExpired = fmt.Errorf("session has expired")
 func (x *Session) Validate() error {
 	now := time.Now()
 	for name, expiresAt := range map[string]*timestamppb.Timestamp{
-		"session": x.GetExpiresAt(),
+		"session":      x.GetExpiresAt(),
 		"access_token": x.GetOauthToken().GetExpiresAt(),
-		"id_token": x.GetIdToken().GetExpiresAt(),
+		"id_token":     x.GetIdToken().GetExpiresAt(),
 	} {
 		if expiresAt != nil && now.After(expiresAt.AsTime()) {
 			return fmt.Errorf("%s: %w", name, ErrSessionExpired)

--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -4,6 +4,7 @@ package session
 import (
 	context "context"
 	"fmt"
+	"time"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -85,4 +86,23 @@ func (x *Session) RemoveDeviceCredentialID(deviceCredentialID string) {
 	x.DeviceCredentials = slices.Filter(x.DeviceCredentials, func(el *Session_DeviceCredential) bool {
 		return el.GetId() != deviceCredentialID
 	})
+}
+
+// ErrSessionExpired indicates the session has expired
+var ErrSessionExpired = fmt.Errorf("session has expired")
+
+// Validate returns an error if the session is not valid.
+func (x *Session) Validate() error {
+	now := time.Now()
+	for _, expiresAt := range []*timestamppb.Timestamp{
+		x.GetExpiresAt(),
+		x.GetOauthToken().GetExpiresAt(),
+		x.GetIdToken().GetExpiresAt(),
+	} {
+		if expiresAt != nil && now.After(expiresAt.AsTime()) {
+			return ErrSessionExpired
+		}
+	}
+
+	return nil
 }

--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -99,7 +99,7 @@ func (x *Session) Validate() error {
 		"access_token": x.GetOauthToken().GetExpiresAt(),
 		"id_token":     x.GetIdToken().GetExpiresAt(),
 	} {
-		if expiresAt.AsTime().Year() > 1 && now.After(expiresAt.AsTime()) {
+		if expiresAt.AsTime().Year() > 1970 && now.After(expiresAt.AsTime()) {
 			return fmt.Errorf("%w: %s expired at %s", ErrSessionExpired, name, expiresAt.AsTime())
 		}
 	}

--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -94,13 +94,13 @@ var ErrSessionExpired = fmt.Errorf("session has expired")
 // Validate returns an error if the session is not valid.
 func (x *Session) Validate() error {
 	now := time.Now()
-	for _, expiresAt := range []*timestamppb.Timestamp{
-		x.GetExpiresAt(),
-		x.GetOauthToken().GetExpiresAt(),
-		x.GetIdToken().GetExpiresAt(),
+	for name, expiresAt := range map[string]*timestamppb.Timestamp{
+		"session": x.GetExpiresAt(),
+		"access_token": x.GetOauthToken().GetExpiresAt(),
+		"id_token": x.GetIdToken().GetExpiresAt(),
 	} {
 		if expiresAt != nil && now.After(expiresAt.AsTime()) {
-			return ErrSessionExpired
+			return fmt.Errorf("%s: %w", name, ErrSessionExpired)
 		}
 	}
 

--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -99,8 +99,8 @@ func (x *Session) Validate() error {
 		"access_token": x.GetOauthToken().GetExpiresAt(),
 		"id_token":     x.GetIdToken().GetExpiresAt(),
 	} {
-		if expiresAt != nil && now.After(expiresAt.AsTime()) {
-			return fmt.Errorf("%s: %w", name, ErrSessionExpired)
+		if expiresAt.AsTime().Year() > 1 && now.After(expiresAt.AsTime()) {
+			return fmt.Errorf("%w: %s expired at %s", ErrSessionExpired, name, expiresAt.AsTime())
 		}
 	}
 

--- a/pkg/grpc/session/session_test.go
+++ b/pkg/grpc/session/session_test.go
@@ -1,0 +1,32 @@
+package session
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestSession_Validate(t *testing.T) {
+	t.Parallel()
+
+	t0 := timestamppb.New(time.Now().Add(-time.Second))
+	for _, tc := range []struct {
+		name    string
+		session *Session
+		expect  error
+	}{
+		{"valid", &Session{}, nil},
+		{"expired", &Session{ExpiresAt: t0}, ErrSessionExpired},
+		{"expired id token", &Session{IdToken: &IDToken{ExpiresAt: t0}}, ErrSessionExpired},
+		{"expired oauth token", &Session{OauthToken: &OAuthToken{ExpiresAt: t0}}, ErrSessionExpired},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.ErrorIs(t, tc.session.Validate(), tc.expect)
+		})
+	}
+}

--- a/pkg/grpc/user/user.go
+++ b/pkg/grpc/user/user.go
@@ -40,7 +40,7 @@ func (x *ServiceAccount) Validate() error {
 	for _, expiresAt := range []*timestamppb.Timestamp{
 		x.GetExpiresAt(),
 	} {
-		if expiresAt.AsTime().Year() > 1 && now.After(expiresAt.AsTime()) {
+		if expiresAt.AsTime().Year() > 1970 && now.After(expiresAt.AsTime()) {
 			return ErrServiceAccountExpired
 		}
 	}

--- a/pkg/grpc/user/user.go
+++ b/pkg/grpc/user/user.go
@@ -40,7 +40,7 @@ func (x *ServiceAccount) Validate() error {
 	for _, expiresAt := range []*timestamppb.Timestamp{
 		x.GetExpiresAt(),
 	} {
-		if expiresAt != nil && now.After(expiresAt.AsTime()) {
+		if expiresAt.AsTime().Year() > 1 && now.After(expiresAt.AsTime()) {
 			return ErrServiceAccountExpired
 		}
 	}

--- a/pkg/grpc/user/user.go
+++ b/pkg/grpc/user/user.go
@@ -3,8 +3,11 @@ package user
 
 import (
 	context "context"
+	"fmt"
+	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
+	timestamppb "google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/internal/identity"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
@@ -26,6 +29,23 @@ func GetServiceAccount(ctx context.Context, client databroker.DataBrokerServiceC
 // PutServiceAccount saves a service account to the databroker.
 func PutServiceAccount(ctx context.Context, client databroker.DataBrokerServiceClient, serviceAccount *ServiceAccount) (*databroker.PutResponse, error) {
 	return databroker.Put(ctx, client, serviceAccount)
+}
+
+// ErrServiceAccountExpired indicates the service account has expired.
+var ErrServiceAccountExpired = fmt.Errorf("service account has expired")
+
+// Validate returns an error if the service account is not valid.
+func (x *ServiceAccount) Validate() error {
+	now := time.Now()
+	for _, expiresAt := range []*timestamppb.Timestamp{
+		x.GetExpiresAt(),
+	} {
+		if expiresAt != nil && now.After(expiresAt.AsTime()) {
+			return ErrServiceAccountExpired
+		}
+	}
+
+	return nil
 }
 
 // AddClaims adds the flattened claims to the user.

--- a/pkg/grpc/user/user_test.go
+++ b/pkg/grpc/user/user_test.go
@@ -1,0 +1,30 @@
+package user
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestServiceAccount_Validate(t *testing.T) {
+	t.Parallel()
+
+	t0 := timestamppb.New(time.Now().Add(-time.Second))
+	for _, tc := range []struct {
+		name           string
+		serviceAccount *ServiceAccount
+		expect         error
+	}{
+		{"valid", &ServiceAccount{}, nil},
+		{"expired", &ServiceAccount{ExpiresAt: t0}, ErrServiceAccountExpired},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.ErrorIs(t, tc.serviceAccount.Validate(), tc.expect)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Add a validation check on sessions or service accounts to ensure they don't have expired tokens.

## Related issues
- https://github.com/pomerium/internal/issues/1527
 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
