### PR TITLE
core/envoy: allow TLS 1.3

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -297,30 +297,7 @@ func (b *Builder) buildPolicyTransportSocket(
 	}
 	tlsContext := &envoy_extensions_transport_sockets_tls_v3.UpstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
-			TlsParams: &envoy_extensions_transport_sockets_tls_v3.TlsParameters{
-				CipherSuites: []string{
-					"ECDHE-ECDSA-AES256-GCM-SHA384",
-					"ECDHE-RSA-AES256-GCM-SHA384",
-					"ECDHE-ECDSA-AES128-GCM-SHA256",
-					"ECDHE-RSA-AES128-GCM-SHA256",
-					"ECDHE-ECDSA-CHACHA20-POLY1305",
-					"ECDHE-RSA-CHACHA20-POLY1305",
-					"ECDHE-ECDSA-AES128-SHA",
-					"ECDHE-RSA-AES128-SHA",
-					"AES128-GCM-SHA256",
-					"AES128-SHA",
-					"ECDHE-ECDSA-AES256-SHA",
-					"ECDHE-RSA-AES256-SHA",
-					"AES256-GCM-SHA384",
-					"AES256-SHA",
-				},
-				EcdhCurves: []string{
-					"X25519",
-					"P-256",
-					"P-384",
-					"P-521",
-				},
-			},
+			TlsParams:     tlsUpstreamParams,
 			AlpnProtocols: buildUpstreamALPN(upstreamProtocol),
 			ValidationContextType: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{
 				ValidationContext: vc,

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -94,7 +94,9 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"P-256",
 								"P-384",
 								"P-521"
-							]
+							],
+							"tlsMinimumProtocolVersion": "TLSv1_2",
+							"tlsMaximumProtocolVersion": "TLSv1_3"
 						},
 						"validationContext": {
 							"matchTypedSubjectAltNames": [{
@@ -148,7 +150,9 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"P-256",
 								"P-384",
 								"P-521"
-							]
+							],
+							"tlsMinimumProtocolVersion": "TLSv1_2",
+							"tlsMaximumProtocolVersion": "TLSv1_3"
 						},
 						"validationContext": {
 							"matchTypedSubjectAltNames": [{
@@ -202,7 +206,9 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"P-256",
 								"P-384",
 								"P-521"
-							]
+							],
+							"tlsMinimumProtocolVersion": "TLSv1_2",
+							"tlsMaximumProtocolVersion": "TLSv1_3"
 						},
 						"validationContext": {
 							"matchTypedSubjectAltNames": [{
@@ -256,7 +262,9 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"P-256",
 								"P-384",
 								"P-521"
-							]
+							],
+							"tlsMinimumProtocolVersion": "TLSv1_2",
+							"tlsMaximumProtocolVersion": "TLSv1_3"
 						},
 						"validationContext": {
 							"matchTypedSubjectAltNames": [{
@@ -311,7 +319,9 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"P-256",
 								"P-384",
 								"P-521"
-							]
+							],
+							"tlsMinimumProtocolVersion": "TLSv1_2",
+							"tlsMaximumProtocolVersion": "TLSv1_3"
 						},
 						"validationContext": {
 							"matchTypedSubjectAltNames": [{
@@ -364,7 +374,9 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"P-256",
 								"P-384",
 								"P-521"
-							]
+							],
+							"tlsMinimumProtocolVersion": "TLSv1_2",
+							"tlsMaximumProtocolVersion": "TLSv1_3"
 						},
 						"validationContext": {
 							"matchTypedSubjectAltNames": [{
@@ -419,7 +431,9 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"P-256",
 								"P-384",
 								"P-521"
-							]
+							],
+							"tlsMinimumProtocolVersion": "TLSv1_2",
+							"tlsMaximumProtocolVersion": "TLSv1_3"
 						},
 						"tlsCertificates": [{
 							"certificateChain":{
@@ -482,7 +496,9 @@ func Test_buildPolicyTransportSocket(t *testing.T) {
 								"P-256",
 								"P-384",
 								"P-521"
-							]
+							],
+							"tlsMinimumProtocolVersion": "TLSv1_2",
+							"tlsMaximumProtocolVersion": "TLSv1_3"
 						},
 						"validationContext": {
 							"matchTypedSubjectAltNames": [{
@@ -619,7 +635,9 @@ func Test_buildCluster(t *testing.T) {
 										"P-256",
 										"P-384",
 										"P-521"
-									]
+									],
+									"tlsMinimumProtocolVersion": "TLSv1_2",
+									"tlsMaximumProtocolVersion": "TLSv1_3"
 								},
 								"validationContext": {
 									"matchTypedSubjectAltNames": [{
@@ -665,7 +683,9 @@ func Test_buildCluster(t *testing.T) {
 									"P-256",
 									"P-384",
 									"P-521"
-								]
+								],
+								"tlsMinimumProtocolVersion": "TLSv1_2",
+								"tlsMaximumProtocolVersion": "TLSv1_3"
 							},
 							"validationContext": {
 								"matchTypedSubjectAltNames": [{

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -34,18 +34,6 @@ import (
 
 const listenerBufferLimit uint32 = 32 * 1024
 
-var tlsParams = &envoy_extensions_transport_sockets_tls_v3.TlsParameters{
-	CipherSuites: []string{
-		"ECDHE-ECDSA-AES256-GCM-SHA384",
-		"ECDHE-RSA-AES256-GCM-SHA384",
-		"ECDHE-ECDSA-AES128-GCM-SHA256",
-		"ECDHE-RSA-AES128-GCM-SHA256",
-		"ECDHE-ECDSA-CHACHA20-POLY1305",
-		"ECDHE-RSA-CHACHA20-POLY1305",
-	},
-	TlsMinimumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_2,
-}
-
 // BuildListeners builds envoy listeners from the given config.
 func (b *Builder) BuildListeners(
 	ctx context.Context,
@@ -222,7 +210,7 @@ func (b *Builder) buildMetricsListener(cfg *config.Config) (*envoy_config_listen
 	if cert != nil {
 		dtc := &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{
 			CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
-				TlsParams: tlsParams,
+				TlsParams: tlsDownstreamParams,
 				TlsCertificates: []*envoy_extensions_transport_sockets_tls_v3.TlsCertificate{
 					b.envoyTLSCertificateFromGoTLSCertificate(context.TODO(), cert),
 				},
@@ -449,7 +437,7 @@ func (b *Builder) buildGRPCListener(ctx context.Context, cfg *config.Config) (*e
 	}
 	tlsContext := &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
-			TlsParams:       tlsParams,
+			TlsParams:       tlsDownstreamParams,
 			TlsCertificates: envoyCerts,
 			AlpnProtocols:   []string{"h2"}, // gRPC requires HTTP/2
 		},
@@ -558,7 +546,7 @@ func (b *Builder) buildDownstreamTLSContextMulti(
 	}
 	dtc := &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
-			TlsParams:       tlsParams,
+			TlsParams:       tlsDownstreamParams,
 			TlsCertificates: envoyCerts,
 			AlpnProtocols:   getALPNProtos(cfg.Options),
 		},

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -130,7 +130,8 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 						"ECDHE-ECDSA-CHACHA20-POLY1305",
 						"ECDHE-RSA-CHACHA20-POLY1305"
 					],
-					"tlsMinimumProtocolVersion": "TLSv1_2"
+					"tlsMinimumProtocolVersion": "TLSv1_2",
+					"tlsMaximumProtocolVersion": "TLSv1_3"
 				},
 				"alpnProtocols": ["h2", "http/1.1"]
 			}
@@ -154,7 +155,8 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 						"ECDHE-ECDSA-CHACHA20-POLY1305",
 						"ECDHE-RSA-CHACHA20-POLY1305"
 					],
-					"tlsMinimumProtocolVersion": "TLSv1_2"
+					"tlsMinimumProtocolVersion": "TLSv1_2",
+					"tlsMaximumProtocolVersion": "TLSv1_3"
 				},
 				"alpnProtocols": ["h2", "http/1.1"],
 				"validationContext": {
@@ -187,7 +189,8 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 						"ECDHE-ECDSA-CHACHA20-POLY1305",
 						"ECDHE-RSA-CHACHA20-POLY1305"
 					],
-					"tlsMinimumProtocolVersion": "TLSv1_2"
+					"tlsMinimumProtocolVersion": "TLSv1_2",
+					"tlsMaximumProtocolVersion": "TLSv1_3"
 				},
 				"alpnProtocols": ["h2", "http/1.1"],
 				"validationContext": {
@@ -223,7 +226,8 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 						"ECDHE-ECDSA-CHACHA20-POLY1305",
 						"ECDHE-RSA-CHACHA20-POLY1305"
 					],
-					"tlsMinimumProtocolVersion": "TLSv1_2"
+					"tlsMinimumProtocolVersion": "TLSv1_2",
+					"tlsMaximumProtocolVersion": "TLSv1_3"
 				},
 				"alpnProtocols": ["h2", "http/1.1"],
 				"validationContext": {
@@ -360,7 +364,8 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 						"ECDHE-ECDSA-CHACHA20-POLY1305",
 						"ECDHE-RSA-CHACHA20-POLY1305"
 					],
-					"tlsMinimumProtocolVersion": "TLSv1_2"
+					"tlsMinimumProtocolVersion": "TLSv1_2",
+					"tlsMaximumProtocolVersion": "TLSv1_3"
 				},
 				"alpnProtocols": ["http/1.1"]
 			}
@@ -385,7 +390,8 @@ func Test_buildDownstreamTLSContext(t *testing.T) {
 						"ECDHE-ECDSA-CHACHA20-POLY1305",
 						"ECDHE-RSA-CHACHA20-POLY1305"
 					],
-					"tlsMinimumProtocolVersion": "TLSv1_2"
+					"tlsMinimumProtocolVersion": "TLSv1_2",
+					"tlsMaximumProtocolVersion": "TLSv1_3"
 				},
 				"alpnProtocols": ["h2"]
 			}

--- a/config/envoyconfig/testdata/metrics_http_connection_manager.json
+++ b/config/envoyconfig/testdata/metrics_http_connection_manager.json
@@ -72,7 +72,8 @@
                 "ECDHE-ECDSA-CHACHA20-POLY1305",
                 "ECDHE-RSA-CHACHA20-POLY1305"
               ],
-              "tlsMinimumProtocolVersion": "TLSv1_2"
+              "tlsMinimumProtocolVersion": "TLSv1_2",
+              "tlsMaximumProtocolVersion": "TLSv1_3"
             },
             "alpnProtocols": ["h2", "http/1.1"],
             "tlsCertificates": [

--- a/config/envoyconfig/tls.go
+++ b/config/envoyconfig/tls.go
@@ -14,6 +14,47 @@ import (
 	envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 )
 
+var (
+	tlsDownstreamParams = &envoy_extensions_transport_sockets_tls_v3.TlsParameters{
+		CipherSuites: []string{
+			"ECDHE-ECDSA-AES256-GCM-SHA384",
+			"ECDHE-RSA-AES256-GCM-SHA384",
+			"ECDHE-ECDSA-AES128-GCM-SHA256",
+			"ECDHE-RSA-AES128-GCM-SHA256",
+			"ECDHE-ECDSA-CHACHA20-POLY1305",
+			"ECDHE-RSA-CHACHA20-POLY1305",
+		},
+		TlsMinimumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_2,
+		TlsMaximumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_3,
+	}
+	tlsUpstreamParams = &envoy_extensions_transport_sockets_tls_v3.TlsParameters{
+		CipherSuites: []string{
+			"ECDHE-ECDSA-AES256-GCM-SHA384",
+			"ECDHE-RSA-AES256-GCM-SHA384",
+			"ECDHE-ECDSA-AES128-GCM-SHA256",
+			"ECDHE-RSA-AES128-GCM-SHA256",
+			"ECDHE-ECDSA-CHACHA20-POLY1305",
+			"ECDHE-RSA-CHACHA20-POLY1305",
+			"ECDHE-ECDSA-AES128-SHA",
+			"ECDHE-RSA-AES128-SHA",
+			"AES128-GCM-SHA256",
+			"AES128-SHA",
+			"ECDHE-ECDSA-AES256-SHA",
+			"ECDHE-RSA-AES256-SHA",
+			"AES256-GCM-SHA384",
+			"AES256-SHA",
+		},
+		EcdhCurves: []string{
+			"X25519",
+			"P-256",
+			"P-384",
+			"P-521",
+		},
+		TlsMinimumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_2,
+		TlsMaximumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_3,
+	}
+)
+
 var oidMustStaple = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}
 
 func (b *Builder) buildSubjectAltNameMatcher(


### PR DESCRIPTION
## Summary
By default envoy only allows TLS v1.2 for upstream connections. This PR updates the cluster config in envoy to support TLS v1.3 as well.

## Related issues
- https://github.com/pomerium/pomerium/issues/5247
 

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
