### PR TITLE
Fix race condition in databroker restart test

### DIFF
--- a/internal/zero/controller/databroker_restart_test.go
+++ b/internal/zero/controller/databroker_restart_test.go
@@ -108,6 +108,6 @@ func TestDatabrokerRestart(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, 2, count)
-		require.NotEqual(t, clients[0], clients[1])
+		require.NotSame(t, clients[0], clients[1])
 	})
 }


### PR DESCRIPTION
## Summary

The existing check was using NotEqual which was trying to compare internal grpc client structs recursively, including fields which should not be compared.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
