### PR TITLE
Add new request header variable 'pomerium.jwt'

### DIFF
--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -162,6 +162,7 @@ func TestHeadersEvaluator(t *testing.T) {
 					"X-ID-Token":              "${pomerium.id_token}",
 					"X-Access-Token":          "${pomerium.access_token}",
 					"Client-Cert-Fingerprint": "${pomerium.client_cert_fingerprint}",
+					"Authorization":           "Bearer ${pomerium.jwt}",
 					"Foo":                     "escaped $$dollar sign",
 				},
 				ClientCertificate: ClientCertificateInfo{Leaf: testValidCert},
@@ -174,6 +175,15 @@ func TestHeadersEvaluator(t *testing.T) {
 		assert.Equal(t, "3febe6467787e93f0a01030e0803072feaa710f724a9dc74de05cfba3d4a6d23",
 			output.Headers.Get("Client-Cert-Fingerprint"))
 		assert.Equal(t, "escaped $dollar sign", output.Headers.Get("Foo"))
+		authHeader := output.Headers.Get("Authorization")
+		assert.True(t, strings.HasPrefix(authHeader, "Bearer "))
+		authHeader = strings.TrimPrefix(authHeader, "Bearer ")
+		token, err := jwt.ParseSigned(authHeader)
+		require.NoError(t, err)
+		var claims jwt.Claims
+		require.NoError(t, token.Claims(publicJWK, &claims))
+		assert.Equal(t, "from.example.com", claims.Issuer)
+		assert.Equal(t, jwt.Audience{"from.example.com"}, claims.Audience)
 	})
 
 	t.Run("set_request_headers no repeated substitution", func(t *testing.T) {

--- a/authorize/evaluator/opa/policy/headers.rego
+++ b/authorize/evaluator/opa/policy/headers.rego
@@ -201,6 +201,7 @@ set_request_headers := h if {
 		"pomerium.id_token": session_id_token,
 		"pomerium.access_token": session_access_token,
 		"pomerium.client_cert_fingerprint": client_cert_fingerprint,
+		"pomerium.jwt": signed_jwt,
 	}
 	h := [[header_name, header_value] |
 		some header_name


### PR DESCRIPTION
## Summary

This is a prerequisite for supporting k8s structured authentication config. Adds a new variable `${pomerium.jwt}` that will substitute the pomerium JWT into request headers.

## Related issues

https://github.com/pomerium/pomerium/issues/5342

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
