### PR TITLE
cluster api: add shared secret to the cluster bootstrap params

### DIFF
--- a/pkg/zero/cluster/models.gen.go
+++ b/pkg/zero/cluster/models.gen.go
@@ -20,6 +20,9 @@ const (
 type BootstrapConfig struct {
 	// DatabrokerStorageConnection databroker storage connection string
 	DatabrokerStorageConnection *string `json:"databrokerStorageConnection,omitempty"`
+
+	// SharedSecret shared secret
+	SharedSecret []byte `json:"sharedSecret"`
 }
 
 // Bundle defines model for Bundle.

--- a/pkg/zero/cluster/openapi.yaml
+++ b/pkg/zero/cluster/openapi.yaml
@@ -166,6 +166,12 @@ components:
         databrokerStorageConnection:
           type: string
           description: databroker storage connection string
+        sharedSecret:
+          type: string
+          format: byte
+          description: shared secret
+      required:
+        - sharedSecret
 
     Bundle:
       type: object


### PR DESCRIPTION
## Summary

Adds `shared_secret` to the cluster bootstrap API spec.

## Related issues

Related: https://github.com/pomerium/pomerium-zero/issues/1260

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
