### PR TITLE
rework session updates to use new patch method

### DIFF
--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -299,7 +299,7 @@ func (m mockDataBrokerServiceClient) Patch(ctx context.Context, in *databroker.P
 		getResponse, err := m.Get(ctx, &databroker.GetRequest{
 			Type: record.GetType(),
 			Id:   record.GetId(),
-		})
+		}, opts...)
 		if storage.IsNotFound(err) {
 			continue
 		} else if err != nil {
@@ -313,7 +313,7 @@ func (m mockDataBrokerServiceClient) Patch(ctx context.Context, in *databroker.P
 
 		records = append(records, record)
 	}
-	putResponse, err := m.Put(ctx, &databroker.PutRequest{Records: records})
+	putResponse, err := m.Put(ctx, &databroker.PutRequest{Records: records}, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/identity/manager/manager.go
+++ b/internal/identity/manager/manager.go
@@ -289,7 +289,7 @@ func (mgr *Manager) refreshSessionInternal(
 		return false
 	}
 
-	fm, err := fieldmaskpb.New(s.Session, "oauth_token", "claims")
+	fm, err := fieldmaskpb.New(s.Session, "oauth_token", "id_token", "claims")
 	if err != nil {
 		log.Error(ctx).Err(err).Msg("internal error")
 		return false

--- a/internal/identity/manager/manager_test.go
+++ b/internal/identity/manager/manager_test.go
@@ -250,7 +250,7 @@ func TestManager_refreshSession(t *testing.T) {
 				Data: protoutil.NewAny(expectedSession),
 			}},
 			FieldMask: &fieldmaskpb.FieldMask{
-				Paths: []string{"oauth_token", "claims"},
+				Paths: []string{"oauth_token", "id_token", "claims"},
 			},
 		}}).
 		Return(nil /* this result is currently unused */, nil)

--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -59,6 +60,24 @@ func Put(ctx context.Context, client databroker.DataBrokerServiceClient, s *Sess
 			Id:   s.Id,
 			Data: data,
 		}},
+	})
+	return res, err
+}
+
+// Patch updates specific fields of an existing session in the databroker.
+func Patch(
+	ctx context.Context, client databroker.DataBrokerServiceClient,
+	s *Session, fields *fieldmaskpb.FieldMask,
+) (*databroker.PatchResponse, error) {
+	s = proto.Clone(s).(*Session)
+	data := protoutil.NewAny(s)
+	res, err := client.Patch(ctx, &databroker.PatchRequest{
+		Records: []*databroker.Record{{
+			Type: data.GetTypeUrl(),
+			Id:   s.Id,
+			Data: data,
+		}},
+		FieldMask: fields,
 	})
 	return res, err
 }


### PR DESCRIPTION
## Summary

Update the AccessTracker, WebAuthn handlers, and identity manager refresh loop to perform their session record updates using the databroker Patch() method.

This should prevent any of these updates from conflicting.

## Related issues

- https://github.com/pomerium/internal/issues/1536

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
