### PR TITLE
authenticate: apply branding to sign out pages

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -89,7 +89,7 @@ func (a *Authenticate) mountDashboard(r *mux.Router) {
 
 	// routes that don't need a session:
 	sr.Path("/sign_out").Handler(httputil.HandlerFunc(a.SignOut))
-	sr.Path("/signed_out").Handler(handlers.SignedOut(handlers.SignedOutData{})).Methods(http.MethodGet)
+	sr.Path("/signed_out").Handler(httputil.HandlerFunc(a.signedOut)).Methods(http.MethodGet)
 
 	// routes that need a session:
 	sr = sr.NewRoute().Subrouter()
@@ -186,7 +186,8 @@ func (a *Authenticate) SignOut(w http.ResponseWriter, r *http.Request) error {
 		}
 
 		handlers.SignOutConfirm(handlers.SignOutConfirmData{
-			URL: urlutil.SignOutURL(r, authenticateURL, a.state.Load().sharedKey),
+			URL:             urlutil.SignOutURL(r, authenticateURL, a.state.Load().sharedKey),
+			BrandingOptions: a.options.Load().BrandingOptions,
 		}).ServeHTTP(w, r)
 		return nil
 	}
@@ -237,6 +238,13 @@ func (a *Authenticate) signOutRedirect(w http.ResponseWriter, r *http.Request) e
 	}
 
 	httputil.Redirect(w, r, signOutURL, http.StatusFound)
+	return nil
+}
+
+func (a *Authenticate) signedOut(w http.ResponseWriter, r *http.Request) error {
+	handlers.SignedOut(handlers.SignedOutData{
+		BrandingOptions: a.options.Load().BrandingOptions,
+	}).ServeHTTP(w, r)
 	return nil
 }
 

--- a/internal/handlers/signedout.go
+++ b/internal/handlers/signedout.go
@@ -8,11 +8,15 @@ import (
 )
 
 // SignedOutData is the data for the SignedOut page.
-type SignedOutData struct{}
+type SignedOutData struct {
+	BrandingOptions httputil.BrandingOptions
+}
 
 // ToJSON converts the data into a JSON map.
 func (data SignedOutData) ToJSON() map[string]interface{} {
-	return map[string]interface{}{}
+	m := map[string]interface{}{}
+	httputil.AddBrandingOptionsToMap(m, data.BrandingOptions)
+	return m
 }
 
 // SignedOut returns a handler that renders the signed out page.

--- a/internal/handlers/signout.go
+++ b/internal/handlers/signout.go
@@ -9,14 +9,17 @@ import (
 
 // SignOutConfirmData is the data for the SignOutConfirm page.
 type SignOutConfirmData struct {
-	URL string
+	URL             string
+	BrandingOptions httputil.BrandingOptions
 }
 
 // ToJSON converts the data into a JSON map.
 func (data SignOutConfirmData) ToJSON() map[string]interface{} {
-	return map[string]interface{}{
+	m := map[string]interface{}{
 		"url": data.URL,
 	}
+	httputil.AddBrandingOptionsToMap(m, data.BrandingOptions)
+	return m
 }
 
 // SignOutConfirm returns a handler that renders the sign out confirm page.


### PR DESCRIPTION
## Summary

Add support for the Enterprise branding options to the `sign_out` and `signed_out` page handlers.

## Related issues

- https://github.com/pomerium/pomerium-console/issues/4103

## User Explanation

Apply Enterprise branding options to the authenticate service sign out pages.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
