### PR TITLE
envoyconfig: address strconv.Atoi warnings

### DIFF
--- a/config/envoyconfig/acmetlsalpn.go
+++ b/config/envoyconfig/acmetlsalpn.go
@@ -23,7 +23,7 @@ const (
 func (b *Builder) buildACMETLSALPNCluster(
 	cfg *config.Config,
 ) *envoy_config_cluster_v3.Cluster {
-	port, _ := strconv.Atoi(cfg.ACMETLSALPNPort)
+	port, _ := strconv.ParseUint(cfg.ACMETLSALPNPort, 10, 32)
 	return &envoy_config_cluster_v3.Cluster{
 		Name: acmeTLSALPNClusterName,
 		LoadAssignment: &envoy_config_endpoint_v3.ClusterLoadAssignment{
@@ -32,7 +32,7 @@ func (b *Builder) buildACMETLSALPNCluster(
 				LbEndpoints: []*envoy_config_endpoint_v3.LbEndpoint{{
 					HostIdentifier: &envoy_config_endpoint_v3.LbEndpoint_Endpoint{
 						Endpoint: &envoy_config_endpoint_v3.Endpoint{
-							Address: buildAddress("127.0.0.1", port),
+							Address: buildAddress("127.0.0.1", uint32(port)),
 						},
 					},
 				}},

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -473,7 +473,7 @@ func grpcHealthChecks(name string) []*envoy_config_core_v3.HealthCheck {
 func (b *Builder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoint_v3.LbEndpoint, error) {
 	var lbes []*envoy_config_endpoint_v3.LbEndpoint
 	for _, e := range endpoints {
-		defaultPort := 80
+		defaultPort := uint32(80)
 		if e.transportSocket != nil && e.transportSocket.Name == "tls" {
 			defaultPort = 443
 		}

--- a/pkg/envoy/misc.go
+++ b/pkg/envoy/misc.go
@@ -1,13 +1,5 @@
 package envoy
 
-import (
-	"fmt"
-	"net"
-	"strconv"
-
-	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
-)
-
 func firstNonEmpty[T interface{ ~string }](args ...T) T {
 	for _, a := range args {
 		if a != "" {
@@ -15,23 +7,4 @@ func firstNonEmpty[T interface{ ~string }](args ...T) T {
 		}
 	}
 	return ""
-}
-
-// ParseAddress parses a string address into an envoy address.
-func ParseAddress(raw string) (*envoy_config_core_v3.Address, error) {
-	if host, portstr, err := net.SplitHostPort(raw); err == nil {
-		if port, err := strconv.Atoi(portstr); err == nil {
-			return &envoy_config_core_v3.Address{
-				Address: &envoy_config_core_v3.Address_SocketAddress{
-					SocketAddress: &envoy_config_core_v3.SocketAddress{
-						Address: host,
-						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
-							PortValue: uint32(port),
-						},
-					},
-				},
-			}, nil
-		}
-	}
-	return nil, fmt.Errorf("unknown address format: %s", raw)
 }


### PR DESCRIPTION
## Summary

We recently enabled CodeQL scanning. This has flagged a few instances where we parse an integer using `strconv.Atoi()` and then convert to a `uint32`. Let's resolve these warnings by using `strconv.ParseUint()` instead, like @calebdoxsey did in https://github.com/pomerium/pomerium/pull/5066/commits/5b06b27ebbdc0401644e2b5ec22eb171724aac11.

One of this instances is in a function that appears to be unused ([GitHub search link](https://github.com/search?q=org%3Apomerium%20pkg%2Fenvoy%20ParseAddress&type=code)), so let's go ahead and delete that function.

## Related issues

- https://github.com/pomerium/pomerium/security/code-scanning/2
- https://github.com/pomerium/pomerium/security/code-scanning/3
- https://github.com/pomerium/pomerium/security/code-scanning/5

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
