### PR TITLE
update README: link to Contributing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,4 +26,3 @@ See [Contributing] for information on how you can contribute to Pomerium.
 [contributing]: https://www.pomerium.com/docs/community/contributing
 [documentation]: https://www.pomerium.com/docs/
 [godocs]: https://pkg.go.dev/github.com/pomerium/pomerium
-

--- a/README.md
+++ b/README.md
@@ -19,34 +19,11 @@ It’s not a VPN alternative – it’s the trusted, foolproof way to protect yo
 
 For comprehensive docs, and tutorials see our [documentation].
 
-[documentation]: https://pomerium.com/docs/
-[go environment]: https://golang.org/doc/install
-[godocs]: https://godoc.org/github.com/pomerium/pomerium
-[quick start guide]: https://www.pomerium.com/docs/install/quickstart
+## Contributing
 
-## Integration Tests
+See [Contributing] for information on how you can contribute to Pomerium.
 
-To run the integration tests locally, first build a local development image:
+[contributing]: https://www.pomerium.com/docs/community/contributing
+[documentation]: https://www.pomerium.com/docs/
+[godocs]: https://pkg.go.dev/github.com/pomerium/pomerium
 
-```bash
-./scripts/build-dev-docker.bash
-```
-
-Next go to the `integration/clusters` folder and pick a cluster, for example `google-single`, then use docker-compose to start the cluster. We use an environment variable to specify the `dev` docker image we built earlier:
-
-```bash
-cd integration/clusters/google-single
-env POMERIUM_TAG=dev docker-compose up -V
-```
-
-Once that's up and running you can run the integration tests from another terminal:
-
-```bash
-go test -count=1 -v ./integration/...
-```
-
-If you need to make a change to the clusters themselves, there's a `tpl` folder that contains `jsonnet` files. Make a change and then rebuild the clusters by running:
-
-```bash
-go run ./integration/cmd/pomerium-integration-tests/ generate-configuration
-```


### PR DESCRIPTION
## Summary

Remove the inline integration test instructions in favor of a link to the Contributing page on the documentation site. Remove some unused link definitions and update the godoc.org link to use pkg.go.dev instead.

## Related issues

- https://github.com/pomerium/pomerium/issues/5069

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
