### PR TITLE
Add an 'issuer' field to the /.well-known/pomerium endpoint

### DIFF
--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -52,6 +52,7 @@ func TestServerHTTP(t *testing.T) {
 		require.NoError(t, err)
 
 		expect := map[string]any{
+			"issuer":                           fmt.Sprintf("https://localhost:%s/", src.GetConfig().HTTPPort),
 			"authentication_callback_endpoint": "https://authenticate.localhost.pomerium.io/oauth2/callback",
 			"frontchannel_logout_uri":          fmt.Sprintf("https://localhost:%s/.pomerium/sign_out", src.GetConfig().HTTPPort),
 			"jwks_uri":                         fmt.Sprintf("https://localhost:%s/.well-known/pomerium/jwks.json", src.GetConfig().HTTPPort),

--- a/internal/handlers/well_known_pomerium.go
+++ b/internal/handlers/well_known_pomerium.go
@@ -15,10 +15,12 @@ import (
 func WellKnownPomerium(authenticateURL *url.URL) http.Handler {
 	return cors.AllowAll().Handler(httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		wellKnownURLs := struct {
+			Issuer                string `json:"issuer"`
 			OAuth2Callback        string `json:"authentication_callback_endpoint"` // RFC6749
 			JSONWebKeySetURL      string `json:"jwks_uri"`                         // RFC7517
 			FrontchannelLogoutURI string `json:"frontchannel_logout_uri"`          // https://openid.net/specs/openid-connect-frontchannel-1_0.html
 		}{
+			urlutil.GetAbsoluteURL(r).ResolveReference(&url.URL{Path: "/"}).String(),
 			authenticateURL.ResolveReference(&url.URL{Path: "/oauth2/callback"}).String(),
 			urlutil.GetAbsoluteURL(r).ResolveReference(&url.URL{Path: "/.well-known/pomerium/jwks.json"}).String(),
 			urlutil.GetAbsoluteURL(r).ResolveReference(&url.URL{Path: "/.pomerium/sign_out"}).String(),

--- a/internal/handlers/well_known_pomerium_test.go
+++ b/internal/handlers/well_known_pomerium_test.go
@@ -27,6 +27,7 @@ func TestWellKnownPomeriumHandler(t *testing.T) {
 		r := httptest.NewRequest(http.MethodGet, "https://route.example.com", nil)
 		WellKnownPomerium(authenticateURL).ServeHTTP(w, r)
 		assert.JSONEq(t, `{
+			"issuer": "https://route.example.com/",
 			"authentication_callback_endpoint": "https://authenticate.example.com/oauth2/callback",
 			"frontchannel_logout_uri": "https://route.example.com/.pomerium/sign_out",
 			"jwks_uri": "https://route.example.com/.well-known/pomerium/jwks.json"


### PR DESCRIPTION
## Summary

This adds an `issuer` field to the `/.well-known/pomerium` endpoint available on any route. The field contains the route's base uri, including the https:// scheme and ending with a trailing slash. 

For example, the route with hostname foo.example.com will have an endpoint `https://foo.example.com/.well-known/pomerium` which will contain (along with the existing fields) `"issuer":"https://foo.example.com/"`. 

This is part of Kubernetes structured authentication support, but could also be used by other compatible upstream services.

## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
