### PR TITLE
zero/api: reset token and url cache if 401 is received

### DIFF
--- a/internal/zero/api/api.go
+++ b/internal/zero/api/api.go
@@ -63,7 +63,7 @@ func NewAPI(ctx context.Context, opts ...Option) (*API, error) {
 
 	tokenCache := token_api.NewCache(fetcher, cfg.apiToken)
 
-	clusterClient, err := cluster_api.NewAuthorizedClient(cfg.clusterAPIEndpoint, tokenCache.GetToken, cfg.httpClient)
+	clusterClient, err := cluster_api.NewAuthorizedClient(cfg.clusterAPIEndpoint, tokenCache, cfg.httpClient)
 	if err != nil {
 		return nil, fmt.Errorf("error creating cluster client: %w", err)
 	}
@@ -104,14 +104,14 @@ func (api *API) Watch(ctx context.Context, opts ...WatchOption) error {
 
 // GetClusterBootstrapConfig fetches the bootstrap configuration from the cluster API
 func (api *API) GetClusterBootstrapConfig(ctx context.Context) (*cluster_api.BootstrapConfig, error) {
-	return apierror.CheckResponse[cluster_api.BootstrapConfig](
+	return apierror.CheckResponse(
 		api.cluster.GetClusterBootstrapConfigWithResponse(ctx),
 	)
 }
 
 // GetClusterResourceBundles fetches the resource bundles from the cluster API
 func (api *API) GetClusterResourceBundles(ctx context.Context) (*cluster_api.GetBundlesResponse, error) {
-	return apierror.CheckResponse[cluster_api.GetBundlesResponse](
+	return apierror.CheckResponse(
 		api.cluster.GetClusterResourceBundlesWithResponse(ctx),
 	)
 }

--- a/pkg/zero/cluster/client.go
+++ b/pkg/zero/cluster/client.go
@@ -17,18 +17,23 @@ const (
 var userAgent = version.UserAgent()
 
 type client struct {
-	tokenProvider TokenProviderFn
+	tokenProvider TokenCache
 	httpClient    *http.Client
 	minTokenTTL   time.Duration
 }
 
-// TokenProviderFn is a function that returns a token that is expected to be valid for at least minTTL
-type TokenProviderFn func(ctx context.Context, minTTL time.Duration) (string, error)
+// TokenCache interface for fetching and caching tokens
+type TokenCache interface {
+	// GetToken returns a token that is expected to be valid for at least minTTL duration
+	GetToken(ctx context.Context, minTTL time.Duration) (string, error)
+	// Reset resets the token cache
+	Reset()
+}
 
 // NewAuthorizedClient creates a new HTTP client that will automatically add an authorization header
 func NewAuthorizedClient(
 	endpoint string,
-	tokenProvider TokenProviderFn,
+	tokenProvider TokenCache,
 	httpClient *http.Client,
 ) (ClientWithResponsesInterface, error) {
 	c := &client{
@@ -43,12 +48,21 @@ func NewAuthorizedClient(
 
 func (c *client) Do(req *http.Request) (*http.Response, error) {
 	ctx := req.Context()
-	token, err := c.tokenProvider(ctx, c.minTokenTTL)
+	token, err := c.tokenProvider.GetToken(ctx, c.minTokenTTL)
 	if err != nil {
 		return nil, fmt.Errorf("error getting token: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("User-Agent", userAgent)
 
-	return c.httpClient.Do(req)
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode == http.StatusUnauthorized {
+		c.tokenProvider.Reset()
+	}
+
+	return resp, nil
 }

--- a/pkg/zero/cluster/client_test.go
+++ b/pkg/zero/cluster/client_test.go
@@ -46,7 +46,7 @@ func TestAPIClient(t *testing.T) {
 	require.NoError(t, err)
 
 	tokenCache := token.NewCache(fetcher, "refresh-token")
-	client, err := api.NewAuthorizedClient(srv.URL, tokenCache.GetToken, http.DefaultClient)
+	client, err := api.NewAuthorizedClient(srv.URL, tokenCache, http.DefaultClient)
 	require.NoError(t, err)
 
 	resp, err := client.ExchangeClusterIdentityTokenWithResponse(context.Background(),

--- a/pkg/zero/cluster/urlcache.go
+++ b/pkg/zero/cluster/urlcache.go
@@ -29,6 +29,13 @@ func NewURLCache() *URLCache {
 	}
 }
 
+func (c *URLCache) Delete(key string) {
+	c.mx.Lock()
+	defer c.mx.Unlock()
+
+	delete(c.cache, key)
+}
+
 // Get gets the cache entry for the given key, if it exists and has not expired.
 func (c *URLCache) Get(key string, minTTL time.Duration) (*DownloadCacheEntry, bool) {
 	c.mx.RLock()


### PR DESCRIPTION
## Summary

When interacting with zero api, we currently cache the access token and download URLs for the period of time they've been issued for. 

However, those tokens may become invalid and that would cause 401 Unauthorized returned by the API. 

Currently, such response would be handled via a retry, similarly to any other error. The retry would therefore continue until the cache is expired.

This PR changes the behaviour - if 401 is returned by zero API or the blob download service, a cached token or download url would be invalidated, that would cause the operation to be retried requesting a new token or download url. 

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
