### PR TITLE
core/authenticate: redirect to /.pomerium/signed_out when no signout redirect url is defined

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -237,6 +237,11 @@ func (a *Authenticate) signOutRedirect(w http.ResponseWriter, r *http.Request) e
 		log.Warn(r.Context()).Err(err).Msg("authenticate: failed to get sign out url for authenticator")
 	}
 
+	// if the authenticator failed to sign out, and no sign out url is defined, just go to the signed out page
+	if signOutURL == "" {
+		signOutURL = authenticateSignedOutURL
+	}
+
 	httputil.Redirect(w, r, signOutURL, http.StatusFound)
 	return nil
 }


### PR DESCRIPTION
## Summary
Currently if an IdP does not support the `SignOut` method, and a signout redirect URL is not defined, and a redirect URL is not passed on the query string, we default to redirecting to `/`. This PR updates the logic to redirect to the signed out URL instead (`/.pomerium/signed_out`).

## Related issues
- https://github.com/pomerium/internal/issues/1767


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
