### PR TITLE
config: do not add route headers to global map

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -1121,9 +1121,12 @@ func (o *Options) GetSetResponseHeaders() map[string]string {
 
 // GetSetResponseHeadersForPolicy gets the SetResponseHeaders for a policy.
 func (o *Options) GetSetResponseHeadersForPolicy(policy *Policy) map[string]string {
-	hdrs := o.SetResponseHeaders
-	if hdrs == nil {
-		hdrs = make(map[string]string)
+	hdrs := make(map[string]string)
+	for k, v := range o.SetResponseHeaders {
+		hdrs[k] = v
+	}
+
+	if o.SetResponseHeaders == nil {
 		for k, v := range defaultSetResponseHeaders {
 			hdrs[k] = v
 		}

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1026,6 +1026,25 @@ func TestOptions_GetSetResponseHeadersForPolicy(t *testing.T) {
 			"X-XSS-Protection":          "1; mode=block",
 		}, options.GetSetResponseHeadersForPolicy(policy))
 	})
+	t.Run("multiple policies", func(t *testing.T) {
+		options := NewDefaultOptions()
+		options.SetResponseHeaders = map[string]string{"global": "foo"}
+		p1 := &Policy{
+			SetResponseHeaders: map[string]string{"route-1": "bar"},
+		}
+		p2 := &Policy{
+			SetResponseHeaders: map[string]string{"route-2": "baz"},
+		}
+		assert.Equal(t, map[string]string{
+			"global":  "foo",
+			"route-1": "bar",
+		}, options.GetSetResponseHeadersForPolicy(p1))
+		assert.Equal(t, map[string]string{
+			"global":  "foo",
+			"route-2": "baz",
+		}, options.GetSetResponseHeadersForPolicy(p2))
+		assert.Equal(t, map[string]string{"global": "foo"}, options.GetSetResponseHeaders())
+	})
 }
 
 func TestOptions_GetSharedKey(t *testing.T) {


### PR DESCRIPTION
## Summary

Currently the `GetSetResponseHeadersForPolicy()` method may add entries to the global `SetResponseHeaders` map, which can lead to one route's headers being applied to other routes.

Instead, make a copy of the `SetResponseHeaders` map before adding any route-specific response header entries.

Add additional unit tests for `GetSetResponseHeaders()` and `GetSetResponseHeadersForPolicy()`.

## Related issues

https://github.com/pomerium/pomerium/issues/4628

## User Explanation

Fix a bug where headers from the per-route [Set Response Headers](https://www.pomerium.com/docs/reference/routes/headers#set-response-headers) option might be applied incorrectly to other routes.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
