### PR TITLE
core/logs: remove warnings

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -234,7 +234,7 @@ func (a *Authenticate) signOutRedirect(w http.ResponseWriter, r *http.Request) e
 	if err := authenticator.SignOut(w, r, rawIDToken, authenticateSignedOutURL, signOutURL); err == nil {
 		return nil
 	} else if !errors.Is(err, oidc.ErrSignoutNotImplemented) {
-		log.Warn(r.Context()).Err(err).Msg("authenticate: failed to get sign out url for authenticator")
+		log.Error(r.Context()).Err(err).Msg("authenticate: failed to get sign out url for authenticator")
 	}
 
 	// if the authenticator failed to sign out, and no sign out url is defined, just go to the signed out page

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -194,7 +194,7 @@ func getClientCertificateInfo(
 
 	chain, err := url.QueryUnescape(escapedChain)
 	if err != nil {
-		log.Info(ctx).Str("chain", escapedChain).Err(err).
+		log.Error(ctx).Str("chain", escapedChain).Err(err).
 			Msg(`received unexpected client certificate "chain" value`)
 		return c
 	}
@@ -202,7 +202,7 @@ func getClientCertificateInfo(
 	// Split the chain into the leaf and any intermediate certificates.
 	p, rest := pem.Decode([]byte(chain))
 	if p == nil {
-		log.Info(ctx).Str("chain", escapedChain).
+		log.Error(ctx).Str("chain", escapedChain).
 			Msg(`received unexpected client certificate "chain" value (no PEM block found)`)
 		return c
 	}

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -55,7 +55,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 	if sessionState != nil {
 		s, err = a.getDataBrokerSessionOrServiceAccount(ctx, sessionState.ID, sessionState.DatabrokerRecordVersion)
 		if err != nil {
-			log.Warn(ctx).Err(err).Msg("clearing session due to missing or invalid session or service account")
+			log.Info(ctx).Err(err).Msg("clearing session due to missing or invalid session or service account")
 			sessionState = nil
 		}
 	}
@@ -65,7 +65,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 
 	req, err := a.getEvaluatorRequestFromCheckRequest(ctx, in, sessionState)
 	if err != nil {
-		log.Warn(ctx).Err(err).Msg("error building evaluator request")
+		log.Error(ctx).Err(err).Msg("error building evaluator request")
 		return nil, err
 	}
 
@@ -194,7 +194,7 @@ func getClientCertificateInfo(
 
 	chain, err := url.QueryUnescape(escapedChain)
 	if err != nil {
-		log.Warn(ctx).Str("chain", escapedChain).Err(err).
+		log.Info(ctx).Str("chain", escapedChain).Err(err).
 			Msg(`received unexpected client certificate "chain" value`)
 		return c
 	}
@@ -202,7 +202,7 @@ func getClientCertificateInfo(
 	// Split the chain into the leaf and any intermediate certificates.
 	p, rest := pem.Decode([]byte(chain))
 	if p == nil {
-		log.Warn(ctx).Str("chain", escapedChain).
+		log.Info(ctx).Str("chain", escapedChain).
 			Msg(`received unexpected client certificate "chain" value (no PEM block found)`)
 		return c
 	}

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -238,7 +238,7 @@ fYCZHo3CID0gRSemaQ/jYMgyeBFrHIr6icZh
 			false,
 			"invalid%URL%encoding",
 			evaluator.ClientCertificateInfo{},
-			`{"chain":"invalid%URL%encoding","error":"invalid URL escape \"%UR\"","level":"warn","message":"received unexpected client certificate \"chain\" value"}`,
+			`{"chain":"invalid%URL%encoding","error":"invalid URL escape \"%UR\"","level":"info","message":"received unexpected client certificate \"chain\" value"}`,
 		},
 		{
 			"invalid chain PEM encoding",
@@ -247,7 +247,7 @@ fYCZHo3CID0gRSemaQ/jYMgyeBFrHIr6icZh
 			evaluator.ClientCertificateInfo{
 				Presented: true,
 			},
-			`{"chain":"not valid PEM data","level":"warn","message":"received unexpected client certificate \"chain\" value (no PEM block found)"}`,
+			`{"chain":"not valid PEM data","level":"info","message":"received unexpected client certificate \"chain\" value (no PEM block found)"}`,
 		},
 	}
 

--- a/authorize/log.go
+++ b/authorize/log.go
@@ -66,7 +66,7 @@ func (a *Authorize) logAuthorizeCheck(
 		}
 		sealed, err := enc.Encrypt(record)
 		if err != nil {
-			log.Warn(ctx).Err(err).Msg("authorize: error encrypting audit record")
+			log.Error(ctx).Err(err).Msg("authorize: error encrypting audit record")
 			return
 		}
 		log.Info(ctx).

--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -175,7 +175,7 @@ func (b *Builder) envoyTLSCertificateFromGoTLSCertificate(
 			},
 		))
 	} else {
-		log.Warn(ctx).Err(err).Msg("failed to marshal private key for tls config")
+		log.Error(ctx).Err(err).Msg("failed to marshal private key for tls config")
 	}
 	for _, scts := range cert.SignedCertificateTimestamps {
 		envoyCert.SignedCertificateTimestamp = append(envoyCert.SignedCertificateTimestamp,

--- a/config/options.go
+++ b/config/options.go
@@ -415,7 +415,7 @@ func checkConfigKeysErrors(configFile string, o *Options, unused []string) error
 			evt = log.Error(ctx)
 			err = errInvalidConfigKeys
 		default:
-			evt = log.Warn(ctx)
+			evt = log.Error(ctx)
 		}
 		evt.Str("config_file", configFile).Str("key", check.Key)
 		if check.DocsURL != "" {
@@ -427,7 +427,7 @@ func checkConfigKeysErrors(configFile string, o *Options, unused []string) error
 	// check for unknown runtime flags
 	for flag := range o.RuntimeFlags {
 		if _, ok := defaultRuntimeFlags[flag]; !ok {
-			log.Warn(ctx).Str("config_file", configFile).Str("flag", string(flag)).Msg("unknown runtime flag")
+			log.Error(ctx).Str("config_file", configFile).Str("flag", string(flag)).Msg("unknown runtime flag")
 		}
 	}
 
@@ -716,7 +716,7 @@ func (o *Options) Validate() error {
 	o.HTTPRedirectAddr = strings.Trim(o.HTTPRedirectAddr, `"'`)
 
 	if !o.InsecureServer && !hasCert && !o.AutocertOptions.Enable {
-		log.Warn(ctx).Msg("neither `autocert`, " +
+		log.Info(ctx).Msg("neither `autocert`, " +
 			"`insecure_server` or manually provided certificates were provided, server will be using a self-signed certificate")
 	}
 
@@ -824,7 +824,7 @@ func (o *Options) UseStatelessAuthenticateFlow() bool {
 		} else if flow == "stateful" {
 			return false
 		}
-		log.Warn(context.Background()).
+		log.Error(context.Background()).
 			Msgf("ignoring unknown DEBUG_FORCE_AUTHENTICATE_FLOW setting %q", flow)
 	}
 	u, err := o.GetInternalAuthenticateURL()

--- a/config/policy.go
+++ b/config/policy.go
@@ -458,7 +458,7 @@ func (p *Policy) Validate() error {
 			source.String())
 	}
 	if source.Scheme == "http" {
-		log.Warn(context.Background()).Msgf("config: policy source url (%s) uses HTTP but only HTTPS is supported",
+		log.Info(context.Background()).Msgf("config: policy source url (%s) uses HTTP but only HTTPS is supported",
 			source.String())
 	}
 
@@ -522,7 +522,7 @@ func (p *Policy) Validate() error {
 		"reference/routes/tls#tls-downstream-client-certificate-authority for more information"
 
 	if p.TLSDownstreamClientCA != "" {
-		log.Warn(context.Background()).Msgf(clientCADeprecationMsg, "tls_downstream_client_ca")
+		log.Info(context.Background()).Msgf(clientCADeprecationMsg, "tls_downstream_client_ca")
 		_, err := base64.StdEncoding.DecodeString(p.TLSDownstreamClientCA)
 		if err != nil {
 			return fmt.Errorf("config: couldn't decode downstream client ca: %w", err)
@@ -530,7 +530,7 @@ func (p *Policy) Validate() error {
 	}
 
 	if p.TLSDownstreamClientCAFile != "" {
-		log.Warn(context.Background()).Msgf(clientCADeprecationMsg, "tls_downstream_client_ca_file")
+		log.Info(context.Background()).Msgf(clientCADeprecationMsg, "tls_downstream_client_ca_file")
 		bs, err := os.ReadFile(p.TLSDownstreamClientCAFile)
 		if err != nil {
 			return fmt.Errorf("config: couldn't load downstream client ca: %w", err)

--- a/internal/authenticateflow/stateful.go
+++ b/internal/authenticateflow/stateful.go
@@ -267,7 +267,7 @@ func (s *Stateful) RevokeSession(
 	})
 	if err != nil {
 		err = fmt.Errorf("couldn't get session to be revoked: %w", err)
-		log.Ctx(ctx).Warn().Err(err).Msg("authenticate: failed to revoke access token")
+		log.Ctx(ctx).Error().Err(err).Msg("authenticate: failed to revoke access token")
 		return ""
 	}
 
@@ -276,7 +276,7 @@ func (s *Stateful) RevokeSession(
 	var sess session.Session
 	if err := record.GetData().UnmarshalTo(&sess); err != nil {
 		err = fmt.Errorf("couldn't unmarshal data of session to be revoked: %w", err)
-		log.Ctx(ctx).Warn().Err(err).Msg("authenticate: failed to revoke access token")
+		log.Ctx(ctx).Error().Err(err).Msg("authenticate: failed to revoke access token")
 		return ""
 	}
 
@@ -284,7 +284,7 @@ func (s *Stateful) RevokeSession(
 	if sess.OauthToken != nil {
 		rawIDToken = sess.GetIdToken().GetRaw()
 		if err := authenticator.Revoke(ctx, manager.FromOAuthToken(sess.OauthToken)); err != nil {
-			log.Ctx(ctx).Warn().Err(err).Msg("authenticate: failed to revoke access token")
+			log.Ctx(ctx).Error().Err(err).Msg("authenticate: failed to revoke access token")
 		}
 	}
 
@@ -293,7 +293,7 @@ func (s *Stateful) RevokeSession(
 		Records: []*databroker.Record{record},
 	})
 	if err != nil {
-		log.Ctx(ctx).Warn().Err(err).
+		log.Ctx(ctx).Error().Err(err).
 			Msg("authenticate: failed to delete session from session store")
 	}
 	return rawIDToken

--- a/internal/authenticateflow/stateless.go
+++ b/internal/authenticateflow/stateless.go
@@ -259,7 +259,7 @@ func (s *Stateless) RevokeSession(
 	oauthToken := new(oauth2.Token)
 	_ = json.Unmarshal(profile.GetOauthToken(), oauthToken)
 	if err := authenticator.Revoke(ctx, oauthToken); err != nil {
-		log.Ctx(ctx).Warn().Err(err).Msg("authenticate: failed to revoke access token")
+		log.Ctx(ctx).Error().Err(err).Msg("authenticate: failed to revoke access token")
 	}
 
 	return string(profile.GetIdToken())
@@ -293,7 +293,7 @@ func (s *Stateless) logAuthenticateEvent(r *http.Request, profile *identitypb.Pr
 	ctx := r.Context()
 	pub, params, err := hpke.DecryptURLValues(s.hpkePrivateKey, r.Form)
 	if err != nil {
-		log.Warn(ctx).Err(err).Msg("log authenticate event: failed to decrypt request params")
+		log.Error(ctx).Err(err).Msg("log authenticate event: failed to decrypt request params")
 	}
 
 	evt := events.AuthEvent{

--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -275,7 +275,7 @@ func (mgr *Manager) renewCert(ctx context.Context, domain string, cert certmagic
 		if expired {
 			return certmagic.Certificate{}, errRenewCertFailed
 		}
-		log.Warn(ctx).Err(err).Msg("renew client certificated failed, use existing cert")
+		log.Error(ctx).Err(err).Msg("renew client certificated failed, use existing cert")
 	}
 	return cm.CacheManagedCertificate(ctx, domain)
 }

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -312,7 +312,7 @@ func (s *syncerHandler) UpdateRecords(ctx context.Context, _ uint64, records []*
 		var cfgpb configpb.Config
 		err := record.GetData().UnmarshalTo(&cfgpb)
 		if err != nil {
-			log.Warn(ctx).Err(err).Msg("databroker: error decoding config")
+			log.Error(ctx).Err(err).Msg("databroker: error decoding config")
 			delete(s.src.dbConfigs, record.GetId())
 			continue
 		}

--- a/internal/events/manager.go
+++ b/internal/events/manager.go
@@ -29,7 +29,7 @@ func (mgr *Manager) Dispatch(evt Event) {
 	mgr.mu.RUnlock()
 
 	if dropped {
-		log.Warn(context.Background()).
+		log.Error(context.Background()).
 			Interface("event", evt).
 			Msg("controlplane: dropping event due to full channel")
 	}

--- a/internal/httputil/reproxy/reproxy.go
+++ b/internal/httputil/reproxy/reproxy.go
@@ -137,7 +137,7 @@ func (h *Handler) Update(ctx context.Context, cfg *config.Config) {
 	for p := range cfg.Options.GetAllPolicies() {
 		id, err := p.RouteID()
 		if err != nil {
-			log.Warn(ctx).Err(err).Msg("reproxy: error getting route id")
+			log.Error(ctx).Err(err).Msg("reproxy: error getting route id")
 			continue
 		}
 		h.policies[id] = p

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -85,14 +85,6 @@ func ExampleInfo() {
 	// Output: {"level":"info","time":"2008-01-08T17:05:05Z","message":"hello world"}
 }
 
-// Example of a log at a particular "level" (in this case, "warn")
-func ExampleWarn() {
-	captureOutput(func() {
-		log.Warn(context.Background()).Msg("hello world")
-	})
-	// Output: {"level":"warn","time":"2008-01-08T17:05:05Z","message":"hello world"}
-}
-
 // Example of a log at a particular "level" (in this case, "error")
 func ExampleError() {
 	captureOutput(func() {
@@ -175,9 +167,9 @@ func ExampleContext() {
 			return c.Str("param_two", "two")
 		})
 
-		log.Warn(bg).Str("non_context_param", "value").Msg("background")
-		log.Warn(ctx1).Str("non_context_param", "value").Msg("first")
-		log.Warn(ctx2).Str("non_context_param", "value").Msg("second")
+		log.Error(bg).Str("non_context_param", "value").Msg("background")
+		log.Error(ctx1).Str("non_context_param", "value").Msg("first")
+		log.Error(ctx2).Str("non_context_param", "value").Msg("second")
 
 		for i := 0; i < 10; i++ {
 			ctx1 = log.WithContext(ctx1, func(c zerolog.Context) zerolog.Context {
@@ -187,8 +179,8 @@ func ExampleContext() {
 		log.Info(ctx1).Str("non_ctx_param", "value").Msg("after counter")
 	})
 	// Output:
-	// {"level":"warn","non_context_param":"value","time":"2008-01-08T17:05:05Z","message":"background"}
-	// {"level":"warn","param_one":"one","non_context_param":"value","time":"2008-01-08T17:05:05Z","message":"first"}
-	// {"level":"warn","param_one":"one","param_two":"two","non_context_param":"value","time":"2008-01-08T17:05:05Z","message":"second"}
+	// {"level":"error","non_context_param":"value","time":"2008-01-08T17:05:05Z","message":"background"}
+	// {"level":"error","param_one":"one","non_context_param":"value","time":"2008-01-08T17:05:05Z","message":"first"}
+	// {"level":"error","param_one":"one","param_two":"two","non_context_param":"value","time":"2008-01-08T17:05:05Z","message":"second"}
 	// {"level":"info","param_one":"one","counter":0,"counter":1,"counter":2,"counter":3,"counter":4,"counter":5,"counter":6,"counter":7,"counter":8,"counter":9,"non_ctx_param":"value","time":"2008-01-08T17:05:05Z","message":"after counter"}
 }

--- a/internal/log/warnings.go
+++ b/internal/log/warnings.go
@@ -12,7 +12,7 @@ var warnCookieSecretOnce sync.Once
 // WarnCookieSecret warns about the cookie secret.
 func WarnCookieSecret() {
 	warnCookieSecretOnce.Do(func() {
-		Warn(context.Background()).
+		Info(context.Background()).
 			Msg("using a generated COOKIE_SECRET. " +
 				"Set the COOKIE_SECRET to avoid users being logged out on restart. " +
 				"https://www.pomerium.com/docs/reference/cookie-secret")
@@ -24,7 +24,7 @@ var warnNoTLSCertificateOnce syncutil.OnceMap[string]
 // WarnNoTLSCertificate warns about no TLS certificate.
 func WarnNoTLSCertificate(domain string) {
 	warnNoTLSCertificateOnce.Do(domain, func() {
-		Warn(context.Background()).
+		Info(context.Background()).
 			Str("domain", domain).
 			Msg("no TLS certificate found for domain, using a self-signed certificate")
 	})
@@ -35,7 +35,7 @@ var warnWebSocketHTTP1_1Once syncutil.OnceMap[string]
 // WarnWebSocketHTTP1_1 warns about falling back to http 1.1 due to web socket support.
 func WarnWebSocketHTTP1_1(clusterID string) {
 	warnWebSocketHTTP1_1Once.Do(clusterID, func() {
-		Warn(context.Background()).
+		Info(context.Background()).
 			Str("cluster-id", clusterID).
 			Msg("forcing http/1.1 due to web socket support")
 	})

--- a/internal/registry/reporter.go
+++ b/internal/registry/reporter.go
@@ -38,7 +38,7 @@ func (r *Reporter) OnConfigChange(ctx context.Context, cfg *config.Config) {
 
 	services, err := getReportedServices(cfg)
 	if err != nil {
-		log.Warn(ctx).Err(err).Msg("metrics announce to service registry is disabled")
+		log.Error(ctx).Err(err).Msg("metrics announce to service registry is disabled")
 	}
 
 	sharedKey, err := cfg.Options.GetSharedKey()

--- a/internal/retry/backoff.go
+++ b/internal/retry/backoff.go
@@ -32,7 +32,7 @@ func WithBackoff(ctx context.Context, name string, fn func(context.Context) erro
 		},
 		backoff.WithContext(b, ctx),
 		func(err error, next time.Duration) {
-			log.Warn(ctx).Err(err).Str("service-name", name).Dur("next", next).Msg("retrying")
+			log.Error(ctx).Err(err).Str("service-name", name).Dur("next", next).Msg("retrying")
 		},
 	)
 }

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -41,13 +41,13 @@ restart:
 			log.Ctx(ctx).Error().Err(err).Msg("terminal error")
 			return err
 		}
-		log.Ctx(ctx).Warn().Msg(err.Error())
+		log.Ctx(ctx).Error().Msg(err.Error())
 
 		backoff.Reset()
 	backoff:
 		for {
 			interval := backoff.NextBackOff()
-			log.Ctx(ctx).Warn().Msgf("backing off for %s...", interval.String())
+			log.Ctx(ctx).Info().Msgf("backing off for %s...", interval.String())
 			timer := time.NewTimer(interval)
 			s := makeSelect(ctx, watches, name, timer.C, fn)
 			next, err := s.Exec(ctx)
@@ -70,7 +70,7 @@ restart:
 func logNext(ctx context.Context, next next, err error) {
 	evt := log.Ctx(ctx).Info()
 	if err != nil {
-		evt = log.Ctx(ctx).Warn().Err(err)
+		evt = log.Ctx(ctx).Error().Err(err)
 	}
 
 	switch next {

--- a/internal/telemetry/metrics/envoy.go
+++ b/internal/telemetry/metrics/envoy.go
@@ -75,7 +75,7 @@ func RecordEnvoyOverloadActionState(ctx context.Context, tags EnvoyOverloadActio
 		EnvoyOverloadActionState.M(state),
 	)
 	if err != nil {
-		log.Warn(ctx).Err(err).Msg("internal/telemetry/metrics: failed to record")
+		log.Error(ctx).Err(err).Msg("internal/telemetry/metrics: failed to record")
 	}
 }
 
@@ -87,7 +87,7 @@ func RecordEnvoyOverloadActionThreshold(ctx context.Context, actionName string, 
 		EnvoyOverloadActionThreshold.M(threshold),
 	)
 	if err != nil {
-		log.Warn(ctx).Err(err).Msg("internal/telemetry/metrics: failed to record")
+		log.Error(ctx).Err(err).Msg("internal/telemetry/metrics: failed to record")
 	}
 }
 
@@ -99,6 +99,6 @@ func RecordEnvoyCgroupMemorySaturation(ctx context.Context, cgroup string, perce
 		EnvoyCgroupMemorySaturation.M(percent),
 	)
 	if err != nil {
-		log.Warn(ctx).Err(err).Msg("internal/telemetry/metrics: failed to record")
+		log.Error(ctx).Err(err).Msg("internal/telemetry/metrics: failed to record")
 	}
 }

--- a/internal/telemetry/metrics/grpc.go
+++ b/internal/telemetry/metrics/grpc.go
@@ -143,7 +143,7 @@ func GRPCClientInterceptor(service string) grpc.UnaryClientInterceptor {
 			tag.Upsert(TagKeyGRPCService, rpcService),
 		)
 		if tagErr != nil {
-			log.Warn(ctx).Err(tagErr).Str("context", "GRPCClientInterceptor").Msg("telemetry/metrics: failed to create context")
+			log.Error(ctx).Err(tagErr).Str("context", "GRPCClientInterceptor").Msg("telemetry/metrics: failed to create context")
 			return invoker(ctx, method, req, reply, cc, opts...)
 		}
 
@@ -182,7 +182,7 @@ func (h *GRPCServerMetricsHandler) TagRPC(ctx context.Context, tagInfo *grpcstat
 		tag.Upsert(TagKeyGRPCService, rpcService),
 	)
 	if tagErr != nil {
-		log.Warn(ctx).Err(tagErr).Str("context", "GRPCServerStatsHandler").Msg("telemetry/metrics: failed to create context")
+		log.Error(ctx).Err(tagErr).Str("context", "GRPCServerStatsHandler").Msg("telemetry/metrics: failed to create context")
 		return ctx
 
 	}

--- a/internal/telemetry/metrics/http.go
+++ b/internal/telemetry/metrics/http.go
@@ -120,7 +120,7 @@ func HTTPMetricsHandler(_ func() string, service string) func(next http.Handler)
 				tag.Upsert(TagKeyHTTPMethod, r.Method),
 			)
 			if tagErr != nil {
-				log.Warn(ctx).Err(tagErr).Str("context", "HTTPMetricsHandler").Msg("telemetry/metrics: failed to create metrics tag")
+				log.Error(ctx).Err(tagErr).Str("context", "HTTPMetricsHandler").Msg("telemetry/metrics: failed to create metrics tag")
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -147,7 +147,7 @@ func HTTPMetricsRoundTripper(_ func() string, service string) func(next http.Rou
 				tag.Upsert(TagKeyHTTPMethod, r.Method),
 			)
 			if tagErr != nil {
-				log.Warn(ctx).Err(tagErr).Str("context", "HTTPMetricsRoundTripper").Msg("telemetry/metrics: failed to create metrics tag")
+				log.Error(ctx).Err(tagErr).Str("context", "HTTPMetricsRoundTripper").Msg("telemetry/metrics: failed to create metrics tag")
 				return next.RoundTrip(r)
 			}
 

--- a/internal/telemetry/metrics/info.go
+++ b/internal/telemetry/metrics/info.go
@@ -345,7 +345,7 @@ func SetDBConfigInfo(ctx context.Context, service, configID string, version uint
 
 // SetDBConfigRejected records that a certain databroker config version has been rejected
 func SetDBConfigRejected(ctx context.Context, service, configID string, version uint64, err error) {
-	log.Warn(ctx).Err(err).Msg("databroker: invalid config detected, ignoring")
+	log.Error(ctx).Err(err).Msg("databroker: invalid config detected, ignoring")
 	SetDBConfigInfo(ctx, service, configID, version, -1)
 }
 

--- a/internal/telemetry/metrics/storage.go
+++ b/internal/telemetry/metrics/storage.go
@@ -57,6 +57,6 @@ func RecordStorageOperation(ctx context.Context, tags *StorageOperationTags, dur
 		storageOperationDuration.M(duration.Milliseconds()),
 	)
 	if err != nil {
-		log.Warn(ctx).Err(err).Msg("internal/telemetry/metrics: failed to record")
+		log.Error(ctx).Err(err).Msg("internal/telemetry/metrics: failed to record")
 	}
 }

--- a/internal/zero/telemetry/reporter/healthcheck.go
+++ b/internal/zero/telemetry/reporter/healthcheck.go
@@ -78,7 +78,7 @@ func (r *healthCheckReporter) ReportOK(check health.Check, attr ...health.Attr) 
 // ReportError implements health.Provider interface
 func (r *healthCheckReporter) ReportError(check health.Check, err error, attr ...health.Attr) {
 	ctx := context.Background()
-	log.Ctx(ctx).Warn().Str("check", string(check)).Err(err).Msg("health check error")
+	log.Ctx(ctx).Error().Str("check", string(check)).Err(err).Msg("health check error")
 	_, span := r.tracer.Start(ctx, string(check))
 	span.SetStatus(codes.Error, err.Error())
 	setAttributes(span, attr...)

--- a/internal/zero/telemetry/telemetry.go
+++ b/internal/zero/telemetry/telemetry.go
@@ -95,7 +95,7 @@ func (srv *Telemetry) handleRequests(ctx context.Context) error {
 				select {
 				case requests <- req:
 				default:
-					log.Warn(ctx).Msg("dropping telemetry request")
+					log.Error(ctx).Msg("dropping telemetry request")
 				}
 			}))
 	})

--- a/pkg/envoy/envoy_linux.go
+++ b/pkg/envoy/envoy_linux.go
@@ -69,7 +69,7 @@ func (srv *Server) prepareRunEnvoyCommand(ctx context.Context, sharedArgs []stri
 		log.Info(ctx).Msg("envoy: releasing envoy process for hot-reload")
 		err := srv.cmd.Process.Release()
 		if err != nil {
-			log.Warn(ctx).Err(err).Str("service", "envoy").Msg("envoy: failed to release envoy process for hot-reload")
+			log.Error(ctx).Err(err).Str("service", "envoy").Msg("envoy: failed to release envoy process for hot-reload")
 		}
 	}
 

--- a/pkg/envoy/extract.go
+++ b/pkg/envoy/extract.go
@@ -107,14 +107,14 @@ func extract(dstName string) (err error) {
 func cleanTempDir(tmpDir string) {
 	d, err := os.Open(tmpDir)
 	if err != nil {
-		log.Warn().Msg("envoy: failed to open temp directory for clean up")
+		log.Error().Msg("envoy: failed to open temp directory for clean up")
 		return
 	}
 	defer d.Close()
 
 	fs, err := d.Readdir(-1)
 	if err != nil {
-		log.Warn().Msg("envoy: failed to read files in temporary directory")
+		log.Error().Msg("envoy: failed to read files in temporary directory")
 		return
 	}
 
@@ -122,7 +122,7 @@ func cleanTempDir(tmpDir string) {
 		if f.IsDir() && strings.HasPrefix(f.Name(), envoyPrefix) {
 			err := os.RemoveAll(filepath.Join(tmpDir, f.Name()))
 			if err != nil {
-				log.Warn().Err(err).Msg("envoy: failed to delete previous extracted envoy")
+				log.Error().Err(err).Msg("envoy: failed to delete previous extracted envoy")
 			}
 		}
 	}

--- a/pkg/grpc/databroker/leaser.go
+++ b/pkg/grpc/databroker/leaser.go
@@ -95,7 +95,7 @@ func (locker *Leaser) runOnce(ctx context.Context, resetBackoff func()) error {
 	if status.Code(err) == codes.AlreadyExists {
 		return nil
 	} else if err != nil {
-		log.Warn(ctx).Err(err).Str("lease_name", locker.leaseName).Msg("leaser: error acquiring lease")
+		log.Error(ctx).Err(err).Str("lease_name", locker.leaseName).Msg("leaser: error acquiring lease")
 		return retryableError{err}
 	}
 	resetBackoff()
@@ -149,7 +149,7 @@ func (locker *Leaser) withLease(ctx context.Context, leaseID string) error {
 				// failed to renew lease
 				return nil
 			} else if err != nil {
-				log.Warn(ctx).Err(err).Str("lease_name", locker.leaseName).Msg("leaser: error renewing lease")
+				log.Error(ctx).Err(err).Str("lease_name", locker.leaseName).Msg("leaser: error renewing lease")
 				return retryableError{err}
 			}
 		}

--- a/pkg/identity/legacymanager/manager.go
+++ b/pkg/identity/legacymanager/manager.go
@@ -212,7 +212,7 @@ func (mgr *Manager) refreshSession(ctx context.Context, userID, sessionID string
 
 	s, ok := mgr.sessions.Get(userID, sessionID)
 	if !ok {
-		log.Warn(ctx).
+		log.Info(ctx).
 			Str("user_id", userID).
 			Str("session_id", sessionID).
 			Msg("no session found for refresh")
@@ -253,7 +253,7 @@ func (mgr *Manager) refreshSessionInternal(
 	}
 
 	if s.Session == nil || s.Session.OauthToken == nil {
-		log.Warn(ctx).
+		log.Info(ctx).
 			Str("user_id", userID).
 			Str("session_id", sessionID).
 			Msg("no session oauth2 token found for refresh")
@@ -324,7 +324,7 @@ func (mgr *Manager) refreshUser(ctx context.Context, userID string) {
 
 	u, ok := mgr.users.Get(userID)
 	if !ok {
-		log.Warn(ctx).
+		log.Info(ctx).
 			Str("user_id", userID).
 			Msg("no user found for refresh")
 		return
@@ -334,7 +334,7 @@ func (mgr *Manager) refreshUser(ctx context.Context, userID string) {
 
 	for _, s := range mgr.sessions.GetSessionsForUser(userID) {
 		if s.Session == nil || s.Session.OauthToken == nil {
-			log.Warn(ctx).
+			log.Info(ctx).
 				Str("user_id", userID).
 				Msg("no session oauth2 token found for refresh")
 			continue
@@ -378,7 +378,7 @@ func (mgr *Manager) onUpdateRecords(ctx context.Context, msg updateRecordsMessag
 			var pbSession session.Session
 			err := record.GetData().UnmarshalTo(&pbSession)
 			if err != nil {
-				log.Warn(ctx).Msgf("error unmarshaling session: %s", err)
+				log.Error(ctx).Msgf("error unmarshaling session: %s", err)
 				continue
 			}
 			mgr.onUpdateSession(record, &pbSession)
@@ -386,7 +386,7 @@ func (mgr *Manager) onUpdateRecords(ctx context.Context, msg updateRecordsMessag
 			var pbUser user.User
 			err := record.GetData().UnmarshalTo(&pbUser)
 			if err != nil {
-				log.Warn(ctx).Msgf("error unmarshaling user: %s", err)
+				log.Error(ctx).Msgf("error unmarshaling user: %s", err)
 				continue
 			}
 			mgr.onUpdateUser(ctx, record, &pbUser)

--- a/pkg/identity/manager/manager.go
+++ b/pkg/identity/manager/manager.go
@@ -199,7 +199,7 @@ func (mgr *Manager) refreshSession(ctx context.Context, sessionID string) {
 	mgr.mu.Unlock()
 
 	if s == nil {
-		log.Ctx(ctx).Warn().
+		log.Ctx(ctx).Info().
 			Str("user_id", u.GetId()).
 			Str("session_id", sessionID).
 			Msg("no session found for refresh")
@@ -227,7 +227,7 @@ func (mgr *Manager) refreshSession(ctx context.Context, sessionID string) {
 	}
 
 	if s.GetOauthToken() == nil {
-		log.Warn(ctx).
+		log.Info(ctx).
 			Str("user_id", s.GetUserId()).
 			Str("session_id", s.GetId()).
 			Msg("no session oauth2 token found for refresh")
@@ -290,7 +290,7 @@ func (mgr *Manager) updateUserInfo(ctx context.Context, userID string) {
 	mgr.mu.Unlock()
 
 	if u == nil {
-		log.Ctx(ctx).Warn().
+		log.Ctx(ctx).Error().
 			Str("user_id", userID).
 			Msg("no user found for update")
 		return
@@ -298,7 +298,7 @@ func (mgr *Manager) updateUserInfo(ctx context.Context, userID string) {
 
 	for _, s := range ss {
 		if s.GetOauthToken() == nil {
-			log.Ctx(ctx).Warn().
+			log.Ctx(ctx).Error().
 				Str("user_id", s.GetUserId()).
 				Str("session_id", s.GetId()).
 				Msg("no session oauth2 token found for updating user info")

--- a/pkg/identity/manager/sync.go
+++ b/pkg/identity/manager/sync.go
@@ -36,7 +36,7 @@ func (h sessionSyncerHandler) UpdateRecords(ctx context.Context, _ uint64, recor
 			var s session.Session
 			err := record.Data.UnmarshalTo(&s)
 			if err != nil {
-				log.Ctx(ctx).Warn().Err(err).Msg("invalid data in session record, ignoring")
+				log.Ctx(ctx).Error().Err(err).Msg("invalid data in session record, ignoring")
 			} else {
 				h.mgr.onUpdateSession(h.baseCtx, &s)
 			}
@@ -70,7 +70,7 @@ func (h userSyncerHandler) UpdateRecords(ctx context.Context, _ uint64, records 
 			var u user.User
 			err := record.Data.UnmarshalTo(&u)
 			if err != nil {
-				log.Ctx(ctx).Warn().Err(err).Msg("invalid data in user record, ignoring")
+				log.Ctx(ctx).Error().Err(err).Msg("invalid data in user record, ignoring")
 			} else {
 				h.mgr.onUpdateUser(h.baseCtx, &u)
 			}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -104,7 +104,7 @@ func (p *Proxy) OnConfigChange(_ context.Context, cfg *config.Config) {
 
 func (p *Proxy) setHandlers(opts *config.Options) error {
 	if opts.NumPolicies() == 0 {
-		log.Warn(context.TODO()).Msg("proxy: configuration has no policies")
+		log.Info(context.TODO()).Msg("proxy: configuration has no policies")
 	}
 	r := httputil.NewRouter()
 	r.NotFoundHandler = httputil.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) error {


### PR DESCRIPTION
## Summary
According to https://www.pomerium.com/docs/community/contributing#logging we should not use `.Warn`.

## Related issues
- https://github.com/pomerium/pomerium-zero/issues/2046


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
