### PR TITLE
authorize: log service account user ID

### DIFF
--- a/authorize/log.go
+++ b/authorize/log.go
@@ -212,7 +212,11 @@ func populateLogEvent(
 		}
 		return evt
 	case log.AuthorizeLogFieldUser:
-		return evt.Str(string(field), s.GetUserId())
+		var userID string
+		if s != nil {
+			userID = s.GetUserId()
+		}
+		return evt.Str(string(field), userID)
 	default:
 		return evt
 	}

--- a/authorize/log.go
+++ b/authorize/log.go
@@ -212,7 +212,7 @@ func populateLogEvent(
 		}
 		return evt
 	case log.AuthorizeLogFieldUser:
-		return evt.Str(string(field), u.GetId())
+		return evt.Str(string(field), s.GetUserId())
 	default:
 		return evt
 	}

--- a/authorize/log_test.go
+++ b/authorize/log_test.go
@@ -49,9 +49,11 @@ func Test_populateLogEvent(t *testing.T) {
 		IdToken: &session.IDToken{
 			Raw: "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1aWxkZXIiLCJpYXQiOjE2OTAzMTU4NjIsImV4cCI6MTcyMTg1MTg2MiwiYXVkIjoid3d3LmV4YW1wbGUuY29tIiwic3ViIjoianJvY2tldEBleGFtcGxlLmNvbSIsIkdpdmVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjpbIk1hbmFnZXIiLCJQcm9qZWN0IEFkbWluaXN0cmF0b3IiXX0.AAojgaG0fjMFwMCAC6YALHHMFIZEedFSP_vMGhiHhso",
 		},
+		UserId: "USER-ID",
 	}
 	sa := &user.ServiceAccount{
-		Id: "SERVICE-ACCOUNT-ID",
+		Id:     "SERVICE-ACCOUNT-ID",
+		UserId: "SERVICE-ACCOUNT-USER-ID",
 	}
 	u := &user.User{
 		Id:    "USER-ID",
@@ -84,6 +86,7 @@ func Test_populateLogEvent(t *testing.T) {
 		{log.AuthorizeLogFieldServiceAccountID, sa, `{"service-account-id":"SERVICE-ACCOUNT-ID"}`},
 		{log.AuthorizeLogFieldSessionID, s, `{"session-id":"SESSION-ID"}`},
 		{log.AuthorizeLogFieldUser, s, `{"user":"USER-ID"}`},
+		{log.AuthorizeLogFieldUser, sa, `{"user":"SERVICE-ACCOUNT-USER-ID"}`},
 	} {
 
 		tc := tc

--- a/authorize/log_test.go
+++ b/authorize/log_test.go
@@ -87,6 +87,7 @@ func Test_populateLogEvent(t *testing.T) {
 		{log.AuthorizeLogFieldSessionID, s, `{"session-id":"SESSION-ID"}`},
 		{log.AuthorizeLogFieldUser, s, `{"user":"USER-ID"}`},
 		{log.AuthorizeLogFieldUser, sa, `{"user":"SERVICE-ACCOUNT-USER-ID"}`},
+		{log.AuthorizeLogFieldUser, nil, `{"user":""}`},
 	} {
 
 		tc := tc


### PR DESCRIPTION
## Summary

Currently the `user` field of the authorize logs is empty for requests authenticated via a service account, as there is no associated User object. Instead, populate this log field directly from the the `sessionOrServiceAccount` value, to handle both types of user.

## Related issues

- pomerium/internal#1740

## User Explanation

Populate the authorize logs `user` field for requests authenticated via a service account.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
