### PR TITLE
zero/k8s: deployment manifests

### DIFF
--- a/k8s/zero/.gitignore
+++ b/k8s/zero/.gitignore
@@ -1,0 +1,1 @@
+pomerium-secret.yaml

--- a/k8s/zero/README.md
+++ b/k8s/zero/README.md
@@ -1,0 +1,43 @@
+# Installing Pomerium Zero
+
+Visit https://console.pomerium.app and register for an account.
+
+# Install base pomerium zero
+
+```shell
+kubectl apply -k https://github.com/pomerium/pomerium/k8s/zero?ref=main
+```
+
+(that would install an evergreen `main`)
+
+# Create a secret with Pomerium Zero token to complete your installation
+
+```yaml filename="pomerium-secret.yaml"
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pomerium
+  namespace: pomerium-zero
+type: Opaque
+stringData:
+    pomerium_zero_token:
+```
+
+```shell
+kubectl apply -f pomerium-secret.yaml
+```
+
+Now your Pomerium deployment should be up and running.
+
+# Update Pomerium cluster configuration
+
+1. The externally available address of your Pomerium Cluster should be set to the value assigned by your Load Balancer:
+
+```shell
+kubectl get svc/pomerium-proxy -n pomerium-zero -o=jsonpath='{.status.loadBalancer.ingress[0].ip}'
+```
+
+2. Because container is configured to run as non-root, the following should be adjusted:
+
+- http redirect address set to `:8080`
+- server address set to `:8443`

--- a/k8s/zero/deployment/base.yaml
+++ b/k8s/zero/deployment/base.yaml
@@ -1,9 +1,13 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: pomerium
 spec:
+  serviceName: "pomerium-proxy"
   replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: pomerium-zero
   template:
     spec:
       containers:

--- a/k8s/zero/deployment/base.yaml
+++ b/k8s/zero/deployment/base.yaml
@@ -1,0 +1,11 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: pomerium
+      terminationGracePeriodSeconds: 10

--- a/k8s/zero/deployment/env.yaml
+++ b/k8s/zero/deployment/env.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      containers:
+        - name: pomerium
+          env:
+            - name: CONNECT_SERVER_ENDPOINT
+              value: "https://connect.pomerium.app"
+            - name: CLUSTER_API_ENDPOINT
+              value: "https://console.pomerium.app/cluster/v1"
+            - name: POMERIUM_ZERO_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: pomerium
+                  key: pomerium_zero_token
+                  optional: false
+            - name: POMERIUM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP

--- a/k8s/zero/deployment/env.yaml
+++ b/k8s/zero/deployment/env.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: pomerium
 spec:
@@ -8,10 +8,6 @@ spec:
       containers:
         - name: pomerium
           env:
-            - name: CONNECT_SERVER_ENDPOINT
-              value: "https://connect.pomerium.app"
-            - name: CLUSTER_API_ENDPOINT
-              value: "https://console.pomerium.app/cluster/v1"
             - name: POMERIUM_ZERO_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/zero/deployment/image.yaml
+++ b/k8s/zero/deployment/image.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  replicas: 1
+  template:
+    spec:
+      containers:
+        - name: pomerium
+          image: pomerium/pomerium:main
+          imagePullPolicy: Always

--- a/k8s/zero/deployment/image.yaml
+++ b/k8s/zero/deployment/image.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: pomerium
 spec:

--- a/k8s/zero/deployment/kustomization.yaml
+++ b/k8s/zero/deployment/kustomization.yaml
@@ -7,3 +7,4 @@ patchesStrategicMerge:
   - resources.yaml
   - no-root.yaml
   - readonly-root-fs.yaml
+  - volumes.yaml

--- a/k8s/zero/deployment/kustomization.yaml
+++ b/k8s/zero/deployment/kustomization.yaml
@@ -1,0 +1,9 @@
+resources:
+  - base.yaml
+patchesStrategicMerge:
+  - env.yaml
+  - image.yaml
+  - ports.yaml
+  - resources.yaml
+  - no-root.yaml
+  - readonly-root-fs.yaml

--- a/k8s/zero/deployment/no-root.yaml
+++ b/k8s/zero/deployment/no-root.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: pomerium
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsGroup: 1000
+            runAsUser: 1000

--- a/k8s/zero/deployment/no-root.yaml
+++ b/k8s/zero/deployment/no-root.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: pomerium
 spec:
@@ -7,10 +7,10 @@ spec:
     spec:
       securityContext:
         runAsNonRoot: true
+        runAsGroup: 1000
+        runAsUser: 1000
+        fsGroup: 1000
       containers:
         - name: pomerium
           securityContext:
             allowPrivilegeEscalation: false
-            runAsNonRoot: true
-            runAsGroup: 1000
-            runAsUser: 1000

--- a/k8s/zero/deployment/no-root.yaml
+++ b/k8s/zero/deployment/no-root.yaml
@@ -6,11 +6,17 @@ spec:
   template:
     spec:
       securityContext:
+        fsGroup: 1000
         runAsNonRoot: true
         runAsGroup: 1000
         runAsUser: 1000
-        fsGroup: 1000
+        sysctls:
+          - name: net.ipv4.ip_unprivileged_port_start
+            value: "80"
       containers:
         - name: pomerium
           securityContext:
             allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL

--- a/k8s/zero/deployment/ports.yaml
+++ b/k8s/zero/deployment/ports.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      containers:
+        - name: pomerium
+          ports:
+            - containerPort: 8443
+              name: https
+              protocol: TCP
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP

--- a/k8s/zero/deployment/ports.yaml
+++ b/k8s/zero/deployment/ports.yaml
@@ -8,11 +8,11 @@ spec:
       containers:
         - name: pomerium
           ports:
-            - containerPort: 8443
+            - containerPort: 443
               name: https
               protocol: TCP
             - name: http
-              containerPort: 8080
+              containerPort: 80
               protocol: TCP
             - name: metrics
               containerPort: 9090

--- a/k8s/zero/deployment/ports.yaml
+++ b/k8s/zero/deployment/ports.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: pomerium
 spec:

--- a/k8s/zero/deployment/readonly-root-fs.yaml
+++ b/k8s/zero/deployment/readonly-root-fs.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: pomerium
+          securityContext:
+            readOnlyRootFilesystem: true
+          env:
+            - name: TMPDIR
+              value: "/tmp/pomerium"
+            - name: XDG_CACHE_HOME
+              value: "/tmp"
+          volumeMounts:
+            - mountPath: "/tmp/pomerium"
+              name: tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/k8s/zero/deployment/readonly-root-fs.yaml
+++ b/k8s/zero/deployment/readonly-root-fs.yaml
@@ -1,24 +1,11 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: pomerium
 spec:
   template:
     spec:
-      nodeSelector:
-        kubernetes.io/os: linux
       containers:
         - name: pomerium
           securityContext:
             readOnlyRootFilesystem: true
-          env:
-            - name: TMPDIR
-              value: "/tmp/pomerium"
-            - name: XDG_CACHE_HOME
-              value: "/tmp"
-          volumeMounts:
-            - mountPath: "/tmp/pomerium"
-              name: tmp
-      volumes:
-        - name: tmp
-          emptyDir: {}

--- a/k8s/zero/deployment/resources.yaml
+++ b/k8s/zero/deployment/resources.yaml
@@ -1,0 +1,16 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      containers:
+        - name: pomerium
+          resources:
+            limits:
+              cpu: 5000m
+              memory: 1Gi
+            requests:
+              cpu: 300m
+              memory: 200Mi

--- a/k8s/zero/deployment/resources.yaml
+++ b/k8s/zero/deployment/resources.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: pomerium
 spec:

--- a/k8s/zero/deployment/volumes.yaml
+++ b/k8s/zero/deployment/volumes.yaml
@@ -14,6 +14,8 @@ spec:
               value: "/tmp/pomerium"
             - name: XDG_CACHE_HOME
               value: "/var/cache"
+            - name: XDG_DATA_HOME
+              value: "/var/cache"
           volumeMounts:
             - mountPath: "/tmp/pomerium"
               name: tmp

--- a/k8s/zero/deployment/volumes.yaml
+++ b/k8s/zero/deployment/volumes.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: pomerium
+spec:
+  template:
+    spec:
+      nodeSelector:
+        kubernetes.io/os: linux
+      containers:
+        - name: pomerium
+          env:
+            - name: TMPDIR
+              value: "/tmp/pomerium"
+            - name: XDG_CACHE_HOME
+              value: "/var/cache"
+          volumeMounts:
+            - mountPath: "/tmp/pomerium"
+              name: tmp
+            - mountPath: "/var/cache"
+              name: pomerium-cache
+      volumes:
+        - name: tmp
+          emptyDir: {}
+  volumeClaimTemplates:
+  - metadata:
+      name: pomerium-cache
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: 100Mi

--- a/k8s/zero/kustomization.yaml
+++ b/k8s/zero/kustomization.yaml
@@ -1,0 +1,7 @@
+namespace: pomerium-zero
+commonLabels:
+  app.kubernetes.io/name: pomerium-zero
+resources:
+  - namespace.yaml
+  - ./deployment
+  - ./service

--- a/k8s/zero/namespace.yaml
+++ b/k8s/zero/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: pomerium-zero

--- a/k8s/zero/pomerium-secret.yaml.example
+++ b/k8s/zero/pomerium-secret.yaml.example
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: pomerium
+  namespace: pomerium-zero
+type: Opaque
+stringData:
+    pomerium_zero_token: YOUR_TOKEN_HERE

--- a/k8s/zero/service/kustomization.yaml
+++ b/k8s/zero/service/kustomization.yaml
@@ -1,0 +1,2 @@
+resources:
+  - proxy.yaml

--- a/k8s/zero/service/proxy.yaml
+++ b/k8s/zero/service/proxy.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: pomerium-proxy
+spec:
+  type: LoadBalancer
+  ports:
+    - port: 443
+      targetPort: https
+      protocol: TCP
+      name: https
+    - name: http
+      targetPort: http
+      protocol: TCP
+      port: 80


### PR DESCRIPTION
## Summary

Creates manifests to deploy Pomerium Zero into Kubernetes cluster (see README.md)

## Related issues

Implements https://github.com/pomerium/pomerium-zero/issues/1479

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [x] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
