### PR TITLE
core/storage: fix nil data unmarshal

### DIFF
--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -126,13 +126,17 @@ func getNextChangedRecord(ctx context.Context, q querier, recordType string, aft
 		return nil, fmt.Errorf("error querying next changed record: %w", err)
 	}
 
-	a, err := protoutil.UnmarshalAnyJSON(data)
-	if isUnknownType(err) {
-		a = protoutil.ToAny(protoutil.ToStruct(map[string]string{
-			"id": recordID,
-		}))
-	} else if err != nil {
-		return nil, fmt.Errorf("error unmarshaling changed record data: %w", err)
+	// data may be nil if a record is deleted
+	var a *anypb.Any
+	if len(data) != 0 {
+		a, err = protoutil.UnmarshalAnyJSON(data)
+		if isUnknownType(err) {
+			a = protoutil.ToAny(protoutil.ToStruct(map[string]string{
+				"id": recordID,
+			}))
+		} else if err != nil {
+			return nil, fmt.Errorf("error unmarshaling changed record data: %w", err)
+		}
 	}
 
 	return &databroker.Record{


### PR DESCRIPTION
## Summary
When deleting a record it's possible to set `data` to be nil. In that case the row would be removed from the `records` table, but there would be an entry in the `record_changes` table with `nil` data. The call to stream changes would then attempt to convert this row into a record and fail with an error. This PR updates the code to tolerate nil data.

Any consuming code would also need to tolerate nil data accordingly. Whether that's the case or not for all known usages is unclear.

## Related issues
Fixes #4733 

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
