### PR TITLE
integration: check for profile cookies

### DIFF
--- a/integration/authentication_test.go
+++ b/integration/authentication_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/integration/flows"
+	"github.com/pomerium/pomerium/pkg/slices"
 )
 
 func TestRouteSessions(t *testing.T) {
@@ -48,6 +49,14 @@ func TestRouteSessions(t *testing.T) {
 		// Under the stateful authenticate flow, the two routes should share
 		// the same session.
 		assert.Equal(t, claims1.ID, claims2.ID)
+
+		// The only cookies set on the authenticate service domain should be
+		// "_pomerium_authenticate" and "_pomerium_csrf". (No identity profile
+		// cookies should be present.)
+		c := client.Jar.Cookies(mustParseURL("https://authenticate.localhost.pomerium.io"))
+		assert.Equal(t, 2, len(c))
+		cookieNames := slices.Map(c, func(c *http.Cookie) string { return c.Name })
+		assert.ElementsMatch(t, []string{"_pomerium_authenticate", "_pomerium_csrf"}, cookieNames)
 	}
 }
 

--- a/pkg/slices/slices.go
+++ b/pkg/slices/slices.go
@@ -22,6 +22,16 @@ func Filter[S ~[]E, E any](s S, f func(E) bool) S {
 	return ns
 }
 
+// Map constructs a new slice containing the elements obtained by invoking the
+// function f on each element of s.
+func Map[S ~[]E, E, T any](s S, f func(E) T) []T {
+	ns := make([]T, len(s))
+	for i := range s {
+		ns[i] = f(s[i])
+	}
+	return ns
+}
+
 // Remove removes e from s.
 func Remove[S ~[]E, E comparable](s S, e E) S {
 	var ns S

--- a/pkg/slices/slices_test.go
+++ b/pkg/slices/slices_test.go
@@ -1,10 +1,22 @@
 package slices
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestMap(t *testing.T) {
+	t.Parallel()
+
+	in := []string{"one", "two", "three", "four"}
+
+	assert.Equal(t, []string{"ONE", "TWO", "THREE", "FOUR"}, Map(in, strings.ToUpper))
+
+	stringLen := func(s string) int { return len(s) }
+	assert.Equal(t, []int{3, 3, 5, 4}, Map(in, stringLen))
+}
 
 func TestReverse(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

Update the authentication flow integration test to verify that the `pomerium_identity_profile` cookies are not present for the stateful authentication flow.

## Related issues

- https://github.com/pomerium/pomerium/issues/4627
- https://github.com/pomerium/pomerium/issues/4819

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
