### PR TITLE
envoy: add Tap http filter if configured

### DIFF
--- a/config/envoyconfig/filters.go
+++ b/config/envoyconfig/filters.go
@@ -3,9 +3,11 @@ package envoyconfig
 import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	tapv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/common/tap/v3"
 	envoy_extensions_filters_http_ext_authz_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	envoy_extensions_filters_http_lua_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
 	envoy_extensions_filters_http_router_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	envoy_extensions_filters_http_tap_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/tap/v3"
 	envoy_extensions_filters_listener_proxy_protocol_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/proxy_protocol/v3"
 	envoy_extensions_filters_listener_tls_inspector_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/listener/tls_inspector/v3"
 	envoy_extensions_filters_network_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
@@ -73,6 +75,25 @@ func LuaFilter(defaultSourceCode string) *envoy_extensions_filters_network_http_
 				DefaultSourceCode: &envoy_config_core_v3.DataSource{
 					Specifier: &envoy_config_core_v3.DataSource_InlineString{
 						InlineString: defaultSourceCode,
+					},
+				},
+			}),
+		},
+	}
+}
+
+// TapViaAdminEndpointFilter creates a tap HTTP filter which can be used via envoy admin endpoint.
+func TapViaAdminEndpointFilter(id string) *envoy_extensions_filters_network_http_connection_manager.HttpFilter {
+	return &envoy_extensions_filters_network_http_connection_manager.HttpFilter{
+		Name: "envoy.filters.http.tap",
+		ConfigType: &envoy_extensions_filters_network_http_connection_manager.HttpFilter_TypedConfig{
+			TypedConfig: protoutil.NewAny(&envoy_extensions_filters_http_tap_v3.Tap{
+				RecordHeadersReceivedTime: true,
+				CommonConfig: &tapv3.CommonExtensionConfig{
+					ConfigType: &tapv3.CommonExtensionConfig_AdminConfig{
+						AdminConfig: &tapv3.AdminConfig{
+							ConfigId: id,
+						},
 					},
 				},
 			}),

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -271,6 +271,10 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 		LuaFilter(luascripts.CleanUpstream),
 		LuaFilter(luascripts.RewriteHeaders),
 	}
+	if cfg.Options.EnvoyAdminEnableTap {
+		filters = append(filters, TapViaAdminEndpointFilter("downstream"))
+	}
+
 	filters = append(filters, HTTPRouterFilter())
 
 	var maxStreamDuration *durationpb.Duration

--- a/config/options.go
+++ b/config/options.go
@@ -275,6 +275,8 @@ type Options struct {
 	// see https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers.html?highlight=xff_num_trusted_hops#x-forwarded-for
 	XffNumTrustedHops uint32 `mapstructure:"xff_num_trusted_hops" yaml:"xff_num_trusted_hops,omitempty" json:"xff_num_trusted_hops,omitempty"`
 
+	EnvoyAdminEnableTap  bool `mapstructure:"envoy_admin_enable_tap" yaml:"envoy_admin_enable_tap,omitempty" json:"envoy_admin_enable_tap,omitempty"`
+
 	// Envoy bootstrap options. These do not support dynamic updates.
 	EnvoyAdminAccessLogPath      string    `mapstructure:"envoy_admin_access_log_path" yaml:"envoy_admin_access_log_path"`
 	EnvoyAdminProfilePath        string    `mapstructure:"envoy_admin_profile_path" yaml:"envoy_admin_profile_path"`


### PR DESCRIPTION
## Summary
If configured an tap http filter is added to the envoy config.
The added tap filter is configured for admin control and therefore available if the envoy admin endpoint is configured.

## How to test
Prerequisite enable envoy admin endpoint via config:
`envoy_admin_address: localhost:9901` 

Set config `envoy_admin_enable_tap` to `true`

and subscribe to the tap:
```
curl -X POST http://localhost:9901/tap -H "Content-Type: application/yaml" \
-d 'config_id: downstream
tap_config:
  match_config:
    any_match: true
  output_config:
    sinks:
      - format: JSON_BODY_AS_STRING
        streaming_admin: {}'

```

see also:
* Pure Envoy Demo: https://github.com/denniskniep/envoy-tap-and-accesslogs-demo
* Docs: https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/tap_filter

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
