### PR TITLE
zero/health-checks: fix early checks sometimes missing

### DIFF
--- a/pkg/health/deduplicate.go
+++ b/pkg/health/deduplicate.go
@@ -5,18 +5,19 @@ import (
 	"sync"
 )
 
-var _ Provider = (*deduplicator)(nil)
+var _ Provider = (*Deduplicator)(nil)
 
-// deduplicator is a health check provider that deduplicates health check reports
+// Deduplicator is a health check provider that deduplicates health check reports
 // i.e. it only reports a health check if the status or attributes have changed
-type deduplicator struct {
-	seen     sync.Map
+type Deduplicator struct {
+	lock     sync.Mutex
+	records  map[Check]*record
 	provider Provider
 }
 
 type record struct {
 	attr map[string]string
-	err  *string
+	err  error
 }
 
 func newOKRecord(attrs []Attr) *record {
@@ -24,11 +25,10 @@ func newOKRecord(attrs []Attr) *record {
 }
 
 func newErrorRecord(err error, attrs []Attr) *record {
-	errTxt := err.Error()
-	return newRecord(&errTxt, attrs)
+	return newRecord(err, attrs)
 }
 
-func newRecord(err *string, attrs []Attr) *record {
+func newRecord(err error, attrs []Attr) *record {
 	r := &record{err: err, attr: make(map[string]string)}
 	for _, a := range attrs {
 		r.attr[a.Key] = a.Value
@@ -36,44 +36,90 @@ func newRecord(err *string, attrs []Attr) *record {
 	return r
 }
 
+func (r *record) Attr() []Attr {
+	attrs := make([]Attr, 0, len(r.attr))
+	for k, v := range r.attr {
+		attrs = append(attrs, Attr{Key: k, Value: v})
+	}
+	return attrs
+}
+
 func (r *record) Equals(other *record) bool {
-	return r.equalError(other) &&
+	return equalError(r.err, other.err) &&
 		maps.Equal(r.attr, other.attr)
 }
 
-func (r *record) equalError(other *record) bool {
-	if r.err == nil || other.err == nil {
-		return r.err == other.err
+func equalError(a, b error) bool {
+	if a == nil || b == nil {
+		return a == b //nolint:errorlint
 	}
-	return *r.err == *other.err
+	return a.Error() == b.Error()
 }
 
-func NewDeduplicator(provider Provider) Provider {
-	return &deduplicator{provider: provider}
+func report(p Provider, check Check, err error, attrs ...Attr) {
+	if err != nil {
+		p.ReportError(check, err, attrs...)
+	} else {
+		p.ReportOK(check, attrs...)
+	}
 }
 
-func (d *deduplicator) swap(check Check, next *record) *record {
-	prev, there := d.seen.Swap(check, next)
-	if !there {
-		return nil
+func NewDeduplicator() *Deduplicator {
+	return &Deduplicator{
+		records:  make(map[Check]*record),
+		provider: &noopProvider{},
 	}
-	return prev.(*record)
+}
+
+func (d *Deduplicator) SetProvider(p Provider) {
+	d.setProvider(p)()
+}
+
+func (d *Deduplicator) setProvider(p Provider) func() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	if p == nil {
+		p = &noopProvider{}
+	}
+	d.provider = p
+	records := maps.Clone(d.records)
+
+	return func() {
+		for check, record := range records {
+			report(p, check, record.err, record.Attr()...)
+		}
+	}
+}
+
+func (d *Deduplicator) update(check Check, next *record) func() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	prev := d.records[check]
+	d.records[check] = next
+	if prev != nil && next.Equals(prev) {
+		return func() {}
+	}
+
+	p := d.provider
+	return func() {
+		report(p, check, next.err, next.Attr()...)
+	}
 }
 
 // ReportError implements the Provider interface
-func (d *deduplicator) ReportError(check Check, err error, attrs ...Attr) {
-	cur := newErrorRecord(err, attrs)
-	prev := d.swap(check, cur)
-	if prev == nil || !cur.Equals(prev) {
-		d.provider.ReportError(check, err, attrs...)
-	}
+func (d *Deduplicator) ReportError(check Check, err error, attrs ...Attr) {
+	d.update(check, newErrorRecord(err, attrs))()
 }
 
 // ReportOK implements the Provider interface
-func (d *deduplicator) ReportOK(check Check, attrs ...Attr) {
-	cur := newOKRecord(attrs)
-	prev := d.swap(check, cur)
-	if prev == nil || !cur.Equals(prev) {
-		d.provider.ReportOK(check, attrs...)
-	}
+func (d *Deduplicator) ReportOK(check Check, attrs ...Attr) {
+	d.update(check, newOKRecord(attrs))()
 }
+
+type noopProvider struct{}
+
+func (n *noopProvider) ReportOK(Check, ...Attr) {}
+
+func (n *noopProvider) ReportError(Check, error, ...Attr) {}

--- a/pkg/health/deduplicate_test.go
+++ b/pkg/health/deduplicate_test.go
@@ -14,28 +14,38 @@ import (
 func TestDeduplicate(t *testing.T) {
 	t.Parallel()
 
-	p := NewMockProvider(gomock.NewController(t))
-	dp := health.NewDeduplicator(p)
+	p1 := NewMockProvider(gomock.NewController(t))
+	dp := health.NewDeduplicator()
+	dp.SetProvider(p1)
 
-	check1, check2 := health.Check("check-1"), health.Check("check-2")
-	p.EXPECT().ReportOK(check1).Times(1)
-	p.EXPECT().ReportOK(check2).Times(1)
+	check1, check2, check3 := health.Check("check-1"), health.Check("check-2"), health.Check("check-3")
+	p1.EXPECT().ReportOK(check1).Times(1)
+	p1.EXPECT().ReportOK(check2).Times(1)
+	p1.EXPECT().ReportError(check3, errors.New("error-3")).Times(1)
 	dp.ReportOK(check1)
 	dp.ReportOK(check2)
 	dp.ReportOK(check1)
+	dp.ReportError(check3, errors.New("error-3"))
 
-	p.EXPECT().ReportError(check1, gomock.Any()).Times(1)
+	p1.EXPECT().ReportError(check1, errors.New("error")).Times(1)
 	dp.ReportError(check1, errors.New("error"))
 	dp.ReportError(check1, errors.New("error"))
 
-	p.EXPECT().ReportOK(check1).Times(1)
+	p1.EXPECT().ReportOK(check1).Times(1)
 	dp.ReportOK(check1)
 
-	p.EXPECT().ReportOK(check1, health.StrAttr("k1", "v1")).Times(2)
-	p.EXPECT().ReportOK(check1, health.StrAttr("k1", "v2")).Times(1)
+	p1.EXPECT().ReportOK(check1, health.StrAttr("k1", "v1")).Times(2)
+	p1.EXPECT().ReportOK(check1, health.StrAttr("k1", "v2")).Times(1)
 	dp.ReportOK(check1, health.StrAttr("k1", "v1"))
 	dp.ReportOK(check1, health.StrAttr("k1", "v2"))
 	dp.ReportOK(check1, health.StrAttr("k1", "v1"))
+
+	// after setting new provider, current state should be reported
+	p2 := NewMockProvider(gomock.NewController(t))
+	p2.EXPECT().ReportOK(check1, health.StrAttr("k1", "v1")).Times(1)
+	p2.EXPECT().ReportOK(check2).Times(1)
+	p2.EXPECT().ReportError(check3, errors.New("error-3")).Times(1)
+	dp.SetProvider(p2)
 }
 
 func TestDefault(t *testing.T) {


### PR DESCRIPTION
## Summary

Health checks are reported and should be picked up by the reporter. During start up, some checks were sometimes reported before the reporting provider was set, and were discarded. 
This PR fixes that behaviour and makes sure the latest known state of the health checks is replayed when provider is set, allowing it to catch up.

It also fixes the telemetry shutdown context to allow up to 10s for spooling of the pending events.

## Related issues

Fixes https://github.com/pomerium/pomerium-zero/issues/2893

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
