### PR TITLE
core/zero: add pseudonymization key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,8 @@ type Config struct {
 	ZeroClusterID string
 	// ZeroOrganizationID is the zero organization id, only set when in zero mode.
 	ZeroOrganizationID string
+	// ZeroPseudonymizationKey is the zero key used to pseudonymize data, only set in zero mode.
+	ZeroPseudonymizationKey []byte
 }
 
 // Clone creates a clone of the config.

--- a/internal/zero/bootstrap/source.go
+++ b/internal/zero/bootstrap/source.go
@@ -92,4 +92,5 @@ func applyBootstrapConfig(dst *config.Config, src *cluster_api.BootstrapConfig) 
 	}
 	dst.ZeroClusterID = src.ClusterId
 	dst.ZeroOrganizationID = src.OrganizationId
+	dst.ZeroPseudonymizationKey = src.PseudonymizationKey
 }

--- a/internal/zero/bootstrap/writers/k8s/secret_test.go
+++ b/internal/zero/bootstrap/writers/k8s/secret_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -63,6 +64,7 @@ func TestSecretWriter(t *testing.T) {
 		txt := "test"
 		src := cluster_api.BootstrapConfig{
 			DatabrokerStorageConnection: &txt,
+			PseudonymizationKey:         []byte{1, 2, 3},
 		}
 
 		writer = writer.WithOptions(writers.ConfigWriterOptions{
@@ -95,7 +97,13 @@ func TestSecretWriter(t *testing.T) {
 				"namespace": "pomerium",
 			},
 			"data": map[string]any{
-				"bootstrap.dat": `{"clusterId":"","databrokerStorageConnection":"test","organizationId":"","sharedSecret":null}`,
+				"bootstrap.dat": mustJSON(map[string]any{
+					"clusterId":                   "",
+					"databrokerStorageConnection": "test",
+					"organizationId":              "",
+					"pseudonymizationKey":         "AQID",
+					"sharedSecret":                nil,
+				}),
 			},
 		}, unstructured)
 	})
@@ -151,4 +159,12 @@ func TestSecretWriter(t *testing.T) {
 			}
 		}
 	})
+}
+
+func mustJSON(v any) string {
+	bs, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return string(bs)
 }

--- a/internal/zero/controller/controller.go
+++ b/internal/zero/controller/controller.go
@@ -211,7 +211,7 @@ func (c *controller) runHealthChecksLeased(ctx context.Context, client databroke
 }
 
 func (c *controller) runUsageReporter(ctx context.Context, client databroker.DataBrokerServiceClient) error {
-	ur := usagereporter.New(c.api, c.bootstrapConfig.GetConfig().ZeroOrganizationID, time.Minute)
+	ur := usagereporter.New(c.api, c.bootstrapConfig.GetConfig().ZeroPseudonymizationKey, time.Minute)
 	return retry.WithBackoff(ctx, "zero-usage-reporter", func(ctx context.Context) error {
 		// start the usage reporter
 		return ur.Run(ctx, client)

--- a/internal/zero/controller/usagereporter/usagereporter_test.go
+++ b/internal/zero/controller/usagereporter/usagereporter_test.go
@@ -55,7 +55,7 @@ func TestUsageReporter(t *testing.T) {
 			}
 			return nil
 		},
-	}, "bQjwPpxcwJRbvsSMFgbZFkXmxFJ", time.Millisecond*100)
+	}, []byte("bQjwPpxcwJRbvsSMFgbZFkXmxFJ"), time.Millisecond*100)
 
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
@@ -125,12 +125,12 @@ func Test_convertUsageReporterRecords(t *testing.T) {
 
 	tm1 := time.Date(2024, time.September, 11, 11, 56, 0, 0, time.UTC)
 
-	assert.Empty(t, convertUsageReporterRecords("XXX", nil))
+	assert.Empty(t, convertUsageReporterRecords([]byte("XXX"), nil))
 	assert.Equal(t, []cluster.ReportUsageUser{{
 		LastSignedInAt:    tm1,
 		PseudonymousId:    "T9V1yL/UueF/LVuF6XjoSNde0INElXG10zKepmyPke8=",
 		PseudonymousEmail: "8w5rtnZyv0EGkpHmTlkmupgb1jCzn/IxGCfvpdGGnvI=",
-	}}, convertUsageReporterRecords("XXX", []usageReporterRecord{{
+	}}, convertUsageReporterRecords([]byte("XXX"), []usageReporterRecord{{
 		userID:         "ID",
 		userEmail:      "EMAIL@example.com",
 		lastSignedInAt: tm1,
@@ -138,7 +138,7 @@ func Test_convertUsageReporterRecords(t *testing.T) {
 	assert.Equal(t, []cluster.ReportUsageUser{{
 		LastSignedInAt: tm1,
 		PseudonymousId: "T9V1yL/UueF/LVuF6XjoSNde0INElXG10zKepmyPke8=",
-	}}, convertUsageReporterRecords("XXX", []usageReporterRecord{{
+	}}, convertUsageReporterRecords([]byte("XXX"), []usageReporterRecord{{
 		userID:         "ID",
 		lastSignedInAt: tm1,
 	}}), "should leave empty email")

--- a/pkg/cryptutil/pseudonymize.go
+++ b/pkg/cryptutil/pseudonymize.go
@@ -8,8 +8,8 @@ import (
 )
 
 // Pseudonymize pseudonymizes data by computing the HMAC-SHA256 of the data.
-func Pseudonymize(organizationID string, data string) string {
-	h := hmac.New(sha256.New, []byte(organizationID))
+func Pseudonymize(key []byte, data string) string {
+	h := hmac.New(sha256.New, key)
 	_, _ = io.WriteString(h, data)
 	bs := h.Sum(nil)
 	return base64.StdEncoding.EncodeToString(bs)

--- a/pkg/zero/cluster/models.gen.go
+++ b/pkg/zero/cluster/models.gen.go
@@ -27,6 +27,7 @@ type BootstrapConfig struct {
 	// DatabrokerStorageConnection databroker storage connection string
 	DatabrokerStorageConnection *string `json:"databrokerStorageConnection,omitempty"`
 	OrganizationId              string  `json:"organizationId"`
+	PseudonymizationKey         []byte  `json:"pseudonymizationKey"`
 
 	// SharedSecret shared secret
 	SharedSecret []byte `json:"sharedSecret"`

--- a/pkg/zero/cluster/openapi.yaml
+++ b/pkg/zero/cluster/openapi.yaml
@@ -197,6 +197,9 @@ components:
           description: databroker storage connection string
         organizationId:
           type: string
+        pseudonymizationKey:
+          type: string
+          format: byte
         sharedSecret:
           type: string
           format: byte
@@ -204,6 +207,7 @@ components:
       required:
         - clusterId
         - organizationId
+        - pseudonymizationKey
         - sharedSecret
 
     Bundle:


### PR DESCRIPTION
## Summary
Add a dedicated psuedonymization key instead of just using the organization id.

## Related issues
- https://github.com/pomerium/pomerium-zero/issues/2964

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
