### PR TITLE
health-check: building config from databroker source

### DIFF
--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -21,6 +21,7 @@ import (
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
+	"github.com/pomerium/pomerium/pkg/health"
 )
 
 // ConfigSource provides a new Config source that decorates an underlying config with
@@ -100,9 +101,11 @@ func (src *ConfigSource) rebuild(ctx context.Context, firstTime firstTime) {
 	now = time.Now()
 	err := src.buildNewConfigLocked(ctx, cfg)
 	if err != nil {
+		health.ReportError(health.BuildDatabrokerConfig, err)
 		log.Error(ctx).Err(err).Msg("databroker: failed to build new config")
 		return
 	}
+	health.ReportOK(health.BuildDatabrokerConfig)
 	log.Debug(ctx).Str("elapsed", time.Since(now).String()).Msg("databroker: built new config")
 
 	src.computedConfig = cfg

--- a/pkg/health/check.go
+++ b/pkg/health/check.go
@@ -5,6 +5,8 @@ import "fmt"
 type Check string
 
 const (
+	// BuildDatabrokerConfig checks whether the Databroker config was applied
+	BuildDatabrokerConfig = Check("config.databroker.build")
 	// StorageBackend checks whether the storage backend is healthy
 	StorageBackend = Check("storage.backend")
 	// XDSCluster checks whether the XDS Cluster resources were applied


### PR DESCRIPTION
## Summary

Adds health check to report whether rebuilding config from the databroker source was successful.

## Related issues

Related: https://github.com/pomerium/pomerium-zero/issues/2318


<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
