### PR TITLE
core/authorize: add support for rego print statements

### DIFF
--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -105,6 +105,7 @@ func NewHeadersEvaluator(ctx context.Context, store *store.Store) (*HeadersEvalu
 		rego.Store(store),
 		rego.Module("pomerium.headers", opa.HeadersRego),
 		rego.Query("result := data.pomerium.headers"),
+		rego.EnablePrintStatements(true),
 		getGoogleCloudServerlessHeadersRegoOption,
 		variableSubstitutionFunctionRegoOption,
 		store.GetDataBrokerRecordOption(),

--- a/authorize/evaluator/log.go
+++ b/authorize/evaluator/log.go
@@ -1,0 +1,19 @@
+package evaluator
+
+import (
+	"github.com/open-policy-agent/opa/topdown/print"
+	"github.com/rs/zerolog"
+)
+
+type regoPrintHook struct {
+	logger zerolog.Logger
+}
+
+var _ print.Hook = (*regoPrintHook)(nil)
+
+func (h regoPrintHook) Print(ctx print.Context, msg string) error {
+	h.logger.Debug().
+		Any("location", ctx.Location).
+		Msg("rego: " + msg)
+	return nil
+}

--- a/authorize/evaluator/log_test.go
+++ b/authorize/evaluator/log_test.go
@@ -1,0 +1,49 @@
+package evaluator
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrintHook(t *testing.T) {
+	t.Parallel()
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	t.Cleanup(clearTimeout)
+
+	r := rego.New(
+		rego.Module("policy.rego", `
+package pomerium.policy
+
+import rego.v1
+
+allow if {
+	print("HELLO WORLD")
+	true
+}
+		`),
+		rego.EnablePrintStatements(true),
+		rego.Query("data.pomerium.policy.allow"),
+	)
+	q, err := r.PrepareForEval(ctx)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	logger := zerolog.New(&buf).Level(zerolog.DebugLevel)
+
+	rs, err := q.Eval(ctx, rego.EvalPrintHook(regoPrintHook{
+		logger: logger,
+	}))
+	require.NoError(t, err)
+	assert.True(t, rs.Allowed())
+
+	assert.Equal(t, `{"level":"debug","location":{"file":"policy.rego","row":7,"col":2},"message":"rego: HELLO WORLD"}`, strings.TrimSpace(buf.String()))
+}


### PR DESCRIPTION
## Summary
To make custom rego easier to debug add support for `print` statements.

## Related issues
Fixes https://github.com/pomerium/pomerium-console/issues/4095

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
