### PR TITLE
health-check: add storage health check

### DIFF
--- a/pkg/health/check.go
+++ b/pkg/health/check.go
@@ -15,6 +15,8 @@ const (
 	XDSOther = Check("xds.other")
 	// ZeroBootstrapConfigSave checks whether the Zero bootstrap config was saved
 	ZeroBootstrapConfigSave = Check("zero.bootstrap-config.save")
+	// StorageBackend checks whether the storage backend is healthy
+	StorageBackend = Check("storage.backend")
 )
 
 // ZeroResourceBundle checks whether the Zero resource bundle was applied

--- a/pkg/storage/inmemory/backend.go
+++ b/pkg/storage/inmemory/backend.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pomerium/pomerium/internal/signal"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/health"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
 
@@ -86,6 +87,9 @@ func New(options ...Option) *Backend {
 			}
 		}()
 	}
+
+	health.ReportOK(health.StorageBackend, health.StrAttr("backend", "in-memory"))
+
 	return backend
 }
 


### PR DESCRIPTION
## Summary

This PR adds a periodic health check for storage backend health. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Fixes https://github.com/pomerium/pomerium-zero/issues/2106

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
