### PR TITLE
github: update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -11,7 +11,7 @@ The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
 ## Related issues
 
 <!-- For example...
-Fixes #159
+- #159
 -->
 
 ## User Explanation
@@ -23,8 +23,6 @@ this blank. If filled out, add the `docs` label -->
 ## Checklist
 
 - [ ] reference any related issues
-- [ ] updated docs
 - [ ] updated unit tests
-- [ ] updated UPGRADING.md
-- [ ] add appropriate tag (`improvement` / `bug` / etc)
+- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
 - [ ] ready for review


### PR DESCRIPTION
Update the PR template to better reflect our current workflow:

- Do not suggest using the "Fixes" keyword, as this will close linked issues upon merge. (For most issues, the process is to let QA verify and then close the issue.)
- Remove the "updated docs" and "updated UPGRADING.md" checklist steps. As documentation lives in a separate repository, it is no longer possible to update docs in the same PR.
- Expand the list of labels, based on the changelog categories (omitting "security" because security issues should be reported separately)