### PR TITLE
zero: fix bootstrap config path

### DIFF
--- a/internal/zero/bootstrap/new.go
+++ b/internal/zero/bootstrap/new.go
@@ -25,7 +25,7 @@ type Source struct {
 
 	api *sdk.API
 
-	fileCachePath string
+	fileCachePath *string
 	fileCipher    cipher.AEAD
 
 	checkForUpdate chan struct{}
@@ -33,7 +33,7 @@ type Source struct {
 }
 
 // New creates a new bootstrap config source
-func New(secret []byte) (*Source, error) {
+func New(secret []byte, fileCachePath *string, api *sdk.API) (*Source, error) {
 	cfg := new(config.Config)
 
 	err := setConfigDefaults(cfg)
@@ -54,7 +54,9 @@ func New(secret []byte) (*Source, error) {
 	}
 
 	svc := &Source{
+		api:            api,
 		source:         source{ready: make(chan struct{})},
+		fileCachePath:  fileCachePath,
 		fileCipher:     cipher,
 		checkForUpdate: make(chan struct{}, 1),
 	}

--- a/internal/zero/bootstrap/new_test.go
+++ b/internal/zero/bootstrap/new_test.go
@@ -11,7 +11,7 @@ import (
 func TestConfigDeterministic(t *testing.T) {
 	secret := []byte("secret")
 
-	src, err := bootstrap.New(secret)
+	src, err := bootstrap.New(secret, nil, nil)
 	require.NoError(t, err)
 	cfg := src.GetConfig()
 	require.NotNil(t, cfg)
@@ -20,7 +20,7 @@ func TestConfigDeterministic(t *testing.T) {
 	require.NoError(t, cfg.Options.Validate())
 
 	// test that the config is deterministic
-	src2, err := bootstrap.New(secret)
+	src2, err := bootstrap.New(secret, nil, nil)
 	require.NoError(t, err)
 
 	cfg2 := src2.GetConfig()

--- a/internal/zero/bootstrap/source_test.go
+++ b/internal/zero/bootstrap/source_test.go
@@ -18,7 +18,7 @@ func TestConfigChanges(t *testing.T) {
 
 	secret := []byte("secret")
 
-	src, err := bootstrap.New(secret)
+	src, err := bootstrap.New(secret, nil, nil)
 	require.NoError(t, err)
 
 	ptr := func(s string) *string { return &s }

--- a/internal/zero/controller/config.go
+++ b/internal/zero/controller/config.go
@@ -12,7 +12,7 @@ type controllerConfig struct {
 	otelEndpoint       string
 
 	tmpDir                  string
-	bootstrapConfigFileName string
+	bootstrapConfigFileName *string
 
 	reconcilerLeaseDuration  time.Duration
 	databrokerRequestTimeout time.Duration
@@ -56,7 +56,7 @@ func WithAPIToken(token string) Option {
 // WithBootstrapConfigFileName sets the name of the file to store the bootstrap config in.
 func WithBootstrapConfigFileName(name string) Option {
 	return func(c *controllerConfig) {
-		c.bootstrapConfigFileName = name
+		c.bootstrapConfigFileName = &name
 	}
 }
 

--- a/internal/zero/controller/controller.go
+++ b/internal/zero/controller/controller.go
@@ -31,7 +31,7 @@ func Run(ctx context.Context, opts ...Option) error {
 		return fmt.Errorf("init api: %w", err)
 	}
 
-	src, err := bootstrap.New([]byte(c.cfg.apiToken))
+	src, err := bootstrap.New([]byte(c.cfg.apiToken), c.cfg.bootstrapConfigFileName, c.api)
 	if err != nil {
 		return fmt.Errorf("error creating bootstrap config: %w", err)
 	}
@@ -82,7 +82,7 @@ func (c *controller) runBootstrap(ctx context.Context) error {
 	ctx = log.WithContext(ctx, func(c zerolog.Context) zerolog.Context {
 		return c.Str("service", "zero-bootstrap")
 	})
-	return c.bootstrapConfig.Run(ctx, c.api, c.cfg.bootstrapConfigFileName)
+	return c.bootstrapConfig.Run(ctx)
 }
 
 func (c *controller) runPomeriumCore(ctx context.Context) error {


### PR DESCRIPTION
## Summary

When Pomerium starts in zero mode, it tries to write bootstrap parameters to a local cache file, 
so that it may start independently from the control plane, if necessary. 

This PR ensures the inability to create a cache file is just a warning in the log, and not a fatal 
error.

## Related issues

Related: https://github.com/pomerium/pomerium-zero/issues/2011

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
