### PR TITLE
core/authorize: use uuid for jti, current time for iat and exp

### DIFF
--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -100,8 +100,8 @@ type HeadersEvaluator struct {
 }
 
 // NewHeadersEvaluator creates a new HeadersEvaluator.
-func NewHeadersEvaluator(ctx context.Context, store *store.Store) (*HeadersEvaluator, error) {
-	r := rego.New(
+func NewHeadersEvaluator(ctx context.Context, store *store.Store, options ...func(rego *rego.Rego)) (*HeadersEvaluator, error) {
+	r := rego.New(append([]func(*rego.Rego){
 		rego.Store(store),
 		rego.Module("pomerium.headers", opa.HeadersRego),
 		rego.Query("result := data.pomerium.headers"),
@@ -110,7 +110,7 @@ func NewHeadersEvaluator(ctx context.Context, store *store.Store) (*HeadersEvalu
 		variableSubstitutionFunctionRegoOption,
 		store.GetDataBrokerRecordOption(),
 		rego.SetRegoVersion(ast.RegoV1),
-	)
+	}, options...)...)
 
 	q, err := r.PrepareForEval(ctx)
 	if err != nil {

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"math"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/open-policy-agent/opa/rego"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -74,13 +75,15 @@ func TestHeadersEvaluator(t *testing.T) {
 	publicJWK, err := cryptutil.PublicJWKFromBytes(encodedSigningKey)
 	require.NoError(t, err)
 
+	evalTime := time.Now().Round(time.Second)
+
 	eval := func(t *testing.T, data []proto.Message, input *HeadersRequest) (*HeadersResponse, error) {
 		ctx := context.Background()
 		ctx = storage.WithQuerier(ctx, storage.NewStaticQuerier(data...))
 		store := store.New()
 		store.UpdateJWTClaimHeaders(config.NewJWTClaimHeaders("email", "groups", "user", "CUSTOM_KEY"))
 		store.UpdateSigningKey(privateJWK)
-		e, err := NewHeadersEvaluator(ctx, store)
+		e, err := NewHeadersEvaluator(ctx, store, rego.Time(evalTime))
 		require.NoError(t, err)
 		return e.Evaluate(ctx, input)
 	}
@@ -119,14 +122,10 @@ func TestHeadersEvaluator(t *testing.T) {
 		require.NoError(t, err)
 
 		// The 'iat' claim is set from the session store.
-		assert.Equal(t, json.Number("1686870680"), jwtPayloadDecoded["iat"],
+		assert.Equal(t, json.Number(fmt.Sprint(evalTime.Unix())), jwtPayloadDecoded["iat"],
 			"unexpected 'iat' timestamp format")
-
-		// The 'exp' claim will vary with the current time, but we can still
-		// use Atoi() to verify that it can be parsed as an integer.
-		exp := string(jwtPayloadDecoded["exp"].(json.Number))
-		_, err = strconv.Atoi(exp)
-		assert.NoError(t, err, "unexpected 'exp' timestamp format")
+		assert.Equal(t, json.Number(fmt.Sprint(evalTime.Add(5*time.Minute).Unix())), jwtPayloadDecoded["exp"],
+			"unexpected 'exp' timestamp format")
 
 		rawJWT, err := jwt.ParseSigned(jwtHeader)
 		require.NoError(t, err)
@@ -135,6 +134,7 @@ func TestHeadersEvaluator(t *testing.T) {
 		err = rawJWT.Claims(publicJWK, &claims)
 		require.NoError(t, err)
 
+		assert.NotEmpty(t, claims["jti"])
 		assert.Equal(t, claims["iss"], "from.example.com")
 		assert.Equal(t, claims["aud"], "from.example.com")
 		assert.Equal(t, claims["exp"], math.Round(claims["exp"].(float64)))

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -121,7 +121,7 @@ func TestHeadersEvaluator(t *testing.T) {
 		err = d.Decode(&jwtPayloadDecoded)
 		require.NoError(t, err)
 
-		// The 'iat' claim is set from the session store.
+		// The 'iat' and 'exp' claims are set based on the current time.
 		assert.Equal(t, json.Number(fmt.Sprint(evalTime.Unix())), jwtPayloadDecoded["iat"],
 			"unexpected 'iat' timestamp format")
 		assert.Equal(t, json.Number(fmt.Sprint(evalTime.Add(5*time.Minute).Unix())), jwtPayloadDecoded["exp"],

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -537,7 +537,7 @@ func TestPomeriumJWT(t *testing.T) {
 
 	// Obtain a Pomerium attestation JWT from the /.pomerium/jwt endpoint. The
 	// contents should be identical to the JWT header (except possibly the
-	// timestamps). (https://github.com/pomerium/pomerium/issues/4210)
+	// timestamps and the jtis). (https://github.com/pomerium/pomerium/issues/4210)
 	res, err = client.Get("https://restricted-httpdetails.localhost.pomerium.io/.pomerium/jwt")
 	require.NoError(t, err)
 	defer res.Body.Close()
@@ -549,8 +549,10 @@ func TestPomeriumJWT(t *testing.T) {
 	// Remove timestamps before comparing.
 	delete(p, "iat")
 	delete(p, "exp")
+	delete(p, "jti")
 	delete(p2, "iat")
 	delete(p2, "exp")
+	delete(p2, "jti")
 	assert.Equal(t, p, p2)
 }
 


### PR DESCRIPTION
## Summary
Update JWT assertion generation:

1. `jti` is now a random UUID instead of the session id
2. `iat` is now the current time
3. `exp` is now the current time + 5 minutes

## Related issues
- https://github.com/pomerium/internal/issues/1834


## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
