### PR TITLE
Add metric request error in log

### DIFF
--- a/internal/telemetry/metrics/providers.go
+++ b/internal/telemetry/metrics/providers.go
@@ -106,7 +106,7 @@ func newProxyMetricsHandler(exporter *ocprom.Exporter, endpoints []ScrapeEndpoin
 			scrapeEndpoints(endpoints, labels),
 			ocExport("pomerium", exporter, r, labels)),
 		); err != nil {
-			log.Error(ctx).Msg("responding to metrics request")
+			log.Error(ctx).Err(err).Msg("responding to metrics request")
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Add the error in the logs

## Related issues

N/A

## User Explanation

I have those errors:

```
{"level":"error","config_file_source":"/etc/pomerium/config.yaml","bootstrap":true,"time":"2023-09-21T06:19:49Z","message":"responding to metrics request"}
{"level":"error","config_file_source":"/etc/pomerium/config.yaml","bootstrap":true,"time":"2023-09-21T06:20:04Z","message":"responding to metrics request"}
{"level":"error","config_file_source":"/etc/pomerium/config.yaml","bootstrap":true,"time":"2023-09-21T06:20:19Z","message":"responding to metrics request"}
```

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
