### PR TITLE
xds: add type url to log

### DIFF
--- a/internal/controlplane/xdsmgr/xdsmgr.go
+++ b/internal/controlplane/xdsmgr/xdsmgr.go
@@ -108,6 +108,7 @@ func (mgr *Manager) DeltaAggregatedResources(
 			// neither an ACK or a NACK
 		case req.GetErrorDetail() != nil:
 			log.Info(ctx).
+				Str("type-url", req.GetTypeUrl()).
 				Any("error-detail", req.GetErrorDetail()).
 				Msg("xdsmgr: nack")
 			// a NACK
@@ -118,6 +119,7 @@ func (mgr *Manager) DeltaAggregatedResources(
 			}
 		case req.GetResponseNonce() == mgr.nonce:
 			log.Info(ctx).
+				Str("type-url", req.GetTypeUrl()).
 				Msg("xdsmgr: ack")
 			// an ACK for the last response
 			// - set the client resource versions to the current resource versions
@@ -128,6 +130,7 @@ func (mgr *Manager) DeltaAggregatedResources(
 		default:
 			// an ACK for a response that's not the last response
 			log.Info(ctx).
+				Str("type-url", req.GetTypeUrl()).
 				Msg("xdsmgr: ack")
 		}
 
@@ -209,6 +212,7 @@ func (mgr *Manager) DeltaAggregatedResources(
 				return ctx.Err()
 			case res := <-outgoing:
 				log.Info(ctx).
+					Str("type-url", res.GetTypeUrl()).
 					Int("resource-count", len(res.GetResources())).
 					Int("removed-resource-count", len(res.GetRemovedResources())).
 					Msg("xdsmgr: sending resources")


### PR DESCRIPTION
## Summary

Adds `type-url` to XDS logs so that it would be clearer which resource types are updated. 

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
