### PR TITLE
zero: derive signing key first thing

### DIFF
--- a/internal/zero/bootstrap/new.go
+++ b/internal/zero/bootstrap/new.go
@@ -43,14 +43,14 @@ func New(secret []byte) (*Source, error) {
 
 	rnd := hkdf.New(sha256.New, secret, nil, nil)
 
-	cipher, err := initCipher(rnd)
-	if err != nil {
-		return nil, fmt.Errorf("init cypher: %w", err)
-	}
-
 	err = initSecrets(cfg, rnd)
 	if err != nil {
 		return nil, fmt.Errorf("init secrets: %w", err)
+	}
+
+	cipher, err := initCipher(rnd)
+	if err != nil {
+		return nil, fmt.Errorf("init cypher: %w", err)
 	}
 
 	svc := &Source{


### PR DESCRIPTION
## Summary

Derive a signing key first. 

## Related issues

Related: https://github.com/pomerium/pomerium-zero/issues/826

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
