### PR TITLE
zero: log organization and cluster IDs on startup

### DIFF
--- a/internal/zero/bootstrap/source.go
+++ b/internal/zero/bootstrap/source.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/atomicutil"
+	"github.com/pomerium/pomerium/internal/log"
 	cluster_api "github.com/pomerium/pomerium/pkg/zero/cluster"
 )
 
@@ -62,7 +63,13 @@ func (src *source) UpdateBootstrap(ctx context.Context, cfg cluster_api.Bootstra
 	}
 
 	src.cfg.Store(incoming)
-	src.markReady.Do(func() { close(src.ready) })
+	src.markReady.Do(func() {
+		log.Ctx(ctx).Info().
+			Str("organization-id", cfg.OrganizationId).
+			Str("cluster-id", cfg.ClusterId).
+			Msg("loaded Pomerium Zero bootstrap config")
+		close(src.ready)
+	})
 
 	src.notifyListeners(ctx, incoming)
 


### PR DESCRIPTION
## Summary

In Zero-managed mode, log the organization ID and cluster ID on startup. (These are newly available in the bootstrap config, and surfacing this information should help when debugging problems.)

## Related issues

- pomerium/pomerium-zero#2848

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
