### PR TITLE
core/config: disable strict-transport-security header with staging autocert

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -1155,7 +1155,7 @@ func (o *Options) GetSetResponseHeadersForPolicy(policy *Policy) map[string]stri
 			hdrs[k] = v
 		}
 
-		if !o.HasCertificates() {
+		if !o.HasCertificates() || o.AutocertOptions.UseStaging {
 			delete(hdrs, "Strict-Transport-Security")
 		}
 	}

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -979,6 +979,15 @@ func TestOptions_GetSetResponseHeaders(t *testing.T) {
 			"X-XSS-Protection":          "1; mode=block",
 		}, options.GetSetResponseHeaders())
 	})
+	t.Run("autocert-staging", func(t *testing.T) {
+		options := NewDefaultOptions()
+		options.Cert = "CERT"
+		options.AutocertOptions.UseStaging = true
+		assert.Equal(t, map[string]string{
+			"X-Frame-Options":  "SAMEORIGIN",
+			"X-XSS-Protection": "1; mode=block",
+		}, options.GetSetResponseHeaders())
+	})
 	t.Run("disable", func(t *testing.T) {
 		options := NewDefaultOptions()
 		options.SetResponseHeaders = map[string]string{DisableHeaderKey: "1", "x-other": "xyz"}


### PR DESCRIPTION
## Summary
Remove the `Strict-Transport-Security` header when staging autocert is being used.

## Related issues
Fixes https://github.com/pomerium/internal/issues/1577

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
