### PR TITLE
zero: use os.UserCacheDir for boostrap config path

### DIFF
--- a/internal/zero/bootstrap/bootstrap.go
+++ b/internal/zero/bootstrap/bootstrap.go
@@ -39,6 +39,9 @@ func (svc *Source) Run(
 	api *sdk.API,
 	fileCachePath string,
 ) error {
+	log.Ctx(ctx).Info().Str("bootstrap-config-path", fileCachePath).
+		Msg("initializing bootstrap config source")
+
 	svc.api = api
 	svc.fileCachePath = fileCachePath
 

--- a/internal/zero/controller/config.go
+++ b/internal/zero/controller/config.go
@@ -72,7 +72,6 @@ func newControllerConfig(opts ...Option) *controllerConfig {
 	for _, opt := range []Option{
 		WithClusterAPIEndpoint("https://console.pomerium.com/cluster/v1"),
 		WithConnectAPIEndpoint("https://connect.pomerium.com"),
-		WithBootstrapConfigFileName("/var/cache/pomerium-bootstrap.dat"),
 		WithDatabrokerLeaseDuration(time.Second * 30),
 		WithDatabrokerRequestTimeout(time.Second * 30),
 	} {


### PR DESCRIPTION
## Summary

The /var/cache/ directory may not exist (e.g. on macOS). Instead, create a sub-directory under the path returned by [os.UserCacheDir()](https://pkg.go.dev/os#UserCacheDir) for the bootstrap config file.

## Related issues

- https://github.com/pomerium/internal/issues/1588

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
