### PR TITLE
envoy: enable TCP keepalive for internal clusters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,7 @@ issues:
 
   exclude-rules:
     # Exclude some linters from running on test files.
-    - path: _test\.go$|^tests/|^integration/|^samples/|templates\.go$
+    - path: _test\.go$|^tests/|^integration/|^samples/|^internal/testutil/|templates\.go$
       linters:
         - bodyclose
         - errcheck

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -142,6 +142,10 @@ func (b *Builder) buildInternalCluster(
 ) (*envoy_config_cluster_v3.Cluster, error) {
 	cluster := newDefaultEnvoyClusterConfig()
 	cluster.DnsLookupFamily = config.GetEnvoyDNSLookupFamily(cfg.Options.DNSLookupFamily)
+	cluster.UpstreamConnectionOptions = &envoy_config_cluster_v3.UpstreamConnectionOptions{
+		// Enable TCP keepalive with OS default settings.
+		TcpKeepalive: &envoy_config_core_v3.TcpKeepalive{},
+	}
 	var endpoints []Endpoint
 	for _, dst := range dsts {
 		ts, err := b.buildInternalTransportSocket(ctx, cfg, dst)

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -142,9 +142,13 @@ func (b *Builder) buildInternalCluster(
 ) (*envoy_config_cluster_v3.Cluster, error) {
 	cluster := newDefaultEnvoyClusterConfig()
 	cluster.DnsLookupFamily = config.GetEnvoyDNSLookupFamily(cfg.Options.DNSLookupFamily)
+	// Match the Go standard library default TCP keepalive settings.
+	const keepaliveTimeSeconds = 15
 	cluster.UpstreamConnectionOptions = &envoy_config_cluster_v3.UpstreamConnectionOptions{
-		// Enable TCP keepalive with OS default settings.
-		TcpKeepalive: &envoy_config_core_v3.TcpKeepalive{},
+		TcpKeepalive: &envoy_config_core_v3.TcpKeepalive{
+			KeepaliveTime:     wrapperspb.UInt32(keepaliveTimeSeconds),
+			KeepaliveInterval: wrapperspb.UInt32(keepaliveTimeSeconds),
+		},
 	}
 	var endpoints []Endpoint
 	for _, dst := range dsts {

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -20,6 +20,23 @@ import (
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
+func Test_BuildClusters(t *testing.T) {
+	// The admin address path is based on os.TempDir(), which will vary from
+	// system to system, so replace this with a stable location.
+	originalEnvoyAdminAddressPath := envoyAdminAddressPath
+	envoyAdminAddressPath = "/tmp/pomerium-envoy-admin.sock"
+	t.Cleanup(func() {
+		envoyAdminAddressPath = originalEnvoyAdminAddressPath
+	})
+
+	opts := config.NewDefaultOptions()
+	ctx := context.Background()
+	b := New("local-grpc", "local-http", "local-metrics", filemgr.NewManager(), nil)
+	clusters, err := b.BuildClusters(ctx, &config.Config{Options: opts})
+	require.NoError(t, err)
+	testutil.AssertProtoJSONFileEqual(t, "testdata/clusters.json", clusters)
+}
+
 func Test_buildPolicyTransportSocket(t *testing.T) {
 	ctx := context.Background()
 	cacheDir, _ := os.UserCacheDir()

--- a/config/envoyconfig/testdata/clusters.json
+++ b/config/envoyconfig/testdata/clusters.json
@@ -62,7 +62,10 @@
       }
     },
     "upstreamConnectionOptions": {
-      "tcpKeepalive": {}
+      "tcpKeepalive": {
+        "keepaliveInterval": 15,
+        "keepaliveTime": 15
+      }
     }
   },
   {
@@ -110,7 +113,10 @@
       }
     },
     "upstreamConnectionOptions": {
-      "tcpKeepalive": {}
+      "tcpKeepalive": {
+        "keepaliveInterval": 15,
+        "keepaliveTime": 15
+      }
     }
   },
   {
@@ -158,7 +164,10 @@
       }
     },
     "upstreamConnectionOptions": {
-      "tcpKeepalive": {}
+      "tcpKeepalive": {
+        "keepaliveInterval": 15,
+        "keepaliveTime": 15
+      }
     }
   },
   {
@@ -202,7 +211,10 @@
       }
     },
     "upstreamConnectionOptions": {
-      "tcpKeepalive": {}
+      "tcpKeepalive": {
+        "keepaliveInterval": 15,
+        "keepaliveTime": 15
+      }
     }
   },
   {
@@ -246,7 +258,10 @@
       }
     },
     "upstreamConnectionOptions": {
-      "tcpKeepalive": {}
+      "tcpKeepalive": {
+        "keepaliveInterval": 15,
+        "keepaliveTime": 15
+      }
     }
   },
   {

--- a/config/envoyconfig/testdata/clusters.json
+++ b/config/envoyconfig/testdata/clusters.json
@@ -1,0 +1,274 @@
+[
+  {
+    "loadAssignment": {
+      "clusterName": "pomerium-acme-tls-alpn",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "127.0.0.1",
+                    "portValue": 0
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "name": "pomerium-acme-tls-alpn"
+  },
+  {
+    "connectTimeout": "10s",
+    "dnsLookupFamily": "V4_PREFERRED",
+    "loadAssignment": {
+      "clusterName": "pomerium-control-plane-grpc",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "local-grpc",
+                    "portValue": 80
+                  }
+                }
+              },
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    "name": "pomerium-control-plane-grpc",
+    "perConnectionBufferLimitBytes": 32768,
+    "respectDnsTtl": true,
+    "type": "STRICT_DNS",
+    "typedExtensionProtocolOptions": {
+      "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+        "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+        "explicitHttpConfig": {
+          "http2ProtocolOptions": {
+            "allowConnect": true,
+            "initialConnectionWindowSize": 1048576,
+            "initialStreamWindowSize": 65536,
+            "maxConcurrentStreams": 100
+          }
+        }
+      }
+    },
+    "upstreamConnectionOptions": {
+      "tcpKeepalive": {}
+    }
+  },
+  {
+    "connectTimeout": "10s",
+    "dnsLookupFamily": "V4_PREFERRED",
+    "loadAssignment": {
+      "clusterName": "pomerium-control-plane-http",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "local-http",
+                    "portValue": 80
+                  }
+                }
+              },
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    "name": "pomerium-control-plane-http",
+    "perConnectionBufferLimitBytes": 32768,
+    "respectDnsTtl": true,
+    "type": "STRICT_DNS",
+    "typedExtensionProtocolOptions": {
+      "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+        "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+        "explicitHttpConfig": {
+          "httpProtocolOptions": {
+            "headerKeyFormat": {
+              "statefulFormatter": {
+                "name": "preserve_case",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "upstreamConnectionOptions": {
+      "tcpKeepalive": {}
+    }
+  },
+  {
+    "connectTimeout": "10s",
+    "dnsLookupFamily": "V4_PREFERRED",
+    "loadAssignment": {
+      "clusterName": "pomerium-control-plane-metrics",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "local-metrics",
+                    "portValue": 80
+                  }
+                }
+              },
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    "name": "pomerium-control-plane-metrics",
+    "perConnectionBufferLimitBytes": 32768,
+    "respectDnsTtl": true,
+    "type": "STRICT_DNS",
+    "typedExtensionProtocolOptions": {
+      "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+        "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+        "explicitHttpConfig": {
+          "httpProtocolOptions": {
+            "headerKeyFormat": {
+              "statefulFormatter": {
+                "name": "preserve_case",
+                "typedConfig": {
+                  "@type": "type.googleapis.com/envoy.extensions.http.header_formatters.preserve_case.v3.PreserveCaseFormatterConfig"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "upstreamConnectionOptions": {
+      "tcpKeepalive": {}
+    }
+  },
+  {
+    "connectTimeout": "10s",
+    "dnsLookupFamily": "V4_PREFERRED",
+    "loadAssignment": {
+      "clusterName": "pomerium-authorize",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "local-grpc",
+                    "portValue": 80
+                  }
+                }
+              },
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    "name": "pomerium-authorize",
+    "perConnectionBufferLimitBytes": 32768,
+    "respectDnsTtl": true,
+    "type": "STRICT_DNS",
+    "typedExtensionProtocolOptions": {
+      "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+        "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+        "explicitHttpConfig": {
+          "http2ProtocolOptions": {
+            "allowConnect": true,
+            "initialConnectionWindowSize": 1048576,
+            "initialStreamWindowSize": 65536,
+            "maxConcurrentStreams": 100
+          }
+        }
+      }
+    },
+    "upstreamConnectionOptions": {
+      "tcpKeepalive": {}
+    }
+  },
+  {
+    "connectTimeout": "10s",
+    "dnsLookupFamily": "V4_PREFERRED",
+    "loadAssignment": {
+      "clusterName": "pomerium-databroker",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "socketAddress": {
+                    "address": "local-grpc",
+                    "portValue": 80
+                  }
+                }
+              },
+              "loadBalancingWeight": 1
+            }
+          ]
+        }
+      ]
+    },
+    "name": "pomerium-databroker",
+    "perConnectionBufferLimitBytes": 32768,
+    "respectDnsTtl": true,
+    "type": "STRICT_DNS",
+    "typedExtensionProtocolOptions": {
+      "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
+        "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
+        "explicitHttpConfig": {
+          "http2ProtocolOptions": {
+            "allowConnect": true,
+            "initialConnectionWindowSize": 1048576,
+            "initialStreamWindowSize": 65536,
+            "maxConcurrentStreams": 100
+          }
+        }
+      }
+    },
+    "upstreamConnectionOptions": {
+      "tcpKeepalive": {}
+    }
+  },
+  {
+    "connectTimeout": "10s",
+    "loadAssignment": {
+      "clusterName": "pomerium-envoy-admin",
+      "endpoints": [
+        {
+          "lbEndpoints": [
+            {
+              "endpoint": {
+                "address": {
+                  "pipe": {
+                    "path": "/tmp/pomerium-envoy-admin.sock"
+                  }
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    "name": "pomerium-envoy-admin"
+  }
+]


### PR DESCRIPTION
## Summary

In split service mode, and during periods of inactivity, the gRPC connections to the databroker may fall idle. Some network firewalls may eventually time out an idle TCP connection and even start dropping subsequent packets once connection traffic resumes. Combined with Linux default TCP retransmission settings, this could cause a broken connection to persist for over 15 minutes.

In an attempt to avoid this scenario, enable TCP keepalive for outbound gRPC connections, matching the Go standard library default settings for time & interval: 15 seconds for both. (The probe count does not appear to be set, so it will remain at the OS default.)

Add a test case exercising the `BuildClusters()` method with the default configuration options, comparing the results with a reference "golden" file in the testdata directory. Also add an `-update` flag to make it easier to update the reference golden when needed:

    go test ./config/envoyconfig -update

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

- https://github.com/pomerium/internal/issues/1592

## User Explanation

Enable TCP keepalive for Pomerium internal gRPC connections.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
