### PR TITLE
Temporarily disable gci linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - errcheck
     - errorlint
     - exportloopref
-    - gci
+    # - gci # https://github.com/daixiang0/gci/issues/209
     - gocheckcompilerdirectives
     - gofumpt
     - goimports


### PR DESCRIPTION
## Summary

Disables the GCI linter temporarily due to a bug preventing it from working correctly with new Go 1.23 imports.

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
