### PR TITLE
config: fix redirect response code

### DIFF
--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -385,7 +385,7 @@ func (b *Builder) buildPolicyRouteRedirectAction(r *config.PolicyRedirect) (*env
 		}
 	}
 	if r.ResponseCode != nil {
-		action.ResponseCode = envoy_config_route_v3.RedirectAction_RedirectResponseCode(*r.ResponseCode)
+		action.ResponseCode, _ = r.GetEnvoyResponseCode()
 	}
 	if r.StripQuery != nil {
 		action.StripQuery = *r.StripQuery

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -1985,13 +1985,28 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 		}, action)
 	})
 	t.Run("ResponseCode", func(t *testing.T) {
-		action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
-			ResponseCode: proto.Int32(301),
-		})
-		require.NoError(t, err)
-		assert.Equal(t, &envoy_config_route_v3.RedirectAction{
-			ResponseCode: 301,
-		}, action)
+		codes := []struct {
+			Number int32
+			Enum   envoy_config_route_v3.RedirectAction_RedirectResponseCode
+		}{
+			{301, envoy_config_route_v3.RedirectAction_MOVED_PERMANENTLY},
+			{302, envoy_config_route_v3.RedirectAction_FOUND},
+			{303, envoy_config_route_v3.RedirectAction_SEE_OTHER},
+			{307, envoy_config_route_v3.RedirectAction_TEMPORARY_REDIRECT},
+			{308, envoy_config_route_v3.RedirectAction_PERMANENT_REDIRECT},
+		}
+		for i := range codes {
+			c := &codes[i]
+			t.Run(fmt.Sprint(c.Number), func(t *testing.T) {
+				action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
+					ResponseCode: &c.Number,
+				})
+				require.NoError(t, err)
+				assert.Equal(t, &envoy_config_route_v3.RedirectAction{
+					ResponseCode: c.Enum,
+				}, action)
+			})
+		}
 	})
 	t.Run("StripQuery", func(t *testing.T) {
 		action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/url"
 	"testing"
 
@@ -58,6 +59,51 @@ func Test_PolicyValidate(t *testing.T) {
 			err := tt.policy.Validate()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Validate() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_PolicyValidate_RedirectResponseCode(t *testing.T) {
+	t.Parallel()
+
+	var r PolicyRedirect
+	p := Policy{
+		From:     "http://example.com",
+		Redirect: &r,
+	}
+
+	cases := []struct {
+		Code          int32
+		ExpectedError string
+	}{
+		{0, "unsupported redirect response code 0"},
+		{100, "unsupported redirect response code 100"},
+		{200, "unsupported redirect response code 200"},
+		{300, "unsupported redirect response code 300"},
+		{301, ""},
+		{302, ""},
+		{303, ""},
+		{304, "unsupported redirect response code 304"},
+		{305, "unsupported redirect response code 305"},
+		{306, "unsupported redirect response code 306"},
+		{307, ""},
+		{308, ""},
+		{309, "unsupported redirect response code 309"},
+		{400, "unsupported redirect response code 400"},
+		{500, "unsupported redirect response code 500"},
+		{600, "unsupported redirect response code 600"},
+	}
+
+	for i := range cases {
+		c := &cases[i]
+		t.Run(fmt.Sprint(c.Code), func(t *testing.T) {
+			r.ResponseCode = &c.Code
+			err := p.Validate()
+			if c.ExpectedError != "" {
+				assert.ErrorContains(t, err, c.ExpectedError)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

The `response_code` [redirect option](https://www.pomerium.com/docs/reference/routes/redirect#redirect-options) does not behave as documented. It currently accepts an Envoy [RedirectResponseCode](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#enum-config-route-v3-redirectaction-redirectresponsecode) enum value (in the range 0 through 4) instead of an HTTP status code.

Fix this option to behave as documented, by adding a translation step from numerical HTTP status code to the appropriate Envoy RedirectResponseCode enum value.

Add validation logic to reject any redirect status code that Envoy does not support.

## Related issues

- https://github.com/pomerium/pomerium/issues/4903

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
