### PR TITLE
move events.go out of internal/authenticateflow

### DIFF
--- a/authenticate/config.go
+++ b/authenticate/config.go
@@ -1,8 +1,8 @@
 package authenticate
 
 import (
+	"github.com/pomerium/pomerium/authenticate/events"
 	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/authenticateflow"
 	"github.com/pomerium/pomerium/internal/identity"
 	identitypb "github.com/pomerium/pomerium/pkg/grpc/identity"
 )
@@ -10,7 +10,7 @@ import (
 type authenticateConfig struct {
 	getIdentityProvider func(options *config.Options, idpID string) (identity.Authenticator, error)
 	profileTrimFn       func(*identitypb.Profile)
-	authEventFn         authenticateflow.AuthEventFn
+	authEventFn         events.AuthEventFn
 }
 
 // An Option customizes the Authenticate config.
@@ -40,7 +40,7 @@ func WithProfileTrimFn(profileTrimFn func(*identitypb.Profile)) Option {
 }
 
 // WithOnAuthenticationEventHook sets the authEventFn function in the config
-func WithOnAuthenticationEventHook(fn authenticateflow.AuthEventFn) Option {
+func WithOnAuthenticationEventHook(fn events.AuthEventFn) Option {
 	return func(cfg *authenticateConfig) {
 		cfg.authEventFn = fn
 	}

--- a/authenticate/events/events.go
+++ b/authenticate/events/events.go
@@ -1,4 +1,4 @@
-package authenticateflow
+package events
 
 import (
 	"context"

--- a/authenticate/events/events.go
+++ b/authenticate/events/events.go
@@ -1,3 +1,4 @@
+// Package events defines authentication flow event types.
 package events
 
 import (


### PR DESCRIPTION
## Summary

Commit b7896b3153 moved events.go from the 'authenticate' package to 'internal/authenticateflow' in order to avoid an import cycle. However this location is not actually suitable, as the hosted authenticate service refers to `AuthEvent` and `AuthEventFn`.

Move events.go back out from under 'internal', to a new package 'authenticate/events'. This should still avoid an import cycle between 'authenticate' and 'internal/authenticateflow', while also allowing the hosted authenticate service to use the events types.

## Related issues

- https://github.com/pomerium/pomerium/issues/4819

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
