### PR TITLE
Optimize evaluator

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -43,16 +43,11 @@ type Authorize struct {
 func New(cfg *config.Config) (*Authorize, error) {
 	a := &Authorize{
 		currentOptions: config.NewAtomicOptions(),
+		state:          atomicutil.NewValue[*authorizeState](nil),
 		store:          store.New(),
 		globalCache:    storage.NewGlobalCache(time.Minute),
 	}
 	a.accessTracker = NewAccessTracker(a, accessTrackerMaxSize, accessTrackerDebouncePeriod)
-
-	state, err := newAuthorizeStateFromConfig(cfg, a.store, nil)
-	if err != nil {
-		return nil, err
-	}
-	a.state = atomicutil.NewValue(state)
 
 	return a, nil
 }
@@ -150,7 +145,11 @@ func newPolicyEvaluator(
 func (a *Authorize) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	currentState := a.state.Load()
 	a.currentOptions.Store(cfg.Options)
-	if state, err := newAuthorizeStateFromConfig(cfg, a.store, currentState.evaluator); err != nil {
+	var prev *evaluator.Evaluator
+	if currentState != nil {
+		prev = currentState.evaluator
+	}
+	if state, err := newAuthorizeStateFromConfig(cfg, a.store, prev); err != nil {
 		log.Error(ctx).Err(err).Msg("authorize: error updating state")
 	} else {
 		a.state.Store(state)

--- a/authorize/authorize_test.go
+++ b/authorize/authorize_test.go
@@ -82,7 +82,7 @@ func TestNew(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := New(&config.Config{Options: &tt.config})
+			_, err := newAuthorizeStateFromConfig(&config.Config{Options: &tt.config}, store.New(), nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("New() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -114,12 +114,13 @@ func TestAuthorize_OnConfigChange(t *testing.T) {
 				SharedKey:             tc.SharedKey,
 				Policies:              tc.Policies,
 			}
-			a, err := New(&config.Config{Options: o})
+			cfg := &config.Config{Options: o}
+			a, err := New(cfg)
+			a.OnConfigChange(context.Background(), cfg)
 			require.NoError(t, err)
 			require.NotNil(t, a)
 
 			oldPe := a.state.Load().evaluator
-			cfg := &config.Config{Options: o}
 			assertFunc := assert.True
 			o.SigningKey = "bad-share-key"
 			if tc.expectedChange {

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -34,7 +34,9 @@ func TestAuthorize_handleResult(t *testing.T) {
 	t.Cleanup(authnSrv.Close)
 	opt.AuthenticateURLString = authnSrv.URL
 
-	a, err := New(&config.Config{Options: opt})
+	cfg := &config.Config{Options: opt}
+	a, err := New(cfg)
+	a.OnConfigChange(context.Background(), cfg)
 	require.NoError(t, err)
 
 	t.Run("user-unauthenticated", func(t *testing.T) {
@@ -327,7 +329,9 @@ func TestRequireLogin(t *testing.T) {
 	t.Cleanup(authnSrv.Close)
 	opt.AuthenticateURLString = authnSrv.URL
 
-	a, err := New(&config.Config{Options: opt})
+	cfg := &config.Config{Options: opt}
+	a, err := New(cfg)
+	a.OnConfigChange(context.Background(), cfg)
 	require.NoError(t, err)
 
 	t.Run("accept empty", func(t *testing.T) {

--- a/authorize/evaluator/config.go
+++ b/authorize/evaluator/config.go
@@ -1,6 +1,8 @@
 package evaluator
 
 import (
+	"sync"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/hashutil"
 )
@@ -15,22 +17,26 @@ type evaluatorConfig struct {
 	AuthenticateURL                                   string
 	GoogleCloudServerlessAuthenticationServiceAccount string
 	JWTClaimsHeaders                                  config.JWTClaimHeaders
+
+	cacheKeyOnce     sync.Once
+	computedCacheKey uint64
 }
 
 // cacheKey() returns a hash over the configuration, except for the policies.
 func (e *evaluatorConfig) cacheKey() uint64 {
-	return hashutil.MustHash(e)
+	e.cacheKeyOnce.Do(func() {
+		e.computedCacheKey = hashutil.MustHash(e)
+	})
+	return e.computedCacheKey
 }
 
 // An Option customizes the evaluator config.
 type Option func(*evaluatorConfig)
 
-func getConfig(options ...Option) *evaluatorConfig {
-	cfg := new(evaluatorConfig)
-	for _, o := range options {
-		o(cfg)
+func (o *evaluatorConfig) apply(options ...Option) {
+	for _, opt := range options {
+		opt(o)
 	}
-	return cfg
 }
 
 // WithPolicies sets the policies in the config.

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -2,20 +2,27 @@
 package evaluator
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"fmt"
+	"maps"
+	"math/bits"
 	"net/http"
 	"net/url"
+	"runtime"
+	rttrace "runtime/trace"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-jose/go-jose/v3"
 	"github.com/open-policy-agent/opa/rego"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/pomerium/pomerium/authorize/internal/store"
 	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/errgrouputil"
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
@@ -89,51 +96,190 @@ type Result struct {
 	Traces  []contextutil.PolicyEvaluationTrace
 }
 
+type EvaluatorCacheStats struct {
+	CacheHits   int64
+	CacheMisses int64
+}
+
+type EvaluatorCache struct {
+	evalsMu             sync.RWMutex
+	evaluatorsByRouteID map[uint64]*PolicyEvaluator
+
+	cacheHits   atomic.Int64
+	cacheMisses atomic.Int64
+}
+
+type QueryCacheStats struct {
+	CacheHits       int64
+	CacheMisses     int64
+	BuildsSucceeded int64
+	BuildsFailed    int64
+	BuildsShared    int64
+}
+
+type QueryCache struct {
+	queriesMu               sync.RWMutex
+	queriesByScriptChecksum map[string]rego.PreparedEvalQuery
+	sf                      singleflight.Group
+
+	cacheHits       atomic.Int64
+	cacheMisses     atomic.Int64
+	buildsSucceeded atomic.Int64
+	buildsFailed    atomic.Int64
+	buildsShared    atomic.Int64
+}
+
+func NewPolicyEvaluatorCache(initialSize int) *EvaluatorCache {
+	return &EvaluatorCache{
+		evaluatorsByRouteID: make(map[uint64]*PolicyEvaluator, initialSize),
+	}
+}
+
+func NewQueryCache(initialSize int) *QueryCache {
+	return &QueryCache{
+		queriesByScriptChecksum: make(map[string]rego.PreparedEvalQuery, initialSize),
+	}
+}
+
+func (c *EvaluatorCache) NumCachedEvaluators() int {
+	c.evalsMu.RLock()
+	defer c.evalsMu.RUnlock()
+	return len(c.evaluatorsByRouteID)
+}
+
+func (c *EvaluatorCache) StoreEvaluator(routeID uint64, eval *PolicyEvaluator) {
+	c.evalsMu.Lock()
+	defer c.evalsMu.Unlock()
+	c.evaluatorsByRouteID[routeID] = eval
+}
+
+func (c *EvaluatorCache) LookupEvaluator(routeID uint64) (*PolicyEvaluator, bool) {
+	c.evalsMu.RLock()
+	defer c.evalsMu.RUnlock()
+	eval, ok := c.evaluatorsByRouteID[routeID]
+	if ok {
+		c.cacheHits.Add(1)
+	} else {
+		c.cacheMisses.Add(1)
+	}
+	return eval, ok
+}
+
+func (c *EvaluatorCache) Stats() EvaluatorCacheStats {
+	return EvaluatorCacheStats{
+		CacheHits:   c.cacheHits.Load(),
+		CacheMisses: c.cacheMisses.Load(),
+	}
+}
+
+func (c *QueryCache) NumCachedQueries() int {
+	c.queriesMu.RLock()
+	defer c.queriesMu.RUnlock()
+	return len(c.queriesByScriptChecksum)
+}
+
+func (c *QueryCache) Stats() QueryCacheStats {
+	return QueryCacheStats{
+		CacheHits:       c.cacheHits.Load(),
+		CacheMisses:     c.cacheMisses.Load(),
+		BuildsSucceeded: c.buildsSucceeded.Load(),
+		BuildsFailed:    c.buildsFailed.Load(),
+		BuildsShared:    c.buildsShared.Load(),
+	}
+}
+
+func (c *QueryCache) LookupOrBuild(q *policyQuery, builder func() (rego.PreparedEvalQuery, error)) (rego.PreparedEvalQuery, bool, error) {
+	checksum := q.checksum()
+	c.queriesMu.RLock()
+	cached, ok := c.queriesByScriptChecksum[checksum]
+	c.queriesMu.RUnlock()
+	if ok {
+		c.cacheHits.Add(1)
+		return cached, true, nil
+	}
+	c.cacheMisses.Add(1)
+	var ours bool
+	pq, err, shared := c.sf.Do(checksum, func() (any, error) {
+		ours = true
+		res, err := builder()
+		if err == nil {
+			c.queriesMu.Lock()
+			c.queriesByScriptChecksum[checksum] = res
+			c.queriesMu.Unlock()
+			c.buildsSucceeded.Add(1)
+		} else {
+			c.buildsFailed.Add(1)
+		}
+		return res, err
+	})
+	if err != nil {
+		return rego.PreparedEvalQuery{}, false, err
+	}
+	if shared && !ours {
+		c.buildsShared.Add(1)
+	}
+	return pq.(rego.PreparedEvalQuery), false, nil
+}
+
 // An Evaluator evaluates policies.
 type Evaluator struct {
-	store                 *store.Store
-	policyEvaluators      map[uint64]*PolicyEvaluator
-	headersEvaluators     *HeadersEvaluator
-	clientCA              []byte
-	clientCRL             []byte
-	clientCertConstraints ClientCertConstraints
-
-	cfgCacheKey uint64
+	opts             *evaluatorConfig
+	store            *store.Store
+	evalCache        *EvaluatorCache
+	queryCache       *QueryCache
+	headersEvaluator *HeadersEvaluator
 }
 
 // New creates a new Evaluator.
 func New(
-	ctx context.Context, store *store.Store, previous *Evaluator, options ...Option,
+	ctx context.Context,
+	store *store.Store,
+	previous *Evaluator,
+	options ...Option,
 ) (*Evaluator, error) {
-	cfg := getConfig(options...)
+	ctx, task := rttrace.NewTask(ctx, "evaluator.New")
+	defer task.End()
+	defer rttrace.StartRegion(ctx, "evaluator.New").End()
 
-	err := updateStore(store, cfg)
-	if err != nil {
-		return nil, err
-	}
+	var opts evaluatorConfig
+	opts.apply(options...)
 
 	e := &Evaluator{
-		store:                 store,
-		clientCA:              cfg.ClientCA,
-		clientCRL:             cfg.ClientCRL,
-		clientCertConstraints: cfg.ClientCertConstraints,
-		cfgCacheKey:           cfg.cacheKey(),
+		opts:  &opts,
+		store: store,
 	}
 
-	// If there is a previous Evaluator constructed from the same settings, we
-	// can reuse the HeadersEvaluator along with any PolicyEvaluators for
-	// unchanged policies.
-	var cachedPolicyEvaluators map[uint64]*PolicyEvaluator
-	if previous != nil && previous.cfgCacheKey == e.cfgCacheKey {
-		e.headersEvaluators = previous.headersEvaluators
-		cachedPolicyEvaluators = previous.policyEvaluators
-	} else {
-		e.headersEvaluators, err = NewHeadersEvaluator(ctx, store)
+	if previous == nil || opts.cacheKey() != previous.opts.cacheKey() {
+		var err error
+		rttrace.WithRegion(ctx, "update store", func() {
+			err = updateStore(store, &opts, previous)
+		})
 		if err != nil {
 			return nil, err
 		}
+
+		rttrace.WithRegion(ctx, "create headers evaluator", func() {
+			e.headersEvaluator, err = NewHeadersEvaluator(ctx, store)
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		e.evalCache = NewPolicyEvaluatorCache(len(opts.Policies))
+		e.queryCache = NewQueryCache(len(opts.Policies))
+	} else {
+		// If there is a previous Evaluator constructed from the same settings, we
+		// can reuse the HeadersEvaluator along with any PolicyEvaluators for
+		// unchanged policies.
+		e.headersEvaluator = previous.headersEvaluator
+		e.evalCache = previous.evalCache
+		e.queryCache = previous.queryCache
 	}
-	e.policyEvaluators, err = getOrCreatePolicyEvaluators(ctx, cfg, store, cachedPolicyEvaluators)
+
+	var err error
+	rttrace.WithRegion(ctx, "update policy evaluators", func() {
+		err = getOrCreatePolicyEvaluators(ctx, &opts, store, e.evalCache, e.queryCache)
+	})
 	if err != nil {
 		return nil, err
 	}
@@ -142,61 +288,224 @@ func New(
 }
 
 type routeEvaluator struct {
-	id        uint64
-	evaluator *PolicyEvaluator
+	id               uint64
+	evaluator        *PolicyEvaluator
+	computedChecksum uint64
+}
+
+var (
+	workerPoolSize      = runtime.NumCPU() - 1
+	workerPoolTaskQueue = make(chan func(), (workerPoolSize+1)*2)
+)
+
+func init() {
+	for i := 0; i < workerPoolSize; i++ {
+		go worker()
+	}
+}
+
+func worker() {
+	for fn := range workerPoolTaskQueue {
+		fn()
+	}
+}
+
+const chunkSize = 64
+
+type workerContext struct {
+	context.Context
+	Cfg           *evaluatorConfig
+	Store         *store.Store
+	StatusBits    []uint64
+	StatusCounts  []uint8
+	TotalModified *atomic.Int32
+	Evaluators    []routeEvaluator
+	EvalCache     *EvaluatorCache
+	QueryCache    *QueryCache
+	Errs          *sync.Map
+}
+
+type partition struct{ Begin, End int }
+
+func computeChecksums(wctx *workerContext, part partition) {
+	defer rttrace.StartRegion(wctx, "worker-checksum").End()
+	for chunkIdx := part.Begin; chunkIdx < part.End; chunkIdx++ {
+		var chunkStatus uint64
+		off := chunkIdx * chunkSize
+		limit := min(chunkSize, len(wctx.Cfg.Policies)-int(off))
+		for i := 0; i < limit; i++ {
+			p := wctx.Cfg.Policies[off+i]
+			id, err := p.RouteID()
+			if err != nil {
+				wctx.Errs.Store(off+i, fmt.Errorf("authorize: error computing policy route id: %w", err))
+				continue
+			}
+			eval := &wctx.Evaluators[off+i]
+			eval.id = id
+			eval.computedChecksum = p.ChecksumWithID(id)
+			cached, ok := wctx.EvalCache.LookupEvaluator(id)
+			if !ok {
+				rttrace.Logf(wctx, "", "policy for route ID %d not found in cache", id)
+				chunkStatus |= 1 << i
+			} else if cached.policyChecksum != eval.computedChecksum {
+				rttrace.Logf(wctx, "", "policy for route ID %d changed", id)
+				chunkStatus |= 1 << i
+			}
+		}
+		wctx.StatusBits[chunkIdx] = chunkStatus
+		popcnt := bits.OnesCount64(chunkStatus)
+		rttrace.Logf(wctx, "", "chunk %d: %d/%d changed", chunkIdx, popcnt, limit)
+		wctx.StatusCounts[chunkIdx] = uint8(popcnt)
+		wctx.TotalModified.Add(int32(popcnt))
+	}
+}
+
+func buildEvaluators(wctx *workerContext, part partition) {
+	defer rttrace.StartRegion(wctx, "worker-build").End()
+	addDefaultCert := wctx.Cfg.AddDefaultClientCertificateRule
+	var err error
+	for chunkIdx := part.Begin; chunkIdx < part.End; chunkIdx++ {
+		stat := wctx.StatusBits[chunkIdx]
+		rttrace.Logf(wctx, "", "chunk %d: status: %b", chunkIdx, stat)
+		for stat != 0 {
+			bit := bits.TrailingZeros64(stat)
+			stat &^= 1 << bit
+			idx := bit + (chunkSize * chunkIdx)
+			p := wctx.Cfg.Policies[idx]
+			eval := &wctx.Evaluators[idx]
+			eval.evaluator, err = NewPolicyEvaluator(wctx, wctx.Store, p, eval.computedChecksum, addDefaultCert, wctx.QueryCache)
+			if err != nil {
+				wctx.Errs.Store(idx, err)
+			}
+		}
+	}
 }
 
 func getOrCreatePolicyEvaluators(
-	ctx context.Context, cfg *evaluatorConfig, store *store.Store,
-	cachedPolicyEvaluators map[uint64]*PolicyEvaluator,
-) (map[uint64]*PolicyEvaluator, error) {
+	ctx context.Context,
+	cfg *evaluatorConfig,
+	store *store.Store,
+	evalCache *EvaluatorCache,
+	queryCache *QueryCache,
+) error {
+	rttrace.Logf(ctx, "", "using %d cached policy evaluators", evalCache.NumCachedEvaluators())
 	now := time.Now()
 
-	var reusedCount int
-	m := make(map[uint64]*PolicyEvaluator)
-	var builders []errgrouputil.BuilderFunc[routeEvaluator]
-	for i := range cfg.Policies {
-		configPolicy := cfg.Policies[i]
-		id, err := configPolicy.RouteID()
-		if err != nil {
-			return nil, fmt.Errorf("authorize: error computing policy route id: %w", err)
-		}
-		p := cachedPolicyEvaluators[id]
-		if p != nil && p.policyChecksum == configPolicy.Checksum() {
-			m[id] = p
-			reusedCount++
-			continue
-		}
-		builders = append(builders, func(ctx context.Context) (*routeEvaluator, error) {
-			evaluator, err := NewPolicyEvaluator(ctx, store, configPolicy, cfg.AddDefaultClientCertificateRule)
-			if err != nil {
-				return nil, fmt.Errorf("authorize: error building evaluator for route id=%s: %w", configPolicy.ID, err)
+	numChunks := len(cfg.Policies) / chunkSize
+	if len(cfg.Policies)%chunkSize != 0 {
+		numChunks++
+	}
+	statusBits := make([]uint64, numChunks) // 0=no change, 1=changed
+	statusCounts := make([]uint8, numChunks)
+	var totalModified atomic.Int32
+	evaluators := make([]routeEvaluator, len(cfg.Policies))
+	if len(evaluators) == 0 {
+		return nil // nothing to do
+	}
+	numWorkers := min(workerPoolSize, numChunks)
+	minChunksPerWorker := numChunks / numWorkers
+	overflow := numChunks % numWorkers // number of workers which get an additional chunk
+
+	wctx := &workerContext{
+		Context:       ctx,
+		Cfg:           cfg,
+		Store:         store,
+		StatusBits:    statusBits,
+		StatusCounts:  statusCounts,
+		TotalModified: &totalModified,
+		Evaluators:    evaluators,
+		EvalCache:     evalCache,
+		QueryCache:    queryCache,
+		Errs:          &sync.Map{}, // slice index->error
+	}
+
+	partitions := make([]partition, numWorkers)
+	rttrace.WithRegion(ctx, "partitioning", func() {
+		chunkIdx := 0
+		for workerIdx := range numWorkers {
+			chunkStart := chunkIdx
+			chunkEnd := chunkStart + minChunksPerWorker
+			if workerIdx < overflow {
+				chunkEnd++
 			}
-			return &routeEvaluator{
-				id:        id,
-				evaluator: evaluator,
-			}, nil
-		})
-	}
-
-	evals, errs := errgrouputil.Build(ctx, builders...)
-	if len(errs) > 0 {
-		for _, err := range errs {
-			log.Error(ctx).Msg(err.Error())
+			chunkIdx = chunkEnd
+			partitions[workerIdx] = partition{chunkStart, chunkEnd}
 		}
-		return nil, fmt.Errorf("authorize: error building policy evaluators")
+	})
+
+	// compute route checksums
+	rttrace.WithRegion(ctx, "computing checksums", func() {
+		var wg sync.WaitGroup
+		for _, part := range partitions {
+			wg.Add(1)
+			workerPoolTaskQueue <- func() {
+				defer wg.Done()
+				computeChecksums(wctx, part)
+			}
+		}
+		wg.Wait()
+	})
+
+	hasErrs := false
+	wctx.Errs.Range(func(key, value any) bool {
+		log.Error(ctx).Msg(value.(error).Error())
+		hasErrs = true
+		return true
+	})
+	if hasErrs {
+		return fmt.Errorf("authorize: error computing one or more policy route IDs")
 	}
 
-	for _, p := range evals {
-		m[p.id] = p.evaluator
+	if totalModified.Load() == 0 {
+		return nil
+	}
+
+	// spawn workers
+	rttrace.WithRegion(ctx, "running workers", func() {
+		var wg sync.WaitGroup
+		for _, part := range partitions {
+			for part.Begin < part.End && statusCounts[part.Begin] == 0 {
+				part.Begin++
+			}
+			for part.Begin < (part.End)-1 && statusCounts[part.End-1] == 0 {
+				part.End--
+			}
+			if part.Begin == part.End {
+				continue
+			}
+			wg.Add(1)
+			workerPoolTaskQueue <- func() {
+				defer wg.Done()
+				buildEvaluators(wctx, part)
+			}
+		}
+		wg.Wait()
+	})
+
+	hasErrs = false
+	wctx.Errs.Range(func(key, value any) bool {
+		log.Error(ctx).Msg(value.(error).Error())
+		hasErrs = true
+		return true
+	})
+	if hasErrs {
+		return fmt.Errorf("authorize: error building policy evaluators")
+	}
+
+	updatedCount := 0
+	for _, p := range evaluators {
+		if p.evaluator != nil {
+			updatedCount++
+			evalCache.StoreEvaluator(p.id, p.evaluator)
+		}
 	}
 
 	log.Debug(ctx).
 		Dur("duration", time.Since(now)).
-		Int("reused-policies", reusedCount).
-		Int("created-policies", len(cfg.Policies)-reusedCount).
+		Int("reused-policies", len(cfg.Policies)-updatedCount).
+		Int("created-policies", updatedCount).
 		Msg("updated policy evaluators")
-	return m, nil
+	return nil
 }
 
 // Evaluate evaluates the rego for the given policy and generates the identity headers.
@@ -265,7 +574,7 @@ func (e *Evaluator) evaluatePolicy(ctx context.Context, req *Request) (*PolicyRe
 		return nil, fmt.Errorf("authorize: error computing policy route id: %w", err)
 	}
 
-	policyEvaluator, ok := e.policyEvaluators[id]
+	policyEvaluator, ok := e.evalCache.LookupEvaluator(id)
 	if !ok {
 		return &PolicyResponse{
 			Deny: NewRuleResult(true, criteria.ReasonRouteNotFound),
@@ -278,7 +587,7 @@ func (e *Evaluator) evaluatePolicy(ctx context.Context, req *Request) (*PolicyRe
 	}
 
 	isValidClientCertificate, err := isValidClientCertificate(
-		clientCA, string(e.clientCRL), req.HTTP.ClientCertificate, e.clientCertConstraints)
+		clientCA, string(e.opts.ClientCRL), req.HTTP.ClientCertificate, e.opts.ClientCertConstraints)
 	if err != nil {
 		return nil, fmt.Errorf("authorize: error validating client certificate: %w", err)
 	}
@@ -293,7 +602,7 @@ func (e *Evaluator) evaluatePolicy(ctx context.Context, req *Request) (*PolicyRe
 func (e *Evaluator) evaluateHeaders(ctx context.Context, req *Request) (*HeadersResponse, error) {
 	headersReq := NewHeadersRequestFromPolicy(req.Policy, req.HTTP)
 	headersReq.Session = req.Session
-	res, err := e.headersEvaluators.Evaluate(ctx, headersReq)
+	res, err := e.headersEvaluator.Evaluate(ctx, headersReq)
 	if err != nil {
 		return nil, err
 	}
@@ -312,29 +621,36 @@ func (e *Evaluator) getClientCA(policy *config.Policy) (string, error) {
 		return string(bs), nil
 	}
 
-	return string(e.clientCA), nil
+	return string(e.opts.ClientCA), nil
 }
 
-func updateStore(store *store.Store, cfg *evaluatorConfig) error {
-	jwk, err := getJWK(cfg)
-	if err != nil {
-		return fmt.Errorf("authorize: couldn't create signer: %w", err)
+func updateStore(store *store.Store, cfg *evaluatorConfig, previous *Evaluator) error {
+	if previous == nil || !bytes.Equal(cfg.SigningKey, previous.opts.SigningKey) {
+		jwk, err := getJWK(cfg.SigningKey)
+		if err != nil {
+			return fmt.Errorf("authorize: couldn't create signer: %w", err)
+		}
+		store.UpdateSigningKey(jwk)
 	}
 
-	store.UpdateGoogleCloudServerlessAuthenticationServiceAccount(
-		cfg.GoogleCloudServerlessAuthenticationServiceAccount,
-	)
-	store.UpdateJWTClaimHeaders(cfg.JWTClaimsHeaders)
-	store.UpdateRoutePolicies(cfg.Policies)
-	store.UpdateSigningKey(jwk)
+	if previous == nil || cfg.GoogleCloudServerlessAuthenticationServiceAccount != previous.opts.GoogleCloudServerlessAuthenticationServiceAccount {
+		store.UpdateGoogleCloudServerlessAuthenticationServiceAccount(
+			cfg.GoogleCloudServerlessAuthenticationServiceAccount,
+		)
+	}
 
+	if previous == nil || !maps.Equal(cfg.JWTClaimsHeaders, previous.opts.JWTClaimsHeaders) {
+		store.UpdateJWTClaimHeaders(cfg.JWTClaimsHeaders)
+	}
+
+	store.UpdateRoutePolicies(cfg.Policies)
 	return nil
 }
 
-func getJWK(cfg *evaluatorConfig) (*jose.JSONWebKey, error) {
+func getJWK(signingKey []byte) (*jose.JSONWebKey, error) {
 	var decodedCert []byte
 	// if we don't have a signing key, generate one
-	if len(cfg.SigningKey) == 0 {
+	if len(signingKey) == 0 {
 		key, err := cryptutil.NewSigningKey()
 		if err != nil {
 			return nil, fmt.Errorf("couldn't generate signing key: %w", err)
@@ -344,7 +660,7 @@ func getJWK(cfg *evaluatorConfig) (*jose.JSONWebKey, error) {
 			return nil, fmt.Errorf("bad signing key: %w", err)
 		}
 	} else {
-		decodedCert = cfg.SigningKey
+		decodedCert = signingKey
 	}
 
 	jwk, err := cryptutil.PrivateJWKFromBytes(decodedCert)

--- a/authorize/evaluator/evaluator_export_test.go
+++ b/authorize/evaluator/evaluator_export_test.go
@@ -1,0 +1,28 @@
+package evaluator
+
+import (
+	"maps"
+)
+
+func (c *EvaluatorCache) XClone() *EvaluatorCache {
+	c.evalsMu.Lock()
+	defer c.evalsMu.Unlock()
+	return &EvaluatorCache{
+		evaluatorsByRouteID: maps.Clone(c.evaluatorsByRouteID),
+	}
+}
+
+func (e *Evaluator) XEvaluatorCache() *EvaluatorCache {
+	return e.evalCache
+}
+
+func (e *Evaluator) XQueryCache() *QueryCache {
+	return e.queryCache
+}
+
+var (
+	XGetGoogleCloudServerlessTokenSource = getGoogleCloudServerlessTokenSource
+	XIsValidClientCertificate            = isValidClientCertificate
+	XNormalizeServiceAccount             = normalizeServiceAccount
+	XWorkerPoolSize                      = workerPoolSize
+)

--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -1,19 +1,32 @@
-package evaluator
+package evaluator_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
+	"fmt"
+	"io"
 	"net/http"
 	"net/url"
+	"runtime/trace"
+	"strings"
 	"testing"
+	"time"
 
+	xtrace "golang.org/x/exp/trace"
+
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	"google.golang.org/protobuf/proto"
+	"gopkg.in/yaml.v3"
 
+	"github.com/pomerium/pomerium/authorize/evaluator"
 	"github.com/pomerium/pomerium/authorize/internal/store"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/httputil"
+	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
@@ -30,13 +43,13 @@ func TestEvaluator(t *testing.T) {
 	privateJWK, err := cryptutil.PrivateJWKFromBytes(encodedSigningKey)
 	require.NoError(t, err)
 
-	eval := func(t *testing.T, options []Option, data []proto.Message, req *Request) (*Result, error) {
+	eval := func(t *testing.T, options []evaluator.Option, data []proto.Message, req *evaluator.Request) (*evaluator.Result, error) {
 		ctx := context.Background()
 		ctx = storage.WithQuerier(ctx, storage.NewStaticQuerier(data...))
 		store := store.New()
 		store.UpdateJWTClaimHeaders(config.NewJWTClaimHeaders("email", "groups", "user", "CUSTOM_KEY"))
 		store.UpdateSigningKey(privateJWK)
-		e, err := New(ctx, store, nil, options...)
+		e, err := evaluator.New(ctx, store, nil, options...)
 		require.NoError(t, err)
 		return e.Evaluate(ctx, req)
 	}
@@ -128,42 +141,42 @@ func TestEvaluator(t *testing.T) {
 			},
 		},
 	}
-	options := []Option{
-		WithAuthenticateURL("https://authn.example.com"),
-		WithPolicies(policies),
+	options := []evaluator.Option{
+		evaluator.WithAuthenticateURL("https://authn.example.com"),
+		evaluator.WithPolicies(policies),
 	}
 
-	validCertInfo := ClientCertificateInfo{
+	validCertInfo := evaluator.ClientCertificateInfo{
 		Presented: true,
 		Leaf:      testValidCert,
 	}
 
 	t.Run("client certificate (default CA)", func(t *testing.T) {
 		// Clone the existing options and add a default client CA.
-		options := append([]Option(nil), options...)
-		options = append(options, WithClientCA([]byte(testCA)),
-			WithAddDefaultClientCertificateRule(true))
+		options := append([]evaluator.Option(nil), options...)
+		options = append(options, evaluator.WithClientCA([]byte(testCA)),
+			evaluator.WithAddDefaultClientCertificateRule(true))
 		t.Run("missing", func(t *testing.T) {
-			res, err := eval(t, options, nil, &Request{
+			res, err := eval(t, options, nil, &evaluator.Request{
 				Policy: policies[0],
 			})
 			require.NoError(t, err)
-			assert.Equal(t, NewRuleResult(true, criteria.ReasonClientCertificateRequired), res.Deny)
+			assert.Equal(t, evaluator.NewRuleResult(true, criteria.ReasonClientCertificateRequired), res.Deny)
 		})
 		t.Run("invalid", func(t *testing.T) {
-			res, err := eval(t, options, nil, &Request{
+			res, err := eval(t, options, nil, &evaluator.Request{
 				Policy: policies[0],
-				HTTP: RequestHTTP{
-					ClientCertificate: ClientCertificateInfo{Presented: true},
+				HTTP: evaluator.RequestHTTP{
+					ClientCertificate: evaluator.ClientCertificateInfo{Presented: true},
 				},
 			})
 			require.NoError(t, err)
-			assert.Equal(t, NewRuleResult(true, criteria.ReasonInvalidClientCertificate), res.Deny)
+			assert.Equal(t, evaluator.NewRuleResult(true, criteria.ReasonInvalidClientCertificate), res.Deny)
 		})
 		t.Run("valid", func(t *testing.T) {
-			res, err := eval(t, options, nil, &Request{
+			res, err := eval(t, options, nil, &evaluator.Request{
 				Policy: policies[0],
-				HTTP: RequestHTTP{
+				HTTP: evaluator.RequestHTTP{
 					ClientCertificate: validCertInfo,
 				},
 			})
@@ -173,32 +186,32 @@ func TestEvaluator(t *testing.T) {
 	})
 	t.Run("client certificate (per-policy CA)", func(t *testing.T) {
 		// Clone existing options and add the default client certificate rule.
-		options := append([]Option(nil), options...)
-		options = append(options, WithAddDefaultClientCertificateRule(true))
+		options := append([]evaluator.Option(nil), options...)
+		options = append(options, evaluator.WithAddDefaultClientCertificateRule(true))
 		t.Run("missing", func(t *testing.T) {
-			res, err := eval(t, options, nil, &Request{
+			res, err := eval(t, options, nil, &evaluator.Request{
 				Policy: policies[10],
 			})
 			require.NoError(t, err)
-			assert.Equal(t, NewRuleResult(true, criteria.ReasonClientCertificateRequired), res.Deny)
+			assert.Equal(t, evaluator.NewRuleResult(true, criteria.ReasonClientCertificateRequired), res.Deny)
 		})
 		t.Run("invalid", func(t *testing.T) {
-			res, err := eval(t, options, nil, &Request{
+			res, err := eval(t, options, nil, &evaluator.Request{
 				Policy: policies[10],
-				HTTP: RequestHTTP{
-					ClientCertificate: ClientCertificateInfo{
+				HTTP: evaluator.RequestHTTP{
+					ClientCertificate: evaluator.ClientCertificateInfo{
 						Presented: true,
 						Leaf:      testUntrustedCert,
 					},
 				},
 			})
 			require.NoError(t, err)
-			assert.Equal(t, NewRuleResult(true, criteria.ReasonInvalidClientCertificate), res.Deny)
+			assert.Equal(t, evaluator.NewRuleResult(true, criteria.ReasonInvalidClientCertificate), res.Deny)
 		})
 		t.Run("valid", func(t *testing.T) {
-			res, err := eval(t, options, nil, &Request{
+			res, err := eval(t, options, nil, &evaluator.Request{
 				Policy: policies[10],
-				HTTP: RequestHTTP{
+				HTTP: evaluator.RequestHTTP{
 					ClientCertificate: validCertInfo,
 				},
 			})
@@ -209,13 +222,13 @@ func TestEvaluator(t *testing.T) {
 	t.Run("explicit client certificate rule", func(t *testing.T) {
 		// Clone the existing options and add a default client CA (but no
 		// default deny rule).
-		options := append([]Option(nil), options...)
-		options = append(options, WithClientCA([]byte(testCA)))
+		options := append([]evaluator.Option(nil), options...)
+		options = append(options, evaluator.WithClientCA([]byte(testCA)))
 		t.Run("invalid but allowed", func(t *testing.T) {
-			res, err := eval(t, options, nil, &Request{
+			res, err := eval(t, options, nil, &evaluator.Request{
 				Policy: policies[0], // no explicit deny rule
-				HTTP: RequestHTTP{
-					ClientCertificate: ClientCertificateInfo{
+				HTTP: evaluator.RequestHTTP{
+					ClientCertificate: evaluator.ClientCertificateInfo{
 						Presented: true,
 						Leaf:      testUntrustedCert,
 					},
@@ -225,17 +238,17 @@ func TestEvaluator(t *testing.T) {
 			assert.False(t, res.Deny.Value)
 		})
 		t.Run("invalid", func(t *testing.T) {
-			res, err := eval(t, options, nil, &Request{
+			res, err := eval(t, options, nil, &evaluator.Request{
 				Policy: policies[11], // policy has explicit deny rule
-				HTTP: RequestHTTP{
-					ClientCertificate: ClientCertificateInfo{
+				HTTP: evaluator.RequestHTTP{
+					ClientCertificate: evaluator.ClientCertificateInfo{
 						Presented: true,
 						Leaf:      testUntrustedCert,
 					},
 				},
 			})
 			require.NoError(t, err)
-			assert.Equal(t, NewRuleResult(true, criteria.ReasonInvalidClientCertificate), res.Deny)
+			assert.Equal(t, evaluator.NewRuleResult(true, criteria.ReasonInvalidClientCertificate), res.Deny)
 		})
 	})
 	t.Run("identity_headers", func(t *testing.T) {
@@ -249,12 +262,12 @@ func TestEvaluator(t *testing.T) {
 					Id:    "user1",
 					Email: "a@example.com",
 				},
-			}, &Request{
+			}, &evaluator.Request{
 				Policy: policies[1],
-				Session: RequestSession{
+				Session: evaluator.RequestSession{
 					ID: "session1",
 				},
-				HTTP: RequestHTTP{
+				HTTP: evaluator.RequestHTTP{
 					Method: http.MethodGet,
 					URL:    "https://from.example.com",
 				},
@@ -273,12 +286,12 @@ func TestEvaluator(t *testing.T) {
 						Id:    "user1",
 						Email: "a@example.com",
 					},
-				}, &Request{
+				}, &evaluator.Request{
 					Policy: policies[2],
-					Session: RequestSession{
+					Session: evaluator.RequestSession{
 						ID: "session1",
 					},
-					HTTP: RequestHTTP{
+					HTTP: evaluator.RequestHTTP{
 						Method: http.MethodGet,
 						URL:    "https://from.example.com",
 					},
@@ -299,12 +312,12 @@ func TestEvaluator(t *testing.T) {
 					Id:    "user1",
 					Email: "a@example.com",
 				},
-			}, &Request{
+			}, &evaluator.Request{
 				Policy: policies[3],
-				Session: RequestSession{
+				Session: evaluator.RequestSession{
 					ID: "session1",
 				},
-				HTTP: RequestHTTP{
+				HTTP: evaluator.RequestHTTP{
 					Method: http.MethodGet,
 					URL:    "https://from.example.com",
 				},
@@ -322,12 +335,12 @@ func TestEvaluator(t *testing.T) {
 					Id:    "user1",
 					Email: "a@example.com",
 				},
-			}, &Request{
+			}, &evaluator.Request{
 				Policy: policies[4],
-				Session: RequestSession{
+				Session: evaluator.RequestSession{
 					ID: "session1",
 				},
-				HTTP: RequestHTTP{
+				HTTP: evaluator.RequestHTTP{
 					Method: http.MethodGet,
 					URL:    "https://from.example.com",
 				},
@@ -345,12 +358,12 @@ func TestEvaluator(t *testing.T) {
 					Id:    "user1",
 					Email: "b@example.com",
 				},
-			}, &Request{
+			}, &evaluator.Request{
 				Policy: policies[3],
-				Session: RequestSession{
+				Session: evaluator.RequestSession{
 					ID: "session1",
 				},
-				HTTP: RequestHTTP{
+				HTTP: evaluator.RequestHTTP{
 					Method: http.MethodGet,
 					URL:    "https://from.example.com",
 				},
@@ -375,12 +388,12 @@ func TestEvaluator(t *testing.T) {
 					Id:    "user1",
 					Email: "a@example.com",
 				},
-			}, &Request{
+			}, &evaluator.Request{
 				Policy: policies[3],
-				Session: RequestSession{
+				Session: evaluator.RequestSession{
 					ID: "session2",
 				},
-				HTTP: RequestHTTP{
+				HTTP: evaluator.RequestHTTP{
 					Method: http.MethodGet,
 					URL:    "https://from.example.com",
 				},
@@ -399,12 +412,12 @@ func TestEvaluator(t *testing.T) {
 				Id:    "example/1234",
 				Email: "a@example.com",
 			},
-		}, &Request{
+		}, &evaluator.Request{
 			Policy: policies[5],
-			Session: RequestSession{
+			Session: evaluator.RequestSession{
 				ID: "session1",
 			},
-			HTTP: RequestHTTP{
+			HTTP: evaluator.RequestHTTP{
 				Method: http.MethodGet,
 				URL:    "https://from.example.com",
 			},
@@ -422,12 +435,12 @@ func TestEvaluator(t *testing.T) {
 				Id:    "user1",
 				Email: "a@example.com",
 			},
-		}, &Request{
+		}, &evaluator.Request{
 			Policy: policies[6],
-			Session: RequestSession{
+			Session: evaluator.RequestSession{
 				ID: "session1",
 			},
-			HTTP: RequestHTTP{
+			HTTP: evaluator.RequestHTTP{
 				Method: http.MethodGet,
 				URL:    "https://from.example.com",
 			},
@@ -450,12 +463,12 @@ func TestEvaluator(t *testing.T) {
 				Id:    "user1",
 				Email: "a@example.com",
 			},
-		}, &Request{
+		}, &evaluator.Request{
 			Policy: policies[6],
-			Session: RequestSession{
+			Session: evaluator.RequestSession{
 				ID: "session1",
 			},
-			HTTP: RequestHTTP{
+			HTTP: evaluator.RequestHTTP{
 				Method: http.MethodGet,
 				URL:    "https://from.example.com",
 			},
@@ -472,12 +485,12 @@ func TestEvaluator(t *testing.T) {
 			&user.User{
 				Id: "user1",
 			},
-		}, &Request{
+		}, &evaluator.Request{
 			Policy: policies[7],
-			Session: RequestSession{
+			Session: evaluator.RequestSession{
 				ID: "session1",
 			},
-			HTTP: RequestHTTP{
+			HTTP: evaluator.RequestHTTP{
 				Method: http.MethodGet,
 				URL:    "https://from.example.com",
 			},
@@ -508,12 +521,12 @@ func TestEvaluator(t *testing.T) {
 				&user.User{
 					Id: "user1",
 				},
-			}, &Request{
+			}, &evaluator.Request{
 				Policy: policies[8],
-				Session: RequestSession{
+				Session: evaluator.RequestSession{
 					ID: "session1",
 				},
-				HTTP: RequestHTTP{
+				HTTP: evaluator.RequestHTTP{
 					Method:  http.MethodGet,
 					URL:     "https://from.example.com",
 					Headers: tc.src,
@@ -525,13 +538,13 @@ func TestEvaluator(t *testing.T) {
 		}
 	})
 	t.Run("http method", func(t *testing.T) {
-		res, err := eval(t, options, []proto.Message{}, &Request{
+		res, err := eval(t, options, []proto.Message{}, &evaluator.Request{
 			Policy: policies[8],
-			HTTP: NewRequestHTTP(
+			HTTP: evaluator.NewRequestHTTP(
 				http.MethodGet,
 				*mustParseURL("https://from.example.com/"),
 				nil,
-				ClientCertificateInfo{},
+				evaluator.ClientCertificateInfo{},
 				"",
 			),
 		})
@@ -539,13 +552,13 @@ func TestEvaluator(t *testing.T) {
 		assert.True(t, res.Allow.Value)
 	})
 	t.Run("http path", func(t *testing.T) {
-		res, err := eval(t, options, []proto.Message{}, &Request{
+		res, err := eval(t, options, []proto.Message{}, &evaluator.Request{
 			Policy: policies[9],
-			HTTP: NewRequestHTTP(
+			HTTP: evaluator.NewRequestHTTP(
 				"POST",
 				*mustParseURL("https://from.example.com/test"),
 				nil,
-				ClientCertificateInfo{},
+				evaluator.ClientCertificateInfo{},
 				"",
 			),
 		})
@@ -566,30 +579,36 @@ func TestPolicyEvaluatorReuse(t *testing.T) {
 		{To: singleToURL("https://to4.example.com")},
 	}
 
-	options := []Option{
-		WithPolicies(policies),
+	options := []evaluator.Option{
+		evaluator.WithPolicies(policies),
 	}
 
-	initial, err := New(ctx, store, nil, options...)
+	initial, err := evaluator.New(ctx, store, nil, options...)
 	require.NoError(t, err)
 
-	assertPolicyEvaluatorReused := func(t *testing.T, e *Evaluator, p *config.Policy) {
+	initialEvaluators := initial.XEvaluatorCache().XClone()
+
+	assertPolicyEvaluatorReused := func(t *testing.T, e *evaluator.Evaluator, p *config.Policy) {
 		t.Helper()
 		routeID, err := p.RouteID()
 		require.NoError(t, err)
-		p1 := initial.policyEvaluators[routeID]
+		p1, ok := initialEvaluators.LookupEvaluator(routeID)
+		require.True(t, ok)
 		require.NotNil(t, p1)
-		p2 := e.policyEvaluators[routeID]
+		p2, ok := e.XEvaluatorCache().LookupEvaluator(routeID)
+		require.True(t, ok)
 		assert.Same(t, p1, p2, routeID)
 	}
 
-	assertPolicyEvaluatorUpdated := func(t *testing.T, e *Evaluator, p *config.Policy) {
+	assertPolicyEvaluatorUpdated := func(t *testing.T, e *evaluator.Evaluator, p *config.Policy) {
 		t.Helper()
 		routeID, err := p.RouteID()
 		require.NoError(t, err)
-		p1 := initial.policyEvaluators[routeID]
+		p1, ok := initialEvaluators.LookupEvaluator(routeID)
+		require.True(t, ok)
 		require.NotNil(t, p1)
-		p2 := e.policyEvaluators[routeID]
+		p2, ok := e.XEvaluatorCache().LookupEvaluator(routeID)
+		require.True(t, ok)
 		require.NotNil(t, p2)
 		assert.NotSame(t, p1, p2, routeID)
 	}
@@ -597,15 +616,15 @@ func TestPolicyEvaluatorReuse(t *testing.T) {
 	// If the evaluatorConfig is identical, all of the policy evaluators should
 	// be reused.
 	t.Run("identical", func(t *testing.T) {
-		e, err := New(ctx, store, initial, options...)
+		e, err := evaluator.New(ctx, store, initial, options...)
 		require.NoError(t, err)
 		for i := range policies {
 			assertPolicyEvaluatorReused(t, e, policies[i])
 		}
 	})
 
-	assertNoneReused := func(t *testing.T, o Option) {
-		e, err := New(ctx, store, initial, append(options, o)...)
+	assertNoneReused := func(t *testing.T, o evaluator.Option) {
+		e, err := evaluator.New(ctx, store, initial, append(options, o)...)
 		require.NoError(t, err)
 		for i := range policies {
 			assertPolicyEvaluatorUpdated(t, e, policies[i])
@@ -615,32 +634,32 @@ func TestPolicyEvaluatorReuse(t *testing.T) {
 	// If any of the evaluatorConfig fields besides the Policies change, no
 	// policy evaluators should be reused.
 	t.Run("ClientCA changed", func(t *testing.T) {
-		assertNoneReused(t, WithClientCA([]byte("dummy-ca")))
+		assertNoneReused(t, evaluator.WithClientCA([]byte("dummy-ca")))
 	})
 	t.Run("ClientCRL changed", func(t *testing.T) {
-		assertNoneReused(t, WithClientCRL([]byte("dummy-crl")))
+		assertNoneReused(t, evaluator.WithClientCRL([]byte("dummy-crl")))
 	})
 	t.Run("AddDefaultClientCertificateRule changed", func(t *testing.T) {
-		assertNoneReused(t, WithAddDefaultClientCertificateRule(true))
+		assertNoneReused(t, evaluator.WithAddDefaultClientCertificateRule(true))
 	})
 	t.Run("ClientCertConstraints changed", func(t *testing.T) {
-		assertNoneReused(t, WithClientCertConstraints(&ClientCertConstraints{MaxVerifyDepth: 3}))
+		assertNoneReused(t, evaluator.WithClientCertConstraints(&evaluator.ClientCertConstraints{MaxVerifyDepth: 3}))
 	})
 	t.Run("SigningKey changed", func(t *testing.T) {
 		signingKey, err := cryptutil.NewSigningKey()
 		require.NoError(t, err)
 		encodedSigningKey, err := cryptutil.EncodePrivateKey(signingKey)
 		require.NoError(t, err)
-		assertNoneReused(t, WithSigningKey(encodedSigningKey))
+		assertNoneReused(t, evaluator.WithSigningKey(encodedSigningKey))
 	})
 	t.Run("AuthenticateURL changed", func(t *testing.T) {
-		assertNoneReused(t, WithAuthenticateURL("authenticate.example.com"))
+		assertNoneReused(t, evaluator.WithAuthenticateURL("authenticate.example.com"))
 	})
 	t.Run("GoogleCloudServerlessAuthenticationServiceAccount changed", func(t *testing.T) {
-		assertNoneReused(t, WithGoogleCloudServerlessAuthenticationServiceAccount("dummy-account"))
+		assertNoneReused(t, evaluator.WithGoogleCloudServerlessAuthenticationServiceAccount("dummy-account"))
 	})
 	t.Run("JWTClaimsHeaders changed", func(t *testing.T) {
-		assertNoneReused(t, WithJWTClaimsHeaders(config.JWTClaimHeaders{"dummy": "header"}))
+		assertNoneReused(t, evaluator.WithJWTClaimsHeaders(config.JWTClaimHeaders{"dummy": "header"}))
 	})
 
 	// If some policies have changed, but the evaluatorConfig is otherwise
@@ -658,7 +677,7 @@ func TestPolicyEvaluatorReuse(t *testing.T) {
 				AllowAnyAuthenticatedUser: true},
 		}
 
-		e, err := New(ctx, store, initial, WithPolicies(newPolicies))
+		e, err := evaluator.New(ctx, store, initial, evaluator.WithPolicies(newPolicies))
 		require.NoError(t, err)
 
 		// Only the first and the third policy evaluators should be reused.
@@ -670,9 +689,11 @@ func TestPolicyEvaluatorReuse(t *testing.T) {
 		// evaluators.
 		rid, err := newPolicies[3].RouteID()
 		require.NoError(t, err)
-		_, exists := initial.policyEvaluators[rid]
+		_, exists := initialEvaluators.LookupEvaluator(rid)
 		assert.False(t, exists, "initial evaluator should not have a policy for route ID", rid)
-		assert.NotNil(t, e.policyEvaluators[rid])
+		eval, ok := e.XEvaluatorCache().LookupEvaluator(rid)
+		assert.True(t, ok, "new evaluator should have a policy for route ID", rid)
+		assert.NotNil(t, eval)
 	})
 }
 
@@ -686,4 +707,421 @@ func mustParseURL(str string) *url.URL {
 		panic(err)
 	}
 	return u
+}
+
+func BenchmarkEvaluator(b *testing.B) {
+	log.SetLevel(zerolog.WarnLevel)
+
+	b.Run("append new policies", func(b *testing.B) {
+		b.Run("same ppl for all routes", func(b *testing.B) {
+			store := store.New()
+			ppl := `
+allow:
+  and:
+    - email:
+        is: foo@bar.com
+`
+			var pplPolicy config.PPLPolicy
+			err := yaml.Unmarshal([]byte(ppl), &pplPolicy)
+			require.NoError(b, err)
+
+			var e *evaluator.Evaluator
+			policies := make([]*config.Policy, 0, 4096)
+			for i := 0; i < b.N; i++ {
+				policies = append(policies, &config.Policy{
+					From:   fmt.Sprintf("https://from%d.example.com", i),
+					To:     singleToURL(fmt.Sprintf("https://to%d.example.com", i)),
+					Policy: &pplPolicy,
+				})
+				var err error
+				e, err = evaluator.New(context.Background(), store, e, evaluator.WithPolicies(policies))
+				require.NoError(b, err)
+				require.Equal(b, e.XEvaluatorCache().NumCachedEvaluators(), len(policies))
+			}
+		})
+		b.Run("unique ppl per route", func(b *testing.B) {
+			store := store.New()
+			newPPLPolicy := func(i int) *config.PPLPolicy {
+				ppl := fmt.Sprintf(`
+allow:
+  and:
+    - email:
+        is: user-%d@example.com
+`, i)
+				var pplPolicy config.PPLPolicy
+				err := yaml.Unmarshal([]byte(ppl), &pplPolicy)
+				require.NoError(b, err)
+				return &pplPolicy
+			}
+
+			var e *evaluator.Evaluator
+			policies := make([]*config.Policy, 0, 4096)
+			timeout := time.Minute
+			for i := 0; i < b.N; i++ {
+				policies = append(policies, &config.Policy{
+					From:            fmt.Sprintf("https://from%d.example.com", i),
+					To:              singleToURL(fmt.Sprintf("https://to%d.example.com", i)),
+					Policy:          newPPLPolicy(i),
+					UpstreamTimeout: &timeout,
+					TLSSkipVerify:   true,
+				})
+				var err error
+				e, err = evaluator.New(context.Background(), store, e, evaluator.WithPolicies(policies))
+				require.NoError(b, err)
+				require.Equal(b, e.XEvaluatorCache().NumCachedEvaluators(), len(policies))
+			}
+		})
+	})
+}
+
+type logAssertion struct {
+	before time.Time
+	after  time.Time
+	msg    string
+}
+
+type logAssertionGroup struct {
+	before            time.Time
+	after             time.Time
+	unorderedMessages []string
+}
+
+type GetOrCreatePolicyEvaluatorsSuite struct {
+	suite.Suite
+
+	logAssertions []any
+	traceBuffer   bytes.Buffer
+}
+
+var _ interface {
+	suite.SetupTestSuite
+	suite.TearDownTestSuite
+} = (*GetOrCreatePolicyEvaluatorsSuite)(nil)
+
+const (
+	staticPolicyFormat = `
+allow:
+  and:
+    - email:
+        is: foo@example.com
+`
+	uniquePerUserPolicyFormat = `
+allow:
+  and:
+    - email:
+        is: user-%d@example.com
+`
+)
+
+func (s *GetOrCreatePolicyEvaluatorsSuite) generateRoutes(start, n int, policyFormat string) []*config.Policy {
+	newPPLPolicy := func(i int, format string) *config.PPLPolicy {
+		var pplPolicy config.PPLPolicy
+		if strings.Contains(format, "%d") {
+			format = fmt.Sprintf(format, i)
+		}
+		err := yaml.Unmarshal([]byte(format), &pplPolicy)
+		s.NoError(err)
+		return &pplPolicy
+	}
+	list := make([]*config.Policy, 0, n)
+	for i := 0; i < n; i++ {
+		list = append(list, &config.Policy{
+			From:   fmt.Sprintf("https://from%d.example.com", start+i),
+			To:     singleToURL(fmt.Sprintf("https://to%d.example.com", start+i)),
+			Policy: newPPLPolicy(start+i, policyFormat),
+		})
+	}
+	return list
+}
+
+func (s *GetOrCreatePolicyEvaluatorsSuite) SetupTest() {
+	s.traceBuffer.Reset()
+	s.logAssertions = []any{}
+	s.Require().NoError(trace.Start(&s.traceBuffer))
+}
+
+func (s *GetOrCreatePolicyEvaluatorsSuite) TearDownTest() {
+	trace.Stop()
+	traceReader, err := xtrace.NewReader(&s.traceBuffer)
+	s.Require().NoError(err)
+	logsReceived := []xtrace.Event{}
+	for {
+		ev, err := traceReader.ReadEvent()
+		if err == io.EOF {
+			break
+		}
+		s.Require().NoError(err)
+		switch ev.Kind() {
+		case xtrace.EventLog:
+			logsReceived = append(logsReceived, ev)
+		}
+	}
+
+	if len(s.logAssertions) == 0 {
+		return
+	}
+
+	var laIdx, lrIdx int
+	for ; lrIdx < len(logsReceived); lrIdx++ {
+		if laIdx >= len(s.logAssertions) {
+			s.Fail(fmt.Sprintf("log %q received, but no more logs were expected", logsReceived[lrIdx].Log().Message))
+			continue
+		}
+		la := s.logAssertions[laIdx]
+		laIdx++
+		switch la := la.(type) {
+		case logAssertion:
+			lr := logsReceived[lrIdx]
+			if la.msg == lr.Log().Message {
+				if !la.before.IsZero() {
+					s.Less(time.Unix(0, int64(lr.Time())), la.before)
+				} else if !la.after.IsZero() {
+					s.Greater(time.Unix(0, int64(lr.Time())), la.after)
+				}
+			} else if lrIdx+1 < len(logsReceived) && la.msg == logsReceived[lrIdx+1].Log().Message {
+				s.Fail(fmt.Sprintf("unexpected log %q received prior to the expected log %q", lr.Log().Message, la.msg))
+				laIdx--
+			} else {
+				s.Equal(la.msg, lr.Log().Message, "log message does not match")
+			}
+		case logAssertionGroup:
+			// read up to len(la) logs
+			logs := make([]xtrace.Event, 0, len(la.unorderedMessages))
+			for j := 0; j < len(la.unorderedMessages) && lrIdx+j < len(logsReceived); j++ {
+				logs = append(logs, logsReceived[lrIdx+j])
+			}
+			lrIdx += len(logs) - 1
+			messages := []string{}
+			for _, lr := range logs {
+				messages = append(messages, lr.Log().Message)
+				if !la.before.IsZero() {
+					s.Less(time.Unix(0, int64(lr.Time())), la.before)
+				} else if !la.after.IsZero() {
+					s.Greater(time.Unix(0, int64(lr.Time())), la.after)
+				}
+			}
+			s.ElementsMatch(la.unorderedMessages, messages)
+		default:
+			panic(fmt.Sprintf("test bug: unknown log assertion type %#T", la))
+		}
+	}
+}
+
+func (s *GetOrCreatePolicyEvaluatorsSuite) expectLogsF(f func() []string) {
+	s.expectLogs(f()...)
+}
+
+func (s *GetOrCreatePolicyEvaluatorsSuite) expectLogsUnorderedF(f func() []string) {
+	s.expectLogsUnordered(f()...)
+}
+
+func (s *GetOrCreatePolicyEvaluatorsSuite) expectLogs(msgs ...string) {
+	now := time.Now()
+	for _, msg := range msgs {
+		s.logAssertions = append(s.logAssertions, logAssertion{
+			before: now,
+			msg:    msg,
+		})
+	}
+}
+
+func (s *GetOrCreatePolicyEvaluatorsSuite) expectLogsUnordered(msgs ...string) {
+	now := time.Now()
+	s.logAssertions = append(s.logAssertions, logAssertionGroup{
+		before:            now,
+		unorderedMessages: msgs,
+	})
+}
+
+func (s *GetOrCreatePolicyEvaluatorsSuite) TestWorkers() {
+	// generate 10 routes
+	routes1 := s.generateRoutes(0, 10, staticPolicyFormat)
+	store := store.New()
+	eval, err := evaluator.New(context.Background(), store, nil, evaluator.WithPolicies(routes1))
+	s.Require().NoError(err)
+	s.expectLogs("using 0 cached policy evaluators")
+	for _, route := range routes1 {
+		rid, err := route.RouteID()
+		s.NoError(err)
+		s.expectLogs(fmt.Sprintf("policy for route ID %d not found in cache", rid))
+	}
+	s.expectLogs("chunk 0: 10/10 changed")
+	s.expectLogs("chunk 0: status: 1111111111")
+	s.Equal(evaluator.EvaluatorCacheStats{
+		CacheHits:   0,
+		CacheMisses: 10,
+	}, eval.XEvaluatorCache().Stats())
+	s.Equal(evaluator.QueryCacheStats{
+		CacheHits:       9,
+		CacheMisses:     1,
+		BuildsSucceeded: 1,
+		BuildsFailed:    0,
+		BuildsShared:    0,
+	}, eval.XQueryCache().Stats())
+
+	// generate 10 more routes, with the first 10 cached
+	routes2 := s.generateRoutes(10, 10, staticPolicyFormat)
+	eval, err = evaluator.New(context.Background(), store, eval, evaluator.WithPolicies(append(routes1, routes2...)))
+	s.Require().NoError(err)
+	s.expectLogs("using 10 cached policy evaluators")
+	for _, route := range routes2 {
+		s.expectLogs(fmt.Sprintf("policy for route ID %d not found in cache", route.MustRouteID()))
+	}
+	s.expectLogs("chunk 0: 10/20 changed")
+	s.expectLogs("chunk 0: status: 11111111110000000000")
+	s.Equal(evaluator.EvaluatorCacheStats{
+		CacheHits:   0 + 10,
+		CacheMisses: 10 + 10,
+	}, eval.XEvaluatorCache().Stats())
+	s.Equal(evaluator.QueryCacheStats{
+		CacheHits:       9 + 10,
+		CacheMisses:     1 + 0,
+		BuildsSucceeded: 1 + 0,
+		BuildsFailed:    0 + 0,
+		BuildsShared:    0 + 0,
+	}, eval.XQueryCache().Stats())
+
+	// generate 44 more routes, and change some existing ones around
+	routes3 := s.generateRoutes(20, 44, staticPolicyFormat)
+	routes1[4].AllowWebsockets = true // does not change the route id
+	routes1[7].IDPClientID = "foo"    // does not change the route id
+	routes1[7].IDPClientSecret = "bar"
+	routes2[1].To = nil // changes the route id
+	routes2[1].Redirect = &config.PolicyRedirect{
+		PathRedirect: proto.String("/test"),
+	}
+	routes2[8].To = nil // changes the route id
+	routes2[8].Response = &config.DirectResponse{
+		Status: 200,
+		Body:   "OK",
+	}
+	eval, err = evaluator.New(context.Background(), store, eval, evaluator.WithPolicies(append(append(routes1, routes2...), routes3...)))
+	s.Require().NoError(err)
+	s.expectLogs("using 20 cached policy evaluators")
+	s.expectLogs(
+		fmt.Sprintf("policy for route ID %d changed", routes1[4].MustRouteID()),
+		fmt.Sprintf("policy for route ID %d changed", routes1[7].MustRouteID()),
+		fmt.Sprintf("policy for route ID %d not found in cache", routes2[1].MustRouteID()),
+		fmt.Sprintf("policy for route ID %d not found in cache", routes2[8].MustRouteID()),
+	)
+	for _, route := range routes3 {
+		s.expectLogs(fmt.Sprintf("policy for route ID %d not found in cache", route.MustRouteID()))
+	}
+	s.expectLogs("chunk 0: 48/64 changed")
+	s.expectLogs(fmt.Sprintf("chunk 0: status: %s01000000100010010000", strings.Repeat("1", 44)))
+	s.Equal(evaluator.EvaluatorCacheStats{
+		CacheHits:   0 + 10 + 18,
+		CacheMisses: 10 + 10 + 46,
+	}, eval.XEvaluatorCache().Stats())
+	s.Equal(evaluator.QueryCacheStats{
+		CacheHits:       9 + 10 + 48,
+		CacheMisses:     1 + 0 + 0,
+		BuildsSucceeded: 1 + 0 + 0,
+		BuildsFailed:    0 + 0 + 0,
+		BuildsShared:    0 + 0 + 0,
+	}, eval.XQueryCache().Stats())
+
+	// any additional routes should now be split into a second chunk
+	routes4 := s.generateRoutes(65, 1, staticPolicyFormat)
+	eval, err = evaluator.New(context.Background(), store, eval, evaluator.WithPolicies(append(append(append(routes1, routes2...), routes3...), routes4...)))
+	s.Require().NoError(err)
+	s.expectLogs("using 66 cached policy evaluators") // +2 because of the other policies that were modified
+	for _, route := range routes4 {
+		s.expectLogs(fmt.Sprintf("policy for route ID %d not found in cache", route.MustRouteID()))
+	}
+	s.expectLogsUnordered(
+		"chunk 0: 0/64 changed",
+		"chunk 1: 1/1 changed",
+		"chunk 1: status: 1",
+	)
+	s.Equal(evaluator.EvaluatorCacheStats{
+		CacheHits:   0 + 10 + 18 + 64,
+		CacheMisses: 10 + 10 + 46 + 1,
+	}, eval.XEvaluatorCache().Stats())
+	s.Equal(evaluator.QueryCacheStats{
+		CacheHits:       9 + 10 + 48 + 1,
+		CacheMisses:     1 + 0 + 0 + 0,
+		BuildsSucceeded: 1 + 0 + 0 + 0,
+		BuildsFailed:    0 + 0 + 0 + 0,
+		BuildsShared:    0 + 0 + 0 + 0,
+	}, eval.XQueryCache().Stats())
+}
+
+func (s *GetOrCreatePolicyEvaluatorsSuite) TestSharedBuilds() {
+	largePPL := strings.Builder{}
+	largePPL.WriteString(`
+allow:
+  or:
+`)
+	for i := 0; i < 25; i++ {
+		largePPL.WriteString(`
+  - client_certificate:
+      fingerprint: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+`)
+	}
+	routes := s.generateRoutes(0, 650, largePPL.String())
+	store := store.New()
+	eval, err := evaluator.New(context.Background(), store, nil, evaluator.WithPolicies(routes))
+	s.Require().NoError(err)
+	s.Equal(evaluator.QueryCacheStats{
+		CacheHits:       639,
+		CacheMisses:     11,
+		BuildsSucceeded: 1,
+		BuildsFailed:    0,
+		BuildsShared:    10,
+	}, eval.XQueryCache().Stats())
+}
+
+func (s *GetOrCreatePolicyEvaluatorsSuite) TestPartitioning() {
+	routes := s.generateRoutes(0, 64*evaluator.XWorkerPoolSize+10, uniquePerUserPolicyFormat)
+	store := store.New()
+	eval, err := evaluator.New(context.Background(), store, nil, evaluator.WithPolicies(routes))
+	s.Require().NoError(err)
+	s.Equal(evaluator.QueryCacheStats{
+		CacheHits:       0,
+		CacheMisses:     64*int64(evaluator.XWorkerPoolSize) + 10,
+		BuildsSucceeded: 64*int64(evaluator.XWorkerPoolSize) + 10,
+		BuildsFailed:    0,
+		BuildsShared:    0,
+	}, eval.XQueryCache().Stats())
+	s.expectLogs("using 0 cached policy evaluators")
+
+	s.expectLogsUnorderedF(func() (logs []string) {
+		for _, route := range routes {
+			logs = append(logs, fmt.Sprintf("policy for route ID %d not found in cache", route.MustRouteID()))
+		}
+		for i := range evaluator.XWorkerPoolSize {
+			logs = append(logs, fmt.Sprintf("chunk %d: 64/64 changed", i))
+		}
+		logs = append(logs, fmt.Sprintf("chunk %d: 10/10 changed", evaluator.XWorkerPoolSize))
+		return
+	})
+	s.expectLogsUnorderedF(func() (logs []string) {
+		for i := range evaluator.XWorkerPoolSize {
+			logs = append(logs, fmt.Sprintf("chunk %d: status: %s", i, strings.Repeat("1", 64)))
+		}
+		logs = append(logs, fmt.Sprintf("chunk %d: status: 1111111111", evaluator.XWorkerPoolSize))
+		return
+	})
+
+	routes[63].AllowWebsockets = true
+	eval, err = evaluator.New(context.Background(), store, eval, evaluator.WithPolicies(routes))
+	s.Require().NoError(err)
+	s.expectLogs(fmt.Sprintf("using %d cached policy evaluators", 64*evaluator.XWorkerPoolSize+10))
+	s.expectLogsUnorderedF(func() (logs []string) {
+		logs = append(logs, fmt.Sprintf("policy for route ID %d changed", routes[63].MustRouteID()))
+		logs = append(logs, "chunk 0: 1/64 changed")
+		for i := 1; i < evaluator.XWorkerPoolSize; i++ {
+			logs = append(logs, fmt.Sprintf("chunk %d: 0/64 changed", i))
+		}
+		logs = append(logs, "chunk 31: 0/10 changed")
+		return
+	})
+	s.expectLogs("chunk 0: status: 1000000000000000000000000000000000000000000000000000000000000000")
+
+	// chunk 1 should be skipped even though it will be partitioned into worker 0
+}
+
+func TestGetOrCreatePolicyEvaluatorsSuite(t *testing.T) {
+	suite.Run(t, &GetOrCreatePolicyEvaluatorsSuite{})
 }

--- a/authorize/evaluator/google_cloud_serverless_test.go
+++ b/authorize/evaluator/google_cloud_serverless_test.go
@@ -1,4 +1,4 @@
-package evaluator
+package evaluator_test
 
 import (
 	"net/http"
@@ -7,17 +7,19 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/authorize/evaluator"
 )
 
 func withMockGCP(t *testing.T, f func()) {
-	originalGCPIdentityDocURL := GCPIdentityDocURL
+	originalGCPIdentityDocURL := evaluator.GCPIdentityDocURL
 	defer func() {
-		GCPIdentityDocURL = originalGCPIdentityDocURL
-		GCPIdentityNow = time.Now
+		evaluator.GCPIdentityDocURL = originalGCPIdentityDocURL
+		evaluator.GCPIdentityNow = time.Now
 	}()
 
 	now := time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)
-	GCPIdentityNow = func() time.Time {
+	evaluator.GCPIdentityNow = func() time.Time {
 		return now
 	}
 
@@ -28,13 +30,13 @@ func withMockGCP(t *testing.T, f func()) {
 	}))
 	defer srv.Close()
 
-	GCPIdentityDocURL = srv.URL
+	evaluator.GCPIdentityDocURL = srv.URL
 	f()
 }
 
 func TestGCPIdentityTokenSource(t *testing.T) {
 	withMockGCP(t, func() {
-		src, err := getGoogleCloudServerlessTokenSource("", "example")
+		src, err := evaluator.XGetGoogleCloudServerlessTokenSource("", "example")
 		assert.NoError(t, err)
 
 		token, err := src.Token()
@@ -62,7 +64,7 @@ func Test_normalizeServiceAccount(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			gotServiceAccount, err := normalizeServiceAccount(tc.serviceAccount)
+			gotServiceAccount, err := evaluator.XNormalizeServiceAccount(tc.serviceAccount)
 			assert.True(t, (err != nil) == tc.wantError)
 			assert.Equal(t, tc.expectedServiceAccount, gotServiceAccount)
 		})

--- a/authorize/evaluator/policy_evaluator.go
+++ b/authorize/evaluator/policy_evaluator.go
@@ -3,11 +3,10 @@ package evaluator
 import (
 	"context"
 	"fmt"
+	rttrace "runtime/trace"
 	"strings"
 
 	"github.com/open-policy-agent/opa/rego"
-	octrace "go.opencensus.io/trace"
-
 	"github.com/pomerium/pomerium/authorize/internal/store"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
@@ -16,6 +15,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/policy"
 	"github.com/pomerium/pomerium/pkg/policy/criteria"
+	octrace "go.opencensus.io/trace"
 )
 
 // PolicyRequest is the input to policy evaluation.
@@ -109,25 +109,36 @@ type PolicyEvaluator struct {
 
 // NewPolicyEvaluator creates a new PolicyEvaluator.
 func NewPolicyEvaluator(
-	ctx context.Context, store *store.Store, configPolicy *config.Policy,
+	ctx context.Context,
+	store *store.Store,
+	configPolicy *config.Policy,
+	policyChecksum uint64,
 	addDefaultClientCertificateRule bool,
+	cache *QueryCache,
 ) (*PolicyEvaluator, error) {
 	e := new(PolicyEvaluator)
-	e.policyChecksum = configPolicy.Checksum()
+	e.policyChecksum = policyChecksum
 
-	// generate the base rego script for the policy
-	ppl := configPolicy.ToPPL()
-	if addDefaultClientCertificateRule {
-		ppl.AddDefaultClientCertificateRule()
-	}
-	base, err := policy.GenerateRegoFromPolicy(ppl)
+	var err error
+	rttrace.WithRegion(ctx, "Generate Rego", func() {
+		// generate the base rego script for the policy
+		ppl := configPolicy.ToPPL()
+		if addDefaultClientCertificateRule {
+			ppl.AddDefaultClientCertificateRule()
+		}
+		var base string
+		base, err = policy.GenerateRegoFromPolicy(ppl)
+		if err != nil {
+			return
+		}
+
+		e.queries = []policyQuery{{
+			script: base,
+		}}
+	})
 	if err != nil {
 		return nil, err
 	}
-
-	e.queries = []policyQuery{{
-		script: base,
-	}}
 
 	// add any custom rego
 	for _, sp := range configPolicy.SubPolicies {
@@ -145,41 +156,49 @@ func NewPolicyEvaluator(
 		}
 	}
 
-	// for each script, create a rego and prepare a query.
-	for i := range e.queries {
-		log.Debug(ctx).
-			Str("script", e.queries[i].script).
-			Str("from", configPolicy.From).
-			Interface("to", configPolicy.To).
-			Msg("authorize: rego script for policy evaluation")
+	// for each script, create a rego object and prepare a query.
+	rttrace.WithRegion(ctx, "Compile Rego", func() {
+		numCached := 0
+		for i := range e.queries {
+			var cached bool
+			e.queries[i].PreparedEvalQuery, cached, err = cache.LookupOrBuild(&e.queries[i], func() (rego.PreparedEvalQuery, error) {
+				r := rego.New(
+					rego.Store(store),
+					rego.Module("pomerium.policy", e.queries[i].script),
+					rego.Query("result = data.pomerium.policy"),
+					rego.EnablePrintStatements(true),
+					getGoogleCloudServerlessHeadersRegoOption,
+					store.GetDataBrokerRecordOption(),
+				)
 
-		r := rego.New(
-			rego.Store(store),
-			rego.Module("pomerium.policy", e.queries[i].script),
-			rego.Query("result = data.pomerium.policy"),
-			rego.EnablePrintStatements(true),
-			getGoogleCloudServerlessHeadersRegoOption,
-			store.GetDataBrokerRecordOption(),
-		)
-
-		q, err := r.PrepareForEval(ctx)
-		// if no package is in the src, add it
-		if err != nil && strings.Contains(err.Error(), "package expected") {
-			r := rego.New(
-				rego.Store(store),
-				rego.Module("pomerium.policy", "package pomerium.policy\n\n"+e.queries[i].script),
-				rego.Query("result = data.pomerium.policy"),
-				rego.EnablePrintStatements(true),
-				getGoogleCloudServerlessHeadersRegoOption,
-				store.GetDataBrokerRecordOption(),
-			)
-			q, err = r.PrepareForEval(ctx)
+				q, err := r.PrepareForEval(ctx)
+				// if no package is in the src, add it
+				if err != nil && strings.Contains(err.Error(), "package expected") {
+					r := rego.New(
+						rego.Store(store),
+						rego.Module("pomerium.policy", "package pomerium.policy\n\n"+e.queries[i].script),
+						rego.Query("result = data.pomerium.policy"),
+						rego.EnablePrintStatements(true),
+						getGoogleCloudServerlessHeadersRegoOption,
+						store.GetDataBrokerRecordOption(),
+					)
+					q, err = r.PrepareForEval(ctx)
+				}
+				if err != nil {
+					return rego.PreparedEvalQuery{}, err
+				}
+				return q, nil
+			})
+			if err != nil {
+				return
+			}
+			if cached {
+				numCached++
+			}
 		}
-		if err != nil {
-			return nil, err
-		}
-
-		e.queries[i].PreparedEvalQuery = q
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return e, nil

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -17,9 +17,10 @@ import (
 
 	"github.com/pomerium/pomerium/authorize/evaluator"
 	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/atomicutil"
+	"github.com/pomerium/pomerium/config/envoyconfig"
 	"github.com/pomerium/pomerium/internal/sessions"
 	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
@@ -49,15 +50,27 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 -----END CERTIFICATE-----`
 
 func Test_getEvaluatorRequest(t *testing.T) {
-	a := &Authorize{currentOptions: config.NewAtomicOptions(), state: atomicutil.NewValue(new(authorizeState))}
-	a.currentOptions.Store(&config.Options{
-		Policies: []config.Policy{{
-			From: "https://example.com",
-			SubPolicies: []config.SubPolicy{{
-				Rego: []string{"allow = true"},
-			}},
+	policies := []config.Policy{{
+		From: "https://example.com",
+		To:   mustParseWeightedURLs(t, "https://foo.bar"),
+		SubPolicies: []config.SubPolicy{{
+			Rego: []string{"allow = true"},
 		}},
-	})
+	}}
+
+	policy0RouteID, err := policies[0].RouteID()
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Options: &config.Options{
+			SharedKey:    cryptutil.NewBase64Key(),
+			CookieSecret: cryptutil.NewBase64Key(),
+			Policies:     policies,
+		},
+	}
+	a, err := New(cfg)
+	a.OnConfigChange(context.Background(), cfg)
+	require.NoError(t, err)
 
 	actual, err := a.getEvaluatorRequestFromCheckRequest(context.Background(),
 		&envoy_service_auth_v3.CheckRequest{
@@ -76,6 +89,7 @@ func Test_getEvaluatorRequest(t *testing.T) {
 						Body:   "BODY",
 					},
 				},
+				ContextExtensions: envoyconfig.MakeExtAuthzContextExtensions(false, policy0RouteID),
 				MetadataContext: &envoy_config_core_v3.Metadata{
 					FilterMetadata: map[string]*structpb.Struct{
 						"com.pomerium.client-certificate-info": {
@@ -117,15 +131,27 @@ func Test_getEvaluatorRequest(t *testing.T) {
 }
 
 func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
-	a := &Authorize{currentOptions: config.NewAtomicOptions(), state: atomicutil.NewValue(new(authorizeState))}
-	a.currentOptions.Store(&config.Options{
-		Policies: []config.Policy{{
-			From: "https://example.com",
-			SubPolicies: []config.SubPolicy{{
-				Rego: []string{"allow = true"},
-			}},
+	policies := []config.Policy{{
+		From: "https://example.com",
+		To:   mustParseWeightedURLs(t, "https://foo.bar"),
+		SubPolicies: []config.SubPolicy{{
+			Rego: []string{"allow = true"},
 		}},
-	})
+	}}
+
+	policy0RouteID, err := policies[0].RouteID()
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Options: &config.Options{
+			SharedKey:    cryptutil.NewBase64Key(),
+			CookieSecret: cryptutil.NewBase64Key(),
+			Policies:     policies,
+		},
+	}
+	a, err := New(cfg)
+	a.OnConfigChange(context.Background(), cfg)
+	require.NoError(t, err)
 
 	actual, err := a.getEvaluatorRequestFromCheckRequest(context.Background(),
 		&envoy_service_auth_v3.CheckRequest{
@@ -144,11 +170,12 @@ func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 						Body:   "BODY",
 					},
 				},
+				ContextExtensions: envoyconfig.MakeExtAuthzContextExtensions(false, policy0RouteID),
 			},
 		}, nil)
 	require.NoError(t, err)
 	expect := &evaluator.Request{
-		Policy:  &a.currentOptions.Load().Policies[0],
+		Policy:  &policies[0],
 		Session: evaluator.RequestSession{},
 		HTTP: evaluator.NewRequestHTTP(
 			http.MethodGet,


### PR DESCRIPTION
## Summary

This optimizes the Evaluator in the Authorize service to scale to very large numbers of routes. Additional caching was also added when building rego policy query evaluators in parallel to allow sharing work and to avoid building evaluators for scripts with the same contents.


<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
