### PR TITLE
core/ui: fix page title

### DIFF
--- a/internal/handlers/device-enrolled.go
+++ b/internal/handlers/device-enrolled.go
@@ -10,6 +10,6 @@ import (
 // DeviceEnrolled displays an HTML page informing the user that they've successfully enrolled a device.
 func DeviceEnrolled(data UserInfoData) http.Handler {
 	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		return ui.ServePage(w, r, "DeviceEnrolled", data.ToJSON())
+		return ui.ServePage(w, r, "DeviceEnrolled", "Device Enrolled", data.ToJSON())
 	})
 }

--- a/internal/handlers/signedout.go
+++ b/internal/handlers/signedout.go
@@ -24,6 +24,6 @@ func SignedOut(data SignedOutData) http.Handler {
 		}
 
 		// otherwise show the signed-out page
-		return ui.ServePage(w, r, "SignedOut", data.ToJSON())
+		return ui.ServePage(w, r, "SignedOut", "Signed Out", data.ToJSON())
 	})
 }

--- a/internal/handlers/signout.go
+++ b/internal/handlers/signout.go
@@ -22,6 +22,6 @@ func (data SignOutConfirmData) ToJSON() map[string]interface{} {
 // SignOutConfirm returns a handler that renders the sign out confirm page.
 func SignOutConfirm(data SignOutConfirmData) http.Handler {
 	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		return ui.ServePage(w, r, "SignOutConfirm", data.ToJSON())
+		return ui.ServePage(w, r, "SignOutConfirm", "Confirm Sign Out", data.ToJSON())
 	})
 }

--- a/internal/handlers/userinfo.go
+++ b/internal/handlers/userinfo.go
@@ -65,6 +65,6 @@ func (data UserInfoData) ToJSON() map[string]any {
 // UserInfo returns a handler that renders the user info page.
 func UserInfo(data UserInfoData) http.Handler {
 	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		return ui.ServePage(w, r, "UserInfo", data.ToJSON())
+		return ui.ServePage(w, r, "UserInfo", "User Info Dashboard", data.ToJSON())
 	})
 }

--- a/internal/handlers/webauthn/webauthn.go
+++ b/internal/handlers/webauthn/webauthn.go
@@ -402,7 +402,7 @@ func (h *Handler) handleView(w http.ResponseWriter, r *http.Request, state *Stat
 		"selfUrl":         r.URL.String(),
 	}
 	httputil.AddBrandingOptionsToMap(m, state.BrandingOptions)
-	return ui.ServePage(w, r, "WebAuthnRegistration", m)
+	return ui.ServePage(w, r, "WebAuthnRegistration", "Device Registration", m)
 }
 
 func (h *Handler) saveSessionAndRedirect(w http.ResponseWriter, r *http.Request, state *State, rawRedirectURI string) error {

--- a/internal/httputil/errors.go
+++ b/internal/httputil/errors.go
@@ -2,6 +2,7 @@ package httputil
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/url"
 
@@ -101,7 +102,7 @@ func (e *HTTPError) ErrorResponse(ctx context.Context, w http.ResponseWriter, r 
 
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
 	w.WriteHeader(response.Status)
-	if err := ui.ServePage(w, r, "Error", m); err != nil {
+	if err := ui.ServePage(w, r, "Error", fmt.Sprintf("%d %s", response.Status, response.StatusText), m); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/ui/dist/index.gohtml
+++ b/ui/dist/index.gohtml
@@ -25,14 +25,14 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>User info dashboard</title>
+    <title>{{.Title}}</title>
     <link rel="stylesheet" href="/.pomerium/index.css" />
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
     <script>
-      window.POMERIUM_DATA = {};
+      window.POMERIUM_DATA = {{.Data}};
     </script>
     <script src="/.pomerium/index.js"></script>
   </body>

--- a/ui/embed_ext.go
+++ b/ui/embed_ext.go
@@ -7,10 +7,8 @@ import (
 	"io/fs"
 )
 
-var (
-	// ExtUIFS must be set to provide access to UI dist/ files
-	ExtUIFS fs.FS
-)
+// ExtUIFS must be set to provide access to UI dist/ files
+var ExtUIFS fs.FS
 
 func openFile(name string) (f fs.File, etag string, err error) {
 	if ExtUIFS == nil {


### PR DESCRIPTION
## Summary
Set the page title for UI pages. For pages like the dashboard they are set to a title that makes sense for that page. For errors we set the title to something like `403 Forbidden`.

The `index.html` file was converted to a Go template.

## Related issues
- https://github.com/pomerium/internal/issues/1698
 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
