### PR TITLE
connect: add gRPC keep-alive

### DIFF
--- a/internal/zero/grpcconn/client.go
+++ b/internal/zero/grpcconn/client.go
@@ -25,8 +25,9 @@ func New(
 	ctx context.Context,
 	endpoint string,
 	tokenProvider TokenProviderFn,
+	dialOpts ...grpc.DialOption,
 ) (*grpc.ClientConn, error) {
-	cfg, err := getConfig(endpoint)
+	cfg, err := getConfig(endpoint, dialOpts...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/zero/grpcconn/config.go
+++ b/internal/zero/grpcconn/config.go
@@ -25,8 +25,11 @@ type config struct {
 // NewConfig returns a new Config from an endpoint string, that has to be in a URL format.
 // The endpoint can be either http:// or https:// that will be used to determine whether TLS should be used.
 // if port is not specified, it will be inferred from the scheme (80 for http, 443 for https).
-func getConfig(endpoint string) (*config, error) {
-	c := new(config)
+func getConfig(
+	endpoint string,
+	opts ...grpc.DialOption,
+) (*config, error) {
+	c := &config{opts: opts}
 	err := c.parseEndpoint(endpoint)
 	if err != nil {
 		return nil, fmt.Errorf("invalid endpoint: %w", err)


### PR DESCRIPTION
## Summary

When running in Zero managed mode, Pomerium must maintain a streaming gRPC to the Connect signalling service in the cloud, in order to receive configuration updates from the cloud as they appear. 

It was noticed that sometimes the gRPC connection may be in the `READY` state while the end to end connection to the Connect gRPC server, is in fact, long time gone. 

This PR introduces a client-side keepalive with infrequent 1-minute interval for the Connect service, to ensure we are still maintain gRPC connection.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Fixes https://github.com/pomerium/pomerium-zero/issues/1711

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
