### PR TITLE
core/authenticate: validate the identity profile

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -143,12 +143,21 @@ func (a *Authenticate) VerifySession(next http.Handler) http.Handler {
 			return a.reauthenticateOrFail(w, r, err)
 		}
 
-		_, err = a.loadIdentityProfile(r, state.cookieCipher)
+		profile, err := a.loadIdentityProfile(r, state.cookieCipher)
 		if err != nil {
 			log.FromRequest(r).Info().
 				Err(err).
 				Str("idp_id", idpID).
 				Msg("authenticate: identity profile load error")
+			return a.reauthenticateOrFail(w, r, err)
+		}
+
+		err = a.validateIdentityProfile(ctx, profile)
+		if err != nil {
+			log.FromRequest(r).Info().
+				Err(err).
+				Str("idp_id", idpID).
+				Msg("authenticate: invalid identity profile")
 			return a.reauthenticateOrFail(w, r, err)
 		}
 


### PR DESCRIPTION
## Summary
Validate the identity profile by checking that the oauth token is still valid and calling the user info endpoint. If the access token has been revoked that call should fail and the identity profile will be treated as if it doesn't exist. This will then trigger the re-authentication flow.

## Related issues
- https://github.com/pomerium/internal/issues/1527

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
