### PR TITLE
core/ci: store ui bundles in lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js filter=lfs diff=lfs merge=lfs -text
+*.css filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -27,12 +27,6 @@ jobs:
           go-version: ${{ matrix.go-version }}
           cache: false
 
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: yarn
-          cache-dependency-path: ui/yarn.lock
-
       - name: set env vars
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,11 +25,6 @@ jobs:
       - name: Unshallow
         run: git fetch --prune --unshallow
 
-      - name: Set up Node.js
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
-        with:
-          node-version: 16.x
-
       - name: Set up Go
         uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,7 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [1.22.x]
-        node-version: [16.x]
         platform: [ubuntu-latest]
         deployment: [multi, single]
         authenticate-flow: [stateful, stateless]
@@ -25,12 +24,6 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
           cache: false
-
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: yarn
-          cache-dependency-path: ui/yarn.lock
 
       - name: set env vars
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
@@ -64,16 +57,10 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
 
-      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
-        with:
-          node-version: ${{ matrix.node-version }}
-          cache: yarn
-          cache-dependency-path: ui/yarn.lock
-
       - name: build
         run: |
           make build-deps
-          make build
+          make build-go
 
       - name: save binary
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
@@ -128,6 +115,12 @@ jobs:
         with:
           go-version: 1.22.x
           cache: false
+
+      - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8
+        with:
+          node-version: 16.x
+          cache: yarn
+          cache-dependency-path: ui/yarn.lock
 
       - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -41,12 +41,10 @@ _testmain.go
 # Without this, the *.[568vq] above ignores this folder.
 !**/graphrbac/1.6
 
-
 .DS_Store
 .idea
 .vscode
 
-dist/*
 bin/*
 tags
 
@@ -59,16 +57,8 @@ tags
 *.ipr
 *.iml
 
-
-# dependencies
-ui/node_modules
-ui/bower_components
-ui/dist/index.js
-ui/dist/index.css
-
 # for building static assets
 node_modules
-package-lock.json
 
 # docs
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,3 +21,10 @@ repos:
         args: ["lint"]
         types: ["go"]
         pass_filenames: false
+      - id: ui
+        name: ui
+        language: system
+        entry: make
+        args: ["build-ui"]
+        files: "^ui/.*$"
+        pass_filenames: false

--- a/scripts/build-dev-docker.bash
+++ b/scripts/build-dev-docker.bash
@@ -5,7 +5,7 @@ _dir=/tmp/pomerium-dev-docker
 mkdir -p "$_dir"
 
 # build linux binary
-env GOOS=linux make build
+env GOOS=linux make build-go
 cp bin/pomerium $_dir/
 
 # build docker image

--- a/ui/dist/index.css
+++ b/ui/dist/index.css
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:34f0acb4526a45d4cea191afe8e550ed60e8b51596b31145d06d4e74380007b0
+size 128373

--- a/ui/dist/index.js
+++ b/ui/dist/index.js
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:91209bde5c37e460b2d7a9a29b9ccdd20a4eda35586eee567a0f5977451536bd
+size 3839392


### PR DESCRIPTION
## Summary
Store `index.js` and `index.css` using LFS.

## Related issues
For https://github.com/pomerium/internal/issues/1788
 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
