### PR TITLE
config: remove deprecated client_ca option

### DIFF
--- a/config/config_source.go
+++ b/config/config_source.go
@@ -270,7 +270,6 @@ func getAllConfigFilePaths(cfg *Config) []string {
 	fs := []string{
 		cfg.Options.CAFile,
 		cfg.Options.CertFile,
-		cfg.Options.ClientCAFile,
 		cfg.Options.ClientSecretFile,
 		cfg.Options.CookieSecretFile,
 		cfg.Options.DataBrokerStorageCAFile,

--- a/config/options.go
+++ b/config/options.go
@@ -254,15 +254,6 @@ type Options struct {
 	DataBrokerStorageCAFile           string `mapstructure:"databroker_storage_ca_file" yaml:"databroker_storage_ca_file,omitempty"`
 	DataBrokerStorageCertSkipVerify   bool   `mapstructure:"databroker_storage_tls_skip_verify" yaml:"databroker_storage_tls_skip_verify,omitempty"`
 
-	// ClientCA is the base64-encoded certificate authority to validate client mTLS certificates against.
-	//
-	// Deprecated: Use DownstreamMTLS.CA instead.
-	ClientCA string `mapstructure:"client_ca" yaml:"client_ca,omitempty"`
-	// ClientCAFile points to a file that contains the certificate authority to validate client mTLS certificates against.
-	//
-	// Deprecated: Use DownstreamMTLS.CAFile instead.
-	ClientCAFile string `mapstructure:"client_ca_file" yaml:"client_ca_file,omitempty"`
-
 	// DownstreamMTLS holds all downstream mTLS settings.
 	DownstreamMTLS DownstreamMTLSSettings `mapstructure:"downstream_mtls" yaml:"downstream_mtls,omitempty"`
 
@@ -697,21 +688,6 @@ func (o *Options) Validate() error {
 	if o.DataBrokerStorageCAFile != "" {
 		if _, err := os.Stat(o.DataBrokerStorageCAFile); err != nil {
 			return fmt.Errorf("config: bad databroker ca file: %w", err)
-		}
-	}
-
-	if o.ClientCA != "" {
-		log.Warn(context.Background()).Msg("config: client_ca is deprecated, set " +
-			"downstream_mtls.ca instead")
-		if o.DownstreamMTLS.CA == "" {
-			o.DownstreamMTLS.CA = o.ClientCA
-		}
-	}
-	if o.ClientCAFile != "" {
-		log.Warn(context.Background()).Msg("config: client_ca_file is deprecated, set " +
-			"downstream_mtls.ca_file instead")
-		if o.DownstreamMTLS.CAFile == "" {
-			o.DownstreamMTLS.CAFile = o.ClientCAFile
 		}
 	}
 

--- a/config/options_check.go
+++ b/config/options_check.go
@@ -28,6 +28,8 @@ var reKeyPath = regexp.MustCompile(`\[\d+\]`)
 var (
 	// options that were deprecated in the config
 	removedConfigFields = map[string]string{
+		"client_ca":                       "https://www.pomerium.com/docs/deploy/core/upgrading#new-downstream-mtls-settings",
+		"client_ca_file":                  "https://www.pomerium.com/docs/deploy/core/upgrading#new-downstream-mtls-settings",
 		"idp_service_account":             "https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync",
 		"idp_refresh_directory_timeout":   "https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync",
 		"idp_refresh_directory_interval":  "https://docs.pomerium.com/docs/overview/upgrading#idp-directory-sync",


### PR DESCRIPTION
## Summary

The `client_ca` and `client_ca_file` settings were deprecated in v0.23. Remove these options and add a link to the corresponding explanation on the Upgrading docs page.

## Related issues

- https://github.com/pomerium/pomerium/issues/4917

## User Explanation

Remove the deprecated `client_ca` and `client_ca_file` settings.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
