### PR TITLE
zero: set k8s deployment to follow :latest tag

### DIFF
--- a/k8s/zero/deployment/image.yaml
+++ b/k8s/zero/deployment/image.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
         - name: pomerium
-          image: pomerium/pomerium:v0.27.0
-          imagePullPolicy: IfNotPresent
+          image: pomerium/pomerium:latest
+          imagePullPolicy: Always


### PR DESCRIPTION
## Summary

Set the Pomerium Zero k8s deployment manifest to use the `latest` tag (in the `main` branch).

This way, users installing from the `main` branch will stay up to date as we make new releases, and we won't need to keep this tag in sync between `main` and the current release branch during patch releases.

## Related issues

n/a

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
