### PR TITLE
Revert "config: allow overriding port numbers using environment variables (#5194)"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 
 	"github.com/pomerium/pomerium/internal/fileutil"
 	"github.com/pomerium/pomerium/internal/hashutil"
@@ -129,36 +128,12 @@ func (cfg *Config) Checksum() uint64 {
 
 // AllocatePorts populates
 func (cfg *Config) AllocatePorts(ports [6]string) {
-	if port, ok := os.LookupEnv("POMERIUM_GRPC_PORT"); ok {
-		cfg.GRPCPort = port
-	} else {
-		cfg.GRPCPort = ports[0]
-	}
-	if port, ok := os.LookupEnv("POMERIUM_HTTP_PORT"); ok {
-		cfg.HTTPPort = port
-	} else {
-		cfg.HTTPPort = ports[1]
-	}
-	if port, ok := os.LookupEnv("POMERIUM_OUTBOUND_PORT"); ok {
-		cfg.OutboundPort = port
-	} else {
-		cfg.OutboundPort = ports[2]
-	}
-	if port, ok := os.LookupEnv("POMERIUM_METRICS_PORT"); ok {
-		cfg.MetricsPort = port
-	} else {
-		cfg.MetricsPort = ports[3]
-	}
-	if port, ok := os.LookupEnv("POMERIUM_DEBUG_PORT"); ok {
-		cfg.DebugPort = port
-	} else {
-		cfg.DebugPort = ports[4]
-	}
-	if port, ok := os.LookupEnv("POMERIUM_ACMETLSALPN_PORT"); ok {
-		cfg.ACMETLSALPNPort = port
-	} else {
-		cfg.ACMETLSALPNPort = ports[5]
-	}
+	cfg.GRPCPort = ports[0]
+	cfg.HTTPPort = ports[1]
+	cfg.OutboundPort = ports[2]
+	cfg.MetricsPort = ports[3]
+	cfg.DebugPort = ports[4]
+	cfg.ACMETLSALPNPort = ports[5]
 }
 
 // GetTLSClientConfig returns TLS configuration that accounts for additional CA entries


### PR DESCRIPTION
This reverts commit fdefcf9a16333b007058707f81cfbd1b97463c4f (https://github.com/pomerium/pomerium/pull/5194)

This was originally intended for a specific integration test use case, but it did not end up being needed. Additionally, the environment variable names can conflict with Kubernetes service environment variables.

Fixes https://github.com/pomerium/internal/issues/1900

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
