### PR TITLE
core/ui: no-cache html, force back

### DIFF
--- a/ui/embed.go
+++ b/ui/embed.go
@@ -52,7 +52,8 @@ func ServePage(w http.ResponseWriter, r *http.Request, page, title string, data 
 		return err
 	}
 
-	http.ServeContent(w, r, "index.html", time.Now(), bytes.NewReader(bs))
+	w.Header().Set("Cache-Control", "no-cache, must-revalidate")
+	http.ServeContent(w, r, "index.html", time.Time{}, bytes.NewReader(bs))
 	return nil
 }
 

--- a/ui/src/components/SignOutConfirmPage.tsx
+++ b/ui/src/components/SignOutConfirmPage.tsx
@@ -17,7 +17,11 @@ type SignOutConfirmPageProps = {
 const SignOutConfirmPage: FC<SignOutConfirmPageProps> = ({ data }) => {
   function handleClickCancel(evt: React.MouseEvent) {
     evt.preventDefault();
-    history.back();
+    if (document.referrer) {
+      location.href = document.referrer;
+    } else {
+      history.back();
+    }
   }
 
   function handleClickLogout(evt: React.MouseEvent) {


### PR DESCRIPTION
## Summary
The UI HTML page should not be cached as it contains data that changes frequently. I don't think it was being cached, since we used `time.Now`, but now we explicitly set the `Cache-Control` header to make sure it doesn't get cached.

Also update the `history.back` so that it will reload the page if you cancel the logout.

## Related issues
- https://github.com/pomerium/pomerium-console/issues/3968

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
