### PR TITLE
authenticate: getUserInfoData() cleanup

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -98,12 +98,7 @@ func (a *Authenticate) mountDashboard(r *mux.Router) {
 	sr.Path("/").Handler(a.requireValidSignatureOnRedirect(a.userInfo))
 	sr.Path("/sign_in").Handler(httputil.HandlerFunc(a.SignIn))
 	sr.Path("/device-enrolled").Handler(httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		userInfoData, err := a.getUserInfoData(r)
-		if err != nil {
-			return err
-		}
-
-		handlers.DeviceEnrolled(userInfoData).ServeHTTP(w, r)
+		handlers.DeviceEnrolled(a.getUserInfoData(r)).ServeHTTP(w, r)
 		return nil
 	}))
 
@@ -502,16 +497,11 @@ func (a *Authenticate) userInfo(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	}
 
-	userInfoData, err := a.getUserInfoData(r)
-	if err != nil {
-		return err
-	}
-
-	handlers.UserInfo(userInfoData).ServeHTTP(w, r)
+	handlers.UserInfo(a.getUserInfoData(r)).ServeHTTP(w, r)
 	return nil
 }
 
-func (a *Authenticate) getUserInfoData(r *http.Request) (handlers.UserInfoData, error) {
+func (a *Authenticate) getUserInfoData(r *http.Request) handlers.UserInfoData {
 	state := a.state.Load()
 
 	s, err := a.getSessionFromCtx(r.Context())
@@ -527,7 +517,7 @@ func (a *Authenticate) getUserInfoData(r *http.Request) (handlers.UserInfoData, 
 
 		BrandingOptions: a.options.Load().BrandingOptions,
 	}
-	return data, nil
+	return data
 }
 
 // revokeSession always clears the local session and tries to revoke the associated session stored in the


### PR DESCRIPTION
## Summary

The `Authenticate.getUserInfoData()` method has an error return value, but always returns `nil` for this value. Let's remove this return value from the method signature.

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
