### PR TITLE
add v0.27.0 changelog

### DIFF
--- a/changelogs/v0.27.0.md
+++ b/changelogs/v0.27.0.md
@@ -1,0 +1,90 @@
+## What's Changed
+
+### Breaking
+* proxy: deprecate the /.pomerium/jwt endpoint by @kenjenkins in https://github.com/pomerium/pomerium/pull/5254
+* zero/k8s: use Deployment instead of StatefulSet by @wasaga in https://github.com/pomerium/pomerium/pull/5248
+
+### New
+* authorize: use uuid for jti, current time for iat and exp by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5147
+* config: add runtime flag to allow disabling config hot-reload (#5079) by @kralicky in https://github.com/pomerium/pomerium/pull/5112
+* config: add mTLS UserPrincipalName SAN match by @kenjenkins in https://github.com/pomerium/pomerium/pull/5177
+* config: allow overriding port numbers using environment variables by @kralicky in https://github.com/pomerium/pomerium/pull/5194
+* config: add `databroker_storage_connection_string_file` by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5242
+* envoy: resource monitoring & overload manager configuration by @kralicky in https://github.com/pomerium/pomerium/pull/5106
+* envoy: allow TLS 1.3 for upstream connections by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5263
+* envoy: support http2 prior knowledge for insecure upstream targets (h2c://) by @kralicky in https://github.com/pomerium/pomerium/pull/5205
+* envoy: log TLS connection failures in the mTLS `reject_connection` mode by @kralicky in https://github.com/pomerium/pomerium/pull/5210
+* ui: add "Policy ID" label to error details page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5127
+* ui: user info dashboard improvements by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5128
+* ui: add user info link to error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5158
+* ui: add request id to upstream error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5166
+* zero/connect: add re-run health checks command by @wasaga in https://github.com/pomerium/pomerium/pull/5219
+* zero/k8s: write bootstrap configuration to a secret by @kralicky in https://github.com/pomerium/pomerium/pull/5114
+
+### Fixes
+* authorize: require new login when authenticate url changes by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5165
+* controlplane: avoid calling Close on nil listener by @kenjenkins in https://github.com/pomerium/pomerium/pull/5156
+* databroker/leaser: set timeout on ReleaseLease by @wasaga in https://github.com/pomerium/pomerium/pull/5208
+* logging: add support for using the standard grpc env vars to control log severity and verbosity by @kralicky in https://github.com/pomerium/pomerium/pull/5120
+* session: do not invalidate based on ID token by @kenjenkins in https://github.com/pomerium/pomerium/pull/5182
+* ui: fix cycle in profile data by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5168
+* ui: set Cache-Control: no-cache, tweak sign-out cancel button behavior by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5264
+* zero/connect: ignore unknown message types by @wasaga in https://github.com/pomerium/pomerium/pull/5223
+* zero/health-checks: fix early checks sometimes missing by @wasaga in https://github.com/pomerium/pomerium/pull/5229
+* zero/health-checks: zero route availability improvements by @wasaga in https://github.com/pomerium/pomerium/pull/5111
+
+### Changed
+* authenticate: rework session ID token handling by @kenjenkins in https://github.com/pomerium/pomerium/pull/5178
+* authorize: add request-id to error messages by @wasaga in https://github.com/pomerium/pomerium/pull/5267
+* ci: do not include timestamp into buildmeta by @wasaga in https://github.com/pomerium/pomerium/pull/5215
+* config: optimize policy iterators by @kralicky in https://github.com/pomerium/pomerium/pull/5184
+* config: sort runtime flags, name consistency by @kenjenkins in https://github.com/pomerium/pomerium/pull/5255
+* envoy: upgrade to v1.31.0 by @kenjenkins in https://github.com/pomerium/pomerium/pull/5183
+* github: update README.md by @cmo-pomerium in https://github.com/pomerium/pomerium/pull/5163
+* github: update README.md by @nikhil-pomerium in https://github.com/pomerium/pomerium/pull/5253
+* go: update to Go 1.23 by @kralicky in https://github.com/pomerium/pomerium/pull/5216
+* logging: convert warnings to info or error by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5235
+* logging: change log.Error function by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5251
+* proto: update protoc dependencies by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5218
+* ui: update logo by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5249
+* zero: refactor controller by @wasaga in https://github.com/pomerium/pomerium/pull/5134
+* zero/api: switch to github.com/oapi-codegen/oapi-codegen by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5226
+* zero/api: reset token and url cache if 401 is received by @wasaga in https://github.com/pomerium/pomerium/pull/5256
+* zero/api: generate error methods for response types by @kralicky in https://github.com/pomerium/pomerium/pull/5252
+* zero/bundle-download: update metadata by @wasaga in https://github.com/pomerium/pomerium/pull/5212
+* zero/cmd: make it more evident what caused shutdown by @wasaga in https://github.com/pomerium/pomerium/pull/5209
+* zero/connect: add telemetry request command by @wasaga in https://github.com/pomerium/pomerium/pull/5131
+* zero/telemetry: add prometheus streaming converter to OTLP by @wasaga in https://github.com/pomerium/pomerium/pull/5132
+* zero/telemetry: refactor telemetry and controller by @wasaga in https://github.com/pomerium/pomerium/pull/5135
+* zero/telemetry: internal envoy stats scraper and metrics producer by @wasaga in https://github.com/pomerium/pomerium/pull/5136
+* zero/telemetry: collect limited core metrics by @wasaga in https://github.com/pomerium/pomerium/pull/5142
+* zero/telemetry: add hostname and version by @wasaga in https://github.com/pomerium/pomerium/pull/5146
+* zero/k8s: set externalTrafficPolicy: Local by @wasaga in https://github.com/pomerium/pomerium/pull/5266
+
+### Dependency Updates
+* chore(deps): bump the docker group in /.github with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5124
+* chore(deps): bump the github-actions group with 9 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5121
+* chore(deps): bump the docker group with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5123
+* chore(deps): bump the go group with 27 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5122
+* chore(deps): bump braces from 3.0.2 to 3.0.3 in /ui by @dependabot in https://github.com/pomerium/pomerium/pull/5139
+* chore(deps): bump busybox from `5eef5ed` to `9ae97d3` in /.github in the docker group by @dependabot in https://github.com/pomerium/pomerium/pull/5161
+* chore(deps): bump the github-actions group with 4 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5160
+* chore(deps): bump the docker group with 2 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5159
+* chore(deps): bump the go group with 21 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5162
+* chore(deps): bump google.golang.org/grpc from 1.64.0 to 1.64.1 by @dependabot in https://github.com/pomerium/pomerium/pull/5169
+* chore(deps): bump github.com/docker/docker from 27.0.3+incompatible to 27.1.0+incompatible by @dependabot in https://github.com/pomerium/pomerium/pull/5193
+* chore(deps): bump the docker group with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5201
+* chore(deps): bump the github-actions group with 9 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5200
+* chore(deps): bump the go group across 1 directory with 26 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5207
+* chore(deps): bump the docker group in /.github with 2 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5202
+* Replace usages of x/exp/maps + bump golang.org/x/exp by @kralicky in https://github.com/pomerium/pomerium/pull/5221
+* chore(deps): bump micromatch from 4.0.5 to 4.0.8 in /ui by @dependabot in https://github.com/pomerium/pomerium/pull/5240
+* chore(deps): bump busybox from `9ae97d3` to `8274294` in /.github in the docker group by @dependabot in https://github.com/pomerium/pomerium/pull/5260
+* chore(deps): bump the github-actions group with 6 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5259
+* chore(deps): bump the docker group with 2 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5258
+* chore(deps): bump github.com/opencontainers/runc from 1.1.12 to 1.1.14 by @dependabot in https://github.com/pomerium/pomerium/pull/5261
+* chore(deps): bump the go group across 1 directory with 28 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5262
+
+## New Contributors
+* @kralicky made their first contribution in https://github.com/pomerium/pomerium/pull/5116
+* @nikhil-pomerium made their first contribution in https://github.com/pomerium/pomerium/pull/5253

--- a/changelogs/v0.27.0.md
+++ b/changelogs/v0.27.0.md
@@ -1,90 +1,86 @@
 ## What's Changed
 
 ### Breaking
-* proxy: deprecate the /.pomerium/jwt endpoint by @kenjenkins in https://github.com/pomerium/pomerium/pull/5254
-* zero/k8s: use Deployment instead of StatefulSet by @wasaga in https://github.com/pomerium/pomerium/pull/5248
+* **proxy** deprecate the /.pomerium/jwt endpoint by @kenjenkins in https://github.com/pomerium/pomerium/pull/5254
+* **zero/k8s** use Deployment instead of StatefulSet by @wasaga in https://github.com/pomerium/pomerium/pull/5248
 
 ### New
-* authorize: use uuid for jti, current time for iat and exp by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5147
-* config: add runtime flag to allow disabling config hot-reload (#5079) by @kralicky in https://github.com/pomerium/pomerium/pull/5112
-* config: add mTLS UserPrincipalName SAN match by @kenjenkins in https://github.com/pomerium/pomerium/pull/5177
-* config: allow overriding port numbers using environment variables by @kralicky in https://github.com/pomerium/pomerium/pull/5194
-* config: add `databroker_storage_connection_string_file` by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5242
-* envoy: resource monitoring & overload manager configuration by @kralicky in https://github.com/pomerium/pomerium/pull/5106
-* envoy: allow TLS 1.3 for upstream connections by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5263
-* envoy: support http2 prior knowledge for insecure upstream targets (h2c://) by @kralicky in https://github.com/pomerium/pomerium/pull/5205
-* envoy: log TLS connection failures in the mTLS `reject_connection` mode by @kralicky in https://github.com/pomerium/pomerium/pull/5210
-* ui: add "Policy ID" label to error details page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5127
-* ui: user info dashboard improvements by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5128
-* ui: add user info link to error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5158
-* ui: add request id to upstream error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5166
-* zero/connect: add re-run health checks command by @wasaga in https://github.com/pomerium/pomerium/pull/5219
-* zero/k8s: write bootstrap configuration to a secret by @kralicky in https://github.com/pomerium/pomerium/pull/5114
+* **authorize** use uuid for jti, current time for iat and exp by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5147
+* **config** add runtime flag to allow disabling config hot-reload (#5079) by @kralicky in https://github.com/pomerium/pomerium/pull/5112
+* **config** add mTLS UserPrincipalName SAN match by @kenjenkins in https://github.com/pomerium/pomerium/pull/5177
+* **config** allow overriding port numbers using environment variables by @kralicky in https://github.com/pomerium/pomerium/pull/5194
+* **config** add `databroker_storage_connection_string_file` by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5242
+* **envoy** resource monitoring & overload manager configuration by @kralicky in https://github.com/pomerium/pomerium/pull/5106
+* **envoy** allow TLS 1.3 for upstream connections by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5263
+* **envoy** support http2 prior knowledge for insecure upstream targets (h2c://) by @kralicky in https://github.com/pomerium/pomerium/pull/5205
+* **envoy** log TLS connection failures in the mTLS `reject_connection` mode by @kralicky in https://github.com/pomerium/pomerium/pull/5210
+* **ui** add "Policy ID" label to error details page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5127
+* **ui** user info dashboard improvements by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5128
+* **ui** add user info link to error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5158
+* **ui** add request id to upstream error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5166
+* **zero/connect** add re-run health checks command by @wasaga in https://github.com/pomerium/pomerium/pull/5219
+* **zero/k8s** write bootstrap configuration to a secret by @kralicky in https://github.com/pomerium/pomerium/pull/5114
 
 ### Fixes
-* authorize: require new login when authenticate url changes by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5165
-* controlplane: avoid calling Close on nil listener by @kenjenkins in https://github.com/pomerium/pomerium/pull/5156
-* databroker/leaser: set timeout on ReleaseLease by @wasaga in https://github.com/pomerium/pomerium/pull/5208
-* logging: add support for using the standard grpc env vars to control log severity and verbosity by @kralicky in https://github.com/pomerium/pomerium/pull/5120
-* session: do not invalidate based on ID token by @kenjenkins in https://github.com/pomerium/pomerium/pull/5182
-* ui: fix cycle in profile data by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5168
-* ui: set Cache-Control: no-cache, tweak sign-out cancel button behavior by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5264
-* zero/connect: ignore unknown message types by @wasaga in https://github.com/pomerium/pomerium/pull/5223
-* zero/health-checks: fix early checks sometimes missing by @wasaga in https://github.com/pomerium/pomerium/pull/5229
-* zero/health-checks: zero route availability improvements by @wasaga in https://github.com/pomerium/pomerium/pull/5111
+* **authorize** require new login when authenticate url changes by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5165
+* **controlplane** avoid calling Close on nil listener by @kenjenkins in https://github.com/pomerium/pomerium/pull/5156
+* **databroker/leaser** set timeout on ReleaseLease by @wasaga in https://github.com/pomerium/pomerium/pull/5208
+* **logging** add support for using the standard grpc env vars to control log severity and verbosity by @kralicky in https://github.com/pomerium/pomerium/pull/5120
+* **session** do not invalidate based on ID token by @kenjenkins in https://github.com/pomerium/pomerium/pull/5182
+* **ui** fix cycle in profile data by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5168
+* **ui** set Cache-Control: no-cache, tweak sign-out cancel button behavior by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5264
+* **zero/connect** ignore unknown message types by @wasaga in https://github.com/pomerium/pomerium/pull/5223
+* **zero/health-checks** fix early checks sometimes missing by @wasaga in https://github.com/pomerium/pomerium/pull/5229
+* **zero/health-checks** zero route availability improvements by @wasaga in https://github.com/pomerium/pomerium/pull/5111
 
 ### Changed
-* authenticate: rework session ID token handling by @kenjenkins in https://github.com/pomerium/pomerium/pull/5178
-* authorize: add request-id to error messages by @wasaga in https://github.com/pomerium/pomerium/pull/5267
-* ci: do not include timestamp into buildmeta by @wasaga in https://github.com/pomerium/pomerium/pull/5215
-* config: optimize policy iterators by @kralicky in https://github.com/pomerium/pomerium/pull/5184
-* config: sort runtime flags, name consistency by @kenjenkins in https://github.com/pomerium/pomerium/pull/5255
-* envoy: upgrade to v1.31.0 by @kenjenkins in https://github.com/pomerium/pomerium/pull/5183
-* github: update README.md by @cmo-pomerium in https://github.com/pomerium/pomerium/pull/5163
-* github: update README.md by @nikhil-pomerium in https://github.com/pomerium/pomerium/pull/5253
-* go: update to Go 1.23 by @kralicky in https://github.com/pomerium/pomerium/pull/5216
-* logging: convert warnings to info or error by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5235
-* logging: change log.Error function by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5251
-* proto: update protoc dependencies by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5218
-* ui: update logo by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5249
-* zero: refactor controller by @wasaga in https://github.com/pomerium/pomerium/pull/5134
-* zero/api: switch to github.com/oapi-codegen/oapi-codegen by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5226
-* zero/api: reset token and url cache if 401 is received by @wasaga in https://github.com/pomerium/pomerium/pull/5256
-* zero/api: generate error methods for response types by @kralicky in https://github.com/pomerium/pomerium/pull/5252
-* zero/bundle-download: update metadata by @wasaga in https://github.com/pomerium/pomerium/pull/5212
-* zero/cmd: make it more evident what caused shutdown by @wasaga in https://github.com/pomerium/pomerium/pull/5209
-* zero/connect: add telemetry request command by @wasaga in https://github.com/pomerium/pomerium/pull/5131
-* zero/telemetry: add prometheus streaming converter to OTLP by @wasaga in https://github.com/pomerium/pomerium/pull/5132
-* zero/telemetry: refactor telemetry and controller by @wasaga in https://github.com/pomerium/pomerium/pull/5135
-* zero/telemetry: internal envoy stats scraper and metrics producer by @wasaga in https://github.com/pomerium/pomerium/pull/5136
-* zero/telemetry: collect limited core metrics by @wasaga in https://github.com/pomerium/pomerium/pull/5142
-* zero/telemetry: add hostname and version by @wasaga in https://github.com/pomerium/pomerium/pull/5146
-* zero/k8s: set externalTrafficPolicy: Local by @wasaga in https://github.com/pomerium/pomerium/pull/5266
+* **authenticate** rework session ID token handling by @kenjenkins in https://github.com/pomerium/pomerium/pull/5178
+* **authorize** add request-id to error messages by @wasaga in https://github.com/pomerium/pomerium/pull/5267
+* **ci** do not include timestamp into buildmeta by @wasaga in https://github.com/pomerium/pomerium/pull/5215
+* **config** optimize policy iterators by @kralicky in https://github.com/pomerium/pomerium/pull/5184
+* **config** sort runtime flags, name consistency by @kenjenkins in https://github.com/pomerium/pomerium/pull/5255
+* **envoy** upgrade to v1.31.0 by @kenjenkins in https://github.com/pomerium/pomerium/pull/5183
+* **github** update README.md by @cmo-pomerium in https://github.com/pomerium/pomerium/pull/5163
+* **github** update README.md by @nikhil-pomerium in https://github.com/pomerium/pomerium/pull/5253
+* **go** update to Go 1.23 by @kralicky in https://github.com/pomerium/pomerium/pull/5216
+* **logging** convert warnings to info or error by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5235
+* **logging** change log.Error function by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5251
+* **proto** update protoc dependencies by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5218
+* **ui** update logo by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5249
+* **zero** refactor controller by @wasaga in https://github.com/pomerium/pomerium/pull/5134
+* **zero/api** switch to github.com/oapi-codegen/oapi-codegen by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5226
+* **zero/api** reset token and url cache if 401 is received by @wasaga in https://github.com/pomerium/pomerium/pull/5256
+* **zero/api** generate error methods for response types by @kralicky in https://github.com/pomerium/pomerium/pull/5252
+* **zero/bundle-download** update metadata by @wasaga in https://github.com/pomerium/pomerium/pull/5212
+* **zero/cmd** make it more evident what caused shutdown by @wasaga in https://github.com/pomerium/pomerium/pull/5209
+* **zero/connect** add telemetry request command by @wasaga in https://github.com/pomerium/pomerium/pull/5131
+* **zero/telemetry** add prometheus streaming converter to OTLP by @wasaga in https://github.com/pomerium/pomerium/pull/5132
+* **zero/telemetry** refactor telemetry and controller by @wasaga in https://github.com/pomerium/pomerium/pull/5135
+* **zero/telemetry** internal envoy stats scraper and metrics producer by @wasaga in https://github.com/pomerium/pomerium/pull/5136
+* **zero/telemetry** collect limited core metrics by @wasaga in https://github.com/pomerium/pomerium/pull/5142
+* **zero/telemetry** add hostname and version by @wasaga in https://github.com/pomerium/pomerium/pull/5146
+* **zero/k8s** set externalTrafficPolicy: Local by @wasaga in https://github.com/pomerium/pomerium/pull/5266
 
 ### Dependency Updates
-* chore(deps): bump the docker group in /.github with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5124
-* chore(deps): bump the github-actions group with 9 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5121
-* chore(deps): bump the docker group with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5123
-* chore(deps): bump the go group with 27 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5122
-* chore(deps): bump braces from 3.0.2 to 3.0.3 in /ui by @dependabot in https://github.com/pomerium/pomerium/pull/5139
-* chore(deps): bump busybox from `5eef5ed` to `9ae97d3` in /.github in the docker group by @dependabot in https://github.com/pomerium/pomerium/pull/5161
-* chore(deps): bump the github-actions group with 4 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5160
-* chore(deps): bump the docker group with 2 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5159
-* chore(deps): bump the go group with 21 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5162
-* chore(deps): bump google.golang.org/grpc from 1.64.0 to 1.64.1 by @dependabot in https://github.com/pomerium/pomerium/pull/5169
-* chore(deps): bump github.com/docker/docker from 27.0.3+incompatible to 27.1.0+incompatible by @dependabot in https://github.com/pomerium/pomerium/pull/5193
-* chore(deps): bump the docker group with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5201
-* chore(deps): bump the github-actions group with 9 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5200
-* chore(deps): bump the go group across 1 directory with 26 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5207
-* chore(deps): bump the docker group in /.github with 2 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5202
-* Replace usages of x/exp/maps + bump golang.org/x/exp by @kralicky in https://github.com/pomerium/pomerium/pull/5221
-* chore(deps): bump micromatch from 4.0.5 to 4.0.8 in /ui by @dependabot in https://github.com/pomerium/pomerium/pull/5240
-* chore(deps): bump busybox from `9ae97d3` to `8274294` in /.github in the docker group by @dependabot in https://github.com/pomerium/pomerium/pull/5260
-* chore(deps): bump the github-actions group with 6 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5259
-* chore(deps): bump the docker group with 2 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5258
-* chore(deps): bump github.com/opencontainers/runc from 1.1.12 to 1.1.14 by @dependabot in https://github.com/pomerium/pomerium/pull/5261
-* chore(deps): bump the go group across 1 directory with 28 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5262
-
-## New Contributors
-* @kralicky made their first contribution in https://github.com/pomerium/pomerium/pull/5116
-* @nikhil-pomerium made their first contribution in https://github.com/pomerium/pomerium/pull/5253
+* bump the docker group in /.github with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5124
+* bump the github-actions group with 9 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5121
+* bump the docker group with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5123
+* bump the go group with 27 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5122
+* bump braces from 3.0.2 to 3.0.3 in /ui by @dependabot in https://github.com/pomerium/pomerium/pull/5139
+* bump busybox from `5eef5ed` to `9ae97d3` in /.github in the docker group by @dependabot in https://github.com/pomerium/pomerium/pull/5161
+* bump the github-actions group with 4 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5160
+* bump the docker group with 2 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5159
+* bump the go group with 21 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5162
+* bump google.golang.org/grpc from 1.64.0 to 1.64.1 by @dependabot in https://github.com/pomerium/pomerium/pull/5169
+* bump github.com/docker/docker from 27.0.3+incompatible to 27.1.0+incompatible by @dependabot in https://github.com/pomerium/pomerium/pull/5193
+* bump the docker group with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5201
+* bump the github-actions group with 9 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5200
+* bump the go group across 1 directory with 26 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5207
+* bump the docker group in /.github with 2 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5202
+* replace usages of x/exp/maps + bump golang.org/x/exp by @kralicky in https://github.com/pomerium/pomerium/pull/5221
+* bump micromatch from 4.0.5 to 4.0.8 in /ui by @dependabot in https://github.com/pomerium/pomerium/pull/5240
+* bump busybox from `9ae97d3` to `8274294` in /.github in the docker group by @dependabot in https://github.com/pomerium/pomerium/pull/5260
+* bump the github-actions group with 6 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5259
+* bump the docker group with 2 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5258
+* bump github.com/opencontainers/runc from 1.1.12 to 1.1.14 by @dependabot in https://github.com/pomerium/pomerium/pull/5261
+* bump the go group across 1 directory with 28 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5262

--- a/changelogs/v0.27.0.md
+++ b/changelogs/v0.27.0.md
@@ -9,7 +9,6 @@
 * **config**: add `databroker_storage_connection_string_file` by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5242
 * **config**: add mTLS UserPrincipalName SAN match by @kenjenkins in https://github.com/pomerium/pomerium/pull/5177
 * **config**: add runtime flag to allow disabling config hot-reload (#5079) by @kralicky in https://github.com/pomerium/pomerium/pull/5112
-* **config**: allow overriding port numbers using environment variables by @kralicky in https://github.com/pomerium/pomerium/pull/5194
 * **envoy**: allow TLS 1.3 for upstream connections by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5263
 * **envoy**: log TLS connection failures in the mTLS `reject_connection` mode by @kralicky in https://github.com/pomerium/pomerium/pull/5210
 * **envoy**: resource monitoring & overload manager configuration by @kralicky in https://github.com/pomerium/pomerium/pull/5106

--- a/changelogs/v0.27.0.md
+++ b/changelogs/v0.27.0.md
@@ -6,18 +6,18 @@
 
 ### New
 * **authorize** use uuid for jti, current time for iat and exp by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5147
-* **config** add runtime flag to allow disabling config hot-reload (#5079) by @kralicky in https://github.com/pomerium/pomerium/pull/5112
-* **config** add mTLS UserPrincipalName SAN match by @kenjenkins in https://github.com/pomerium/pomerium/pull/5177
-* **config** allow overriding port numbers using environment variables by @kralicky in https://github.com/pomerium/pomerium/pull/5194
 * **config** add `databroker_storage_connection_string_file` by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5242
-* **envoy** resource monitoring & overload manager configuration by @kralicky in https://github.com/pomerium/pomerium/pull/5106
+* **config** add mTLS UserPrincipalName SAN match by @kenjenkins in https://github.com/pomerium/pomerium/pull/5177
+* **config** add runtime flag to allow disabling config hot-reload (#5079) by @kralicky in https://github.com/pomerium/pomerium/pull/5112
+* **config** allow overriding port numbers using environment variables by @kralicky in https://github.com/pomerium/pomerium/pull/5194
 * **envoy** allow TLS 1.3 for upstream connections by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5263
-* **envoy** support http2 prior knowledge for insecure upstream targets (h2c://) by @kralicky in https://github.com/pomerium/pomerium/pull/5205
 * **envoy** log TLS connection failures in the mTLS `reject_connection` mode by @kralicky in https://github.com/pomerium/pomerium/pull/5210
+* **envoy** resource monitoring & overload manager configuration by @kralicky in https://github.com/pomerium/pomerium/pull/5106
+* **envoy** support http2 prior knowledge for insecure upstream targets (h2c://) by @kralicky in https://github.com/pomerium/pomerium/pull/5205
 * **ui** add "Policy ID" label to error details page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5127
-* **ui** user info dashboard improvements by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5128
-* **ui** add user info link to error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5158
 * **ui** add request id to upstream error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5166
+* **ui** add user info link to error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5158
+* **ui** user info dashboard improvements by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5128
 * **zero/connect** add re-run health checks command by @wasaga in https://github.com/pomerium/pomerium/pull/5219
 * **zero/k8s** write bootstrap configuration to a secret by @kralicky in https://github.com/pomerium/pomerium/pull/5114
 
@@ -43,23 +43,23 @@
 * **github** update README.md by @cmo-pomerium in https://github.com/pomerium/pomerium/pull/5163
 * **github** update README.md by @nikhil-pomerium in https://github.com/pomerium/pomerium/pull/5253
 * **go** update to Go 1.23 by @kralicky in https://github.com/pomerium/pomerium/pull/5216
-* **logging** convert warnings to info or error by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5235
 * **logging** change log.Error function by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5251
+* **logging** convert warnings to info or error by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5235
 * **proto** update protoc dependencies by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5218
 * **ui** update logo by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5249
 * **zero** refactor controller by @wasaga in https://github.com/pomerium/pomerium/pull/5134
-* **zero/api** switch to github.com/oapi-codegen/oapi-codegen by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5226
-* **zero/api** reset token and url cache if 401 is received by @wasaga in https://github.com/pomerium/pomerium/pull/5256
 * **zero/api** generate error methods for response types by @kralicky in https://github.com/pomerium/pomerium/pull/5252
+* **zero/api** reset token and url cache if 401 is received by @wasaga in https://github.com/pomerium/pomerium/pull/5256
+* **zero/api** switch to github.com/oapi-codegen/oapi-codegen by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5226
 * **zero/bundle-download** update metadata by @wasaga in https://github.com/pomerium/pomerium/pull/5212
 * **zero/cmd** make it more evident what caused shutdown by @wasaga in https://github.com/pomerium/pomerium/pull/5209
 * **zero/connect** add telemetry request command by @wasaga in https://github.com/pomerium/pomerium/pull/5131
-* **zero/telemetry** add prometheus streaming converter to OTLP by @wasaga in https://github.com/pomerium/pomerium/pull/5132
-* **zero/telemetry** refactor telemetry and controller by @wasaga in https://github.com/pomerium/pomerium/pull/5135
-* **zero/telemetry** internal envoy stats scraper and metrics producer by @wasaga in https://github.com/pomerium/pomerium/pull/5136
-* **zero/telemetry** collect limited core metrics by @wasaga in https://github.com/pomerium/pomerium/pull/5142
-* **zero/telemetry** add hostname and version by @wasaga in https://github.com/pomerium/pomerium/pull/5146
 * **zero/k8s** set externalTrafficPolicy: Local by @wasaga in https://github.com/pomerium/pomerium/pull/5266
+* **zero/telemetry** add hostname and version by @wasaga in https://github.com/pomerium/pomerium/pull/5146
+* **zero/telemetry** add prometheus streaming converter to OTLP by @wasaga in https://github.com/pomerium/pomerium/pull/5132
+* **zero/telemetry** collect limited core metrics by @wasaga in https://github.com/pomerium/pomerium/pull/5142
+* **zero/telemetry** internal envoy stats scraper and metrics producer by @wasaga in https://github.com/pomerium/pomerium/pull/5136
+* **zero/telemetry** refactor telemetry and controller by @wasaga in https://github.com/pomerium/pomerium/pull/5135
 
 ### Dependency Updates
 * bump the docker group in /.github with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5124

--- a/changelogs/v0.27.0.md
+++ b/changelogs/v0.27.0.md
@@ -1,65 +1,65 @@
 ## What's Changed
 
 ### Breaking
-* **proxy** deprecate the /.pomerium/jwt endpoint by @kenjenkins in https://github.com/pomerium/pomerium/pull/5254
-* **zero/k8s** use Deployment instead of StatefulSet by @wasaga in https://github.com/pomerium/pomerium/pull/5248
+* **proxy**: deprecate the /.pomerium/jwt endpoint by @kenjenkins in https://github.com/pomerium/pomerium/pull/5254
+* **zero/k8s**: use Deployment instead of StatefulSet by @wasaga in https://github.com/pomerium/pomerium/pull/5248
 
 ### New
-* **authorize** use uuid for jti, current time for iat and exp by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5147
-* **config** add `databroker_storage_connection_string_file` by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5242
-* **config** add mTLS UserPrincipalName SAN match by @kenjenkins in https://github.com/pomerium/pomerium/pull/5177
-* **config** add runtime flag to allow disabling config hot-reload (#5079) by @kralicky in https://github.com/pomerium/pomerium/pull/5112
-* **config** allow overriding port numbers using environment variables by @kralicky in https://github.com/pomerium/pomerium/pull/5194
-* **envoy** allow TLS 1.3 for upstream connections by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5263
-* **envoy** log TLS connection failures in the mTLS `reject_connection` mode by @kralicky in https://github.com/pomerium/pomerium/pull/5210
-* **envoy** resource monitoring & overload manager configuration by @kralicky in https://github.com/pomerium/pomerium/pull/5106
-* **envoy** support http2 prior knowledge for insecure upstream targets (h2c://) by @kralicky in https://github.com/pomerium/pomerium/pull/5205
-* **ui** add "Policy ID" label to error details page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5127
-* **ui** add request id to upstream error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5166
-* **ui** add user info link to error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5158
-* **ui** user info dashboard improvements by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5128
-* **zero/connect** add re-run health checks command by @wasaga in https://github.com/pomerium/pomerium/pull/5219
-* **zero/k8s** write bootstrap configuration to a secret by @kralicky in https://github.com/pomerium/pomerium/pull/5114
+* **authorize**: use uuid for jti, current time for iat and exp by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5147
+* **config**: add `databroker_storage_connection_string_file` by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5242
+* **config**: add mTLS UserPrincipalName SAN match by @kenjenkins in https://github.com/pomerium/pomerium/pull/5177
+* **config**: add runtime flag to allow disabling config hot-reload (#5079) by @kralicky in https://github.com/pomerium/pomerium/pull/5112
+* **config**: allow overriding port numbers using environment variables by @kralicky in https://github.com/pomerium/pomerium/pull/5194
+* **envoy**: allow TLS 1.3 for upstream connections by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5263
+* **envoy**: log TLS connection failures in the mTLS `reject_connection` mode by @kralicky in https://github.com/pomerium/pomerium/pull/5210
+* **envoy**: resource monitoring & overload manager configuration by @kralicky in https://github.com/pomerium/pomerium/pull/5106
+* **envoy**: support http2 prior knowledge for insecure upstream targets (h2c://) by @kralicky in https://github.com/pomerium/pomerium/pull/5205
+* **ui**: add "Policy ID" label to error details page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5127
+* **ui**: add request id to upstream error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5166
+* **ui**: add user info link to error page by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5158
+* **ui**: user info dashboard improvements by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5128
+* **zero/connect**: add re-run health checks command by @wasaga in https://github.com/pomerium/pomerium/pull/5219
+* **zero/k8s**: write bootstrap configuration to a secret by @kralicky in https://github.com/pomerium/pomerium/pull/5114
 
 ### Fixes
-* **authorize** require new login when authenticate url changes by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5165
-* **controlplane** avoid calling Close on nil listener by @kenjenkins in https://github.com/pomerium/pomerium/pull/5156
-* **databroker/leaser** set timeout on ReleaseLease by @wasaga in https://github.com/pomerium/pomerium/pull/5208
-* **logging** add support for using the standard grpc env vars to control log severity and verbosity by @kralicky in https://github.com/pomerium/pomerium/pull/5120
-* **session** do not invalidate based on ID token by @kenjenkins in https://github.com/pomerium/pomerium/pull/5182
-* **ui** fix cycle in profile data by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5168
-* **ui** set Cache-Control: no-cache, tweak sign-out cancel button behavior by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5264
-* **zero/connect** ignore unknown message types by @wasaga in https://github.com/pomerium/pomerium/pull/5223
-* **zero/health-checks** fix early checks sometimes missing by @wasaga in https://github.com/pomerium/pomerium/pull/5229
-* **zero/health-checks** zero route availability improvements by @wasaga in https://github.com/pomerium/pomerium/pull/5111
+* **authorize**: require new login when authenticate url changes by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5165
+* **controlplane**: avoid calling Close on nil listener by @kenjenkins in https://github.com/pomerium/pomerium/pull/5156
+* **databroker/leaser**: set timeout on ReleaseLease by @wasaga in https://github.com/pomerium/pomerium/pull/5208
+* **logging**: add support for using the standard grpc env vars to control log severity and verbosity by @kralicky in https://github.com/pomerium/pomerium/pull/5120
+* **session**: do not invalidate based on ID token by @kenjenkins in https://github.com/pomerium/pomerium/pull/5182
+* **ui**: fix cycle in profile data by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5168
+* **ui**: set Cache-Control: no-cache, tweak sign-out cancel button behavior by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5264
+* **zero/connect**: ignore unknown message types by @wasaga in https://github.com/pomerium/pomerium/pull/5223
+* **zero/health-checks**: fix early checks sometimes missing by @wasaga in https://github.com/pomerium/pomerium/pull/5229
+* **zero/health-checks**: zero route availability improvements by @wasaga in https://github.com/pomerium/pomerium/pull/5111
 
 ### Changed
-* **authenticate** rework session ID token handling by @kenjenkins in https://github.com/pomerium/pomerium/pull/5178
-* **authorize** add request-id to error messages by @wasaga in https://github.com/pomerium/pomerium/pull/5267
-* **ci** do not include timestamp into buildmeta by @wasaga in https://github.com/pomerium/pomerium/pull/5215
-* **config** optimize policy iterators by @kralicky in https://github.com/pomerium/pomerium/pull/5184
-* **config** sort runtime flags, name consistency by @kenjenkins in https://github.com/pomerium/pomerium/pull/5255
-* **envoy** upgrade to v1.31.0 by @kenjenkins in https://github.com/pomerium/pomerium/pull/5183
-* **github** update README.md by @cmo-pomerium in https://github.com/pomerium/pomerium/pull/5163
-* **github** update README.md by @nikhil-pomerium in https://github.com/pomerium/pomerium/pull/5253
-* **go** update to Go 1.23 by @kralicky in https://github.com/pomerium/pomerium/pull/5216
-* **logging** change log.Error function by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5251
-* **logging** convert warnings to info or error by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5235
-* **proto** update protoc dependencies by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5218
-* **ui** update logo by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5249
-* **zero** refactor controller by @wasaga in https://github.com/pomerium/pomerium/pull/5134
-* **zero/api** generate error methods for response types by @kralicky in https://github.com/pomerium/pomerium/pull/5252
-* **zero/api** reset token and url cache if 401 is received by @wasaga in https://github.com/pomerium/pomerium/pull/5256
-* **zero/api** switch to github.com/oapi-codegen/oapi-codegen by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5226
-* **zero/bundle-download** update metadata by @wasaga in https://github.com/pomerium/pomerium/pull/5212
-* **zero/cmd** make it more evident what caused shutdown by @wasaga in https://github.com/pomerium/pomerium/pull/5209
-* **zero/connect** add telemetry request command by @wasaga in https://github.com/pomerium/pomerium/pull/5131
-* **zero/k8s** set externalTrafficPolicy: Local by @wasaga in https://github.com/pomerium/pomerium/pull/5266
-* **zero/telemetry** add hostname and version by @wasaga in https://github.com/pomerium/pomerium/pull/5146
-* **zero/telemetry** add prometheus streaming converter to OTLP by @wasaga in https://github.com/pomerium/pomerium/pull/5132
-* **zero/telemetry** collect limited core metrics by @wasaga in https://github.com/pomerium/pomerium/pull/5142
-* **zero/telemetry** internal envoy stats scraper and metrics producer by @wasaga in https://github.com/pomerium/pomerium/pull/5136
-* **zero/telemetry** refactor telemetry and controller by @wasaga in https://github.com/pomerium/pomerium/pull/5135
+* **authenticate**: rework session ID token handling by @kenjenkins in https://github.com/pomerium/pomerium/pull/5178
+* **authorize**: add request-id to error messages by @wasaga in https://github.com/pomerium/pomerium/pull/5267
+* **ci**: do not include timestamp into buildmeta by @wasaga in https://github.com/pomerium/pomerium/pull/5215
+* **config**: optimize policy iterators by @kralicky in https://github.com/pomerium/pomerium/pull/5184
+* **config**: sort runtime flags, name consistency by @kenjenkins in https://github.com/pomerium/pomerium/pull/5255
+* **envoy**: upgrade to v1.31.0 by @kenjenkins in https://github.com/pomerium/pomerium/pull/5183
+* **github**: update README.md by @cmo-pomerium in https://github.com/pomerium/pomerium/pull/5163
+* **github**: update README.md by @nikhil-pomerium in https://github.com/pomerium/pomerium/pull/5253
+* **go**: update to Go 1.23 by @kralicky in https://github.com/pomerium/pomerium/pull/5216
+* **logging**: change log.Error function by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5251
+* **logging**: convert warnings to info or error by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5235
+* **proto**: update protoc dependencies by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5218
+* **ui**: update logo by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5249
+* **zero**: refactor controller by @wasaga in https://github.com/pomerium/pomerium/pull/5134
+* **zero/api**: generate error methods for response types by @kralicky in https://github.com/pomerium/pomerium/pull/5252
+* **zero/api**: reset token and url cache if 401 is received by @wasaga in https://github.com/pomerium/pomerium/pull/5256
+* **zero/api**: switch to github.com/oapi-codegen/oapi-codegen by @calebdoxsey in https://github.com/pomerium/pomerium/pull/5226
+* **zero/bundle-download**: update metadata by @wasaga in https://github.com/pomerium/pomerium/pull/5212
+* **zero/cmd**: make it more evident what caused shutdown by @wasaga in https://github.com/pomerium/pomerium/pull/5209
+* **zero/connect**: add telemetry request command by @wasaga in https://github.com/pomerium/pomerium/pull/5131
+* **zero/k8s**: set externalTrafficPolicy: Local by @wasaga in https://github.com/pomerium/pomerium/pull/5266
+* **zero/telemetry**: add hostname and version by @wasaga in https://github.com/pomerium/pomerium/pull/5146
+* **zero/telemetry**: add prometheus streaming converter to OTLP by @wasaga in https://github.com/pomerium/pomerium/pull/5132
+* **zero/telemetry**: collect limited core metrics by @wasaga in https://github.com/pomerium/pomerium/pull/5142
+* **zero/telemetry**: internal envoy stats scraper and metrics producer by @wasaga in https://github.com/pomerium/pomerium/pull/5136
+* **zero/telemetry**: refactor telemetry and controller by @wasaga in https://github.com/pomerium/pomerium/pull/5135
 
 ### Dependency Updates
 * bump the docker group in /.github with 3 updates by @dependabot in https://github.com/pomerium/pomerium/pull/5124


### PR DESCRIPTION
Add v0.27.0 changelog.

I removed a few items that appeared to affect only tests or CI checks (e.g. linter version update).
I tried to standardize and alphabetize the category tags, and update a few descriptions to provide additional detail.