### PR TITLE
envoy: unescape and redirect if path contains escaped values

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -300,11 +300,12 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 			Provider:       tracingProvider,
 		},
 		// See https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for
-		UseRemoteAddress:  &wrapperspb.BoolValue{Value: true},
-		SkipXffAppend:     cfg.Options.SkipXffAppend,
-		XffNumTrustedHops: cfg.Options.XffNumTrustedHops,
-		LocalReplyConfig:  b.buildLocalReplyConfig(cfg.Options),
-		NormalizePath:     wrapperspb.Bool(true),
+		UseRemoteAddress:             &wrapperspb.BoolValue{Value: true},
+		SkipXffAppend:                cfg.Options.SkipXffAppend,
+		XffNumTrustedHops:            cfg.Options.XffNumTrustedHops,
+		LocalReplyConfig:             b.buildLocalReplyConfig(cfg.Options),
+		NormalizePath:                wrapperspb.Bool(true),
+		PathWithEscapedSlashesAction: envoy_http_connection_manager.HttpConnectionManager_UNESCAPE_AND_REDIRECT,
 	}
 
 	if fullyStatic {

--- a/config/envoyconfig/testdata/main_http_connection_manager_filter.json
+++ b/config/envoyconfig/testdata/main_http_connection_manager_filter.json
@@ -132,6 +132,7 @@
     },
     "requestTimeout": "30s",
     "normalizePath": true,
+    "pathWithEscapedSlashesAction": "UNESCAPE_AND_REDIRECT",
     "rds": {
       "configSource": {
         "ads": {},


### PR DESCRIPTION
## Summary

In order to disambiguate path evaluation, make sure it is RFC3986 compliant, by unescaping and redirecting an incoming request that contains escaped slashes.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Related: https://github.com/pomerium/internal/issues/1733

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
