### PR TITLE
auth: prevent caching of sign-in redirect

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -208,7 +208,8 @@ func (a *Authorize) requireLoginResponse(
 	}
 
 	return a.deniedResponse(ctx, in, http.StatusFound, "Login", map[string]string{
-		"Location": redirectTo,
+		"Cache-Control": "no-store",
+		"Location":      redirectTo,
 	})
 }
 

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -266,6 +266,8 @@ func TestRequireLogin(t *testing.T) {
 			&evaluator.Request{})
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusFound, int(res.GetDeniedResponse().GetStatus().GetCode()))
+		testutil.AssertProtoEqual(t, mkHeader("Cache-Control", "no-store"),
+			getDeniedResponseHeader(res, "Cache-Control"))
 	})
 	t.Run("accept html", func(t *testing.T) {
 		res, err := a.requireLoginResponse(context.Background(),
@@ -283,6 +285,8 @@ func TestRequireLogin(t *testing.T) {
 			&evaluator.Request{})
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusFound, int(res.GetDeniedResponse().GetStatus().GetCode()))
+		testutil.AssertProtoEqual(t, mkHeader("Cache-Control", "no-store"),
+			getDeniedResponseHeader(res, "Cache-Control"))
 	})
 	t.Run("accept json", func(t *testing.T) {
 		res, err := a.requireLoginResponse(context.Background(),
@@ -300,5 +304,18 @@ func TestRequireLogin(t *testing.T) {
 			&evaluator.Request{})
 		require.NoError(t, err)
 		assert.Equal(t, http.StatusUnauthorized, int(res.GetDeniedResponse().GetStatus().GetCode()))
+		assert.Nil(t, getDeniedResponseHeader(res, "Cache-Control"))
+		assert.Nil(t, getDeniedResponseHeader(res, "Location"))
 	})
+}
+
+func getDeniedResponseHeader(
+	res *envoy_service_auth_v3.CheckResponse, header string,
+) *envoy_config_core_v3.HeaderValueOption {
+	for _, h := range res.GetDeniedResponse().GetHeaders() {
+		if h.GetHeader().GetKey() == header {
+			return h
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

Add a `Cache-Control: no-store` header to the sign-in redirect at the start of the authentication flow. This should discourage browsers from caching this redirect.

## Related issues

- https://github.com/pomerium/pomerium-console/issues/3968

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
