### PR TITLE
core/ci: disable dependabot for npm

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -20,8 +20,3 @@ updates:
     schedule:
       interval: "monthly"
     open-pull-requests-limit: 50
-  - package-ecosystem: "npm"
-    directory: "/ui"
-    schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 50


### PR DESCRIPTION
For https://github.com/pomerium/internal/issues/1594