### PR TITLE
Optimize Policy RouteID and Checksum

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -25,11 +25,11 @@ type MetricsScrapeEndpoint metrics.ScrapeEndpoint
 // Config holds pomerium configuration options.
 type Config struct {
 	Options          *Options
-	AutoCertificates []tls.Certificate
+	AutoCertificates []tls.Certificate `hash:"-"`
 	EnvoyVersion     string
 
 	// DerivedCertificates are TLS certificates derived from the shared secret
-	DerivedCertificates []tls.Certificate
+	DerivedCertificates []tls.Certificate `hash:"-"`
 	// DerivedCAPEM is a PEM-encoded certificate authority
 	// derived from the shared secret
 	DerivedCAPEM []byte

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -77,7 +77,7 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 						],
 						"route": {
 							"autoHostRewrite": true,
-							"cluster": "route-5d678ee30d16332b",
+							"cluster": "route-f6a1c77f275e05b4",
 							"hashPolicy": [
 								{ "header": { "headerName": "x-pomerium-routing-key" }, "terminal": true },
 								{ "connectionProperties": { "sourceIp": true }, "terminal": true }
@@ -94,7 +94,7 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 								"checkSettings": {
 									"contextExtensions": {
 										"internal": "false",
-										"route_id": "6730505273956774699"
+										"route_id": "17771704953515935156"
 									}
 								}
 							}
@@ -130,7 +130,7 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 						],
 						"route": {
 							"autoHostRewrite": true,
-							"cluster": "route-5d678ee30d16332b",
+							"cluster": "route-f6a1c77f275e05b4",
 							"hashPolicy": [
 								{ "header": { "headerName": "x-pomerium-routing-key" }, "terminal": true },
 								{ "connectionProperties": { "sourceIp": true }, "terminal": true }
@@ -147,7 +147,7 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 								"checkSettings": {
 									"contextExtensions": {
 										"internal": "false",
-										"route_id": "6730505273956774699"
+										"route_id": "17771704953515935156"
 									}
 								}
 							}

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -444,7 +444,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "16913502743845432363"
+								"route_id": "17646041018298562268"
 							}
 						}
 					}
@@ -515,7 +515,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "911713133804109577"
+								"route_id": "10365886941185626220"
 							}
 						}
 					}
@@ -585,7 +585,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "6407864870815560799"
+								"route_id": "9041273544631654369"
 							}
 						}
 					}
@@ -657,7 +657,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "1103677309004574500"
+								"route_id": "16542454514621720875"
 							}
 						}
 					}
@@ -728,7 +728,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "6407864870815560799"
+								"route_id": "9041273544631654369"
 							}
 						}
 					}
@@ -798,7 +798,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "911713133804109577"
+								"route_id": "10365886941185626220"
 							}
 						}
 					}
@@ -869,7 +869,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "911713133804109577"
+								"route_id": "10365886941185626220"
 							}
 						}
 					}
@@ -940,7 +940,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "17831746838845374842"
+								"route_id": "15525921082478698962"
 							}
 						}
 					}
@@ -1123,7 +1123,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "10474912405080199536"
+								"route_id": "1853558570678532702"
 							}
 						}
 					}
@@ -1195,7 +1195,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "15730681265277585877"
+								"route_id": "3410110120199695623"
 							}
 						}
 					}
@@ -1293,7 +1293,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 							"checkSettings": {
 								"contextExtensions": {
 									"internal": "false",
-									"route_id": "16598125949405432745"
+									"route_id": "18442885336125624707"
 								}
 							}
 						}
@@ -1423,7 +1423,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "13828028232508831592"
+								"route_id": "4985795602702748187"
 							}
 						}
 					}
@@ -1494,7 +1494,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "13828028232508831592"
+								"route_id": "4985795602702748187"
 							}
 						}
 					}
@@ -1570,7 +1570,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "13828028232508831592"
+								"route_id": "4985795602702748187"
 							}
 						}
 					}
@@ -1641,7 +1641,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "13828028232508831592"
+								"route_id": "4985795602702748187"
 							}
 						}
 					}
@@ -1712,7 +1712,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "13828028232508831592"
+								"route_id": "4985795602702748187"
 							}
 						}
 					}
@@ -1788,7 +1788,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_id": "13828028232508831592"
+								"route_id": "4985795602702748187"
 							}
 						}
 					}

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1304,7 +1304,7 @@ func encodeCert(cert *tls.Certificate) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
 }
 
-func mustParseWeightedURLs(t *testing.T, urls ...string) []WeightedURL {
+func mustParseWeightedURLs(t testing.TB, urls ...string) []WeightedURL {
 	wu, err := ParseWeightedUrls(urls...)
 	require.NoError(t, err)
 	return wu

--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	github.com/tniswong/go.rfcx v0.0.0-20181019234604-07783c52761f
+	github.com/valyala/bytebufferpool v1.0.0
 	github.com/volatiletech/null/v9 v9.0.0
 	github.com/yuin/gopher-lua v1.1.1
 	go.opencensus.io v0.24.0

--- a/go.sum
+++ b/go.sum
@@ -630,6 +630,8 @@ github.com/tniswong/go.rfcx v0.0.0-20181019234604-07783c52761f/go.mod h1:N+sR0vL
 github.com/uber/jaeger-client-go v2.25.0+incompatible h1:IxcNZ7WRY1Y3G4poYlx24szfsn/3LvK9QHCq9oQw8+U=
 github.com/uber/jaeger-client-go v2.25.0+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/ulikunitz/xz v0.5.11/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
+github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
+github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/gozstd v1.20.1 h1:xPnnnvjmaDDitMFfDxmQ4vpx0+3CdTg2o3lALvXTU/g=
 github.com/valyala/gozstd v1.20.1/go.mod h1:y5Ew47GLlP37EkTB+B4s7r6A5rdaeB7ftbl9zoYiIPQ=
 github.com/volatiletech/null/v9 v9.0.0 h1:JCdlHEiSRVxOi7/MABiEfdsqmuj9oTV20Ao7VvZ0JkE=

--- a/internal/hashutil/hashutil.go
+++ b/internal/hashutil/hashutil.go
@@ -4,6 +4,8 @@
 package hashutil
 
 import (
+	"encoding/binary"
+
 	"github.com/cespare/xxhash/v2"
 	"github.com/mitchellh/hashstructure/v2"
 )
@@ -26,4 +28,16 @@ func Hash(v any) (uint64, error) {
 		Hasher: xxhash.New(),
 	}
 	return hashstructure.Hash(v, hashstructure.FormatV2, opts)
+}
+
+// MapHash efficiently computes a non-cryptographic hash of a map of strings.
+func MapHash(iv uint64, m map[string]string) uint64 {
+	accum := iv
+	var buf [16]byte
+	for k, v := range m {
+		binary.BigEndian.PutUint64(buf[0:8], xxhash.Sum64String(k))
+		binary.BigEndian.PutUint64(buf[8:16], xxhash.Sum64String(v))
+		accum ^= xxhash.Sum64(buf[:])
+	}
+	return accum
 }

--- a/internal/hashutil/hashutil_test.go
+++ b/internal/hashutil/hashutil_test.go
@@ -1,9 +1,14 @@
 // Package hashutil provides NON-CRYPTOGRAPHIC utility functions for hashing
-package hashutil
+package hashutil_test
 
 import (
+	"fmt"
+	"math/rand/v2"
+	"net/url"
 	"testing"
 
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/hashutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,10 +45,10 @@ func TestHash(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := MustHash(tt.v); got != tt.want {
+			if got := hashutil.MustHash(tt.v); got != tt.want {
 				t.Errorf("MustHash() = %v, want %v", got, tt.want)
 			}
-			got, err := Hash(tt.v)
+			got, err := hashutil.Hash(tt.v)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
@@ -51,6 +56,124 @@ func TestHash(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("Hash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHashCodec(t *testing.T) {
+	policies1 := []config.Policy{
+		{To: singleToURL("https://to1.example.com")},
+		{To: singleToURL("https://to2.example.com")},
+		{To: singleToURL("https://to3.example.com")},
+		{To: singleToURL("https://to4.example.com")},
+	}
+
+	policies2 := []config.Policy{
+		{To: singleToURL("https://to1.example.com")},
+		{
+			To:           singleToURL("https://to2.example.com"),
+			AllowedUsers: []string{"user-id-1"},
+		}, // change just the policy itself
+		{To: singleToURL("https://to3.example.com")},
+		{To: singleToURL("https://foo.example.com"), // change route ID too
+			AllowAnyAuthenticatedUser: true},
+	}
+
+	assert.Equal(t, hashutil.MustHash(&policies1[0]), hashutil.MustHash(&policies2[0]))
+	assert.NotEqual(t, hashutil.MustHash(&policies1[1]), hashutil.MustHash(&policies2[1]))
+	assert.Equal(t, hashutil.MustHash(&policies1[2]), hashutil.MustHash(&policies2[2]))
+	assert.NotEqual(t, hashutil.MustHash(&policies1[3]), hashutil.MustHash(&policies2[3]))
+}
+
+func singleToURL(url string) config.WeightedURLs {
+	return config.WeightedURLs{{URL: *mustParseURL(url)}}
+}
+
+func mustParseURL(str string) *url.URL {
+	u, err := url.Parse(str)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func TestMapHash_Equal(t *testing.T) {
+	t.Parallel()
+	for _, elems := range []int{13, 50, 100, 1000} {
+		t.Run(fmt.Sprintf("%d elements", elems), func(t *testing.T) {
+			t.Parallel()
+			numbers := make([]int64, elems)
+			for i := range len(numbers) {
+				numbers[i] = rand.Int64()
+			}
+			m := make(map[string]string, elems)
+			for _, n := range numbers {
+				m[fmt.Sprintf("key%d", n)] = fmt.Sprintf("value%d", n)
+			}
+			expected := hashutil.MapHash(0, m)
+			for i := 0; i < 1000; i++ {
+				rand.Shuffle(len(numbers), func(i, j int) {
+					numbers[i], numbers[j] = numbers[j], numbers[i]
+				})
+
+				m := make(map[string]string, elems)
+				for _, n := range numbers {
+					m[fmt.Sprintf("key%d", n)] = fmt.Sprintf("value%d", n)
+				}
+				assert.Equal(t, expected, hashutil.MapHash(0, m))
+			}
+		})
+	}
+}
+
+func TestMapHash_NotEqual(t *testing.T) {
+	t.Parallel()
+	for _, elems := range []int{1, 5, 10, 100, 1000} {
+		t.Run(fmt.Sprintf("%d elements", elems), func(t *testing.T) {
+			t.Parallel()
+			seen := make(map[uint64]struct{}, 1000)
+			for i := 0; i < 1000; i++ {
+				numbers := make([]int64, elems)
+				for i := range len(numbers) {
+					numbers[i] = rand.Int64()
+				}
+				m := make(map[string]string, elems)
+				mInverse := make(map[string]string, elems)
+				mEqual := make(map[string]string, elems)
+				for _, n := range numbers {
+					m[fmt.Sprintf("key%d", n)] = fmt.Sprintf("value%d", n)
+					mInverse[fmt.Sprintf("key%d", n)] = fmt.Sprintf("value%d", n)
+					mEqual[fmt.Sprintf("%d", n)] = fmt.Sprintf("%d", n)
+				}
+				h := hashutil.MapHash(0, m)
+				hInverse := hashutil.MapHash(0, mInverse)
+				hEqual := hashutil.MapHash(0, mEqual)
+				assert.NotContains(t, seen, h)
+				assert.NotContains(t, seen, hInverse)
+				assert.NotContains(t, seen, hEqual)
+				seen[h] = struct{}{}
+				seen[hInverse] = struct{}{}
+				seen[hEqual] = struct{}{}
+			}
+		})
+	}
+}
+
+func TestMapHash_IV(t *testing.T) {
+	t.Parallel()
+	for _, elems := range []int{5, 10, 100, 1000} {
+		t.Run(fmt.Sprintf("%d elements", elems), func(t *testing.T) {
+			t.Parallel()
+			m := make(map[string]string, elems)
+			for i := 0; i < elems; i++ {
+				m[fmt.Sprintf("key%d", i)] = fmt.Sprintf("value%d", i)
+			}
+			seen := make(map[uint64]struct{}, 5000)
+			for i := 0; i < 5000; i++ {
+				h := hashutil.MapHash(rand.Uint64(), m)
+				assert.NotContains(t, seen, h)
+				seen[h] = struct{}{}
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

This significantly optimizes the (*Policy).RouteID() and (*Policy).Checksum() methods for both speed and memory usage.

A new method (*Policy).ChecksumWithID(uint64) can be used to skip a call to RouteID() if the ID is already known. Checksum() is implemented in terms of this new method, and will always recompute the route ID on each call.

RouteID() does not allocate heap memory. Checksum() may allocate heap memory, depending on which fields are set. If all of the following are true, Checksum() makes zero allocations:
1. The policy uses redirect or direct-response mode
2. The policy has no sub-policies
3. The policy has no response header rewrite config

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
