### PR TITLE
databroker: changeset: prevent nil data in the deleted records

### DIFF
--- a/pkg/grpc/databroker/changeset.go
+++ b/pkg/grpc/databroker/changeset.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -37,6 +38,7 @@ func (cs *changeSet) Remove(typ string, id string) {
 		Type:      typ,
 		Id:        id,
 		DeletedAt: cs.now,
+		Data:      &anypb.Any{TypeUrl: typ},
 	})
 }
 


### PR DESCRIPTION
## Summary

Prevents `Record.Data` being `nil` in the deleted records, by setting it to empty `protobuf.Any` of desired type.

## Related issues

Related: https://github.com/pomerium/pomerium/issues/4733

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
