### PR TITLE
session: do not invalidate based on ID token

### DIFF
--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -116,7 +116,6 @@ func (x *Session) Validate() error {
 	for name, expiresAt := range map[string]*timestamppb.Timestamp{
 		"session":      x.GetExpiresAt(),
 		"access_token": x.GetOauthToken().GetExpiresAt(),
-		"id_token":     x.GetIdToken().GetExpiresAt(),
 	} {
 		if expiresAt.AsTime().Year() > 1970 && now.After(expiresAt.AsTime()) {
 			return fmt.Errorf("%w: %s expired at %s", ErrSessionExpired, name, expiresAt.AsTime())

--- a/pkg/grpc/session/session_test.go
+++ b/pkg/grpc/session/session_test.go
@@ -181,8 +181,9 @@ func TestSession_Validate(t *testing.T) {
 	}{
 		{"valid", &Session{}, nil},
 		{"expired", &Session{ExpiresAt: t0}, ErrSessionExpired},
-		{"expired id token", &Session{IdToken: &IDToken{ExpiresAt: t0}}, ErrSessionExpired},
 		{"expired oauth token", &Session{OauthToken: &OAuthToken{ExpiresAt: t0}}, ErrSessionExpired},
+		// Expiry of the ID token does not indicate expiry of the underlying session.
+		{"expired id token ok", &Session{IdToken: &IDToken{ExpiresAt: t0}}, nil},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Per the OIDC spec, section 2:

> NOTE: The ID Token expiration time is unrelated [to] the lifetime of the authenticated session between the RP and the OP.

A Pomerium session should remain valid for as long as the underlying OAuth2 session.

## Related issues

- https://github.com/pomerium/pomerium/issues/5181

## User Explanation

Fix an issue where Pomerium sessions might expire earlier than intended, in cases where the OIDC ID token expires before the OAuth access token.

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
