### PR TITLE
zero/k8s: set externalTrafficPolicy: Local

### DIFF
--- a/k8s/zero/service/proxy.yaml
+++ b/k8s/zero/service/proxy.yaml
@@ -4,6 +4,7 @@ metadata:
   name: pomerium-proxy
 spec:
   type: LoadBalancer
+  externalTrafficPolicy: Local
   ports:
     - port: 443
       targetPort: https


### PR DESCRIPTION
## Summary

Allow preserving the original client IP address by default when deploying to Kubernetes in Zero managed mode. 

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Related: https://github.com/pomerium/pomerium/issues/5265

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
