### PR TITLE
core/zero: add organization id and cluster id to bootstrap config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,11 @@ type Config struct {
 
 	// MetricsScrapeEndpoints additional metrics endpoints to scrape and provide part of metrics
 	MetricsScrapeEndpoints []MetricsScrapeEndpoint
+
+	// ZeroClusterID is the zero cluster id, only set when in zero mode.
+	ZeroClusterID string
+	// ZeroOrganizationID is the zero organization id, only set when in zero mode.
+	ZeroOrganizationID string
 }
 
 // Clone creates a clone of the config.

--- a/internal/zero/bootstrap/source.go
+++ b/internal/zero/bootstrap/source.go
@@ -55,9 +55,9 @@ func (src *source) OnConfigChange(_ context.Context, l config.ChangeListener) {
 func (src *source) UpdateBootstrap(ctx context.Context, cfg cluster_api.BootstrapConfig) bool {
 	current := src.cfg.Load()
 	incoming := current.Clone()
-	applyBootstrapConfig(incoming.Options, &cfg)
+	applyBootstrapConfig(incoming, &cfg)
 
-	if cmp.Equal(incoming.Options, current.Options, cmpOpts...) {
+	if cmp.Equal(incoming, current, cmpOpts...) {
 		return false
 	}
 
@@ -81,13 +81,15 @@ func (src *source) notifyListeners(ctx context.Context, cfg *config.Config) {
 	}
 }
 
-func applyBootstrapConfig(dst *config.Options, src *cluster_api.BootstrapConfig) {
-	dst.SharedKey = base64.StdEncoding.EncodeToString(src.SharedSecret)
+func applyBootstrapConfig(dst *config.Config, src *cluster_api.BootstrapConfig) {
+	dst.Options.SharedKey = base64.StdEncoding.EncodeToString(src.SharedSecret)
 	if src.DatabrokerStorageConnection != nil {
-		dst.DataBrokerStorageType = config.StoragePostgresName
-		dst.DataBrokerStorageConnectionString = *src.DatabrokerStorageConnection
+		dst.Options.DataBrokerStorageType = config.StoragePostgresName
+		dst.Options.DataBrokerStorageConnectionString = *src.DatabrokerStorageConnection
 	} else {
-		dst.DataBrokerStorageType = config.StorageInMemoryName
-		dst.DataBrokerStorageConnectionString = ""
+		dst.Options.DataBrokerStorageType = config.StorageInMemoryName
+		dst.Options.DataBrokerStorageConnectionString = ""
 	}
+	dst.ZeroClusterID = src.ClusterId
+	dst.ZeroOrganizationID = src.OrganizationId
 }

--- a/internal/zero/bootstrap/writers/k8s/secret_test.go
+++ b/internal/zero/bootstrap/writers/k8s/secret_test.go
@@ -95,7 +95,7 @@ func TestSecretWriter(t *testing.T) {
 				"namespace": "pomerium",
 			},
 			"data": map[string]any{
-				"bootstrap.dat": `{"databrokerStorageConnection":"test","sharedSecret":null}`,
+				"bootstrap.dat": `{"clusterId":"","databrokerStorageConnection":"test","organizationId":"","sharedSecret":null}`,
 			},
 		}, unstructured)
 	})

--- a/pkg/zero/cluster/models.gen.go
+++ b/pkg/zero/cluster/models.gen.go
@@ -18,8 +18,11 @@ const (
 
 // BootstrapConfig defines model for BootstrapConfig.
 type BootstrapConfig struct {
+	ClusterId string `json:"clusterId"`
+
 	// DatabrokerStorageConnection databroker storage connection string
 	DatabrokerStorageConnection *string `json:"databrokerStorageConnection,omitempty"`
+	OrganizationId              string  `json:"organizationId"`
 
 	// SharedSecret shared secret
 	SharedSecret []byte `json:"sharedSecret"`

--- a/pkg/zero/cluster/openapi.yaml
+++ b/pkg/zero/cluster/openapi.yaml
@@ -163,14 +163,20 @@ components:
     BootstrapConfig:
       type: object
       properties:
+        clusterId:
+          type: string
         databrokerStorageConnection:
           type: string
           description: databroker storage connection string
+        organizationId:
+          type: string
         sharedSecret:
           type: string
           format: byte
           description: shared secret
       required:
+        - clusterId
+        - organizationId
         - sharedSecret
 
     Bundle:


### PR DESCRIPTION
## Summary
Add the organization id and the cluster id to the zero config.

## Related issues
- https://github.com/pomerium/pomerium-zero/issues/2964

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
