### PR TITLE
core/envoy: clean up temporary directory on start

### DIFF
--- a/pkg/envoy/extract_test.go
+++ b/pkg/envoy/extract_test.go
@@ -1,0 +1,31 @@
+package envoy
+
+import (
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClean(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+	d1, err := os.MkdirTemp(tmpDir, envoyPrefix)
+	require.NoError(t, err)
+	d2, err := os.MkdirTemp(tmpDir, envoyPrefix)
+	require.NoError(t, err)
+	d3, err := os.MkdirTemp(tmpDir, envoyPrefix)
+	require.NoError(t, err)
+
+	cleanTempDir(tmpDir)
+
+	_, err = os.Stat(d1)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	_, err = os.Stat(d2)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+	_, err = os.Stat(d3)
+	assert.ErrorIs(t, err, fs.ErrNotExist)
+}


### PR DESCRIPTION
## Summary
Clean up any existing temporary extracted envoy binaries on start.

## Related issues
For https://github.com/pomerium/internal/issues/1680


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
