### PR TITLE
connect/client: ignore unknown message types

### DIFF
--- a/internal/zero/connect-mux/messages.go
+++ b/internal/zero/connect-mux/messages.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pomerium/pomerium/internal/zero/apierror"
 	"github.com/pomerium/pomerium/pkg/zero/connect"
+	"github.com/rs/zerolog/log"
 )
 
 // Watch watches for changes to the config until either context is canceled,
@@ -54,7 +55,7 @@ func dispatch(ctx context.Context, cfg *config, msg message) error {
 		case *connect.Message_TelemetryRequest:
 			cfg.onTelemetryRequested(ctx, msg.Message.GetTelemetryRequest())
 		default:
-			return fmt.Errorf("unknown message type")
+			log.Ctx(ctx).Debug().Msg("unknown message type, ignored")
 		}
 	default:
 		return fmt.Errorf("unknown message payload")


### PR DESCRIPTION
## Summary

When running in zero managed mode, cloud may send a message over the `connect.proto` channel that is not recognized and would cause an error and shutdown. This PR changes the behaviour to ignore such message. 

## Related issues

Fixes: https://github.com/pomerium/pomerium-zero/issues/2839

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
