### PR TITLE
core/proxy: support loading sessions from headers and query string

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -48,7 +48,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 	requestID := requestid.FromHTTPHeader(hreq.Header)
 	ctx = requestid.WithValue(ctx, requestID)
 
-	sessionState, _ := state.sessionStore.LoadSessionState(hreq)
+	sessionState, _ := state.sessionStore.LoadSessionStateAndCheckIDP(hreq)
 
 	var s sessionOrServiceAccount
 	var u *user.User

--- a/config/session_test.go
+++ b/config/session_test.go
@@ -70,7 +70,7 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 	t.Run("mssing", func(t *testing.T) {
 		r, err := http.NewRequest(http.MethodGet, "https://p1.example.com", nil)
 		require.NoError(t, err)
-		s, err := store.LoadSessionState(r)
+		s, err := store.LoadSessionStateAndCheckIDP(r)
 		assert.ErrorIs(t, err, sessions.ErrNoSessionFound)
 		assert.Nil(t, s)
 	})
@@ -85,7 +85,7 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 			urlutil.QuerySession: {rawJWS},
 		}.Encode(), nil)
 		require.NoError(t, err)
-		s, err := store.LoadSessionState(r)
+		s, err := store.LoadSessionStateAndCheckIDP(r)
 		assert.NoError(t, err)
 		assert.Empty(t, cmp.Diff(&sessions.State{
 			Issuer:             "authenticate.example.com",
@@ -103,7 +103,7 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 		r, err := http.NewRequest(http.MethodGet, "https://p2.example.com", nil)
 		require.NoError(t, err)
 		r.Header.Set(httputil.HeaderPomeriumAuthorization, rawJWS)
-		s, err := store.LoadSessionState(r)
+		s, err := store.LoadSessionStateAndCheckIDP(r)
 		assert.NoError(t, err)
 		assert.Empty(t, cmp.Diff(&sessions.State{
 			Issuer:             "authenticate.example.com",
@@ -121,7 +121,7 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 		r, err := http.NewRequest(http.MethodGet, "https://p2.example.com", nil)
 		require.NoError(t, err)
 		r.Header.Set(httputil.HeaderPomeriumAuthorization, rawJWS)
-		s, err := store.LoadSessionState(r)
+		s, err := store.LoadSessionStateAndCheckIDP(r)
 		assert.Error(t, err)
 		assert.Nil(t, s)
 	})
@@ -134,7 +134,7 @@ func TestSessionStore_LoadSessionState(t *testing.T) {
 		r, err := http.NewRequest(http.MethodGet, "https://p2.example.com", nil)
 		require.NoError(t, err)
 		r.Header.Set(httputil.HeaderPomeriumAuthorization, rawJWS)
-		s, err := store.LoadSessionState(r)
+		s, err := store.LoadSessionStateAndCheckIDP(r)
 		assert.NoError(t, err)
 		assert.Empty(t, cmp.Diff(&sessions.State{
 			Issuer: "authenticate.example.com",

--- a/proxy/data.go
+++ b/proxy/data.go
@@ -6,11 +6,8 @@ import (
 
 	"github.com/pomerium/csrf"
 	"github.com/pomerium/datasource/pkg/directory"
-	"github.com/pomerium/pomerium/internal/encoding/jws"
 	"github.com/pomerium/pomerium/internal/handlers"
 	"github.com/pomerium/pomerium/internal/handlers/webauthn"
-	"github.com/pomerium/pomerium/internal/httputil"
-	"github.com/pomerium/pomerium/internal/sessions"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
@@ -31,33 +28,12 @@ func (p *Proxy) getSession(ctx context.Context, sessionID string) (s *session.Se
 	return s, isImpersonated, err
 }
 
-func (p *Proxy) getSessionState(r *http.Request) (sessions.State, error) {
-	state := p.state.Load()
-
-	rawJWT, err := state.sessionStore.LoadSession(r)
-	if err != nil {
-		return sessions.State{}, err
-	}
-
-	encoder, err := jws.NewHS256Signer(state.sharedKey)
-	if err != nil {
-		return sessions.State{}, err
-	}
-
-	var sessionState sessions.State
-	if err := encoder.Unmarshal([]byte(rawJWT), &sessionState); err != nil {
-		return sessions.State{}, httputil.NewError(http.StatusBadRequest, err)
-	}
-
-	return sessionState, nil
-}
-
 func (p *Proxy) getUser(ctx context.Context, userID string) (*user.User, error) {
 	client := p.state.Load().dataBrokerClient
 	return user.Get(ctx, client, userID)
 }
 
-func (p *Proxy) getUserInfoData(r *http.Request) (handlers.UserInfoData, error) {
+func (p *Proxy) getUserInfoData(r *http.Request) handlers.UserInfoData {
 	options := p.currentOptions.Load()
 	state := p.state.Load()
 
@@ -66,7 +42,7 @@ func (p *Proxy) getUserInfoData(r *http.Request) (handlers.UserInfoData, error) 
 		BrandingOptions: options.BrandingOptions,
 	}
 
-	ss, err := p.getSessionState(r)
+	ss, err := p.state.Load().sessionStore.LoadSessionState(r)
 	if err == nil {
 		data.Session, data.IsImpersonated, err = p.getSession(r.Context(), ss.ID)
 		if err != nil {
@@ -82,7 +58,7 @@ func (p *Proxy) getUserInfoData(r *http.Request) (handlers.UserInfoData, error) 
 	data.WebAuthnCreationOptions, data.WebAuthnRequestOptions, _ = p.webauthn.GetOptions(r)
 	data.WebAuthnURL = urlutil.WebAuthnURL(r, urlutil.GetAbsoluteURL(r), state.sharedKey, r.URL.Query())
 	p.fillEnterpriseUserInfoData(r.Context(), &data)
-	return data, nil
+	return data
 }
 
 func (p *Proxy) fillEnterpriseUserInfoData(ctx context.Context, data *handlers.UserInfoData) {
@@ -109,7 +85,7 @@ func (p *Proxy) getWebauthnState(r *http.Request) (*webauthn.State, error) {
 	options := p.currentOptions.Load()
 	state := p.state.Load()
 
-	ss, err := p.getSessionState(r)
+	ss, err := p.state.Load().sessionStore.LoadSessionState(r)
 	if err != nil {
 		return nil, err
 	}
@@ -135,7 +111,7 @@ func (p *Proxy) getWebauthnState(r *http.Request) (*webauthn.State, error) {
 		SharedKey:               state.sharedKey,
 		Client:                  state.dataBrokerClient,
 		Session:                 s,
-		SessionState:            &ss,
+		SessionState:            ss,
 		SessionStore:            state.sessionStore,
 		RelyingParty:            webauthnutil.GetRelyingParty(r, state.dataBrokerClient),
 		BrandingOptions:         options.BrandingOptions,

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -80,19 +80,13 @@ func (p *Proxy) SignOut(w http.ResponseWriter, r *http.Request) error {
 }
 
 func (p *Proxy) userInfo(w http.ResponseWriter, r *http.Request) error {
-	data, err := p.getUserInfoData(r)
-	if err != nil {
-		return err
-	}
+	data := p.getUserInfoData(r)
 	handlers.UserInfo(data).ServeHTTP(w, r)
 	return nil
 }
 
 func (p *Proxy) deviceEnrolled(w http.ResponseWriter, r *http.Request) error {
-	data, err := p.getUserInfoData(r)
-	if err != nil {
-		return err
-	}
+	data := p.getUserInfoData(r)
 	handlers.DeviceEnrolled(data).ServeHTTP(w, r)
 	return nil
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -71,6 +71,7 @@ func New(cfg *config.Config) (*Proxy, error) {
 		currentOptions: config.NewAtomicOptions(),
 		currentRouter:  atomicutil.NewValue(httputil.NewRouter()),
 	}
+	p.OnConfigChange(context.Background(), cfg)
 	p.webauthn = webauthn.New(p.getWebauthnState)
 
 	metrics.AddPolicyCountCallback("pomerium-proxy", func() int64 {


### PR DESCRIPTION
## Summary
Currently the proxy service will only load sessions from cookies. We also support sessions stored in headers and query string parameters. This PR updates the proxy code to support loading sessions from these places as well.

## Related issues
- https://github.com/pomerium/pomerium/issues/5246


## Checklist

- [x] reference any related issues
- [ ] updated docs
- [x] updated unit tests
- [ ] updated UPGRADING.md
- [x] add appropriate tag (`improvement` / `bug` / etc)
- [x] ready for review
