### PR TITLE
config: set_response_headers is not unknown

### DIFF
--- a/config/options_check.go
+++ b/config/options_check.go
@@ -38,10 +38,12 @@ var (
 		"routes.set_authorization_header": "https://www.pomerium.com/docs/deploy/core/upgrading#set-authorization-header",
 	}
 
-	// mapstructure has issues with embedded protobuf structs that we should ignore
 	ignoreConfigFields = map[string]struct{}{
+		// mapstructure has issues with embedded protobuf structs that we should ignore
 		"routes.outlier_detection": {},
 		"routes.health_checks":     {},
+		// set_response_headers is handled separately from mapstructure
+		"set_response_headers": {},
 	}
 )
 


### PR DESCRIPTION
## Summary

Most fields in the [config.Options](https://github.com/pomerium/pomerium/blob/075ea01b0add1563da73461bb3e5d78896d6fb46/config/options.go#L59) struct are populated by the `mapstructure` package, but the [SetResponseHeaders](https://github.com/pomerium/pomerium/blob/075ea01b0add1563da73461bb3e5d78896d6fb46/config/options.go#L192) field is handled separately. As a result, when the `set_response_headers` key is present, it also shows up as an unknown config option.

Add this key to the [ignoreConfigFields](https://github.com/pomerium/pomerium/blob/075ea01b0add1563da73461bb3e5d78896d6fb46/config/options_check.go#L42) map, to avoid logging an incorrect "unknown config option" message when set.

## Related issues

- https://github.com/pomerium/pomerium-zero/issues/3093

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
