### PR TITLE
authenticateflow: verify redirect in Callback test

### DIFF
--- a/internal/authenticateflow/stateful_test.go
+++ b/internal/authenticateflow/stateful_test.go
@@ -261,7 +261,6 @@ func TestStatefulCallback(t *testing.T) {
 			}
 
 			r := httptest.NewRequest(http.MethodGet, uri.String(), nil)
-			// fmt.Println(uri.String())
 			r.Host = r.URL.Host
 
 			r.Header.Set("Accept", "application/json")
@@ -272,13 +271,14 @@ func TestStatefulCallback(t *testing.T) {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)
 				}
+				location, _ := url.Parse(w.Result().Header.Get("Location"))
+				assert.Equal(t, "example.com", location.Host)
+				assert.Equal(t, "ok", location.Query().Get("pomerium_callback_uri"))
 			} else {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErrorMsg) {
 					t.Errorf("expected error containing %q; got %v", tt.wantErrorMsg, err)
 				}
 			}
-
-			// XXX: assert redirect URL
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Add assertions for the redirect URL in the unit test for the stateful authentication flow Callback() method. Remove a commented-out line of debug logging.

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
