### PR TITLE
policy: add client cert SAN match criteria

### DIFF
--- a/pkg/policy/criteria/client_certificate.go
+++ b/pkg/policy/criteria/client_certificate.go
@@ -50,6 +50,12 @@ func (c clientCertificateCriterion) GenerateRule(
 			err = addCertFingerprintCondition(&body, v)
 		case "spki_hash":
 			err = addCertSPKIHashCondition(&body, v)
+		case "san_email":
+			err = matchString(&body, ast.VarTerm("cert.EmailAddresses[_]"), v)
+		case "san_dns":
+			err = matchString(&body, ast.VarTerm("cert.DNSNames[_]"), v)
+		case "san_uri":
+			err = matchString(&body, ast.VarTerm("cert.URIStrings[_]"), v)
 		default:
 			err = fmt.Errorf("unsupported certificate matcher condition: %s", k)
 		}


### PR DESCRIPTION
## Summary

Expand the [Certificate Matcher](https://www.pomerium.com/docs/capabilities/ppl#certificate-matcher) capabilities to support matching on DNS, email, or URI Subject Alternative Names, using the existing String Matcher conditions.

## Related issues

- https://github.com/pomerium/pomerium/issues/4615

## User Explanation

Expand the [Certificate Matcher](https://www.pomerium.com/docs/capabilities/ppl#certificate-matcher) capabilities to support matching on DNS, email, or URI Subject Alternative Names.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
