### PR TITLE
ci: switch to regular runners

### DIFF
--- a/.github/workflows/docker-version-branches.yaml
+++ b/.github/workflows/docker-version-branches.yaml
@@ -8,9 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on:
-      group: large-runners
-      labels: linux
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11


### PR DESCRIPTION
## Summary

Switch to regular GitHub Actions runners in the 'Docker Release Branches' workflow, matching how the 'Docker Main' workflow is configured.

## Related issues

- https://github.com/pomerium/internal/issues/1584#issuecomment-1887663893

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
