### PR TITLE
grpc: add some debug options

### DIFF
--- a/internal/featureflags/env.go
+++ b/internal/featureflags/env.go
@@ -20,6 +20,7 @@ var flags = make(map[string]struct{})
 func init() {
 	for _, env := range []string{
 		GRPCLogConnectionState,
+		GRPCConnectDisableKeepalive,
 	} {
 		if _, ok := os.LookupEnv(fmt.Sprintf("POMERIUM_%s", env)); ok {
 			flags[env] = struct{}{}

--- a/internal/featureflags/env.go
+++ b/internal/featureflags/env.go
@@ -13,7 +13,7 @@ var (
 	// GRPCLogConnectionState connection logs gRPC connection state transitions
 	// which is less verbose than logs enabled via https://github.com/grpc/grpc-go/blob/master/README.md#how-to-turn-on-logging
 	GRPCLogConnectionState = option("GRPC_LOG_CONNECTION_STATE", false)
-	// GRPCConnectKeepalive disables gRPC keepalive to zero connect service
+	// GRPCConnectKeepalive enables gRPC keepalive to zero connect service
 	GRPCConnectKeepalive = option("GRPC_CONNECT_KEEPALIVE", true)
 )
 

--- a/internal/featureflags/env.go
+++ b/internal/featureflags/env.go
@@ -1,0 +1,34 @@
+// Package featureflags enables feature flags that are set via environment variables.
+// the feature flags are used to enable or disable experimental features.
+package featureflags
+
+import (
+	"fmt"
+	"os"
+)
+
+const (
+	// GRPCLogConnectionState connection logs gRPC connection state transitions
+	// which is less verbose than logs enabled via https://github.com/grpc/grpc-go/blob/master/README.md#how-to-turn-on-logging
+	GRPCLogConnectionState = "GRPC_LOG_CONNECTION_STATE"
+	// GRPCConnectDisableKeepalive disables gRPC keepalive to zero connect service
+	GRPCConnectDisableKeepalive = "GRPC_CONNECT_DISABLE_KEEPALIVE"
+)
+
+var flags = make(map[string]struct{})
+
+func init() {
+	for _, env := range []string{
+		GRPCLogConnectionState,
+	} {
+		if _, ok := os.LookupEnv(fmt.Sprintf("POMERIUM_%s", env)); ok {
+			flags[env] = struct{}{}
+		}
+	}
+}
+
+// IsSet returns true if the feature flag is set.
+func IsSet(flag string) bool {
+	_, ok := flags[flag]
+	return ok
+}

--- a/internal/zero/api/api.go
+++ b/internal/zero/api/api.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/pomerium/pomerium/internal/zero/apierror"
@@ -70,7 +69,7 @@ func NewAPI(ctx context.Context, opts ...Option) (*API, error) {
 
 	connectGRPCConn, err := grpcconn.New(ctx, cfg.connectAPIEndpoint, func(ctx context.Context) (string, error) {
 		return tokenCache.GetToken(ctx, minConnectTokenTTL)
-	}, grpc.WithKeepaliveParams(connectClientKeepaliveParams))
+	}, cfg.dialOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("error creating connect grpc client: %w", err)
 	}

--- a/internal/zero/api/config.go
+++ b/internal/zero/api/config.go
@@ -74,7 +74,7 @@ func newConfig(opts ...Option) (*config, error) {
 		opt(cfg)
 	}
 
-	if !featureflags.IsSet(featureflags.GRPCConnectKeepalive) {
+	if featureflags.IsSet(featureflags.GRPCConnectKeepalive) {
 		cfg.dialOptions = append(cfg.dialOptions, grpc.WithKeepaliveParams(connectClientKeepaliveParams))
 	}
 

--- a/internal/zero/api/config.go
+++ b/internal/zero/api/config.go
@@ -4,6 +4,10 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"google.golang.org/grpc"
+
+	"github.com/pomerium/pomerium/internal/featureflags"
 )
 
 // Option is a functional option for the SDK
@@ -16,6 +20,7 @@ type config struct {
 	apiToken            string
 	httpClient          *http.Client
 	downloadURLCacheTTL time.Duration
+	dialOptions         []grpc.DialOption
 }
 
 // WithClusterAPIEndpoint sets the cluster API endpoint
@@ -67,6 +72,10 @@ func newConfig(opts ...Option) (*config, error) {
 		WithDownloadURLCacheTTL(15 * time.Minute),
 	} {
 		opt(cfg)
+	}
+
+	if !featureflags.IsSet(featureflags.GRPCConnectDisableKeepalive) {
+		cfg.dialOptions = append(cfg.dialOptions, grpc.WithKeepaliveParams(connectClientKeepaliveParams))
 	}
 
 	for _, opt := range opts {

--- a/internal/zero/api/config.go
+++ b/internal/zero/api/config.go
@@ -74,7 +74,7 @@ func newConfig(opts ...Option) (*config, error) {
 		opt(cfg)
 	}
 
-	if !featureflags.IsSet(featureflags.GRPCConnectDisableKeepalive) {
+	if !featureflags.IsSet(featureflags.GRPCConnectKeepalive) {
 		cfg.dialOptions = append(cfg.dialOptions, grpc.WithKeepaliveParams(connectClientKeepaliveParams))
 	}
 

--- a/pkg/cmd/pomerium/pomerium.go
+++ b/pkg/cmd/pomerium/pomerium.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"runtime"
 	"syscall"
 
 	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
@@ -20,6 +21,7 @@ import (
 	"github.com/pomerium/pomerium/internal/controlplane"
 	"github.com/pomerium/pomerium/internal/databroker"
 	"github.com/pomerium/pomerium/internal/events"
+	"github.com/pomerium/pomerium/internal/featureflags"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/registry"
 	"github.com/pomerium/pomerium/internal/version"
@@ -32,8 +34,10 @@ import (
 // Run runs the main pomerium application.
 func Run(ctx context.Context, src config.Source) error {
 	log.Info(ctx).
+		Str("go_version", runtime.Version()).
 		Str("envoy_version", files.FullVersion()).
 		Str("version", version.FullVersion()).
+		Interface("feature_flags", featureflags.Flags()).
 		Msg("cmd/pomerium")
 
 	src, err := config.NewLayeredSource(ctx, src, derivecert_config.NewBuilder())

--- a/pkg/grpcutil/log.go
+++ b/pkg/grpcutil/log.go
@@ -1,0 +1,33 @@
+package grpcutil
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/connectivity"
+
+	"github.com/pomerium/pomerium/internal/featureflags"
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+// LogConnectionState logs the state of a gRPC connection on change.
+func LogConnectionState(ctx context.Context, conn *grpc.ClientConn) {
+	if !featureflags.IsSet(featureflags.GRPCLogConnectionState) {
+		return
+	}
+
+	var state connectivity.State = -1
+	endpoint := conn.Target()
+	for ctx.Err() == nil && state != connectivity.Shutdown {
+		_ = conn.WaitForStateChange(ctx, state)
+		state = conn.GetState()
+		log.Ctx(ctx).Info().
+			Str("endpoint", endpoint).
+			Str("state", state.String()).
+			Msg("grpc connection state")
+	}
+	log.Ctx(ctx).Info().
+		Str("endpoint", endpoint).
+		Str("state", state.String()).
+		Msg("grpc connection shutdown")
+}


### PR DESCRIPTION
## Summary

Adds some gRPC related debug options configurable via setting environment variables:

- `POMERIUM_GRPC_LOG_CONNECTION_STATE` - enables logging gRPC connection state transition. this is significantly less verbose compared to enabling standard gRPC debug logging.
- `POMERIUM_GRPC_CONNECT_KEEPALIVE` - enables gRPC keepalive (on by default).

Also updates some deprecated grpc configuration options.

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
