### PR TITLE
grpc: add databroker keepalive option

### DIFF
--- a/config/envoyconfig/bootstrap.go
+++ b/config/envoyconfig/bootstrap.go
@@ -219,7 +219,7 @@ func (b *Builder) BuildBootstrapStaticResources(
 				},
 			},
 		},
-		TypedExtensionProtocolOptions: buildTypedExtensionProtocolOptions(nil, upstreamProtocolHTTP2),
+		TypedExtensionProtocolOptions: buildTypedExtensionProtocolOptions(nil, upstreamProtocolHTTP2, Keepalive(false)),
 	}
 
 	staticResources.Clusters = append(staticResources.Clusters, controlPlaneCluster)

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/featureflags"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
 	"github.com/pomerium/pomerium/internal/urlutil"
@@ -55,22 +56,22 @@ func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*env
 		}
 	}
 
-	controlGRPC, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-grpc", grpcURLs, upstreamProtocolHTTP2)
+	controlGRPC, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-grpc", grpcURLs, upstreamProtocolHTTP2, Keepalive(false))
 	if err != nil {
 		return nil, err
 	}
 
-	controlHTTP, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-http", []*url.URL{httpURL}, upstreamProtocolAuto)
+	controlHTTP, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-http", []*url.URL{httpURL}, upstreamProtocolAuto, Keepalive(false))
 	if err != nil {
 		return nil, err
 	}
 
-	controlMetrics, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-metrics", []*url.URL{metricsURL}, upstreamProtocolAuto)
+	controlMetrics, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-metrics", []*url.URL{metricsURL}, upstreamProtocolAuto, Keepalive(false))
 	if err != nil {
 		return nil, err
 	}
 
-	authorizeCluster, err := b.buildInternalCluster(ctx, cfg, "pomerium-authorize", authorizeURLs, upstreamProtocolHTTP2)
+	authorizeCluster, err := b.buildInternalCluster(ctx, cfg, "pomerium-authorize", authorizeURLs, upstreamProtocolHTTP2, Keepalive(false))
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +80,8 @@ func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*env
 		authorizeCluster.OutlierDetection = grpcOutlierDetection()
 	}
 
-	databrokerCluster, err := b.buildInternalCluster(ctx, cfg, "pomerium-databroker", databrokerURLs, upstreamProtocolHTTP2)
+	databrokerKeepalive := Keepalive(featureflags.IsSet(featureflags.GRPCDatabrokerKeepalive))
+	databrokerCluster, err := b.buildInternalCluster(ctx, cfg, "pomerium-databroker", databrokerURLs, upstreamProtocolHTTP2, databrokerKeepalive)
 	if err != nil {
 		return nil, err
 	}
@@ -139,6 +141,7 @@ func (b *Builder) buildInternalCluster(
 	name string,
 	dsts []*url.URL,
 	upstreamProtocol upstreamProtocolConfig,
+	keepalive Keepalive,
 ) (*envoy_config_cluster_v3.Cluster, error) {
 	cluster := newDefaultEnvoyClusterConfig()
 	cluster.DnsLookupFamily = config.GetEnvoyDNSLookupFamily(cfg.Options.DNSLookupFamily)
@@ -158,7 +161,7 @@ func (b *Builder) buildInternalCluster(
 		}
 		endpoints = append(endpoints, NewEndpoint(dst, ts, 1))
 	}
-	if err := b.buildCluster(cluster, name, endpoints, upstreamProtocol); err != nil {
+	if err := b.buildCluster(cluster, name, endpoints, upstreamProtocol, keepalive); err != nil {
 		return nil, err
 	}
 
@@ -207,7 +210,7 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 		cluster.DnsLookupFamily = envoy_config_cluster_v3.Cluster_V4_ONLY
 	}
 
-	if err := b.buildCluster(cluster, name, endpoints, upstreamProtocol); err != nil {
+	if err := b.buildCluster(cluster, name, endpoints, upstreamProtocol, Keepalive(false)); err != nil {
 		return nil, err
 	}
 
@@ -388,6 +391,7 @@ func (b *Builder) buildCluster(
 	name string,
 	endpoints []Endpoint,
 	upstreamProtocol upstreamProtocolConfig,
+	keepalive Keepalive,
 ) error {
 	if len(endpoints) == 0 {
 		return errNoEndpoints
@@ -418,7 +422,7 @@ func (b *Builder) buildCluster(
 		cluster.TransportSocket = cluster.TransportSocketMatches[0].TransportSocket
 	}
 
-	cluster.TypedExtensionProtocolOptions = buildTypedExtensionProtocolOptions(endpoints, upstreamProtocol)
+	cluster.TypedExtensionProtocolOptions = buildTypedExtensionProtocolOptions(endpoints, upstreamProtocol, keepalive)
 	cluster.ClusterDiscoveryType = getClusterDiscoveryType(lbEndpoints)
 
 	return cluster.Validate()

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -577,7 +577,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		require.NoError(t, err)
 		cluster := newDefaultEnvoyClusterConfig()
-		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, Keepalive(false))
+		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, Keepalive(true))
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -690,7 +690,15 @@ func Test_buildCluster(t *testing.T) {
 								"allowConnect": true,
 								"initialConnectionWindowSize": 1048576,
 								"initialStreamWindowSize": 65536,
-								"maxConcurrentStreams": 100
+								"maxConcurrentStreams": 100,
+								"connectionKeepalive": {
+									"connectionIdleInterval": "300s",
+									"interval": "60s",
+									"intervalJitter": {
+										"value": 15
+									},
+									"timeout": "60s"
+								}
 							}
 						}
 					}

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -516,7 +516,7 @@ func Test_buildCluster(t *testing.T) {
 		require.NoError(t, err)
 		cluster := newDefaultEnvoyClusterConfig()
 		cluster.DnsLookupFamily = envoy_config_cluster_v3.Cluster_V4_ONLY
-		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2)
+		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, Keepalive(false))
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -577,7 +577,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		require.NoError(t, err)
 		cluster := newDefaultEnvoyClusterConfig()
-		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2)
+		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, Keepalive(false))
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -745,7 +745,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		require.NoError(t, err)
 		cluster := newDefaultEnvoyClusterConfig()
-		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2)
+		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, Keepalive(false))
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -803,7 +803,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		require.NoError(t, err)
 		cluster := newDefaultEnvoyClusterConfig()
-		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2)
+		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, Keepalive(false))
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -863,7 +863,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		require.NoError(t, err)
 		cluster := newDefaultEnvoyClusterConfig()
-		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2)
+		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, Keepalive(false))
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -916,7 +916,7 @@ func Test_buildCluster(t *testing.T) {
 			EnforcingConsecutive_5Xx:       wrapperspb.UInt32(17),
 			SplitExternalLocalOriginErrors: true,
 		}
-		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2)
+		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, Keepalive(false))
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{

--- a/config/envoyconfig/protocols.go
+++ b/config/envoyconfig/protocols.go
@@ -47,19 +47,24 @@ var http1ProtocolOptions = &envoy_config_core_v3.Http1ProtocolOptions{
 // Keepalive is a type to enable or disable keepalive
 type Keepalive bool
 
-// h2Keepalive uses HTTP2 PING frames to keep the connection alive
-var h2Keepalive = &envoy_config_core_v3.KeepaliveSettings{
-	Interval:               durationpb.New(time.Minute),
-	Timeout:                durationpb.New(time.Minute),
-	IntervalJitter:         &typev3.Percent{Value: 15}, // envoy's default
-	ConnectionIdleInterval: durationpb.New(5 * time.Minute),
-}
-
 var http2ProtocolOptions = &envoy_config_core_v3.Http2ProtocolOptions{
 	AllowConnect:                true,
 	MaxConcurrentStreams:        wrapperspb.UInt32(maxConcurrentStreams),
 	InitialStreamWindowSize:     wrapperspb.UInt32(initialStreamWindowSizeLimit),
 	InitialConnectionWindowSize: wrapperspb.UInt32(initialConnectionWindowSizeLimit),
+}
+
+var http2ProtocolOptionsWithKeepalive = &envoy_config_core_v3.Http2ProtocolOptions{
+	AllowConnect:                true,
+	MaxConcurrentStreams:        wrapperspb.UInt32(maxConcurrentStreams),
+	InitialStreamWindowSize:     wrapperspb.UInt32(initialStreamWindowSizeLimit),
+	InitialConnectionWindowSize: wrapperspb.UInt32(initialConnectionWindowSizeLimit),
+	ConnectionKeepalive: &envoy_config_core_v3.KeepaliveSettings{
+		Interval:               durationpb.New(time.Minute),
+		Timeout:                durationpb.New(time.Minute),
+		IntervalJitter:         &typev3.Percent{Value: 15}, // envoy's default
+		ConnectionIdleInterval: durationpb.New(5 * time.Minute),
+	},
 }
 
 func buildTypedExtensionProtocolOptions(
@@ -81,14 +86,14 @@ func buildUpstreamProtocolOptions(
 	case upstreamProtocolHTTP2:
 		h2opt := http2ProtocolOptions
 		if keepalive {
-			h2opt.ConnectionKeepalive = h2Keepalive
+			h2opt = http2ProtocolOptionsWithKeepalive
 		}
 		// when explicitly configured, force HTTP/2
 		return &envoy_extensions_upstreams_http_v3.HttpProtocolOptions{
 			UpstreamProtocolOptions: &envoy_extensions_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_{
 				ExplicitHttpConfig: &envoy_extensions_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig{
 					ProtocolConfig: &envoy_extensions_upstreams_http_v3.HttpProtocolOptions_ExplicitHttpConfig_Http2ProtocolOptions{
-						Http2ProtocolOptions: http2ProtocolOptions,
+						Http2ProtocolOptions: h2opt,
 					},
 				},
 			},

--- a/config/envoyconfig/protocols_test.go
+++ b/config/envoyconfig/protocols_test.go
@@ -32,5 +32,5 @@ func Test_buildUpstreamProtocolOptions(t *testing.T) {
 					},
 				},
 			},
-		}, buildUpstreamProtocolOptions(nil, upstreamProtocolHTTP1), protocmp.Transform()))
+		}, buildUpstreamProtocolOptions(nil, upstreamProtocolHTTP1, Keepalive(false)), protocmp.Transform()))
 }

--- a/internal/featureflags/env.go
+++ b/internal/featureflags/env.go
@@ -13,8 +13,10 @@ var (
 	// GRPCLogConnectionState connection logs gRPC connection state transitions
 	// which is less verbose than logs enabled via https://github.com/grpc/grpc-go/blob/master/README.md#how-to-turn-on-logging
 	GRPCLogConnectionState = option("GRPC_LOG_CONNECTION_STATE", false)
-	// GRPCConnectKeepalive disables gRPC keepalive to zero connect service
+	// GRPCConnectKeepalive enables gRPC keepalive to zero connect service
 	GRPCConnectKeepalive = option("GRPC_CONNECT_KEEPALIVE", true)
+	// GRPCDatabrokerKeepalive enables gRPC keepalive to the databroker service
+	GRPCDatabrokerKeepalive = option("GRPC_DATABROKER_KEEPALIVE", false)
 )
 
 // Option is a feature flag option.


### PR DESCRIPTION
## Summary

Various components maintain a streaming `databroker.Sync` call to a databroker, that may potentially be located behind an external load balancer, that are outside of our control. 

The load balancer may quietly drop the gRPC connection to the upstream while keeping a TCP connection live with the downstream (databroker gRPC client). 

This PR adds an experimental option that forces HTTP2 PING frames to be sent to the (remote) databroker gRPC cluster. We cannot use native Go gRPC keepalives as that part of the connection is to the localhost Envoy.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Related: https://github.com/pomerium/internal/issues/1730

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
