### PR TITLE
authenticate: remove extra UpdateUserInfo() call

### DIFF
--- a/authenticate/identity_profile.go
+++ b/authenticate/identity_profile.go
@@ -29,18 +29,7 @@ func (a *Authenticate) buildIdentityProfile(
 	claims identity.SessionClaims,
 	oauthToken *oauth2.Token,
 ) (*identitypb.Profile, error) {
-	options := a.options.Load()
 	idpID := r.FormValue(urlutil.QueryIdentityProviderID)
-
-	authenticator, err := a.cfg.getIdentityProvider(options, idpID)
-	if err != nil {
-		return nil, fmt.Errorf("authenticate: error getting identity provider authenticator: %w", err)
-	}
-
-	err = authenticator.UpdateUserInfo(ctx, oauthToken, &claims)
-	if err != nil {
-		return nil, fmt.Errorf("authenticate: error retrieving user info: %w", err)
-	}
 
 	rawIDToken := []byte(claims.RawIDToken)
 	rawOAuthToken, err := json.Marshal(oauthToken)


### PR DESCRIPTION
## Summary

The `buildIdentityProfile()` method is called only from `Authenticate.getOAuthCallback()` ([L454](https://github.com/pomerium/pomerium/blob/2edd63c58a81cecfeeb5e46344dde38e9d92e542/authenticate/handlers.go#L454)), which has previously called `Authenticator.Authenticate()` ([L437](https://github.com/pomerium/pomerium/blob/2edd63c58a81cecfeeb5e46344dde38e9d92e542/authenticate/handlers.go#L437)). It looks like all implementations of the `Authenticator` interface already call `UpdateUserInfo()` from `Authenticate()` ([oidc](https://github.com/pomerium/pomerium/blob/2edd63c58a81cecfeeb5e46344dde38e9d92e542/internal/identity/oidc/oidc.go#L180), [apple](https://github.com/pomerium/pomerium/blob/2edd63c58a81cecfeeb5e46344dde38e9d92e542/internal/identity/oauth/apple/apple.go#L123), [github](https://github.com/pomerium/pomerium/blob/2edd63c58a81cecfeeb5e46344dde38e9d92e542/internal/identity/oauth/github/github.go#L101)), so we shouldn't need to call `UpdateUserInfo()` a second time from `buildIdentityProfile()`.

This should simplify the code a little and provide a slight performance improvement (by avoiding one network request).


<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
