### PR TITLE
reconciler: allow custom comparison function

### DIFF
--- a/pkg/grpc/databroker/changeset.go
+++ b/pkg/grpc/databroker/changeset.go
@@ -9,13 +9,13 @@ import (
 
 // GetChangeSet returns list of changes between the current and target record sets,
 // that may be applied to the databroker to bring it to the target state.
-func GetChangeSet(current, target RecordSetBundle) []*Record {
+func GetChangeSet(current, target RecordSetBundle, cmpFn RecordCompareFn) []*Record {
 	cs := &changeSet{now: timestamppb.Now()}
 
 	for _, rec := range current.GetRemoved(target).Flatten() {
 		cs.Remove(rec.GetType(), rec.GetId())
 	}
-	for _, rec := range current.GetModified(target).Flatten() {
+	for _, rec := range current.GetModified(target, cmpFn).Flatten() {
 		cs.Upsert(rec)
 	}
 	for _, rec := range current.GetAdded(target).Flatten() {

--- a/pkg/grpc/databroker/recordset_test.go
+++ b/pkg/grpc/databroker/recordset_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/protoutil"
@@ -17,6 +18,10 @@ func TestRecords(t *testing.T) {
 			Type: typ,
 			Data: protoutil.NewAnyString(val),
 		}
+	}
+
+	cmpFn := func(a, b *databroker.Record) bool {
+		return proto.Equal(a, b)
 	}
 
 	initial := make(databroker.RecordSetBundle)
@@ -68,7 +73,7 @@ func TestRecords(t *testing.T) {
 		},
 	})
 
-	modified := initial.GetModified(updated)
+	modified := initial.GetModified(updated, cmpFn)
 	equalJSON(modified, databroker.RecordSetBundle{
 		"a": databroker.RecordSet{
 			"1": tr("1", "a", "a-1-1"),


### PR DESCRIPTION
## Summary

it's not enough to compare records using `proto.Equal`, we sometimes need ignore fields such as `version`, `accessed_at`, `updated_at` as they would never be in sync between core and observer.

 ## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
