### PR TITLE
Optimize envoy config building

### DIFF
--- a/config/envoyconfig/acmetlsalpn.go
+++ b/config/envoyconfig/acmetlsalpn.go
@@ -6,8 +6,6 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
-
-	"github.com/pomerium/pomerium/config"
 )
 
 // Pomerium implements the ACME TLS-ALPN protocol by adding a filter chain to the main HTTPS listener
@@ -20,10 +18,8 @@ const (
 	acmeTLSALPNClusterName         = "pomerium-acme-tls-alpn"
 )
 
-func (b *Builder) buildACMETLSALPNCluster(
-	cfg *config.Config,
-) *envoy_config_cluster_v3.Cluster {
-	port, _ := strconv.ParseUint(cfg.ACMETLSALPNPort, 10, 32)
+func (b *ScopedBuilder) buildACMETLSALPNCluster() *envoy_config_cluster_v3.Cluster {
+	port, _ := strconv.ParseUint(b.cfg.ACMETLSALPNPort, 10, 32)
 	return &envoy_config_cluster_v3.Cluster{
 		Name: acmeTLSALPNClusterName,
 		LoadAssignment: &envoy_config_endpoint_v3.ClusterLoadAssignment{
@@ -41,7 +37,7 @@ func (b *Builder) buildACMETLSALPNCluster(
 	}
 }
 
-func (b *Builder) buildACMETLSALPNFilterChain() *envoy_config_listener_v3.FilterChain {
+func (b *ScopedBuilder) buildACMETLSALPNFilterChain() *envoy_config_listener_v3.FilterChain {
 	return &envoy_config_listener_v3.FilterChain{
 		FilterChainMatch: &envoy_config_listener_v3.FilterChainMatch{
 			ApplicationProtocols: []string{acmeTLSALPNApplicationProtocol},

--- a/config/envoyconfig/acmetlsalpn_test.go
+++ b/config/envoyconfig/acmetlsalpn_test.go
@@ -28,9 +28,9 @@ func TestBuilder_buildACMETLSALPNCluster(t *testing.T) {
 				}]
 			}
 		}`,
-		b.buildACMETLSALPNCluster(&config.Config{
+		b.WithConfig(&config.Config{
 			ACMETLSALPNPort: "1234",
-		}))
+		}).buildACMETLSALPNCluster())
 }
 
 func TestBuilder_buildACMETLSALPNFilterChain(t *testing.T) {
@@ -49,5 +49,5 @@ func TestBuilder_buildACMETLSALPNFilterChain(t *testing.T) {
 				}
 			}]
 		}`,
-		b.buildACMETLSALPNFilterChain())
+		b.WithConfig(&config.Config{}).buildACMETLSALPNFilterChain())
 }

--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -14,11 +14,11 @@ import (
 func TestBuilder_BuildBootstrapAdmin(t *testing.T) {
 	b := New("local-grpc", "local-http", "local-metrics", filemgr.NewManager(), nil)
 	t.Run("valid", func(t *testing.T) {
-		adminCfg, err := b.BuildBootstrapAdmin(&config.Config{
+		adminCfg, err := b.WithConfig(&config.Config{
 			Options: &config.Options{
 				EnvoyAdminAddress: "localhost:9901",
 			},
-		})
+		}).BuildBootstrapAdmin(context.Background())
 		assert.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -35,7 +35,7 @@ func TestBuilder_BuildBootstrapAdmin(t *testing.T) {
 
 func TestBuilder_BuildBootstrapLayeredRuntime(t *testing.T) {
 	b := New("localhost:1111", "localhost:2222", "localhost:3333", filemgr.NewManager(), nil)
-	staticCfg, err := b.BuildBootstrapLayeredRuntime()
+	staticCfg, err := b.WithConfig(&config.Config{}).BuildBootstrapLayeredRuntime(context.Background())
 	assert.NoError(t, err)
 	testutil.AssertProtoJSONEqual(t, `
 		{ "layers": [{
@@ -55,7 +55,7 @@ func TestBuilder_BuildBootstrapLayeredRuntime(t *testing.T) {
 func TestBuilder_BuildBootstrapStaticResources(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		b := New("localhost:1111", "localhost:2222", "localhost:3333", filemgr.NewManager(), nil)
-		staticCfg, err := b.BuildBootstrapStaticResources(context.Background(), &config.Config{}, false)
+		staticCfg, err := b.WithConfig(&config.Config{}).BuildBootstrapStaticResources(context.Background(), false)
 		assert.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -99,7 +99,7 @@ func TestBuilder_BuildBootstrapStaticResources(t *testing.T) {
 	})
 	t.Run("bad gRPC address", func(t *testing.T) {
 		b := New("xyz:zyx", "localhost:2222", "localhost:3333", filemgr.NewManager(), nil)
-		_, err := b.BuildBootstrapStaticResources(context.Background(), &config.Config{}, false)
+		_, err := b.WithConfig(&config.Config{}).BuildBootstrapStaticResources(context.Background(), false)
 		assert.Error(t, err)
 	})
 }
@@ -107,11 +107,11 @@ func TestBuilder_BuildBootstrapStaticResources(t *testing.T) {
 func TestBuilder_BuildBootstrapStatsConfig(t *testing.T) {
 	b := New("local-grpc", "local-http", "local-metrics", filemgr.NewManager(), nil)
 	t.Run("valid", func(t *testing.T) {
-		statsCfg, err := b.BuildBootstrapStatsConfig(&config.Config{
+		statsCfg, err := b.WithConfig(&config.Config{
 			Options: &config.Options{
 				Services: "all",
 			},
-		})
+		}).BuildBootstrapStatsConfig(context.Background())
 		assert.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -127,11 +127,11 @@ func TestBuilder_BuildBootstrapStatsConfig(t *testing.T) {
 func TestBuilder_BuildBootstrap(t *testing.T) {
 	b := New("localhost:1111", "localhost:2222", "localhost:3333", filemgr.NewManager(), nil)
 	t.Run("OverloadManager", func(t *testing.T) {
-		bootstrap, err := b.BuildBootstrap(context.Background(), &config.Config{
+		bootstrap, err := b.WithConfig(&config.Config{
 			Options: &config.Options{
 				EnvoyAdminAddress: "localhost:9901",
 			},
-		}, false)
+		}).BuildBootstrap(context.Background(), false)
 		assert.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{

--- a/config/envoyconfig/builder.go
+++ b/config/envoyconfig/builder.go
@@ -1,17 +1,115 @@
 package envoyconfig
 
 import (
+	"context"
+	"net/url"
+
+	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
 	"github.com/pomerium/pomerium/internal/httputil/reproxy"
+	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
 // A Builder builds envoy config from pomerium config.
 type Builder struct {
+	staticBuilderConfig
+}
+
+type staticBuilderConfig struct {
 	localGRPCAddress    string
 	localHTTPAddress    string
 	localMetricsAddress string
 	filemgr             *filemgr.Manager
 	reproxy             *reproxy.Handler
+}
+
+type ScopedBuilder struct {
+	*staticBuilderConfig
+	cfg *config.Config
+
+	staticHttpRoutes             []*envoy_config_route_v3.Route
+	staticAuthenticateHttpRoutes []*envoy_config_route_v3.Route
+
+	authenticateURL         *url.URL
+	internalAuthenticateURL *url.URL
+	authorizeURLs           []*url.URL
+	internalAuthorizeURLs   []*url.URL
+	dataBrokerURLs          []*url.URL
+	internalDataBrokerURLs  []*url.URL
+
+	domainsForWellKnownURLs map[*url.URL][]string
+}
+
+func (b *ScopedBuilder) computeWellKnownFields(ctx context.Context) error {
+	b.staticHttpRoutes = []*envoy_config_route_v3.Route{
+		b.buildControlPlanePathRoute(ctx, "/ping"),
+		b.buildControlPlanePathRoute(ctx, "/healthz"),
+		b.buildControlPlanePathRoute(ctx, "/.pomerium"),
+		b.buildControlPlanePrefixRoute(ctx, "/.pomerium/"),
+		b.buildControlPlanePathRoute(ctx, "/.well-known/pomerium"),
+		b.buildControlPlanePrefixRoute(ctx, "/.well-known/pomerium/"),
+	}
+	b.staticAuthenticateHttpRoutes = []*envoy_config_route_v3.Route{
+		b.buildControlPlanePathRoute(ctx, b.cfg.Options.AuthenticateCallbackPath),
+		b.buildControlPlanePathRoute(ctx, "/"),
+		b.buildControlPlanePathRoute(ctx, "/robots.txt"),
+	}
+	var err error
+	b.authenticateURL, err = b.cfg.Options.GetAuthenticateURL()
+	if err != nil {
+		return err
+	}
+	b.internalAuthenticateURL, err = b.cfg.Options.GetInternalAuthenticateURL()
+	if err != nil {
+		return err
+	}
+	b.authorizeURLs, err = b.cfg.Options.GetAuthorizeURLs()
+	if err != nil {
+		return err
+	}
+	b.internalAuthorizeURLs, err = b.cfg.Options.GetInternalAuthorizeURLs()
+	if err != nil {
+		return err
+	}
+	b.dataBrokerURLs, err = b.cfg.Options.GetDataBrokerURLs()
+	if err != nil {
+		return err
+	}
+	b.internalDataBrokerURLs, err = b.cfg.Options.GetInternalDataBrokerURLs()
+	if err != nil {
+		return err
+	}
+
+	b.domainsForWellKnownURLs = map[*url.URL][]string{
+		b.authenticateURL:         urlutil.GetDomainsForURL(b.authenticateURL, true),
+		b.internalAuthenticateURL: urlutil.GetDomainsForURL(b.internalAuthenticateURL, true),
+	}
+	for _, u := range b.authorizeURLs {
+		b.domainsForWellKnownURLs[u] = urlutil.GetDomainsForURL(u, true)
+	}
+	for _, u := range b.internalAuthorizeURLs {
+		b.domainsForWellKnownURLs[u] = urlutil.GetDomainsForURL(u, true)
+	}
+	for _, u := range b.dataBrokerURLs {
+		b.domainsForWellKnownURLs[u] = urlutil.GetDomainsForURL(u, true)
+	}
+	for _, u := range b.internalDataBrokerURLs {
+		b.domainsForWellKnownURLs[u] = urlutil.GetDomainsForURL(u, true)
+	}
+	return nil
+}
+
+func (b *Builder) WithConfig(cfg *config.Config) *ScopedBuilder {
+	if cfg.Options == nil {
+		cfg.Options = &config.Options{}
+	}
+	sb := &ScopedBuilder{
+		staticBuilderConfig: &b.staticBuilderConfig,
+		cfg:                 cfg,
+	}
+	sb.computeWellKnownFields(context.TODO())
+	return sb
 }
 
 // New creates a new Builder.
@@ -26,10 +124,12 @@ func New(
 		reproxyHandler = reproxy.New()
 	}
 	return &Builder{
-		localGRPCAddress:    localGRPCAddress,
-		localHTTPAddress:    localHTTPAddress,
-		localMetricsAddress: localMetricsAddress,
-		filemgr:             fileManager,
-		reproxy:             reproxyHandler,
+		staticBuilderConfig: staticBuilderConfig{
+			localGRPCAddress:    localGRPCAddress,
+			localHTTPAddress:    localHTTPAddress,
+			localMetricsAddress: localMetricsAddress,
+			filemgr:             fileManager,
+			reproxy:             reproxyHandler,
+		},
 	}
 }

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"slices"
 	"strings"
 	"time"
 
@@ -25,7 +26,7 @@ import (
 )
 
 // BuildClusters builds envoy clusters from the given config.
-func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*envoy_config_cluster_v3.Cluster, error) {
+func (b *ScopedBuilder) BuildClusters(ctx context.Context) ([]*envoy_config_cluster_v3.Cluster, error) {
 	ctx, span := trace.StartSpan(ctx, "envoyconfig.Builder.BuildClusters")
 	defer span.End()
 
@@ -43,34 +44,34 @@ func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*env
 	}
 
 	authorizeURLs, databrokerURLs := grpcURLs, grpcURLs
-	if !config.IsAll(cfg.Options.Services) {
+	if !config.IsAll(b.cfg.Options.Services) {
 		var err error
-		authorizeURLs, err = cfg.Options.GetInternalAuthorizeURLs()
+		authorizeURLs, err = b.cfg.Options.GetInternalAuthorizeURLs()
 		if err != nil {
 			return nil, err
 		}
-		databrokerURLs, err = cfg.Options.GetDataBrokerURLs()
+		databrokerURLs, err = b.cfg.Options.GetDataBrokerURLs()
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	controlGRPC, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-grpc", grpcURLs, upstreamProtocolHTTP2, Keepalive(false))
+	controlGRPC, err := b.buildInternalCluster(ctx, "pomerium-control-plane-grpc", grpcURLs, upstreamProtocolHTTP2, Keepalive(false))
 	if err != nil {
 		return nil, err
 	}
 
-	controlHTTP, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-http", []*url.URL{httpURL}, upstreamProtocolAuto, Keepalive(false))
+	controlHTTP, err := b.buildInternalCluster(ctx, "pomerium-control-plane-http", []*url.URL{httpURL}, upstreamProtocolAuto, Keepalive(false))
 	if err != nil {
 		return nil, err
 	}
 
-	controlMetrics, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-metrics", []*url.URL{metricsURL}, upstreamProtocolAuto, Keepalive(false))
+	controlMetrics, err := b.buildInternalCluster(ctx, "pomerium-control-plane-metrics", []*url.URL{metricsURL}, upstreamProtocolAuto, Keepalive(false))
 	if err != nil {
 		return nil, err
 	}
 
-	authorizeCluster, err := b.buildInternalCluster(ctx, cfg, "pomerium-authorize", authorizeURLs, upstreamProtocolHTTP2, Keepalive(false))
+	authorizeCluster, err := b.buildInternalCluster(ctx, "pomerium-authorize", authorizeURLs, upstreamProtocolHTTP2, Keepalive(false))
 	if err != nil {
 		return nil, err
 	}
@@ -79,8 +80,8 @@ func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*env
 		authorizeCluster.OutlierDetection = grpcOutlierDetection()
 	}
 
-	databrokerKeepalive := Keepalive(cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagGRPCDatabrokerKeepalive))
-	databrokerCluster, err := b.buildInternalCluster(ctx, cfg, "pomerium-databroker", databrokerURLs, upstreamProtocolHTTP2, databrokerKeepalive)
+	databrokerKeepalive := Keepalive(b.cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagGRPCDatabrokerKeepalive))
+	databrokerCluster, err := b.buildInternalCluster(ctx, "pomerium-databroker", databrokerURLs, upstreamProtocolHTTP2, databrokerKeepalive)
 	if err != nil {
 		return nil, err
 	}
@@ -89,13 +90,13 @@ func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*env
 		databrokerCluster.OutlierDetection = grpcOutlierDetection()
 	}
 
-	envoyAdminCluster, err := b.buildEnvoyAdminCluster(ctx, cfg)
+	envoyAdminCluster, err := b.buildEnvoyAdminCluster(ctx)
 	if err != nil {
 		return nil, err
 	}
 
 	clusters := []*envoy_config_cluster_v3.Cluster{
-		b.buildACMETLSALPNCluster(cfg),
+		b.buildACMETLSALPNCluster(),
 		controlGRPC,
 		controlHTTP,
 		controlMetrics,
@@ -104,20 +105,21 @@ func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*env
 		envoyAdminCluster,
 	}
 
-	tracingCluster, err := buildTracingCluster(cfg.Options)
+	tracingCluster, err := buildTracingCluster(b.cfg.Options)
 	if err != nil {
 		return nil, err
 	} else if tracingCluster != nil {
 		clusters = append(clusters, tracingCluster)
 	}
 
-	if config.IsProxy(cfg.Options.Services) {
-		for policy := range cfg.Options.GetAllPolicies() {
+	if config.IsProxy(b.cfg.Options.Services) {
+		clusters = slices.Grow(clusters, b.cfg.Options.NumPolicies())
+		for policy := range b.cfg.Options.GetAllPolicies() {
 			if policy.EnvoyOpts == nil {
 				policy.EnvoyOpts = newDefaultEnvoyClusterConfig()
 			}
 			if len(policy.To) > 0 {
-				cluster, err := b.buildPolicyCluster(ctx, cfg, policy)
+				cluster, err := b.buildPolicyCluster(ctx, policy)
 				if err != nil {
 					return nil, fmt.Errorf("policy %q: %w", policy.String(), err)
 				}
@@ -133,16 +135,15 @@ func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*env
 	return clusters, nil
 }
 
-func (b *Builder) buildInternalCluster(
+func (b *ScopedBuilder) buildInternalCluster(
 	ctx context.Context,
-	cfg *config.Config,
 	name string,
 	dsts []*url.URL,
 	upstreamProtocol upstreamProtocolConfig,
 	keepalive Keepalive,
 ) (*envoy_config_cluster_v3.Cluster, error) {
 	cluster := newDefaultEnvoyClusterConfig()
-	cluster.DnsLookupFamily = config.GetEnvoyDNSLookupFamily(cfg.Options.DNSLookupFamily)
+	cluster.DnsLookupFamily = config.GetEnvoyDNSLookupFamily(b.cfg.Options.DNSLookupFamily)
 	// Match the Go standard library default TCP keepalive settings.
 	const keepaliveTimeSeconds = 15
 	cluster.UpstreamConnectionOptions = &envoy_config_cluster_v3.UpstreamConnectionOptions{
@@ -153,7 +154,7 @@ func (b *Builder) buildInternalCluster(
 	}
 	var endpoints []Endpoint
 	for _, dst := range dsts {
-		ts, err := b.buildInternalTransportSocket(ctx, cfg, dst)
+		ts, err := b.buildInternalTransportSocket(ctx, dst)
 		if err != nil {
 			return nil, err
 		}
@@ -166,11 +167,11 @@ func (b *Builder) buildInternalCluster(
 	return cluster, nil
 }
 
-func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, policy *config.Policy) (*envoy_config_cluster_v3.Cluster, error) {
+func (b *ScopedBuilder) buildPolicyCluster(ctx context.Context, policy *config.Policy) (*envoy_config_cluster_v3.Cluster, error) {
 	cluster := new(envoy_config_cluster_v3.Cluster)
 	proto.Merge(cluster, policy.EnvoyOpts)
 
-	options := cfg.Options
+	options := b.cfg.Options
 
 	if options.EnvoyBindConfigFreebind.IsSet() || options.EnvoyBindConfigSourceAddress != "" {
 		cluster.UpstreamBindConfig = new(envoy_config_core_v3.BindConfig)
@@ -198,7 +199,7 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 	upstreamProtocol := getUpstreamProtocolForPolicy(ctx, policy)
 
 	name := getClusterID(policy)
-	endpoints, err := b.buildPolicyEndpoints(ctx, cfg, policy)
+	endpoints, err := b.buildPolicyEndpoints(ctx, policy)
 	if err != nil {
 		return nil, err
 	}
@@ -215,15 +216,14 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 	return cluster, nil
 }
 
-func (b *Builder) buildPolicyEndpoints(
+func (b *ScopedBuilder) buildPolicyEndpoints(
 	ctx context.Context,
-	cfg *config.Config,
 	policy *config.Policy,
 ) ([]Endpoint, error) {
 	var endpoints []Endpoint
 	for _, dst := range policy.To {
 		dst := dst
-		ts, err := b.buildPolicyTransportSocket(ctx, cfg, policy, dst.URL)
+		ts, err := b.buildPolicyTransportSocket(ctx, policy, dst.URL)
 		if err != nil {
 			return nil, err
 		}
@@ -232,9 +232,8 @@ func (b *Builder) buildPolicyEndpoints(
 	return endpoints, nil
 }
 
-func (b *Builder) buildInternalTransportSocket(
+func (b *ScopedBuilder) buildInternalTransportSocket(
 	ctx context.Context,
-	cfg *config.Config,
 	endpoint *url.URL,
 ) (*envoy_config_core_v3.TransportSocket, error) {
 	if endpoint.Scheme != "https" {
@@ -243,10 +242,10 @@ func (b *Builder) buildInternalTransportSocket(
 
 	validationContext := &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
 		MatchTypedSubjectAltNames: []*envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher{
-			b.buildSubjectAltNameMatcher(endpoint, cfg.Options.OverrideCertificateName),
+			b.buildSubjectAltNameMatcher(endpoint, b.cfg.Options.OverrideCertificateName),
 		},
 	}
-	bs, err := getCombinedCertificateAuthority(cfg)
+	bs, err := getCombinedCertificateAuthority(b.cfg)
 	if err != nil {
 		log.Error(ctx).Err(err).Msg("unable to enable certificate verification because no root CAs were found")
 	} else {
@@ -259,7 +258,7 @@ func (b *Builder) buildInternalTransportSocket(
 				ValidationContext: validationContext,
 			},
 		},
-		Sni: b.buildSubjectNameIndication(endpoint, cfg.Options.OverrideCertificateName),
+		Sni: b.buildSubjectNameIndication(endpoint, b.cfg.Options.OverrideCertificateName),
 	}
 	tlsConfig := marshalAny(tlsContext)
 	return &envoy_config_core_v3.TransportSocket{
@@ -270,9 +269,8 @@ func (b *Builder) buildInternalTransportSocket(
 	}, nil
 }
 
-func (b *Builder) buildPolicyTransportSocket(
+func (b *ScopedBuilder) buildPolicyTransportSocket(
 	ctx context.Context,
-	cfg *config.Config,
 	policy *config.Policy,
 	dst url.URL,
 ) (*envoy_config_core_v3.TransportSocket, error) {
@@ -282,7 +280,7 @@ func (b *Builder) buildPolicyTransportSocket(
 
 	upstreamProtocol := getUpstreamProtocolForPolicy(ctx, policy)
 
-	vc, err := b.buildPolicyValidationContext(ctx, cfg, policy, dst)
+	vc, err := b.buildPolicyValidationContext(ctx, policy, dst)
 	if err != nil {
 		return nil, err
 	}
@@ -342,9 +340,8 @@ func (b *Builder) buildPolicyTransportSocket(
 	}, nil
 }
 
-func (b *Builder) buildPolicyValidationContext(
+func (b *ScopedBuilder) buildPolicyValidationContext(
 	ctx context.Context,
-	cfg *config.Config,
 	policy *config.Policy,
 	dst url.URL,
 ) (*envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext, error) {
@@ -369,7 +366,7 @@ func (b *Builder) buildPolicyValidationContext(
 		}
 		validationContext.TrustedCa = b.filemgr.BytesDataSource("custom-ca.pem", bs)
 	} else {
-		bs, err := getCombinedCertificateAuthority(cfg)
+		bs, err := getCombinedCertificateAuthority(b.cfg)
 		if err != nil {
 			log.Error(ctx).Err(err).Msg("unable to enable certificate verification because no root CAs were found")
 		} else {
@@ -384,7 +381,7 @@ func (b *Builder) buildPolicyValidationContext(
 	return validationContext, nil
 }
 
-func (b *Builder) buildCluster(
+func (b *ScopedBuilder) buildCluster(
 	cluster *envoy_config_cluster_v3.Cluster,
 	name string,
 	endpoints []Endpoint,
@@ -469,7 +466,7 @@ func grpcHealthChecks(name string) []*envoy_config_core_v3.HealthCheck {
 	}}
 }
 
-func (b *Builder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoint_v3.LbEndpoint, error) {
+func (b *ScopedBuilder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoint_v3.LbEndpoint, error) {
 	var lbes []*envoy_config_endpoint_v3.LbEndpoint
 	for _, e := range endpoints {
 		defaultPort := uint32(80)
@@ -508,7 +505,7 @@ func (b *Builder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoi
 	return lbes, nil
 }
 
-func (b *Builder) buildTransportSocketMatches(endpoints []Endpoint) ([]*envoy_config_cluster_v3.Cluster_TransportSocketMatch, error) {
+func (b *ScopedBuilder) buildTransportSocketMatches(endpoints []Endpoint) ([]*envoy_config_cluster_v3.Cluster_TransportSocketMatch, error) {
 	var tsms []*envoy_config_cluster_v3.Cluster_TransportSocketMatch
 	seen := map[string]struct{}{}
 	for _, e := range endpoints {

--- a/config/envoyconfig/clusters_envoy_admin.go
+++ b/config/envoyconfig/clusters_envoy_admin.go
@@ -6,11 +6,9 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_endpoint_v3 "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
-
-	"github.com/pomerium/pomerium/config"
 )
 
-func (b *Builder) buildEnvoyAdminCluster(_ context.Context, _ *config.Config) (*envoy_config_cluster_v3.Cluster, error) {
+func (b *ScopedBuilder) buildEnvoyAdminCluster(ctx context.Context) (*envoy_config_cluster_v3.Cluster, error) {
 	return &envoy_config_cluster_v3.Cluster{
 		Name:           envoyAdminClusterName,
 		ConnectTimeout: defaultConnectionTimeout,

--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -151,7 +151,7 @@ func buildAddress(hostport string, defaultPort uint32) *envoy_config_core_v3.Add
 	}
 }
 
-func (b *Builder) envoyTLSCertificateFromGoTLSCertificate(
+func (b *ScopedBuilder) envoyTLSCertificateFromGoTLSCertificate(
 	ctx context.Context,
 	cert *tls.Certificate,
 ) *envoy_extensions_transport_sockets_tls_v3.TlsCertificate {

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -9,7 +9,6 @@ import (
 	"net"
 	"net/url"
 	"runtime"
-	"strings"
 	"time"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -45,9 +44,8 @@ var tlsParams = &envoy_extensions_transport_sockets_tls_v3.TlsParameters{
 }
 
 // BuildListeners builds envoy listeners from the given config.
-func (b *Builder) BuildListeners(
+func (b *ScopedBuilder) BuildListeners(
 	ctx context.Context,
-	cfg *config.Config,
 	fullyStatic bool,
 ) ([]*envoy_config_listener_v3.Listener, error) {
 	ctx, span := trace.StartSpan(ctx, "envoyconfig.Builder.BuildListeners")
@@ -55,39 +53,39 @@ func (b *Builder) BuildListeners(
 
 	var listeners []*envoy_config_listener_v3.Listener
 
-	if shouldStartMainListener(cfg.Options) {
-		li, err := b.buildMainListener(ctx, cfg, fullyStatic)
+	if shouldStartMainListener(b.cfg.Options) {
+		li, err := b.buildMainListener(ctx, fullyStatic)
 		if err != nil {
 			return nil, err
 		}
 		listeners = append(listeners, li)
 	}
 
-	if shouldStartGRPCListener(cfg.Options) {
-		li, err := b.buildGRPCListener(ctx, cfg)
+	if shouldStartGRPCListener(b.cfg.Options) {
+		li, err := b.buildGRPCListener(ctx)
 		if err != nil {
 			return nil, err
 		}
 		listeners = append(listeners, li)
 	}
 
-	if cfg.Options.MetricsAddr != "" {
-		li, err := b.buildMetricsListener(cfg)
+	if b.cfg.Options.MetricsAddr != "" {
+		li, err := b.buildMetricsListener(ctx)
 		if err != nil {
 			return nil, err
 		}
 		listeners = append(listeners, li)
 	}
 
-	if cfg.Options.EnvoyAdminAddress != "" {
-		li, err := b.buildEnvoyAdminListener(ctx, cfg)
+	if b.cfg.Options.EnvoyAdminAddress != "" {
+		li, err := b.buildEnvoyAdminListener(ctx)
 		if err != nil {
 			return nil, err
 		}
 		listeners = append(listeners, li)
 	}
 
-	li, err := b.buildOutboundListener(cfg)
+	li, err := b.buildOutboundListener(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -110,8 +108,8 @@ func getAllCertificates(cfg *config.Config) ([]tls.Certificate, error) {
 	return append(allCertificates, *wc), nil
 }
 
-func (b *Builder) buildTLSSocket(ctx context.Context, cfg *config.Config, certs []tls.Certificate) (*envoy_config_core_v3.TransportSocket, error) {
-	tlsContext, err := b.buildDownstreamTLSContextMulti(ctx, cfg, certs)
+func (b *ScopedBuilder) buildTLSSocket(ctx context.Context, cfg *config.Config, certs []tls.Certificate) (*envoy_config_core_v3.TransportSocket, error) {
+	tlsContext, err := b.buildDownstreamTLSContextMulti(ctx, certs)
 	if err != nil {
 		return nil, err
 	}
@@ -123,20 +121,19 @@ func (b *Builder) buildTLSSocket(ctx context.Context, cfg *config.Config, certs 
 	}, nil
 }
 
-func (b *Builder) buildMainListener(
+func (b *ScopedBuilder) buildMainListener(
 	ctx context.Context,
-	cfg *config.Config,
 	fullyStatic bool,
 ) (*envoy_config_listener_v3.Listener, error) {
 	li := newEnvoyListener("http-ingress")
-	if cfg.Options.UseProxyProtocol {
+	if b.cfg.Options.UseProxyProtocol {
 		li.ListenerFilters = append(li.ListenerFilters, ProxyProtocolFilter())
 	}
 
-	if cfg.Options.InsecureServer {
-		li.Address = buildAddress(cfg.Options.Addr, 80)
+	if b.cfg.Options.InsecureServer {
+		li.Address = buildAddress(b.cfg.Options.Addr, 80)
 
-		filter, err := b.buildMainHTTPConnectionManagerFilter(ctx, cfg, fullyStatic)
+		filter, err := b.buildMainHTTPConnectionManagerFilter(ctx, fullyStatic)
 		if err != nil {
 			return nil, err
 		}
@@ -147,17 +144,17 @@ func (b *Builder) buildMainListener(
 			},
 		}}
 	} else {
-		li.Address = buildAddress(cfg.Options.Addr, 443)
+		li.Address = buildAddress(b.cfg.Options.Addr, 443)
 		li.ListenerFilters = append(li.ListenerFilters, TLSInspectorFilter())
 
 		li.FilterChains = append(li.FilterChains, b.buildACMETLSALPNFilterChain())
 
-		allCertificates, err := getAllCertificates(cfg)
+		allCertificates, err := getAllCertificates(b.cfg)
 		if err != nil {
 			return nil, err
 		}
 
-		filter, err := b.buildMainHTTPConnectionManagerFilter(ctx, cfg, fullyStatic)
+		filter, err := b.buildMainHTTPConnectionManagerFilter(ctx, fullyStatic)
 		if err != nil {
 			return nil, err
 		}
@@ -166,7 +163,7 @@ func (b *Builder) buildMainListener(
 		}
 		li.FilterChains = append(li.FilterChains, filterChain)
 
-		sock, err := b.buildTLSSocket(ctx, cfg, allCertificates)
+		sock, err := b.buildTLSSocket(ctx, b.cfg, allCertificates)
 		if err != nil {
 			return nil, fmt.Errorf("error building TLS socket: %w", err)
 		}
@@ -175,7 +172,7 @@ func (b *Builder) buildMainListener(
 	return li, nil
 }
 
-func (b *Builder) buildMetricsListener(cfg *config.Config) (*envoy_config_listener_v3.Listener, error) {
+func (b *ScopedBuilder) buildMetricsListener(ctx context.Context) (*envoy_config_listener_v3.Listener, error) {
 	filter, err := b.buildMetricsHTTPConnectionManagerFilter()
 	if err != nil {
 		return nil, err
@@ -187,7 +184,7 @@ func (b *Builder) buildMetricsListener(cfg *config.Config) (*envoy_config_listen
 		},
 	}
 
-	cert, err := cfg.Options.GetMetricsCertificate()
+	cert, err := b.cfg.Options.GetMetricsCertificate()
 	if err != nil {
 		return nil, err
 	}
@@ -202,8 +199,8 @@ func (b *Builder) buildMetricsListener(cfg *config.Config) (*envoy_config_listen
 			},
 		}
 
-		if cfg.Options.MetricsClientCA != "" {
-			bs, err := base64.StdEncoding.DecodeString(cfg.Options.MetricsClientCA)
+		if b.cfg.Options.MetricsClientCA != "" {
+			bs, err := base64.StdEncoding.DecodeString(b.cfg.Options.MetricsClientCA)
 			if err != nil {
 				return nil, fmt.Errorf("xds: invalid metrics_client_ca: %w", err)
 			}
@@ -215,12 +212,12 @@ func (b *Builder) buildMetricsListener(cfg *config.Config) (*envoy_config_listen
 					TrustedCa:              b.filemgr.BytesDataSource("metrics_client_ca.pem", bs),
 				},
 			}
-		} else if cfg.Options.MetricsClientCAFile != "" {
+		} else if b.cfg.Options.MetricsClientCAFile != "" {
 			dtc.RequireClientCertificate = wrapperspb.Bool(true)
 			dtc.CommonTlsContext.ValidationContextType = &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{
 				ValidationContext: &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
 					TrustChainVerification: envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext_VERIFY_TRUST_CHAIN,
-					TrustedCa:              b.filemgr.FileDataSource(cfg.Options.MetricsClientCAFile),
+					TrustedCa:              b.filemgr.FileDataSource(b.cfg.Options.MetricsClientCAFile),
 				},
 			}
 		}
@@ -235,12 +232,12 @@ func (b *Builder) buildMetricsListener(cfg *config.Config) (*envoy_config_listen
 	}
 
 	// we ignore the host part of the address, only binding to
-	host, port, err := net.SplitHostPort(cfg.Options.MetricsAddr)
+	host, port, err := net.SplitHostPort(b.cfg.Options.MetricsAddr)
 	if err != nil {
-		return nil, fmt.Errorf("metrics_addr %s: %w", cfg.Options.MetricsAddr, err)
+		return nil, fmt.Errorf("metrics_addr %s: %w", b.cfg.Options.MetricsAddr, err)
 	}
 	if port == "" {
-		return nil, fmt.Errorf("metrics_addr %s: port is required", cfg.Options.MetricsAddr)
+		return nil, fmt.Errorf("metrics_addr %s: port is required", b.cfg.Options.MetricsAddr)
 	}
 	// unless an explicit IP address was provided, and bind to all interfaces if hostname was provided
 	if net.ParseIP(host) == nil {
@@ -254,14 +251,13 @@ func (b *Builder) buildMetricsListener(cfg *config.Config) (*envoy_config_listen
 	return li, nil
 }
 
-func (b *Builder) buildMainHTTPConnectionManagerFilter(
+func (b *ScopedBuilder) buildMainHTTPConnectionManagerFilter(
 	ctx context.Context,
-	cfg *config.Config,
 	fullyStatic bool,
 ) (*envoy_config_listener_v3.Filter, error) {
 	var grpcClientTimeout *durationpb.Duration
-	if cfg.Options.GRPCClientTimeout != 0 {
-		grpcClientTimeout = durationpb.New(cfg.Options.GRPCClientTimeout)
+	if b.cfg.Options.GRPCClientTimeout != 0 {
+		grpcClientTimeout = durationpb.New(b.cfg.Options.GRPCClientTimeout)
 	} else {
 		grpcClientTimeout = durationpb.New(30 * time.Second)
 	}
@@ -277,46 +273,46 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 	filters = append(filters, HTTPRouterFilter())
 
 	var maxStreamDuration *durationpb.Duration
-	if cfg.Options.WriteTimeout > 0 {
-		maxStreamDuration = durationpb.New(cfg.Options.WriteTimeout)
+	if b.cfg.Options.WriteTimeout > 0 {
+		maxStreamDuration = durationpb.New(b.cfg.Options.WriteTimeout)
 	}
 
-	tracingProvider, err := buildTracingHTTP(cfg.Options)
+	tracingProvider, err := buildTracingHTTP(b.cfg.Options)
 	if err != nil {
 		return nil, err
 	}
 
-	localReply, err := b.buildLocalReplyConfig(cfg.Options)
+	localReply, err := b.buildLocalReplyConfig()
 	if err != nil {
 		return nil, err
 	}
 
 	mgr := &envoy_http_connection_manager.HttpConnectionManager{
 		AlwaysSetRequestIdInResponse: true,
-		CodecType:                    cfg.Options.GetCodecType().ToEnvoy(),
+		CodecType:                    b.cfg.Options.GetCodecType().ToEnvoy(),
 		StatPrefix:                   "ingress",
 		HttpFilters:                  filters,
-		AccessLog:                    buildAccessLogs(cfg.Options),
+		AccessLog:                    buildAccessLogs(b.cfg.Options),
 		CommonHttpProtocolOptions: &envoy_config_core_v3.HttpProtocolOptions{
-			IdleTimeout:       durationpb.New(cfg.Options.IdleTimeout),
+			IdleTimeout:       durationpb.New(b.cfg.Options.IdleTimeout),
 			MaxStreamDuration: maxStreamDuration,
 		},
 		HttpProtocolOptions: http1ProtocolOptions,
-		RequestTimeout:      durationpb.New(cfg.Options.ReadTimeout),
+		RequestTimeout:      durationpb.New(b.cfg.Options.ReadTimeout),
 		Tracing: &envoy_http_connection_manager.HttpConnectionManager_Tracing{
-			RandomSampling: &envoy_type_v3.Percent{Value: cfg.Options.TracingSampleRate * 100},
+			RandomSampling: &envoy_type_v3.Percent{Value: b.cfg.Options.TracingSampleRate * 100},
 			Provider:       tracingProvider,
 		},
 		// See https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for
 		UseRemoteAddress:  &wrapperspb.BoolValue{Value: true},
-		SkipXffAppend:     cfg.Options.SkipXffAppend,
-		XffNumTrustedHops: cfg.Options.XffNumTrustedHops,
+		SkipXffAppend:     b.cfg.Options.SkipXffAppend,
+		XffNumTrustedHops: b.cfg.Options.XffNumTrustedHops,
 		LocalReplyConfig:  localReply,
 		NormalizePath:     wrapperspb.Bool(true),
 	}
 
 	if fullyStatic {
-		routeConfiguration, err := b.buildMainRouteConfiguration(ctx, cfg)
+		routeConfiguration, err := b.buildMainRouteConfiguration(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -338,7 +334,7 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 	return HTTPConnectionManagerFilter(mgr), nil
 }
 
-func (b *Builder) buildMetricsHTTPConnectionManagerFilter() (*envoy_config_listener_v3.Filter, error) {
+func (b *ScopedBuilder) buildMetricsHTTPConnectionManagerFilter() (*envoy_config_listener_v3.Filter, error) {
 	rc, err := b.buildRouteConfiguration("metrics", []*envoy_config_route_v3.VirtualHost{{
 		Name:    "metrics",
 		Domains: []string{"*"},
@@ -388,7 +384,7 @@ func (b *Builder) buildMetricsHTTPConnectionManagerFilter() (*envoy_config_liste
 	}), nil
 }
 
-func (b *Builder) buildGRPCListener(ctx context.Context, cfg *config.Config) (*envoy_config_listener_v3.Listener, error) {
+func (b *ScopedBuilder) buildGRPCListener(ctx context.Context) (*envoy_config_listener_v3.Listener, error) {
 	filter, err := b.buildGRPCHTTPConnectionManagerFilter()
 	if err != nil {
 		return nil, err
@@ -401,17 +397,17 @@ func (b *Builder) buildGRPCListener(ctx context.Context, cfg *config.Config) (*e
 	li := newEnvoyListener("grpc-ingress")
 	li.FilterChains = []*envoy_config_listener_v3.FilterChain{&filterChain}
 
-	if cfg.Options.GetGRPCInsecure() {
-		li.Address = buildAddress(cfg.Options.GetGRPCAddr(), 80)
+	if b.cfg.Options.GetGRPCInsecure() {
+		li.Address = buildAddress(b.cfg.Options.GetGRPCAddr(), 80)
 		return li, nil
 	}
 
-	li.Address = buildAddress(cfg.Options.GetGRPCAddr(), 443)
+	li.Address = buildAddress(b.cfg.Options.GetGRPCAddr(), 443)
 	li.ListenerFilters = []*envoy_config_listener_v3.ListenerFilter{
 		TLSInspectorFilter(),
 	}
 
-	allCertificates, err := getAllCertificates(cfg)
+	allCertificates, err := getAllCertificates(b.cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -435,7 +431,7 @@ func (b *Builder) buildGRPCListener(ctx context.Context, cfg *config.Config) (*e
 	return li, nil
 }
 
-func (b *Builder) buildGRPCHTTPConnectionManagerFilter() (*envoy_config_listener_v3.Filter, error) {
+func (b *ScopedBuilder) buildGRPCHTTPConnectionManagerFilter() (*envoy_config_listener_v3.Filter, error) {
 	allow := []string{
 		"envoy.service.auth.v3.Authorization",
 		"databroker.DataBrokerService",
@@ -491,16 +487,7 @@ func (b *Builder) buildGRPCHTTPConnectionManagerFilter() (*envoy_config_listener
 	}), nil
 }
 
-func (b *Builder) buildRouteConfiguration(name string, virtualHosts []*envoy_config_route_v3.VirtualHost) (*envoy_config_route_v3.RouteConfiguration, error) {
-	return &envoy_config_route_v3.RouteConfiguration{
-		Name:         name,
-		VirtualHosts: virtualHosts,
-		// disable cluster validation since the order of LDS/CDS updates isn't guaranteed
-		ValidateClusters: &wrapperspb.BoolValue{Value: false},
-	}, nil
-}
-
-func (b *Builder) envoyCertificates(ctx context.Context, certs []tls.Certificate) (
+func (b *ScopedBuilder) envoyCertificates(ctx context.Context, certs []tls.Certificate) (
 	[]*envoy_extensions_transport_sockets_tls_v3.TlsCertificate, error,
 ) {
 	envoyCerts := make([]*envoy_extensions_transport_sockets_tls_v3.TlsCertificate, 0, len(certs))
@@ -516,9 +503,8 @@ func (b *Builder) envoyCertificates(ctx context.Context, certs []tls.Certificate
 	return envoyCerts, nil
 }
 
-func (b *Builder) buildDownstreamTLSContextMulti(
+func (b *ScopedBuilder) buildDownstreamTLSContextMulti(
 	ctx context.Context,
-	cfg *config.Config,
 	certs []tls.Certificate,
 ) (
 	*envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext,
@@ -532,10 +518,10 @@ func (b *Builder) buildDownstreamTLSContextMulti(
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
 			TlsParams:       tlsParams,
 			TlsCertificates: envoyCerts,
-			AlpnProtocols:   getALPNProtos(cfg.Options),
+			AlpnProtocols:   getALPNProtos(b.cfg.Options),
 		},
 	}
-	b.buildDownstreamValidationContext(ctx, dtc, cfg)
+	b.buildDownstreamValidationContext(ctx, dtc)
 	return dtc, nil
 }
 
@@ -550,12 +536,11 @@ func getALPNProtos(opts *config.Options) []string {
 	}
 }
 
-func (b *Builder) buildDownstreamValidationContext(
+func (b *ScopedBuilder) buildDownstreamValidationContext(
 	ctx context.Context,
 	dtc *envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext,
-	cfg *config.Config,
 ) {
-	clientCA := clientCABundle(ctx, cfg)
+	clientCA := clientCABundle(ctx, b.cfg)
 	if len(clientCA) == 0 {
 		return
 	}
@@ -563,32 +548,32 @@ func (b *Builder) buildDownstreamValidationContext(
 	vc := &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
 		TrustedCa: b.filemgr.BytesDataSource("client-ca.pem", clientCA),
 		MatchTypedSubjectAltNames: make([]*envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher,
-			0, len(cfg.Options.DownstreamMTLS.MatchSubjectAltNames)),
+			0, len(b.cfg.Options.DownstreamMTLS.MatchSubjectAltNames)),
 		OnlyVerifyLeafCertCrl: true,
 	}
-	for i := range cfg.Options.DownstreamMTLS.MatchSubjectAltNames {
+	for i := range b.cfg.Options.DownstreamMTLS.MatchSubjectAltNames {
 		vc.MatchTypedSubjectAltNames = append(vc.MatchTypedSubjectAltNames,
-			cfg.Options.DownstreamMTLS.MatchSubjectAltNames[i].ToEnvoyProto())
+			b.cfg.Options.DownstreamMTLS.MatchSubjectAltNames[i].ToEnvoyProto())
 	}
 
-	if d := cfg.Options.DownstreamMTLS.GetMaxVerifyDepth(); d > 0 {
+	if d := b.cfg.Options.DownstreamMTLS.GetMaxVerifyDepth(); d > 0 {
 		vc.MaxVerifyDepth = wrapperspb.UInt32(d)
 	}
 
-	if cfg.Options.DownstreamMTLS.GetEnforcement() == config.MTLSEnforcementRejectConnection {
+	if b.cfg.Options.DownstreamMTLS.GetEnforcement() == config.MTLSEnforcementRejectConnection {
 		dtc.RequireClientCertificate = wrapperspb.Bool(true)
 	} else {
 		vc.TrustChainVerification = envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext_ACCEPT_UNTRUSTED
 	}
 
-	if crl := cfg.Options.DownstreamMTLS.CRL; crl != "" {
+	if crl := b.cfg.Options.DownstreamMTLS.CRL; crl != "" {
 		bs, err := base64.StdEncoding.DecodeString(crl)
 		if err != nil {
 			log.Error(ctx).Err(err).Msg("invalid client CRL")
 		} else {
 			vc.Crl = b.filemgr.BytesDataSource("client-crl.pem", bs)
 		}
-	} else if crlf := cfg.Options.DownstreamMTLS.CRLFile; crlf != "" {
+	} else if crlf := b.cfg.Options.DownstreamMTLS.CRLFile; crlf != "" {
 		vc.Crl = b.filemgr.FileDataSource(crlf)
 	}
 
@@ -631,44 +616,54 @@ func addCAToBundle(bundle *bytes.Buffer, ca []byte) {
 	}
 }
 
-func getAllRouteableHosts(options *config.Options, addr string) ([]string, error) {
+func getAllRouteableHosts(options *config.Options, addr string) ([]string, map[string][]config.IndexedPolicy, error) {
 	allHosts := sets.NewSorted[string]()
+	var policiesByHost map[string][]config.IndexedPolicy
 
 	if addr == options.Addr {
-		hosts, err := options.GetAllRouteableHTTPHosts()
+		internalHosts, err := options.GetAllRouteableAuthenticateHTTPHosts()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
-		allHosts.Add(hosts...)
+		policiesByHost, err = options.GetAllRouteablePolicyHTTPHosts()
+		if err != nil {
+			return nil, nil, err
+		}
+		allHosts.Add(internalHosts...)
+		for host := range policiesByHost {
+			allHosts.Add(host)
+		}
 	}
 
 	if addr == options.GetGRPCAddr() {
 		hosts, err := options.GetAllRouteableGRPCHosts()
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		allHosts.Add(hosts...)
 	}
 
-	var filtered []string
-	for _, host := range allHosts.ToSlice() {
-		if !strings.Contains(host, "*") {
-			filtered = append(filtered, host)
-		}
-	}
-	return filtered, nil
+	return allHosts.ToSlice(), policiesByHost, nil
 }
 
-func urlsMatchHost(urls []*url.URL, host string) bool {
+func (b *ScopedBuilder) urlsMatchHost(urls []*url.URL, host string) bool {
 	for _, u := range urls {
-		if urlMatchesHost(u, host) {
+		if b.urlMatchesHost(u, host) {
 			return true
 		}
 	}
 	return false
 }
 
-func urlMatchesHost(u *url.URL, host string) bool {
+func (b *ScopedBuilder) urlMatchesHost(u *url.URL, host string) bool {
+	if domains, ok := b.domainsForWellKnownURLs[u]; ok {
+		for _, d := range domains {
+			if d == host {
+				return true
+			}
+		}
+		return false
+	}
 	for _, h := range urlutil.GetDomainsForURL(u, true) {
 		if h == host {
 			return true

--- a/config/envoyconfig/listeners_envoy_admin.go
+++ b/config/envoyconfig/listeners_envoy_admin.go
@@ -7,11 +7,9 @@ import (
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
 	envoy_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-
-	"github.com/pomerium/pomerium/config"
 )
 
-func (b *Builder) buildEnvoyAdminListener(_ context.Context, cfg *config.Config) (*envoy_config_listener_v3.Listener, error) {
+func (b *ScopedBuilder) buildEnvoyAdminListener(ctx context.Context) (*envoy_config_listener_v3.Listener, error) {
 	filter, err := b.buildEnvoyAdminHTTPConnectionManagerFilter()
 	if err != nil {
 		return nil, err
@@ -23,9 +21,9 @@ func (b *Builder) buildEnvoyAdminListener(_ context.Context, cfg *config.Config)
 		},
 	}
 
-	addr, err := parseAddress(cfg.Options.EnvoyAdminAddress)
+	addr, err := parseAddress(b.cfg.Options.EnvoyAdminAddress)
 	if err != nil {
-		return nil, fmt.Errorf("envoy_admin_addr %s: %w", cfg.Options.EnvoyAdminAddress, err)
+		return nil, fmt.Errorf("envoy_admin_addr %s: %w", b.cfg.Options.EnvoyAdminAddress, err)
 	}
 
 	li := newEnvoyListener("envoy-admin")
@@ -34,7 +32,7 @@ func (b *Builder) buildEnvoyAdminListener(_ context.Context, cfg *config.Config)
 	return li, nil
 }
 
-func (b *Builder) buildEnvoyAdminHTTPConnectionManagerFilter() (*envoy_config_listener_v3.Filter, error) {
+func (b *ScopedBuilder) buildEnvoyAdminHTTPConnectionManagerFilter() (*envoy_config_listener_v3.Filter, error) {
 	rc, err := b.buildRouteConfiguration("envoy-admin", []*envoy_config_route_v3.VirtualHost{{
 		Name:    "envoy-admin",
 		Domains: []string{"*"},

--- a/config/envoyconfig/outbound_test.go
+++ b/config/envoyconfig/outbound_test.go
@@ -3,12 +3,13 @@ package envoyconfig
 import (
 	"testing"
 
+	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/testutil"
 )
 
 func Test_buildOutboundRoutes(t *testing.T) {
 	b := New("local-grpc", "local-http", "local-metrics", nil, nil)
-	routes := b.buildOutboundRoutes()
+	routes := b.WithConfig(&config.Config{}).buildOutboundRoutes()
 	testutil.AssertProtoJSONEqual(t, `[
 		{
 			"match": {

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -31,7 +31,8 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 		},
 	}}
 	b := New("grpc", "http", "metrics", filemgr.NewManager(), nil)
-	routeConfiguration, err := b.buildMainRouteConfiguration(ctx, cfg)
+	sb := b.WithConfig(cfg)
+	routeConfiguration, err := sb.buildMainRouteConfiguration(ctx)
 	assert.NoError(t, err)
 	testutil.AssertProtoJSONEqual(t, `{
 		"name": "main",
@@ -41,12 +42,12 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 				"name": "catch-all",
 				"domains": ["*"],
 				"routes": [
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/ping"))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/healthz"))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.pomerium"))+`,
-					`+protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.pomerium/"))+`,
-					`+protojson.Format(b.buildControlPlanePathRoute(cfg.Options, "/.well-known/pomerium"))+`,
-					`+protojson.Format(b.buildControlPlanePrefixRoute(cfg.Options, "/.well-known/pomerium/"))+`,
+					`+protojson.Format(sb.buildControlPlanePathRoute(context.Background(), "/ping"))+`,
+					`+protojson.Format(sb.buildControlPlanePathRoute(context.Background(), "/healthz"))+`,
+					`+protojson.Format(sb.buildControlPlanePathRoute(context.Background(), "/.pomerium"))+`,
+					`+protojson.Format(sb.buildControlPlanePrefixRoute(context.Background(), "/.pomerium/"))+`,
+					`+protojson.Format(sb.buildControlPlanePathRoute(context.Background(), "/.well-known/pomerium"))+`,
+					`+protojson.Format(sb.buildControlPlanePrefixRoute(context.Background(), "/.well-known/pomerium/"))+`,
 					{
 						"name": "policy-0",
 						"match": {

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -1,9 +1,9 @@
 package envoyconfig
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
-	"net/url"
 	"sort"
 	"strings"
 
@@ -24,7 +24,7 @@ const (
 	httpCluster = "pomerium-control-plane-http"
 )
 
-func (b *Builder) buildGRPCRoutes() ([]*envoy_config_route_v3.Route, error) {
+func (b *ScopedBuilder) buildGRPCRoutes() ([]*envoy_config_route_v3.Route, error) {
 	action := &envoy_config_route_v3.Route_Route{
 		Route: &envoy_config_route_v3.RouteAction{
 			ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
@@ -47,30 +47,23 @@ func (b *Builder) buildGRPCRoutes() ([]*envoy_config_route_v3.Route, error) {
 	}}, nil
 }
 
-func (b *Builder) buildPomeriumHTTPRoutes(
-	options *config.Options,
+func (b *ScopedBuilder) buildPomeriumHTTPRoutes(
+	ctx context.Context,
 	host string,
 ) ([]*envoy_config_route_v3.Route, error) {
 	var routes []*envoy_config_route_v3.Route
 
 	// if this is the pomerium proxy in front of the the authenticate service, don't add
 	// these routes since they will be handled by authenticate
-	isFrontingAuthenticate, err := isProxyFrontingAuthenticate(options, host)
+	isFrontingAuthenticate, err := b.isProxyFrontingAuthenticate(host)
 	if err != nil {
 		return nil, err
 	}
 	if !isFrontingAuthenticate {
-		routes = append(routes,
-			b.buildControlPlanePathRoute(options, "/ping"),
-			b.buildControlPlanePathRoute(options, "/healthz"),
-			b.buildControlPlanePathRoute(options, "/.pomerium"),
-			b.buildControlPlanePrefixRoute(options, "/.pomerium/"),
-			b.buildControlPlanePathRoute(options, "/.well-known/pomerium"),
-			b.buildControlPlanePrefixRoute(options, "/.well-known/pomerium/"),
-		)
+		routes = append(routes, b.staticHttpRoutes...)
 	}
 
-	authRoutes, err := b.buildPomeriumAuthenticateHTTPRoutes(options, host)
+	authRoutes, err := b.buildPomeriumAuthenticateHTTPRoutes(ctx, host)
 	if err != nil {
 		return nil, err
 	}
@@ -78,35 +71,27 @@ func (b *Builder) buildPomeriumHTTPRoutes(
 	return routes, nil
 }
 
-func (b *Builder) buildPomeriumAuthenticateHTTPRoutes(
-	options *config.Options,
+func (b *ScopedBuilder) buildPomeriumAuthenticateHTTPRoutes(
+	ctx context.Context,
 	host string,
 ) ([]*envoy_config_route_v3.Route, error) {
-	if !config.IsAuthenticate(options.Services) {
+	if !config.IsAuthenticate(b.cfg.Options.Services) {
 		return nil, nil
 	}
 
-	for _, fn := range []func() (*url.URL, error){
-		options.GetAuthenticateURL,
-		options.GetInternalAuthenticateURL,
-	} {
-		u, err := fn()
-		if err != nil {
-			return nil, err
-		}
-		if urlMatchesHost(u, host) {
-			return []*envoy_config_route_v3.Route{
-				b.buildControlPlanePathRoute(options, options.AuthenticateCallbackPath),
-				b.buildControlPlanePathRoute(options, "/"),
-				b.buildControlPlanePathRoute(options, "/robots.txt"),
-			}, nil
-		}
+	if b.urlMatchesHost(b.authenticateURL, host) {
+		return b.staticAuthenticateHttpRoutes, nil
 	}
+
+	if b.urlMatchesHost(b.internalAuthenticateURL, host) {
+		return b.staticAuthenticateHttpRoutes, nil
+	}
+
 	return nil, nil
 }
 
-func (b *Builder) buildControlPlanePathRoute(
-	options *config.Options,
+func (b *ScopedBuilder) buildControlPlanePathRoute(
+	ctx context.Context,
 	path string,
 ) *envoy_config_route_v3.Route {
 	r := &envoy_config_route_v3.Route{
@@ -121,7 +106,7 @@ func (b *Builder) buildControlPlanePathRoute(
 				},
 			},
 		},
-		ResponseHeadersToAdd: toEnvoyHeaders(options.GetSetResponseHeaders()),
+		ResponseHeadersToAdd: toEnvoyHeaders(b.cfg.Options.GetSetResponseHeaders()),
 		TypedPerFilterConfig: map[string]*anypb.Any{
 			PerFilterConfigExtAuthzName: PerFilterConfigExtAuthzContextExtensions(MakeExtAuthzContextExtensions(true, 0)),
 		},
@@ -129,8 +114,8 @@ func (b *Builder) buildControlPlanePathRoute(
 	return r
 }
 
-func (b *Builder) buildControlPlanePrefixRoute(
-	options *config.Options,
+func (b *ScopedBuilder) buildControlPlanePrefixRoute(
+	ctx context.Context,
 	prefix string,
 ) *envoy_config_route_v3.Route {
 	r := &envoy_config_route_v3.Route{
@@ -145,7 +130,7 @@ func (b *Builder) buildControlPlanePrefixRoute(
 				},
 			},
 		},
-		ResponseHeadersToAdd: toEnvoyHeaders(options.GetSetResponseHeaders()),
+		ResponseHeadersToAdd: toEnvoyHeaders(b.cfg.Options.GetSetResponseHeaders()),
 		TypedPerFilterConfig: map[string]*anypb.Any{
 			PerFilterConfigExtAuthzName: PerFilterConfigExtAuthzContextExtensions(MakeExtAuthzContextExtensions(true, 0)),
 		},
@@ -172,23 +157,22 @@ func getClusterStatsName(policy *config.Policy) string {
 	return ""
 }
 
-func (b *Builder) buildRoutesForPoliciesWithHost(
-	cfg *config.Config,
+func (b *ScopedBuilder) buildRoutesForPoliciesWithHost(
+	ctx context.Context,
 	host string,
 ) ([]*envoy_config_route_v3.Route, error) {
 	var routes []*envoy_config_route_v3.Route
-	for i, p := range cfg.Options.GetAllPoliciesIndexed() {
-		policy := p
-		fromURL, err := urlutil.ParseAndValidateURL(policy.From)
+	for i, p := range b.cfg.Options.GetAllPoliciesIndexed() {
+		fromURL, err := urlutil.ParseAndValidateSharedURL(p.From)
 		if err != nil {
 			return nil, err
 		}
 
-		if !urlMatchesHost(fromURL, host) {
+		if !b.urlMatchesHost(fromURL.URL, host) {
 			continue
 		}
 
-		policyRoutes, err := b.buildRoutesForPolicy(cfg, policy, fmt.Sprintf("policy-%d", i))
+		policyRoutes, err := b.buildRoutesForPolicy(ctx, p, fmt.Sprintf("policy-%d", i))
 		if err != nil {
 			return nil, err
 		}
@@ -198,36 +182,12 @@ func (b *Builder) buildRoutesForPoliciesWithHost(
 	return routes, nil
 }
 
-func (b *Builder) buildRoutesForPoliciesWithCatchAll(
-	cfg *config.Config,
-) ([]*envoy_config_route_v3.Route, error) {
-	var routes []*envoy_config_route_v3.Route
-	for i, policy := range cfg.Options.GetAllPoliciesIndexed() {
-		fromURL, err := urlutil.ParseAndValidateURL(policy.From)
-		if err != nil {
-			return nil, err
-		}
-
-		if !strings.Contains(fromURL.Host, "*") {
-			continue
-		}
-
-		policyRoutes, err := b.buildRoutesForPolicy(cfg, policy, fmt.Sprintf("policy-%d", i))
-		if err != nil {
-			return nil, err
-		}
-
-		routes = append(routes, policyRoutes...)
-	}
-	return routes, nil
-}
-
-func (b *Builder) buildRoutesForPolicy(
-	cfg *config.Config,
+func (b *ScopedBuilder) buildRoutesForPolicy(
+	ctx context.Context,
 	policy *config.Policy,
 	name string,
 ) ([]*envoy_config_route_v3.Route, error) {
-	fromURL, err := urlutil.ParseAndValidateURL(policy.From)
+	fromURL, err := urlutil.ParseAndValidateSharedURL(policy.From)
 	if err != nil {
 		return nil, err
 	}
@@ -235,15 +195,15 @@ func (b *Builder) buildRoutesForPolicy(
 	var routes []*envoy_config_route_v3.Route
 	if strings.Contains(fromURL.Host, "*") {
 		// we have to match '*.example.com' and '*.example.com:443', so there are two routes
-		for _, host := range urlutil.GetDomainsForURL(fromURL, !cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMatchAnyIncomingPort)) {
-			route, err := b.buildRouteForPolicyAndMatch(cfg, policy, name, mkRouteMatchForHost(cfg.Options, policy, host))
+		for host := range urlutil.AllDomainsForURL(fromURL.URL, !b.cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMatchAnyIncomingPort)) {
+			route, err := b.buildRouteForPolicyAndMatch(ctx, policy, name, mkRouteMatchForHost(b.cfg.Options, policy, host))
 			if err != nil {
 				return nil, err
 			}
 			routes = append(routes, route)
 		}
 	} else {
-		route, err := b.buildRouteForPolicyAndMatch(cfg, policy, name, mkRouteMatch(policy))
+		route, err := b.buildRouteForPolicyAndMatch(ctx, policy, name, mkRouteMatch(policy))
 		if err != nil {
 			return nil, err
 		}
@@ -252,13 +212,13 @@ func (b *Builder) buildRoutesForPolicy(
 	return routes, nil
 }
 
-func (b *Builder) buildRouteForPolicyAndMatch(
-	cfg *config.Config,
+func (b *ScopedBuilder) buildRouteForPolicyAndMatch(
+	ctx context.Context,
 	policy *config.Policy,
 	name string,
 	match *envoy_config_route_v3.RouteMatch,
 ) (*envoy_config_route_v3.Route, error) {
-	fromURL, err := urlutil.ParseAndValidateURL(policy.From)
+	fromURL, err := urlutil.ParseAndValidateSharedURL(policy.From)
 	if err != nil {
 		return nil, err
 	}
@@ -272,8 +232,8 @@ func (b *Builder) buildRouteForPolicyAndMatch(
 		Name:                   name,
 		Match:                  match,
 		Metadata:               &envoy_config_core_v3.Metadata{},
-		RequestHeadersToRemove: getRequestHeadersToRemove(cfg.Options, policy),
-		ResponseHeadersToAdd:   toEnvoyHeaders(cfg.Options.GetSetResponseHeadersForPolicy(policy)),
+		RequestHeadersToRemove: getRequestHeadersToRemove(b.cfg.Options, policy),
+		ResponseHeadersToAdd:   toEnvoyHeaders(b.cfg.Options.GetSetResponseHeadersForPolicy(policy)),
 	}
 	if policy.Redirect != nil {
 		action, err := b.buildPolicyRouteRedirectAction(policy.Redirect)
@@ -285,7 +245,7 @@ func (b *Builder) buildRouteForPolicyAndMatch(
 		action := b.buildPolicyRouteDirectResponseAction(policy.Response)
 		route.Action = &envoy_config_route_v3.Route_DirectResponse{DirectResponse: action}
 	} else {
-		action, err := b.buildPolicyRouteRouteAction(cfg.Options, policy)
+		action, err := b.buildPolicyRouteRouteAction(b.cfg.Options, policy)
 		if err != nil {
 			return nil, err
 		}
@@ -297,7 +257,7 @@ func (b *Builder) buildRouteForPolicyAndMatch(
 	}
 
 	// disable authentication entirely when the proxy is fronting authenticate
-	isFrontingAuthenticate, err := isProxyFrontingAuthenticate(cfg.Options, fromURL.Hostname())
+	isFrontingAuthenticate, err := b.isProxyFrontingAuthenticate(fromURL.Hostname())
 	if err != nil {
 		return nil, err
 	}
@@ -311,7 +271,7 @@ func (b *Builder) buildRouteForPolicyAndMatch(
 		}
 		luaMetadata["remove_pomerium_cookie"] = &structpb.Value{
 			Kind: &structpb.Value_StringValue{
-				StringValue: cfg.Options.CookieName,
+				StringValue: b.cfg.Options.CookieName,
 			},
 		}
 		luaMetadata["remove_pomerium_authorization"] = &structpb.Value{
@@ -345,7 +305,7 @@ func (b *Builder) buildRouteForPolicyAndMatch(
 	return route, nil
 }
 
-func (b *Builder) buildPolicyRouteDirectResponseAction(r *config.DirectResponse) *envoy_config_route_v3.DirectResponseAction {
+func (b *ScopedBuilder) buildPolicyRouteDirectResponseAction(r *config.DirectResponse) *envoy_config_route_v3.DirectResponseAction {
 	return &envoy_config_route_v3.DirectResponseAction{
 		Status: uint32(r.Status),
 		Body: &envoy_config_core_v3.DataSource{
@@ -356,7 +316,7 @@ func (b *Builder) buildPolicyRouteDirectResponseAction(r *config.DirectResponse)
 	}
 }
 
-func (b *Builder) buildPolicyRouteRedirectAction(r *config.PolicyRedirect) (*envoy_config_route_v3.RedirectAction, error) {
+func (b *ScopedBuilder) buildPolicyRouteRedirectAction(r *config.PolicyRedirect) (*envoy_config_route_v3.RedirectAction, error) {
 	action := &envoy_config_route_v3.RedirectAction{}
 	switch {
 	case r.HTTPSRedirect != nil:
@@ -393,7 +353,7 @@ func (b *Builder) buildPolicyRouteRedirectAction(r *config.PolicyRedirect) (*env
 	return action, nil
 }
 
-func (b *Builder) buildPolicyRouteRouteAction(options *config.Options, policy *config.Policy) (*envoy_config_route_v3.RouteAction, error) {
+func (b *ScopedBuilder) buildPolicyRouteRouteAction(options *config.Options, policy *config.Policy) (*envoy_config_route_v3.RouteAction, error) {
 	clusterName := getClusterID(policy)
 	// kubernetes requests are sent to the http control plane to be reproxied
 	if policy.IsForKubernetes() {
@@ -623,16 +583,10 @@ func setHostRewriteOptions(policy *config.Policy, action *envoy_config_route_v3.
 	}
 }
 
-func isProxyFrontingAuthenticate(options *config.Options, host string) (bool, error) {
-	authenticateURL, err := options.GetAuthenticateURL()
-	if err != nil {
-		return false, err
-	}
-
-	if !config.IsAuthenticate(options.Services) && urlMatchesHost(authenticateURL, host) {
+func (b *ScopedBuilder) isProxyFrontingAuthenticate(host string) (bool, error) {
+	if !config.IsAuthenticate(b.cfg.Options.Services) && b.urlMatchesHost(b.authenticateURL, host) {
 		return true, nil
 	}
-
 	return false, nil
 }
 

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -1,6 +1,7 @@
 package envoyconfig
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strings"
@@ -28,8 +29,8 @@ func policyNameFunc() func(*config.Policy) string {
 }
 
 func Test_buildGRPCRoutes(t *testing.T) {
-	b := &Builder{filemgr: filemgr.NewManager()}
-	routes, err := b.buildGRPCRoutes()
+	b := &Builder{staticBuilderConfig{filemgr: filemgr.NewManager()}}
+	routes, err := b.WithConfig(&config.Config{}).buildGRPCRoutes()
 	require.NoError(t, err)
 	testutil.AssertProtoJSONEqual(t, `
 		[
@@ -54,7 +55,7 @@ func Test_buildGRPCRoutes(t *testing.T) {
 }
 
 func Test_buildPomeriumHTTPRoutes(t *testing.T) {
-	b := &Builder{filemgr: filemgr.NewManager()}
+	b := &Builder{staticBuilderConfig{filemgr: filemgr.NewManager()}}
 	routeString := func(typ, name string) string {
 		str := `{
 			"name": "pomerium-` + typ + `-` + name + `",
@@ -100,7 +101,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 			AuthenticateURLString:    "https://authenticate.example.com",
 			AuthenticateCallbackPath: "/oauth2/callback",
 		}
-		routes, err := b.buildPomeriumHTTPRoutes(options, "authenticate.example.com")
+		routes, err := b.WithConfig(&config.Config{Options: options}).buildPomeriumHTTPRoutes(context.Background(), "authenticate.example.com")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `[
@@ -121,7 +122,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 			AuthenticateURLString:    "https://authenticate.example.com",
 			AuthenticateCallbackPath: "/oauth2/callback",
 		}
-		routes, err := b.buildPomeriumHTTPRoutes(options, "authenticate.example.com")
+		routes, err := b.WithConfig(&config.Config{Options: options}).buildPomeriumHTTPRoutes(context.Background(), "authenticate.example.com")
 		require.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, "null", routes)
 	})
@@ -129,8 +130,8 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 
 func Test_buildControlPlanePathRoute(t *testing.T) {
 	options := config.NewDefaultOptions()
-	b := &Builder{filemgr: filemgr.NewManager()}
-	route := b.buildControlPlanePathRoute(options, "/hello/world")
+	b := &Builder{staticBuilderConfig{filemgr: filemgr.NewManager()}}
+	route := b.WithConfig(&config.Config{Options: options}).buildControlPlanePathRoute(context.Background(), "/hello/world")
 	testutil.AssertProtoJSONEqual(t, `
 		{
 			"name": "pomerium-path-/hello/world",
@@ -173,8 +174,8 @@ func Test_buildControlPlanePathRoute(t *testing.T) {
 
 func Test_buildControlPlanePrefixRoute(t *testing.T) {
 	options := config.NewDefaultOptions()
-	b := &Builder{filemgr: filemgr.NewManager()}
-	route := b.buildControlPlanePrefixRoute(options, "/hello/world/")
+	b := &Builder{staticBuilderConfig{filemgr: filemgr.NewManager()}}
+	route := b.WithConfig(&config.Config{Options: options}).buildControlPlanePrefixRoute(context.Background(), "/hello/world/")
 	testutil.AssertProtoJSONEqual(t, `
 		{
 			"name": "pomerium-prefix-/hello/world/",
@@ -246,8 +247,8 @@ func TestTimeouts(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		b := &Builder{filemgr: filemgr.NewManager()}
-		routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
+		b := &Builder{staticBuilderConfig{filemgr: filemgr.NewManager()}}
+		routes, err := b.WithConfig(&config.Config{Options: &config.Options{
 			CookieName:             "pomerium",
 			DefaultUpstreamTimeout: time.Second * 3,
 			SharedKey:              cryptutil.NewBase64Key(),
@@ -261,7 +262,7 @@ func TestTimeouts(t *testing.T) {
 					AllowWebsockets: tc.allowWebsockets,
 				},
 			},
-		}}, "example.com")
+		}}).buildRoutesForPoliciesWithHost(context.Background(), "example.com")
 		if !assert.NoError(t, err, "%v", tc) || !assert.Len(t, routes, 1, tc) || !assert.NotNil(t, routes[0].GetRoute(), "%v", tc) {
 			continue
 		}
@@ -302,8 +303,8 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	oneMinute := time.Minute
 	ten := time.Second * 10
 
-	b := &Builder{filemgr: filemgr.NewManager()}
-	routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
+	b := &Builder{staticBuilderConfig{filemgr: filemgr.NewManager()}}
+	routes, err := b.WithConfig(&config.Config{Options: &config.Options{
 		CookieName:             "pomerium",
 		DefaultUpstreamTimeout: time.Second * 3,
 		SharedKey:              cryptutil.NewBase64Key(),
@@ -375,7 +376,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				UpstreamTimeout:     &ten,
 			},
 		},
-	}}, "example.com")
+	}}).buildRoutesForPoliciesWithHost(context.Background(), "example.com")
 	require.NoError(t, err)
 
 	testutil.AssertProtoJSONEqual(t, `
@@ -950,7 +951,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	`, routes)
 
 	t.Run("fronting-authenticate", func(t *testing.T) {
-		routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
+		routes, err := b.WithConfig(&config.Config{Options: &config.Options{
 			AuthenticateURLString:  "https://authenticate.example.com",
 			Services:               "proxy",
 			CookieName:             "pomerium",
@@ -963,7 +964,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					PassIdentityHeaders: ptr(true),
 				},
 			},
-		}}, "authenticate.example.com")
+		}}).buildRoutesForPoliciesWithHost(context.Background(), "authenticate.example.com")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `
@@ -1035,7 +1036,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	})
 
 	t.Run("tcp", func(t *testing.T) {
-		routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
+		routes, err := b.WithConfig(&config.Config{Options: &config.Options{
 			CookieName:             "pomerium",
 			DefaultUpstreamTimeout: time.Second * 3,
 			SharedKey:              cryptutil.NewBase64Key(),
@@ -1052,7 +1053,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					UpstreamTimeout:     &ten,
 				},
 			},
-		}}, "example.com:22")
+		}}).buildRoutesForPoliciesWithHost(context.Background(), "example.com:22")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `
@@ -1206,7 +1207,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	})
 
 	t.Run("remove-pomerium-headers", func(t *testing.T) {
-		routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
+		routes, err := b.WithConfig(&config.Config{Options: &config.Options{
 			AuthenticateURLString:  "https://authenticate.example.com",
 			Services:               "proxy",
 			CookieName:             "pomerium",
@@ -1221,7 +1222,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					To:   mustParseWeightedURLs(t, "https://to.example.com"),
 				},
 			},
-		}}, "from.example.com")
+		}}).buildRoutesForPoliciesWithHost(context.Background(), "from.example.com")
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `
@@ -1309,8 +1310,8 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 		getClusterID = f
 	}(getClusterID)
 	getClusterID = policyNameFunc()
-	b := &Builder{filemgr: filemgr.NewManager()}
-	routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
+	b := &Builder{staticBuilderConfig{filemgr: filemgr.NewManager()}}
+	routes, err := b.WithConfig(&config.Config{Options: &config.Options{
 		CookieName:             "pomerium",
 		DefaultUpstreamTimeout: time.Second * 3,
 		SharedKey:              cryptutil.NewBase64Key(),
@@ -1353,7 +1354,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 				HostPathRegexRewriteSubstitution: "\\1",
 			},
 		},
-	}}, "example.com")
+	}}).buildRoutesForPoliciesWithHost(context.Background(), "example.com")
 	require.NoError(t, err)
 
 	testutil.AssertProtoJSONEqual(t, `
@@ -1799,9 +1800,10 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 }
 
 func Test_buildPolicyRouteRedirectAction(t *testing.T) {
-	b := &Builder{filemgr: filemgr.NewManager()}
+	b := &Builder{staticBuilderConfig{filemgr: filemgr.NewManager()}}
+	sb := b.WithConfig(&config.Config{})
 	t.Run("HTTPSRedirect", func(t *testing.T) {
-		action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
+		action, err := sb.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
 			HTTPSRedirect: proto.Bool(true),
 		})
 		require.NoError(t, err)
@@ -1811,7 +1813,7 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 			},
 		}, action)
 
-		action, err = b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
+		action, err = sb.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
 			HTTPSRedirect: proto.Bool(false),
 		})
 		require.NoError(t, err)
@@ -1822,7 +1824,7 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 		}, action)
 	})
 	t.Run("SchemeRedirect", func(t *testing.T) {
-		action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
+		action, err := sb.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
 			SchemeRedirect: proto.String("https"),
 		})
 		require.NoError(t, err)
@@ -1833,7 +1835,7 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 		}, action)
 	})
 	t.Run("HostRedirect", func(t *testing.T) {
-		action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
+		action, err := sb.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
 			HostRedirect: proto.String("HOST"),
 		})
 		require.NoError(t, err)
@@ -1842,7 +1844,7 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 		}, action)
 	})
 	t.Run("PortRedirect", func(t *testing.T) {
-		action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
+		action, err := sb.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
 			PortRedirect: proto.Uint32(1234),
 		})
 		require.NoError(t, err)
@@ -1851,7 +1853,7 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 		}, action)
 	})
 	t.Run("PathRedirect", func(t *testing.T) {
-		action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
+		action, err := sb.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
 			PathRedirect: proto.String("PATH"),
 		})
 		require.NoError(t, err)
@@ -1862,7 +1864,7 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 		}, action)
 	})
 	t.Run("PrefixRewrite", func(t *testing.T) {
-		action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
+		action, err := sb.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
 			PrefixRewrite: proto.String("PREFIX_REWRITE"),
 		})
 		require.NoError(t, err)
@@ -1873,7 +1875,7 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 		}, action)
 	})
 	t.Run("ResponseCode", func(t *testing.T) {
-		action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
+		action, err := sb.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
 			ResponseCode: proto.Int32(301),
 		})
 		require.NoError(t, err)
@@ -1882,7 +1884,7 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 		}, action)
 	})
 	t.Run("StripQuery", func(t *testing.T) {
-		action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
+		action, err := sb.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
 			StripQuery: proto.Bool(true),
 		})
 		require.NoError(t, err)

--- a/config/envoyconfig/tls.go
+++ b/config/envoyconfig/tls.go
@@ -16,7 +16,7 @@ import (
 
 var oidMustStaple = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
 
-func (b *Builder) buildSubjectAltNameMatcher(
+func (b *ScopedBuilder) buildSubjectAltNameMatcher(
 	dst *url.URL,
 	overrideName string,
 ) *envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher {
@@ -68,7 +68,7 @@ func (b *Builder) buildSubjectAltNameMatcher(
 	}
 }
 
-func (b *Builder) buildSubjectNameIndication(
+func (b *ScopedBuilder) buildSubjectNameIndication(
 	dst *url.URL,
 	overrideName string,
 ) string {

--- a/config/envoyconfig/tls_test.go
+++ b/config/envoyconfig/tls_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
@@ -20,31 +21,31 @@ func TestBuildSubjectAltNameMatcher(t *testing.T) {
 		"matcher": {
 			"exact": "example.com"
 		}
-	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "example.com:1234"}, ""))
+	}`, b.WithConfig(&config.Config{}).buildSubjectAltNameMatcher(&url.URL{Host: "example.com:1234"}, ""))
 	testutil.AssertProtoJSONEqual(t, `{
 		"sanType": "IP_ADDRESS",
 		"matcher": {
 			"exact": "10.0.0.1"
 		}
-	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "10.0.0.1:1234"}, ""))
+	}`, b.WithConfig(&config.Config{}).buildSubjectAltNameMatcher(&url.URL{Host: "10.0.0.1:1234"}, ""))
 	testutil.AssertProtoJSONEqual(t, `{
 		"sanType": "IP_ADDRESS",
 		"matcher": {
 			"exact": "fd12:3456:789a:1::1"
 		}
-	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "[fd12:3456:789a:1::1]:1234"}, ""))
+	}`, b.WithConfig(&config.Config{}).buildSubjectAltNameMatcher(&url.URL{Host: "[fd12:3456:789a:1::1]:1234"}, ""))
 	testutil.AssertProtoJSONEqual(t, `{
 		"sanType": "IP_ADDRESS",
 		"matcher": {
 			"exact": "fe80::1ff:fe23:4567:890a"
 		}
-	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "[fe80::1ff:fe23:4567:890a%eth2]:1234"}, ""))
+	}`, b.WithConfig(&config.Config{}).buildSubjectAltNameMatcher(&url.URL{Host: "[fe80::1ff:fe23:4567:890a%eth2]:1234"}, ""))
 	testutil.AssertProtoJSONEqual(t, `{
 		"sanType": "DNS",
 		"matcher": {
 			"exact": "example.org"
 		}
-	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "example.com:1234"}, "example.org"))
+	}`, b.WithConfig(&config.Config{}).buildSubjectAltNameMatcher(&url.URL{Host: "example.com:1234"}, "example.org"))
 	testutil.AssertProtoJSONEqual(t, `{
 		"sanType": "DNS",
 		"matcher": {
@@ -53,14 +54,15 @@ func TestBuildSubjectAltNameMatcher(t *testing.T) {
 				"regex": ".*\\.example\\.org"
 			}
 		}
-	}`, b.buildSubjectAltNameMatcher(&url.URL{Host: "example.com:1234"}, "*.example.org"))
+	}`, b.WithConfig(&config.Config{}).buildSubjectAltNameMatcher(&url.URL{Host: "example.com:1234"}, "*.example.org"))
 }
 
 func TestBuildSubjectNameIndication(t *testing.T) {
 	b := new(Builder)
-	assert.Equal(t, "example.com", b.buildSubjectNameIndication(&url.URL{Host: "example.com:1234"}, ""))
-	assert.Equal(t, "example.org", b.buildSubjectNameIndication(&url.URL{Host: "example.com:1234"}, "example.org"))
-	assert.Equal(t, "example.example.org", b.buildSubjectNameIndication(&url.URL{Host: "example.com:1234"}, "*.example.org"))
+	sb := b.WithConfig(&config.Config{})
+	assert.Equal(t, "example.com", sb.buildSubjectNameIndication(&url.URL{Host: "example.com:1234"}, ""))
+	assert.Equal(t, "example.org", sb.buildSubjectNameIndication(&url.URL{Host: "example.com:1234"}, "example.org"))
+	assert.Equal(t, "example.example.org", sb.buildSubjectNameIndication(&url.URL{Host: "example.com:1234"}, "*.example.org"))
 }
 
 func TestValidateCertificate(t *testing.T) {

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -892,21 +892,25 @@ func TestOptions_GetAllRouteableHTTPHosts(t *testing.T) {
 		Policies:              []Policy{p1, p2, p3},
 		Services:              "all",
 	}
-	hosts, err := opts.GetAllRouteableHTTPHosts()
+	hosts, err := opts.GetAllRouteableAuthenticateHTTPHosts()
 	assert.NoError(t, err)
 
 	assert.Equal(t, []string{
 		"authenticate.example.com",
 		"authenticate.example.com:443",
-		"from.example.com",
-		"from.example.com:443",
-		"from1.example.com",
-		"from1.example.com:443",
-		"from2.example.com",
-		"from2.example.com:443",
-		"from3.example.com",
-		"from3.example.com:443",
 	}, hosts)
+	policiesByHost, err := opts.GetAllRouteablePolicyHTTPHosts()
+	assert.NoError(t, err)
+	assert.Equal(t, map[string][]IndexedPolicy{
+		"from.example.com":      {{Policy: &p3, Index: 2}},
+		"from.example.com:443":  {{Policy: &p3, Index: 2}},
+		"from1.example.com":     {{Policy: &p1, Index: 0}},
+		"from1.example.com:443": {{Policy: &p1, Index: 0}},
+		"from2.example.com":     {{Policy: &p2, Index: 1}},
+		"from2.example.com:443": {{Policy: &p2, Index: 1}},
+		"from3.example.com":     {{Policy: &p3, Index: 2}},
+		"from3.example.com:443": {{Policy: &p3, Index: 2}},
+	}, policiesByHost)
 }
 
 func TestOptions_ApplySettings(t *testing.T) {

--- a/internal/controlplane/xds.go
+++ b/internal/controlplane/xds.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	rttrace "runtime/trace"
 
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"golang.org/x/sync/errgroup"
@@ -23,6 +24,8 @@ const (
 func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*envoy_service_discovery_v3.Resource, error) {
 	ctx, span := trace.StartSpan(ctx, "controlplane.Server.buildDiscoveryResources")
 	defer span.End()
+	ctx, task := rttrace.NewTask(ctx, "controlplane.Server.buildDiscoveryResources")
+	defer task.End()
 
 	cfg := srv.currentConfig.Load()
 
@@ -30,9 +33,11 @@ func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*e
 
 	eg, ctx := errgroup.WithContext(ctx)
 
+	sb := srv.Builder.WithConfig(cfg)
+
 	var clusterResources []*envoy_service_discovery_v3.Resource
 	eg.Go(func() error {
-		clusters, err := srv.Builder.BuildClusters(ctx, cfg)
+		clusters, err := sb.BuildClusters(ctx)
 		if err != nil {
 			return fmt.Errorf("error building clusters: %w", err)
 		}
@@ -48,7 +53,7 @@ func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*e
 
 	var listenerResources []*envoy_service_discovery_v3.Resource
 	eg.Go(func() error {
-		listeners, err := srv.Builder.BuildListeners(ctx, cfg, false)
+		listeners, err := sb.BuildListeners(ctx, false)
 		if err != nil {
 			return fmt.Errorf("error building listeners: %w", err)
 		}
@@ -64,17 +69,15 @@ func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*e
 
 	var routeConfigurationResources []*envoy_service_discovery_v3.Resource
 	eg.Go(func() error {
-		routeConfigurations, err := srv.Builder.BuildRouteConfigurations(ctx, cfg)
+		routeConfiguration, err := sb.BuildRouteConfiguration(ctx)
 		if err != nil {
 			return fmt.Errorf("error building route configurations: %w", err)
 		}
-		for _, routeConfiguration := range routeConfigurations {
-			routeConfigurationResources = append(routeConfigurationResources, &envoy_service_discovery_v3.Resource{
-				Name:     routeConfiguration.Name,
-				Version:  hex.EncodeToString(cryptutil.HashProto(routeConfiguration)),
-				Resource: protoutil.NewAny(routeConfiguration),
-			})
-		}
+		routeConfigurationResources = append(routeConfigurationResources, &envoy_service_discovery_v3.Resource{
+			Name:     routeConfiguration.Name,
+			Version:  hex.EncodeToString(cryptutil.HashProto(routeConfiguration)),
+			Resource: protoutil.NewAny(routeConfiguration),
+		})
 		return nil
 	})
 

--- a/internal/urlutil/url.go
+++ b/internal/urlutil/url.go
@@ -2,14 +2,19 @@
 package urlutil
 
 import (
+	"bytes"
 	"fmt"
+	"iter"
 	"net"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/caddyserver/certmagic"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -50,6 +55,55 @@ func ParseAndValidateURL(rawurl string) (*url.URL, error) {
 		return nil, err
 	}
 	return u, nil
+}
+
+type SharedURL struct {
+	*url.URL
+	initDone uint32
+	hostname func() string
+}
+
+func (s *SharedURL) lazyInit() {
+	if atomic.CompareAndSwapUint32(&s.initDone, 0, 1) {
+		s.hostname = sync.OnceValue(s.URL.Hostname)
+	}
+}
+
+func (s *SharedURL) Hostname() string {
+	s.lazyInit()
+	return s.hostname()
+}
+
+func (s *SharedURL) Mutable() *url.URL {
+	u := *s.URL
+	if u.User != nil {
+		user := *u.User
+		u.User = &user
+	}
+	return &u
+}
+
+var (
+	urlCache sync.Map // map[string]*url.URL
+	sf       singleflight.Group
+)
+
+func ParseAndValidateSharedURL(rawurl string) (*SharedURL, error) {
+	if v, ok := urlCache.Load(rawurl); ok {
+		return &SharedURL{URL: v.(*url.URL)}, nil
+	}
+	v, err, _ := sf.Do(rawurl, func() (any, error) {
+		url, err := ParseAndValidateURL(rawurl)
+		if err != nil {
+			return nil, err
+		}
+		urlCache.Store(rawurl, url)
+		return url, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &SharedURL{URL: v.(*url.URL)}, nil
 }
 
 // MustParseAndValidateURL parses the URL via ParseAndValidateURL but panics if there is an error.
@@ -147,6 +201,87 @@ func GetDomainsForURL(u *url.URL, includeDefaultPort bool) []string {
 
 	// for everything else we return two routes: 'example.com' and 'example.com:443'
 	return []string{u.Hostname(), net.JoinHostPort(u.Hostname(), defaultPort)}
+}
+
+var (
+	b80  = []byte("80")
+	b443 = []byte("443")
+)
+
+func AllDomainsForURL(u *url.URL, includeDefaultPort bool) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		if u == nil {
+			return
+		}
+
+		// tcp+https://ssh.example.com:22
+		// => ssh.example.com:22
+		// tcp+https://proxy.example.com/ssh.example.com:22
+		// => ssh.example.com:22
+		if strings.HasPrefix(u.Scheme, "tcp+") {
+			hosts := strings.Split(u.Path, "/")[1:]
+			if len(hosts) == 0 {
+				// if there are no domains in the path part of the URL, use the host
+				yield(u.Host)
+			} else {
+				// otherwise use the path parts of the URL as the hosts
+				for _, h := range hosts {
+					if !yield(h) {
+						break
+					}
+				}
+			}
+			return
+		}
+
+		var defaultPort []byte
+		if u.Scheme == "http" {
+			defaultPort = b80
+		} else {
+			defaultPort = b443
+		}
+
+		// for hosts like 'example.com:1234' we only return one route
+		host, port := splitHostPort([]byte(u.Host))
+		if len(port) > 0 {
+			if !bytes.Equal(port, defaultPort) {
+				yield(string(u.Host))
+				return
+			}
+		}
+
+		if !includeDefaultPort {
+			yield(string(host))
+			return
+		}
+
+		// for everything else we return two routes: 'example.com' and 'example.com:443'
+		hostStr := string(host)
+		if !yield(hostStr) {
+			return
+		}
+		hostWithDefaultPort := strings.Builder{}
+		hostWithDefaultPort.Write(host)
+		hostWithDefaultPort.WriteByte(':')
+		hostWithDefaultPort.Write(defaultPort)
+		yield(hostWithDefaultPort.String())
+	}
+}
+
+func splitHostPort(hostport []byte) ([]byte, []byte) {
+	lastColonIdx := bytes.LastIndexByte(hostport, ':')
+	if lastColonIdx < 0 {
+		return hostport, nil
+	}
+	for i, l := lastColonIdx+1, len(hostport); i < l; i++ {
+		if hostport[i] < '0' || hostport[i] > '9' {
+			return hostport, nil
+		}
+	}
+	if lastColonIdx > 1 && hostport[0] == '[' && hostport[lastColonIdx-1] == ']' {
+		return hostport[1 : lastColonIdx-1], hostport[lastColonIdx+1:]
+	}
+	return hostport[:lastColonIdx], hostport[lastColonIdx+1:]
 }
 
 // Join joins elements of a URL with '/'.

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -219,7 +219,7 @@ func (srv *Server) writeConfig(ctx context.Context, cfg *config.Config) error {
 }
 
 func (srv *Server) buildBootstrapConfig(ctx context.Context, cfg *config.Config) ([]byte, error) {
-	bootstrapCfg, err := srv.builder.BuildBootstrap(ctx, cfg, false)
+	bootstrapCfg, err := srv.builder.WithConfig(cfg).BuildBootstrap(ctx, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/envoy/resource_monitor_test.go
+++ b/pkg/envoy/resource_monitor_test.go
@@ -730,11 +730,11 @@ func TestBootstrapConfig(t *testing.T) {
 	}))
 	require.NoError(t, err)
 
-	bootstrap, err := b.BuildBootstrap(context.Background(), &config.Config{
+	bootstrap, err := b.WithConfig(&config.Config{
 		Options: &config.Options{
 			EnvoyAdminAddress: "localhost:9901",
 		},
-	}, false)
+	}).BuildBootstrap(context.Background(), false)
 	assert.NoError(t, err)
 
 	monitor.ApplyBootstrapConfig(bootstrap)


### PR DESCRIPTION
## Summary

This optimizes the envoy config builder to scale to a very large number of routes, by aggresively caching and reusing policy, url, and route objects. This significantly reduces GC overhead and minimizes the amount of time we spend duplicating work while building the envoy route list from the configuration.

There is still more room for optimization here; in particular, use of the new go 1.23 `unique` package might provide some performance improvements around URL comparisons.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
