### PR TITLE
core/proxy: handle missing session for user info endpoint

### DIFF
--- a/proxy/data.go
+++ b/proxy/data.go
@@ -67,18 +67,16 @@ func (p *Proxy) getUserInfoData(r *http.Request) (handlers.UserInfoData, error) 
 	}
 
 	ss, err := p.getSessionState(r)
-	if err != nil {
-		return handlers.UserInfoData{}, err
-	}
+	if err == nil {
+		data.Session, data.IsImpersonated, err = p.getSession(r.Context(), ss.ID)
+		if err != nil {
+			data.Session = &session.Session{Id: ss.ID}
+		}
 
-	data.Session, data.IsImpersonated, err = p.getSession(r.Context(), ss.ID)
-	if err != nil {
-		data.Session = &session.Session{Id: ss.ID}
-	}
-
-	data.User, err = p.getUser(r.Context(), data.Session.GetUserId())
-	if err != nil {
-		data.User = &user.User{Id: data.Session.GetUserId()}
+		data.User, err = p.getUser(r.Context(), data.Session.GetUserId())
+		if err != nil {
+			data.User = &user.User{Id: data.Session.GetUserId()}
+		}
 	}
 
 	data.WebAuthnCreationOptions, data.WebAuthnRequestOptions, _ = p.webauthn.GetOptions(r)

--- a/ui/src/components/SessionDetails.tsx
+++ b/ui/src/components/SessionDetails.tsx
@@ -1,3 +1,5 @@
+import Alert from "@mui/material/Alert";
+import AlertTitle from "@mui/material/AlertTitle";
 import Stack from "@mui/material/Stack";
 import Table from "@mui/material/Table";
 import TableBody from "@mui/material/TableBody";
@@ -20,50 +22,66 @@ export const SessionDetails: FC<SessionDetailsProps> = ({
   profile,
 }) => {
   return (
-    <Section title="User Details">
-      <Stack spacing={3}>
-        <TableContainer>
-          <Table size="small">
-            <TableBody>
-              <TableRow>
-                <TableCell width={"18%"} variant="head">
-                  Session ID
-                </TableCell>
-                <TableCell align="left">
-                  <IDField value={session?.id} />
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell variant="head">User ID</TableCell>
-                <TableCell align="left">
-                  <IDField
-                    value={session?.userId || `${profile?.claims?.sub}`}
-                  />
-                </TableCell>
-              </TableRow>
-              <TableRow>
-                <TableCell variant="head">Expires At</TableCell>
-                <TableCell align="left">{session?.expiresAt || ""}</TableCell>
-              </TableRow>
-              {Object.entries(session?.claims || {}).map(([key, values]) => (
-                <ClaimRow
-                  key={`session/${key}`}
-                  claimKey={key}
-                  claimValue={values}
-                />
-              ))}
-              {Object.entries(profile?.claims || {}).map(([key, value]) => (
-                <ClaimRow
-                  key={`profile/${key}`}
-                  claimKey={key}
-                  claimValue={value}
-                />
-              ))}
-            </TableBody>
-          </Table>
-        </TableContainer>
-      </Stack>
-    </Section>
+    <>
+      {session?.id ? (
+        <Section title="User Details">
+          <Stack spacing={3}>
+            <TableContainer>
+              <Table size="small">
+                <TableBody>
+                  <TableRow>
+                    <TableCell width={"18%"} variant="head">
+                      Session ID
+                    </TableCell>
+                    <TableCell align="left">
+                      <IDField value={session?.id} />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell variant="head">User ID</TableCell>
+                    <TableCell align="left">
+                      <IDField
+                        value={
+                          session?.userId || `${profile?.claims?.sub || ""}`
+                        }
+                      />
+                    </TableCell>
+                  </TableRow>
+                  <TableRow>
+                    <TableCell variant="head">Expires At</TableCell>
+                    <TableCell align="left">
+                      {session?.expiresAt || ""}
+                    </TableCell>
+                  </TableRow>
+                  {Object.entries(session?.claims || {}).map(
+                    ([key, values]) => (
+                      <ClaimRow
+                        key={`session/${key}`}
+                        claimKey={key}
+                        claimValue={values}
+                      />
+                    )
+                  )}
+                  {Object.entries(profile?.claims || {}).map(([key, value]) => (
+                    <ClaimRow
+                      key={`profile/${key}`}
+                      claimKey={key}
+                      claimValue={value}
+                    />
+                  ))}
+                </TableBody>
+              </Table>
+            </TableContainer>
+          </Stack>
+        </Section>
+      ) : (
+        <Alert severity="warning">
+          <AlertTitle>User Details Not Available</AlertTitle>
+          Have you signed in yet? <br />
+          <a href="/">{location.origin}</a>.
+        </Alert>
+      )}
+    </>
   );
 };
 export default SessionDetails;


### PR DESCRIPTION
## Summary
Currently we display an "Internal Server Error" when you visit the `/.pomerium/` page with no session. This PR changes it so instead of returning an error we render the user info page with empty session and user data and the show a warning with a link to the root of the domain.

<img width="1026" alt="Screenshot 2023-11-28 at 3 54 32 PM" src="https://github.com/pomerium/pomerium/assets/395272/965cdf7a-578b-4c49-8bc1-044f1d9d4e04">

## Related issues
Fixes https://github.com/pomerium/internal/issues/1578


## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
