### PR TITLE
envoy: upgrade to v1.30.3

### DIFF
--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	envoyVersion = "1.30.2"
+	envoyVersion = "1.30.3"
 	targets      = []string{
 		"darwin-amd64",
 		"darwin-arm64",


### PR DESCRIPTION
## Summary

Upgrade Envoy from v1.30.2 to v1.30.3.

Release notes:

- https://www.envoyproxy.io/docs/envoy/v1.30.3/version_history/v1.30/v1.30.3

## Related issues

- https://github.com/pomerium/internal/issues/1821

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
