### PR TITLE
zero/k8s: use deployments

### DIFF
--- a/k8s/zero/deployment/base.yaml
+++ b/k8s/zero/deployment/base.yaml
@@ -1,15 +1,15 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: pomerium
 spec:
-  serviceName: "pomerium-proxy"
   replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/name: pomerium-zero
   template:
     spec:
+      serviceAccountName: pomerium-zero
       containers:
         - name: pomerium
       terminationGracePeriodSeconds: 10

--- a/k8s/zero/deployment/env.yaml
+++ b/k8s/zero/deployment/env.yaml
@@ -22,7 +22,7 @@ spec:
             - name: BOOTSTRAP_CONFIG_FILE
               value: "/var/run/secrets/pomerium/bootstrap.dat"
             - name: BOOTSTRAP_CONFIG_WRITEBACK_URI
-              value: "secret://pomerium-zero/pomerium/bootstrap"
+              value: "secret://$(POMERIUM_NAMESPACE)/pomerium/bootstrap"
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/k8s/zero/deployment/env.yaml
+++ b/k8s/zero/deployment/env.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: pomerium
 spec:
@@ -19,6 +19,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: BOOTSTRAP_CONFIG_FILE
+              value: "/var/run/secrets/pomerium/bootstrap.dat"
+            - name: BOOTSTRAP_CONFIG_WRITEBACK_URI
+              value: "secret://pomerium-zero/pomerium/bootstrap"
             - name: POD_IP
               valueFrom:
                 fieldRef:

--- a/k8s/zero/deployment/image.yaml
+++ b/k8s/zero/deployment/image.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: pomerium
 spec:

--- a/k8s/zero/deployment/no-root.yaml
+++ b/k8s/zero/deployment/no-root.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: pomerium
 spec:

--- a/k8s/zero/deployment/ports.yaml
+++ b/k8s/zero/deployment/ports.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: pomerium
 spec:

--- a/k8s/zero/deployment/readonly-root-fs.yaml
+++ b/k8s/zero/deployment/readonly-root-fs.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: pomerium
 spec:

--- a/k8s/zero/deployment/resources.yaml
+++ b/k8s/zero/deployment/resources.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: pomerium
 spec:

--- a/k8s/zero/deployment/volumes.yaml
+++ b/k8s/zero/deployment/volumes.yaml
@@ -21,6 +21,7 @@ spec:
               name: tmp
             - mountPath: "/var/run/secrets/pomerium"
               name: bootstrap
+              readOnly: true
       volumes:
         - name: tmp
           emptyDir: {}

--- a/k8s/zero/deployment/volumes.yaml
+++ b/k8s/zero/deployment/volumes.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: StatefulSet
+kind: Deployment
 metadata:
   name: pomerium
 spec:
@@ -13,22 +13,20 @@ spec:
             - name: TMPDIR
               value: "/tmp/pomerium"
             - name: XDG_CACHE_HOME
-              value: "/var/cache"
+              value: "/tmp/pomerium/cache"
             - name: XDG_DATA_HOME
-              value: "/var/cache"
+              value: "/tmp/pomerium/cache"
           volumeMounts:
             - mountPath: "/tmp/pomerium"
               name: tmp
-            - mountPath: "/var/cache"
-              name: pomerium-cache
+            - mountPath: "/var/run/secrets/pomerium"
+              name: bootstrap
       volumes:
         - name: tmp
           emptyDir: {}
-  volumeClaimTemplates:
-  - metadata:
-      name: pomerium-cache
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: 100Mi
+        - name: bootstrap
+          secret:
+            secretName: pomerium
+            items:
+              - key: bootstrap
+                path: bootstrap.dat

--- a/k8s/zero/deployment/volumes.yaml
+++ b/k8s/zero/deployment/volumes.yaml
@@ -27,6 +27,7 @@ spec:
           emptyDir: {}
         - name: bootstrap
           secret:
+            optional: true
             secretName: pomerium
             items:
               - key: bootstrap

--- a/k8s/zero/kustomization.yaml
+++ b/k8s/zero/kustomization.yaml
@@ -3,5 +3,6 @@ commonLabels:
   app.kubernetes.io/name: pomerium-zero
 resources:
   - namespace.yaml
+  - ./rbac
   - ./deployment
   - ./service

--- a/k8s/zero/rbac/kustomization.yaml
+++ b/k8s/zero/rbac/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- role.yaml
+- role_binding.yaml
+- service_account.yaml

--- a/k8s/zero/rbac/role.yaml
+++ b/k8s/zero/rbac/role.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: pomerium-zero
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - patch
+    resourceNames:
+      - pomerium

--- a/k8s/zero/rbac/role_binding.yaml
+++ b/k8s/zero/rbac/role_binding.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: pomerium-zero
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: pomerium-zero
+subjects:
+  - kind: ServiceAccount
+    name: pomerium-zero

--- a/k8s/zero/rbac/service_account.yaml
+++ b/k8s/zero/rbac/service_account.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: pomerium-zero


### PR DESCRIPTION
## Summary

Previously, Pomerium in Zero mode was deployed using `StatefulSet` and required a PVC to store the bootstrap piece.

Support to store the bootstrap piece in a kubernetes secret was added in #5114. 

This PR updates manifests accordingly to use stateless `Deployment` and configures the bootstrap writeback to the `pomerium-zero/pomerium` `Secret` that is already required to store `POMERIUM_ZERO_TOKEN`. 


## Related issues

Related: https://github.com/pomerium/pomerium-zero/issues/2405

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
