### PR TITLE
ppl: support additional types for string matchers

### DIFF
--- a/pkg/policy/criteria/matchers.go
+++ b/pkg/policy/criteria/matchers.go
@@ -11,16 +11,11 @@ import (
 type matcher func(*ast.Body, *ast.Term, parser.Value) error
 
 func matchString(dst *ast.Body, left *ast.Term, right parser.Value) error {
-	str, ok := right.(parser.String)
-	if ok {
-		right = parser.Object{
-			"is": str,
-		}
-	}
-
 	obj, ok := right.(parser.Object)
 	if !ok {
-		return fmt.Errorf("expected object for string matcher, got: %T", right)
+		obj = parser.Object{
+			"is": right,
+		}
 	}
 
 	lookup := map[string]matcher{
@@ -63,16 +58,11 @@ func matchStringStartsWith(dst *ast.Body, left *ast.Term, right parser.Value) er
 }
 
 func matchStringList(dst *ast.Body, left *ast.Term, right parser.Value) error {
-	str, ok := right.(parser.String)
-	if ok {
-		right = parser.Object{
-			"has": str,
-		}
-	}
-
 	obj, ok := right.(parser.Object)
 	if !ok {
-		return fmt.Errorf("expected object for string list matcher, got: %T", right)
+		obj = parser.Object{
+			"has": right,
+		}
 	}
 
 	lookup := map[string]matcher{

--- a/pkg/policy/criteria/matchers_test.go
+++ b/pkg/policy/criteria/matchers_test.go
@@ -68,6 +68,30 @@ func TestStringMatcher(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, `example == "test"`, str(body))
 	})
+	t.Run("boolean", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchString(&body, ast.VarTerm("example"), parser.Boolean(true))
+		require.NoError(t, err)
+		assert.Equal(t, `example == true`, str(body))
+	})
+	t.Run("number", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchString(&body, ast.VarTerm("example"), parser.Number("1234"))
+		require.NoError(t, err)
+		assert.Equal(t, `example == 1234`, str(body))
+	})
+	t.Run("null", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchString(&body, ast.VarTerm("example"), parser.Null{})
+		require.NoError(t, err)
+		assert.Equal(t, `example == null`, str(body))
+	})
 }
 
 func TestStringListMatcher(t *testing.T) {
@@ -85,6 +109,8 @@ func TestStringListMatcher(t *testing.T) {
 		assert.Equal(t, `count([true | some v; v = example[_]; v == "test"]) > 0`, str(body))
 	})
 	t.Run("is", func(t *testing.T) {
+		t.Parallel()
+
 		var body ast.Body
 		err := matchStringList(&body, ast.VarTerm("example"), parser.Object{
 			"is": parser.String("test"),
@@ -99,5 +125,29 @@ func TestStringListMatcher(t *testing.T) {
 		err := matchStringList(&body, ast.VarTerm("example"), parser.String("test"))
 		require.NoError(t, err)
 		assert.Equal(t, `count([true | some v; v = example[_]; v == "test"]) > 0`, str(body))
+	})
+	t.Run("boolean", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchStringList(&body, ast.VarTerm("example"), parser.Boolean(true))
+		require.NoError(t, err)
+		assert.Equal(t, `count([true | some v; v = example[_]; v == true]) > 0`, str(body))
+	})
+	t.Run("number", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchStringList(&body, ast.VarTerm("example"), parser.Number("1234"))
+		require.NoError(t, err)
+		assert.Equal(t, `count([true | some v; v = example[_]; v == 1234]) > 0`, str(body))
+	})
+	t.Run("null", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchStringList(&body, ast.VarTerm("example"), parser.Null{})
+		require.NoError(t, err)
+		assert.Equal(t, `count([true | some v; v = example[_]; v == null]) > 0`, str(body))
 	})
 }


### PR DESCRIPTION
## Summary
For string and string list matchers rather than only supporting a string or object value on the right side, support any type.

## Related issues
Fixes #5347 
 

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
