### PR TITLE
zero: set fixed start time for active users test

### DIFF
--- a/internal/zero/telemetry/sessions/activeusers_test.go
+++ b/internal/zero/telemetry/sessions/activeusers_test.go
@@ -12,7 +12,7 @@ import (
 func TestActiveUsers(t *testing.T) {
 	t.Parallel()
 
-	startTime := time.Now().UTC()
+	startTime := time.Date(2024, time.June, 26, 12, 0, 0, 0, time.UTC)
 
 	// Create a new counter that resets on a daily interval
 	c := sessions.NewActiveUsersCounter(sessions.ResetDailyUTC, startTime)


### PR DESCRIPTION
## Summary

Set a fixed start time in the TestActiveUsers unit test to avoid any unintended behavior if run just before midnight UTC.

## Related issues

- https://github.com/pomerium/pomerium/issues/5153

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
