### PR TITLE
zero: update k8s manifest to prepare for v0.27.1

### DIFF
--- a/k8s/zero/deployment/image.yaml
+++ b/k8s/zero/deployment/image.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         - name: pomerium
-          image: pomerium/pomerium:v0.27.0
+          image: pomerium/pomerium:v0.27.1
           imagePullPolicy: IfNotFound


### PR DESCRIPTION
## Summary

Bump Zero k8s manifest image tag to v0.27.1.

## Related issues

n/a

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
