### PR TITLE
databroker: remove unused serverConfig fields

### DIFF
--- a/databroker/databroker.go
+++ b/databroker/databroker.go
@@ -57,7 +57,6 @@ func (srv *dataBrokerServer) getOptions(cfg *config.Config) ([]databroker.Server
 	}
 
 	return []databroker.ServerOption{
-		databroker.WithGetSharedKey(cfg.Options.GetSharedKey),
 		databroker.WithStorageType(cfg.Options.DataBrokerStorageType),
 		databroker.WithStorageConnectionString(dataBrokerStorageConnectionString),
 	}, nil

--- a/internal/databroker/config.go
+++ b/internal/databroker/config.go
@@ -2,37 +2,24 @@ package databroker
 
 import (
 	"time"
-
-	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
 var (
-	// DefaultDeletePermanentlyAfter is the default amount of time to wait before deleting
-	// a record permanently.
-	DefaultDeletePermanentlyAfter = time.Hour
 	// DefaultStorageType is the default storage type that Server use
 	DefaultStorageType = "memory"
-	// DefaultGetAllPageSize is the default page size for GetAll calls.
-	DefaultGetAllPageSize = 50
 	// DefaultRegistryTTL is the default registry time to live.
 	DefaultRegistryTTL = time.Minute
 )
 
 type serverConfig struct {
-	deletePermanentlyAfter  time.Duration
-	secret                  []byte
 	storageType             string
 	storageConnectionString string
-	getAllPageSize          int
 	registryTTL             time.Duration
 }
 
 func newServerConfig(options ...ServerOption) *serverConfig {
 	cfg := new(serverConfig)
-	WithDeletePermanentlyAfter(DefaultDeletePermanentlyAfter)(cfg)
 	WithStorageType(DefaultStorageType)(cfg)
-	WithGetAllPageSize(DefaultGetAllPageSize)(cfg)
 	WithRegistryTTL(DefaultRegistryTTL)(cfg)
 	for _, option := range options {
 		option(cfg)
@@ -43,38 +30,10 @@ func newServerConfig(options ...ServerOption) *serverConfig {
 // A ServerOption customizes the server.
 type ServerOption func(*serverConfig)
 
-// WithDeletePermanentlyAfter sets the deletePermanentlyAfter duration.
-// If a record is deleted via Delete, it will be permanently deleted after
-// the given duration.
-func WithDeletePermanentlyAfter(dur time.Duration) ServerOption {
-	return func(cfg *serverConfig) {
-		cfg.deletePermanentlyAfter = dur
-	}
-}
-
-// WithGetAllPageSize sets the page size for GetAll calls.
-func WithGetAllPageSize(pageSize int) ServerOption {
-	return func(cfg *serverConfig) {
-		cfg.getAllPageSize = pageSize
-	}
-}
-
 // WithRegistryTTL sets the registry time to live in the config.
 func WithRegistryTTL(ttl time.Duration) ServerOption {
 	return func(cfg *serverConfig) {
 		cfg.registryTTL = ttl
-	}
-}
-
-// WithGetSharedKey sets the secret in the config.
-func WithGetSharedKey(getSharedKey func() ([]byte, error)) ServerOption {
-	return func(cfg *serverConfig) {
-		sharedKey, err := getSharedKey()
-		if err != nil {
-			log.Error().Err(err).Msgf("shared key is required and must be %d bytes long", cryptutil.DefaultKeySize)
-			return
-		}
-		cfg.secret = sharedKey
 	}
 }
 


### PR DESCRIPTION
## Summary

The `databroker.serverConfig` struct has a few fields which are written to but never read. Let's remove these.

## Related issues

n/a

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated docs
- [ ] updated unit tests
- [ ] updated UPGRADING.md
- [ ] add appropriate tag (`improvement` / `bug` / etc)
- [ ] ready for review
