### PR TITLE
update dev Dockerfiles to use Go 1.22.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN make yarn
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.22.1-bookworm@sha256:d996c645c9934e770e64f05fc2bc103755197b43fd999b3aa5419142e1ee6d78 as build
+FROM golang:1.22.2-bookworm@sha256:3c7ad81405250a6b8027c7c9c2a9ab23cd8d4f9870994bf350ee6045704d47a5 as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -13,7 +13,7 @@ RUN make yarn
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.22.1-bookworm@sha256:d996c645c9934e770e64f05fc2bc103755197b43fd999b3aa5419142e1ee6d78 as build
+FROM golang:1.22.2-bookworm@sha256:3c7ad81405250a6b8027c7c9c2a9ab23cd8d4f9870994bf350ee6045704d47a5 as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \


### PR DESCRIPTION
## Summary

This is in preparation for https://github.com/pomerium/pomerium/pull/5061:
 - the dev Dockerfile and Dockerfile.debug files use a base Go image `golang:1.22.1-bookworm`
 - the base Go images set `ENV GOTOOLCHAIN=local`, which disables automatic toolchain fetching
 - this means they won't build if we set a `go 1.22.2` directive in the go.mod file

Let's update the dev docker images to use `golang:1.22.2-bookworm`.

I obtained the current digest for `golang:1.22.2-bookworm` from [Docker hub](https://hub.docker.com/layers/library/golang/1.22.2-bookworm/images/sha256-cac8fb1c85bf96316112f5dd2671c8da0c19d2dfce88af9551b3141499a59eaf?context=explore):

<img width="629" alt="Screen Shot 2024-04-10 at 1 18 24 PM" src="https://github.com/pomerium/pomerium/assets/51246568/a8dec945-53b1-4182-a7c7-dbd39b1e6781">


## Related issues

- https://github.com/pomerium/internal/issues/1773

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
