### PR TITLE
controlplane: avoid calling Close on nil listener

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -121,7 +121,7 @@ func NewServer(cfg *config.Config, metricsMgr *config.MetricsManager, eventsMgr 
 	if err != nil {
 		_ = srv.GRPCListener.Close()
 		_ = srv.HTTPListener.Close()
-		_ = srv.DebugListener.Close()
+		_ = srv.MetricsListener.Close()
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary

Tweak the cleanup logic in controlplane.NewServer(). Following the pattern of the other two `net.Listen` calls I think the intent was to call `MetricsListener.Close()` if the `DebugListener` fails to start, rather than `DebugListener.Close()`.

There was a nil panic from this line in a recent integration test run:
https://github.com/pomerium/pomerium/actions/runs/9688646705/job/26735594932?pr=5155#step:8:74

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
