### PR TITLE
support both stateful and stateless authenticate

### DIFF
--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -144,13 +144,17 @@ func newAuthenticateStateFromConfig(
 		}
 	}
 
-	state.flow, err = authenticateflow.NewStateless(
-		cfg,
-		cookieStore,
-		authenticateConfig.getIdentityProvider,
-		authenticateConfig.profileTrimFn,
-		authenticateConfig.authEventFn,
-	)
+	if cfg.Options.UseStatelessAuthenticateFlow() {
+		state.flow, err = authenticateflow.NewStateless(
+			cfg,
+			cookieStore,
+			authenticateConfig.getIdentityProvider,
+			authenticateConfig.profileTrimFn,
+			authenticateConfig.authEventFn,
+		)
+	} else {
+		state.flow, err = authenticateflow.NewStateful(cfg, cookieStore)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -83,7 +83,11 @@ func newAuthorizeStateFromConfig(
 		return nil, fmt.Errorf("authorize: invalid session store: %w", err)
 	}
 
-	state.authenticateFlow, err = authenticateflow.NewStateless(cfg, nil, nil, nil, nil)
+	if cfg.Options.UseStatelessAuthenticateFlow() {
+		state.authenticateFlow, err = authenticateflow.NewStateless(cfg, nil, nil, nil, nil)
+	} else {
+		state.authenticateFlow, err = authenticateflow.NewStateful(cfg, nil)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/config/options.go
+++ b/config/options.go
@@ -827,6 +827,16 @@ func (o *Options) GetInternalAuthenticateURL() (*url.URL, error) {
 	return urlutil.ParseAndValidateURL(o.AuthenticateInternalURLString)
 }
 
+// UseStatelessAuthenticateFlow returns true if the stateless authentication
+// flow should be used (i.e. for hosted authenticate).
+func (o *Options) UseStatelessAuthenticateFlow() bool {
+	u, err := o.GetInternalAuthenticateURL()
+	if err != nil {
+		return false
+	}
+	return urlutil.IsHostedAuthenticateDomain(u.Hostname())
+}
+
 // GetAuthorizeURLs returns the AuthorizeURLs in the options or 127.0.0.1:5443.
 func (o *Options) GetAuthorizeURLs() ([]*url.URL, error) {
 	if IsAll(o.Services) && o.AuthorizeURLString == "" && len(o.AuthorizeURLStrings) == 0 {

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -856,6 +856,21 @@ func TestOptions_DefaultURL(t *testing.T) {
 	}
 }
 
+func TestOptions_UseStatelessAuthenticateFlow(t *testing.T) {
+	t.Run("enabled by default", func(t *testing.T) {
+		options := &Options{}
+		assert.True(t, options.UseStatelessAuthenticateFlow())
+	})
+	t.Run("enabled explicitly", func(t *testing.T) {
+		options := &Options{AuthenticateURLString: "https://authenticate.pomerium.app"}
+		assert.True(t, options.UseStatelessAuthenticateFlow())
+	})
+	t.Run("disabled", func(t *testing.T) {
+		options := &Options{AuthenticateURLString: "https://authenticate.example.com"}
+		assert.False(t, options.UseStatelessAuthenticateFlow())
+	})
+}
+
 func TestOptions_GetOauthOptions(t *testing.T) {
 	opts := &Options{AuthenticateURLString: "https://authenticate.example.com"}
 	oauthOptions, err := opts.GetOauthOptions()

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -114,8 +114,12 @@ func newProxyStateFromConfig(cfg *config.Config) (*proxyState, error) {
 
 	state.programmaticRedirectDomainWhitelist = cfg.Options.ProgrammaticRedirectDomainWhitelist
 
-	state.authenticateFlow, err = authenticateflow.NewStateless(
-		cfg, state.sessionStore, nil, nil, nil)
+	if cfg.Options.UseStatelessAuthenticateFlow() {
+		state.authenticateFlow, err = authenticateflow.NewStateless(
+			cfg, state.sessionStore, nil, nil, nil)
+	} else {
+		state.authenticateFlow, err = authenticateflow.NewStateful(cfg, state.sessionStore)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Update the initialization logic for the authenticate, authorize, and proxy services to automatically select between the stateful authentication flow and the stateless authentication flow, depending on whether Pomerium is configured to use the hosted authenticate service.

## Related issues

- https://github.com/pomerium/pomerium/issues/4819

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
