### PR TITLE
core/config: add databroker_storage_connection_string_file

### DIFF
--- a/config/config_source.go
+++ b/config/config_source.go
@@ -281,6 +281,7 @@ func getAllConfigFilePaths(cfg *Config) []string {
 		cfg.Options.CertFile,
 		cfg.Options.ClientSecretFile,
 		cfg.Options.CookieSecretFile,
+		cfg.Options.DataBrokerStorageConnectionStringFile,
 		cfg.Options.DataBrokerStorageCAFile,
 		cfg.Options.DataBrokerStorageCertFile,
 		cfg.Options.DataBrokerStorageCertKeyFile,

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1318,6 +1318,7 @@ func TestOptions_GetDataBrokerStorageConnectionString(t *testing.T) {
 		assert.NoError(t, o.Validate(),
 			"should have no error when the dsn is set")
 
+		o.DataBrokerStorageConnectionString = ""
 		o.DataBrokerStorageConnectionStringFile = "DSN_FILE"
 		assert.NoError(t, o.Validate(),
 			"should have no error when the dsn file is set")

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1300,6 +1300,65 @@ func TestOptions_RuntimeFlags(t *testing.T) {
 	}
 }
 
+func TestOptions_GetDataBrokerStorageConnectionString(t *testing.T) {
+	t.Parallel()
+
+	t.Run("validate", func(t *testing.T) {
+		t.Parallel()
+
+		o := NewDefaultOptions()
+		o.Services = "databroker"
+		o.DataBrokerStorageType = "postgres"
+		o.SharedKey = cryptutil.NewBase64Key()
+
+		assert.ErrorContains(t, o.Validate(), "missing databroker storage backend dsn",
+			"should validate DSN")
+
+		o.DataBrokerStorageConnectionString = "DSN"
+		assert.NoError(t, o.Validate(),
+			"should have no error when the dsn is set")
+
+		o.DataBrokerStorageConnectionStringFile = "DSN_FILE"
+		assert.NoError(t, o.Validate(),
+			"should have no error when the dsn file is set")
+	})
+	t.Run("literal", func(t *testing.T) {
+		t.Parallel()
+
+		o := NewDefaultOptions()
+		o.DataBrokerStorageConnectionString = "DSN"
+
+		dsn, err := o.GetDataBrokerStorageConnectionString()
+		assert.NoError(t, err)
+		assert.Equal(t, "DSN", dsn)
+	})
+	t.Run("file", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		fp := filepath.Join(dir, "DSN_FILE")
+
+		o := NewDefaultOptions()
+		o.DataBrokerStorageConnectionStringFile = fp
+		o.DataBrokerStorageConnectionString = "IGNORED"
+
+		dsn, err := o.GetDataBrokerStorageConnectionString()
+		assert.Error(t, err,
+			"should return an error when the file doesn't exist")
+		assert.Empty(t, dsn)
+
+		os.WriteFile(fp, []byte(`
+			DSN
+		`), 0o644)
+
+		dsn, err = o.GetDataBrokerStorageConnectionString()
+		assert.NoError(t, err,
+			"should not return an error when the file exists")
+		assert.Equal(t, "DSN", dsn,
+			"should return the trimmed contents of the file")
+	})
+}
+
 func encodeCert(cert *tls.Certificate) []byte {
 	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Certificate[0]})
 }

--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -91,7 +91,10 @@ func New(cfg *config.Config, eventsMgr *events.Manager) (*DataBroker, error) {
 		return nil, err
 	}
 
-	dataBrokerServer := newDataBrokerServer(cfg)
+	dataBrokerServer, err := newDataBrokerServer(cfg)
+	if err != nil {
+		return nil, err
+	}
 
 	c := &DataBroker{
 		dataBrokerServer:    dataBrokerServer,


### PR DESCRIPTION
## Summary
Add support for loading the `DataBrokerStorageConnectionString` from a file.

## Related issues
- https://github.com/pomerium/pomerium/issues/5228

## Checklist
- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
