### PR TITLE
core/config: allow websockets and spdy by default for k8s urls

### DIFF
--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -405,11 +405,11 @@ func (b *Builder) buildPolicyRouteRouteAction(options *config.Options, policy *c
 	upgradeConfigs := []*envoy_config_route_v3.RouteAction_UpgradeConfig{
 		{
 			UpgradeType: "websocket",
-			Enabled:     &wrapperspb.BoolValue{Value: policy.AllowWebsockets},
+			Enabled:     &wrapperspb.BoolValue{Value: policy.AllowWebsockets || policy.IsForKubernetes()},
 		},
 		{
 			UpgradeType: "spdy/3.1",
-			Enabled:     &wrapperspb.BoolValue{Value: policy.AllowSPDY},
+			Enabled:     &wrapperspb.BoolValue{Value: policy.AllowSPDY || policy.IsForKubernetes()},
 		},
 	}
 

--- a/internal/httputil/reproxy/reproxy.go
+++ b/internal/httputil/reproxy/reproxy.go
@@ -116,7 +116,7 @@ func (h *Handler) Middleware(next http.Handler) http.Handler {
 
 		// when SPDY is being used, disable HTTP/2 because the two can't be used together with the reverse proxy
 		// Issue #2126
-		disableHTTP2 := isSPDY(r)
+		disableHTTP2 := isSPDY(r) || isWebsocket(r)
 
 		h := stdhttputil.NewSingleHostReverseProxy(&dst)
 		h.ErrorLog = stdlog.New(log.Logger(), "", 0)
@@ -146,4 +146,8 @@ func (h *Handler) Update(ctx context.Context, cfg *config.Config) {
 
 func isSPDY(r *http.Request) bool {
 	return strings.HasPrefix(strings.ToLower(r.Header.Get(httputil.HeaderUpgrade)), "spdy/")
+}
+
+func isWebsocket(r *http.Request) bool {
+	return strings.HasPrefix(strings.ToLower(r.Header.Get(httputil.HeaderUpgrade)), "websocket/")
 }


### PR DESCRIPTION
## Summary
Several `kubectl` commands use spdy, and in more recent versions websockets, so go ahead and enable those features if a kubernetes service account token is being used for a route.

Also update the reproxy handler to disable HTTP/2 when using websockets.

## Related issues
- https://github.com/pomerium/pomerium/issues/5293
 

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
