### PR TITLE
connect: add health check

### DIFF
--- a/pkg/health/check.go
+++ b/pkg/health/check.go
@@ -5,6 +5,8 @@ import "fmt"
 type Check string
 
 const (
+	// StorageBackend checks whether the storage backend is healthy
+	StorageBackend = Check("storage.backend")
 	// XDSCluster checks whether the XDS Cluster resources were applied
 	XDSCluster = Check("xds.cluster")
 	// XDSListener checks whether the XDS Listener resources were applied
@@ -15,8 +17,8 @@ const (
 	XDSOther = Check("xds.other")
 	// ZeroBootstrapConfigSave checks whether the Zero bootstrap config was saved
 	ZeroBootstrapConfigSave = Check("zero.bootstrap-config.save")
-	// StorageBackend checks whether the storage backend is healthy
-	StorageBackend = Check("storage.backend")
+	// ZeroConnect checks whether the Zero Connect service is connected
+	ZeroConnect = Check("zero.connect")
 )
 
 // ZeroResourceBundle checks whether the Zero resource bundle was applied


### PR DESCRIPTION
## Summary

Adds health check for zero connect service.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Related: https://github.com/pomerium/pomerium-zero/issues/2105

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
