### PR TITLE
zero/core: set drwx------ for cache dir

### DIFF
--- a/internal/zero/cmd/command.go
+++ b/internal/zero/cmd/command.go
@@ -96,8 +96,8 @@ func getBootstrapConfigFileName() (string, error) {
 	}
 
 	dir := filepath.Join(cacheDir, "pomerium")
-	if err := os.MkdirAll(dir, 0644); err != nil {
-		return "", err
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", fmt.Errorf("error creating cache directory: %w", err)
 	}
 
 	return filepath.Join(dir, "bootstrap.dat"), nil


### PR DESCRIPTION
## Summary

The UserCacheDir()/pomerium is also used to cache envoy keypairs, and it would fail to create files otherwise when non-root.

```
{"level":"error","error":"mkdir /var/cache/pomerium/envoy: permission denied","message":"filemgr: error creating cache directory, falling back to inline bytes"}
```

## Related issues

Related: https://github.com/pomerium/pomerium/pull/4744

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
