### PR TITLE
zero: add user-agent to requests

### DIFF
--- a/internal/zero/grpcconn/config.go
+++ b/internal/zero/grpcconn/config.go
@@ -11,6 +11,8 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/pomerium/pomerium/internal/version"
 )
 
 // config is the configuration for the gRPC client
@@ -29,6 +31,7 @@ func getConfig(
 	endpoint string,
 	opts ...grpc.DialOption,
 ) (*config, error) {
+	opts = append(opts, grpc.WithUserAgent(version.UserAgent()))
 	c := &config{opts: opts}
 	err := c.parseEndpoint(endpoint)
 	if err != nil {

--- a/internal/zero/reconciler/report_status.go
+++ b/internal/zero/reconciler/report_status.go
@@ -1,8 +1,6 @@
 package reconciler
 
 import (
-	"fmt"
-
 	"github.com/pomerium/pomerium/pkg/health"
 )
 
@@ -12,7 +10,7 @@ func (c *service) ReportBundleAppliedSuccess(
 ) {
 	var attr []health.Attr
 	for k, v := range metadata {
-		attr = append(attr, health.StrAttr(fmt.Sprintf("download-metadata-%s", k), v))
+		attr = append(attr, health.StrAttr(k, v))
 	}
 	health.ReportOK(health.ZeroResourceBundle(bundleID), attr...)
 }

--- a/pkg/zero/cluster/client.go
+++ b/pkg/zero/cluster/client.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"net/http"
 	"time"
+
+	"github.com/pomerium/pomerium/internal/version"
 )
 
 const (
 	defaultMinTokenTTL = time.Minute * 5
 )
+
+var userAgent = version.UserAgent()
 
 type client struct {
 	tokenProvider TokenProviderFn
@@ -44,6 +48,7 @@ func (c *client) Do(req *http.Request) (*http.Response, error) {
 		return nil, fmt.Errorf("error getting token: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("User-Agent", userAgent)
 
 	return c.httpClient.Do(req)
 }


### PR DESCRIPTION
## Summary

Adds `User-Agent` header to requests to the control plane. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Fixes https://github.com/pomerium/pomerium-zero/issues/2177

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
