### PR TITLE
core/kubernetes: fix impersonate group header

### DIFF
--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -269,7 +269,7 @@ get_header_string_value(obj) := s if {
 	s := concat(",", [obj])
 }
 
-remove_empty_header_values(arr) := [[k,v]|
+remove_empty_header_values(arr) := [[k, v] |
 	some idx
 	k := arr[idx][0]
 	v := arr[idx][1]

--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -174,11 +174,12 @@ signed_jwt := io.jwt.encode_sign(jwt_headers, jwt_payload, data.signing_key)
 
 kubernetes_headers := h if {
 	input.kubernetes_service_account_token != ""
-	h := [
+
+	h := remove_empty_header_values([
 		["Authorization", concat(" ", ["Bearer", input.kubernetes_service_account_token])],
 		["Impersonate-User", jwt_payload_email],
 		["Impersonate-Group", get_header_string_value(jwt_payload_groups)],
-	]
+	])
 } else := []
 
 google_cloud_serverless_authentication_service_account := s if {
@@ -267,3 +268,10 @@ get_header_string_value(obj) := s if {
 } else := s if {
 	s := concat(",", [obj])
 }
+
+remove_empty_header_values(arr) := [[k,v]|
+	some idx
+	k := arr[idx][0]
+	v := arr[idx][1]
+	v != ""
+]


### PR DESCRIPTION
## Summary
Remove the empty string from the `Impersonate-Group` header.

## Related issues
For #5089 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
