### PR TITLE
core/autocert: fix flaky test

### DIFF
--- a/internal/autocert/manager_test.go
+++ b/internal/autocert/manager_test.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/mholt/acmez/acme"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -215,12 +217,12 @@ func TestConfig(t *testing.T) {
 
 	mockACME = newMockACME(ca, srv)
 
-	tmpdir := t.TempDir()
+	tmpdir := filepath.Join(os.TempDir(), uuid.New().String())
+	_ = os.MkdirAll(tmpdir, 0o755)
+	defer os.RemoveAll(tmpdir)
 
 	li, err := net.Listen("tcp", "127.0.0.1:0")
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 	addr := li.Addr().String()
 	_ = li.Close()
 

--- a/internal/autocert/manager_test.go
+++ b/internal/autocert/manager_test.go
@@ -217,6 +217,7 @@ func TestConfig(t *testing.T) {
 
 	mockACME = newMockACME(ca, srv)
 
+	// avoid using t.TempDir so tests don't fail: https://github.com/pomerium/pomerium/issues/4757
 	tmpdir := filepath.Join(os.TempDir(), uuid.New().String())
 	_ = os.MkdirAll(tmpdir, 0o755)
 	defer os.RemoveAll(tmpdir)


### PR DESCRIPTION
## Summary
Revert back to manual temporary directory creating and removal in the autocert test. Apparently sometimes a background process will continue writing files even after the test completes. `t.TempDir` causes the test to fail when this happens. Doing it manually if `RemoveAll` fails we can ignore the error.

I was not able to reproduce the flakiness despite running the test with `-count 100`, but it happened on github actions once.

## Related issues
Fixes https://github.com/pomerium/pomerium/issues/4757

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
