### PR TITLE
core/ui: add user info link

### DIFF
--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -123,10 +123,10 @@ func NewHeadersEvaluator(ctx context.Context, store *store.Store, options ...fun
 }
 
 // Evaluate evaluates the headers.rego script.
-func (e *HeadersEvaluator) Evaluate(ctx context.Context, req *HeadersRequest) (*HeadersResponse, error) {
+func (e *HeadersEvaluator) Evaluate(ctx context.Context, req *HeadersRequest, options ...rego.EvalOption) (*HeadersResponse, error) {
 	ctx, span := trace.StartSpan(ctx, "authorize.HeadersEvaluator.Evaluate")
 	defer span.End()
-	rs, err := safeEval(ctx, e.q, rego.EvalInput(req))
+	rs, err := safeEval(ctx, e.q, append([]rego.EvalOption{rego.EvalInput(req)}, options...)...)
 	if err != nil {
 		return nil, fmt.Errorf("authorize: error evaluating headers.rego: %w", err)
 	}

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -68,6 +68,11 @@ const Header: FC<HeaderProps> = ({ includeSidebar, data }) => {
     setDrawerOpen(false);
   };
 
+  const handleUserInfo = (evt: React.MouseEvent): void => {
+    evt.preventDefault();
+    location.href = "/.pomerium/";
+  };
+
   const handleLogout = (evt: React.MouseEvent): void => {
     evt.preventDefault();
     location.href = "/.pomerium/sign_out";
@@ -139,6 +144,7 @@ const Header: FC<HeaderProps> = ({ includeSidebar, data }) => {
           open={!!anchorEl}
           anchorEl={anchorEl}
         >
+          <MenuItem onClick={handleUserInfo}>User Info</MenuItem>
           <MenuItem onClick={handleLogout}>Logout</MenuItem>
         </Menu>
       </Toolbar>

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -70,7 +70,7 @@ const Header: FC<HeaderProps> = ({ includeSidebar, data }) => {
 
   const handleUserInfo = (evt: React.MouseEvent): void => {
     evt.preventDefault();
-    location.href = "/.pomerium/";
+    window.open("/.pomerium/");
   };
 
   const handleLogout = (evt: React.MouseEvent): void => {


### PR DESCRIPTION
## Summary
Add a user info link in the header dropdown that points to `/.pomerium/`.

## Related issues
For https://github.com/pomerium/internal/issues/1831


## Checklist
- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
