### PR TITLE
core: use context.WithoutCancel

### DIFF
--- a/pkg/contextutil/contextutil.go
+++ b/pkg/contextutil/contextutil.go
@@ -64,25 +64,3 @@ func (mc *mergedCtx) Value(key interface{}) interface{} {
 	}
 	return mc.doneCtx.Value(key)
 }
-
-type onlyValues struct {
-	context.Context
-}
-
-// OnlyValues returns a derived context that removes deadlines and cancellation,
-// but keeps values.
-func OnlyValues(ctx context.Context) context.Context {
-	return onlyValues{ctx}
-}
-
-func (o onlyValues) Deadline() (time.Time, bool) {
-	return time.Time{}, false
-}
-
-func (o onlyValues) Done() <-chan struct{} {
-	return nil
-}
-
-func (o onlyValues) Err() error {
-	return nil
-}

--- a/pkg/httputil/serve.go
+++ b/pkg/httputil/serve.go
@@ -7,8 +7,6 @@ import (
 	"net"
 	"net/http"
 	"time"
-
-	"github.com/pomerium/pomerium/pkg/contextutil"
 )
 
 // ServeWithGracefulStop serves the HTTP listener until ctx.Done(), and then gracefully stops and waits for gracefulTimeout
@@ -17,7 +15,7 @@ func ServeWithGracefulStop(ctx context.Context, handler http.Handler, li net.Lis
 	// create a context that will be used for the http requests
 	// it will only be cancelled when baseCancel is called but will
 	// preserve the values from ctx
-	baseCtx, baseCancel := context.WithCancelCause(contextutil.OnlyValues(ctx))
+	baseCtx, baseCancel := context.WithCancelCause(context.WithoutCancel(ctx))
 
 	srv := http.Server{
 		Handler: handler,


### PR DESCRIPTION
## Summary
Turns out there's a `WithoutCancel` function in the `context` package that does the same thing as `contextutil.OnlyValues`.
 

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
