### PR TITLE
ppl: fix empty/no-op allow block added in some cases to converted PPL policies

### DIFF
--- a/config/policy_ppl.go
+++ b/config/policy_ppl.go
@@ -77,10 +77,14 @@ func (p *Policy) ToPPL() *parser.Policy {
 				},
 			})
 	}
-	ppl.Rules = append(ppl.Rules, allowRule)
 
+	hasEmbeddedPolicy := (p.Policy != nil && p.Policy.Policy != nil)
+	// omit the default allow rule if it is empty and there is an embedded policy
+	if len(allowRule.Or) > 0 || !hasEmbeddedPolicy {
+		ppl.Rules = append(ppl.Rules, allowRule)
+	}
 	// append embedded PPL policy rules
-	if p.Policy != nil && p.Policy.Policy != nil {
+	if hasEmbeddedPolicy {
 		ppl.Rules = append(ppl.Rules, p.Policy.Policy.Rules...)
 	}
 

--- a/config/policy_ppl_test.go
+++ b/config/policy_ppl_test.go
@@ -533,3 +533,73 @@ else := value if {
 }
 `, str)
 }
+
+func TestPolicy_ToPPL_Embedded(t *testing.T) {
+	policy := Policy{
+		Policy: &PPLPolicy{
+			Policy: &parser.Policy{
+				Rules: []parser.Rule{
+					{
+						Action: parser.ActionAllow,
+						Or: []parser.Criterion{
+							{
+								Name: "foo",
+								Data: parser.Number("5"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, policy.Policy.Policy, policy.ToPPL())
+
+	policy2 := Policy{
+		AllowedUsers: []string{"test"},
+		Policy: &PPLPolicy{
+			Policy: &parser.Policy{
+				Rules: []parser.Rule{
+					{
+						Action: parser.ActionAllow,
+						Or: []parser.Criterion{
+							{
+								Name: "foo",
+								Data: parser.Number("5"),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	assert.Equal(t, &parser.Policy{
+		Rules: []parser.Rule{
+			{
+				Action: parser.ActionAllow,
+				Or: []parser.Criterion{
+					{
+						Name: "user",
+						Data: parser.Object{
+							"is": parser.String("test"),
+						},
+					},
+					{
+						Name: "email",
+						Data: parser.Object{
+							"is": parser.String("test"),
+						},
+					},
+				},
+			},
+			{
+				Action: parser.ActionAllow,
+				Or: []parser.Criterion{
+					{
+						Name: "foo",
+						Data: parser.Number("5"),
+					},
+				},
+			},
+		},
+	}, policy2.ToPPL())
+}


### PR DESCRIPTION
When converting a core route to a PPL policy, if an embedded policy object is present but none of the shorthand options that translate to PPL snippets (`allowed_users`, etc.) are present, omit the empty (no-op) allow block from the resulting policy.

This doesn't change any semantics of the policy, but it may be confusing for users if we display the converted yaml.

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
Fixes #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
