### PR TITLE
core/authenticate: refactor idp sign out

### DIFF
--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -135,7 +135,7 @@ func TestAuthenticate_SignOut(t *testing.T) {
 			"",
 			"sig",
 			"ts",
-			identity.MockProvider{LogOutResponse: (*uriParseHelper("https://microsoft.com"))},
+			identity.MockProvider{GetSignOutURLResponse: "https://microsoft.com"},
 			&mstore.Store{Encrypted: true, Session: &sessions.State{}},
 			http.StatusFound,
 			"",
@@ -148,7 +148,7 @@ func TestAuthenticate_SignOut(t *testing.T) {
 			"https://signout-redirect-url.example.com",
 			"sig",
 			"ts",
-			identity.MockProvider{LogOutResponse: (*uriParseHelper("https://microsoft.com"))},
+			identity.MockProvider{GetSignOutURLError: oidc.ErrSignoutNotImplemented},
 			&mstore.Store{Encrypted: true, Session: &sessions.State{}},
 			http.StatusFound,
 			"",
@@ -161,7 +161,7 @@ func TestAuthenticate_SignOut(t *testing.T) {
 			"",
 			"sig",
 			"ts",
-			identity.MockProvider{RevokeError: errors.New("OH NO")},
+			identity.MockProvider{GetSignOutURLError: oidc.ErrSignoutNotImplemented, RevokeError: errors.New("OH NO")},
 			&mstore.Store{Encrypted: true, Session: &sessions.State{}},
 			http.StatusFound,
 			"",
@@ -174,7 +174,7 @@ func TestAuthenticate_SignOut(t *testing.T) {
 			"",
 			"sig",
 			"ts",
-			identity.MockProvider{RevokeError: errors.New("OH NO")},
+			identity.MockProvider{GetSignOutURLError: oidc.ErrSignoutNotImplemented, RevokeError: errors.New("OH NO")},
 			&mstore.Store{Encrypted: true, Session: &sessions.State{}},
 			http.StatusFound,
 			"",
@@ -187,23 +187,10 @@ func TestAuthenticate_SignOut(t *testing.T) {
 			"",
 			"sig",
 			"ts",
-			identity.MockProvider{LogOutError: oidc.ErrSignoutNotImplemented},
+			identity.MockProvider{GetSignOutURLError: oidc.ErrSignoutNotImplemented},
 			&mstore.Store{Encrypted: true, Session: &sessions.State{}},
 			http.StatusFound,
 			"",
-		},
-		{
-			"no redirect uri",
-			http.MethodPost,
-			nil,
-			"",
-			"",
-			"sig",
-			"ts",
-			identity.MockProvider{LogOutResponse: (*uriParseHelper("https://microsoft.com"))},
-			&mstore.Store{Encrypted: true, Session: &sessions.State{}},
-			http.StatusOK,
-			"{\"Status\":200}\n",
 		},
 	}
 	for _, tt := range tests {
@@ -253,7 +240,7 @@ func TestAuthenticate_SignOut(t *testing.T) {
 			}
 			if tt.signoutRedirectURL != "" {
 				loc := w.Header().Get("Location")
-				assert.Contains(t, loc, url.QueryEscape(tt.signoutRedirectURL))
+				assert.Contains(t, loc, tt.signoutRedirectURL)
 			}
 		})
 	}

--- a/internal/handlers/signedout.go
+++ b/internal/handlers/signedout.go
@@ -1,0 +1,23 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/pomerium/pomerium/internal/httputil"
+	"github.com/pomerium/pomerium/ui"
+)
+
+// SignedOutData is the data for the SignedOut page.
+type SignedOutData struct{}
+
+// ToJSON converts the data into a JSON map.
+func (data SignedOutData) ToJSON() map[string]interface{} {
+	return map[string]interface{}{}
+}
+
+// SignedOut returns a handler that renders the signed out page.
+func SignedOut(data SignedOutData) http.Handler {
+	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+		return ui.ServePage(w, r, "SignedOut", data.ToJSON())
+	})
+}

--- a/internal/identity/mock_provider.go
+++ b/internal/identity/mock_provider.go
@@ -39,7 +39,7 @@ func (mp MockProvider) Revoke(_ context.Context, _ *oauth2.Token) error {
 // GetSignInURL is a mocked providers function.
 func (mp MockProvider) GetSignInURL(_ string) (string, error) { return mp.GetSignInURLResponse, nil }
 
-// LogOut is a mocked providers function.
+// GetSignOutURL is a mocked providers function.
 func (mp MockProvider) GetSignOutURL(_, _ string) (string, error) {
 	return mp.GetSignOutURLResponse, mp.GetSignOutURLError
 }

--- a/internal/identity/mock_provider.go
+++ b/internal/identity/mock_provider.go
@@ -2,7 +2,6 @@ package identity
 
 import (
 	"context"
-	"net/url"
 
 	"golang.org/x/oauth2"
 
@@ -11,15 +10,15 @@ import (
 
 // MockProvider provides a mocked implementation of the providers interface.
 type MockProvider struct {
-	AuthenticateResponse oauth2.Token
-	AuthenticateError    error
-	RefreshResponse      oauth2.Token
-	RefreshError         error
-	RevokeError          error
-	GetSignInURLResponse string
-	LogOutResponse       url.URL
-	LogOutError          error
-	UpdateUserInfoError  error
+	AuthenticateResponse  oauth2.Token
+	AuthenticateError     error
+	RefreshResponse       oauth2.Token
+	RefreshError          error
+	RevokeError           error
+	GetSignInURLResponse  string
+	GetSignOutURLResponse string
+	GetSignOutURLError    error
+	UpdateUserInfoError   error
 }
 
 // Authenticate is a mocked providers function.
@@ -41,7 +40,9 @@ func (mp MockProvider) Revoke(_ context.Context, _ *oauth2.Token) error {
 func (mp MockProvider) GetSignInURL(_ string) (string, error) { return mp.GetSignInURLResponse, nil }
 
 // LogOut is a mocked providers function.
-func (mp MockProvider) LogOut() (*url.URL, error) { return &mp.LogOutResponse, mp.LogOutError }
+func (mp MockProvider) GetSignOutURL(_, _ string) (string, error) {
+	return mp.GetSignOutURLResponse, mp.GetSignOutURLError
+}
 
 // UpdateUserInfo is a mocked providers function.
 func (mp MockProvider) UpdateUserInfo(_ context.Context, _ *oauth2.Token, _ interface{}) error {

--- a/internal/identity/oauth/apple/apple.go
+++ b/internal/identity/oauth/apple/apple.go
@@ -104,7 +104,7 @@ func (p *Provider) GetSignInURL(state string) (string, error) {
 }
 
 // GetSignOutURL is not implemented.
-func (p *Provider) GetSignOutURL(idTokenHint, redirectToURL string) (string, error) {
+func (p *Provider) GetSignOutURL(_, _ string) (string, error) {
 	return "", oidc.ErrSignoutNotImplemented
 }
 

--- a/internal/identity/oauth/apple/apple.go
+++ b/internal/identity/oauth/apple/apple.go
@@ -103,6 +103,11 @@ func (p *Provider) GetSignInURL(state string) (string, error) {
 	return authURL, nil
 }
 
+// GetSignOutURL is not implemented.
+func (p *Provider) GetSignOutURL(idTokenHint, redirectToURL string) (string, error) {
+	return "", oidc.ErrSignoutNotImplemented
+}
+
 // Authenticate converts an authorization code returned from the identity
 // provider into a token which is then converted into a user session.
 func (p *Provider) Authenticate(ctx context.Context, code string, v identity.State) (*oauth2.Token, error) {
@@ -121,11 +126,6 @@ func (p *Provider) Authenticate(ctx context.Context, code string, v identity.Sta
 	}
 
 	return oauth2Token, nil
-}
-
-// LogOut is not implemented by Apple.
-func (p *Provider) LogOut() (*url.URL, error) {
-	return nil, oidc.ErrSignoutNotImplemented
 }
 
 // Refresh renews a user's session.

--- a/internal/identity/oauth/github/github.go
+++ b/internal/identity/oauth/github/github.go
@@ -245,9 +245,9 @@ func (p *Provider) GetSignInURL(state string) (string, error) {
 	return p.Oauth.AuthCodeURL(state, oauth2.AccessTypeOffline), nil
 }
 
-// LogOut is not implemented by github.
-func (p *Provider) LogOut() (*url.URL, error) {
-	return nil, oidc.ErrSignoutNotImplemented
+// GetSignOutURL is not implemented.
+func (p *Provider) GetSignOutURL(idTokenHint, redirectToURL string) (string, error) {
+	return "", oidc.ErrSignoutNotImplemented
 }
 
 // Name returns the provider name.

--- a/internal/identity/oauth/github/github.go
+++ b/internal/identity/oauth/github/github.go
@@ -246,7 +246,7 @@ func (p *Provider) GetSignInURL(state string) (string, error) {
 }
 
 // GetSignOutURL is not implemented.
-func (p *Provider) GetSignOutURL(idTokenHint, redirectToURL string) (string, error) {
+func (p *Provider) GetSignOutURL(_, _ string) (string, error) {
 	return "", oidc.ErrSignoutNotImplemented
 }
 

--- a/internal/identity/oidc/auth0/auth0.go
+++ b/internal/identity/oidc/auth0/auth0.go
@@ -6,10 +6,12 @@ package auth0
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"strings"
 
 	"github.com/pomerium/pomerium/internal/identity/oauth"
 	pom_oidc "github.com/pomerium/pomerium/internal/identity/oidc"
+	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
 const (
@@ -46,4 +48,29 @@ func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
 // Name returns the provider name.
 func (p *Provider) Name() string {
 	return Name
+}
+
+// GetSignOutURL implements logout as described in https://auth0.com/docs/api/authentication#logout.
+func (p *Provider) GetSignOutURL(_, redirectToURL string) (string, error) {
+	oa, err := p.GetOauthConfig()
+	if err != nil {
+		return "", fmt.Errorf("error getting auth0 oauth config: %w", err)
+	}
+
+	authURL, err := urlutil.ParseAndValidateURL(oa.Endpoint.AuthURL)
+	if err != nil {
+		return "", fmt.Errorf("error parsing auth0 endpoint auth url: %w", err)
+	}
+
+	logoutQuery := url.Values{
+		"client_id": {oa.ClientID},
+	}
+	if redirectToURL != "" {
+		logoutQuery.Set("returnTo", redirectToURL)
+	}
+	logoutURL := authURL.ResolveReference(&url.URL{
+		Path:     "/v2/logout",
+		RawQuery: logoutQuery.Encode(),
+	})
+	return logoutURL.String(), nil
 }

--- a/internal/identity/oidc/auth0/auth0_test.go
+++ b/internal/identity/oidc/auth0/auth0_test.go
@@ -1,0 +1,61 @@
+package auth0
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/internal/identity/oauth"
+)
+
+func TestProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	t.Cleanup(clearTimeout)
+
+	var srv *httptest.Server
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseURL, err := url.Parse(srv.URL + "/")
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                 baseURL.String(),
+				"authorization_endpoint": srv.URL + "/authorize",
+			})
+
+		default:
+			assert.Failf(t, "unexpected http request", "url: %s", r.URL.String())
+		}
+	})
+	srv = httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	redirectURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	p, err := New(ctx, &oauth.Options{
+		ProviderURL:  srv.URL,
+		RedirectURL:  redirectURL,
+		ClientID:     "CLIENT_ID",
+		ClientSecret: "CLIENT_SECRET",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	t.Run("GetSignOutURL", func(t *testing.T) {
+		signOutURL, err := p.GetSignOutURL("", "https://www.example.com?a=b")
+		assert.NoError(t, err)
+		assert.Equal(t, srv.URL+"/v2/logout?client_id=CLIENT_ID&returnTo=https%3A%2F%2Fwww.example.com%3Fa%3Db", signOutURL)
+	})
+}

--- a/internal/identity/oidc/cognito/cognito.go
+++ b/internal/identity/oidc/cognito/cognito.go
@@ -52,7 +52,7 @@ func New(ctx context.Context, opts *oauth.Options) (*Provider, error) {
 }
 
 // GetSignOutURL gets the sign out URL according to https://docs.aws.amazon.com/cognito/latest/developerguide/logout-endpoint.html.
-func (p *Provider) GetSignOutURL(idTokenHint, returnToURL string) (string, error) {
+func (p *Provider) GetSignOutURL(_, returnToURL string) (string, error) {
 	oa, err := p.GetOauthConfig()
 	if err != nil {
 		return "", fmt.Errorf("error getting cognito oauth config: %w", err)

--- a/internal/identity/oidc/cognito/cognito_test.go
+++ b/internal/identity/oidc/cognito/cognito_test.go
@@ -1,0 +1,61 @@
+package cognito
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/internal/identity/oauth"
+)
+
+func TestProvider(t *testing.T) {
+	t.Parallel()
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	t.Cleanup(clearTimeout)
+
+	var srv *httptest.Server
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseURL, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                 baseURL.String(),
+				"authorization_endpoint": srv.URL + "/authorize",
+			})
+
+		default:
+			assert.Failf(t, "unexpected http request", "url: %s", r.URL.String())
+		}
+	})
+	srv = httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	redirectURL, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+
+	p, err := New(ctx, &oauth.Options{
+		ProviderURL:  srv.URL,
+		RedirectURL:  redirectURL,
+		ClientID:     "CLIENT_ID",
+		ClientSecret: "CLIENT_SECRET",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, p)
+
+	t.Run("GetSignOutURL", func(t *testing.T) {
+		signOutURL, err := p.GetSignOutURL("", "https://www.example.com?a=b")
+		assert.NoError(t, err)
+		assert.Equal(t, srv.URL+"/logout?client_id=CLIENT_ID&logout_uri=https%3A%2F%2Fwww.example.com%3Fa%3Db", signOutURL)
+	})
+}

--- a/internal/identity/providers.go
+++ b/internal/identity/providers.go
@@ -5,7 +5,6 @@ package identity
 import (
 	"context"
 	"fmt"
-	"net/url"
 
 	"golang.org/x/oauth2"
 
@@ -30,8 +29,8 @@ type Authenticator interface {
 	Refresh(context.Context, *oauth2.Token, identity.State) (*oauth2.Token, error)
 	Revoke(context.Context, *oauth2.Token) error
 	GetSignInURL(state string) (string, error)
+	GetSignOutURL(idTokenHint, redirectToURL string) (string, error)
 	Name() string
-	LogOut() (*url.URL, error)
 	UpdateUserInfo(ctx context.Context, t *oauth2.Token, v interface{}) error
 }
 

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,12 +1,13 @@
 import Box from "@mui/material/Box";
 import CssBaseline from "@mui/material/CssBaseline";
 import { ThemeProvider } from "@mui/material/styles";
-import React, {FC, useLayoutEffect} from "react";
+import React, { FC, useLayoutEffect } from "react";
 
 import ErrorPage from "./components/ErrorPage";
 import Footer from "./components/Footer";
 import Header from "./components/Header";
 import SignOutConfirmPage from "./components/SignOutConfirmPage";
+import SignedOutPage from "./components/SignedOutPage";
 import { ToolbarOffset } from "./components/ToolbarOffset";
 import UserInfoPage from "./components/UserInfoPage";
 import WebAuthnRegistrationPage from "./components/WebAuthnRegistrationPage";
@@ -27,6 +28,9 @@ const App: FC = () => {
     case "SignOutConfirm":
       body = <SignOutConfirmPage data={data} />;
       break;
+    case "SignedOut":
+      body = <SignedOutPage data={data} />;
+      break;
     case "DeviceEnrolled":
     case "UserInfo":
       body = <UserInfoPage data={data} />;
@@ -38,18 +42,18 @@ const App: FC = () => {
 
   useLayoutEffect(() => {
     const favicon = document.getElementById(
-      'favicon'
+      "favicon"
     ) as HTMLAnchorElement | null;
     if (favicon) {
-      favicon.href = data?.faviconUrl || '/.pomerium/favicon.ico';
+      favicon.href = data?.faviconUrl || "/.pomerium/favicon.ico";
     }
     const extraFaviconLinks = document.getElementsByClassName(
-      'pomerium_favicon'
+      "pomerium_favicon"
     ) as HTMLCollectionOf<HTMLAnchorElement> | null;
     for (const link of extraFaviconLinks) {
-      link.style.display = data?.faviconUrl ? 'none' : '';
+      link.style.display = data?.faviconUrl ? "none" : "";
     }
-  }, [])
+  }, []);
 
   return (
     <ThemeProvider theme={theme}>

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -57,6 +57,8 @@ const Header: FC<HeaderProps> = ({ includeSidebar, data }) => {
     get(data, "user.claims.picture") ||
     get(data, "profile.claims.picture") ||
     null;
+  const showAvatar =
+    data?.page !== "SignOutConfirm" && data?.page !== "SignedOut";
 
   const handleDrawerOpen = () => {
     setDrawerOpen(true);
@@ -122,9 +124,11 @@ const Header: FC<HeaderProps> = ({ includeSidebar, data }) => {
           </a>
         )}
         <Box flexGrow={1} />
-        <IconButton color="inherit" onClick={handleMenuOpen}>
-          <Avatar name={userName} url={userPictureUrl} />
-        </IconButton>
+        {showAvatar && (
+          <IconButton color="inherit" onClick={handleMenuOpen}>
+            <Avatar name={userName} url={userPictureUrl} />
+          </IconButton>
+        )}
         <Menu
           onClose={handleMenuClose}
           anchorOrigin={{

--- a/ui/src/components/SignedOutPage.tsx
+++ b/ui/src/components/SignedOutPage.tsx
@@ -9,7 +9,7 @@ type SignedOutPageProps = {
 const SignedOutPage: FC<SignedOutPageProps> = ({ data }) => {
   return (
     <Container>
-      <Alert color="info">User has been Logged Out</Alert>
+      <Alert color="info">User has been logged out.</Alert>
     </Container>
   );
 };

--- a/ui/src/components/SignedOutPage.tsx
+++ b/ui/src/components/SignedOutPage.tsx
@@ -1,0 +1,16 @@
+import { Alert } from "@mui/material";
+import Container from "@mui/material/Container";
+import React, { FC } from "react";
+import { SignedOutPageData } from "src/types";
+
+type SignedOutPageProps = {
+  data: SignedOutPageData;
+};
+const SignedOutPage: FC<SignedOutPageProps> = ({ data }) => {
+  return (
+    <Container>
+      <Alert color="info">User has been Logged Out</Alert>
+    </Container>
+  );
+};
+export default SignedOutPage;

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -132,6 +132,10 @@ export type SignOutConfirmPageData = BasePageData & {
   url: string;
 };
 
+export type SignedOutPageData = BasePageData & {
+  page: "SignedOut";
+};
+
 export type UserInfoPageData = BasePageData &
   UserInfoData & {
     page: "UserInfo";
@@ -150,6 +154,7 @@ export type PageData =
   | ErrorPageData
   | DeviceEnrolledPageData
   | SignOutConfirmPageData
+  | SignedOutPageData
   | UserInfoPageData
   | WebAuthnRegistrationPageData;
 


### PR DESCRIPTION
## Summary
Refactor how IdP sign out works. Instead of a method called `LogOut` we now have a method called `GetSignOutURL` which more accurately describes what `LogOut` was supposed to do. It takes an id token hint and a URL to return to, and returns a new URL that when redirected to will sign the user out of the IdP.

The previous flow is hard to understand. Previously we would return a special error page if neither the redirect URL nor the signout redirect URL were defined. We will now unconditionally redirect, and if neither the redirect URL nor the signout redirect URL are defined, we will redirect to `https://authenticate/.pomerium/signed_out`. Regardless, if the IdP supports sign out, we will redirect there first.

Auth0 and Cognito have custom implementations of `GetSignOutURL` that follows their documentation. The default implementation is https://openid.net/specs/openid-connect-rpinitiated-1_0.html.

## Related issues
Fixes #4539 
Fixes #4180

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
