### PR TITLE
k8s/zero: set automountServiceAccountToken: true

### DIFF
--- a/k8s/zero/deployment/base.yaml
+++ b/k8s/zero/deployment/base.yaml
@@ -9,6 +9,7 @@ spec:
       app.kubernetes.io/name: pomerium-zero
   template:
     spec:
+      automountServiceAccountToken: true
       serviceAccountName: pomerium-zero
       containers:
         - name: pomerium


### PR DESCRIPTION
## Summary

Sets `automountServiceAccountToken: true` for k8s zero deployments. 

## Related issues

Fixes #5279

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
