### PR TITLE
core/authorize: always pass jwt

### DIFF
--- a/authorize/authorize_test.go
+++ b/authorize/authorize_test.go
@@ -189,8 +189,9 @@ func TestNewPolicyEvaluator_addDefaultClientCertificateRule(t *testing.T) {
 			require.NoError(t, err)
 
 			r, err := e.Evaluate(context.Background(), &evaluator.Request{
-				Policy: &c.opts.Policies[0],
-				HTTP:   evaluator.RequestHTTP{},
+				Options: c.opts,
+				Policy:  &c.opts.Policies[0],
+				HTTP:    evaluator.RequestHTTP{},
 			})
 			require.NoError(t, err)
 			assert.Equal(t, c.expected, r.Deny)

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -27,6 +27,7 @@ import (
 // Request contains the inputs needed for evaluation.
 type Request struct {
 	IsInternal bool
+	Options    *config.Options
 	Policy     *config.Policy
 	HTTP       RequestHTTP
 	Session    RequestSession
@@ -291,7 +292,7 @@ func (e *Evaluator) evaluatePolicy(ctx context.Context, req *Request) (*PolicyRe
 }
 
 func (e *Evaluator) evaluateHeaders(ctx context.Context, req *Request) (*HeadersResponse, error) {
-	headersReq := NewHeadersRequestFromPolicy(req.Policy, req.HTTP)
+	headersReq := NewHeadersRequestFromPolicy(req.Options, req.Policy, req.HTTP)
 	headersReq.Session = req.Session
 	res, err := e.headersEvaluators.Evaluate(ctx, headersReq)
 	if err != nil {

--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -27,10 +27,11 @@ type HeadersRequest struct {
 	Session                                   RequestSession        `json:"session"`
 	ClientCertificate                         ClientCertificateInfo `json:"client_certificate"`
 	SetRequestHeaders                         map[string]string     `json:"set_request_headers"`
+	PassIdentityHeaders                       bool                  `json:"pass_identity_headers"`
 }
 
 // NewHeadersRequestFromPolicy creates a new HeadersRequest from a policy.
-func NewHeadersRequestFromPolicy(policy *config.Policy, http RequestHTTP) *HeadersRequest {
+func NewHeadersRequestFromPolicy(options *config.Options, policy *config.Policy, http RequestHTTP) *HeadersRequest {
 	input := new(HeadersRequest)
 	input.Issuer = http.Hostname
 	if policy != nil {
@@ -43,6 +44,7 @@ func NewHeadersRequestFromPolicy(policy *config.Policy, http RequestHTTP) *Heade
 		}
 		input.ClientCertificate = http.ClientCertificate
 		input.SetRequestHeaders = policy.SetRequestHeaders
+		input.PassIdentityHeaders = policy.GetPassIdentityHeaders(options)
 	}
 	return input
 }

--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -46,6 +46,10 @@ func NewHeadersRequestFromPolicy(options *config.Options, policy *config.Policy,
 		input.SetRequestHeaders = policy.SetRequestHeaders
 		input.PassIdentityHeaders = policy.GetPassIdentityHeaders(options)
 	}
+	// always pass identity headers when requesting the special /.pomerium/jwt endpoint
+	if http.Path == "/.pomerium/jwt" {
+		input.PassIdentityHeaders = true
+	}
 	return input
 }
 

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestNewHeadersRequestFromPolicy(t *testing.T) {
-	req := NewHeadersRequestFromPolicy(&config.Policy{
+	req := NewHeadersRequestFromPolicy(&config.Options{}, &config.Policy{
 		EnableGoogleCloudServerlessAuthentication: true,
 		From: "https://*.example.com",
 		To: config.WeightedURLs{
@@ -54,7 +54,7 @@ func TestNewHeadersRequestFromPolicy(t *testing.T) {
 }
 
 func TestNewHeadersRequestFromPolicy_nil(t *testing.T) {
-	req := NewHeadersRequestFromPolicy(nil, RequestHTTP{Hostname: "from.example.com"})
+	req := NewHeadersRequestFromPolicy(nil, nil, RequestHTTP{Hostname: "from.example.com"})
 	assert.Equal(t, &HeadersRequest{
 		Issuer: "from.example.com",
 	}, req)
@@ -104,6 +104,7 @@ func TestHeadersEvaluator(t *testing.T) {
 				Session: RequestSession{
 					ID: "s1",
 				},
+				PassIdentityHeaders: true,
 			})
 		require.NoError(t, err)
 

--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -86,7 +86,7 @@ jwt_payload_jti := uuid.rfc4122("jti")
 
 jwt_payload_iat := now_s
 
-jwt_payload_exp := now_s + (5*60) # 5 minutes from now
+jwt_payload_exp := now_s + (5 * 60) # 5 minutes from now
 
 jwt_payload_sub := v if {
 	v = session.user_id
@@ -152,17 +152,17 @@ additional_jwt_claims := [[k, v] |
 
 jwt_claims := array.concat(base_jwt_claims, additional_jwt_claims)
 
-non_nil_jwt_claims := {key: value |
+jwt_claims_object[k] := v if {
 	# use a comprehension over an array to remove nil values
-	[key, value] := jwt_claims[_]
-	value != null
+	some [k, v] in jwt_claims
+	v != null
 }
 
-jwt_payload := non_nil_jwt_claims if {
+jwt_payload := jwt_claims_object if {
 	input.pass_identity_headers
-} else := { key: value |
-	[key,value] := non_nil_jwt_claims[_]
-	key in ["iss","aud","jti","iat","exp"]
+} else := {k: v |
+	some k, v in jwt_claims_object
+	k in {"iss", "aud", "jti", "iat", "exp"}
 }
 
 signed_jwt := io.jwt.encode_sign(jwt_headers, jwt_payload, data.signing_key)

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -108,6 +108,7 @@ func (a *Authorize) getEvaluatorRequestFromCheckRequest(
 			getClientCertificateInfo(ctx, clientCertMetadata),
 			attrs.GetSource().GetAddress().GetSocketAddress().GetAddress(),
 		),
+		Options: a.currentOptions.Load(),
 	}
 	if sessionState != nil {
 		req.Session = evaluator.RequestSession{

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -94,7 +94,8 @@ func Test_getEvaluatorRequest(t *testing.T) {
 	)
 	require.NoError(t, err)
 	expect := &evaluator.Request{
-		Policy: &a.currentOptions.Load().Policies[0],
+		Options: a.currentOptions.Load(),
+		Policy:  &a.currentOptions.Load().Policies[0],
 		Session: evaluator.RequestSession{
 			ID: "SESSION_ID",
 		},
@@ -148,6 +149,7 @@ func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 		}, nil)
 	require.NoError(t, err)
 	expect := &evaluator.Request{
+		Options: a.currentOptions.Load(),
 		Policy:  &a.currentOptions.Load().Policies[0],
 		Session: evaluator.RequestSession{},
 		HTTP: evaluator.NewRequestHTTP(

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -66,8 +66,6 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 							}
 						},
 						"requestHeadersToRemove": [
-							"x-pomerium-jwt-assertion",
-							"x-pomerium-jwt-assertion-for",
 							"x-pomerium-reproxy-policy",
 							"x-pomerium-reproxy-policy-hmac"
 						],
@@ -119,8 +117,6 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 							}
 						},
 						"requestHeadersToRemove": [
-							"x-pomerium-jwt-assertion",
-							"x-pomerium-jwt-assertion-for",
 							"x-pomerium-reproxy-policy",
 							"x-pomerium-reproxy-policy-hmac"
 						],

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -533,9 +533,6 @@ func mkRouteMatchForHost(
 func getRequestHeadersToRemove(options *config.Options, policy *config.Policy) []string {
 	requestHeadersToRemove := policy.RemoveRequestHeaders
 	if !policy.GetPassIdentityHeaders(options) {
-		requestHeadersToRemove = append(requestHeadersToRemove,
-			httputil.HeaderPomeriumJWTAssertion,
-			httputil.HeaderPomeriumJWTAssertionFor)
 		for headerName := range options.JWTClaimsHeaders {
 			requestHeadersToRemove = append(requestHeadersToRemove, headerName)
 		}

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -1265,8 +1265,6 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						]
 					},
 					"requestHeadersToRemove": [
-						"x-pomerium-jwt-assertion",
-						"x-pomerium-jwt-assertion-for",
 						"x-email",
 						"x-pomerium-reproxy-policy",
 						"x-pomerium-reproxy-policy-hmac"

--- a/config/policy.go
+++ b/config/policy.go
@@ -142,11 +142,7 @@ type Policy struct {
 	PreserveHostHeader bool `mapstructure:"preserve_host_header" yaml:"preserve_host_header,omitempty"`
 
 	// PassIdentityHeaders controls whether to add a user's identity headers to the upstream request.
-	// These include:
-	//
-	//  - X-Pomerium-Jwt-Assertion
-	//  - X-Pomerium-Claim-*
-	//
+	// These include: X-Pomerium-Claim-*, and user-specific claims in X-Pomerium-Jwt-Assertion.
 	PassIdentityHeaders *bool `mapstructure:"pass_identity_headers" yaml:"pass_identity_headers,omitempty"`
 
 	// KubernetesServiceAccountToken is the kubernetes token to use for upstream requests.

--- a/integration/policy_test.go
+++ b/integration/policy_test.go
@@ -559,7 +559,7 @@ func TestPomeriumJWT(t *testing.T) {
 func rawJWTPayload(t *testing.T, jwt string) map[string]any {
 	t.Helper()
 	s := strings.Split(jwt, ".")
-	require.Equal(t, 3, len(s), "unexpected JWT format")
+	require.Equal(t, 3, len(s), "unexpected JWT format: %s", jwt)
 	payload, err := base64.RawURLEncoding.DecodeString(s[1])
 	require.NoError(t, err, "JWT payload could not be decoded")
 	d := json.NewDecoder(bytes.NewReader(payload))

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/gorilla/mux"
 
 	"github.com/pomerium/pomerium/internal/handlers"
@@ -141,18 +140,6 @@ func (p *Proxy) jwtAssertion(w http.ResponseWriter, r *http.Request) error {
 	rawAssertionJWT := r.Header.Get(httputil.HeaderPomeriumJWTAssertion)
 	if rawAssertionJWT == "" {
 		return httputil.NewError(http.StatusNotFound, errors.New("jwt not found"))
-	}
-
-	assertionJWT, err := jwt.ParseSigned(rawAssertionJWT)
-	if err != nil {
-		return httputil.NewError(http.StatusNotFound, errors.New("jwt not found"))
-	}
-
-	var dst struct {
-		Subject string `json:"sub"`
-	}
-	if assertionJWT.UnsafeClaimsWithoutVerification(&dst) != nil || dst.Subject == "" {
-		return httputil.NewError(http.StatusUnauthorized, errors.New("jwt not found"))
 	}
 
 	w.Header().Set("Content-Type", "application/jwt")


### PR DESCRIPTION
## Summary
Always pass the JWT assertion header regardless of the pass identity header option. The option will now only remove the user-specific claims. 

If the header is not desired it can be removed using the remove request headers option: https://www.pomerium.com/docs/reference/routes/headers#remove-request-headers.

## Related issues
For https://github.com/pomerium/pomerium/issues/5171
 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
