### PR TITLE
core/config: remove unnecessary authenticate route

### DIFF
--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -445,6 +445,16 @@ func Test_getAllDomains(t *testing.T) {
 			assert.Equal(t, expect, actual)
 		})
 	})
+
+	t.Run("exclude default authenticate", func(t *testing.T) {
+		options := config.NewDefaultOptions()
+		options.Policies = []config.Policy{
+			{From: "https://a.example.com"},
+		}
+		actual, err := getAllRouteableHosts(options, ":443")
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a.example.com", "a.example.com:443"}, actual)
+	})
 }
 
 func Test_urlMatchesHost(t *testing.T) {

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -411,7 +411,6 @@ func TestOptionsFromViper(t *testing.T) {
 				CookieSecure:             true,
 				InsecureServer:           true,
 				CookieHTTPOnly:           true,
-				AuthenticateURLString:    "https://authenticate.pomerium.app",
 				AuthenticateCallbackPath: "/oauth2/callback",
 				DataBrokerStorageType:    "memory",
 				EnvoyAdminAccessLogPath:  os.DevNull,
@@ -425,7 +424,6 @@ func TestOptionsFromViper(t *testing.T) {
 			&Options{
 				Policies:                 []Policy{{From: "https://from.example", To: mustParseWeightedURLs(t, "https://to.example")}},
 				CookieName:               "_pomerium",
-				AuthenticateURLString:    "https://authenticate.pomerium.app",
 				AuthenticateCallbackPath: "/oauth2/callback",
 				CookieSecure:             true,
 				CookieHTTPOnly:           true,
@@ -848,9 +846,7 @@ func TestOptions_DefaultURL(t *testing.T) {
 		f              func() (*url.URL, error)
 		expectedURLStr string
 	}{
-		{"default authenticate url", defaultOptions.GetAuthenticateURL, "https://127.0.0.1"},
-		{"default authorize url", defaultOptions.GetAuthenticateURL, "https://127.0.0.1"},
-		{"default databroker url", defaultOptions.GetAuthenticateURL, "https://127.0.0.1"},
+		{"default authenticate url", defaultOptions.GetAuthenticateURL, "https://authenticate.pomerium.app"},
 		{"good authenticate url", opts.GetAuthenticateURL, "https://authenticate.example.com"},
 		{"good authorize url", firstURL(opts.GetAuthorizeURLs), "https://authorize.example.com"},
 		{"good databroker url", firstURL(opts.GetDataBrokerURLs), "https://databroker.example.com"},


### PR DESCRIPTION
## Summary
If we're using the default `authenticate.pomerium.app` authenticate URL, don't add a route to envoy.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1416


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
