### PR TITLE
Optimize identity provider lookup

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/atomicutil"
+	"github.com/pomerium/pomerium/internal/authenticateflow"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
@@ -50,6 +51,14 @@ func New(ctx context.Context, cfg *config.Config, options ...Option) (*Authentic
 		cfg:     authenticateConfig,
 		options: config.NewAtomicOptions(),
 		state:   atomicutil.NewValue(newAuthenticateState()),
+	}
+
+	if authenticateConfig.getIdentityProvider == nil {
+		idpCache, err := config.NewIdentityProviderCache(cfg.Options)
+		if err != nil {
+			return nil, err
+		}
+		authenticateConfig.getIdentityProvider = authenticateflow.IdentityProviderLookupFromCache(idpCache)
 	}
 
 	a.options.Store(cfg.Options)

--- a/authenticate/config.go
+++ b/authenticate/config.go
@@ -18,7 +18,6 @@ type Option func(*authenticateConfig)
 
 func getAuthenticateConfig(options ...Option) *authenticateConfig {
 	cfg := new(authenticateConfig)
-	WithGetIdentityProvider(defaultGetIdentityProvider)(cfg)
 	for _, option := range options {
 		option(cfg)
 	}

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -407,7 +407,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 	})
 
-	idp, _ := new(config.Options).GetIdentityProviderForID("")
+	idp, _ := new(config.Options).GetIdentityProviderForPolicy(nil)
 
 	tests := []struct {
 		name    string

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -53,6 +53,7 @@ func New(ctx context.Context, cfg *config.Config) (*Authorize, error) {
 		return nil, err
 	}
 	a.state = atomicutil.NewValue(state)
+	a.currentOptions.Store(cfg.Options) // FIXME: this is refactored out in a different branch
 
 	return a, nil
 }

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -17,9 +17,10 @@ import (
 
 	"github.com/pomerium/pomerium/authorize/evaluator"
 	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/atomicutil"
+	"github.com/pomerium/pomerium/config/envoyconfig"
 	"github.com/pomerium/pomerium/internal/sessions"
 	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
@@ -49,15 +50,25 @@ yE+vPxsiUkvQHdO2fojCkY8jg70jxM+gu59tPDNbw3Uh/2Ij310FgTHsnGQMyA==
 -----END CERTIFICATE-----`
 
 func Test_getEvaluatorRequest(t *testing.T) {
-	a := &Authorize{currentOptions: config.NewAtomicOptions(), state: atomicutil.NewValue(new(authorizeState))}
-	a.currentOptions.Store(&config.Options{
-		Policies: []config.Policy{{
-			From: "https://example.com",
-			SubPolicies: []config.SubPolicy{{
-				Rego: []string{"allow = true"},
-			}},
+	policies := []config.Policy{{
+		From: "https://example.com",
+		To:   mustParseWeightedURLs(t, "https://foo.bar"),
+		SubPolicies: []config.SubPolicy{{
+			Rego: []string{"allow = true"},
 		}},
+	}}
+
+	policy0RouteID, err := policies[0].RouteID()
+	require.NoError(t, err)
+
+	a, err := New(context.Background(), &config.Config{
+		Options: &config.Options{
+			SharedKey:    cryptutil.NewBase64Key(),
+			CookieSecret: cryptutil.NewBase64Key(),
+			Policies:     policies,
+		},
 	})
+	require.NoError(t, err)
 
 	actual, err := a.getEvaluatorRequestFromCheckRequest(context.Background(),
 		&envoy_service_auth_v3.CheckRequest{
@@ -76,6 +87,7 @@ func Test_getEvaluatorRequest(t *testing.T) {
 						Body:   "BODY",
 					},
 				},
+				ContextExtensions: envoyconfig.MakeExtAuthzContextExtensions(false, policy0RouteID),
 				MetadataContext: &envoy_config_core_v3.Metadata{
 					FilterMetadata: map[string]*structpb.Struct{
 						"com.pomerium.client-certificate-info": {
@@ -94,7 +106,7 @@ func Test_getEvaluatorRequest(t *testing.T) {
 	)
 	require.NoError(t, err)
 	expect := &evaluator.Request{
-		Policy: &a.currentOptions.Load().Policies[0],
+		Policy: &policies[0],
 		Session: evaluator.RequestSession{
 			ID: "SESSION_ID",
 		},
@@ -117,16 +129,24 @@ func Test_getEvaluatorRequest(t *testing.T) {
 }
 
 func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
-	a := &Authorize{currentOptions: config.NewAtomicOptions(), state: atomicutil.NewValue(new(authorizeState))}
-	a.currentOptions.Store(&config.Options{
-		Policies: []config.Policy{{
-			From: "https://example.com",
-			SubPolicies: []config.SubPolicy{{
-				Rego: []string{"allow = true"},
-			}},
+	policies := []config.Policy{{
+		From: "https://example.com",
+		To:   mustParseWeightedURLs(t, "https://foo.bar"),
+		SubPolicies: []config.SubPolicy{{
+			Rego: []string{"allow = true"},
 		}},
-	})
+	}}
+	policy0RouteID, err := policies[0].RouteID()
+	require.NoError(t, err)
 
+	a, err := New(context.Background(), &config.Config{
+		Options: &config.Options{
+			SharedKey:    cryptutil.NewBase64Key(),
+			CookieSecret: cryptutil.NewBase64Key(),
+			Policies:     policies,
+		},
+	})
+	require.NoError(t, err)
 	actual, err := a.getEvaluatorRequestFromCheckRequest(context.Background(),
 		&envoy_service_auth_v3.CheckRequest{
 			Attributes: &envoy_service_auth_v3.AttributeContext{
@@ -144,11 +164,12 @@ func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 						Body:   "BODY",
 					},
 				},
+				ContextExtensions: envoyconfig.MakeExtAuthzContextExtensions(false, policy0RouteID),
 			},
 		}, nil)
 	require.NoError(t, err)
 	expect := &evaluator.Request{
-		Policy:  &a.currentOptions.Load().Policies[0],
+		Policy:  &policies[0],
 		Session: evaluator.RequestSession{},
 		HTTP: evaluator.NewRequestHTTP(
 			http.MethodGet,

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -29,6 +29,7 @@ type authorizeState struct {
 	dataBrokerClient           databroker.DataBrokerServiceClient
 	auditEncryptor             *protoutil.Encryptor
 	sessionStore               *config.SessionStore
+	idpCache                   *config.IdentityProviderCache
 	authenticateFlow           authenticateFlow
 }
 
@@ -79,13 +80,20 @@ func newAuthorizeStateFromConfig(
 		state.auditEncryptor = protoutil.NewEncryptor(auditKey)
 	}
 
-	state.sessionStore, err = config.NewSessionStore(cfg.Options)
+	idpCache, err := config.NewIdentityProviderCache(cfg.Options)
+	if err != nil {
+		return nil, err
+	}
+	state.idpCache = idpCache
+
+	state.sessionStore, err = config.NewSessionStore(cfg.Options, state.idpCache)
 	if err != nil {
 		return nil, fmt.Errorf("authorize: invalid session store: %w", err)
 	}
 
 	if cfg.Options.UseStatelessAuthenticateFlow() {
-		state.authenticateFlow, err = authenticateflow.NewStateless(ctx, cfg, nil, nil, nil, nil)
+		state.authenticateFlow, err = authenticateflow.NewStateless(ctx, cfg, nil,
+			authenticateflow.IdentityProviderLookupFromCache(idpCache), nil, nil)
 	} else {
 		state.authenticateFlow, err = authenticateflow.NewStateful(ctx, cfg, nil)
 	}


### PR DESCRIPTION
## Summary

This contains a subset of the code from https://github.com/pomerium/pomerium/pull/5167, adding a cache that can be used to quickly look up the identity provider that corresponds with a route.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
