### PR TITLE
core/identity: trim trailing slashes

### DIFF
--- a/pkg/identity/oauth/apple/apple.go
+++ b/pkg/identity/oauth/apple/apple.go
@@ -48,13 +48,7 @@ type Provider struct {
 
 // New instantiates an OpenID Connect (OIDC) provider for Apple.
 func New(_ context.Context, o *oauth.Options) (*Provider, error) {
-	options := *o
-	if options.ProviderURL == "" {
-		options.ProviderURL = defaultProviderURL
-	}
-	if len(options.Scopes) == 0 {
-		options.Scopes = defaultScopes
-	}
+	options := *GetOptions(o)
 
 	p := Provider{}
 	p.authCodeOptions = make(map[string]string)
@@ -181,4 +175,10 @@ func (p *Provider) SignIn(w http.ResponseWriter, r *http.Request, state string) 
 // SignOut is not implemented.
 func (p *Provider) SignOut(_ http.ResponseWriter, _ *http.Request, _, _, _ string) error {
 	return oidc.ErrSignoutNotImplemented
+}
+
+// GetOptions gets the options as expected for apple.
+func GetOptions(o *oauth.Options) *oauth.Options {
+	return o.SetDefaultProviderURL(defaultProviderURL).
+		SetDefaultScopes(defaultScopes)
 }

--- a/pkg/identity/oauth/apple/apple_test.go
+++ b/pkg/identity/oauth/apple/apple_test.go
@@ -1,0 +1,23 @@
+package apple_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oauth/apple"
+)
+
+func TestGetOptions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"https://appleid.apple.com",
+		apple.GetOptions(&oauth.Options{}).ProviderURL,
+		"should set default provider url")
+	assert.Equal(t,
+		[]string{"name", "email"},
+		apple.GetOptions(&oauth.Options{}).Scopes,
+		"should set default scopes")
+}

--- a/pkg/identity/oauth/github/github.go
+++ b/pkg/identity/oauth/github/github.go
@@ -57,10 +57,9 @@ type Provider struct {
 
 // New instantiates an OAuth2 provider for Github.
 func New(_ context.Context, o *oauth.Options) (*Provider, error) {
+	o = GetOptions(o)
+
 	p := Provider{}
-	if o.ProviderURL == "" {
-		o.ProviderURL = defaultProviderURL
-	}
 
 	// when the default provider url is used, use the Github API endpoint
 	if o.ProviderURL == defaultProviderURL {
@@ -71,9 +70,6 @@ func New(_ context.Context, o *oauth.Options) (*Provider, error) {
 		p.emailEndpoint = urlutil.Join(o.ProviderURL, emailPath)
 	}
 
-	if len(o.Scopes) == 0 {
-		o.Scopes = defaultScopes
-	}
 	p.Oauth = &oauth2.Config{
 		ClientID:     o.ClientID,
 		ClientSecret: o.ClientSecret,
@@ -255,4 +251,10 @@ func (p *Provider) SignIn(w http.ResponseWriter, r *http.Request, state string) 
 // SignOut is not implemented.
 func (p *Provider) SignOut(_ http.ResponseWriter, _ *http.Request, _, _, _ string) error {
 	return oidc.ErrSignoutNotImplemented
+}
+
+// GetOptions gets the options as expected for github.
+func GetOptions(o *oauth.Options) *oauth.Options {
+	return o.SetDefaultProviderURL(defaultProviderURL).
+		SetDefaultScopes(defaultScopes)
 }

--- a/pkg/identity/oauth/github/github_test.go
+++ b/pkg/identity/oauth/github/github_test.go
@@ -1,0 +1,23 @@
+package github_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oauth/github"
+)
+
+func TestGetOptions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"https://github.com",
+		github.GetOptions(&oauth.Options{}).ProviderURL,
+		"should set default provider url")
+	assert.Equal(t,
+		[]string{"user:email", "read:org"},
+		github.GetOptions(&oauth.Options{}).Scopes,
+		"should set default scopes")
+}

--- a/pkg/identity/oauth/options.go
+++ b/pkg/identity/oauth/options.go
@@ -3,7 +3,10 @@
 // authorization with Bearer JWT.
 package oauth
 
-import "net/url"
+import (
+	"net/url"
+	"strings"
+)
 
 // Options contains the fields required for an OAuth 2.0 (inc. OIDC) auth flow.
 //
@@ -29,4 +32,48 @@ type Options struct {
 	// AuthCodeOptions specifies additional key value pairs query params to add
 	// to the request flow signin url.
 	AuthCodeOptions map[string]string
+}
+
+func (o *Options) EnsureTrailingSlashOnProviderURL() *Options {
+	if strings.HasSuffix(o.ProviderURL, "/") {
+		return o
+	}
+
+	n := new(Options)
+	*n = *o
+	n.ProviderURL += "/"
+	return n
+}
+
+func (o *Options) SetDefaultProviderURL(defaultProviderURL string) *Options {
+	if o.ProviderURL != "" {
+		return o
+	}
+
+	n := new(Options)
+	*n = *o
+	n.ProviderURL = defaultProviderURL
+	return n
+}
+
+func (o *Options) SetDefaultScopes(defaultScopes []string) *Options {
+	if len(o.Scopes) != 0 {
+		return o
+	}
+
+	n := new(Options)
+	*n = *o
+	n.Scopes = defaultScopes
+	return n
+}
+
+func (o *Options) TrimTrailingSlashFromProviderURL() *Options {
+	if !strings.HasSuffix(o.ProviderURL, "/") {
+		return o
+	}
+
+	n := new(Options)
+	*n = *o
+	n.ProviderURL = strings.TrimSuffix(n.ProviderURL, "/")
+	return n
 }

--- a/pkg/identity/oidc/auth0/auth0.go
+++ b/pkg/identity/oidc/auth0/auth0.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/urlutil"
@@ -28,13 +27,7 @@ type Provider struct {
 
 // New instantiates an OpenID Connect (OIDC) provider for Auth0.
 func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
-	// allow URLs that don't have a trailing slash
-	if !strings.HasSuffix(o.ProviderURL, "/") {
-		tmp := new(oauth.Options)
-		*tmp = *o
-		tmp.ProviderURL += "/"
-		o = tmp
-	}
+	o = GetOptions(o)
 
 	var p Provider
 	var err error
@@ -79,4 +72,9 @@ func (p *Provider) SignOut(w http.ResponseWriter, r *http.Request, _, authentica
 
 	httputil.Redirect(w, r, logoutURL.String(), http.StatusFound)
 	return nil
+}
+
+// GetOptions gets the options as expected for auth0.
+func GetOptions(o *oauth.Options) *oauth.Options {
+	return o.EnsureTrailingSlashOnProviderURL()
 }

--- a/pkg/identity/oidc/auth0/auth0_test.go
+++ b/pkg/identity/oidc/auth0/auth0_test.go
@@ -1,4 +1,4 @@
-package auth0
+package auth0_test
 
 import (
 	"context"
@@ -13,7 +13,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/auth0"
 )
+
+func TestGetOptions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"https://www.example.com/",
+		auth0.GetOptions(&oauth.Options{ProviderURL: "https://www.example.com"}).ProviderURL,
+		"should ensure trailing slash")
+}
 
 func TestProvider(t *testing.T) {
 	t.Parallel()
@@ -44,7 +54,7 @@ func TestProvider(t *testing.T) {
 	redirectURL, err := url.Parse(srv.URL)
 	require.NoError(t, err)
 
-	p, err := New(ctx, &oauth.Options{
+	p, err := auth0.New(ctx, &oauth.Options{
 		ProviderURL:  srv.URL,
 		RedirectURL:  redirectURL,
 		ClientID:     "CLIENT_ID",

--- a/pkg/identity/oidc/azure/microsoft.go
+++ b/pkg/identity/oidc/azure/microsoft.go
@@ -41,11 +41,10 @@ type Provider struct {
 
 // New instantiates an OpenID Connect (OIDC) provider for Azure.
 func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
+	o = GetOptions(o)
+
 	var p Provider
 	var err error
-	if o.ProviderURL == "" {
-		o.ProviderURL = defaultProviderURL
-	}
 	genericOidc, err := newProvider(ctx, o,
 		pom_oidc.WithGetVerifier(func(provider *go_oidc.Provider) *go_oidc.IDTokenVerifier {
 			return provider.Verifier(&go_oidc.Config{
@@ -127,4 +126,10 @@ func (transport *wellKnownConfiguration) RoundTrip(req *http.Request) (*http.Res
 
 	res.Body = io.NopCloser(bytes.NewReader(bs))
 	return res, nil
+}
+
+// GetOptions gets the options as expected for azure.
+func GetOptions(o *oauth.Options) *oauth.Options {
+	return o.SetDefaultProviderURL(defaultProviderURL).
+		TrimTrailingSlashFromProviderURL()
 }

--- a/pkg/identity/oidc/azure/microsoft_test.go
+++ b/pkg/identity/oidc/azure/microsoft_test.go
@@ -1,4 +1,4 @@
-package azure
+package azure_test
 
 import (
 	"context"
@@ -8,16 +8,30 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/azure"
 )
 
 func TestAuthCodeOptions(t *testing.T) {
 	var options oauth.Options
-	p, err := New(context.Background(), &options)
+	p, err := azure.New(context.Background(), &options)
 	require.NoError(t, err)
-	assert.Equal(t, defaultAuthCodeOptions, p.AuthCodeOptions)
+	assert.Equal(t, map[string]string{"prompt": "select_account"}, p.AuthCodeOptions)
 
 	options.AuthCodeOptions = map[string]string{}
-	p, err = New(context.Background(), &options)
+	p, err = azure.New(context.Background(), &options)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{}, p.AuthCodeOptions)
+}
+
+func TestGetOptions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"https://login.microsoftonline.com/common/v2.0",
+		azure.GetOptions(&oauth.Options{}).ProviderURL,
+		"should set default provider url")
+	assert.Equal(t,
+		"https://www.example.com",
+		azure.GetOptions(&oauth.Options{ProviderURL: "https://www.example.com/"}).ProviderURL,
+		"should trim trailing slash")
 }

--- a/pkg/identity/oidc/cognito/cognito.go
+++ b/pkg/identity/oidc/cognito/cognito.go
@@ -24,14 +24,12 @@ type Provider struct {
 }
 
 // New instantiates an OpenID Connect (OIDC) provider for AWS Cognito.
-func New(ctx context.Context, opts *oauth.Options) (*Provider, error) {
+func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
+	o = GetOptions(o)
+
 	var p Provider
 
-	if opts.Scopes == nil {
-		opts.Scopes = defaultScopes
-	}
-
-	genericOIDC, err := pom_oidc.New(ctx, opts)
+	genericOIDC, err := pom_oidc.New(ctx, o)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating oidc provider: %w", err)
 	}
@@ -80,4 +78,10 @@ func (p *Provider) SignOut(w http.ResponseWriter, r *http.Request, _, authentica
 	})
 	httputil.Redirect(w, r, logOutURL.String(), http.StatusFound)
 	return nil
+}
+
+// GetOptions gets the options as expected for cognito.
+func GetOptions(o *oauth.Options) *oauth.Options {
+	return o.SetDefaultScopes(defaultScopes).
+		TrimTrailingSlashFromProviderURL()
 }

--- a/pkg/identity/oidc/cognito/cognito_test.go
+++ b/pkg/identity/oidc/cognito/cognito_test.go
@@ -1,4 +1,4 @@
-package cognito
+package cognito_test
 
 import (
 	"context"
@@ -13,7 +13,21 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/cognito"
 )
+
+func TestGetOptions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		[]string{"openid", "email", "profile"},
+		cognito.GetOptions(&oauth.Options{}).Scopes,
+		"should set default scopes")
+	assert.Equal(t,
+		"https://www.example.com",
+		cognito.GetOptions(&oauth.Options{ProviderURL: "https://www.example.com/"}).ProviderURL,
+		"should trim trailing slash")
+}
 
 func TestProvider(t *testing.T) {
 	t.Parallel()
@@ -44,7 +58,7 @@ func TestProvider(t *testing.T) {
 	redirectURL, err := url.Parse(srv.URL)
 	require.NoError(t, err)
 
-	p, err := New(ctx, &oauth.Options{
+	p, err := cognito.New(ctx, &oauth.Options{
 		ProviderURL:  srv.URL,
 		RedirectURL:  redirectURL,
 		ClientID:     "CLIENT_ID",

--- a/pkg/identity/oidc/gitlab/gitlab.go
+++ b/pkg/identity/oidc/gitlab/gitlab.go
@@ -29,14 +29,10 @@ type Provider struct {
 
 // New instantiates an OpenID Connect (OIDC) provider for Gitlab.
 func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
+	o = GetOptions(o)
+
 	var p Provider
 	var err error
-	if o.ProviderURL == "" {
-		o.ProviderURL = defaultProviderURL
-	}
-	if len(o.Scopes) == 0 {
-		o.Scopes = defaultScopes
-	}
 	genericOidc, err := pom_oidc.New(ctx, o)
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed creating oidc provider: %w", Name, err)
@@ -49,4 +45,11 @@ func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
 // Name returns the provider name.
 func (p *Provider) Name() string {
 	return Name
+}
+
+// GetOptions gets the options as expected for gitlab.
+func GetOptions(o *oauth.Options) *oauth.Options {
+	return o.SetDefaultProviderURL(defaultProviderURL).
+		SetDefaultScopes(defaultScopes).
+		TrimTrailingSlashFromProviderURL()
 }

--- a/pkg/identity/oidc/gitlab/gitlab_test.go
+++ b/pkg/identity/oidc/gitlab/gitlab_test.go
@@ -1,0 +1,72 @@
+package gitlab_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/gitlab"
+)
+
+func TestGetOptions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"https://gitlab.com",
+		gitlab.GetOptions(&oauth.Options{}).ProviderURL,
+		"should set default provider url")
+	assert.Equal(t,
+		[]string{"openid", "profile", "email"},
+		gitlab.GetOptions(&oauth.Options{}).Scopes,
+		"should set default scopes")
+	assert.Equal(t,
+		"https://gitlab.com",
+		gitlab.GetOptions(&oauth.Options{ProviderURL: "https://gitlab.com/"}).ProviderURL,
+		"should trim trailing slash")
+}
+
+func TestTrimsSlash(t *testing.T) {
+	t.Parallel()
+
+	srv := startMockServer(t)
+
+	ctx := context.Background()
+	options := &oauth.Options{
+		ProviderName: gitlab.Name,
+		ProviderURL:  srv.URL + "/",
+	}
+	provider, err := gitlab.New(ctx, options)
+	assert.NoError(t, err)
+	_, err = provider.GetProvider()
+	assert.NoError(t, err)
+}
+
+func startMockServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	var srv *httptest.Server
+	srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		baseURL, err := url.Parse(srv.URL)
+		require.NoError(t, err)
+
+		switch r.URL.Path {
+		case "/.well-known/openid-configuration":
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]any{
+				"issuer":                 baseURL.String(),
+				"authorization_endpoint": srv.URL + "/authorize",
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}

--- a/pkg/identity/oidc/google/google.go
+++ b/pkg/identity/oidc/google/google.go
@@ -40,14 +40,10 @@ type Provider struct {
 
 // New instantiates an OpenID Connect (OIDC) session with Google.
 func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
+	o = GetOptions(o)
+
 	var p Provider
 	var err error
-	if o.ProviderURL == "" {
-		o.ProviderURL = defaultProviderURL
-	}
-	if len(o.Scopes) == 0 {
-		o.Scopes = defaultScopes
-	}
 	genericOidc, err := pom_oidc.New(ctx, o)
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed creating oidc provider: %w", Name, err)
@@ -64,4 +60,11 @@ func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
 // Name returns the provider name.
 func (p *Provider) Name() string {
 	return Name
+}
+
+// GetOptions gets the options as expected for google.
+func GetOptions(o *oauth.Options) *oauth.Options {
+	return o.SetDefaultProviderURL(defaultProviderURL).
+		SetDefaultScopes(defaultScopes).
+		TrimTrailingSlashFromProviderURL()
 }

--- a/pkg/identity/oidc/google/google_test.go
+++ b/pkg/identity/oidc/google/google_test.go
@@ -1,4 +1,4 @@
-package google
+package google_test
 
 import (
 	"context"
@@ -8,16 +8,36 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/google"
 )
 
 func TestAuthCodeOptions(t *testing.T) {
+	t.Parallel()
+
 	var options oauth.Options
-	p, err := New(context.Background(), &options)
+	p, err := google.New(context.Background(), &options)
 	require.NoError(t, err)
-	assert.Equal(t, defaultAuthCodeOptions, p.AuthCodeOptions)
+	assert.Equal(t, map[string]string{"prompt": "select_account consent", "access_type": "offline"}, p.AuthCodeOptions)
 
 	options.AuthCodeOptions = map[string]string{}
-	p, err = New(context.Background(), &options)
+	p, err = google.New(context.Background(), &options)
 	require.NoError(t, err)
 	assert.Equal(t, map[string]string{}, p.AuthCodeOptions)
+}
+
+func TestGetOptions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"https://accounts.google.com",
+		google.GetOptions(&oauth.Options{}).ProviderURL,
+		"should set default provider url")
+	assert.Equal(t,
+		[]string{"openid", "profile", "email"},
+		google.GetOptions(&oauth.Options{}).Scopes,
+		"should set default scopes")
+	assert.Equal(t,
+		"https://accounts.google.com",
+		google.GetOptions(&oauth.Options{ProviderURL: "https://accounts.google.com/"}).ProviderURL,
+		"should trim trailing slash")
 }

--- a/pkg/identity/oidc/okta/okta.go
+++ b/pkg/identity/oidc/okta/okta.go
@@ -23,6 +23,8 @@ type Provider struct {
 
 // New instantiates an OpenID Connect (OIDC) provider for Okta.
 func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
+	o = GetOptions(o)
+
 	var p Provider
 	var err error
 	genericOidc, err := pom_oidc.New(ctx, o)
@@ -37,4 +39,9 @@ func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
 // Name returns the provider name.
 func (p *Provider) Name() string {
 	return Name
+}
+
+// GetOptions gets the options as expected for okta.
+func GetOptions(o *oauth.Options) *oauth.Options {
+	return o.TrimTrailingSlashFromProviderURL()
 }

--- a/pkg/identity/oidc/okta/okta_test.go
+++ b/pkg/identity/oidc/okta/okta_test.go
@@ -1,0 +1,19 @@
+package okta_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/okta"
+)
+
+func TestGetOptions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"https://awesomecompany.okta.com",
+		okta.GetOptions(&oauth.Options{ProviderURL: "https://awesomecompany.okta.com/"}).ProviderURL,
+		"should trim trailing slash")
+}

--- a/pkg/identity/oidc/onelogin/onelogin.go
+++ b/pkg/identity/oidc/onelogin/onelogin.go
@@ -33,16 +33,10 @@ type Provider struct {
 
 // New instantiates an OpenID Connect (OIDC) provider for OneLogin.
 func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
+	o = GetOptions(o)
+
 	var p Provider
 	var err error
-	if o.ProviderURL == "" {
-		o.ProviderURL = defaultProviderURL
-	}
-	if strings.Contains(o.ProviderURL, "/oidc/2") {
-		o.Scopes = defaultV2Scopes
-	} else {
-		o.Scopes = defaultV1Scopes
-	}
 	genericOidc, err := pom_oidc.New(ctx, o)
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed creating oidc provider: %w", Name, err)
@@ -54,4 +48,16 @@ func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
 // Name returns the provider name.
 func (p *Provider) Name() string {
 	return Name
+}
+
+// GetOptions gets the options as expected for onelogin.
+func GetOptions(o *oauth.Options) *oauth.Options {
+	o = o.SetDefaultProviderURL(defaultProviderURL).
+		TrimTrailingSlashFromProviderURL()
+	if strings.Contains(o.ProviderURL, "/oidc/2") {
+		o = o.SetDefaultScopes(defaultV2Scopes)
+	} else {
+		o = o.SetDefaultScopes(defaultV1Scopes)
+	}
+	return o
 }

--- a/pkg/identity/oidc/onelogin/onelogin_test.go
+++ b/pkg/identity/oidc/onelogin/onelogin_test.go
@@ -1,0 +1,31 @@
+package onelogin_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/onelogin"
+)
+
+func TestGetOptions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"https://openid-connect.onelogin.com/oidc",
+		onelogin.GetOptions(&oauth.Options{}).ProviderURL,
+		"should set default provider url")
+	assert.Equal(t,
+		[]string{"openid", "profile", "email", "groups", "offline_access"},
+		onelogin.GetOptions(&oauth.Options{ProviderURL: "https://openid-connect.onelogin.com/oidc"}).Scopes,
+		"should set default v1 scopes")
+	assert.Equal(t,
+		[]string{"openid", "profile", "email", "groups"},
+		onelogin.GetOptions(&oauth.Options{ProviderURL: "https://openid-connect.onelogin.com/oidc/2"}).Scopes,
+		"should set default v2 scopes")
+	assert.Equal(t,
+		"https://openid-connect.onelogin.com/oidc",
+		onelogin.GetOptions(&oauth.Options{ProviderURL: "https://openid-connect.onelogin.com/oidc/"}).ProviderURL,
+		"should trim trailing slash")
+}

--- a/pkg/identity/oidc/ping/ping.go
+++ b/pkg/identity/oidc/ping/ping.go
@@ -23,6 +23,8 @@ type Provider struct {
 
 // New instantiates an OpenID Connect (OIDC) provider for Ping.
 func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
+	o = GetOptions(o)
+
 	var p Provider
 	var err error
 	genericOidc, err := pom_oidc.New(ctx, o)
@@ -36,4 +38,9 @@ func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
 // Name returns the provider name.
 func (p *Provider) Name() string {
 	return Name
+}
+
+// GetOptions gets the options as expected for ping.
+func GetOptions(o *oauth.Options) *oauth.Options {
+	return o.TrimTrailingSlashFromProviderURL()
 }

--- a/pkg/identity/oidc/ping/ping_test.go
+++ b/pkg/identity/oidc/ping/ping_test.go
@@ -1,0 +1,19 @@
+package ping_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/ping"
+)
+
+func TestGetOptions(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t,
+		"https://www.example.com",
+		ping.GetOptions(&oauth.Options{ProviderURL: "https://www.example.com/"}).ProviderURL,
+		"should trim trailing slash")
+}


### PR DESCRIPTION
## Summary

With `gitlab` if the `idp_provider_url` has a trailing slash like `https://gitlab.com/` a 500 will be returned with this error:

```json
{
  "level": "error",
  "ip": "127.0.0.1",
  "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36",
  "request-id": "c5869945-12e4-4de3-900b-c0e5b0637b20",
  "error": "failed to sign in: identity/oidc: could not connect to gitlab: oidc: issuer did not match the issuer returned by provider, expected \"https://gitlab.com/\" got \"https://gitlab.com\"",
  "status": 500,
  "status-text": "Internal Server Error",
  "time": "2024-06-28T15:20:11-07:00",
  "message": "httputil: error"
}
```

This PR fixes this.

Confusingly this can't be done universally, in fact `auth0` has just the opposite requirement and the `idp_provider_url` must end in a `/` (we already had code to add this)

So I've added a new `GetOptions` function to every identity provider. This takes in an `*oauth.Options` and modifies it to handle cases like this. It can do the following:

1. Add a trailing slash to the end of the provider URL (for `auth0`)
2. Trim a trailing slash off the end of the provider URL (for everyone else)
3. Set a default provider URL when none is provided
4. Set default scopes when none are provided

Besides trimming trailing slashes there should be no other change in behavior. The other rules were already implemented, they are just done in a consistent place now.


## Related issues
- https://github.com/pomerium/pomerium-zero/issues/2647


## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
