### PR TITLE
core/databroker: disable identity manager user refresh when hosted authenticate is used

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -845,6 +845,24 @@ func (o *Options) UseStatelessAuthenticateFlow() bool {
 	return urlutil.IsHostedAuthenticateDomain(u.Hostname())
 }
 
+// SupportsUserRefresh returns true if the config options support refreshing of user sessions.
+func (o *Options) SupportsUserRefresh() bool {
+	if o == nil {
+		return false
+	}
+
+	if o.Provider == "" {
+		return false
+	}
+
+	u, err := o.GetInternalAuthenticateURL()
+	if err != nil {
+		return false
+	}
+
+	return !urlutil.IsHostedAuthenticateDomain(u.Hostname())
+}
+
 // GetAuthorizeURLs returns the AuthorizeURLs in the options or 127.0.0.1:5443.
 func (o *Options) GetAuthorizeURLs() ([]*url.URL, error) {
 	if IsAll(o.Services) && o.AuthorizeURLString == "" && len(o.AuthorizeURLStrings) == 0 {

--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -160,13 +160,15 @@ func (c *DataBroker) update(ctx context.Context, cfg *config.Config) error {
 		manager.WithEventManager(c.eventsMgr),
 	}
 
-	if cfg.Options.Provider != "" {
+	if cfg.Options.SupportsUserRefresh() {
 		authenticator, err := identity.NewAuthenticator(oauthOptions)
 		if err != nil {
 			log.Error(ctx).Err(err).Msg("databroker: failed to create authenticator")
 		} else {
 			options = append(options, manager.WithAuthenticator(authenticator))
 		}
+	} else {
+		log.Info(ctx).Msg("databroker: disabling refresh of user sessions")
 	}
 
 	if c.manager == nil {


### PR DESCRIPTION
## Summary
If no `authenticate_service_url` is specified we switch to hosted authenticate mode. Hosted authenticate does not currently support user refresh, and user refresh is disabled if no `idp_provider` is specified. However if you specify an `idp_provider` while still using hosted authenticate, the identity manager will attempt to refresh the sessions, resulting in them being deleted after 10 minutes.

This PR changes the identity manager to only enable user refresh if both an `idp_provider` is set and hosted authenticate is not being used.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/3975


## Checklist
- [x] reference any related issues
- [ ] updated unit tests 
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
