### PR TITLE
core/hpke: reduce memory usage from zstd

### DIFF
--- a/pkg/hpke/url.go
+++ b/pkg/hpke/url.go
@@ -152,8 +152,7 @@ func encodeQueryStringV1(values url.Values) []byte {
 const zstdWindowSize = 8 << 10 // 8kiB
 
 var zstdEncoder, _ = zstd.NewWriter(nil,
-	zstd.WithEncoderLevel(zstd.SpeedBestCompression),
-	zstd.WithEncoderConcurrency(1),
+	zstd.WithEncoderLevel(zstd.SpeedDefault),
 	zstd.WithWindowSize(zstdWindowSize),
 )
 
@@ -166,7 +165,6 @@ func decodeQueryStringV1(raw []byte) (url.Values, error) {
 }
 
 var zstdDecoder, _ = zstd.NewReader(nil,
-	zstd.WithDecoderConcurrency(1),
 	zstd.WithDecoderLowmem(true),
 )
 

--- a/pkg/hpke/url_test.go
+++ b/pkg/hpke/url_test.go
@@ -77,3 +77,16 @@ func TestEncryptURLValues(t *testing.T) {
 		assert.Less(t, len(encrypted.Encode()), 1024)
 	})
 }
+
+func BenchmarkZSTD(b *testing.B) {
+	payload := url.Values{
+		"a": {strings.Repeat("b", 128)},
+	}
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		bs := encodeQueryStringV2(payload)
+		_, _ = decodeQueryStringV2(bs)
+	}
+}


### PR DESCRIPTION
## Summary
Based on https://pkg.go.dev/tailscale.com/smallzstd we can use a smaller window size and some options to reduce the memory usage for zstd.

Re-using the encoder and decoder appears to be supported based on the packages documentation. The defaults are not a memory leak, but they do use a lot of memory since they are optimized for large payloads. 

## Related issues
- https://github.com/pomerium/pomerium/issues/4652
- #4648 
 

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
