### PR TITLE
dependabot: also update release Dockerfiles

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,6 +5,11 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 50
+  - package-ecosystem: "docker"
+    directory: "/.github/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 50
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

Update our Dependabot configuration so that it will also update the release Dockerfiles in the /.github/ directory.

## Related issues

Hopefully fixes #4255.

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
