### PR TITLE
core/config: disable gRPC ingress when address is the empty string

### DIFF
--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -71,7 +71,7 @@ func TestBuildListeners(t *testing.T) {
 		for _, li := range lis {
 			hasGRPC = hasGRPC || li.Name == "grpc-ingress"
 		}
-		assert.False(t, hasGRPC, "expected grpc-ingress to be disable when grpc address is set to the empty string")
+		assert.False(t, hasGRPC, "expected grpc-ingress to be disabled when grpc address is set to the empty string")
 	})
 }
 

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -39,6 +39,42 @@ func testData(t *testing.T, name string, data interface{}) string {
 	return buf.String()
 }
 
+func TestBuildListeners(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := &config.Config{
+		Options: config.NewDefaultOptions(),
+
+		GRPCPort:     "10001",
+		HTTPPort:     "10002",
+		OutboundPort: "10003",
+		MetricsPort:  "10004",
+	}
+	b := New("local-grpc", "local-http", "local-metrics", filemgr.NewManager(), nil)
+	t.Run("enable grpc by default", func(t *testing.T) {
+		cfg := cfg.Clone()
+		lis, err := b.BuildListeners(ctx, cfg, false)
+		assert.NoError(t, err)
+		var hasGRPC bool
+		for _, li := range lis {
+			hasGRPC = hasGRPC || li.Name == "grpc-ingress"
+		}
+		assert.True(t, hasGRPC, "expected grpc-ingress to be enabled by default")
+	})
+	t.Run("disable grpc for empty string", func(t *testing.T) {
+		cfg := cfg.Clone()
+		cfg.Options.GRPCAddr = ""
+		lis, err := b.BuildListeners(ctx, cfg, false)
+		assert.NoError(t, err)
+		var hasGRPC bool
+		for _, li := range lis {
+			hasGRPC = hasGRPC || li.Name == "grpc-ingress"
+		}
+		assert.False(t, hasGRPC, "expected grpc-ingress to be disable when grpc address is set to the empty string")
+	})
+}
+
 func Test_buildMetricsHTTPConnectionManagerFilter(t *testing.T) {
 	cacheDir, _ := os.UserCacheDir()
 	certFileName := filepath.Join(cacheDir, "pomerium", "envoy", "files", "tls-crt-32375a484d4f49594c4d374830.pem")

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -272,15 +272,8 @@ func (src *ConfigSource) runUpdater(cfg *config.Config) {
 	}, databroker.WithTypeURL(grpcutil.GetTypeURL(new(configpb.Config))),
 		databroker.WithFastForward())
 	go func() {
-		var databrokerURLs []string
-		urls, _ := cfg.Options.GetDataBrokerURLs()
-		for _, url := range urls {
-			databrokerURLs = append(databrokerURLs, url.String())
-		}
-
 		log.Debug(ctx).
 			Str("outbound_port", cfg.OutboundPort).
-			Strs("databroker_urls", databrokerURLs).
 			Msg("config: starting databroker config source syncer")
 		_ = grpc.WaitForReady(ctx, cc, time.Second*10)
 		_ = syncer.Run(ctx)


### PR DESCRIPTION
## Summary
Currently if the `grpc_address` is set to the empty string:

```yaml
grpc_address: ""
```

We will start the `grpc-ingress` on port `80`. With these changes we will instead disable the `grpc-ingress`. The databroker and authorize service will only listen on the gRPC port, which is randomly chosen on start, and only bound to the local ip.

## Related issues
- https://github.com/pomerium/pomerium-zero/issues/1987


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
