### PR TITLE
ci: update k8s manifests before v0.27.0 release

### DIFF
--- a/k8s/zero/deployment/image.yaml
+++ b/k8s/zero/deployment/image.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         - name: pomerium
-          image: pomerium/pomerium:main
-          imagePullPolicy: Always
+          image: pomerium/pomerium:v0.27.0
+          imagePullPolicy: IfNotFound


### PR DESCRIPTION
## Summary

Set image to `v0.27.0` for zero kubernetes manifests. 

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
