### PR TITLE
core/config: update file watcher source to handle base64 encoded certificates

### DIFF
--- a/config/config_source.go
+++ b/config/config_source.go
@@ -288,7 +288,14 @@ func getAllConfigFilePaths(cfg *Config) []string {
 	}
 
 	for _, pair := range cfg.Options.CertificateFiles {
-		fs = append(fs, pair.CertFile, pair.KeyFile)
+		// #4714 skip base64 certificates stored in CertificateFiles
+		// so only add watches for files that exist
+		if _, err := os.Stat(pair.CertFile); err == nil {
+			fs = append(fs, pair.CertFile)
+		}
+		if _, err := os.Stat(pair.KeyFile); err == nil {
+			fs = append(fs, pair.KeyFile)
+		}
 	}
 
 	for _, policy := range cfg.Options.Policies {

--- a/config/config_source_test.go
+++ b/config/config_source_test.go
@@ -22,7 +22,7 @@ func TestFileWatcherSource(t *testing.T) {
 
 	// capture logs
 	var logOutput bytes.Buffer
-	logger := zerolog.New(io.MultiWriter(&logOutput, zerolog.NewTestWriter(t)))
+	logger := zerolog.New(io.MultiWriter(zerolog.SyncWriter(&logOutput), zerolog.NewTestWriter(t)))
 	originalLogger := log.Logger()
 	log.SetLogger(&logger)
 	t.Cleanup(func() {

--- a/config/config_source_test.go
+++ b/config/config_source_test.go
@@ -1,18 +1,33 @@
 package config
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 func TestFileWatcherSource(t *testing.T) {
 	ctx := context.Background()
+
+	// capture logs
+	var logOutput bytes.Buffer
+	logger := zerolog.New(io.MultiWriter(&logOutput, zerolog.NewTestWriter(t)))
+	originalLogger := log.Logger()
+	log.SetLogger(&logger)
+	t.Cleanup(func() {
+		log.SetLogger(originalLogger)
+	})
 
 	tmpdir := t.TempDir()
 
@@ -26,8 +41,19 @@ func TestFileWatcherSource(t *testing.T) {
 		return
 	}
 
+	testCertFileRef := "./testdata/example-cert.pem"
+	testKeyFileRef := "./testdata/example-key.pem"
+	testCertFile, _ := os.ReadFile(testCertFileRef)
+	testKeyFile, _ := os.ReadFile(testKeyFileRef)
+	testCertAsBase64 := base64.StdEncoding.EncodeToString(testCertFile)
+	testKeyAsBase64 := base64.StdEncoding.EncodeToString(testKeyFile)
+
 	ssrc := NewStaticSource(&Config{
 		Options: &Options{
+			CertificateFiles: []certificateFilePair{{
+				CertFile: testCertAsBase64,
+				KeyFile:  testKeyAsBase64,
+			}},
 			CAFile: filepath.Join(tmpdir, "example.txt"),
 			Policies: []Policy{{
 				KubernetesServiceAccountTokenFile: filepath.Join(tmpdir, "kubernetes-example.txt"),
@@ -77,4 +103,6 @@ func TestFileWatcherSource(t *testing.T) {
 	case <-time.After(time.Second):
 		t.Error("expected OnConfigChange to be fired after triggering a change to the underlying source")
 	}
+
+	assert.NotContains(t, logOutput.String(), "failed to add file to polling-based file watcher")
 }


### PR DESCRIPTION
## Summary
Update the `FileWatcherSource` to handle certificate files which aren't actually files but rather embedded directly as base64.

## Related issues
Fixes #4714 


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
