### PR TITLE
[wip] telemetry: add method to push metrics on demand

### DIFF
--- a/internal/zero/controller/controller.go
+++ b/internal/zero/controller/controller.go
@@ -143,7 +143,7 @@ func (c *controller) runMetricsReporterLeased(ctx context.Context, client databr
 		return c.Str("service", "zero-reporter")
 	})
 
-	return c.api.ReportMetrics(ctx,
+	return c.api.ReportPeriodicMetrics(ctx,
 		reporter.WithCollectInterval(time.Hour),
 		reporter.WithMetrics(analytics.Metrics(func() databroker.DataBrokerServiceClient { return client })...),
 	)

--- a/internal/zero/reporter/reporter.go
+++ b/internal/zero/reporter/reporter.go
@@ -4,10 +4,14 @@ package reporter
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
+	"go.opentelemetry.io/otel/attribute"
 	export_grpc "go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	metric_sdk "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	semconv "go.opentelemetry.io/otel/semconv/v1.4.0"
 	"google.golang.org/grpc"
@@ -16,28 +20,51 @@ import (
 	"github.com/pomerium/pomerium/internal/version"
 )
 
-// Run starts loop that pushes metrics via OTEL protocol until ctx is canceled
-func Run(
+type Reporter struct {
+	exporter *export_grpc.Exporter
+	resource *resource.Resource
+}
+
+func New(ctx context.Context, conn *grpc.ClientConn) (*Reporter, error) {
+	exporter, err := export_grpc.New(ctx, export_grpc.WithGRPCConn(conn))
+	if err != nil {
+		return nil, fmt.Errorf("starting OTEL exporter: %w", err)
+	}
+	return &Reporter{
+		exporter: exporter,
+		resource: getResource(),
+	}, nil
+}
+
+func (r *Reporter) ReportMetrics(ctx context.Context, metrics []metricdata.Metrics) error {
+	bo := backoff.NewExponentialBackOff()
+	bo.MaxElapsedTime = 0
+
+	req := &metricdata.ResourceMetrics{
+		Resource: r.resource,
+		ScopeMetrics: []metricdata.ScopeMetrics{
+			{Metrics: metrics},
+		},
+	}
+	return backoff.RetryNotify(func() error {
+		return r.exporter.Export(ctx, req)
+	}, backoff.WithContext(bo, ctx), func(err error, d time.Duration) {
+		log.Ctx(ctx).Warn().Err(err).Str("retry_in", d.String()).Msg("error exporting metrics")
+	})
+}
+
+// RunPeriodicMetricReporter starts loop that pushes metrics collected periodically via OTEL protocol until ctx is canceled
+func (r *Reporter) RunPeriodicMetricReporter(
 	ctx context.Context,
-	conn *grpc.ClientConn,
 	opts ...Option,
 ) error {
 	cfg := getConfig(opts...)
 
-	exporter, err := export_grpc.New(ctx, export_grpc.WithGRPCConn(conn))
-	if err != nil {
-		return fmt.Errorf("starting OTEL exporter: %w", err)
-	}
-	defer shutdown(exporter.Shutdown, cfg.shutdownTimeout)
-
 	provider := metric_sdk.NewMeterProvider(
-		metric_sdk.WithResource(resource.NewSchemaless(
-			semconv.ServiceNameKey.String("pomerium-managed-core"),
-			semconv.ServiceVersionKey.String(version.FullVersion()),
-		)),
+		metric_sdk.WithResource(r.resource),
 		metric_sdk.WithReader(
 			metric_sdk.NewPeriodicReader(
-				exporter,
+				r.exporter,
 				metric_sdk.WithInterval(cfg.collectInterval),
 			)))
 	defer shutdown(provider.Shutdown, cfg.shutdownTimeout)
@@ -58,4 +85,18 @@ func shutdown(fn func(ctx context.Context) error, timeout time.Duration) {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	_ = fn(ctx)
+}
+
+func getResource() *resource.Resource {
+	attr := []attribute.KeyValue{
+		semconv.ServiceNameKey.String("pomerium-managed-core"),
+		semconv.ServiceVersionKey.String(version.FullVersion()),
+	}
+
+	hostname, err := os.Hostname()
+	if err == nil {
+		attr = append(attr, semconv.HostNameKey.String(hostname))
+	}
+
+	return resource.NewSchemaless(attr...)
 }

--- a/pkg/envoy/resource_monitor_other.go
+++ b/pkg/envoy/resource_monitor_other.go
@@ -9,6 +9,6 @@ import (
 	"github.com/pomerium/pomerium/config"
 )
 
-func NewSharedResourceMonitor(ctx context.Context, src config.Source, tempDir string) (ResourceMonitor, error) {
+func NewSharedResourceMonitor(_ context.Context, _ config.Source, _ string) (ResourceMonitor, error) {
 	return nil, errors.New("unsupported platform")
 }


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
