### PR TITLE
ci: do not include timestamp into buildmeta

### DIFF
--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -34,7 +34,7 @@ builds:
       - -s -w
       - -X github.com/pomerium/pomerium/internal/version.Version={{.Version}}
       - -X github.com/pomerium/pomerium/internal/version.GitCommit={{.ShortCommit}}
-      - -X github.com/pomerium/pomerium/internal/version.BuildMeta={{.Timestamp}}
+      - -X github.com/pomerium/pomerium/internal/version.Timestamp={{.Timestamp}}
       - -X github.com/pomerium/pomerium/internal/version.ProjectName=pomerium
       - -X github.com/pomerium/pomerium/internal/version.ProjectURL=https://www.pomerium.io
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -4,7 +4,9 @@ package version
 import (
 	"fmt"
 	"runtime"
+	"strconv"
 	"strings"
+	"time"
 )
 
 var (
@@ -18,9 +20,19 @@ var (
 	GitCommit = ""
 	// BuildMeta specifies release type (dev,rc1,beta,etc)
 	BuildMeta = ""
+	// Timestamp specifies the build time, set by the compiler as UNIX timestamp.
+	Timestamp = ""
 
 	runtimeVersion = runtime.Version()
 )
+
+func BuildTime() string {
+	tm, err := strconv.Atoi(Timestamp)
+	if err != nil {
+		return ""
+	}
+	return time.Unix(int64(tm), 0).UTC().Format(time.RFC3339)
+}
 
 // FullVersion returns a version string.
 func FullVersion() string {

--- a/pkg/cmd/pomerium/pomerium.go
+++ b/pkg/cmd/pomerium/pomerium.go
@@ -34,10 +34,13 @@ import (
 func Run(ctx context.Context, src config.Source) error {
 	_, _ = maxprocs.Set(maxprocs.Logger(func(s string, i ...any) { log.Debug(context.Background()).Msgf(s, i...) }))
 
-	log.Info(ctx).
+	evt := log.Info(ctx).
 		Str("envoy_version", files.FullVersion()).
-		Str("version", version.FullVersion()).
-		Msg("cmd/pomerium")
+		Str("version", version.FullVersion())
+	if buildTime := version.BuildTime(); buildTime != "" {
+		evt = evt.Str("built", buildTime)
+	}
+	evt.Msg("cmd/pomerium")
 
 	src, err := config.NewLayeredSource(ctx, src, derivecert_config.NewBuilder())
 	if err != nil {


### PR DESCRIPTION
## Summary

Exclude timestamp from the PR, so that instead of `v0.26.1-1719873919+eb8dc899` it would be just `v0.26.1+eb8dc899`

## Related issues

Fixes #5214

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
