### PR TITLE
authenticate: rework session ID token handling

### DIFF
--- a/internal/authenticateflow/authenticateflow.go
+++ b/internal/authenticateflow/authenticateflow.go
@@ -5,6 +5,7 @@ package authenticateflow
 
 import (
 	"fmt"
+	"time"
 
 	"google.golang.org/protobuf/types/known/structpb"
 
@@ -12,6 +13,9 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/identity"
 )
+
+// timeNow is time.Now but pulled out as a variable for tests.
+var timeNow = time.Now
 
 var outboundGRPCConnection = new(grpc.CachedOutboundGRPClientConn)
 

--- a/internal/authenticateflow/identityprofile.go
+++ b/internal/authenticateflow/identityprofile.go
@@ -155,14 +155,8 @@ func populateSessionFromProfile(s *session.Session, p *identitypb.Profile, ss *s
 	s.IssuedAt = timestamppb.Now()
 	s.AccessedAt = timestamppb.Now()
 	s.ExpiresAt = timestamppb.New(time.Now().Add(cookieExpire))
-	s.IdToken = &session.IDToken{
-		Issuer:    ss.Issuer,
-		Subject:   ss.Subject,
-		ExpiresAt: timestamppb.New(time.Now().Add(cookieExpire)),
-		IssuedAt:  timestamppb.Now(),
-		Raw:       string(p.GetIdToken()),
-	}
 	s.OauthToken = manager.ToOAuthToken(oauthToken)
+	s.SetRawIDToken(string(p.GetIdToken()))
 	if s.Claims == nil {
 		s.Claims = make(map[string]*structpb.ListValue)
 	}

--- a/internal/authenticateflow/identityprofile.go
+++ b/internal/authenticateflow/identityprofile.go
@@ -152,9 +152,10 @@ func populateSessionFromProfile(s *session.Session, p *identitypb.Profile, ss *s
 	_ = json.Unmarshal(p.GetOauthToken(), oauthToken)
 
 	s.UserId = ss.UserID()
-	s.IssuedAt = timestamppb.Now()
-	s.AccessedAt = timestamppb.Now()
-	s.ExpiresAt = timestamppb.New(time.Now().Add(cookieExpire))
+	issuedAt := timeNow()
+	s.IssuedAt = timestamppb.New(issuedAt)
+	s.AccessedAt = timestamppb.New(issuedAt)
+	s.ExpiresAt = timestamppb.New(issuedAt.Add(cookieExpire))
 	s.OauthToken = manager.ToOAuthToken(oauthToken)
 	s.SetRawIDToken(string(p.GetIdToken()))
 	if s.Claims == nil {

--- a/internal/authenticateflow/identityprofile_test.go
+++ b/internal/authenticateflow/identityprofile_test.go
@@ -1,0 +1,65 @@
+package authenticateflow
+
+import (
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/pomerium/pomerium/internal/sessions"
+	"github.com/pomerium/pomerium/internal/testutil"
+	identitypb "github.com/pomerium/pomerium/pkg/grpc/identity"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+)
+
+func TestPopulateSessionFromProfile(t *testing.T) {
+	sessionState := &sessions.State{
+		Subject: "user-id",
+	}
+	idToken := "e30." + base64.RawURLEncoding.EncodeToString([]byte(`{
+		"iss": "https://issuer.example.com",
+		"sub": "id-token-user-id",
+		"iat": 1721965070,
+		"exp": 1721965670
+	}`)) + ".fake-signature"
+	profile := &identitypb.Profile{
+		IdToken: []byte(idToken),
+		OauthToken: []byte(`{
+			"access_token": "access-token",
+			"refresh_token": "refresh-token",
+			"expiry": "2024-07-26T12:00:00Z"
+		}`),
+		Claims: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"name":  structpb.NewStringValue("John Doe"),
+				"email": structpb.NewStringValue("john.doe@example.com"),
+			},
+		},
+	}
+
+	var s session.Session
+	populateSessionFromProfile(&s, profile, sessionState, 4*time.Hour)
+
+	assert.Equal(t, 4*time.Hour, s.ExpiresAt.AsTime().Sub(s.IssuedAt.AsTime()))
+	assert.Equal(t, s.IssuedAt, s.AccessedAt)
+	assert.Equal(t, "user-id", s.UserId)
+	testutil.AssertProtoEqual(t, &session.IDToken{
+		Issuer:    "https://issuer.example.com",
+		Subject:   "id-token-user-id",
+		IssuedAt:  &timestamppb.Timestamp{Seconds: 1721965070},
+		ExpiresAt: &timestamppb.Timestamp{Seconds: 1721965670},
+		Raw:       idToken,
+	}, s.IdToken)
+	testutil.AssertProtoEqual(t, &session.OAuthToken{
+		AccessToken:  "access-token",
+		RefreshToken: "refresh-token",
+		ExpiresAt:    &timestamppb.Timestamp{Seconds: 1721995200},
+	}, s.OauthToken)
+	assert.Equal(t, map[string]*structpb.ListValue{
+		"name":  {Values: []*structpb.Value{structpb.NewStringValue("John Doe")}},
+		"email": {Values: []*structpb.Value{structpb.NewStringValue("john.doe@example.com")}},
+	}, s.Claims)
+}

--- a/internal/authenticateflow/stateful.go
+++ b/internal/authenticateflow/stateful.go
@@ -175,13 +175,14 @@ func (s *Stateful) PersistSession(
 	claims identity.SessionClaims,
 	accessToken *oauth2.Token,
 ) error {
-	sessionExpiry := timestamppb.New(time.Now().Add(s.sessionDuration))
+	now := timeNow()
+	sessionExpiry := timestamppb.New(now.Add(s.sessionDuration))
 
 	sess := &session.Session{
 		Id:         sessionState.ID,
 		UserId:     sessionState.UserID(),
-		IssuedAt:   timestamppb.Now(),
-		AccessedAt: timestamppb.Now(),
+		IssuedAt:   timestamppb.New(now),
+		AccessedAt: timestamppb.New(now),
 		ExpiresAt:  sessionExpiry,
 		OauthToken: manager.ToOAuthToken(accessToken),
 		Audience:   sessionState.Audience,

--- a/internal/authenticateflow/stateful.go
+++ b/internal/authenticateflow/stateful.go
@@ -176,7 +176,6 @@ func (s *Stateful) PersistSession(
 	accessToken *oauth2.Token,
 ) error {
 	sessionExpiry := timestamppb.New(time.Now().Add(s.sessionDuration))
-	idTokenIssuedAt := timestamppb.New(sessionState.IssuedAt.Time())
 
 	sess := &session.Session{
 		Id:         sessionState.ID,
@@ -184,12 +183,6 @@ func (s *Stateful) PersistSession(
 		IssuedAt:   timestamppb.Now(),
 		AccessedAt: timestamppb.Now(),
 		ExpiresAt:  sessionExpiry,
-		IdToken: &session.IDToken{
-			Issuer:    sessionState.Issuer, // todo(bdd): the issuer is not authN but the downstream IdP from the claims
-			Subject:   sessionState.Subject,
-			ExpiresAt: sessionExpiry,
-			IssuedAt:  idTokenIssuedAt,
-		},
 		OauthToken: manager.ToOAuthToken(accessToken),
 		Audience:   sessionState.Audience,
 	}

--- a/pkg/grpc/session/session_test.go
+++ b/pkg/grpc/session/session_test.go
@@ -2,6 +2,8 @@ package session
 
 import (
 	context "context"
+	"encoding/base64"
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -191,4 +193,48 @@ func TestSession_Validate(t *testing.T) {
 			assert.ErrorIs(t, tc.session.Validate(), tc.expect)
 		})
 	}
+}
+
+func TestParseIDToken(t *testing.T) {
+	t.Parallel()
+
+	// The empty string should parse as a nil IDToken.
+	parsed, err := ParseIDToken("")
+	require.NoError(t, err)
+	require.Nil(t, parsed)
+
+	// Exercise error handling for malformed ID tokens.
+	parsed, err = ParseIDToken("not a valid JWT")
+	require.Nil(t, parsed)
+	require.ErrorContains(t, err, "compact JWS format must have three parts")
+	parsed, err = ParseIDToken("e30.ImZvbyI.e30")
+	require.Nil(t, parsed)
+	require.ErrorContains(t, err, "cannot unmarshal string")
+
+	// Create a token with a representative set of claims.
+	claimsMap := map[string]any{
+		"iss":            "https://idp.example.com",
+		"aud":            "client-1234.idp.example.com",
+		"sub":            "user_1122334455",
+		"email":          "john.doe@example.com",
+		"email_verified": true,
+		"name":           "John Doe",
+		"iat":            1720800000,
+		"exp":            1720803600,
+	}
+	claimsJSON, err := json.Marshal(claimsMap)
+	require.NoError(t, err)
+
+	// Attach a dummy header and signature (these aren't validated) to form an example token.
+	idToken := "e30." + base64.RawURLEncoding.EncodeToString(claimsJSON) + ".e30"
+
+	parsed, err = ParseIDToken(idToken)
+	assert.NoError(t, err)
+	testutil.AssertProtoEqual(t, &IDToken{
+		Issuer:    "https://idp.example.com",
+		Subject:   "user_1122334455",
+		IssuedAt:  &timestamppb.Timestamp{Seconds: 1720800000},
+		ExpiresAt: &timestamppb.Timestamp{Seconds: 1720803600},
+		Raw:       idToken,
+	}, parsed)
 }

--- a/pkg/identity/legacymanager/data_test.go
+++ b/pkg/identity/legacymanager/data_test.go
@@ -71,11 +71,6 @@ func TestSession_UnmarshalJSON(t *testing.T) {
 	}`), &s)
 	assert.NoError(t, err)
 	assert.NotNil(t, s.Session)
-	assert.NotNil(t, s.Session.IdToken)
-	assert.Equal(t, "https://some.issuer.com", s.Session.IdToken.Issuer)
-	assert.Equal(t, "subject", s.Session.IdToken.Subject)
-	assert.Equal(t, timestamppb.New(tm), s.Session.IdToken.ExpiresAt)
-	assert.Equal(t, timestamppb.New(tm), s.Session.IdToken.IssuedAt)
 	assert.Equal(t, map[string]*structpb.ListValue{
 		"some-other-claim": {Values: []*structpb.Value{protoutil.ToStruct("xyz")}},
 	}, s.Claims)

--- a/pkg/identity/legacymanager/data_test.go
+++ b/pkg/identity/legacymanager/data_test.go
@@ -1,12 +1,20 @@
 package legacymanager
 
 import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
+	go_oidc "github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -71,4 +79,58 @@ func TestSession_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, map[string]*structpb.ListValue{
 		"some-other-claim": {Values: []*structpb.Value{protoutil.ToStruct("xyz")}},
 	}, s.Claims)
+}
+
+// Simulate the behavior during an oidc.Authenticator Refresh() call:
+// SetRawIDToken() followed by a Claims() unmarshal call.
+func TestSession_RefreshUpdate(t *testing.T) {
+	// Create a valid go_oidc.IDToken. This requires a real signing key.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	iat := time.Now().Unix()
+	exp := iat + 3600
+	payload := map[string]any{
+		"iss":              "https://issuer.example.com",
+		"aud":              "https://client.example.com",
+		"sub":              "subject",
+		"exp":              exp,
+		"iat":              iat,
+		"some-other-claim": "xyz",
+	}
+	jwtSigner, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: privateKey}, nil)
+	require.NoError(t, err)
+	rawIDToken, err := jwt.Signed(jwtSigner).Claims(payload).CompactSerialize()
+	require.NoError(t, err)
+
+	keySet := &go_oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{privateKey.Public()}}
+	verifier := go_oidc.NewVerifier("https://issuer.example.com", keySet, &go_oidc.Config{
+		ClientID: "https://client.example.com",
+	})
+
+	// Finally, we can obtain a go_oidc.IDToken.
+	idToken, err := verifier.Verify(context.Background(), rawIDToken)
+	require.NoError(t, err)
+
+	// This is the behavior under test.
+	var s session.Session
+	v := &Session{Session: &s}
+	v.SetRawIDToken(rawIDToken)
+	err = idToken.Claims(v)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, s.IdToken)
+	assert.Equal(t, "https://issuer.example.com", s.IdToken.Issuer)
+	assert.Equal(t, "subject", s.IdToken.Subject)
+	assert.Equal(t, &timestamppb.Timestamp{Seconds: exp}, s.IdToken.ExpiresAt)
+	assert.Equal(t, &timestamppb.Timestamp{Seconds: iat}, s.IdToken.IssuedAt)
+	assert.Equal(t, map[string]*structpb.ListValue{
+		"aud": {
+			Values: []*structpb.Value{structpb.NewStringValue("https://client.example.com")},
+		},
+		"some-other-claim": {
+			Values: []*structpb.Value{structpb.NewStringValue("xyz")},
+		},
+	}, s.Claims)
+	assert.Equal(t, rawIDToken, s.IdToken.Raw)
 }

--- a/pkg/identity/manager/data_test.go
+++ b/pkg/identity/manager/data_test.go
@@ -1,12 +1,20 @@
 package manager
 
 import (
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
 	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
+	go_oidc "github.com/coreos/go-oidc/v3/oidc"
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -67,4 +75,58 @@ func TestSession_UnmarshalJSON(t *testing.T) {
 	assert.Equal(t, map[string]*structpb.ListValue{
 		"some-other-claim": {Values: []*structpb.Value{protoutil.ToStruct("xyz")}},
 	}, s.Claims)
+}
+
+// Simulate the behavior during an oidc.Authenticator Refresh() call:
+// SetRawIDToken() followed by a Claims() unmarshal call.
+func TestSession_RefreshUpdate(t *testing.T) {
+	// Create a valid go_oidc.IDToken. This requires a real signing key.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	iat := time.Now().Unix()
+	exp := iat + 3600
+	payload := map[string]any{
+		"iss":              "https://issuer.example.com",
+		"aud":              "https://client.example.com",
+		"sub":              "subject",
+		"exp":              exp,
+		"iat":              iat,
+		"some-other-claim": "xyz",
+	}
+	jwtSigner, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.RS256, Key: privateKey}, nil)
+	require.NoError(t, err)
+	rawIDToken, err := jwt.Signed(jwtSigner).Claims(payload).CompactSerialize()
+	require.NoError(t, err)
+
+	keySet := &go_oidc.StaticKeySet{PublicKeys: []crypto.PublicKey{privateKey.Public()}}
+	verifier := go_oidc.NewVerifier("https://issuer.example.com", keySet, &go_oidc.Config{
+		ClientID: "https://client.example.com",
+	})
+
+	// Finally, we can obtain a go_oidc.IDToken.
+	idToken, err := verifier.Verify(context.Background(), rawIDToken)
+	require.NoError(t, err)
+
+	// This is the behavior under test.
+	var s session.Session
+	v := newSessionUnmarshaler(&s)
+	v.SetRawIDToken(rawIDToken)
+	err = idToken.Claims(v)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, s.IdToken)
+	assert.Equal(t, "https://issuer.example.com", s.IdToken.Issuer)
+	assert.Equal(t, "subject", s.IdToken.Subject)
+	assert.Equal(t, &timestamppb.Timestamp{Seconds: exp}, s.IdToken.ExpiresAt)
+	assert.Equal(t, &timestamppb.Timestamp{Seconds: iat}, s.IdToken.IssuedAt)
+	assert.Equal(t, map[string]*structpb.ListValue{
+		"aud": {
+			Values: []*structpb.Value{structpb.NewStringValue("https://client.example.com")},
+		},
+		"some-other-claim": {
+			Values: []*structpb.Value{structpb.NewStringValue("xyz")},
+		},
+	}, s.Claims)
+	assert.Equal(t, rawIDToken, s.IdToken.Raw)
 }

--- a/pkg/identity/manager/data_test.go
+++ b/pkg/identity/manager/data_test.go
@@ -67,11 +67,6 @@ func TestSession_UnmarshalJSON(t *testing.T) {
 		"some-other-claim": "xyz"
 	}`), newSessionUnmarshaler(s))
 	assert.NoError(t, err)
-	assert.NotNil(t, s.IdToken)
-	assert.Equal(t, "https://some.issuer.com", s.IdToken.Issuer)
-	assert.Equal(t, "subject", s.IdToken.Subject)
-	assert.Equal(t, timestamppb.New(tm), s.IdToken.ExpiresAt)
-	assert.Equal(t, timestamppb.New(tm), s.IdToken.IssuedAt)
 	assert.Equal(t, map[string]*structpb.ListValue{
 		"some-other-claim": {Values: []*structpb.Value{protoutil.ToStruct("xyz")}},
 	}, s.Claims)


### PR DESCRIPTION


## Summary

Currently, the Session proto [id_token](https://github.com/pomerium/pomerium/blob/e5e6558de6302898b558060b14eeb90e74ed9437/pkg/grpc/session/session.proto#L41) field is populated with Pomerium session data during initial login, but with IdP ID token data after an IdP session refresh.

Instead, only store IdP ID token data in this field.

Update the existing `SetRawIDToken()` method to populate the structured data fields based on the contents of the raw ID token. Remove the other code that sets these fields (in the authenticateflow package and in manager.sessionUnmarshaler).

Add a test for the identity manager, exercising the combined effect of session claims unmarshaling and SetRawIDToken(), to verify that the overall behavior is preserved before and after this change.

## Related issues

- https://github.com/pomerium/internal/issues/1824

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
