### PR TITLE
core/authorize: remove default header logging in debug

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -1455,7 +1455,7 @@ func (o *Options) GetAccessLogFields() []log.AccessLogField {
 // GetAuthorizeLogFields returns the authorize log fields. If none are set, the default fields are returned.
 func (o *Options) GetAuthorizeLogFields() []log.AuthorizeLogField {
 	if o.AuthorizeLogFields == nil {
-		return log.DefaultAuthorizeLogFields()
+		return log.DefaultAuthorizeLogFields
 	}
 	return o.AuthorizeLogFields
 }

--- a/internal/log/authorize.go
+++ b/internal/log/authorize.go
@@ -3,8 +3,6 @@ package log
 import (
 	"errors"
 	"fmt"
-
-	"github.com/rs/zerolog"
 )
 
 // An AuthorizeLogField is a field in the authorize logs.
@@ -31,7 +29,8 @@ const (
 	AuthorizeLogFieldUser                 AuthorizeLogField = "user"
 )
 
-var defaultAuthorizeLogFields = []AuthorizeLogField{
+// DefaultAuthorizeLogFields are the fields to log by default.
+var DefaultAuthorizeLogFields = []AuthorizeLogField{
 	AuthorizeLogFieldRequestID,
 	AuthorizeLogFieldCheckRequestID,
 	AuthorizeLogFieldMethod,
@@ -45,16 +44,6 @@ var defaultAuthorizeLogFields = []AuthorizeLogField{
 	AuthorizeLogFieldServiceAccountID,
 	AuthorizeLogFieldUser,
 	AuthorizeLogFieldEmail,
-}
-
-var defaultDebugAuthorizeLogFields = append(defaultAuthorizeLogFields, AuthorizeLogFieldHeaders)
-
-// DefaultAuthorizeLogFields returns the default authorize log fields.
-func DefaultAuthorizeLogFields() []AuthorizeLogField {
-	if zerolog.GlobalLevel() <= zerolog.DebugLevel {
-		return defaultDebugAuthorizeLogFields
-	}
-	return defaultAuthorizeLogFields
 }
 
 // ErrUnknownAuthorizeLogField indicates that an authorize log field is unknown.


### PR DESCRIPTION
## Summary
Currently we log headers during authorization if the log level is set to debug. This PR changes it to never log headers by default. If a user wants headers logged they need to set the authorization header field to include headers explicitly.

## Related issues
- https://github.com/pomerium/internal/issues/1892


## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
