### PR TITLE
storage/inmemory: fix Patch() error handling

### DIFF
--- a/pkg/storage/inmemory/backend.go
+++ b/pkg/storage/inmemory/backend.go
@@ -269,12 +269,12 @@ func (backend *Backend) Patch(
 			// Skip any record that does not currently exist.
 			continue
 		} else if err != nil {
-			return
+			return serverVersion, patchedRecords, err
 		}
 		patchedRecords = append(patchedRecords, record)
 	}
 
-	return
+	return serverVersion, patchedRecords, nil
 }
 
 // patch updates the specified fields of an existing record, assuming the RWMutex is held.

--- a/pkg/storage/storagetest/storagetest.go
+++ b/pkg/storage/storagetest/storagetest.go
@@ -32,6 +32,17 @@ func TestBackendPatch(t *testing.T, ctx context.Context, backend storage.Backend
 		}
 	}
 
+	t.Run("not found", func(t *testing.T) {
+		mask, err := fieldmaskpb.New(&session.Session{}, "oauth_token")
+		require.NoError(t, err)
+
+		s := &session.Session{Id: "session-id-that-does-not-exist"}
+
+		_, updated, err := backend.Patch(ctx, []*databroker.Record{mkRecord(s)}, mask)
+		require.NoError(t, err)
+		assert.Empty(t, updated)
+	})
+
 	t.Run("basic", func(t *testing.T) {
 		// Populate an initial set of session records.
 		s1 := &session.Session{


### PR DESCRIPTION
## Summary

The `Patch()` method was intended to skip any records that do not currently exist. However, currently [inmemory.Backend.Patch()](https://github.com/pomerium/pomerium/blob/c01d0e045d59976731c2266202e5b180bbaef445/pkg/storage/inmemory/backend.go#L256) will return `ErrNotFound` if the last record in the records slice is not found (it will ignore any other previous records that are not found).

Update the error handling logic here to be consistent with the postgres backend, and add a unit test to exercise this case.

## Related issues

- https://github.com/pomerium/pomerium/issues/4837

## User Explanation

Fix a bug where the session access tracker may repeatedly try and fail to update a session that no longer exists.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
