### PR TITLE
envoy: upgrade to v1.28.2

### DIFF
--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -5,7 +5,7 @@ PATH="$PATH:$(go env GOPATH)/bin"
 export PATH
 
 _project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/.."
-_envoy_version=1.28.0
+_envoy_version=1.28.2
 _dir="$_project_root/pkg/envoy/files"
 
 for _target in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do

--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -5,10 +5,13 @@ PATH="$PATH:$(go env GOPATH)/bin"
 export PATH
 
 _project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/.."
-_envoy_version=1.28.2
 _dir="$_project_root/pkg/envoy/files"
 
 for _target in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do
+  _envoy_version=1.28.2
+  if [[ "$_target" == darwin* ]]; then
+    _envoy_version='1.28.0'
+  fi
   _url="https://github.com/pomerium/envoy-binaries/releases/download/v${_envoy_version}/envoy-${_target}"
 
   curl \


### PR DESCRIPTION
## Summary

Upgrades Envoy to v1.28.2 (Linux only).

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Related: https://github.com/pomerium/internal/issues/1771

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
