### PR TITLE
Ensure k3s runs as pid 1 in docker

### DIFF
--- a/integration/clusters/kubernetes/compose.yml
+++ b/integration/clusters/kubernetes/compose.yml
@@ -16,13 +16,13 @@ services:
           done
         ' &
       fi
-      k3s "$$@"
+      exec k3s "$$@"
     - k3s
     - agent
     environment:
       K3S_TOKEN: TOKEN
       K3S_URL: https://k3s-server:6443
-    image: rancher/k3s:${K3S_TAG:-v1.21.14-k3s1}
+    image: rancher/k3s:${K3S_TAG:-v1.30.0-k3s1}
     networks:
       main:
         aliases:
@@ -1003,7 +1003,7 @@ services:
       END_OF_MANIFEST
       kubectl apply -f /tmp/manifest.json
       sleep 30
-    image: rancher/k3s:${K3S_TAG:-v1.21.14-k3s1}
+    image: rancher/k3s:${K3S_TAG:-v1.30.0-k3s1}
     networks:
       main:
         aliases:
@@ -1038,7 +1038,7 @@ services:
           done
         ' &
       fi
-      k3s "$$@"
+      exec k3s "$$@"
     - k3s
     - server
     - --disable
@@ -1056,7 +1056,7 @@ services:
       - CMD
       - kubectl
       - cluster-info
-    image: rancher/k3s:${K3S_TAG:-v1.21.14-k3s1}
+    image: rancher/k3s:${K3S_TAG:-v1.30.0-k3s1}
     networks:
       main:
         aliases:

--- a/integration/tpl/backends/k3s.libsonnet
+++ b/integration/tpl/backends/k3s.libsonnet
@@ -15,7 +15,7 @@ local Command() =
           done
         ' &
       fi
-      k3s "$$@"
+      exec k3s "$$@"
     |||,
     'k3s',
   ];
@@ -30,7 +30,7 @@ local InstallManifest(manifest) =
     'kubectl wait --for=condition=available deployment/' + manifest.metadata.name,
   ] else []);
 
-local k3s_tag = 'v1.21.14-k3s1';
+local k3s_tag = 'v1.30.0-k3s1';
 
 function(idp, manifests) {
   compose: {


### PR DESCRIPTION
This fixes the k3s entrypoint script in the docker compose integration tests to ensure k3s runs as pid 1. This is required when running k3s in docker if the host is using cgroup2.

## Summary

K3s has some specific cgroup2 setup logic that is necessary for its kubelet to start correctly when running in docker. This logic is only invoked if k3s is running as pid 1.

## Related issues



## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
