### PR TITLE
config: only validate redirect response code when non-nil

### DIFF
--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -1986,20 +1986,21 @@ func Test_buildPolicyRouteRedirectAction(t *testing.T) {
 	})
 	t.Run("ResponseCode", func(t *testing.T) {
 		codes := []struct {
-			Number int32
+			Number *int32
 			Enum   envoy_config_route_v3.RedirectAction_RedirectResponseCode
 		}{
-			{301, envoy_config_route_v3.RedirectAction_MOVED_PERMANENTLY},
-			{302, envoy_config_route_v3.RedirectAction_FOUND},
-			{303, envoy_config_route_v3.RedirectAction_SEE_OTHER},
-			{307, envoy_config_route_v3.RedirectAction_TEMPORARY_REDIRECT},
-			{308, envoy_config_route_v3.RedirectAction_PERMANENT_REDIRECT},
+			{nil, envoy_config_route_v3.RedirectAction_MOVED_PERMANENTLY},
+			{proto.Int32(301), envoy_config_route_v3.RedirectAction_MOVED_PERMANENTLY},
+			{proto.Int32(302), envoy_config_route_v3.RedirectAction_FOUND},
+			{proto.Int32(303), envoy_config_route_v3.RedirectAction_SEE_OTHER},
+			{proto.Int32(307), envoy_config_route_v3.RedirectAction_TEMPORARY_REDIRECT},
+			{proto.Int32(308), envoy_config_route_v3.RedirectAction_PERMANENT_REDIRECT},
 		}
 		for i := range codes {
 			c := &codes[i]
 			t.Run(fmt.Sprint(c.Number), func(t *testing.T) {
 				action, err := b.buildPolicyRouteRedirectAction(&config.PolicyRedirect{
-					ResponseCode: &c.Number,
+					ResponseCode: c.Number,
 				})
 				require.NoError(t, err)
 				assert.Equal(t, &envoy_config_route_v3.RedirectAction{

--- a/config/policy.go
+++ b/config/policy.go
@@ -233,12 +233,10 @@ func (r *PolicyRedirect) validate() error {
 
 // GetEnvoyResponseCode returns the ResponseCode as the corresponding Envoy enum value.
 func (r *PolicyRedirect) GetEnvoyResponseCode() (envoy_config_route_v3.RedirectAction_RedirectResponseCode, error) {
-	var code int32
-	if r != nil && r.ResponseCode != nil {
-		code = *r.ResponseCode
+	if r == nil || r.ResponseCode == nil {
+		return envoy_config_route_v3.RedirectAction_RedirectResponseCode(0), nil
 	}
-
-	switch code {
+	switch code := *r.ResponseCode; code {
 	case http.StatusMovedPermanently:
 		return envoy_config_route_v3.RedirectAction_MOVED_PERMANENTLY, nil
 	case http.StatusFound:

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -74,31 +74,32 @@ func Test_PolicyValidate_RedirectResponseCode(t *testing.T) {
 	}
 
 	cases := []struct {
-		Code          int32
+		Code          *int32
 		ExpectedError string
 	}{
-		{0, "unsupported redirect response code 0"},
-		{100, "unsupported redirect response code 100"},
-		{200, "unsupported redirect response code 200"},
-		{300, "unsupported redirect response code 300"},
-		{301, ""},
-		{302, ""},
-		{303, ""},
-		{304, "unsupported redirect response code 304"},
-		{305, "unsupported redirect response code 305"},
-		{306, "unsupported redirect response code 306"},
-		{307, ""},
-		{308, ""},
-		{309, "unsupported redirect response code 309"},
-		{400, "unsupported redirect response code 400"},
-		{500, "unsupported redirect response code 500"},
-		{600, "unsupported redirect response code 600"},
+		{nil, ""},
+		{proto.Int32(0), "unsupported redirect response code 0"},
+		{proto.Int32(100), "unsupported redirect response code 100"},
+		{proto.Int32(200), "unsupported redirect response code 200"},
+		{proto.Int32(300), "unsupported redirect response code 300"},
+		{proto.Int32(301), ""},
+		{proto.Int32(302), ""},
+		{proto.Int32(303), ""},
+		{proto.Int32(304), "unsupported redirect response code 304"},
+		{proto.Int32(305), "unsupported redirect response code 305"},
+		{proto.Int32(306), "unsupported redirect response code 306"},
+		{proto.Int32(307), ""},
+		{proto.Int32(308), ""},
+		{proto.Int32(309), "unsupported redirect response code 309"},
+		{proto.Int32(400), "unsupported redirect response code 400"},
+		{proto.Int32(500), "unsupported redirect response code 500"},
+		{proto.Int32(600), "unsupported redirect response code 600"},
 	}
 
 	for i := range cases {
 		c := &cases[i]
 		t.Run(fmt.Sprint(c.Code), func(t *testing.T) {
-			r.ResponseCode = &c.Code
+			r.ResponseCode = c.Code
 			err := p.Validate()
 			if c.ExpectedError != "" {
 				assert.ErrorContains(t, err, c.ExpectedError)


### PR DESCRIPTION
## Summary

Small bug fix, follow up to https://github.com/pomerium/pomerium/pull/5346

## Related issues

- https://github.com/pomerium/pomerium/issues/4903

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
