### PR TITLE
core/ui: fix cycle in profile data

### DIFF
--- a/internal/handlers/userinfo.go
+++ b/internal/handlers/userinfo.go
@@ -59,11 +59,7 @@ func (data UserInfoData) profileJSON() map[string]any {
 	}
 
 	m := map[string]any{}
-	claims := make(map[string]any)
-	for k, v := range data.Profile.GetClaims().AsMap() {
-		claims[k] = v
-	}
-	m["claims"] = m
+	m["claims"] = data.Profile.GetClaims().AsMap()
 	return m
 }
 

--- a/internal/handlers/userinfo_test.go
+++ b/internal/handlers/userinfo_test.go
@@ -1,0 +1,37 @@
+package handlers_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pomerium/pomerium/internal/handlers"
+	"github.com/pomerium/pomerium/pkg/grpc/identity"
+)
+
+func TestUserInfoData(t *testing.T) {
+	t.Parallel()
+
+	claims, _ := structpb.NewStruct(map[string]any{
+		"TEST": "VALUE",
+	})
+	data := handlers.UserInfoData{Profile: &identity.Profile{Claims: claims}}
+	m := data.ToJSON()
+	bs, err := json.Marshal(m)
+	assert.NoError(t, err)
+	assert.JSONEq(t, `{
+		"csrfToken": "",
+		"isEnterprise": false,
+		"isImpersonated": false,
+		"profile": {
+			"claims": {"TEST":"VALUE"}
+		},
+		"session": null,
+		"user": null,
+		"webAuthnCreationOptions": null,
+		"webAuthnRequestOptions": null,
+		"webAuthnUrl": ""
+	}`, string(bs))
+}


### PR DESCRIPTION
## Summary
A typo in https://github.com/pomerium/pomerium/pull/5137 caused a cycle in the profile data on the userinfo page. This data is typically only used in the stateless flow in hosted authenticate.

## Related issues
- https://github.com/pomerium/hosted-authenticate/issues/66


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
