### PR TITLE
zero: group funcs that need run within a lease

### DIFF
--- a/internal/zero/leaser/leaser.go
+++ b/internal/zero/leaser/leaser.go
@@ -1,0 +1,49 @@
+// Package leaser groups all Zero services that should run within a lease.
+package leaser
+
+import (
+	"context"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+type service struct {
+	client databroker.DataBrokerServiceClient
+	funcs  []func(ctx context.Context) error
+}
+
+// GetDataBrokerServiceClient implements the databroker.LeaseHandler interface.
+func (c *service) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	return c.client
+}
+
+// RunLeased implements the databroker.LeaseHandler interface.
+func (c *service) RunLeased(ctx context.Context) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	for _, fn := range c.funcs {
+		fn := fn
+		eg.Go(func() error {
+			return fn(ctx)
+		})
+	}
+	return eg.Wait()
+}
+
+// Run runs services within a lease
+func Run(
+	ctx context.Context,
+	client databroker.DataBrokerServiceClient,
+	funcs ...func(ctx context.Context) error,
+) error {
+	srv := &service{
+		client: client,
+		funcs:  funcs,
+	}
+	leaser := databroker.NewLeaser("zero-ctrl", time.Second*30, srv)
+	return RunWithRestart(ctx, func(ctx context.Context) error {
+		return leaser.Run(ctx)
+	}, srv.databrokerChangeMonitor)
+}

--- a/internal/zero/leaser/monitor.go
+++ b/internal/zero/leaser/monitor.go
@@ -1,0 +1,37 @@
+package leaser
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+const typeStr = "pomerium.io/zero/leaser"
+
+// databrokerChangeMonitor runs infinite sync loop to see if there is any change in databroker
+// it doesn't really syncs anything, just checks if the underlying databroker has changed
+func (c *service) databrokerChangeMonitor(ctx context.Context) error {
+	_, recordVersion, serverVersion, err := databroker.InitialSync(ctx, c.GetDataBrokerServiceClient(), &databroker.SyncLatestRequest{
+		Type: typeStr,
+	})
+	if err != nil {
+		return fmt.Errorf("error during initial sync: %w", err)
+	}
+
+	stream, err := c.GetDataBrokerServiceClient().Sync(ctx, &databroker.SyncRequest{
+		Type:          typeStr,
+		ServerVersion: serverVersion,
+		RecordVersion: recordVersion,
+	})
+	if err != nil {
+		return fmt.Errorf("error calling sync: %w", err)
+	}
+
+	for {
+		_, err := stream.Recv()
+		if err != nil {
+			return fmt.Errorf("error receiving record: %w", err)
+		}
+	}
+}

--- a/internal/zero/leaser/restart_test.go
+++ b/internal/zero/leaser/restart_test.go
@@ -1,4 +1,4 @@
-package reconciler_test
+package leaser_test
 
 import (
 	"context"
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/pomerium/pomerium/internal/zero/reconciler"
+	"github.com/pomerium/pomerium/internal/zero/leaser"
 )
 
 func TestRestart(t *testing.T) {
@@ -20,7 +20,7 @@ func TestRestart(t *testing.T) {
 
 			errExpected := errors.New("execFn error")
 			count := 0
-			err := reconciler.RunWithRestart(context.Background(),
+			err := leaser.RunWithRestart(context.Background(),
 				func(context.Context) error {
 					count++
 					if count == 1 {
@@ -40,7 +40,7 @@ func TestRestart(t *testing.T) {
 			t.Parallel()
 
 			count := 0
-			err := reconciler.RunWithRestart(context.Background(),
+			err := leaser.RunWithRestart(context.Background(),
 				func(context.Context) error {
 					count++
 					if count == 1 {
@@ -63,7 +63,7 @@ func TestRestart(t *testing.T) {
 			t.Cleanup(cancel)
 
 			ready := make(chan struct{})
-			err := reconciler.RunWithRestart(ctx,
+			err := leaser.RunWithRestart(ctx,
 				func(context.Context) error {
 					<-ready
 					cancel()
@@ -87,7 +87,7 @@ func TestRestart(t *testing.T) {
 			errExpected := errors.New("execFn error")
 			count := 0
 			ready := make(chan struct{})
-			err := reconciler.RunWithRestart(ctx,
+			err := leaser.RunWithRestart(ctx,
 				func(ctx context.Context) error {
 					count++
 					if count == 1 { // wait for us to be restarted


### PR DESCRIPTION
## Summary

This PR groups Zero control loop functions that should run within a lease:

1. resource bundle reconciler
2. analytics
3. telemetry reporter

Also makes sure when the lease holder is restarted, it happens with exponential backoff. 

## Related issues

Related: https://github.com/pomerium/internal/issues/1639

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
