### PR TITLE
core/config: add support for maps in environments

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -39,4 +39,5 @@ var ViperPolicyHooks = viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 	decodeCodecTypeHookFunc(),
 	decodePPLPolicyHookFunc(),
 	decodeSANMatcherHookFunc(),
+	decodeStringToMapHookFunc(),
 ))

--- a/config/custom.go
+++ b/config/custom.go
@@ -528,6 +528,21 @@ func decodeSANMatcherHookFunc() mapstructure.DecodeHookFunc {
 	}
 }
 
+func decodeStringToMapHookFunc() mapstructure.DecodeHookFunc {
+	return mapstructure.DecodeHookFuncValue(func(f, t reflect.Value) (any, error) {
+		if f.Kind() != reflect.String || t.Kind() != reflect.Map {
+			return f.Interface(), nil
+		}
+
+		err := json.Unmarshal([]byte(f.Interface().(string)), t.Addr().Interface())
+		if err != nil {
+			return nil, err
+		}
+
+		return t.Interface(), nil
+	})
+}
+
 // serializable converts mapstructure nested map into map[string]interface{} that is serializable to JSON
 func serializable(in interface{}) (interface{}, error) {
 	switch typed := in.(type) {

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1263,6 +1263,15 @@ func TestOptions_RequestParams(t *testing.T) {
 	}
 }
 
+func TestOptions_RequestParamsFromEnv(t *testing.T) {
+	t.Setenv("IDP_REQUEST_PARAMS", `{"x":"y"}`)
+
+	options, err := newOptionsFromConfig("")
+	if assert.NoError(t, err) {
+		assert.Equal(t, map[string]string{"x": "y"}, options.RequestParams)
+	}
+}
+
 func encodeCert(cert *tls.Certificate) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
 }


### PR DESCRIPTION
## Summary
Add support for string to map conversion for config options, for example:

```
env IDP_REQUEST_PARAMS='{"x":"y"}' ...
```


## Related issues
Fixes https://github.com/pomerium/pomerium/issues/4343
Fixes https://github.com/pomerium/pomerium/issues/4318


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
