### PR TITLE
envoy: log mtls failures

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -12,9 +12,11 @@ import (
 	"strings"
 	"time"
 
+	envoy_config_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_extensions_access_loggers_grpc_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	envoy_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
@@ -123,6 +125,26 @@ func (b *Builder) buildTLSSocket(ctx context.Context, cfg *config.Config, certs 
 	}, nil
 }
 
+func listenerAccessLog() []*envoy_config_accesslog_v3.AccessLog {
+	tc := marshalAny(&envoy_extensions_access_loggers_grpc_v3.HttpGrpcAccessLogConfig{
+		CommonConfig: &envoy_extensions_access_loggers_grpc_v3.CommonGrpcAccessLogConfig{
+			LogName: "ingress-http-listener",
+			GrpcService: &envoy_config_core_v3.GrpcService{
+				TargetSpecifier: &envoy_config_core_v3.GrpcService_EnvoyGrpc_{
+					EnvoyGrpc: &envoy_config_core_v3.GrpcService_EnvoyGrpc{
+						ClusterName: "pomerium-control-plane-grpc",
+					},
+				},
+			},
+			TransportApiVersion: envoy_config_core_v3.ApiVersion_V3,
+		},
+	})
+	return []*envoy_config_accesslog_v3.AccessLog{{
+		Name:       "envoy.access_loggers.http_grpc",
+		ConfigType: &envoy_config_accesslog_v3.AccessLog_TypedConfig{TypedConfig: tc},
+	}}
+}
+
 func (b *Builder) buildMainListener(
 	ctx context.Context,
 	cfg *config.Config,
@@ -132,6 +154,8 @@ func (b *Builder) buildMainListener(
 	if cfg.Options.UseProxyProtocol {
 		li.ListenerFilters = append(li.ListenerFilters, ProxyProtocolFilter())
 	}
+
+	li.AccessLog = listenerAccessLog() // XXX
 
 	if cfg.Options.InsecureServer {
 		li.Address = buildAddress(cfg.Options.Addr, 80)

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -139,15 +139,10 @@ func listenerAccessLog() []*envoy_config_accesslog_v3.AccessLog {
 	}
 	tcp := marshalAny(
 		&envoy_extensions_access_loggers_grpc_v3.TcpGrpcAccessLogConfig{CommonConfig: cc})
-	http := marshalAny(
-		&envoy_extensions_access_loggers_grpc_v3.HttpGrpcAccessLogConfig{CommonConfig: cc})
 	return []*envoy_config_accesslog_v3.AccessLog{
 		{
 			Name:       "envoy.access_loggers.tcp_grpc",
 			ConfigType: &envoy_config_accesslog_v3.AccessLog_TypedConfig{TypedConfig: tcp},
-		}, {
-			Name:       "envoy.access_loggers.http_grpc",
-			ConfigType: &envoy_config_accesslog_v3.AccessLog_TypedConfig{TypedConfig: http},
 		},
 	}
 }
@@ -162,7 +157,9 @@ func (b *Builder) buildMainListener(
 		li.ListenerFilters = append(li.ListenerFilters, ProxyProtocolFilter())
 	}
 
-	li.AccessLog = listenerAccessLog() // XXX
+	if cfg.Options.DownstreamMTLS.Enforcement == config.MTLSEnforcementRejectConnection {
+		li.AccessLog = listenerAccessLog()
+	}
 
 	if cfg.Options.InsecureServer {
 		li.Address = buildAddress(cfg.Options.Addr, 80)

--- a/internal/controlplane/grpc_accesslog.go
+++ b/internal/controlplane/grpc_accesslog.go
@@ -2,11 +2,13 @@ package controlplane
 
 import (
 	"context"
+	"encoding/json"
 	"strings"
 
 	envoy_data_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/data/accesslog/v3"
 	envoy_service_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/service/accesslog/v3"
 	"github.com/rs/zerolog"
+	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/pomerium/pomerium/internal/log"
 )
@@ -40,17 +42,19 @@ func (srv *Server) StreamAccessLogs(stream envoy_service_accesslog_v3.AccessLogS
 func accessLogListener(
 	ctx context.Context, msg *envoy_service_accesslog_v3.StreamAccessLogsMessage,
 ) {
-	/*for _, entry := range msg.GetTcpLogs().LogEntry {
+	for _, entry := range msg.GetTcpLogs().GetLogEntry() {
+		e, _ := protojson.Marshal(entry)
 		log.Info(ctx).
 			Str("service", "envoy").
-			Interface("log", entry).
-			Msg("listener connect TCP")
-	}*/
-	for _, entry := range msg.GetHttpLogs().LogEntry {
+			Interface("log", json.RawMessage(e)).
+			Msg("listener connect (TCP log)")
+	}
+	for _, entry := range msg.GetHttpLogs().GetLogEntry() {
+		e, _ := protojson.Marshal(entry)
 		log.Info(ctx).
 			Str("service", "envoy").
-			Interface("log", entry).
-			Msg("listener connect")
+			Interface("log", json.RawMessage(e)).
+			Msg("listener connect (HTTP log)")
 	}
 }
 

--- a/internal/log/access.go
+++ b/internal/log/access.go
@@ -24,6 +24,7 @@ const (
 	AccessLogFieldSize                AccessLogField = "size"
 	AccessLogFieldUpstreamCluster     AccessLogField = "upstream-cluster"
 	AccessLogFieldUserAgent           AccessLogField = "user-agent"
+	AccessLogFieldClientCertificate   AccessLogField = "client-certificate"
 )
 
 var defaultAccessLogFields = []AccessLogField{
@@ -64,6 +65,7 @@ var accessLogFieldLookup = map[AccessLogField]struct{}{
 	AccessLogFieldSize:                {},
 	AccessLogFieldUpstreamCluster:     {},
 	AccessLogFieldUserAgent:           {},
+	AccessLogFieldClientCertificate:   {},
 }
 
 // Validate returns an error if the access log field is invalid.


### PR DESCRIPTION
Supersedes https://github.com/pomerium/pomerium/pull/5196

## Summary

This implements limited listener-based access logging for downstream transport failures, only enabled when downstream_mtls.enforcement is set to 'reject_connection'. Client certificate details and the error message will be logged.

Additionally, the new key 'client-certificate' can be set in the access_log_fields list in the configuration, which will add peer certificate properties (issuer, subject, SANs) to the existing per-request http logs.

## Related issues

https://github.com/pomerium/pomerium/issues/5130

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
