### PR TITLE
Update to Go 1.23

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         node-version: [16.x]
         platform: [ubuntu-latest]
     runs-on: ${{ matrix.platform }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -22,5 +22,6 @@ jobs:
 
       - uses: golangci/golangci-lint-action@aaa42aa0628b4ae2578232a66b541047968fac86
         with:
-          version: v1.57
+          install-mode: goinstall
+          version: 1147824c61441fb1a928927ca095aa3d0f208459
           args: --timeout=10m

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           cache: false
 
       - run: make deps-build

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           cache: false
 
       - name: Set up Docker

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         node-version: [16.x]
         platform: [ubuntu-latest]
         deployment: [multi, single]
@@ -53,7 +53,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.22.x]
+        go-version: [1.23.x]
         node-version: [16.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
@@ -126,7 +126,7 @@ jobs:
 
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32
         with:
-          go-version: 1.22.x
+          go-version: 1.23.x
           cache: false
 
       - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.22.0
+golang 1.23.0
 golangci-lint 1.57.2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 golang 1.23.0
-golangci-lint 1.57.2
+golangci-lint 1.60.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN make yarn
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.22.5-bookworm@sha256:af9b40f2b1851be993763b85288f8434af87b5678af04355b1e33ff530b5765f as build
+FROM golang:1.23-bookworm@sha256:4bda3420962ddfc78467f81eb9c2880e29e53604c6c05eae597210fc0fe8b5bf as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -13,7 +13,7 @@ RUN make yarn
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.22.5-bookworm@sha256:af9b40f2b1851be993763b85288f8434af87b5678af04355b1e33ff530b5765f as build
+FROM golang:1.23-bookworm@sha256:4bda3420962ddfc78467f81eb9c2880e29e53604c6c05eae597210fc0fe8b5bf as build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ build-ui: yarn
 .PHONY: lint
 lint: ## Verifies `golint` passes.
 	@echo "==> $@"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@1147824c61441fb1a928927ca095aa3d0f208459 run ./... --fix
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1 run ./... --fix
 
 .PHONY: test
 test: get-envoy ## Runs the go tests.

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ build-ui: yarn
 .PHONY: lint
 lint: ## Verifies `golint` passes.
 	@echo "==> $@"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.57.2 run ./... --fix
+	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@1147824c61441fb1a928927ca095aa3d0f208459 run ./... --fix
 
 .PHONY: test
 test: get-envoy ## Runs the go tests.

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -302,7 +302,7 @@ func (m mockDataBrokerServiceClient) Patch(ctx context.Context, in *databroker.P
 
 		existing := getResponse.GetRecord()
 		if err := storage.PatchRecord(existing, record, in.GetFieldMask()); err != nil {
-			return nil, status.Errorf(codes.Unknown, err.Error())
+			return nil, status.Error(codes.Unknown, err.Error())
 		}
 
 		records = append(records, record)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pomerium/pomerium
 
-go 1.22.2
+go 1.23
 
 require (
 	cloud.google.com/go/storage v1.43.0

--- a/internal/httputil/client.go
+++ b/internal/httputil/client.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -105,7 +104,7 @@ func Do(ctx context.Context, method, endpoint, userAgent string, headers map[str
 			endpoint = u.String()
 		}
 	default:
-		return fmt.Errorf(http.StatusText(http.StatusBadRequest))
+		return errors.New(http.StatusText(http.StatusBadRequest))
 	}
 	req, err := http.NewRequestWithContext(ctx, method, endpoint, body)
 	if err != nil {
@@ -139,9 +138,9 @@ func Do(ctx context.Context, method, endpoint, userAgent string, headers map[str
 			if e == nil && response.ErrorDescription == "Token expired or revoked" {
 				return ErrTokenRevoked
 			}
-			return fmt.Errorf(http.StatusText(http.StatusBadRequest))
+			return errors.New(http.StatusText(http.StatusBadRequest))
 		default:
-			return fmt.Errorf(http.StatusText(resp.StatusCode))
+			return errors.New(http.StatusText(resp.StatusCode))
 		}
 	}
 	if response != nil {

--- a/internal/sessions/cookie/cookie_store_test.go
+++ b/internal/sessions/cookie/cookie_store_test.go
@@ -165,7 +165,7 @@ func TestStore_SaveSession(t *testing.T) {
 			s.ClearSession(w, r)
 			x := w.Header().Get("Set-Cookie")
 			if !strings.Contains(x, "_pomerium=; Path=/;") {
-				t.Errorf(x)
+				t.Error(x)
 			}
 		})
 	}

--- a/internal/telemetry/metrics/providers_test.go
+++ b/internal/telemetry/metrics/providers_test.go
@@ -43,7 +43,7 @@ func getMetrics(t *testing.T, envoyURL *url.URL, header http.Header) []byte {
 	resp := rec.Result()
 	b, _ := io.ReadAll(resp.Body)
 
-	if resp == nil || resp.StatusCode != 200 {
+	if resp == nil || resp.StatusCode != http.StatusOK {
 		t.Errorf("Metrics endpoint failed to respond: %s", b)
 	}
 	return b


### PR DESCRIPTION
## Summary

This updates Go to 1.23 and golangci-lint to 1.60.1, which includes important Go 1.23 related bugfixes for some linters. 

A few new lint errors surfaced after the update, presumably due to regular updates to the linters that golangci-lint runs. These fixes are relatively minor, and have been included in this PR.

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
