### PR TITLE
Optimize IDP lookup using envoy route metadata

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  deadline: 20m
+  timeout: 20m
 
 linters-settings:
   gci:
@@ -52,6 +52,9 @@ issues:
     # go sec : we want to allow skipping tls auth
     - "TLS InsecureSkipVerify set true."
     - "SA1019"
+
+    # usestdlibvars: allow statements like `resp.StatusCode/100`
+    - '"100" can be replaced by http.StatusContinue'
 
   exclude-rules:
     # Exclude some linters from running on test files.

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ build-ui: yarn
 .PHONY: lint
 lint: ## Verifies `golint` passes.
 	@echo "==> $@"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2 run ./... --fix
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.59.1 run ./... --fix
 
 .PHONY: test
 test: get-envoy ## Runs the go tests.

--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/atomicutil"
+	"github.com/pomerium/pomerium/internal/authenticateflow"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
@@ -50,6 +51,14 @@ func New(cfg *config.Config, options ...Option) (*Authenticate, error) {
 		cfg:     authenticateConfig,
 		options: config.NewAtomicOptions(),
 		state:   atomicutil.NewValue(newAuthenticateState()),
+	}
+
+	if authenticateConfig.getIdentityProvider == nil {
+		idpCache, err := config.NewIdentityProviderCache(cfg.Options)
+		if err != nil {
+			return nil, err
+		}
+		authenticateConfig.getIdentityProvider = authenticateflow.IdentityProviderLookupFromCache(idpCache)
 	}
 
 	a.options.Store(cfg.Options)

--- a/authenticate/config.go
+++ b/authenticate/config.go
@@ -18,7 +18,6 @@ type Option func(*authenticateConfig)
 
 func getAuthenticateConfig(options ...Option) *authenticateConfig {
 	cfg := new(authenticateConfig)
-	WithGetIdentityProvider(defaultGetIdentityProvider)(cfg)
 	for _, option := range options {
 		option(cfg)
 	}

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -407,7 +407,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	idp, _ := new(config.Options).GetIdentityProviderForID("")
+	idp, _ := new(config.Options).GetIdentityProviderForPolicy(nil)
 
 	tests := []struct {
 		name    string

--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -64,7 +64,8 @@ func newAuthenticateState() *authenticateState {
 }
 
 func newAuthenticateStateFromConfig(
-	cfg *config.Config, authenticateConfig *authenticateConfig,
+	cfg *config.Config,
+	authenticateConfig *authenticateConfig,
 ) (*authenticateState, error) {
 	err := ValidateOptions(cfg.Options)
 	if err != nil {

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -273,6 +273,7 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 		LuaFilter(luascripts.ExtAuthzSetCookie),
 		LuaFilter(luascripts.CleanUpstream),
 		LuaFilter(luascripts.RewriteHeaders),
+		LuaFilter(luascripts.DropCheckRouteRequests),
 	}
 	filters = append(filters, HTTPRouterFilter())
 

--- a/config/envoyconfig/lua.go
+++ b/config/envoyconfig/lua.go
@@ -9,8 +9,9 @@ import (
 var luaFS embed.FS
 
 var luascripts struct {
-	ExtAuthzSetCookie            string
 	CleanUpstream                string
+	DropCheckRouteRequests       string
+	ExtAuthzSetCookie            string
 	RemoveImpersonateHeaders     string
 	RewriteHeaders               string
 	SetClientCertificateMetadata string
@@ -19,6 +20,7 @@ var luascripts struct {
 func init() {
 	fileToField := map[string]*string{
 		"luascripts/clean-upstream.lua":                  &luascripts.CleanUpstream,
+		"luascripts/drop-check-route-requests.lua":       &luascripts.DropCheckRouteRequests,
 		"luascripts/ext-authz-set-cookie.lua":            &luascripts.ExtAuthzSetCookie,
 		"luascripts/remove-impersonate-headers.lua":      &luascripts.RemoveImpersonateHeaders,
 		"luascripts/rewrite-headers.lua":                 &luascripts.RewriteHeaders,

--- a/config/envoyconfig/luascripts/drop-check-route-requests.lua
+++ b/config/envoyconfig/luascripts/drop-check-route-requests.lua
@@ -1,0 +1,7 @@
+function envoy_on_request(request_handle)
+  local headers = request_handle:headers()
+  if headers:get("x-pomerium-check-route") ~= nil or headers:get(":method") == "TRACE" then
+    request_handle:logErr("check-route request caught by filter")
+    request_handle:respond({[":status"] = "500"}, "Internal Server Error")
+  end
+end

--- a/config/envoyconfig/testdata/main_http_connection_manager_filter.json
+++ b/config/envoyconfig/testdata/main_http_connection_manager_filter.json
@@ -87,6 +87,15 @@
         }
       },
       {
+        "name": "envoy.filters.http.lua",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
+          "defaultSourceCode": {
+            "inlineString": "function envoy_on_request(request_handle)\n  local headers = request_handle:headers()\n  if headers:get(\"x-pomerium-check-route\") ~= nil or headers:get(\":method\") == \"TRACE\" then\n    request_handle:logErr(\"check-route request caught by filter\")\n    request_handle:respond({[\":status\"] = \"500\"}, \"Internal Server Error\")\n  end\nend"
+          }
+        }
+      },
+      {
         "name": "envoy.filters.http.router",
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"

--- a/config/identity.go
+++ b/config/identity.go
@@ -1,26 +1,10 @@
 package config
 
 import (
-	"github.com/pomerium/pomerium/internal/urlutil"
+	"fmt"
+
 	"github.com/pomerium/pomerium/pkg/grpc/identity"
 )
-
-// GetIdentityProviderForID returns the identity provider associated with the given IDP id.
-// If none is found the default provider is returned.
-func (o *Options) GetIdentityProviderForID(idpID string) (*identity.Provider, error) {
-	for _, p := range o.GetAllPolicies() {
-		p := p
-		idp, err := o.GetIdentityProviderForPolicy(&p)
-		if err != nil {
-			return nil, err
-		}
-		if idp.GetId() == idpID {
-			return idp, nil
-		}
-	}
-
-	return o.GetIdentityProviderForPolicy(nil)
-}
 
 // GetIdentityProviderForPolicy gets the identity provider associated with the given policy.
 // If policy is nil, or changes none of the default settings, the default provider is returned.
@@ -50,18 +34,70 @@ func (o *Options) GetIdentityProviderForPolicy(policy *Policy) (*identity.Provid
 	return idp, nil
 }
 
-// GetIdentityProviderForRequestURL gets the identity provider associated with the given request URL.
-func (o *Options) GetIdentityProviderForRequestURL(requestURL string) (*identity.Provider, error) {
-	u, err := urlutil.ParseAndValidateURL(requestURL)
+type IdentityProviderCache struct {
+	idpsByRouteID     map[uint64]*identity.Provider
+	policiesByRouteID map[uint64]Policy
+	idpsByID          map[string]*identity.Provider
+}
+
+func NewIdentityProviderCache(opts *Options) (*IdentityProviderCache, error) {
+	rt := &IdentityProviderCache{
+		idpsByRouteID:     make(map[uint64]*identity.Provider, opts.NumPolicies()),
+		policiesByRouteID: make(map[uint64]Policy, opts.NumPolicies()),
+		idpsByID:          make(map[string]*identity.Provider),
+	}
+
+	for _, policy := range opts.GetAllPolicies() {
+		id, err := policy.RouteID()
+		if err != nil {
+			return nil, err
+		}
+		idp, err := opts.GetIdentityProviderForPolicy(&policy)
+		if err != nil {
+			return nil, err
+		}
+		rt.idpsByRouteID[id] = idp
+		rt.policiesByRouteID[id] = policy
+
+		if _, ok := rt.idpsByID[idp.Id]; !ok {
+			rt.idpsByID[idp.Id] = idp
+		}
+	}
+	return rt, nil
+}
+
+func (rt *IdentityProviderCache) GetIdentityProviderForPolicy(policy *Policy) (*identity.Provider, error) {
+	routeID, err := policy.RouteID()
 	if err != nil {
 		return nil, err
 	}
-
-	for _, p := range o.GetAllPolicies() {
-		p := p
-		if p.Matches(*u, o.IsRuntimeFlagSet(RuntimeFlagMatchAnyIncomingPort)) {
-			return o.GetIdentityProviderForPolicy(&p)
-		}
+	idp, ok := rt.idpsByRouteID[routeID]
+	if !ok {
+		return nil, fmt.Errorf("no identity provider found for route %d", routeID)
 	}
-	return o.GetIdentityProviderForPolicy(nil)
+	return idp, nil
+}
+
+func (rt *IdentityProviderCache) GetIdentityProviderForRouteID(routeID uint64) (*identity.Provider, error) {
+	idp, ok := rt.idpsByRouteID[routeID]
+	if !ok {
+		return nil, fmt.Errorf("no identity provider found for route %d", routeID)
+	}
+	return idp, nil
+}
+
+func (rt *IdentityProviderCache) GetIdentityProviderByID(idpID string) (*identity.Provider, error) {
+	idp, ok := rt.idpsByID[idpID]
+	if !ok {
+		return nil, fmt.Errorf("no identity provider found for id %s", idpID)
+	}
+	return idp, nil
+}
+
+func (rt *IdentityProviderCache) GetPolicyByID(routeID uint64) (*Policy, error) {
+	policy, ok := rt.policiesByRouteID[routeID]
+	if !ok {
+		return nil, fmt.Errorf("no policy found for route %d", routeID)
+	}
+	return &policy, nil
 }

--- a/config/options.go
+++ b/config/options.go
@@ -990,6 +990,10 @@ func (o *Options) GetAllPolicies() []Policy {
 	return policies
 }
 
+func (o *Options) NumPolicies() int {
+	return len(o.Policies) + len(o.Routes) + len(o.AdditionalPolicies)
+}
+
 // GetMetricsBasicAuth gets the metrics basic auth username and password.
 func (o *Options) GetMetricsBasicAuth() (username, password string, ok bool) {
 	if o.MetricsBasicAuth == "" {

--- a/config/session_test.go
+++ b/config/session_test.go
@@ -42,7 +42,10 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 		})
 	require.NoError(t, options.Validate())
 
-	store, err := NewSessionStore(options)
+	idpCache, err := NewIdentityProviderCache(options)
+	require.NoError(t, err)
+
+	store, err := NewSessionStore(options, idpCache)
 	require.NoError(t, err)
 
 	idp1, err := options.GetIdentityProviderForPolicy(nil)
@@ -57,6 +60,11 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, idp3)
 
+	policy0Id, err := options.Policies[0].RouteID()
+	require.NoError(t, err)
+	policy1Id, err := options.Policies[1].RouteID()
+	require.NoError(t, err)
+
 	makeJWS := func(t *testing.T, state *sessions.State) string {
 		e, err := jws.NewHS256Signer(sharedKey)
 		require.NoError(t, err)
@@ -70,7 +78,7 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 	t.Run("mssing", func(t *testing.T) {
 		r, err := http.NewRequest(http.MethodGet, "https://p1.example.com", nil)
 		require.NoError(t, err)
-		s, err := store.LoadSessionState(r)
+		s, err := store.LoadSessionState(r, 0)
 		assert.ErrorIs(t, err, sessions.ErrNoSessionFound)
 		assert.Nil(t, s)
 	})
@@ -85,7 +93,7 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 			urlutil.QuerySession: {rawJWS},
 		}.Encode(), nil)
 		require.NoError(t, err)
-		s, err := store.LoadSessionState(r)
+		s, err := store.LoadSessionState(r, policy0Id)
 		assert.NoError(t, err)
 		assert.Empty(t, cmp.Diff(&sessions.State{
 			Issuer:             "authenticate.example.com",
@@ -103,7 +111,7 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 		r, err := http.NewRequest(http.MethodGet, "https://p2.example.com", nil)
 		require.NoError(t, err)
 		r.Header.Set(httputil.HeaderPomeriumAuthorization, rawJWS)
-		s, err := store.LoadSessionState(r)
+		s, err := store.LoadSessionState(r, policy1Id)
 		assert.NoError(t, err)
 		assert.Empty(t, cmp.Diff(&sessions.State{
 			Issuer:             "authenticate.example.com",
@@ -121,7 +129,7 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 		r, err := http.NewRequest(http.MethodGet, "https://p2.example.com", nil)
 		require.NoError(t, err)
 		r.Header.Set(httputil.HeaderPomeriumAuthorization, rawJWS)
-		s, err := store.LoadSessionState(r)
+		s, err := store.LoadSessionState(r, policy1Id)
 		assert.Error(t, err)
 		assert.Nil(t, s)
 	})
@@ -134,7 +142,7 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 		r, err := http.NewRequest(http.MethodGet, "https://p2.example.com", nil)
 		require.NoError(t, err)
 		r.Header.Set(httputil.HeaderPomeriumAuthorization, rawJWS)
-		s, err := store.LoadSessionState(r)
+		s, err := store.LoadSessionState(r, policy1Id)
 		assert.NoError(t, err)
 		assert.Empty(t, cmp.Diff(&sessions.State{
 			Issuer: "authenticate.example.com",

--- a/internal/telemetry/metrics/providers_test.go
+++ b/internal/telemetry/metrics/providers_test.go
@@ -43,7 +43,7 @@ func getMetrics(t *testing.T, envoyURL *url.URL, header http.Header) []byte {
 	resp := rec.Result()
 	b, _ := io.ReadAll(resp.Body)
 
-	if resp == nil || resp.StatusCode != 200 {
+	if resp == nil || resp.StatusCode != http.StatusOK {
 		t.Errorf("Metrics endpoint failed to respond: %s", b)
 	}
 	return b

--- a/internal/urlutil/query_params.go
+++ b/internal/urlutil/query_params.go
@@ -15,6 +15,7 @@ const (
 	QueryIssued             = "pomerium_issued"
 	QueryPomeriumJWT        = "pomerium_jwt"
 	QueryRedirectURI        = "pomerium_redirect_uri"
+	QueryRequestPath        = "pomerium_request_path"
 	QuerySession            = "pomerium_session"
 	QuerySessionEncrypted   = "pomerium_session_encrypted"
 	QuerySessionState       = "pomerium_session_state"

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -124,7 +124,9 @@ func TestProxy_ProgrammaticLogin(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			p, err := New(&config.Config{Options: tt.options})
+			p, err := New(&config.Config{Options: tt.options}, WithRouteMatcher(RouteMatcherFunc(func(_ *http.Request) (string, error) {
+				return "", nil
+			})))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/proxy/match.go
+++ b/proxy/match.go
@@ -1,0 +1,71 @@
+package proxy
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pomerium/pomerium/internal/atomicutil"
+	"github.com/pomerium/pomerium/internal/urlutil"
+)
+
+type RouteMatcher interface {
+	GetIdentityProviderForRequest(r *http.Request) (string, error)
+}
+
+type RouteMatcherFunc func(r *http.Request) (string, error)
+
+func (f RouteMatcherFunc) GetIdentityProviderForRequest(r *http.Request) (string, error) {
+	return f(r)
+}
+
+func newCheckRouteAPIMatcher(state *atomicutil.Value[*proxyState]) RouteMatcher {
+	return &checkRouteAPIMatcher{state: state}
+}
+
+type checkRouteAPIMatcher struct {
+	state *atomicutil.Value[*proxyState]
+}
+
+func (l *checkRouteAPIMatcher) GetIdentityProviderForRequest(r *http.Request) (string, error) {
+	requestURL := urlutil.NewSignedURL(
+		l.state.Load().cookieSecret,
+		urlutil.GetAbsoluteURL(r).ResolveReference(&url.URL{
+			Path: r.FormValue(urlutil.QueryRequestPath),
+		}),
+	)
+
+	ctx, ca := context.WithTimeout(r.Context(), 10*time.Second)
+	defer ca()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodTrace, requestURL.String(), nil)
+	req.Header.Set("X-Pomerium-Check-Route", "1")
+	req.Header.Set("Accept", "application/json")
+	resp, err := http.DefaultTransport.RoundTrip(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return resp.Status, errors.New(resp.Status)
+	}
+	if resp.Header.Get("Content-Type") != "application/json" {
+		return "", fmt.Errorf("unexpected Content-Type %q returned from route check", resp.Header.Get("Content-Type"))
+	}
+	jsonData, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	type checkRouteResponse struct {
+		RouteID string `json:"route_id"`
+	}
+	var cr checkRouteResponse
+	if err := json.Unmarshal(jsonData, &cr); err != nil {
+		return "", err
+	}
+	return cr.RouteID, nil
+}


### PR DESCRIPTION
Supersedes https://github.com/pomerium/pomerium/pull/5143

## Summary

GetIdentityProviderForRequestURL is very slow when many routes are configured, because it will match routes by checking each one individually. This change makes use of the envoy route metadata passed to our ext_authz handler so we can avoid having to match urls to routes ourselves.

For programmatic login (and device auth), this lookup is accomplished by making a new request to envoy with the same URL, and with the internal header `X-Pomerium-Check-Route` set. When this header is present, our ext_authz handler will deny the request but return the envoy context extensions in the response body. The current implementation uses HTTP `TRACE` to make this request to envoy, which seemed appropriate, but I might change it to just use the same verb as the incoming request, since I don't think it makes any practical difference.

## Related issues

Fixes https://github.com/pomerium/internal/issues/1833

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
