### PR TITLE
envoy: upgrade to v1.30.2

### DIFF
--- a/scripts/get-envoy.bash
+++ b/scripts/get-envoy.bash
@@ -5,7 +5,7 @@ PATH="$PATH:$(go env GOPATH)/bin"
 export PATH
 
 _project_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)/.."
-_envoy_version=1.30.1
+_envoy_version=1.30.2
 _dir="$_project_root/pkg/envoy/files"
 
 for _target in darwin-amd64 darwin-arm64 linux-amd64 linux-arm64; do


### PR DESCRIPTION
## Summary

Upgrade Envoy from v1.30.1 to v1.30.2.

Release notes:

- https://www.envoyproxy.io/docs/envoy/v1.30.2/version_history/v1.30/v1.30.2

## Related issues

- https://github.com/pomerium/internal/issues/1821

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
