### PR TITLE
Makefile: unset GOOS for get-envoy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ all: clean build-deps test lint build ## Runs a clean, build, fmt, lint, test, a
 .PHONY: get-envoy
 get-envoy: ## Fetch envoy binaries
 	@echo "==> $@"
-	@cd pkg/envoy/files && go run ../get-envoy
+	@cd pkg/envoy/files && env -u GOOS go run ../get-envoy
 
 .PHONY: deps-build
 deps-build: get-envoy ## Install build dependencies


### PR DESCRIPTION
## Summary

The build-dev-docker.sh script will run

    env GOOS=linux make build

to build Pomerium for Linux (before copying this binary into a minimal Docker image).

However, now that the `get-envoy` target is implemented using a Go command, it too will be affected by `GOOS`. As a result running this step on macOS will result in an error when trying to execute a Linux `get-envoy` binary.

Instead, let's unset `GOOS` when running the `get-envoy` command, so that it defaults to building for the host OS.

## Related issues

- https://github.com/pomerium/pomerium/issues/5299

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
