### PR TITLE
log/grpc: use standard logger

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -31,6 +31,7 @@ func main() {
 	}
 
 	ctx := context.Background()
+	log.SetLevel(zerolog.InfoLevel)
 	runFn := run
 	if zero_cmd.IsManagedMode(*configFile) {
 		runFn = func(ctx context.Context) error { return zero_cmd.Run(ctx, *configFile) }
@@ -43,7 +44,6 @@ func main() {
 }
 
 func run(ctx context.Context) error {
-	log.SetLevel(zerolog.InfoLevel)
 	ctx = log.WithContext(ctx, func(c zerolog.Context) zerolog.Context {
 		return c.Str("config_file_source", *configFile).Bool("bootstrap", true)
 	})

--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -43,6 +43,7 @@ func main() {
 }
 
 func run(ctx context.Context) error {
+	log.SetLevel(zerolog.InfoLevel)
 	ctx = log.WithContext(ctx, func(c zerolog.Context) zerolog.Context {
 		return c.Str("config_file_source", *configFile).Bool("bootstrap", true)
 	})

--- a/internal/log/grpc.go
+++ b/internal/log/grpc.go
@@ -14,55 +14,55 @@ func init() {
 type grpcLogger struct{}
 
 func (c *grpcLogger) Info(args ...interface{}) {
-	if GetLevel() == zerolog.DebugLevel {
+	if GetLevel() <= zerolog.DebugLevel {
 		Logger().Info().Msg(fmt.Sprint(args...))
 	}
 }
 
 func (c *grpcLogger) Infoln(args ...interface{}) {
-	if GetLevel() == zerolog.DebugLevel {
+	if GetLevel() <= zerolog.DebugLevel {
 		Logger().Info().Msg(fmt.Sprintln(args...))
 	}
 }
 
 func (c *grpcLogger) Infof(format string, args ...interface{}) {
-	if GetLevel() == zerolog.DebugLevel {
+	if GetLevel() <= zerolog.DebugLevel {
 		Logger().Info().Msg(fmt.Sprintf(format, args...))
 	}
 }
 
 func (c *grpcLogger) Warning(args ...interface{}) {
-	if GetLevel() == zerolog.DebugLevel {
+	if GetLevel() <= zerolog.DebugLevel {
 		Logger().Warn().Msg(fmt.Sprint(args...))
 	}
 }
 
 func (c *grpcLogger) Warningln(args ...interface{}) {
-	if GetLevel() == zerolog.DebugLevel {
+	if GetLevel() <= zerolog.DebugLevel {
 		Logger().Warn().Msg(fmt.Sprintln(args...))
 	}
 }
 
 func (c *grpcLogger) Warningf(format string, args ...interface{}) {
-	if GetLevel() == zerolog.DebugLevel {
+	if GetLevel() <= zerolog.DebugLevel {
 		Logger().Warn().Msg(fmt.Sprintf(format, args...))
 	}
 }
 
 func (c *grpcLogger) Error(args ...interface{}) {
-	if GetLevel() == zerolog.DebugLevel {
+	if GetLevel() <= zerolog.DebugLevel {
 		Logger().Error().Msg(fmt.Sprint(args...))
 	}
 }
 
 func (c *grpcLogger) Errorln(args ...interface{}) {
-	if GetLevel() == zerolog.DebugLevel {
+	if GetLevel() <= zerolog.DebugLevel {
 		Logger().Error().Msg(fmt.Sprintln(args...))
 	}
 }
 
 func (c *grpcLogger) Errorf(format string, args ...interface{}) {
-	if GetLevel() == zerolog.DebugLevel {
+	if GetLevel() <= zerolog.DebugLevel {
 		Logger().Error().Msg(fmt.Sprintf(format, args...))
 	}
 }

--- a/internal/log/grpc.go
+++ b/internal/log/grpc.go
@@ -3,6 +3,7 @@ package log
 import (
 	"fmt"
 
+	"github.com/rs/zerolog"
 	"google.golang.org/grpc/grpclog"
 )
 
@@ -13,39 +14,57 @@ func init() {
 type grpcLogger struct{}
 
 func (c *grpcLogger) Info(args ...interface{}) {
-	Logger().Debug().Msg(fmt.Sprint(args...))
+	if GetLevel() == zerolog.DebugLevel {
+		Logger().Info().Msg(fmt.Sprint(args...))
+	}
 }
 
 func (c *grpcLogger) Infoln(args ...interface{}) {
-	Logger().Debug().Msg(fmt.Sprintln(args...))
+	if GetLevel() == zerolog.DebugLevel {
+		Logger().Info().Msg(fmt.Sprintln(args...))
+	}
 }
 
 func (c *grpcLogger) Infof(format string, args ...interface{}) {
-	Logger().Debug().Msg(fmt.Sprintf(format, args...))
+	if GetLevel() == zerolog.DebugLevel {
+		Logger().Info().Msg(fmt.Sprintf(format, args...))
+	}
 }
 
 func (c *grpcLogger) Warning(args ...interface{}) {
-	Logger().Debug().Msg(fmt.Sprint(args...))
+	if GetLevel() == zerolog.DebugLevel {
+		Logger().Warn().Msg(fmt.Sprint(args...))
+	}
 }
 
 func (c *grpcLogger) Warningln(args ...interface{}) {
-	Logger().Debug().Msg(fmt.Sprintln(args...))
+	if GetLevel() == zerolog.DebugLevel {
+		Logger().Warn().Msg(fmt.Sprintln(args...))
+	}
 }
 
 func (c *grpcLogger) Warningf(format string, args ...interface{}) {
-	Logger().Debug().Msg(fmt.Sprintf(format, args...))
+	if GetLevel() == zerolog.DebugLevel {
+		Logger().Warn().Msg(fmt.Sprintf(format, args...))
+	}
 }
 
 func (c *grpcLogger) Error(args ...interface{}) {
-	Logger().Debug().Msg(fmt.Sprint(args...))
+	if GetLevel() == zerolog.DebugLevel {
+		Logger().Error().Msg(fmt.Sprint(args...))
+	}
 }
 
 func (c *grpcLogger) Errorln(args ...interface{}) {
-	Logger().Debug().Msg(fmt.Sprintln(args...))
+	if GetLevel() == zerolog.DebugLevel {
+		Logger().Error().Msg(fmt.Sprintln(args...))
+	}
 }
 
 func (c *grpcLogger) Errorf(format string, args ...interface{}) {
-	Logger().Debug().Msg(fmt.Sprintf(format, args...))
+	if GetLevel() == zerolog.DebugLevel {
+		Logger().Error().Msg(fmt.Sprintf(format, args...))
+	}
 }
 
 func (c *grpcLogger) Fatal(args ...interface{}) {

--- a/internal/log/grpc.go
+++ b/internal/log/grpc.go
@@ -1,0 +1,65 @@
+package log
+
+import (
+	"fmt"
+
+	"google.golang.org/grpc/grpclog"
+)
+
+func init() {
+	grpclog.SetLoggerV2(&grpcLogger{})
+}
+
+type grpcLogger struct{}
+
+func (c *grpcLogger) Info(args ...interface{}) {
+	Logger().Debug().Msg(fmt.Sprint(args...))
+}
+
+func (c *grpcLogger) Infoln(args ...interface{}) {
+	Logger().Debug().Msg(fmt.Sprintln(args...))
+}
+
+func (c *grpcLogger) Infof(format string, args ...interface{}) {
+	Logger().Debug().Msg(fmt.Sprintf(format, args...))
+}
+
+func (c *grpcLogger) Warning(args ...interface{}) {
+	Logger().Debug().Msg(fmt.Sprint(args...))
+}
+
+func (c *grpcLogger) Warningln(args ...interface{}) {
+	Logger().Debug().Msg(fmt.Sprintln(args...))
+}
+
+func (c *grpcLogger) Warningf(format string, args ...interface{}) {
+	Logger().Debug().Msg(fmt.Sprintf(format, args...))
+}
+
+func (c *grpcLogger) Error(args ...interface{}) {
+	Logger().Debug().Msg(fmt.Sprint(args...))
+}
+
+func (c *grpcLogger) Errorln(args ...interface{}) {
+	Logger().Debug().Msg(fmt.Sprintln(args...))
+}
+
+func (c *grpcLogger) Errorf(format string, args ...interface{}) {
+	Logger().Debug().Msg(fmt.Sprintf(format, args...))
+}
+
+func (c *grpcLogger) Fatal(args ...interface{}) {
+	Logger().Fatal().Msg(fmt.Sprint(args...))
+}
+
+func (c *grpcLogger) Fatalln(args ...interface{}) {
+	Logger().Fatal().Msg(fmt.Sprintln(args...))
+}
+
+func (c *grpcLogger) Fatalf(format string, args ...interface{}) {
+	Logger().Fatal().Msg(fmt.Sprintf(format, args...))
+}
+
+func (c *grpcLogger) V(int) bool {
+	return true
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -42,8 +42,7 @@ func init() {
 	log.Logger = l
 	// set the default context logger
 	zerolog.DefaultContextLogger = &l
-
-	SetLevel(zerolog.InfoLevel)
+	zapLevel.SetLevel(zapcore.InfoLevel)
 }
 
 // Logger returns the zerolog Logger.
@@ -54,6 +53,10 @@ func Logger() *zerolog.Logger {
 // ZapLogger returns the global zap logger.
 func ZapLogger() *zap.Logger {
 	return zapLogger.Load()
+}
+
+func GetLevel() zerolog.Level {
+	return zerolog.GlobalLevel()
 }
 
 // SetLevel sets the minimum global log level.

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -42,7 +42,8 @@ func init() {
 	log.Logger = l
 	// set the default context logger
 	zerolog.DefaultContextLogger = &l
-	zapLevel.SetLevel(zapcore.InfoLevel)
+
+	SetLevel(zerolog.InfoLevel)
 }
 
 // Logger returns the zerolog Logger.

--- a/internal/zero/cmd/command.go
+++ b/internal/zero/cmd/command.go
@@ -77,8 +77,6 @@ func setupLogger() error {
 			return err
 		}
 		log.SetLevel(lvl)
-	} else {
-		log.SetLevel(zerolog.InfoLevel)
 	}
 
 	return nil

--- a/internal/zero/cmd/command.go
+++ b/internal/zero/cmd/command.go
@@ -77,6 +77,8 @@ func setupLogger() error {
 			return err
 		}
 		log.SetLevel(lvl)
+	} else {
+		log.SetLevel(zerolog.InfoLevel)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

Previously, gRPC used default global logger, that caused mismatch with levels and format options configured across Pomerium.

This PR: 

1. sets default gRPC logger to use Pomerium global logger
2. only log gRPC related messages if debug level is enabled. 
 - By default, gRPC logs are rather verbose and have numerous transient errors as various Pomerium modules are initializing, that may be confusing to the user. 
 - if user enables pomerium `log_level: debug`, they would also observe all the gRPC transport related errors, without need to specifically adjust gRPC verbosity via [special env variables](https://pkg.go.dev/google.golang.org/grpc/examples/features/debugging#section-readme) which should be handy when troubleshooting Pomerium installation.
3. set default level to `info` in main.go, to avoid interfering with numerous tests that expect zerolog global default level to be debug

## Related issues

Fixes https://github.com/pomerium/internal/issues/1774

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
