### PR TITLE
config: sort runtime flags, name consistency

### DIFF
--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -3,20 +3,22 @@ package config
 import "maps"
 
 var (
-	// RuntimeFlagGRPCDatabrokerKeepalive enables gRPC keepalive to the databroker service
-	RuntimeFlagGRPCDatabrokerKeepalive = runtimeFlag("grpc_databroker_keepalive", false)
-
-	// RuntimeFlagMatchAnyIncomingPort enables ignoring the incoming port when matching routes
-	RuntimeFlagMatchAnyIncomingPort = runtimeFlag("match_any_incoming_port", true)
-
-	// RuntimeFlagLegacyIdentityManager enables the legacy identity manager
-	RuntimeFlagLegacyIdentityManager = runtimeFlag("legacy_identity_manager", false)
-
 	// RuntimeFlagConfigHotReload enables the hot-reloading mechanism for the config file
 	// and any other files referenced within it
 	RuntimeFlagConfigHotReload = runtimeFlag("config_hot_reload", true)
 
-	RuntimeFlagEnvoyResourceManagerEnabled = runtimeFlag("envoy_resource_manager_enabled", true)
+	// RuntimeFlagEnvoyResourceManager enables Envoy overload settings based on
+	// process cgroup limits (Linux only).
+	RuntimeFlagEnvoyResourceManager = runtimeFlag("envoy_resource_manager", true)
+
+	// RuntimeFlagGRPCDatabrokerKeepalive enables gRPC keepalive to the databroker service
+	RuntimeFlagGRPCDatabrokerKeepalive = runtimeFlag("grpc_databroker_keepalive", false)
+
+	// RuntimeFlagLegacyIdentityManager enables the legacy identity manager
+	RuntimeFlagLegacyIdentityManager = runtimeFlag("legacy_identity_manager", false)
+
+	// RuntimeFlagMatchAnyIncomingPort enables ignoring the incoming port when matching routes
+	RuntimeFlagMatchAnyIncomingPort = runtimeFlag("match_any_incoming_port", true)
 )
 
 // RuntimeFlag is a runtime flag that can flip on/off certain features

--- a/pkg/envoy/resource_monitor_linux.go
+++ b/pkg/envoy/resource_monitor_linux.go
@@ -204,10 +204,10 @@ type sharedResourceMonitor struct {
 
 func (s *sharedResourceMonitor) onConfigChange(_ context.Context, cfg *config.Config) {
 	if cfg == nil || cfg.Options == nil {
-		s.enabled.Store(config.DefaultRuntimeFlags()[config.RuntimeFlagEnvoyResourceManagerEnabled])
+		s.enabled.Store(config.DefaultRuntimeFlags()[config.RuntimeFlagEnvoyResourceManager])
 		return
 	}
-	s.enabled.Store(cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagEnvoyResourceManagerEnabled))
+	s.enabled.Store(cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagEnvoyResourceManager))
 }
 
 func (s *sharedResourceMonitor) metricFilename(group, name string) string {

--- a/pkg/envoy/resource_monitor_test.go
+++ b/pkg/envoy/resource_monitor_test.go
@@ -665,7 +665,7 @@ func TestSharedResourceMonitor(t *testing.T) {
 	configSrc.SetConfig(ctx, &config.Config{
 		Options: &config.Options{
 			RuntimeFlags: config.RuntimeFlags{
-				config.RuntimeFlagEnvoyResourceManagerEnabled: false,
+				config.RuntimeFlagEnvoyResourceManager: false,
 			},
 		},
 	})
@@ -677,7 +677,7 @@ func TestSharedResourceMonitor(t *testing.T) {
 	configSrc.SetConfig(ctx, &config.Config{
 		Options: &config.Options{
 			RuntimeFlags: config.RuntimeFlags{
-				config.RuntimeFlagEnvoyResourceManagerEnabled: true,
+				config.RuntimeFlagEnvoyResourceManager: true,
 			},
 		},
 	})


### PR DESCRIPTION
## Summary

Sort the runtime flag definitions alphabetically. Rename `envoy_resource_manager_enabled` to just `envoy_resource_manager` for consistency with the other flag names. (This flag hasn't been released yet, so it should be OK to rename it.) Add a doc comment for this flag.

## Related issues

- https://github.com/pomerium/internal/issues/1744

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
