### PR TITLE
inmemory: add a test for the ListTypes race fix

### DIFF
--- a/pkg/storage/inmemory/backend_test.go
+++ b/pkg/storage/inmemory/backend_test.go
@@ -252,3 +252,17 @@ func TestLease(t *testing.T) {
 		assert.True(t, ok, "expected b to to acquire the lease")
 	}
 }
+
+// Concurrent calls to Put() and ListTypes() should not cause a data race.
+func TestListTypes_concurrent(t *testing.T) {
+	ctx := context.Background()
+	backend := New()
+	for i := 0; i < 10; i++ {
+		t := fmt.Sprintf("Type-%02d", i)
+		go backend.Put(ctx, []*databroker.Record{{
+			Id:   "1",
+			Type: t,
+		}})
+		go backend.ListTypes(ctx)
+	}
+}

--- a/pkg/storage/inmemory/backend_test.go
+++ b/pkg/storage/inmemory/backend_test.go
@@ -254,7 +254,7 @@ func TestLease(t *testing.T) {
 }
 
 // Concurrent calls to Put() and ListTypes() should not cause a data race.
-func TestListTypes_concurrent(t *testing.T) {
+func TestListTypes_concurrent(_ *testing.T) {
 	ctx := context.Background()
 	backend := New()
 	for i := 0; i < 10; i++ {


### PR DESCRIPTION
## Summary

Add a test that interleaves calls to `Put()` (with different type strings) and `ListTypes()`. At least on my machine, this appears to reliably detect the data race fixed in commit 2f8743522d7b60a6b3773fff5a13d6b0b76924ae when run with the Go race detector. (The `make test` and `make cover` targets run with the Go race detector enabled.)

## Related issues

- #5319 

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
