### PR TITLE
envoy: set explicit hostname on cluster endpoints

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -483,7 +483,8 @@ func (b *Builder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoi
 		lbe := &envoy_config_endpoint_v3.LbEndpoint{
 			HostIdentifier: &envoy_config_endpoint_v3.LbEndpoint_Endpoint{
 				Endpoint: &envoy_config_endpoint_v3.Endpoint{
-					Address: buildAddress(u.Host, defaultPort),
+					Address:  buildAddress(u.Host, defaultPort),
+					Hostname: e.url.Host,
 				},
 			},
 			LoadBalancingWeight: e.loadBalancerWeight,

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -549,7 +549,8 @@ func Test_buildCluster(t *testing.T) {
 										"address": "example.com",
 										"portValue": 80
 									}
-								}
+								},
+								"hostname": "example.com"
 							}
 						}, {
 							"endpoint": {
@@ -558,7 +559,8 @@ func Test_buildCluster(t *testing.T) {
 										"address": "1.2.3.4",
 										"portValue": 80
 									}
-								}
+								},
+								"hostname": "1.2.3.4"
 							}
 						}]
 					}]
@@ -704,7 +706,8 @@ func Test_buildCluster(t *testing.T) {
 										"address": "example.com",
 										"portValue": 443
 									}
-								}
+								},
+								"hostname": "example.com"
 							},
 							"metadata": {
 								"filterMetadata": {
@@ -720,7 +723,8 @@ func Test_buildCluster(t *testing.T) {
 										"address": "example.com",
 										"portValue": 443
 									}
-								}
+								},
+								"hostname": "example.com"
 							},
 							"metadata": {
 								"filterMetadata": {
@@ -774,7 +778,8 @@ func Test_buildCluster(t *testing.T) {
 										"address": "127.0.0.1",
 										"portValue": 80
 									}
-								}
+								},
+								"hostname": "127.0.0.1"
 							}
 						},{
 							"endpoint": {
@@ -783,7 +788,8 @@ func Test_buildCluster(t *testing.T) {
 										"address": "127.0.0.2",
 										"portValue": 80
 									}
-								}
+								},
+								"hostname": "127.0.0.2"
 							}
 						}]
 					}]
@@ -830,7 +836,8 @@ func Test_buildCluster(t *testing.T) {
 										"address": "127.0.0.1",
 										"portValue": 8080
 									}
-								}
+								},
+								"hostname": "127.0.0.1:8080"
 							},
 							"loadBalancingWeight": 1
 						},{
@@ -840,7 +847,8 @@ func Test_buildCluster(t *testing.T) {
 										"address": "127.0.0.2",
 										"portValue": 80
 									}
-								}
+								},
+								"hostname": "127.0.0.2"
 							},
 							"loadBalancingWeight": 2
 						}]
@@ -888,7 +896,8 @@ func Test_buildCluster(t *testing.T) {
 										"address": "127.0.0.1",
 										"portValue": 80
 									}
-								}
+								},
+								"hostname": "localhost"
 							}
 						}]
 					}]
@@ -944,7 +953,8 @@ func Test_buildCluster(t *testing.T) {
 										"address": "example.com",
 										"portValue": 80
 									}
-								}
+								},
+								"hostname": "example.com"
 							}
 						}]
 					}]

--- a/config/envoyconfig/testdata/clusters.json
+++ b/config/envoyconfig/testdata/clusters.json
@@ -36,7 +36,8 @@
                     "address": "local-grpc",
                     "portValue": 80
                   }
-                }
+                },
+                "hostname": "local-grpc"
               },
               "loadBalancingWeight": 1
             }
@@ -83,7 +84,8 @@
                     "address": "local-http",
                     "portValue": 80
                   }
-                }
+                },
+                "hostname": "local-http"
               },
               "loadBalancingWeight": 1
             }
@@ -134,7 +136,8 @@
                     "address": "local-metrics",
                     "portValue": 80
                   }
-                }
+                },
+                "hostname": "local-metrics"
               },
               "loadBalancingWeight": 1
             }
@@ -185,7 +188,8 @@
                     "address": "local-grpc",
                     "portValue": 80
                   }
-                }
+                },
+                "hostname": "local-grpc"
               },
               "loadBalancingWeight": 1
             }
@@ -232,7 +236,8 @@
                     "address": "local-grpc",
                     "portValue": 80
                   }
-                }
+                },
+                "hostname": "local-grpc"
               },
               "loadBalancingWeight": 1
             }


### PR DESCRIPTION
## Summary

Envoy has an option `auto_host_rewrite` that rewrites the Host header of an incoming request to match the upstream domain that the proxied request is sent to. Pomerium sets the `auto_host_rewrite` option for all Pomerium routes that do not set one of the [Host Rewrite options](https://www.pomerium.com/docs/reference/routes/headers#host-rewrite-options).

When Envoy rewrites the Host header, it does not include the upstream port, even when it is a non-standard port for the scheme (i.e. a port other than 80 for http or a port other than 443 for https).

I think this behavior does not conform to RFC 9110. The nearest thing I can find in the text is this statement about http and https URIs:
> If the port is equal to the default port for a scheme, the normal form is to omit the port subcomponent.

(from https://datatracker.ietf.org/doc/html/rfc9110#section-4.2.3)

I take this to mean that the port should be specified in other cases.

There is a work-around: we can set an explicit hostname on each cluster endpoint. Let's set this hostname based on the `to` URL(s) from the Pomerium route.

This should change the current behavior in two cases:

 - When a route has a `to` URL with a port number, this port number will now be included in the Host header in the requests made by Pomerium.

 - When a route has a `to` URL with 'localhost' or an IP address as the host, Pomerium will now rewrite the Host header to match the `to` URL.

There should be no change in behavior for routes where one of the "Host Rewrite options" is set.

## Related issues

- https://github.com/pomerium/internal/issues/1750

## User Explanation

Pomerium will now consistently rewrite the `Host` (or `:authority`) header of an incoming request to match the host and port specified in the route `to` URL(s).

(Previously the port would never be included, and previously no rewriting would be performed for `to` URLs where the host is `localhost` or an IP address.)

If `Host` header rewriting is not desired for a particular route, use the [`preserve_host_header`](https://www.pomerium.com/docs/reference/routes/headers#1-preserve-host-header) option.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
