### PR TITLE
ci: switch to docker compose v2

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -44,7 +44,7 @@ jobs:
         run: |
           export POMERIUM_TAG=dev
           cd ./integration/clusters/single-stateful
-          docker-compose up -d
+          docker compose up -d
 
       - name: integration tests
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,7 +43,7 @@ jobs:
         run: |
           export POMERIUM_TAG=dev
           cd ./integration/clusters/${{matrix.deployment}}-${{matrix.authenticate-flow}}
-          docker-compose up -d
+          docker compose up -d
 
       - name: integration tests
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: integration tests
         run: |
-          (cd ./integration/clusters/${{matrix.deployment}}-${{matrix.authenticate-flow}} && docker-compose logs -f &)
+          (cd ./integration/clusters/${{matrix.deployment}}-${{matrix.authenticate-flow}} && docker compose logs -f &)
           go test -v ./integration/...
 
   build:


### PR DESCRIPTION
## Summary

Update the integration test and benchmark workflows to use Docker Compose v2.

## Related issues

- https://github.com/pomerium/internal/issues/1881

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
