### PR TITLE
authenticateflow: move logAuthenticateEvent

### DIFF
--- a/internal/authenticateflow/events.go
+++ b/internal/authenticateflow/events.go
@@ -2,14 +2,6 @@ package authenticateflow
 
 import (
 	"context"
-	"net/http"
-	"net/url"
-
-	"github.com/pomerium/pomerium/internal/httputil"
-	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/internal/urlutil"
-	identitypb "github.com/pomerium/pomerium/pkg/grpc/identity"
-	"github.com/pomerium/pomerium/pkg/hpke"
 )
 
 // AuthEventKind is the type of an authentication event
@@ -44,44 +36,3 @@ type AuthEvent struct {
 
 // AuthEventFn is a function that handles an authentication event
 type AuthEventFn func(context.Context, AuthEvent)
-
-// TODO: move into stateless.go; this is here for now just so that Git will
-// track the file history as a rename from authenticate/events.go.
-func (s *Stateless) logAuthenticateEvent(r *http.Request, profile *identitypb.Profile) {
-	if s.authEventFn == nil {
-		return
-	}
-
-	ctx := r.Context()
-	pub, params, err := hpke.DecryptURLValues(s.hpkePrivateKey, r.Form)
-	if err != nil {
-		log.Warn(ctx).Err(err).Msg("log authenticate event: failed to decrypt request params")
-	}
-
-	evt := AuthEvent{
-		IP:          httputil.GetClientIP(r),
-		Version:     params.Get(urlutil.QueryVersion),
-		RequestUUID: params.Get(urlutil.QueryRequestUUID),
-		PubKey:      pub.String(),
-	}
-
-	if uid := getUserClaim(profile, "sub"); uid != nil {
-		evt.UID = uid
-	}
-	if email := getUserClaim(profile, "email"); email != nil {
-		evt.Email = email
-	}
-
-	if evt.UID != nil {
-		evt.Event = AuthEventSignInComplete
-	} else {
-		evt.Event = AuthEventSignInRequest
-	}
-
-	if redirectURL, err := url.Parse(params.Get(urlutil.QueryRedirectURI)); err == nil {
-		domain := redirectURL.Hostname()
-		evt.Domain = &domain
-	}
-
-	s.authEventFn(ctx, evt)
-}


### PR DESCRIPTION
## Summary

Move the Stateless.logAuthenticateEvent() method into the main stateless.go file.

(This was in events.go temporarily so that Git would track the file history as a rename from authenticate/events.go.)

## Related issues

- https://github.com/pomerium/pomerium/issues/4819

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
