### PR TITLE
core/zero: add support for managed mode from config file

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -32,8 +32,8 @@ func main() {
 
 	ctx := context.Background()
 	runFn := run
-	if zero_cmd.IsManagedMode() {
-		runFn = zero_cmd.Run
+	if zero_cmd.IsManagedMode(*configFile) {
+		runFn = func(ctx context.Context) error { return zero_cmd.Run(ctx, *configFile) }
 	}
 
 	if err := runFn(ctx); err != nil && !errors.Is(err, context.Canceled) {

--- a/internal/zero/cmd/command.go
+++ b/internal/zero/cmd/command.go
@@ -17,13 +17,13 @@ import (
 )
 
 // Run runs the pomerium zero command.
-func Run(ctx context.Context) error {
+func Run(ctx context.Context, configFile string) error {
 	err := setupLogger()
 	if err != nil {
 		return fmt.Errorf("error setting up logger: %w", err)
 	}
 
-	token := getToken()
+	token := getToken(configFile)
 	if token == "" {
 		return errors.New("no token provided")
 	}
@@ -37,8 +37,8 @@ func Run(ctx context.Context) error {
 }
 
 // IsManagedMode returns true if Pomerium should start in managed mode using this command.
-func IsManagedMode() bool {
-	return getToken() != ""
+func IsManagedMode(configFile string) bool {
+	return getToken(configFile) != ""
 }
 
 func withInterrupt(ctx context.Context) context.Context {

--- a/internal/zero/cmd/env.go
+++ b/internal/zero/cmd/env.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "os"
+import (
+	"os"
+
+	"github.com/spf13/viper"
+)
 
 const (
 	// PomeriumZeroTokenEnv is the environment variable name for the API token.
@@ -8,6 +12,20 @@ const (
 	PomeriumZeroTokenEnv = "POMERIUM_ZERO_TOKEN"
 )
 
-func getToken() string {
-	return os.Getenv(PomeriumZeroTokenEnv)
+func getToken(configFile string) string {
+	if token, ok := os.LookupEnv(PomeriumZeroTokenEnv); ok {
+		return token
+	}
+
+	if configFile != "" {
+		// load the token from the config file
+		v := viper.New()
+		v.SetConfigFile(configFile)
+		if v.ReadInConfig() == nil {
+			return v.GetString("pomerium_zero_token")
+		}
+	}
+
+	// we will fallback to normal pomerium if empty
+	return ""
 }

--- a/internal/zero/cmd/env_test.go
+++ b/internal/zero/cmd/env_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getToken(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		assert.Equal(t, "", getToken(""))
+	})
+	t.Run("env", func(t *testing.T) {
+		t.Setenv("POMERIUM_ZERO_TOKEN", "FROM_ENV")
+		assert.Equal(t, "FROM_ENV", getToken(""))
+	})
+	t.Run("json", func(t *testing.T) {
+		fp := filepath.Join(t.TempDir(), "config.json")
+		require.NoError(t, os.WriteFile(fp, []byte(`{
+			"pomerium_zero_token": "FROM_JSON"
+		}`), 0o644))
+		assert.Equal(t, "FROM_JSON", getToken(fp))
+	})
+	t.Run("yaml", func(t *testing.T) {
+		fp := filepath.Join(t.TempDir(), "config.yaml")
+		require.NoError(t, os.WriteFile(fp, []byte(`
+pomerium_zero_token: FROM_YAML
+`), 0o644))
+		assert.Equal(t, "FROM_YAML", getToken(fp))
+	})
+	t.Run("toml", func(t *testing.T) {
+		fp := filepath.Join(t.TempDir(), "config.toml")
+		require.NoError(t, os.WriteFile(fp, []byte(`
+pomerium_zero_token = "FROM_TOML"
+`), 0o644))
+		assert.Equal(t, "FROM_TOML", getToken(fp))
+	})
+}


### PR DESCRIPTION
## Summary
Currently we only support enabling managed mode using the environment variable `POMERIUM_ZERO_TOKEN`. This PR also adds the ability to enable managed mode using the configuration option `pomerium_zero_token: TOKEN`. This way an existing installation of Pomerium can be converted into managed mode with minimal changes, notably to make managed mode compatible with our existing `.deb` and `.rpm` packages, which use config files by default.

## Related issues
- https://github.com/pomerium/pomerium-zero/issues/1081


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
