### PR TITLE
[WIP] automatic mTLS for internal gRPC traffic

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -29,64 +29,69 @@ func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*env
 	ctx, span := trace.StartSpan(ctx, "envoyconfig.Builder.BuildClusters")
 	defer span.End()
 
-	grpcURLs := []*url.URL{{
-		Scheme: "http",
-		Host:   b.localGRPCAddress,
-	}}
-	httpURL := &url.URL{
-		Scheme: "http",
-		Host:   b.localHTTPAddress,
-	}
-	metricsURL := &url.URL{
-		Scheme: "http",
-		Host:   b.localMetricsAddress,
+	controlGRPC, err := b.buildInternalClusterLocal(
+		cfg, "pomerium-control-plane-grpc", b.localGRPCAddress, upstreamProtocolHTTP2)
+	if err != nil {
+		return nil, err
 	}
 
-	authorizeURLs, databrokerURLs := grpcURLs, grpcURLs
-	if !config.IsAll(cfg.Options.Services) {
-		var err error
-		authorizeURLs, err = cfg.Options.GetInternalAuthorizeURLs()
+	controlHTTP, err := b.buildInternalClusterLocal(
+		cfg, "pomerium-control-plane-http", b.localHTTPAddress, upstreamProtocolAuto)
+	if err != nil {
+		return nil, err
+	}
+
+	controlMetrics, err := b.buildInternalClusterLocal(
+		cfg, "pomerium-control-plane-metrics", b.localMetricsAddress, upstreamProtocolAuto)
+	if err != nil {
+		return nil, err
+	}
+
+	var authorizeCluster, databrokerCluster *envoy_config_cluster_v3.Cluster
+	if config.IsAll(cfg.Options.Services) {
+		authorizeCluster, err = b.buildInternalClusterLocal(
+			cfg, "pomerium-authorize", b.localGRPCAddress, upstreamProtocolHTTP2)
 		if err != nil {
 			return nil, err
 		}
-		databrokerURLs, err = cfg.Options.GetDataBrokerURLs()
+		databrokerCluster, err = b.buildInternalClusterLocal(
+			cfg, "pomerium-databroker", b.localGRPCAddress, upstreamProtocolHTTP2)
 		if err != nil {
 			return nil, err
 		}
-	}
-
-	controlGRPC, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-grpc", grpcURLs, upstreamProtocolHTTP2, Keepalive(false))
-	if err != nil {
-		return nil, err
-	}
-
-	controlHTTP, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-http", []*url.URL{httpURL}, upstreamProtocolAuto, Keepalive(false))
-	if err != nil {
-		return nil, err
-	}
-
-	controlMetrics, err := b.buildInternalCluster(ctx, cfg, "pomerium-control-plane-metrics", []*url.URL{metricsURL}, upstreamProtocolAuto, Keepalive(false))
-	if err != nil {
-		return nil, err
-	}
-
-	authorizeCluster, err := b.buildInternalCluster(ctx, cfg, "pomerium-authorize", authorizeURLs, upstreamProtocolHTTP2, Keepalive(false))
-	if err != nil {
-		return nil, err
-	}
-	if len(authorizeURLs) > 1 {
-		authorizeCluster.HealthChecks = grpcHealthChecks("pomerium-authorize")
-		authorizeCluster.OutlierDetection = grpcOutlierDetection()
-	}
-
-	databrokerKeepalive := Keepalive(cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagGRPCDatabrokerKeepalive))
-	databrokerCluster, err := b.buildInternalCluster(ctx, cfg, "pomerium-databroker", databrokerURLs, upstreamProtocolHTTP2, databrokerKeepalive)
-	if err != nil {
-		return nil, err
-	}
-	if len(databrokerURLs) > 1 {
-		databrokerCluster.HealthChecks = grpcHealthChecks("pomerium-databroker")
-		databrokerCluster.OutlierDetection = grpcOutlierDetection()
+	} else {
+		internalCA, err := b.internalCA(cfg)
+		if err != nil {
+			return nil, err
+		}
+		internalCAPEM := internalCA.PEM()
+		cert, err := internalCA.NewClientCertificate()
+		if err != nil {
+			return nil, err
+		}
+		envoyCert := b.envoyTLSCertificateFromGoTLSCertificate(ctx, cert)
+		if err != nil {
+			return nil, err
+		}
+		authorizeURLs, err := cfg.Options.GetInternalAuthorizeURLs()
+		if err != nil {
+			return nil, err
+		}
+		authorizeCluster, err = b.buildInternalClusterInterService(
+			cfg, "pomerium-authorize", authorizeURLs, Keepalive(false), internalCAPEM, envoyCert)
+		if err != nil {
+			return nil, err
+		}
+		databrokerURLs, err := cfg.Options.GetDataBrokerURLs()
+		if err != nil {
+			return nil, err
+		}
+		databrokerKeepalive := Keepalive(cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagGRPCDatabrokerKeepalive))
+		databrokerCluster, err = b.buildInternalClusterInterService(
+			cfg, "pomerium-databroker", databrokerURLs, databrokerKeepalive, internalCAPEM, envoyCert)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	envoyAdminCluster, err := b.buildEnvoyAdminCluster(ctx, cfg)
@@ -130,14 +135,7 @@ func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*env
 	return clusters, nil
 }
 
-func (b *Builder) buildInternalCluster(
-	ctx context.Context,
-	cfg *config.Config,
-	name string,
-	dsts []*url.URL,
-	upstreamProtocol upstreamProtocolConfig,
-	keepalive Keepalive,
-) (*envoy_config_cluster_v3.Cluster, error) {
+func newDefaultInternalCluster(cfg *config.Config) *envoy_config_cluster_v3.Cluster {
 	cluster := newDefaultEnvoyClusterConfig()
 	cluster.DnsLookupFamily = config.GetEnvoyDNSLookupFamily(cfg.Options.DNSLookupFamily)
 	// Match the Go standard library default TCP keepalive settings.
@@ -148,18 +146,51 @@ func (b *Builder) buildInternalCluster(
 			KeepaliveInterval: wrapperspb.UInt32(keepaliveTimeSeconds),
 		},
 	}
+	return cluster
+}
+
+// buildInternalClusterLocal builds an Envoy cluster used to connect from Envoy
+// back to the Pomerium process.
+func (b *Builder) buildInternalClusterLocal(
+	cfg *config.Config,
+	name string,
+	host string,
+	upstreamProtocol upstreamProtocolConfig,
+) (*envoy_config_cluster_v3.Cluster, error) {
+	cluster := newDefaultInternalCluster(cfg)
+	endpoints := []Endpoint{NewEndpoint(&url.URL{Scheme: "http", Host: host}, nil, 1)}
+	if err := b.buildCluster(cluster, name, endpoints, upstreamProtocol, Keepalive(false)); err != nil {
+		return nil, err
+	}
+	return cluster, nil
+}
+
+// buildInternalClusterInterService builds an Envoy cluster used to connect to
+// another Pomerium service (for split-service mode).
+func (b *Builder) buildInternalClusterInterService(
+	cfg *config.Config,
+	name string,
+	dsts []*url.URL,
+	keepalive Keepalive,
+	internalCAPEM []byte,
+	internalCert *envoy_extensions_transport_sockets_tls_v3.TlsCertificate,
+) (*envoy_config_cluster_v3.Cluster, error) {
+	cluster := newDefaultInternalCluster(cfg)
 	var endpoints []Endpoint
 	for _, dst := range dsts {
-		ts, err := b.buildInternalTransportSocket(ctx, cfg, dst)
+		ts, err := b.buildInternalTransportSocket(dst, internalCAPEM, internalCert)
 		if err != nil {
 			return nil, err
 		}
 		endpoints = append(endpoints, NewEndpoint(dst, ts, 1))
 	}
-	if err := b.buildCluster(cluster, name, endpoints, upstreamProtocol, keepalive); err != nil {
+	if err := b.buildCluster(cluster, name, endpoints, upstreamProtocolHTTP2, keepalive); err != nil {
 		return nil, err
 	}
-
+	if len(dsts) > 1 {
+		cluster.HealthChecks = grpcHealthChecks(name)
+		cluster.OutlierDetection = grpcOutlierDetection()
+	}
 	return cluster, nil
 }
 
@@ -234,33 +265,30 @@ func (b *Builder) buildPolicyEndpoints(
 }
 
 func (b *Builder) buildInternalTransportSocket(
-	ctx context.Context,
-	cfg *config.Config,
 	endpoint *url.URL,
+	internalCAPEM []byte,
+	internalCert *envoy_extensions_transport_sockets_tls_v3.TlsCertificate,
 ) (*envoy_config_core_v3.TransportSocket, error) {
 	if endpoint.Scheme != "https" {
-		return nil, nil
+		// XXX: disallow non-https URLs
 	}
 
-	validationContext := &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
-		MatchTypedSubjectAltNames: []*envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher{
-			b.buildSubjectAltNameMatcher(endpoint, cfg.Options.OverrideCertificateName),
+	vct := &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{
+		ValidationContext: &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
+			TrustedCa: b.filemgr.BytesDataSource("ca.pem", internalCAPEM),
+			MatchTypedSubjectAltNames: []*envoy_extensions_transport_sockets_tls_v3.SubjectAltNameMatcher{
+				b.buildSubjectAltNameMatcher(endpoint, ""),
+			},
 		},
-	}
-	bs, err := getCombinedCertificateAuthority(cfg)
-	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("unable to enable certificate verification because no root CAs were found")
-	} else {
-		validationContext.TrustedCa = b.filemgr.BytesDataSource("ca.pem", bs)
 	}
 	tlsContext := &envoy_extensions_transport_sockets_tls_v3.UpstreamTlsContext{
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
-			AlpnProtocols: []string{"h2", "http/1.1"},
-			ValidationContextType: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{
-				ValidationContext: validationContext,
-			},
+			TlsParams:             tlsParamsEdDSAOnly,
+			TlsCertificates:       []*envoy_extensions_transport_sockets_tls_v3.TlsCertificate{internalCert},
+			ValidationContextType: vct,
 		},
-		Sni: b.buildSubjectNameIndication(endpoint, cfg.Options.OverrideCertificateName),
+		// XXX: strip IPv6 zone if present?
+		Sni: endpoint.Hostname(),
 	}
 	tlsConfig := marshalAny(tlsContext)
 	return &envoy_config_core_v3.TransportSocket{

--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/derivecert"
 )
 
 var (
@@ -149,6 +150,14 @@ func buildAddress(hostport string, defaultPort uint32) *envoy_config_core_v3.Add
 			Ipv4Compat:    host == "::" || is4in6,
 		}},
 	}
+}
+
+func (b *Builder) internalCA(cfg *config.Config) (*derivecert.Ed25519CA, error) {
+	r, err := cfg.Options.GetDerivedKDF(config.KDFContextInternalEd25519CA)
+	if err != nil {
+		return nil, err
+	}
+	return derivecert.NewEd25519CA(r)
 }
 
 func (b *Builder) envoyTLSCertificateFromGoTLSCertificate(

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -20,6 +20,7 @@ import (
 	envoy_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/hashicorp/go-set/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -404,6 +405,51 @@ func (b *Builder) buildMetricsHTTPConnectionManagerFilter() (*envoy_config_liste
 	}), nil
 }
 
+func (b *Builder) internalCAAndServerCert(
+	ctx context.Context,
+	cfg *config.Config,
+) ([]byte, *envoy_extensions_transport_sockets_tls_v3.TlsCertificate, error) {
+	// Determine which hostnames might be used to connect to this service.
+	// (Only the authorize and databroker services take internal gRPC traffic.)
+	var internalURLs []*url.URL
+	if config.IsAuthorize(cfg.Options.Services) {
+		urls, err := cfg.Options.GetInternalAuthorizeURLs()
+		if err != nil {
+			return nil, nil, err
+		}
+		internalURLs = append(internalURLs, urls...)
+	}
+	if config.IsDataBroker(cfg.Options.Services) {
+		urls, err := cfg.Options.GetDataBrokerURLs()
+		if err != nil {
+			return nil, nil, err
+		}
+		internalURLs = append(internalURLs, urls...)
+	}
+
+	dnsNames := set.New[string](0)
+	ipAddresses := set.NewHashSetFunc(0, func(ip net.IP) string { return string(ip) })
+	for _, u := range internalURLs {
+		h := u.Hostname()
+		if ip := net.ParseIP(h); ip != nil {
+			ipAddresses.Insert(ip)
+		} else {
+			dnsNames.Insert(h)
+		}
+	}
+
+	// Issue an internal certificate for this service.
+	internalCA, err := b.internalCA(cfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := internalCA.NewServerCertificate(dnsNames.Slice(), ipAddresses.Slice())
+	if err != nil {
+		return nil, nil, err
+	}
+	return internalCA.PEM(), b.envoyTLSCertificateFromGoTLSCertificate(ctx, cert), nil
+}
+
 func (b *Builder) buildGRPCListener(ctx context.Context, cfg *config.Config) (*envoy_config_listener_v3.Listener, error) {
 	filter, err := b.buildGRPCHTTPConnectionManagerFilter()
 	if err != nil {
@@ -417,29 +463,27 @@ func (b *Builder) buildGRPCListener(ctx context.Context, cfg *config.Config) (*e
 	li := newEnvoyListener("grpc-ingress")
 	li.FilterChains = []*envoy_config_listener_v3.FilterChain{&filterChain}
 
-	if cfg.Options.GetGRPCInsecure() {
-		li.Address = buildAddress(cfg.Options.GetGRPCAddr(), 80)
-		return li, nil
-	}
-
 	li.Address = buildAddress(cfg.Options.GetGRPCAddr(), 443)
 	li.ListenerFilters = []*envoy_config_listener_v3.ListenerFilter{
 		TLSInspectorFilter(),
 	}
 
-	allCertificates, err := getAllCertificates(cfg)
+	caCert, serverCert, err := b.internalCAAndServerCert(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
-	envoyCerts, err := b.envoyCertificates(ctx, allCertificates)
-	if err != nil {
-		return nil, err
+	vct := &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext_ValidationContext{
+		ValidationContext: &envoy_extensions_transport_sockets_tls_v3.CertificateValidationContext{
+			TrustedCa: b.filemgr.BytesDataSource("internal-ca.pem", caCert),
+		},
 	}
 	tlsContext := &envoy_extensions_transport_sockets_tls_v3.DownstreamTlsContext{
+		RequireClientCertificate: wrapperspb.Bool(true),
 		CommonTlsContext: &envoy_extensions_transport_sockets_tls_v3.CommonTlsContext{
-			TlsParams:       tlsDownstreamParams,
-			TlsCertificates: envoyCerts,
-			AlpnProtocols:   []string{"h2"}, // gRPC requires HTTP/2
+			TlsParams:             tlsParamsEdDSAOnly,
+			TlsCertificates:       []*envoy_extensions_transport_sockets_tls_v3.TlsCertificate{serverCert},
+			AlpnProtocols:         []string{"h2"}, // gRPC requires HTTP/2
+			ValidationContextType: vct,
 		},
 	}
 	filterChain.TransportSocket = &envoy_config_core_v3.TransportSocket{

--- a/config/envoyconfig/protocols.go
+++ b/config/envoyconfig/protocols.go
@@ -45,7 +45,8 @@ var http1ProtocolOptions = &envoy_config_core_v3.Http1ProtocolOptions{
 	},
 }
 
-// Keepalive is a type to enable or disable keepalive
+// Keepalive is a type to enable or disable HTTP/2 keepalive.
+// (Not to be confused with TCP keepalive, which is always enabled.)
 type Keepalive bool
 
 var http2ProtocolOptions = &envoy_config_core_v3.Http2ProtocolOptions{

--- a/config/envoyconfig/tls.go
+++ b/config/envoyconfig/tls.go
@@ -53,6 +53,11 @@ var (
 		TlsMinimumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_2,
 		TlsMaximumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_3,
 	}
+	tlsParamsEdDSAOnly = &envoy_extensions_transport_sockets_tls_v3.TlsParameters{
+		SignatureAlgorithms:       []string{"ed25519"},
+		TlsMinimumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_3,
+		TlsMaximumProtocolVersion: envoy_extensions_transport_sockets_tls_v3.TlsParameters_TLSv1_3,
+	}
 )
 
 var oidMustStaple = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 1, 24}

--- a/config/options.go
+++ b/config/options.go
@@ -3,11 +3,13 @@ package config
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"iter"
 	"net/http"
 	"net/url"
@@ -22,6 +24,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
 	"github.com/volatiletech/null/v9"
+	"golang.org/x/crypto/hkdf"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/pomerium/csrf"
@@ -909,6 +912,7 @@ func (o *Options) GetGRPCAddr() string {
 }
 
 // GetGRPCInsecure gets whether or not gRPC is insecure.
+// XXX: deprecate
 func (o *Options) GetGRPCInsecure() bool {
 	if o.GRPCInsecure != nil {
 		return *o.GRPCInsecure
@@ -1175,6 +1179,20 @@ func (o *Options) GetSharedKey() ([]byte, error) {
 		return nil, errors.New("shared secret contains whitespace")
 	}
 	return base64.StdEncoding.DecodeString(sharedKey)
+}
+
+type KDFContext []byte
+
+var (
+	KDFContextInternalEd25519CA = KDFContext("internal-ed25519-ca")
+)
+
+func (o *Options) GetDerivedKDF(context KDFContext) (io.Reader, error) {
+	sharedSecret, err := o.GetSharedKey()
+	if err != nil {
+		return nil, err
+	}
+	return hkdf.New(sha256.New, sharedSecret, nil, context), nil
 }
 
 // GetHPKEPrivateKey gets the hpke.PrivateKey dervived from the shared key.

--- a/pkg/derivecert/eddsa.go
+++ b/pkg/derivecert/eddsa.go
@@ -1,0 +1,111 @@
+package derivecert
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"math/big"
+	"net"
+)
+
+type Ed25519CA struct {
+	key  ed25519.PrivateKey
+	cert *x509.Certificate
+}
+
+func NewEd25519CA(prng io.Reader) (*Ed25519CA, error) {
+	_, key, err := ed25519.GenerateKey(prng)
+	if err != nil {
+		return nil, err
+	}
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(0x1000),
+		Subject: pkix.Name{
+			Organization: []string{"Pomerium"},
+			CommonName:   "Pomerium PSK CA",
+		},
+		NotBefore: notBefore,
+		NotAfter:  notAfter,
+		KeyUsage:  x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Ed25519CA{
+		key:  key,
+		cert: cert,
+	}, nil
+}
+
+// PEM returns the CA certificate in PEM format.
+func (ca *Ed25519CA) PEM() []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: ca.cert.Raw})
+}
+
+func (ca *Ed25519CA) NewServerCertificate(dnsNames []string, ipAddresses []net.IP) (*tls.Certificate, error) {
+	return ca.newCertificate(x509.ExtKeyUsageServerAuth, dnsNames, ipAddresses)
+}
+
+func (ca *Ed25519CA) NewClientCertificate() (*tls.Certificate, error) {
+	return ca.newCertificate(x509.ExtKeyUsageClientAuth, nil, nil)
+}
+
+func (ca *Ed25519CA) newCertificate(
+	extKeyUsage x509.ExtKeyUsage,
+	dnsNames []string,
+	ipAddresses []net.IP,
+) (*tls.Certificate, error) {
+	var serialBytes [20]byte
+	if _, err := rand.Read(serialBytes[:]); err != nil {
+		return nil, err
+	}
+	serial := new(big.Int).SetBytes(serialBytes[:])
+
+	template := &x509.Certificate{
+		SerialNumber: serial,
+		Subject:      pkix.Name{Organization: []string{"Pomerium"}},
+		DNSNames:     dnsNames,
+		IPAddresses:  ipAddresses,
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{extKeyUsage},
+	}
+	_, key, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, ca.cert, key.Public(), ca.key)
+	if err != nil {
+		return nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, err
+	}
+
+	return &tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  key,
+		Leaf:        cert,
+	}, nil
+}


### PR DESCRIPTION
## Summary

Expand on the "Auto TLS" functionality to provision both server and client certs for internal gRPC traffic between Pomerium services when running in split service mode.

## Related issues

- https://github.com/pomerium/internal/issues/1457

## User Explanation

## Checklist

- [x] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
