### PR TITLE
authenticate: rework CORS headers log entry

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -75,8 +75,8 @@ func (a *Authenticate) mountDashboard(r *mux.Router) {
 		AllowOriginRequestFunc: func(r *http.Request, _ string) bool {
 			state := a.state.Load()
 			err := state.flow.VerifyAuthenticateSignature(r)
-			if err != nil {
-				log.FromRequest(r).Info().Err(err).Msg("authenticate: origin blocked")
+			if err == nil {
+				log.FromRequest(r).Info().Msg("authenticate: signed URL, adding CORS headers")
 			}
 			return err == nil
 		},


### PR DESCRIPTION
## Summary

Currently most requests to the authenticate service will result in a log entry with the message "authenticate: origin blocked". This may be confusing, as the request is not in fact blocked; instead, what happens is that no special CORS headers are added to the response.

Let's reverse the logging behavior, and instead log a message only for those requests with a valid signature, where we do add CORS headers to the response.

Add a unit test case exercising the CORS middleware.

## Related issues

- https://github.com/pomerium/internal/issues/1631

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
