### PR TITLE
core/envoy: only enable port reuse on linux

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"runtime"
 	"strings"
 	"time"
 
@@ -676,6 +677,11 @@ func newEnvoyListener(name string) *envoy_config_listener_v3.Listener {
 	return &envoy_config_listener_v3.Listener{
 		Name:                          name,
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(listenerBufferLimit),
+
+		// SO_REUSEPORT only works properly on linux and is force-disabled by
+		// envoy on mac and windows, so we disable it explitly to avoid a
+		// noisy log message
+		EnableReusePort: wrapperspb.Bool(runtime.GOOS == "linux"),
 	}
 }
 

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"text/template"
 
@@ -89,7 +90,10 @@ func Test_buildMetricsHTTPConnectionManagerFilter(t *testing.T) {
 		},
 	})
 
-	expect := testData(t, "metrics_http_connection_manager.json", struct{ CertFile, KeyFile string }{certFileName, keyFileName})
+	expect := testData(t, "metrics_http_connection_manager.json", struct {
+		CertFile, KeyFile string
+		EnableReusePort   bool
+	}{certFileName, keyFileName, runtime.GOOS == "linux"})
 	require.NoError(t, err)
 	testutil.AssertProtoJSONEqual(t, expect, li)
 }

--- a/config/envoyconfig/outbound.go
+++ b/config/envoyconfig/outbound.go
@@ -25,23 +25,21 @@ func (b *Builder) buildOutboundListener(cfg *config.Config) (*envoy_config_liste
 		return nil, fmt.Errorf("error building outbound http connection manager filter: %w", err)
 	}
 
-	li := &envoy_config_listener_v3.Listener{
-		Name: "outbound-ingress",
-		Address: &envoy_config_core_v3.Address{
-			Address: &envoy_config_core_v3.Address_SocketAddress{
-				SocketAddress: &envoy_config_core_v3.SocketAddress{
-					Address: "127.0.0.1",
-					PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
-						PortValue: uint32(outboundPort),
-					},
+	li := newEnvoyListener("outbound-ingress")
+	li.Address = &envoy_config_core_v3.Address{
+		Address: &envoy_config_core_v3.Address_SocketAddress{
+			SocketAddress: &envoy_config_core_v3.SocketAddress{
+				Address: "127.0.0.1",
+				PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
+					PortValue: uint32(outboundPort),
 				},
 			},
 		},
-		FilterChains: []*envoy_config_listener_v3.FilterChain{{
-			Name:    "outbound-ingress",
-			Filters: []*envoy_config_listener_v3.Filter{filter},
-		}},
 	}
+	li.FilterChains = []*envoy_config_listener_v3.FilterChain{{
+		Name:    "outbound-ingress",
+		Filters: []*envoy_config_listener_v3.Filter{filter},
+	}}
 	return li, nil
 }
 

--- a/config/envoyconfig/outbound.go
+++ b/config/envoyconfig/outbound.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (b *Builder) buildOutboundListener(cfg *config.Config) (*envoy_config_listener_v3.Listener, error) {
-	outboundPort, err := strconv.Atoi(cfg.OutboundPort)
+	outboundPort, err := strconv.ParseUint(cfg.OutboundPort, 10, 32)
 	if err != nil {
 		return nil, fmt.Errorf("invalid outbound port %v: %w", cfg.OutboundPort, err)
 	}

--- a/config/envoyconfig/testdata/metrics_http_connection_manager.json
+++ b/config/envoyconfig/testdata/metrics_http_connection_manager.json
@@ -7,6 +7,7 @@
       "portValue": 9902
     }
   },
+  "enableReusePort": {{.EnableReusePort}},
   "filterChains": [
     {
       "filters": [


### PR DESCRIPTION
## Summary
On MacOS we see messages like:

```
{"level":"error","service":"envoy","name":"config","time":"2024-04-11T13:42:06-06:00","message":"reuse_port was configured for TCP listener \\'grpc-ingress\\' and is being force disabled because Envoy is not running on Linux. See the documentation for more information."}
```

This PR fixes that.

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
