### PR TITLE
sessions: add exp claim

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -394,13 +394,13 @@ Or contact your administrator.
 		return nil, fmt.Errorf("error redeeming authenticate code: %w", err)
 	}
 
-	s := sessions.NewState(idpID)
+	s := sessions.NewState(idpID, a.options.Load().CookieExpire)
 	err = claims.Claims.Claims(&s)
 	if err != nil {
 		return nil, fmt.Errorf("error unmarshaling session state: %w", err)
 	}
 
-	newState := s.WithNewIssuer(state.redirectURL.Hostname(), []string{state.redirectURL.Hostname()})
+	newState := s.WithNewIssuer(state.redirectURL.Hostname(), []string{state.redirectURL.Hostname()}, a.options.Load().CookieExpire)
 	if nextRedirectURL, err := urlutil.ParseAndValidateURL(redirectURL.Query().Get(urlutil.QueryRedirectURI)); err == nil {
 		newState.Audience = append(newState.Audience, nextRedirectURL.Hostname())
 	}

--- a/internal/authenticateflow/identityprofile.go
+++ b/internal/authenticateflow/identityprofile.go
@@ -126,10 +126,10 @@ func validateIdentityProfile(
 	return nil
 }
 
-func newSessionStateFromProfile(p *identitypb.Profile) *sessions.State {
+func newSessionStateFromProfile(p *identitypb.Profile, sessionDuration time.Duration) *sessions.State {
 	claims := p.GetClaims().AsMap()
 
-	ss := sessions.NewState(p.GetProviderId())
+	ss := sessions.NewState(p.GetProviderId(), sessionDuration)
 
 	// set the subject
 	if v, ok := claims["sub"]; ok {

--- a/internal/authenticateflow/stateful.go
+++ b/internal/authenticateflow/stateful.go
@@ -118,7 +118,7 @@ func (s *Stateful) SignIn(
 
 	// start over if this is a different identity provider
 	if sessionState == nil || sessionState.IdentityProviderID != idpID {
-		sessionState = sessions.NewState(idpID)
+		sessionState = sessions.NewState(idpID, s.sessionDuration)
 	}
 
 	redirectURL, err := urlutil.ParseAndValidateURL(r.FormValue(urlutil.QueryRedirectURI))
@@ -137,7 +137,7 @@ func (s *Stateful) SignIn(
 		jwtAudience = append(jwtAudience, callbackURL.Host)
 	}
 
-	newSession := sessionState.WithNewIssuer(s.authenticateURL.Host, jwtAudience)
+	newSession := sessionState.WithNewIssuer(s.authenticateURL.Host, jwtAudience, s.sessionDuration)
 
 	// re-persist the session, useful when session was evicted from session store
 	if err := s.sessionStore.SaveSession(w, r, sessionState); err != nil {

--- a/internal/authenticateflow/stateless.go
+++ b/internal/authenticateflow/stateless.go
@@ -184,7 +184,7 @@ func (s *Stateless) SignIn(
 
 	// start over if this is a different identity provider
 	if sessionState == nil || sessionState.IdentityProviderID != idpID {
-		sessionState = sessions.NewState(idpID)
+		sessionState = sessions.NewState(idpID, s.options.CookieExpire)
 	}
 
 	// re-persist the session, useful when session was evicted from session store
@@ -394,7 +394,7 @@ func (s *Stateless) Callback(w http.ResponseWriter, r *http.Request) error {
 		return err
 	}
 
-	ss := newSessionStateFromProfile(profile)
+	ss := newSessionStateFromProfile(profile, s.options.CookieExpire)
 	sess, err := session.Get(r.Context(), s.dataBrokerClient, ss.ID)
 	if err != nil {
 		sess = &session.Session{Id: ss.ID}

--- a/internal/sessions/state.go
+++ b/internal/sessions/state.go
@@ -18,11 +18,12 @@ var timeNow = time.Now
 // State is our object that keeps track of a user's session state
 type State struct {
 	// Public claim values (as specified in RFC 7519).
-	Issuer   string           `json:"iss,omitempty"`
-	Subject  string           `json:"sub,omitempty"`
-	Audience jwt.Audience     `json:"aud,omitempty"`
-	IssuedAt *jwt.NumericDate `json:"iat,omitempty"`
-	ID       string           `json:"jti,omitempty"`
+	Issuer    string           `json:"iss,omitempty"`
+	Subject   string           `json:"sub,omitempty"`
+	Audience  jwt.Audience     `json:"aud,omitempty"`
+	IssuedAt  *jwt.NumericDate `json:"iat,omitempty"`
+	ExpiresAt *jwt.NumericDate `json:"exp,omitempty"`
+	ID        string           `json:"jti,omitempty"`
 
 	// Azure returns OID which should be used instead of subject.
 	OID string `json:"oid,omitempty"`
@@ -39,21 +40,25 @@ type State struct {
 }
 
 // NewState creates a new State.
-func NewState(idpID string) *State {
+func NewState(idpID string, sessionDuration time.Duration) *State {
+	now := timeNow()
 	return &State{
-		IssuedAt:           jwt.NewNumericDate(timeNow()),
+		IssuedAt:           jwt.NewNumericDate(now),
+		ExpiresAt:          jwt.NewNumericDate(now.Add(sessionDuration)),
 		ID:                 uuid.NewString(),
 		IdentityProviderID: idpID,
 	}
 }
 
 // WithNewIssuer creates a new State from an existing State.
-func (s *State) WithNewIssuer(issuer string, audience []string) State {
+func (s *State) WithNewIssuer(issuer string, audience []string, sessionDuration time.Duration) State {
 	newState := State{}
 	if s != nil {
 		newState = *s
 	}
-	newState.IssuedAt = jwt.NewNumericDate(timeNow())
+	now := timeNow()
+	newState.IssuedAt = jwt.NewNumericDate(now)
+	newState.ExpiresAt = jwt.NewNumericDate(now.Add(sessionDuration))
 	newState.Audience = audience
 	newState.Issuer = issuer
 	return newState

--- a/internal/sessions/state_test.go
+++ b/internal/sessions/state_test.go
@@ -15,6 +15,7 @@ func TestState_UnmarshalJSON(t *testing.T) {
 		return fixedTime
 	}
 	defer func() { timeNow = time.Now }()
+	expiresAt := fixedTime.Add(time.Minute)
 	tests := []struct {
 		name    string
 		in      *State
@@ -24,25 +25,25 @@ func TestState_UnmarshalJSON(t *testing.T) {
 		{
 			"good",
 			&State{ID: "xyz"},
-			&State{ID: "xyz", IssuedAt: jwt.NewNumericDate(fixedTime)},
+			&State{ID: "xyz", IssuedAt: jwt.NewNumericDate(fixedTime), ExpiresAt: jwt.NewNumericDate(expiresAt)},
 			false,
 		},
 		{
 			"with user",
 			&State{ID: "xyz"},
-			&State{ID: "xyz", IssuedAt: jwt.NewNumericDate(fixedTime)},
+			&State{ID: "xyz", IssuedAt: jwt.NewNumericDate(fixedTime), ExpiresAt: jwt.NewNumericDate(expiresAt)},
 			false,
 		},
 		{
 			"without",
 			&State{ID: "xyz", Subject: "user"},
-			&State{ID: "xyz", Subject: "user", IssuedAt: jwt.NewNumericDate(fixedTime)},
+			&State{ID: "xyz", Subject: "user", IssuedAt: jwt.NewNumericDate(fixedTime), ExpiresAt: jwt.NewNumericDate(expiresAt)},
 			false,
 		},
 		{
 			"missing id",
 			&State{},
-			&State{IssuedAt: jwt.NewNumericDate(fixedTime)},
+			&State{IssuedAt: jwt.NewNumericDate(fixedTime), ExpiresAt: jwt.NewNumericDate(expiresAt)},
 			true,
 		},
 	}
@@ -53,7 +54,7 @@ func TestState_UnmarshalJSON(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			s := NewState("")
+			s := NewState("", time.Minute)
 			s.ID = ""
 			if err := s.UnmarshalJSON(data); (err != nil) != tt.wantErr {
 				t.Errorf("State.UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
## Summary
Add `exp` to the session state JWT.

## Related issues
- https://github.com/pomerium/internal/issues/1983
- https://github.com/pomerium/internal/issues/1984


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
