### PR TITLE
core/zero: use exit code 0 for bad requests

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -6,6 +6,8 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"os"
+	"strings"
 
 	"github.com/rs/zerolog"
 
@@ -40,6 +42,12 @@ func main() {
 	}
 
 	if err := runFn(ctx); err != nil && !errors.Is(err, context.Canceled) {
+		// if the error was due to a bad request, return 0 as the exit code
+		if strings.Contains(err.Error(), "bad request") {
+			log.Logger().WithLevel(zerolog.FatalLevel).Err(err).Msg("cmd/pomerium")
+			log.Writer.Close()
+			os.Exit(0)
+		}
 		log.Fatal().Err(err).Msg("cmd/pomerium")
 	}
 	log.Info(ctx).Msg("cmd/pomerium: exiting")

--- a/internal/log/multiwriter.go
+++ b/internal/log/multiwriter.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"errors"
 	"io"
 	"slices"
 	"sync"
@@ -22,6 +23,19 @@ func (m *MultiWriter) Add(w io.Writer) {
 	m.mu.Lock()
 	m.ws = append(m.ws, w)
 	m.mu.Unlock()
+}
+
+// Close closes the multi writer.
+func (m *MultiWriter) Close() error {
+	var err error
+	m.mu.Lock()
+	for _, w := range m.ws {
+		if c, ok := w.(io.Closer); ok {
+			err = errors.Join(err, c.Close())
+		}
+	}
+	m.mu.Unlock()
+	return err
 }
 
 // Remove removes a writer from the multi writer.


### PR DESCRIPTION
## Summary
Instead of exiting with 1 on a bad request error exit with 0.

## Related issues
- https://github.com/pomerium/pomerium-zero/issues/1748
 

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
