### PR TITLE
ci: allow to override VERSION in Makefile via env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ BUILDTAGS :=
 
 # Populate version variables
 # Add to compile time flags
-VERSION := $(shell git describe --tags)
+VERSION?= $(shell git describe --tags)
 GITCOMMIT := $(shell git rev-parse --short HEAD)
 BUILDMETA:=
 GITUNTRACKEDCHANGES := $(shell git status --porcelain --untracked-files=no)


### PR DESCRIPTION
## Summary

Allow to specify `VERSION` as env to `make build`.

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
