### PR TITLE
storage: fix possible race condition with maps.Keys iterator

### DIFF
--- a/pkg/storage/inmemory/backend.go
+++ b/pkg/storage/inmemory/backend.go
@@ -203,10 +203,10 @@ func (backend *Backend) Lease(_ context.Context, leaseName, leaseID string, ttl 
 // ListTypes lists the record types.
 func (backend *Backend) ListTypes(_ context.Context) ([]string, error) {
 	backend.mu.Lock()
-	keys := maps.Keys(backend.lookup)
-	backend.mu.Unlock()
+	defer backend.mu.Unlock()
+	keys := slices.Sorted(maps.Keys(backend.lookup))
 
-	return slices.Sorted(keys), nil
+	return keys, nil
 }
 
 // Put puts a record into the in-memory store.


### PR DESCRIPTION
## Summary

Fixes a possible race condition in the usage of the maps.Keys iterator in the in-memory databroker storage backend's ListTypes method.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
