### PR TITLE
zero/bootstrap: reset back to inmem databroker if connection string is empty

### DIFF
--- a/internal/zero/bootstrap/source.go
+++ b/internal/zero/bootstrap/source.go
@@ -83,7 +83,10 @@ func (src *source) notifyListeners(ctx context.Context, cfg *config.Config) {
 
 func applyBootstrapConfig(dst *config.Options, src *cluster_api.BootstrapConfig) {
 	if src.DatabrokerStorageConnection != nil {
-		dst.DataBrokerStorageType = "postgres"
+		dst.DataBrokerStorageType = config.StoragePostgresName
 		dst.DataBrokerStorageConnectionString = *src.DatabrokerStorageConnection
+	} else {
+		dst.DataBrokerStorageType = config.StorageInMemoryName
+		dst.DataBrokerStorageConnectionString = ""
 	}
 }

--- a/internal/zero/bootstrap/source_test.go
+++ b/internal/zero/bootstrap/source_test.go
@@ -1,0 +1,68 @@
+package bootstrap_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/zero/bootstrap"
+	cluster_api "github.com/pomerium/pomerium/pkg/zero/cluster"
+)
+
+func TestConfigChanges(t *testing.T) {
+	t.Parallel()
+
+	secret := []byte("secret")
+
+	src, err := bootstrap.New(secret)
+	require.NoError(t, err)
+
+	ptr := func(s string) *string { return &s }
+
+	var listenerCalled bool
+	src.OnConfigChange(nil, func(_ context.Context, _ *config.Config) {
+		listenerCalled = true
+	})
+
+	for i, tc := range []struct {
+		bootstrap                        cluster_api.BootstrapConfig
+		expectChanged                    bool
+		expectDatabrokerType             string
+		expectDatabrokerConnectionString string
+	}{
+		{
+			cluster_api.BootstrapConfig{},
+			false,
+			config.StorageInMemoryName,
+			"",
+		},
+		{
+			cluster_api.BootstrapConfig{
+				DatabrokerStorageConnection: ptr("postgres://"),
+			},
+			true,
+			config.StoragePostgresName,
+			"postgres://",
+		},
+		{
+			cluster_api.BootstrapConfig{},
+			true,
+			config.StorageInMemoryName,
+			"",
+		},
+	} {
+		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+			listenerCalled = false
+			changed := src.UpdateBootstrap(context.Background(), tc.bootstrap)
+			cfg := src.GetConfig()
+			assert.Equal(t, tc.expectChanged, changed, "changed")
+			assert.Equal(t, tc.expectChanged, listenerCalled, "listenerCalled")
+			assert.Equal(t, tc.expectDatabrokerType, cfg.Options.DataBrokerStorageType, "databroker type")
+			assert.Equal(t, tc.expectDatabrokerConnectionString, cfg.Options.DataBrokerStorageConnectionString, "databroker connection string")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

For zero, if postgres configuration is set, we should be able to reset back to in-memory by sending an empty connection 
string in the bootstrap params. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Related: https://github.com/pomerium/pomerium-zero/issues/1659

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
