### PR TITLE
core/metrics: improve memory usage

### DIFF
--- a/internal/telemetry/metrics/providers.go
+++ b/internal/telemetry/metrics/providers.go
@@ -234,8 +234,11 @@ func getCommonLabels(installationID string) map[string]string {
 	if err != nil {
 		hostname = "__none__"
 	}
-	return map[string]string{
-		metrics.InstallationIDLabel: installationID,
-		metrics.HostnameLabel:       hostname,
+	m := map[string]string{
+		metrics.HostnameLabel: hostname,
 	}
+	if installationID != "" {
+		m[metrics.InstallationIDLabel] = installationID
+	}
+	return m
 }

--- a/internal/telemetry/prometheus/convert.go
+++ b/internal/telemetry/prometheus/convert.go
@@ -30,14 +30,9 @@ func ToOTLP(
 	startTime time.Time,
 	now time.Time,
 ) ([]metricdata.Metrics, error) {
-	stream := NewMetricFamilyStream(src)
 	var metrics []metricdata.Metrics
 	var conversionErrors []error
-	for {
-		family, err := stream.Next()
-		if errors.Is(err, io.EOF) {
-			break
-		}
+	for family, err := range NewMetricFamilyStream(src) {
 		if err != nil {
 			return nil, err
 		}

--- a/internal/telemetry/prometheus/export.go
+++ b/internal/telemetry/prometheus/export.go
@@ -1,0 +1,30 @@
+package prometheus
+
+import (
+	"io"
+	"iter"
+
+	dto "github.com/prometheus/client_model/go"
+	"github.com/prometheus/common/expfmt"
+)
+
+// Export writes the metric families to the writer in text format
+func Export(
+	w io.Writer,
+	src iter.Seq2[*dto.MetricFamily, error],
+) error {
+	for mf, err := range src {
+		if err != nil {
+			return err
+		}
+		if err := exportMetricFamily(w, mf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func exportMetricFamily(w io.Writer, mf *dto.MetricFamily) error {
+	_, err := expfmt.MetricFamilyToText(w, mf)
+	return err
+}

--- a/internal/telemetry/prometheus/relabel.go
+++ b/internal/telemetry/prometheus/relabel.go
@@ -1,0 +1,33 @@
+package prometheus
+
+import (
+	"iter"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func AddLabels(
+	src iter.Seq2[*dto.MetricFamily, error],
+	addLabels map[string]string,
+) iter.Seq2[*dto.MetricFamily, error] {
+	return func(yield func(*dto.MetricFamily, error) bool) {
+		for mf, err := range src {
+			if err != nil {
+				yield(nil, err)
+				return
+			}
+			for _, metric := range mf.Metric {
+				for k, v := range addLabels {
+					k, v := k, v
+					metric.Label = append(metric.Label, &dto.LabelPair{
+						Name:  &k,
+						Value: &v,
+					})
+				}
+			}
+			if !yield(mf, nil) {
+				return
+			}
+		}
+	}
+}

--- a/internal/telemetry/prometheus/relabel.go
+++ b/internal/telemetry/prometheus/relabel.go
@@ -10,6 +10,15 @@ func AddLabels(
 	src iter.Seq2[*dto.MetricFamily, error],
 	addLabels map[string]string,
 ) iter.Seq2[*dto.MetricFamily, error] {
+	var extra []*dto.LabelPair
+	for k, v := range addLabels {
+		k, v := k, v
+		extra = append(extra, &dto.LabelPair{
+			Name:  &k,
+			Value: &v,
+		})
+	}
+
 	return func(yield func(*dto.MetricFamily, error) bool) {
 		for mf, err := range src {
 			if err != nil {
@@ -17,13 +26,7 @@ func AddLabels(
 				return
 			}
 			for _, metric := range mf.Metric {
-				for k, v := range addLabels {
-					k, v := k, v
-					metric.Label = append(metric.Label, &dto.LabelPair{
-						Name:  &k,
-						Value: &v,
-					})
-				}
+				metric.Label = append(metric.Label, extra...)
 			}
 			if !yield(mf, nil) {
 				return

--- a/internal/telemetry/prometheus/stream.go
+++ b/internal/telemetry/prometheus/stream.go
@@ -2,11 +2,11 @@ package prometheus
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"io"
 	"iter"
-	"strings"
 
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
@@ -15,7 +15,7 @@ import (
 type metricFamilyStream struct {
 	reader  io.Reader
 	scanner *bufio.Scanner
-	buffer  strings.Builder
+	buffer  bytes.Buffer
 	parser  expfmt.TextParser
 }
 
@@ -42,37 +42,40 @@ func NewMetricFamilyStream(reader io.Reader) iter.Seq2[*dto.MetricFamily, error]
 
 func (mfs *metricFamilyStream) Next() (*dto.MetricFamily, error) {
 	var afterHeader bool
-	var block *strings.Reader
-	for block == nil && mfs.scanner.Scan() {
-		line := mfs.scanner.Text()
-		if line == "" {
+	for mfs.scanner.Scan() {
+		line := mfs.scanner.Bytes()
+		if len(line) == 0 {
 			continue
 		}
 
 		if line[0] == '#' {
 			if afterHeader {
-				block = strings.NewReader(mfs.buffer.String())
+				result, err := mfs.parseMetricFamilyBlock(&mfs.buffer)
 				mfs.buffer.Reset()
+				mfs.buffer.Write(line)
+				mfs.buffer.WriteRune('\n')
+				return result, err
 			}
 		} else {
 			afterHeader = true
 		}
-		mfs.buffer.WriteString(line)
-		mfs.buffer.WriteString("\n")
+		mfs.buffer.Write(line)
+		mfs.buffer.WriteRune('\n')
 	}
 
-	if block == nil {
-		if err := mfs.scanner.Err(); err != nil {
-			return nil, err
-		}
-		if mfs.buffer.Len() == 0 {
-			return nil, io.EOF
-		}
-		block = strings.NewReader(mfs.buffer.String())
-		mfs.buffer.Reset()
+	if err := mfs.scanner.Err(); err != nil {
+		return nil, err
 	}
+	if mfs.buffer.Len() == 0 {
+		return nil, io.EOF
+	}
+	result, err := mfs.parseMetricFamilyBlock(&mfs.buffer)
+	mfs.buffer.Reset()
+	return result, err
+}
 
-	families, err := mfs.parser.TextToMetricFamilies(block)
+func (mfs *metricFamilyStream) parseMetricFamilyBlock(r io.Reader) (*dto.MetricFamily, error) {
+	families, err := mfs.parser.TextToMetricFamilies(r)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/telemetry/prometheus/testdata/large.txt
+++ b/internal/telemetry/prometheus/testdata/large.txt
@@ -1,0 +1,3608 @@
+# TYPE envoy_access_logs_grpc_access_log_logs_dropped counter
+envoy_access_logs_grpc_access_log_logs_dropped{service="pomerium"} 0
+# TYPE envoy_access_logs_grpc_access_log_logs_written counter
+envoy_access_logs_grpc_access_log_logs_written{service="pomerium"} 0
+# TYPE envoy_cluster_assignment_stale counter
+envoy_cluster_assignment_stale{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_assignment_stale{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_assignment_stale{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_assignment_stale{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_assignment_stale{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_assignment_stale{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_assignment_stale{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_assignment_stale{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_assignment_stale{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_assignment_stale{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_assignment_timeout_received counter
+envoy_cluster_assignment_timeout_received{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_assignment_timeout_received{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_assignment_timeout_received{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_assignment_timeout_received{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_assignment_timeout_received{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_assignment_timeout_received{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_assignment_timeout_received{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_assignment_timeout_received{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_assignment_timeout_received{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_assignment_timeout_received{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_assignment_use_cached counter
+envoy_cluster_assignment_use_cached{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_assignment_use_cached{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_assignment_use_cached{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_assignment_use_cached{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_assignment_use_cached{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_assignment_use_cached{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_assignment_use_cached{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_assignment_use_cached{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_assignment_use_cached{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_assignment_use_cached{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_bind_errors counter
+envoy_cluster_bind_errors{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_bind_errors{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_bind_errors{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_bind_errors{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_bind_errors{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_bind_errors{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_bind_errors{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_bind_errors{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_bind_errors{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_bind_errors{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_client_ssl_socket_factory_downstream_context_secrets_not_ready counter
+envoy_cluster_client_ssl_socket_factory_downstream_context_secrets_not_ready{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_client_ssl_socket_factory_ssl_context_update_by_sds counter
+envoy_cluster_client_ssl_socket_factory_ssl_context_update_by_sds{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_client_ssl_socket_factory_upstream_context_secrets_not_ready counter
+envoy_cluster_client_ssl_socket_factory_upstream_context_secrets_not_ready{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_default_total_match_count counter
+envoy_cluster_default_total_match_count{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_default_total_match_count{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 1
+envoy_cluster_default_total_match_count{service="pomerium",envoy_cluster_name="pomerium-authorize"} 1
+envoy_cluster_default_total_match_count{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_default_total_match_count{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 1
+envoy_cluster_default_total_match_count{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 1
+envoy_cluster_default_total_match_count{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_default_total_match_count{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 1
+envoy_cluster_default_total_match_count{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 1
+envoy_cluster_default_total_match_count{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 1
+# TYPE envoy_cluster_external_upstream_rq counter
+envoy_cluster_external_upstream_rq{envoy_response_code="200",service="pomerium",envoy_cluster_name="pomerium-databroker"} 6
+envoy_cluster_external_upstream_rq{envoy_response_code="503",service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_external_upstream_rq{envoy_response_code="200",service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 4
+envoy_cluster_external_upstream_rq{envoy_response_code="404",service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 1
+# TYPE envoy_cluster_external_upstream_rq_completed counter
+envoy_cluster_external_upstream_rq_completed{service="pomerium",envoy_cluster_name="pomerium-databroker"} 7
+envoy_cluster_external_upstream_rq_completed{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 5
+# TYPE envoy_cluster_external_upstream_rq_xx counter
+envoy_cluster_external_upstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_cluster_name="pomerium-databroker"} 6
+envoy_cluster_external_upstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_external_upstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 4
+envoy_cluster_external_upstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 1
+# TYPE envoy_cluster_http1_dropped_headers_with_underscores counter
+envoy_cluster_http1_dropped_headers_with_underscores{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+# TYPE envoy_cluster_http1_metadata_not_supported_error counter
+envoy_cluster_http1_metadata_not_supported_error{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+# TYPE envoy_cluster_http1_requests_rejected_with_underscores_in_headers counter
+envoy_cluster_http1_requests_rejected_with_underscores_in_headers{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+# TYPE envoy_cluster_http1_response_flood counter
+envoy_cluster_http1_response_flood{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+# TYPE envoy_cluster_http2_dropped_headers_with_underscores counter
+envoy_cluster_http2_dropped_headers_with_underscores{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_dropped_headers_with_underscores{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_goaway_sent counter
+envoy_cluster_http2_goaway_sent{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_goaway_sent{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_header_overflow counter
+envoy_cluster_http2_header_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_header_overflow{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_headers_cb_no_stream counter
+envoy_cluster_http2_headers_cb_no_stream{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_headers_cb_no_stream{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_inbound_empty_frames_flood counter
+envoy_cluster_http2_inbound_empty_frames_flood{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_inbound_empty_frames_flood{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_inbound_priority_frames_flood counter
+envoy_cluster_http2_inbound_priority_frames_flood{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_inbound_priority_frames_flood{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_inbound_window_update_frames_flood counter
+envoy_cluster_http2_inbound_window_update_frames_flood{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_inbound_window_update_frames_flood{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_keepalive_timeout counter
+envoy_cluster_http2_keepalive_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_keepalive_timeout{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_metadata_empty_frames counter
+envoy_cluster_http2_metadata_empty_frames{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_metadata_empty_frames{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_outbound_control_flood counter
+envoy_cluster_http2_outbound_control_flood{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_outbound_control_flood{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_outbound_flood counter
+envoy_cluster_http2_outbound_flood{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_outbound_flood{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_requests_rejected_with_underscores_in_headers counter
+envoy_cluster_http2_requests_rejected_with_underscores_in_headers{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_requests_rejected_with_underscores_in_headers{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_rx_messaging_error counter
+envoy_cluster_http2_rx_messaging_error{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_rx_messaging_error{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_rx_reset counter
+envoy_cluster_http2_rx_reset{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_rx_reset{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_stream_refused_errors counter
+envoy_cluster_http2_stream_refused_errors{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_stream_refused_errors{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_trailers counter
+envoy_cluster_http2_trailers{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_trailers{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_tx_flush_timeout counter
+envoy_cluster_http2_tx_flush_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_tx_flush_timeout{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_tx_reset counter
+envoy_cluster_http2_tx_reset{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_tx_reset{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_internal_upstream_rq counter
+envoy_cluster_internal_upstream_rq{envoy_response_code="200",service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_internal_upstream_rq{envoy_response_code="503",service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 7
+# TYPE envoy_cluster_internal_upstream_rq_completed counter
+envoy_cluster_internal_upstream_rq_completed{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 8
+# TYPE envoy_cluster_internal_upstream_rq_xx counter
+envoy_cluster_internal_upstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_internal_upstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 7
+# TYPE envoy_cluster_lb_healthy_panic counter
+envoy_cluster_lb_healthy_panic{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_healthy_panic{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_healthy_panic{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_healthy_panic{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_healthy_panic{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_healthy_panic{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_healthy_panic{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_healthy_panic{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_healthy_panic{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_healthy_panic{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_local_cluster_not_ok counter
+envoy_cluster_lb_local_cluster_not_ok{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_local_cluster_not_ok{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_local_cluster_not_ok{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_local_cluster_not_ok{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_local_cluster_not_ok{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_local_cluster_not_ok{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_local_cluster_not_ok{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_local_cluster_not_ok{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_local_cluster_not_ok{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_local_cluster_not_ok{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_recalculate_zone_structures counter
+envoy_cluster_lb_recalculate_zone_structures{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_recalculate_zone_structures{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_recalculate_zone_structures{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_recalculate_zone_structures{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_recalculate_zone_structures{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_recalculate_zone_structures{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_recalculate_zone_structures{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_recalculate_zone_structures{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_recalculate_zone_structures{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_recalculate_zone_structures{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_subsets_created counter
+envoy_cluster_lb_subsets_created{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_subsets_created{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_subsets_created{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_subsets_created{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_subsets_created{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_subsets_created{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_subsets_created{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_subsets_created{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_subsets_created{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_subsets_created{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_subsets_fallback counter
+envoy_cluster_lb_subsets_fallback{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_subsets_fallback{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_subsets_fallback{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_subsets_fallback{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_subsets_fallback{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_subsets_fallback{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_subsets_fallback{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_subsets_fallback{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_subsets_fallback{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_subsets_fallback{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_subsets_fallback_panic counter
+envoy_cluster_lb_subsets_fallback_panic{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_subsets_fallback_panic{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_subsets_fallback_panic{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_subsets_fallback_panic{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_subsets_fallback_panic{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_subsets_fallback_panic{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_subsets_fallback_panic{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_subsets_fallback_panic{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_subsets_fallback_panic{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_subsets_fallback_panic{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_subsets_removed counter
+envoy_cluster_lb_subsets_removed{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_subsets_removed{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_subsets_removed{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_subsets_removed{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_subsets_removed{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_subsets_removed{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_subsets_removed{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_subsets_removed{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_subsets_removed{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_subsets_removed{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_subsets_selected counter
+envoy_cluster_lb_subsets_selected{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_subsets_selected{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_subsets_selected{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_subsets_selected{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_subsets_selected{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_subsets_selected{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_subsets_selected{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_subsets_selected{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_subsets_selected{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_subsets_selected{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_zone_cluster_too_small counter
+envoy_cluster_lb_zone_cluster_too_small{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_zone_cluster_too_small{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_zone_cluster_too_small{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_zone_cluster_too_small{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_zone_cluster_too_small{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_zone_cluster_too_small{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_zone_cluster_too_small{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_zone_cluster_too_small{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_zone_cluster_too_small{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_zone_cluster_too_small{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_zone_no_capacity_left counter
+envoy_cluster_lb_zone_no_capacity_left{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_zone_no_capacity_left{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_zone_no_capacity_left{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_zone_no_capacity_left{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_zone_no_capacity_left{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_zone_no_capacity_left{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_zone_no_capacity_left{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_zone_no_capacity_left{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_zone_no_capacity_left{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_zone_no_capacity_left{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_zone_number_differs counter
+envoy_cluster_lb_zone_number_differs{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_zone_number_differs{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_zone_number_differs{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_zone_number_differs{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_zone_number_differs{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_zone_number_differs{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_zone_number_differs{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_zone_number_differs{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_zone_number_differs{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_zone_number_differs{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_zone_routing_all_directly counter
+envoy_cluster_lb_zone_routing_all_directly{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_zone_routing_all_directly{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_zone_routing_all_directly{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_zone_routing_all_directly{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_zone_routing_all_directly{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_zone_routing_all_directly{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_zone_routing_all_directly{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_zone_routing_all_directly{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_zone_routing_all_directly{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_zone_routing_all_directly{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_zone_routing_cross_zone counter
+envoy_cluster_lb_zone_routing_cross_zone{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_zone_routing_cross_zone{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_zone_routing_cross_zone{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_zone_routing_cross_zone{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_zone_routing_cross_zone{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_zone_routing_cross_zone{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_zone_routing_cross_zone{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_zone_routing_cross_zone{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_zone_routing_cross_zone{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_zone_routing_cross_zone{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_lb_zone_routing_sampled counter
+envoy_cluster_lb_zone_routing_sampled{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_zone_routing_sampled{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_zone_routing_sampled{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_zone_routing_sampled{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_zone_routing_sampled{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_zone_routing_sampled{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_zone_routing_sampled{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_zone_routing_sampled{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_zone_routing_sampled{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_zone_routing_sampled{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_membership_change counter
+envoy_cluster_membership_change{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 1
+envoy_cluster_membership_change{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 1
+envoy_cluster_membership_change{service="pomerium",envoy_cluster_name="pomerium-authorize"} 1
+envoy_cluster_membership_change{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_membership_change{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 1
+envoy_cluster_membership_change{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 1
+envoy_cluster_membership_change{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_membership_change{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 1
+envoy_cluster_membership_change{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 1
+envoy_cluster_membership_change{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 1
+# TYPE envoy_cluster_original_dst_host_invalid counter
+envoy_cluster_original_dst_host_invalid{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_original_dst_host_invalid{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_original_dst_host_invalid{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_original_dst_host_invalid{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_original_dst_host_invalid{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_original_dst_host_invalid{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_original_dst_host_invalid{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_original_dst_host_invalid{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_original_dst_host_invalid{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_original_dst_host_invalid{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_retry_or_shadow_abandoned counter
+envoy_cluster_retry_or_shadow_abandoned{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_retry_or_shadow_abandoned{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_retry_or_shadow_abandoned{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_retry_or_shadow_abandoned{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_retry_or_shadow_abandoned{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_retry_or_shadow_abandoned{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_retry_or_shadow_abandoned{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_retry_or_shadow_abandoned{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_retry_or_shadow_abandoned{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_retry_or_shadow_abandoned{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_ssl_connection_error counter
+envoy_cluster_ssl_connection_error{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_fail_verify_cert_hash counter
+envoy_cluster_ssl_fail_verify_cert_hash{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_fail_verify_error counter
+envoy_cluster_ssl_fail_verify_error{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_fail_verify_no_cert counter
+envoy_cluster_ssl_fail_verify_no_cert{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_fail_verify_san counter
+envoy_cluster_ssl_fail_verify_san{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_handshake counter
+envoy_cluster_ssl_handshake{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_no_certificate counter
+envoy_cluster_ssl_no_certificate{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_ocsp_staple_failed counter
+envoy_cluster_ssl_ocsp_staple_failed{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_ocsp_staple_omitted counter
+envoy_cluster_ssl_ocsp_staple_omitted{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_ocsp_staple_requests counter
+envoy_cluster_ssl_ocsp_staple_requests{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_ocsp_staple_responses counter
+envoy_cluster_ssl_ocsp_staple_responses{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_session_reused counter
+envoy_cluster_ssl_session_reused{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ssl_was_key_usage_invalid counter
+envoy_cluster_ssl_was_key_usage_invalid{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+# TYPE envoy_cluster_ts_2J99L7DB1GDGM9BIANZWCTM200ZBL2M4XP7S0Y1Z4BSJD208QG_total_match_count counter
+envoy_cluster_ts_2J99L7DB1GDGM9BIANZWCTM200ZBL2M4XP7S0Y1Z4BSJD208QG_total_match_count{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 1
+# TYPE envoy_cluster_update_attempt counter
+envoy_cluster_update_attempt{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 1
+envoy_cluster_update_attempt{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_update_attempt{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_update_attempt{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_update_attempt{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_update_attempt{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_update_attempt{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_update_attempt{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_update_attempt{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_update_attempt{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_update_empty counter
+envoy_cluster_update_empty{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_update_empty{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_update_empty{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_update_empty{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_update_empty{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_update_empty{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_update_empty{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_update_empty{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_update_empty{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_update_empty{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_update_failure counter
+envoy_cluster_update_failure{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_update_failure{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_update_failure{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_update_failure{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_update_failure{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_update_failure{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_update_failure{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_update_failure{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_update_failure{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_update_failure{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_update_no_rebuild counter
+envoy_cluster_update_no_rebuild{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_update_no_rebuild{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_update_no_rebuild{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_update_no_rebuild{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_update_no_rebuild{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_update_no_rebuild{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_update_no_rebuild{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_update_no_rebuild{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_update_no_rebuild{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_update_no_rebuild{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_update_success counter
+envoy_cluster_update_success{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 1
+envoy_cluster_update_success{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_update_success{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_update_success{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_update_success{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_update_success{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_update_success{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_update_success{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_update_success{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_update_success{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_close_notify counter
+envoy_cluster_upstream_cx_close_notify{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_close_notify{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_close_notify{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_close_notify{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_upstream_cx_close_notify{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_close_notify{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_close_notify{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_cx_close_notify{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_close_notify{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_close_notify{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_connect_attempts_exceeded counter
+envoy_cluster_upstream_cx_connect_attempts_exceeded{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_connect_attempts_exceeded{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_connect_attempts_exceeded{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_connect_attempts_exceeded{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_connect_attempts_exceeded{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_connect_attempts_exceeded{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_connect_attempts_exceeded{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_connect_attempts_exceeded{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_connect_attempts_exceeded{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_connect_attempts_exceeded{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_connect_fail counter
+envoy_cluster_upstream_cx_connect_fail{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_connect_fail{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_connect_fail{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_connect_fail{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 7
+envoy_cluster_upstream_cx_connect_fail{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_connect_fail{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_connect_fail{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_connect_fail{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_connect_fail{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_connect_fail{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_connect_timeout counter
+envoy_cluster_upstream_cx_connect_timeout{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_connect_timeout{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_connect_timeout{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_connect_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_connect_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_connect_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_connect_timeout{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_connect_timeout{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_connect_timeout{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_connect_timeout{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_connect_with_0_rtt counter
+envoy_cluster_upstream_cx_connect_with_0_rtt{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_connect_with_0_rtt{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_connect_with_0_rtt{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_connect_with_0_rtt{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_connect_with_0_rtt{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_connect_with_0_rtt{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_connect_with_0_rtt{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_connect_with_0_rtt{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_connect_with_0_rtt{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_connect_with_0_rtt{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_destroy counter
+envoy_cluster_upstream_cx_destroy{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_destroy{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_destroy{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_destroy{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 8
+envoy_cluster_upstream_cx_destroy{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_destroy{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_destroy{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_cx_destroy{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_destroy{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_destroy{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_destroy_local counter
+envoy_cluster_upstream_cx_destroy_local{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_destroy_local{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_destroy_local{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_destroy_local{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_destroy_local{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_destroy_local{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_destroy_local{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_destroy_local{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_destroy_local{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_destroy_local{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_destroy_local_with_active_rq counter
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_destroy_local_with_active_rq{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_destroy_remote counter
+envoy_cluster_upstream_cx_destroy_remote{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_destroy_remote{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_destroy_remote{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_destroy_remote{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 8
+envoy_cluster_upstream_cx_destroy_remote{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_destroy_remote{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_destroy_remote{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_cx_destroy_remote{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_destroy_remote{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_destroy_remote{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_destroy_remote_with_active_rq counter
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_destroy_remote_with_active_rq{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_destroy_with_active_rq counter
+envoy_cluster_upstream_cx_destroy_with_active_rq{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_destroy_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_destroy_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_destroy_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_upstream_cx_destroy_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_destroy_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_destroy_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_cx_destroy_with_active_rq{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_destroy_with_active_rq{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_destroy_with_active_rq{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_http1_total counter
+envoy_cluster_upstream_cx_http1_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_http1_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_http1_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_http1_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_http1_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_http1_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_http1_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_http1_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 2
+envoy_cluster_upstream_cx_http1_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_http1_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_http2_total counter
+envoy_cluster_upstream_cx_http2_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_http2_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_http2_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_http2_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 8
+envoy_cluster_upstream_cx_http2_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_http2_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_http2_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_cx_http2_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_http2_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_http2_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_http3_total counter
+envoy_cluster_upstream_cx_http3_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_http3_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_http3_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_http3_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_http3_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_http3_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_http3_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_http3_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_http3_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_http3_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_idle_timeout counter
+envoy_cluster_upstream_cx_idle_timeout{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_idle_timeout{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_idle_timeout{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_max_duration_reached counter
+envoy_cluster_upstream_cx_max_duration_reached{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_max_duration_reached{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_max_duration_reached{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_max_requests counter
+envoy_cluster_upstream_cx_max_requests{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_max_requests{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_max_requests{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_max_requests{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_max_requests{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_max_requests{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_max_requests{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_max_requests{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_max_requests{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_max_requests{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_none_healthy counter
+envoy_cluster_upstream_cx_none_healthy{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_none_healthy{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_none_healthy{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_none_healthy{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_none_healthy{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_none_healthy{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_none_healthy{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_none_healthy{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_none_healthy{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_none_healthy{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_overflow counter
+envoy_cluster_upstream_cx_overflow{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_overflow{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_overflow{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_overflow{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_overflow{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_overflow{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_overflow{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_pool_overflow counter
+envoy_cluster_upstream_cx_pool_overflow{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_pool_overflow{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_pool_overflow{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_pool_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_pool_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_pool_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_pool_overflow{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_pool_overflow{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_pool_overflow{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_pool_overflow{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_protocol_error counter
+envoy_cluster_upstream_cx_protocol_error{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_protocol_error{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_protocol_error{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_protocol_error{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_protocol_error{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_protocol_error{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_protocol_error{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_protocol_error{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_protocol_error{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_protocol_error{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_rx_bytes_total counter
+envoy_cluster_upstream_cx_rx_bytes_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_rx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_rx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_rx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 33909
+envoy_cluster_upstream_cx_rx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_rx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_rx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 711
+envoy_cluster_upstream_cx_rx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 901598
+envoy_cluster_upstream_cx_rx_bytes_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_rx_bytes_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_total counter
+envoy_cluster_upstream_cx_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 8
+envoy_cluster_upstream_cx_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_cx_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 2
+envoy_cluster_upstream_cx_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_tx_bytes_total counter
+envoy_cluster_upstream_cx_tx_bytes_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_tx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_tx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_tx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 244638
+envoy_cluster_upstream_cx_tx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_tx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_tx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 2142
+envoy_cluster_upstream_cx_tx_bytes_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 4742
+envoy_cluster_upstream_cx_tx_bytes_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_tx_bytes_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_flow_control_backed_up_total counter
+envoy_cluster_upstream_flow_control_backed_up_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_flow_control_backed_up_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_flow_control_backed_up_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_flow_control_backed_up_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_upstream_flow_control_backed_up_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_flow_control_backed_up_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_flow_control_backed_up_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_flow_control_backed_up_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_flow_control_backed_up_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_flow_control_backed_up_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_flow_control_drained_total counter
+envoy_cluster_upstream_flow_control_drained_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_flow_control_drained_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_flow_control_drained_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_flow_control_drained_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_upstream_flow_control_drained_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_flow_control_drained_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_flow_control_drained_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_flow_control_drained_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_flow_control_drained_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_flow_control_drained_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_flow_control_paused_reading_total counter
+envoy_cluster_upstream_flow_control_paused_reading_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_flow_control_paused_reading_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_flow_control_paused_reading_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_flow_control_paused_reading_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_flow_control_paused_reading_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_flow_control_paused_reading_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_flow_control_paused_reading_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_flow_control_paused_reading_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 2
+envoy_cluster_upstream_flow_control_paused_reading_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_flow_control_paused_reading_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_flow_control_resumed_reading_total counter
+envoy_cluster_upstream_flow_control_resumed_reading_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_flow_control_resumed_reading_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_flow_control_resumed_reading_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_flow_control_resumed_reading_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_flow_control_resumed_reading_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_flow_control_resumed_reading_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_flow_control_resumed_reading_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_flow_control_resumed_reading_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 2
+envoy_cluster_upstream_flow_control_resumed_reading_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_flow_control_resumed_reading_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_http3_broken counter
+envoy_cluster_upstream_http3_broken{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_http3_broken{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_http3_broken{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_http3_broken{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_http3_broken{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_http3_broken{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_http3_broken{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_http3_broken{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_http3_broken{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_http3_broken{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_internal_redirect_failed_total counter
+envoy_cluster_upstream_internal_redirect_failed_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_internal_redirect_failed_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_internal_redirect_failed_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_internal_redirect_failed_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_internal_redirect_failed_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_internal_redirect_failed_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_internal_redirect_failed_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_internal_redirect_failed_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_internal_redirect_failed_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_internal_redirect_failed_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_internal_redirect_succeeded_total counter
+envoy_cluster_upstream_internal_redirect_succeeded_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_internal_redirect_succeeded_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_internal_redirect_succeeded_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_internal_redirect_succeeded_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_internal_redirect_succeeded_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_internal_redirect_succeeded_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_internal_redirect_succeeded_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_internal_redirect_succeeded_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_internal_redirect_succeeded_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_internal_redirect_succeeded_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq counter
+envoy_cluster_upstream_rq{envoy_response_code="200",service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_upstream_rq{envoy_response_code="503",service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 7
+envoy_cluster_upstream_rq{envoy_response_code="200",service="pomerium",envoy_cluster_name="pomerium-databroker"} 6
+envoy_cluster_upstream_rq{envoy_response_code="503",service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_rq{envoy_response_code="200",service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 4
+envoy_cluster_upstream_rq{envoy_response_code="404",service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 1
+# TYPE envoy_cluster_upstream_rq_0rtt counter
+envoy_cluster_upstream_rq_0rtt{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_0rtt{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_0rtt{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_0rtt{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_0rtt{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_0rtt{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_0rtt{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_0rtt{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_0rtt{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_0rtt{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_cancelled counter
+envoy_cluster_upstream_rq_cancelled{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_cancelled{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_cancelled{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_cancelled{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_cancelled{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_cancelled{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_cancelled{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_cancelled{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_cancelled{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_cancelled{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_completed counter
+envoy_cluster_upstream_rq_completed{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_completed{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_completed{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_completed{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 8
+envoy_cluster_upstream_rq_completed{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_completed{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_completed{service="pomerium",envoy_cluster_name="pomerium-databroker"} 7
+envoy_cluster_upstream_rq_completed{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 5
+envoy_cluster_upstream_rq_completed{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_completed{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_maintenance_mode counter
+envoy_cluster_upstream_rq_maintenance_mode{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_maintenance_mode{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_maintenance_mode{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_maintenance_mode{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_maintenance_mode{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_maintenance_mode{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_maintenance_mode{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_maintenance_mode{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_maintenance_mode{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_maintenance_mode{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_max_duration_reached counter
+envoy_cluster_upstream_rq_max_duration_reached{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_max_duration_reached{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_max_duration_reached{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_max_duration_reached{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_pending_failure_eject counter
+envoy_cluster_upstream_rq_pending_failure_eject{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_pending_failure_eject{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_pending_failure_eject{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_pending_failure_eject{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 8
+envoy_cluster_upstream_rq_pending_failure_eject{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_pending_failure_eject{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_pending_failure_eject{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_rq_pending_failure_eject{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_pending_failure_eject{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_pending_failure_eject{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_pending_overflow counter
+envoy_cluster_upstream_rq_pending_overflow{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_pending_overflow{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_pending_overflow{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_pending_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_pending_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_pending_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_pending_overflow{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_pending_overflow{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_pending_overflow{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_pending_overflow{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_pending_total counter
+envoy_cluster_upstream_rq_pending_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_pending_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_pending_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_pending_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 8
+envoy_cluster_upstream_rq_pending_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_pending_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_pending_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_rq_pending_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 2
+envoy_cluster_upstream_rq_pending_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_pending_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_per_try_idle_timeout counter
+envoy_cluster_upstream_rq_per_try_idle_timeout{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_per_try_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_per_try_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_per_try_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_per_try_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_per_try_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_per_try_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_per_try_idle_timeout{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_per_try_idle_timeout{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_per_try_idle_timeout{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_per_try_timeout counter
+envoy_cluster_upstream_rq_per_try_timeout{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_per_try_timeout{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_per_try_timeout{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_per_try_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_per_try_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_per_try_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_per_try_timeout{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_per_try_timeout{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_per_try_timeout{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_per_try_timeout{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_retry counter
+envoy_cluster_upstream_rq_retry{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_retry{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_retry{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_retry{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_retry{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_retry{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_retry{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_retry{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_retry{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_retry{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_retry_backoff_exponential counter
+envoy_cluster_upstream_rq_retry_backoff_exponential{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_retry_backoff_exponential{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_retry_backoff_exponential{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_retry_backoff_exponential{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_retry_backoff_exponential{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_retry_backoff_exponential{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_retry_backoff_exponential{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_retry_backoff_exponential{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_retry_backoff_exponential{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_retry_backoff_exponential{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_retry_backoff_ratelimited counter
+envoy_cluster_upstream_rq_retry_backoff_ratelimited{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_retry_backoff_ratelimited{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_retry_backoff_ratelimited{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_retry_backoff_ratelimited{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_retry_backoff_ratelimited{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_retry_backoff_ratelimited{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_retry_backoff_ratelimited{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_retry_backoff_ratelimited{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_retry_backoff_ratelimited{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_retry_backoff_ratelimited{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_retry_limit_exceeded counter
+envoy_cluster_upstream_rq_retry_limit_exceeded{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_retry_limit_exceeded{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_retry_limit_exceeded{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_retry_limit_exceeded{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_retry_limit_exceeded{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_retry_limit_exceeded{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_retry_limit_exceeded{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_retry_limit_exceeded{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_retry_limit_exceeded{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_retry_limit_exceeded{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_retry_overflow counter
+envoy_cluster_upstream_rq_retry_overflow{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_retry_overflow{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_retry_overflow{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_retry_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_retry_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_retry_overflow{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_retry_overflow{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_retry_overflow{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_retry_overflow{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_retry_overflow{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_retry_success counter
+envoy_cluster_upstream_rq_retry_success{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_retry_success{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_retry_success{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_retry_success{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_retry_success{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_retry_success{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_retry_success{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_retry_success{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_retry_success{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_retry_success{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_rx_reset counter
+envoy_cluster_upstream_rq_rx_reset{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_rx_reset{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_rx_reset{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_rx_reset{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_rx_reset{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_rx_reset{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_rx_reset{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_rx_reset{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_rx_reset{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_rx_reset{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_timeout counter
+envoy_cluster_upstream_rq_timeout{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_timeout{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_timeout{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_timeout{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_timeout{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_timeout{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_timeout{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_timeout{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_total counter
+envoy_cluster_upstream_rq_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_upstream_rq_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 7
+envoy_cluster_upstream_rq_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 6
+envoy_cluster_upstream_rq_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_tx_reset counter
+envoy_cluster_upstream_rq_tx_reset{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_tx_reset{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_tx_reset{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_tx_reset{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_tx_reset{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_tx_reset{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_tx_reset{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_tx_reset{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_tx_reset{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_tx_reset{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_xx counter
+envoy_cluster_upstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_upstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 7
+envoy_cluster_upstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_cluster_name="pomerium-databroker"} 6
+envoy_cluster_upstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 4
+envoy_cluster_upstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 1
+# TYPE envoy_cluster_manager_cds_init_fetch_timeout counter
+envoy_cluster_manager_cds_init_fetch_timeout{service="pomerium"} 0
+# TYPE envoy_cluster_manager_cds_update_attempt counter
+envoy_cluster_manager_cds_update_attempt{service="pomerium"} 10
+# TYPE envoy_cluster_manager_cds_update_failure counter
+envoy_cluster_manager_cds_update_failure{service="pomerium"} 8
+# TYPE envoy_cluster_manager_cds_update_rejected counter
+envoy_cluster_manager_cds_update_rejected{service="pomerium"} 0
+# TYPE envoy_cluster_manager_cds_update_success counter
+envoy_cluster_manager_cds_update_success{service="pomerium"} 1
+# TYPE envoy_cluster_manager_cluster_added counter
+envoy_cluster_manager_cluster_added{service="pomerium"} 10
+# TYPE envoy_cluster_manager_cluster_modified counter
+envoy_cluster_manager_cluster_modified{service="pomerium"} 0
+# TYPE envoy_cluster_manager_cluster_removed counter
+envoy_cluster_manager_cluster_removed{service="pomerium"} 0
+# TYPE envoy_cluster_manager_cluster_updated counter
+envoy_cluster_manager_cluster_updated{service="pomerium"} 0
+# TYPE envoy_cluster_manager_cluster_updated_via_merge counter
+envoy_cluster_manager_cluster_updated_via_merge{service="pomerium"} 0
+# TYPE envoy_cluster_manager_update_merge_cancelled counter
+envoy_cluster_manager_update_merge_cancelled{service="pomerium"} 0
+# TYPE envoy_cluster_manager_update_out_of_merge_window counter
+envoy_cluster_manager_update_out_of_merge_window{service="pomerium"} 0
+# TYPE envoy_control_plane_rate_limit_enforced counter
+envoy_control_plane_rate_limit_enforced{service="pomerium"} 0
+# TYPE envoy_dns_apple_connection_failure counter
+envoy_dns_apple_connection_failure{service="pomerium"} 0
+# TYPE envoy_dns_apple_get_addr_failure counter
+envoy_dns_apple_get_addr_failure{service="pomerium"} 0
+# TYPE envoy_dns_apple_network_failure counter
+envoy_dns_apple_network_failure{service="pomerium"} 0
+# TYPE envoy_dns_apple_processing_failure counter
+envoy_dns_apple_processing_failure{service="pomerium"} 0
+# TYPE envoy_dns_apple_socket_failure counter
+envoy_dns_apple_socket_failure{service="pomerium"} 0
+# TYPE envoy_dns_apple_timeout counter
+envoy_dns_apple_timeout{service="pomerium"} 0
+# TYPE envoy_envoy_overload_actions_reset_high_memory_stream_count counter
+envoy_envoy_overload_actions_reset_high_memory_stream_count{service="pomerium"} 0
+# TYPE envoy_filesystem_flushed_by_timer counter
+envoy_filesystem_flushed_by_timer{} 0
+# TYPE envoy_filesystem_reopen_failed counter
+envoy_filesystem_reopen_failed{} 0
+# TYPE envoy_filesystem_write_buffered counter
+envoy_filesystem_write_buffered{} 0
+# TYPE envoy_filesystem_write_completed counter
+envoy_filesystem_write_completed{} 0
+# TYPE envoy_filesystem_write_failed counter
+envoy_filesystem_write_failed{} 0
+# TYPE envoy_http_downstream_cx_delayed_close_timeout counter
+envoy_http_downstream_cx_delayed_close_timeout{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_delayed_close_timeout{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_delayed_close_timeout{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_delayed_close_timeout{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_delayed_close_timeout{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_delayed_close_timeout{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_destroy counter
+envoy_http_downstream_cx_destroy{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_destroy{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 1
+envoy_http_downstream_cx_destroy{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 5
+envoy_http_downstream_cx_destroy{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_destroy{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_destroy{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_destroy_active_rq counter
+envoy_http_downstream_cx_destroy_active_rq{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_destroy_active_rq{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_destroy_active_rq{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_destroy_active_rq{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_destroy_active_rq{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_destroy_active_rq{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_destroy_local counter
+envoy_http_downstream_cx_destroy_local{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_destroy_local{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_destroy_local{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_destroy_local{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_destroy_local{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_destroy_local{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_destroy_local_active_rq counter
+envoy_http_downstream_cx_destroy_local_active_rq{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_destroy_local_active_rq{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_destroy_local_active_rq{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_destroy_local_active_rq{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_destroy_local_active_rq{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_destroy_local_active_rq{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_destroy_remote counter
+envoy_http_downstream_cx_destroy_remote{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_destroy_remote{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 1
+envoy_http_downstream_cx_destroy_remote{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 5
+envoy_http_downstream_cx_destroy_remote{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_destroy_remote{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_destroy_remote{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_destroy_remote_active_rq counter
+envoy_http_downstream_cx_destroy_remote_active_rq{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_destroy_remote_active_rq{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_destroy_remote_active_rq{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_destroy_remote_active_rq{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_destroy_remote_active_rq{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_destroy_remote_active_rq{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_drain_close counter
+envoy_http_downstream_cx_drain_close{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_drain_close{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_drain_close{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_drain_close{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_drain_close{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_drain_close{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_http1_total counter
+envoy_http_downstream_cx_http1_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 2
+envoy_http_downstream_cx_http1_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 2
+envoy_http_downstream_cx_http1_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_http1_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_http1_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_http1_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_http2_total counter
+envoy_http_downstream_cx_http2_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_http2_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_http2_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 5
+envoy_http_downstream_cx_http2_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_http2_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_http2_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_http3_total counter
+envoy_http_downstream_cx_http3_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_http3_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_http3_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_http3_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_http3_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_http3_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_idle_timeout counter
+envoy_http_downstream_cx_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_max_duration_reached counter
+envoy_http_downstream_cx_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_max_requests_reached counter
+envoy_http_downstream_cx_max_requests_reached{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_max_requests_reached{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_max_requests_reached{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_max_requests_reached{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_max_requests_reached{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_max_requests_reached{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_overload_disable_keepalive counter
+envoy_http_downstream_cx_overload_disable_keepalive{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_overload_disable_keepalive{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_overload_disable_keepalive{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_overload_disable_keepalive{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_overload_disable_keepalive{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_overload_disable_keepalive{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_protocol_error counter
+envoy_http_downstream_cx_protocol_error{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_protocol_error{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_protocol_error{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_protocol_error{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_protocol_error{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_protocol_error{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_rx_bytes_total counter
+envoy_http_downstream_cx_rx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 4742
+envoy_http_downstream_cx_rx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 4166
+envoy_http_downstream_cx_rx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 2383
+envoy_http_downstream_cx_rx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_rx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_rx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_ssl_total counter
+envoy_http_downstream_cx_ssl_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_ssl_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_ssl_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_ssl_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_ssl_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_ssl_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_total counter
+envoy_http_downstream_cx_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 2
+envoy_http_downstream_cx_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 4
+envoy_http_downstream_cx_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 5
+envoy_http_downstream_cx_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_tx_bytes_total counter
+envoy_http_downstream_cx_tx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 901598
+envoy_http_downstream_cx_tx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 902572
+envoy_http_downstream_cx_tx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 1239
+envoy_http_downstream_cx_tx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_tx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_tx_bytes_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_upgrades_total counter
+envoy_http_downstream_cx_upgrades_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_upgrades_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_upgrades_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_upgrades_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_upgrades_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_upgrades_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_flow_control_paused_reading_total counter
+envoy_http_downstream_flow_control_paused_reading_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_flow_control_paused_reading_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_flow_control_paused_reading_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_flow_control_paused_reading_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_flow_control_paused_reading_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_flow_control_paused_reading_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_flow_control_resumed_reading_total counter
+envoy_http_downstream_flow_control_resumed_reading_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_flow_control_resumed_reading_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_flow_control_resumed_reading_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_flow_control_resumed_reading_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_flow_control_resumed_reading_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_flow_control_resumed_reading_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_completed counter
+envoy_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="admin"} 5
+envoy_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 5
+envoy_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 7
+envoy_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_failed_path_normalization counter
+envoy_http_downstream_rq_failed_path_normalization{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_failed_path_normalization{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_failed_path_normalization{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_failed_path_normalization{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_failed_path_normalization{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_failed_path_normalization{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_header_timeout counter
+envoy_http_downstream_rq_header_timeout{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_header_timeout{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_header_timeout{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_header_timeout{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_header_timeout{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_header_timeout{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_http1_total counter
+envoy_http_downstream_rq_http1_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 6
+envoy_http_downstream_rq_http1_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 6
+envoy_http_downstream_rq_http1_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_http1_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_http1_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_http1_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_http2_total counter
+envoy_http_downstream_rq_http2_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_http2_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_http2_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 7
+envoy_http_downstream_rq_http2_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_http2_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_http2_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_http3_total counter
+envoy_http_downstream_rq_http3_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_http3_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_http3_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_http3_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_http3_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_http3_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_idle_timeout counter
+envoy_http_downstream_rq_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_idle_timeout{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_max_duration_reached counter
+envoy_http_downstream_rq_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_max_duration_reached{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_non_relative_path counter
+envoy_http_downstream_rq_non_relative_path{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_non_relative_path{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_non_relative_path{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_non_relative_path{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_non_relative_path{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_non_relative_path{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_overload_close counter
+envoy_http_downstream_rq_overload_close{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_overload_close{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_overload_close{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_overload_close{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_overload_close{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_overload_close{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_redirected_with_normalized_path counter
+envoy_http_downstream_rq_redirected_with_normalized_path{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_redirected_with_normalized_path{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_redirected_with_normalized_path{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_redirected_with_normalized_path{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_redirected_with_normalized_path{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_redirected_with_normalized_path{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_rejected_via_ip_detection counter
+envoy_http_downstream_rq_rejected_via_ip_detection{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_rejected_via_ip_detection{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_rejected_via_ip_detection{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_rejected_via_ip_detection{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_rejected_via_ip_detection{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_rejected_via_ip_detection{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_response_before_rq_complete counter
+envoy_http_downstream_rq_response_before_rq_complete{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_response_before_rq_complete{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_response_before_rq_complete{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_response_before_rq_complete{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_response_before_rq_complete{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_response_before_rq_complete{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_rx_reset counter
+envoy_http_downstream_rq_rx_reset{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_rx_reset{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_rx_reset{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_rx_reset{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_rx_reset{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_rx_reset{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_timeout counter
+envoy_http_downstream_rq_timeout{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_timeout{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_timeout{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_timeout{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_timeout{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_timeout{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_too_large counter
+envoy_http_downstream_rq_too_large{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_too_large{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_too_large{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_too_large{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_too_large{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_too_large{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_too_many_premature_resets counter
+envoy_http_downstream_rq_too_many_premature_resets{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_too_many_premature_resets{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_too_many_premature_resets{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_too_many_premature_resets{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_too_many_premature_resets{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_too_many_premature_resets{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_total counter
+envoy_http_downstream_rq_total{service="pomerium",envoy_http_conn_manager_prefix="admin"} 6
+envoy_http_downstream_rq_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 6
+envoy_http_downstream_rq_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 7
+envoy_http_downstream_rq_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_tx_reset counter
+envoy_http_downstream_rq_tx_reset{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_tx_reset{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_tx_reset{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_tx_reset{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_tx_reset{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_tx_reset{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_ws_on_non_ws_route counter
+envoy_http_downstream_rq_ws_on_non_ws_route{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_ws_on_non_ws_route{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_ws_on_non_ws_route{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_ws_on_non_ws_route{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_ws_on_non_ws_route{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_ws_on_non_ws_route{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_xx counter
+envoy_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="admin"} 4
+envoy_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="admin"} 1
+envoy_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 4
+envoy_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 1
+envoy_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 7
+envoy_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+envoy_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_ext_authz_denied counter
+envoy_http_ext_authz_denied{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_ext_authz_disabled counter
+envoy_http_ext_authz_disabled{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_ext_authz_error counter
+envoy_http_ext_authz_error{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_ext_authz_failure_mode_allowed counter
+envoy_http_ext_authz_failure_mode_allowed{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_ext_authz_ignored_dynamic_metadata counter
+envoy_http_ext_authz_ignored_dynamic_metadata{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_ext_authz_invalid counter
+envoy_http_ext_authz_invalid{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_ext_authz_ok counter
+envoy_http_ext_authz_ok{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_lua_errors counter
+envoy_http_lua_errors{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_no_cluster counter
+envoy_http_no_cluster{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_no_cluster{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_no_cluster{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_no_cluster{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_no_cluster{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_no_cluster{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_no_route counter
+envoy_http_no_route{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_no_route{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_no_route{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_no_route{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_no_route{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_no_route{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_passthrough_internal_redirect_bad_location counter
+envoy_http_passthrough_internal_redirect_bad_location{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_passthrough_internal_redirect_bad_location{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_passthrough_internal_redirect_bad_location{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_passthrough_internal_redirect_bad_location{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_passthrough_internal_redirect_bad_location{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_passthrough_internal_redirect_bad_location{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_passthrough_internal_redirect_no_route counter
+envoy_http_passthrough_internal_redirect_no_route{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_passthrough_internal_redirect_no_route{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_passthrough_internal_redirect_no_route{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_passthrough_internal_redirect_no_route{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_passthrough_internal_redirect_no_route{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_passthrough_internal_redirect_no_route{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_passthrough_internal_redirect_predicate counter
+envoy_http_passthrough_internal_redirect_predicate{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_passthrough_internal_redirect_predicate{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_passthrough_internal_redirect_predicate{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_passthrough_internal_redirect_predicate{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_passthrough_internal_redirect_predicate{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_passthrough_internal_redirect_predicate{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_passthrough_internal_redirect_too_many_redirects counter
+envoy_http_passthrough_internal_redirect_too_many_redirects{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_passthrough_internal_redirect_too_many_redirects{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_passthrough_internal_redirect_too_many_redirects{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_passthrough_internal_redirect_too_many_redirects{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_passthrough_internal_redirect_too_many_redirects{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_passthrough_internal_redirect_too_many_redirects{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_passthrough_internal_redirect_unsafe_scheme counter
+envoy_http_passthrough_internal_redirect_unsafe_scheme{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_passthrough_internal_redirect_unsafe_scheme{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_passthrough_internal_redirect_unsafe_scheme{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_passthrough_internal_redirect_unsafe_scheme{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_passthrough_internal_redirect_unsafe_scheme{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_passthrough_internal_redirect_unsafe_scheme{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_rds_config_reload counter
+envoy_http_rds_config_reload{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 1
+# TYPE envoy_http_rds_init_fetch_timeout counter
+envoy_http_rds_init_fetch_timeout{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_rds_update_attempt counter
+envoy_http_rds_update_attempt{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 10
+# TYPE envoy_http_rds_update_empty counter
+envoy_http_rds_update_empty{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_rds_update_failure counter
+envoy_http_rds_update_failure{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 8
+# TYPE envoy_http_rds_update_rejected counter
+envoy_http_rds_update_rejected{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 0
+# TYPE envoy_http_rds_update_success counter
+envoy_http_rds_update_success{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 1
+# TYPE envoy_http_rq_direct_response counter
+envoy_http_rq_direct_response{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_rq_direct_response{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_rq_direct_response{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_rq_direct_response{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_rq_direct_response{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_rq_direct_response{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_rq_overload_local_reply counter
+envoy_http_rq_overload_local_reply{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_rq_overload_local_reply{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_rq_overload_local_reply{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_rq_overload_local_reply{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_rq_overload_local_reply{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_rq_overload_local_reply{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_rq_redirect counter
+envoy_http_rq_redirect{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 0
+envoy_http_rq_redirect{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_rq_redirect{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_rq_redirect{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_rq_redirect{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_rq_redirect{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_rq_reset_after_downstream_response_started counter
+envoy_http_rq_reset_after_downstream_response_started{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 1
+envoy_http_rq_reset_after_downstream_response_started{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_rq_reset_after_downstream_response_started{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_rq_reset_after_downstream_response_started{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_rq_reset_after_downstream_response_started{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_rq_reset_after_downstream_response_started{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_rq_total counter
+envoy_http_rq_total{service="pomerium",envoy_http_conn_manager_prefix="async-client"} 8
+envoy_http_rq_total{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 6
+envoy_http_rq_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 7
+envoy_http_rq_total{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_rq_total{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_rq_total{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_rs_too_large counter
+envoy_http_rs_too_large{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_rs_too_large{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_rs_too_large{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_rs_too_large{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_rs_too_large{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_rs_too_large{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_tracing_client_enabled counter
+envoy_http_tracing_client_enabled{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_tracing_client_enabled{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_tracing_client_enabled{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_tracing_client_enabled{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_tracing_client_enabled{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_tracing_health_check counter
+envoy_http_tracing_health_check{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_tracing_health_check{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_tracing_health_check{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_tracing_health_check{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_tracing_health_check{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_tracing_not_traceable counter
+envoy_http_tracing_not_traceable{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_tracing_not_traceable{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_tracing_not_traceable{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_tracing_not_traceable{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_tracing_not_traceable{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_tracing_random_sampling counter
+envoy_http_tracing_random_sampling{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_tracing_random_sampling{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_tracing_random_sampling{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_tracing_random_sampling{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_tracing_random_sampling{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_tracing_service_forced counter
+envoy_http_tracing_service_forced{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_tracing_service_forced{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_tracing_service_forced{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_tracing_service_forced{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_tracing_service_forced{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http1_dropped_headers_with_underscores counter
+envoy_http1_dropped_headers_with_underscores{service="pomerium"} 0
+# TYPE envoy_http1_metadata_not_supported_error counter
+envoy_http1_metadata_not_supported_error{service="pomerium"} 0
+# TYPE envoy_http1_requests_rejected_with_underscores_in_headers counter
+envoy_http1_requests_rejected_with_underscores_in_headers{service="pomerium"} 0
+# TYPE envoy_http1_response_flood counter
+envoy_http1_response_flood{service="pomerium"} 0
+# TYPE envoy_http2_dropped_headers_with_underscores counter
+envoy_http2_dropped_headers_with_underscores{service="pomerium"} 0
+# TYPE envoy_http2_goaway_sent counter
+envoy_http2_goaway_sent{service="pomerium"} 0
+# TYPE envoy_http2_header_overflow counter
+envoy_http2_header_overflow{service="pomerium"} 0
+# TYPE envoy_http2_headers_cb_no_stream counter
+envoy_http2_headers_cb_no_stream{service="pomerium"} 0
+# TYPE envoy_http2_inbound_empty_frames_flood counter
+envoy_http2_inbound_empty_frames_flood{service="pomerium"} 0
+# TYPE envoy_http2_inbound_priority_frames_flood counter
+envoy_http2_inbound_priority_frames_flood{service="pomerium"} 0
+# TYPE envoy_http2_inbound_window_update_frames_flood counter
+envoy_http2_inbound_window_update_frames_flood{service="pomerium"} 0
+# TYPE envoy_http2_keepalive_timeout counter
+envoy_http2_keepalive_timeout{service="pomerium"} 0
+# TYPE envoy_http2_metadata_empty_frames counter
+envoy_http2_metadata_empty_frames{service="pomerium"} 0
+# TYPE envoy_http2_outbound_control_flood counter
+envoy_http2_outbound_control_flood{service="pomerium"} 0
+# TYPE envoy_http2_outbound_flood counter
+envoy_http2_outbound_flood{service="pomerium"} 0
+# TYPE envoy_http2_requests_rejected_with_underscores_in_headers counter
+envoy_http2_requests_rejected_with_underscores_in_headers{service="pomerium"} 0
+# TYPE envoy_http2_rx_messaging_error counter
+envoy_http2_rx_messaging_error{service="pomerium"} 0
+# TYPE envoy_http2_rx_reset counter
+envoy_http2_rx_reset{service="pomerium"} 0
+# TYPE envoy_http2_stream_refused_errors counter
+envoy_http2_stream_refused_errors{service="pomerium"} 0
+# TYPE envoy_http2_trailers counter
+envoy_http2_trailers{service="pomerium"} 0
+# TYPE envoy_http2_tx_flush_timeout counter
+envoy_http2_tx_flush_timeout{service="pomerium"} 0
+# TYPE envoy_http2_tx_reset counter
+envoy_http2_tx_reset{service="pomerium"} 0
+# TYPE envoy_listener_admin_downstream_cx_destroy counter
+envoy_listener_admin_downstream_cx_destroy{service="pomerium"} 0
+# TYPE envoy_listener_admin_downstream_cx_overflow counter
+envoy_listener_admin_downstream_cx_overflow{service="pomerium"} 0
+# TYPE envoy_listener_admin_downstream_cx_overload_reject counter
+envoy_listener_admin_downstream_cx_overload_reject{service="pomerium"} 0
+# TYPE envoy_listener_admin_downstream_cx_total counter
+envoy_listener_admin_downstream_cx_total{service="pomerium"} 2
+# TYPE envoy_listener_admin_downstream_cx_transport_socket_connect_timeout counter
+envoy_listener_admin_downstream_cx_transport_socket_connect_timeout{service="pomerium"} 0
+# TYPE envoy_listener_admin_downstream_global_cx_overflow counter
+envoy_listener_admin_downstream_global_cx_overflow{service="pomerium"} 0
+# TYPE envoy_listener_admin_downstream_listener_filter_error counter
+envoy_listener_admin_downstream_listener_filter_error{service="pomerium"} 0
+# TYPE envoy_listener_admin_downstream_listener_filter_remote_close counter
+envoy_listener_admin_downstream_listener_filter_remote_close{service="pomerium"} 0
+# TYPE envoy_listener_admin_downstream_pre_cx_timeout counter
+envoy_listener_admin_downstream_pre_cx_timeout{service="pomerium"} 0
+# TYPE envoy_listener_admin_http_downstream_rq_completed counter
+envoy_listener_admin_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="admin"} 5
+# TYPE envoy_listener_admin_http_downstream_rq_xx counter
+envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="admin"} 4
+envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="admin"} 1
+envoy_listener_admin_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+# TYPE envoy_listener_admin_main_thread_downstream_cx_total counter
+envoy_listener_admin_main_thread_downstream_cx_total{service="pomerium"} 2
+# TYPE envoy_listener_admin_no_filter_chain_match counter
+envoy_listener_admin_no_filter_chain_match{service="pomerium"} 0
+# TYPE envoy_listener_downstream_cx_destroy counter
+envoy_listener_downstream_cx_destroy{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 5
+envoy_listener_downstream_cx_destroy{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 1
+envoy_listener_downstream_cx_destroy{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_cx_destroy{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_cx_destroy{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_downstream_cx_overflow counter
+envoy_listener_downstream_cx_overflow{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_downstream_cx_overflow{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_downstream_cx_overflow{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_cx_overflow{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_cx_overflow{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_downstream_cx_overload_reject counter
+envoy_listener_downstream_cx_overload_reject{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_downstream_cx_overload_reject{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_downstream_cx_overload_reject{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_cx_overload_reject{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_cx_overload_reject{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_downstream_cx_total counter
+envoy_listener_downstream_cx_total{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 5
+envoy_listener_downstream_cx_total{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 4
+envoy_listener_downstream_cx_total{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_cx_total{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_cx_total{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_downstream_cx_transport_socket_connect_timeout counter
+envoy_listener_downstream_cx_transport_socket_connect_timeout{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_downstream_cx_transport_socket_connect_timeout{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_downstream_cx_transport_socket_connect_timeout{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_cx_transport_socket_connect_timeout{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_cx_transport_socket_connect_timeout{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_downstream_global_cx_overflow counter
+envoy_listener_downstream_global_cx_overflow{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_downstream_global_cx_overflow{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_downstream_global_cx_overflow{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_global_cx_overflow{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_global_cx_overflow{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_downstream_listener_filter_error counter
+envoy_listener_downstream_listener_filter_error{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_downstream_listener_filter_error{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_downstream_listener_filter_error{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_listener_filter_error{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_listener_filter_error{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_downstream_listener_filter_remote_close counter
+envoy_listener_downstream_listener_filter_remote_close{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_downstream_listener_filter_remote_close{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_downstream_listener_filter_remote_close{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_listener_filter_remote_close{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_listener_filter_remote_close{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_downstream_pre_cx_timeout counter
+envoy_listener_downstream_pre_cx_timeout{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_downstream_pre_cx_timeout{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_downstream_pre_cx_timeout{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_pre_cx_timeout{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_pre_cx_timeout{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_extension_config_missing counter
+envoy_listener_extension_config_missing{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_extension_config_missing{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_extension_config_missing{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_extension_config_missing{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_extension_config_missing{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_http_downstream_rq_completed counter
+envoy_listener_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",envoy_listener_address="127.0.0.1_52718"} 7
+envoy_listener_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",envoy_listener_address="127.0.0.1_9901"} 5
+envoy_listener_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="ingress",envoy_listener_address="[__]_443"} 0
+envoy_listener_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",envoy_listener_address="[__]_5443"} 0
+envoy_listener_http_downstream_rq_completed{service="pomerium",envoy_http_conn_manager_prefix="metrics",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_http_downstream_rq_xx counter
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",envoy_listener_address="127.0.0.1_52718"} 7
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",envoy_listener_address="127.0.0.1_9901"} 4
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",envoy_listener_address="127.0.0.1_9901"} 1
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="ingress",envoy_listener_address="[__]_443"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="ingress",envoy_listener_address="[__]_443"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="ingress",envoy_listener_address="[__]_443"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="ingress",envoy_listener_address="[__]_443"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="ingress",envoy_listener_address="[__]_443"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",envoy_listener_address="[__]_5443"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",envoy_listener_address="[__]_5443"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",envoy_listener_address="[__]_5443"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",envoy_listener_address="[__]_5443"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",envoy_listener_address="[__]_5443"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="1",service="pomerium",envoy_http_conn_manager_prefix="metrics",envoy_listener_address="[__]_9090"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="2",service="pomerium",envoy_http_conn_manager_prefix="metrics",envoy_listener_address="[__]_9090"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="3",service="pomerium",envoy_http_conn_manager_prefix="metrics",envoy_listener_address="[__]_9090"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="4",service="pomerium",envoy_http_conn_manager_prefix="metrics",envoy_listener_address="[__]_9090"} 0
+envoy_listener_http_downstream_rq_xx{envoy_response_code_class="5",service="pomerium",envoy_http_conn_manager_prefix="metrics",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_network_extension_config_missing counter
+envoy_listener_network_extension_config_missing{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_network_extension_config_missing{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_network_extension_config_missing{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_network_extension_config_missing{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_network_extension_config_missing{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_no_filter_chain_match counter
+envoy_listener_no_filter_chain_match{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_no_filter_chain_match{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_no_filter_chain_match{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_no_filter_chain_match{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_no_filter_chain_match{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_server_ssl_socket_factory_downstream_context_secrets_not_ready counter
+envoy_listener_server_ssl_socket_factory_downstream_context_secrets_not_ready{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds counter
+envoy_listener_server_ssl_socket_factory_ssl_context_update_by_sds{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_server_ssl_socket_factory_upstream_context_secrets_not_ready counter
+envoy_listener_server_ssl_socket_factory_upstream_context_secrets_not_ready{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_connection_error counter
+envoy_listener_ssl_connection_error{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_fail_verify_cert_hash counter
+envoy_listener_ssl_fail_verify_cert_hash{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_fail_verify_error counter
+envoy_listener_ssl_fail_verify_error{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_fail_verify_no_cert counter
+envoy_listener_ssl_fail_verify_no_cert{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_fail_verify_san counter
+envoy_listener_ssl_fail_verify_san{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_handshake counter
+envoy_listener_ssl_handshake{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_no_certificate counter
+envoy_listener_ssl_no_certificate{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_ocsp_staple_failed counter
+envoy_listener_ssl_ocsp_staple_failed{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_ocsp_staple_omitted counter
+envoy_listener_ssl_ocsp_staple_omitted{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_ocsp_staple_requests counter
+envoy_listener_ssl_ocsp_staple_requests{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_ocsp_staple_responses counter
+envoy_listener_ssl_ocsp_staple_responses{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_session_reused counter
+envoy_listener_ssl_session_reused{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_ssl_was_key_usage_invalid counter
+envoy_listener_ssl_was_key_usage_invalid{service="pomerium",envoy_listener_address="[__]_443"} 0
+# TYPE envoy_listener_worker_downstream_cx_total counter
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="0",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="1",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="2",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="3",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="4",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="5",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="6",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="7",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 5
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="8",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="9",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="0",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="1",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 1
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="2",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="3",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 1
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="4",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="5",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="6",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="7",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 2
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="8",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="9",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="0",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="1",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="2",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="3",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="4",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="5",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="6",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="7",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="8",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="9",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="0",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="1",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="2",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="3",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="4",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="5",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="6",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="7",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="8",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="9",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="0",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="1",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="2",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="3",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="4",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="5",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="6",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="7",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="8",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_total{envoy_worker_id="9",service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_manager_lds_init_fetch_timeout counter
+envoy_listener_manager_lds_init_fetch_timeout{service="pomerium"} 0
+# TYPE envoy_listener_manager_lds_update_attempt counter
+envoy_listener_manager_lds_update_attempt{service="pomerium"} 10
+# TYPE envoy_listener_manager_lds_update_failure counter
+envoy_listener_manager_lds_update_failure{service="pomerium"} 8
+# TYPE envoy_listener_manager_lds_update_rejected counter
+envoy_listener_manager_lds_update_rejected{service="pomerium"} 0
+# TYPE envoy_listener_manager_lds_update_success counter
+envoy_listener_manager_lds_update_success{service="pomerium"} 1
+# TYPE envoy_listener_manager_listener_added counter
+envoy_listener_manager_listener_added{service="pomerium"} 5
+# TYPE envoy_listener_manager_listener_create_failure counter
+envoy_listener_manager_listener_create_failure{service="pomerium"} 0
+# TYPE envoy_listener_manager_listener_create_success counter
+envoy_listener_manager_listener_create_success{service="pomerium"} 50
+# TYPE envoy_listener_manager_listener_in_place_updated counter
+envoy_listener_manager_listener_in_place_updated{service="pomerium"} 0
+# TYPE envoy_listener_manager_listener_modified counter
+envoy_listener_manager_listener_modified{service="pomerium"} 0
+# TYPE envoy_listener_manager_listener_removed counter
+envoy_listener_manager_listener_removed{service="pomerium"} 0
+# TYPE envoy_listener_manager_listener_stopped counter
+envoy_listener_manager_listener_stopped{service="pomerium"} 0
+# TYPE envoy_main_thread_watchdog_mega_miss counter
+envoy_main_thread_watchdog_mega_miss{service="pomerium"} 0
+# TYPE envoy_main_thread_watchdog_miss counter
+envoy_main_thread_watchdog_miss{service="pomerium"} 0
+# TYPE envoy_overload_envoy_resource_monitors_global_downstream_max_connections_failed_updates counter
+envoy_overload_envoy_resource_monitors_global_downstream_max_connections_failed_updates{service="pomerium"} 0
+# TYPE envoy_runtime_deprecated_feature_use counter
+envoy_runtime_deprecated_feature_use{service="pomerium"} 0
+# TYPE envoy_runtime_load_error counter
+envoy_runtime_load_error{service="pomerium"} 0
+# TYPE envoy_runtime_load_success counter
+envoy_runtime_load_success{service="pomerium"} 1
+# TYPE envoy_runtime_override_dir_exists counter
+envoy_runtime_override_dir_exists{service="pomerium"} 0
+# TYPE envoy_runtime_override_dir_not_exists counter
+envoy_runtime_override_dir_not_exists{service="pomerium"} 1
+# TYPE envoy_server_debug_assertion_failures counter
+envoy_server_debug_assertion_failures{service="pomerium"} 0
+# TYPE envoy_server_dropped_stat_flushes counter
+envoy_server_dropped_stat_flushes{service="pomerium"} 0
+# TYPE envoy_server_dynamic_unknown_fields counter
+envoy_server_dynamic_unknown_fields{service="pomerium"} 0
+# TYPE envoy_server_envoy_bug_failures counter
+envoy_server_envoy_bug_failures{service="pomerium"} 0
+# TYPE envoy_server_main_thread_watchdog_mega_miss counter
+envoy_server_main_thread_watchdog_mega_miss{service="pomerium"} 0
+# TYPE envoy_server_main_thread_watchdog_miss counter
+envoy_server_main_thread_watchdog_miss{service="pomerium"} 0
+# TYPE envoy_server_static_unknown_fields counter
+envoy_server_static_unknown_fields{service="pomerium"} 0
+# TYPE envoy_server_wip_protos counter
+envoy_server_wip_protos{service="pomerium"} 0
+# TYPE envoy_server_worker_watchdog_mega_miss counter
+envoy_server_worker_watchdog_mega_miss{envoy_worker_id="0",service="pomerium"} 0
+envoy_server_worker_watchdog_mega_miss{envoy_worker_id="1",service="pomerium"} 0
+envoy_server_worker_watchdog_mega_miss{envoy_worker_id="2",service="pomerium"} 0
+envoy_server_worker_watchdog_mega_miss{envoy_worker_id="3",service="pomerium"} 0
+envoy_server_worker_watchdog_mega_miss{envoy_worker_id="4",service="pomerium"} 0
+envoy_server_worker_watchdog_mega_miss{envoy_worker_id="5",service="pomerium"} 0
+envoy_server_worker_watchdog_mega_miss{envoy_worker_id="6",service="pomerium"} 0
+envoy_server_worker_watchdog_mega_miss{envoy_worker_id="7",service="pomerium"} 0
+envoy_server_worker_watchdog_mega_miss{envoy_worker_id="8",service="pomerium"} 0
+envoy_server_worker_watchdog_mega_miss{envoy_worker_id="9",service="pomerium"} 0
+# TYPE envoy_server_worker_watchdog_miss counter
+envoy_server_worker_watchdog_miss{envoy_worker_id="0",service="pomerium"} 0
+envoy_server_worker_watchdog_miss{envoy_worker_id="1",service="pomerium"} 0
+envoy_server_worker_watchdog_miss{envoy_worker_id="2",service="pomerium"} 0
+envoy_server_worker_watchdog_miss{envoy_worker_id="3",service="pomerium"} 0
+envoy_server_worker_watchdog_miss{envoy_worker_id="4",service="pomerium"} 0
+envoy_server_worker_watchdog_miss{envoy_worker_id="5",service="pomerium"} 0
+envoy_server_worker_watchdog_miss{envoy_worker_id="6",service="pomerium"} 0
+envoy_server_worker_watchdog_miss{envoy_worker_id="7",service="pomerium"} 0
+envoy_server_worker_watchdog_miss{envoy_worker_id="8",service="pomerium"} 0
+envoy_server_worker_watchdog_miss{envoy_worker_id="9",service="pomerium"} 0
+# TYPE envoy_tcmalloc_released_by_timer counter
+envoy_tcmalloc_released_by_timer{service="pomerium"} 0
+# TYPE envoy_tcp_downstream_cx_no_route counter
+envoy_tcp_downstream_cx_no_route{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tcp_downstream_cx_rx_bytes_total counter
+envoy_tcp_downstream_cx_rx_bytes_total{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tcp_downstream_cx_total counter
+envoy_tcp_downstream_cx_total{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tcp_downstream_cx_tx_bytes_total counter
+envoy_tcp_downstream_cx_tx_bytes_total{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tcp_downstream_flow_control_paused_reading_total counter
+envoy_tcp_downstream_flow_control_paused_reading_total{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tcp_downstream_flow_control_resumed_reading_total counter
+envoy_tcp_downstream_flow_control_resumed_reading_total{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tcp_idle_timeout counter
+envoy_tcp_idle_timeout{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tcp_max_downstream_connection_duration counter
+envoy_tcp_max_downstream_connection_duration{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tcp_upstream_flush_total counter
+envoy_tcp_upstream_flush_total{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tls_inspector_alpn_found counter
+envoy_tls_inspector_alpn_found{service="pomerium"} 0
+# TYPE envoy_tls_inspector_alpn_not_found counter
+envoy_tls_inspector_alpn_not_found{service="pomerium"} 0
+# TYPE envoy_tls_inspector_client_hello_too_large counter
+envoy_tls_inspector_client_hello_too_large{service="pomerium"} 0
+# TYPE envoy_tls_inspector_sni_found counter
+envoy_tls_inspector_sni_found{service="pomerium"} 0
+# TYPE envoy_tls_inspector_sni_not_found counter
+envoy_tls_inspector_sni_not_found{service="pomerium"} 0
+# TYPE envoy_tls_inspector_tls_found counter
+envoy_tls_inspector_tls_found{service="pomerium"} 0
+# TYPE envoy_tls_inspector_tls_not_found counter
+envoy_tls_inspector_tls_not_found{service="pomerium"} 0
+# TYPE envoy_workers_watchdog_mega_miss counter
+envoy_workers_watchdog_mega_miss{service="pomerium"} 0
+# TYPE envoy_workers_watchdog_miss counter
+envoy_workers_watchdog_miss{service="pomerium"} 0
+# TYPE envoy_cluster_circuit_breakers_default_cx_open gauge
+envoy_cluster_circuit_breakers_default_cx_open{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_circuit_breakers_default_cx_open{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_circuit_breakers_default_cx_open{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_circuit_breakers_default_cx_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_circuit_breakers_default_cx_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_circuit_breakers_default_cx_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_circuit_breakers_default_cx_open{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_circuit_breakers_default_cx_open{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_circuit_breakers_default_cx_open{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_circuit_breakers_default_cx_open{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_circuit_breakers_default_cx_pool_open gauge
+envoy_cluster_circuit_breakers_default_cx_pool_open{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_circuit_breakers_default_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_circuit_breakers_default_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_circuit_breakers_default_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_circuit_breakers_default_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_circuit_breakers_default_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_circuit_breakers_default_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_circuit_breakers_default_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_circuit_breakers_default_cx_pool_open{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_circuit_breakers_default_cx_pool_open{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_circuit_breakers_default_rq_open gauge
+envoy_cluster_circuit_breakers_default_rq_open{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_circuit_breakers_default_rq_open{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_circuit_breakers_default_rq_open{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_circuit_breakers_default_rq_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_circuit_breakers_default_rq_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_circuit_breakers_default_rq_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_circuit_breakers_default_rq_open{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_circuit_breakers_default_rq_open{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_circuit_breakers_default_rq_open{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_circuit_breakers_default_rq_open{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_circuit_breakers_default_rq_pending_open gauge
+envoy_cluster_circuit_breakers_default_rq_pending_open{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_circuit_breakers_default_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_circuit_breakers_default_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_circuit_breakers_default_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_circuit_breakers_default_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_circuit_breakers_default_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_circuit_breakers_default_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_circuit_breakers_default_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_circuit_breakers_default_rq_pending_open{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_circuit_breakers_default_rq_pending_open{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_circuit_breakers_default_rq_retry_open gauge
+envoy_cluster_circuit_breakers_default_rq_retry_open{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_circuit_breakers_default_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_circuit_breakers_default_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_circuit_breakers_default_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_circuit_breakers_default_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_circuit_breakers_default_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_circuit_breakers_default_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_circuit_breakers_default_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_circuit_breakers_default_rq_retry_open{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_circuit_breakers_default_rq_retry_open{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_circuit_breakers_high_cx_open gauge
+envoy_cluster_circuit_breakers_high_cx_open{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_circuit_breakers_high_cx_open{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_circuit_breakers_high_cx_open{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_circuit_breakers_high_cx_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_circuit_breakers_high_cx_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_circuit_breakers_high_cx_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_circuit_breakers_high_cx_open{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_circuit_breakers_high_cx_open{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_circuit_breakers_high_cx_open{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_circuit_breakers_high_cx_open{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_circuit_breakers_high_cx_pool_open gauge
+envoy_cluster_circuit_breakers_high_cx_pool_open{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_circuit_breakers_high_cx_pool_open{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_circuit_breakers_high_rq_open gauge
+envoy_cluster_circuit_breakers_high_rq_open{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_circuit_breakers_high_rq_open{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_circuit_breakers_high_rq_open{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_circuit_breakers_high_rq_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_circuit_breakers_high_rq_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_circuit_breakers_high_rq_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_circuit_breakers_high_rq_open{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_circuit_breakers_high_rq_open{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_circuit_breakers_high_rq_open{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_circuit_breakers_high_rq_open{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_circuit_breakers_high_rq_pending_open gauge
+envoy_cluster_circuit_breakers_high_rq_pending_open{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_circuit_breakers_high_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_circuit_breakers_high_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_circuit_breakers_high_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_circuit_breakers_high_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_circuit_breakers_high_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_circuit_breakers_high_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_circuit_breakers_high_rq_pending_open{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_circuit_breakers_high_rq_pending_open{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_circuit_breakers_high_rq_pending_open{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_circuit_breakers_high_rq_retry_open gauge
+envoy_cluster_circuit_breakers_high_rq_retry_open{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_circuit_breakers_high_rq_retry_open{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_http2_deferred_stream_close gauge
+envoy_cluster_http2_deferred_stream_close{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_deferred_stream_close{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_outbound_control_frames_active gauge
+envoy_cluster_http2_outbound_control_frames_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_outbound_control_frames_active{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_outbound_frames_active gauge
+envoy_cluster_http2_outbound_frames_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_outbound_frames_active{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_pending_send_bytes gauge
+envoy_cluster_http2_pending_send_bytes{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_pending_send_bytes{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_http2_streams_active gauge
+envoy_cluster_http2_streams_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_http2_streams_active{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+# TYPE envoy_cluster_lb_subsets_active gauge
+envoy_cluster_lb_subsets_active{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_lb_subsets_active{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_lb_subsets_active{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_lb_subsets_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_lb_subsets_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_lb_subsets_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_lb_subsets_active{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_lb_subsets_active{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_lb_subsets_active{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_lb_subsets_active{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_max_host_weight gauge
+envoy_cluster_max_host_weight{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 1
+envoy_cluster_max_host_weight{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_max_host_weight{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_max_host_weight{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_max_host_weight{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_max_host_weight{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_max_host_weight{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_max_host_weight{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_max_host_weight{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_max_host_weight{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_membership_degraded gauge
+envoy_cluster_membership_degraded{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_membership_degraded{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_membership_degraded{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_membership_degraded{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_membership_degraded{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_membership_degraded{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_membership_degraded{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_membership_degraded{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_membership_degraded{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_membership_degraded{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_membership_excluded gauge
+envoy_cluster_membership_excluded{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_membership_excluded{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_membership_excluded{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_membership_excluded{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_membership_excluded{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_membership_excluded{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_membership_excluded{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_membership_excluded{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_membership_excluded{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_membership_excluded{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_membership_healthy gauge
+envoy_cluster_membership_healthy{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 1
+envoy_cluster_membership_healthy{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 1
+envoy_cluster_membership_healthy{service="pomerium",envoy_cluster_name="pomerium-authorize"} 1
+envoy_cluster_membership_healthy{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_membership_healthy{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 1
+envoy_cluster_membership_healthy{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 1
+envoy_cluster_membership_healthy{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_membership_healthy{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 1
+envoy_cluster_membership_healthy{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 1
+envoy_cluster_membership_healthy{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 1
+# TYPE envoy_cluster_membership_total gauge
+envoy_cluster_membership_total{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 1
+envoy_cluster_membership_total{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 1
+envoy_cluster_membership_total{service="pomerium",envoy_cluster_name="pomerium-authorize"} 1
+envoy_cluster_membership_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_membership_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 1
+envoy_cluster_membership_total{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 1
+envoy_cluster_membership_total{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_membership_total{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 1
+envoy_cluster_membership_total{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 1
+envoy_cluster_membership_total{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 1
+# TYPE envoy_cluster_upstream_cx_active gauge
+envoy_cluster_upstream_cx_active{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_active{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_active{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_active{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_active{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 2
+envoy_cluster_upstream_cx_active{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_active{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_rx_bytes_buffered gauge
+envoy_cluster_upstream_cx_rx_bytes_buffered{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_rx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_rx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_rx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_rx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_rx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_rx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_rx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 6425
+envoy_cluster_upstream_cx_rx_bytes_buffered{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_rx_bytes_buffered{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_tx_bytes_buffered gauge
+envoy_cluster_upstream_cx_tx_bytes_buffered{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_tx_bytes_buffered{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_active gauge
+envoy_cluster_upstream_rq_active{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_active{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_active{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_active{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_active{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 1
+envoy_cluster_upstream_rq_active{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_active{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_pending_active gauge
+envoy_cluster_upstream_rq_pending_active{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_rq_pending_active{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_rq_pending_active{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_rq_pending_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_upstream_rq_pending_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_rq_pending_active{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_rq_pending_active{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_upstream_rq_pending_active{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_rq_pending_active{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_rq_pending_active{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_version gauge
+envoy_cluster_version{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_version{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_version{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_version{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_version{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_version{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_version{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_version{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_version{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_version{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_warming_state gauge
+envoy_cluster_warming_state{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_warming_state{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_warming_state{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_warming_state{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 0
+envoy_cluster_warming_state{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_warming_state{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_warming_state{service="pomerium",envoy_cluster_name="pomerium-databroker"} 0
+envoy_cluster_warming_state{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_warming_state{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_warming_state{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_manager_active_clusters gauge
+envoy_cluster_manager_active_clusters{service="pomerium"} 10
+# TYPE envoy_cluster_manager_cds_update_time gauge
+envoy_cluster_manager_cds_update_time{service="pomerium"} 1730927401419
+# TYPE envoy_cluster_manager_cds_version gauge
+envoy_cluster_manager_cds_version{service="pomerium"} 17241709254077376921
+# TYPE envoy_cluster_manager_warming_clusters gauge
+envoy_cluster_manager_warming_clusters{service="pomerium"} 0
+# TYPE envoy_control_plane_connected_state gauge
+envoy_control_plane_connected_state{service="pomerium"} 0
+# TYPE envoy_control_plane_pending_requests gauge
+envoy_control_plane_pending_requests{service="pomerium"} 0
+# TYPE envoy_filesystem_write_total_buffered gauge
+envoy_filesystem_write_total_buffered{} 0
+# TYPE envoy_http_downstream_cx_active gauge
+envoy_http_downstream_cx_active{service="pomerium",envoy_http_conn_manager_prefix="admin"} 2
+envoy_http_downstream_cx_active{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 3
+envoy_http_downstream_cx_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_active{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_active{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_http1_active gauge
+envoy_http_downstream_cx_http1_active{service="pomerium",envoy_http_conn_manager_prefix="admin"} 2
+envoy_http_downstream_cx_http1_active{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 2
+envoy_http_downstream_cx_http1_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_http1_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_http1_active{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_http1_active{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_http2_active gauge
+envoy_http_downstream_cx_http2_active{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_http2_active{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_http2_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_http2_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_http2_active{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_http2_active{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_http3_active gauge
+envoy_http_downstream_cx_http3_active{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_http3_active{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_http3_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_http3_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_http3_active{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_http3_active{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_rx_bytes_buffered gauge
+envoy_http_downstream_cx_rx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="admin"} 1155
+envoy_http_downstream_cx_rx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 947
+envoy_http_downstream_cx_rx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_rx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_rx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_rx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_ssl_active gauge
+envoy_http_downstream_cx_ssl_active{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_ssl_active{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_ssl_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_ssl_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_ssl_active{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_ssl_active{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_tx_bytes_buffered gauge
+envoy_http_downstream_cx_tx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_tx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_tx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_tx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_tx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_tx_bytes_buffered{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_cx_upgrades_active gauge
+envoy_http_downstream_cx_upgrades_active{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_upgrades_active{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 0
+envoy_http_downstream_cx_upgrades_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_cx_upgrades_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_upgrades_active{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_upgrades_active{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_active gauge
+envoy_http_downstream_rq_active{service="pomerium",envoy_http_conn_manager_prefix="admin"} 1
+envoy_http_downstream_rq_active{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 1
+envoy_http_downstream_rq_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 0
+envoy_http_downstream_rq_active{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_active{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_active{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_rds_config_reload_time_ms gauge
+envoy_http_rds_config_reload_time_ms{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 1730927401429
+# TYPE envoy_http_rds_update_time gauge
+envoy_http_rds_update_time{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 1730927401433
+# TYPE envoy_http_rds_version gauge
+envoy_http_rds_version{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 17241709254077376921
+# TYPE envoy_http2_deferred_stream_close gauge
+envoy_http2_deferred_stream_close{service="pomerium"} 0
+# TYPE envoy_http2_outbound_control_frames_active gauge
+envoy_http2_outbound_control_frames_active{service="pomerium"} 0
+# TYPE envoy_http2_outbound_frames_active gauge
+envoy_http2_outbound_frames_active{service="pomerium"} 0
+# TYPE envoy_http2_pending_send_bytes gauge
+envoy_http2_pending_send_bytes{service="pomerium"} 0
+# TYPE envoy_http2_streams_active gauge
+envoy_http2_streams_active{service="pomerium"} 0
+# TYPE envoy_listener_admin_downstream_cx_active gauge
+envoy_listener_admin_downstream_cx_active{service="pomerium"} 2
+# TYPE envoy_listener_admin_downstream_pre_cx_active gauge
+envoy_listener_admin_downstream_pre_cx_active{service="pomerium"} 0
+# TYPE envoy_listener_admin_main_thread_downstream_cx_active gauge
+envoy_listener_admin_main_thread_downstream_cx_active{service="pomerium"} 2
+# TYPE envoy_listener_downstream_cx_active gauge
+envoy_listener_downstream_cx_active{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_downstream_cx_active{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 3
+envoy_listener_downstream_cx_active{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_cx_active{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_cx_active{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_downstream_pre_cx_active gauge
+envoy_listener_downstream_pre_cx_active{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_downstream_pre_cx_active{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_downstream_pre_cx_active{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_pre_cx_active{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_pre_cx_active{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_worker_downstream_cx_active gauge
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="0",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="1",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="2",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="3",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="4",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="5",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="6",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="7",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="8",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="9",service="pomerium",envoy_listener_address="127.0.0.1_52718"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="0",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="1",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 1
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="2",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="3",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 1
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="4",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="5",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="6",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="7",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 1
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="8",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="9",service="pomerium",envoy_listener_address="127.0.0.1_9901"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="0",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="1",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="2",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="3",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="4",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="5",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="6",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="7",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="8",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="9",service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="0",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="1",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="2",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="3",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="4",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="5",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="6",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="7",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="8",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="9",service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="0",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="1",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="2",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="3",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="4",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="5",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="6",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="7",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="8",service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_worker_downstream_cx_active{envoy_worker_id="9",service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_manager_lds_update_time gauge
+envoy_listener_manager_lds_update_time{service="pomerium"} 1730927401428
+# TYPE envoy_listener_manager_lds_version gauge
+envoy_listener_manager_lds_version{service="pomerium"} 17241709254077376921
+# TYPE envoy_listener_manager_total_filter_chains_draining gauge
+envoy_listener_manager_total_filter_chains_draining{service="pomerium"} 0
+# TYPE envoy_listener_manager_total_listeners_active gauge
+envoy_listener_manager_total_listeners_active{service="pomerium"} 5
+# TYPE envoy_listener_manager_total_listeners_draining gauge
+envoy_listener_manager_total_listeners_draining{service="pomerium"} 0
+# TYPE envoy_listener_manager_total_listeners_warming gauge
+envoy_listener_manager_total_listeners_warming{service="pomerium"} 0
+# TYPE envoy_listener_manager_workers_started gauge
+envoy_listener_manager_workers_started{service="pomerium"} 1
+# TYPE envoy_runtime_admin_overrides_active gauge
+envoy_runtime_admin_overrides_active{service="pomerium"} 0
+# TYPE envoy_runtime_deprecated_feature_seen_since_process_start gauge
+envoy_runtime_deprecated_feature_seen_since_process_start{service="pomerium"} 0
+# TYPE envoy_runtime_num_keys gauge
+envoy_runtime_num_keys{service="pomerium"} 2
+# TYPE envoy_runtime_num_layers gauge
+envoy_runtime_num_layers{service="pomerium"} 1
+# TYPE envoy_server_compilation_settings_fips_mode gauge
+envoy_server_compilation_settings_fips_mode{service="pomerium"} 0
+# TYPE envoy_server_concurrency gauge
+envoy_server_concurrency{service="pomerium"} 10
+# TYPE envoy_server_days_until_first_cert_expiring gauge
+envoy_server_days_until_first_cert_expiring{service="pomerium"} 282
+# TYPE envoy_server_hot_restart_epoch gauge
+envoy_server_hot_restart_epoch{service="pomerium"} 0
+# TYPE envoy_server_live gauge
+envoy_server_live{service="pomerium"} 1
+# TYPE envoy_server_memory_allocated gauge
+envoy_server_memory_allocated{service="pomerium"} 0
+# TYPE envoy_server_memory_heap_size gauge
+envoy_server_memory_heap_size{service="pomerium"} 0
+# TYPE envoy_server_memory_physical_size gauge
+envoy_server_memory_physical_size{service="pomerium"} 0
+# TYPE envoy_server_parent_connections gauge
+envoy_server_parent_connections{service="pomerium"} 0
+# TYPE envoy_server_seconds_until_first_ocsp_response_expiring gauge
+envoy_server_seconds_until_first_ocsp_response_expiring{service="pomerium"} 0
+# TYPE envoy_server_state gauge
+envoy_server_state{service="pomerium"} 0
+# TYPE envoy_server_stats_recent_lookups gauge
+envoy_server_stats_recent_lookups{service="pomerium"} 11743
+# TYPE envoy_server_total_connections gauge
+envoy_server_total_connections{service="pomerium"} 2
+# TYPE envoy_server_uptime gauge
+envoy_server_uptime{service="pomerium"} 160
+# TYPE envoy_server_version gauge
+envoy_server_version{service="pomerium"} 8096687
+# TYPE envoy_tcp_downstream_cx_rx_bytes_buffered gauge
+envoy_tcp_downstream_cx_rx_bytes_buffered{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tcp_downstream_cx_tx_bytes_buffered gauge
+envoy_tcp_downstream_cx_tx_bytes_buffered{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_tcp_upstream_flush_active gauge
+envoy_tcp_upstream_flush_active{service="pomerium",envoy_tcp_prefix="acme_tls_alpn"} 0
+# TYPE envoy_thread_local_cluster_manager_main_thread_clusters_inflated gauge
+envoy_thread_local_cluster_manager_main_thread_clusters_inflated{service="pomerium"} 10
+# TYPE envoy_thread_local_cluster_manager_worker_clusters_inflated gauge
+envoy_thread_local_cluster_manager_worker_clusters_inflated{envoy_worker_id="0",service="pomerium"} 10
+envoy_thread_local_cluster_manager_worker_clusters_inflated{envoy_worker_id="1",service="pomerium"} 10
+envoy_thread_local_cluster_manager_worker_clusters_inflated{envoy_worker_id="2",service="pomerium"} 10
+envoy_thread_local_cluster_manager_worker_clusters_inflated{envoy_worker_id="3",service="pomerium"} 10
+envoy_thread_local_cluster_manager_worker_clusters_inflated{envoy_worker_id="4",service="pomerium"} 10
+envoy_thread_local_cluster_manager_worker_clusters_inflated{envoy_worker_id="5",service="pomerium"} 10
+envoy_thread_local_cluster_manager_worker_clusters_inflated{envoy_worker_id="6",service="pomerium"} 10
+envoy_thread_local_cluster_manager_worker_clusters_inflated{envoy_worker_id="7",service="pomerium"} 10
+envoy_thread_local_cluster_manager_worker_clusters_inflated{envoy_worker_id="8",service="pomerium"} 10
+envoy_thread_local_cluster_manager_worker_clusters_inflated{envoy_worker_id="9",service="pomerium"} 10
+# TYPE envoy_cluster_external_upstream_rq_time histogram
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="0.5"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="5"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="10"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="25"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="50"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="100"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="250"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="500"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1000"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="2500"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="5000"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="10000"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="30000"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="60000"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="300000"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="600000"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1800000"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="3600000"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="+Inf"} 6
+envoy_cluster_external_upstream_rq_time_sum{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1.0500000000000000444089209850063
+envoy_cluster_external_upstream_rq_time_count{service="pomerium",envoy_cluster_name="pomerium-databroker"} 6
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="0.5"} 1
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1"} 1
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="5"} 3
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="10"} 4
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="25"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="50"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="100"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="250"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="500"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1000"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="2500"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="5000"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="10000"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="30000"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="60000"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="300000"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="600000"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1800000"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="3600000"} 5
+envoy_cluster_external_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="+Inf"} 5
+envoy_cluster_external_upstream_rq_time_sum{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 22.6499999999999985789145284798
+envoy_cluster_external_upstream_rq_time_count{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 5
+# TYPE envoy_cluster_upstream_cx_connect_ms histogram
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="0.5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="1"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="10"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="25"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="50"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="100"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="250"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="1000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="2500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="5000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="10000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="30000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="60000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="300000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="1800000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="3600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="+Inf"} 0
+envoy_cluster_upstream_cx_connect_ms_sum{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_connect_ms_count{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="0.5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="1"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="10"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="25"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="50"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="100"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="250"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="1000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="2500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="5000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="10000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="30000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="60000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="300000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="1800000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="3600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="+Inf"} 0
+envoy_cluster_upstream_cx_connect_ms_sum{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_connect_ms_count{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="0.5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="1"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="10"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="25"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="50"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="100"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="250"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="1000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="2500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="5000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="10000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="30000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="60000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="300000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="1800000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="3600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="+Inf"} 0
+envoy_cluster_upstream_cx_connect_ms_sum{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_connect_ms_count{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="0.5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="1"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="5"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="10"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="25"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="50"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="100"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="250"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="500"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="1000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="2500"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="5000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="10000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="30000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="60000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="300000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="600000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="1800000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="3600000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="+Inf"} 1
+envoy_cluster_upstream_cx_connect_ms_sum{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1.0500000000000000444089209850063
+envoy_cluster_upstream_cx_connect_ms_count{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="0.5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="1"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="10"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="25"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="50"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="100"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="250"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="1000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="2500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="5000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="10000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="30000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="60000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="300000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="1800000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="3600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="+Inf"} 0
+envoy_cluster_upstream_cx_connect_ms_sum{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_connect_ms_count{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="0.5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="1"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="10"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="25"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="50"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="100"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="250"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="1000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="2500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="5000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="10000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="30000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="60000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="300000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="1800000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="3600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="+Inf"} 0
+envoy_cluster_upstream_cx_connect_ms_sum{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_connect_ms_count{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="0.5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="5"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="10"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="25"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="50"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="100"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="250"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="500"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="2500"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="5000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="10000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="30000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="60000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="300000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="600000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1800000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="3600000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="+Inf"} 1
+envoy_cluster_upstream_cx_connect_ms_sum{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1.0500000000000000444089209850063
+envoy_cluster_upstream_cx_connect_ms_count{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="0.5"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="5"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="10"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="25"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="50"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="100"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="250"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="500"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="2500"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="5000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="10000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="30000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="60000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="300000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="600000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1800000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="3600000"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="+Inf"} 1
+envoy_cluster_upstream_cx_connect_ms_sum{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_connect_ms_count{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 1
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="0.5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="1"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="10"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="25"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="50"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="100"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="250"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="1000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="2500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="5000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="10000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="30000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="60000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="300000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="1800000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="3600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="+Inf"} 0
+envoy_cluster_upstream_cx_connect_ms_sum{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_connect_ms_count{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="0.5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="1"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="5"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="10"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="25"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="50"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="100"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="250"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="1000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="2500"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="5000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="10000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="30000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="60000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="300000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="1800000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="3600000"} 0
+envoy_cluster_upstream_cx_connect_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="+Inf"} 0
+envoy_cluster_upstream_cx_connect_ms_sum{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+envoy_cluster_upstream_cx_connect_ms_count{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_cx_length_ms histogram
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="10"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="25"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="50"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="100"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="250"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="1000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="2500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="5000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="10000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="30000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="60000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="300000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="1800000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="3600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io",le="+Inf"} 0
+envoy_cluster_upstream_cx_length_ms_sum{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_length_ms_count{service="pomerium",envoy_cluster_name="console-localhost-pomerium-io"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="10"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="25"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="50"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="100"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="250"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="1000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="2500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="5000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="10000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="30000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="60000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="300000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="1800000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="3600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn",le="+Inf"} 0
+envoy_cluster_upstream_cx_length_ms_sum{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_length_ms_count{service="pomerium",envoy_cluster_name="pomerium-acme-tls-alpn"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="10"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="25"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="50"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="100"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="250"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="1000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="2500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="5000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="10000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="30000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="60000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="300000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="1800000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="3600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-authorize",le="+Inf"} 0
+envoy_cluster_upstream_cx_length_ms_sum{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_length_ms_count{service="pomerium",envoy_cluster_name="pomerium-authorize"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="0.5"} 1
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="1"} 1
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="5"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="10"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="25"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="50"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="100"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="250"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="500"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="1000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="2500"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="5000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="10000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="30000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="60000"} 7
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="300000"} 8
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="600000"} 8
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="1800000"} 8
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="3600000"} 8
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc",le="+Inf"} 8
+envoy_cluster_upstream_cx_length_ms_sum{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 125011.30000000000291038304567337
+envoy_cluster_upstream_cx_length_ms_count{service="pomerium",envoy_cluster_name="pomerium-control-plane-grpc"} 8
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="10"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="25"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="50"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="100"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="250"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="1000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="2500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="5000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="10000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="30000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="60000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="300000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="1800000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="3600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-http",le="+Inf"} 0
+envoy_cluster_upstream_cx_length_ms_sum{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_length_ms_count{service="pomerium",envoy_cluster_name="pomerium-control-plane-http"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="10"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="25"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="50"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="100"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="250"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="1000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="2500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="5000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="10000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="30000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="60000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="300000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="1800000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="3600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics",le="+Inf"} 0
+envoy_cluster_upstream_cx_length_ms_sum{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_length_ms_count{service="pomerium",envoy_cluster_name="pomerium-control-plane-metrics"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="10"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="25"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="50"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="100"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="250"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="2500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="5000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="10000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="30000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="60000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="300000"} 1
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="600000"} 1
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1800000"} 1
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="3600000"} 1
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="+Inf"} 1
+envoy_cluster_upstream_cx_length_ms_sum{service="pomerium",envoy_cluster_name="pomerium-databroker"} 125000
+envoy_cluster_upstream_cx_length_ms_count{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="10"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="25"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="50"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="100"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="250"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="2500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="5000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="10000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="30000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="60000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="300000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1800000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="3600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="+Inf"} 0
+envoy_cluster_upstream_cx_length_ms_sum{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_length_ms_count{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="10"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="25"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="50"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="100"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="250"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="1000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="2500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="5000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="10000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="30000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="60000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="300000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="1800000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="3600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909",le="+Inf"} 0
+envoy_cluster_upstream_cx_length_ms_sum{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_length_ms_count{service="pomerium",envoy_cluster_name="route-4db3c17a9745e909"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="0.5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="1"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="5"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="10"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="25"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="50"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="100"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="250"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="1000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="2500"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="5000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="10000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="30000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="60000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="300000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="1800000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="3600000"} 0
+envoy_cluster_upstream_cx_length_ms_bucket{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db",le="+Inf"} 0
+envoy_cluster_upstream_cx_length_ms_sum{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+envoy_cluster_upstream_cx_length_ms_count{service="pomerium",envoy_cluster_name="route-7256892f3f41f5db"} 0
+# TYPE envoy_cluster_upstream_rq_time histogram
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="0.5"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="5"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="10"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="25"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="50"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="100"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="250"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="500"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1000"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="2500"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="5000"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="10000"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="30000"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="60000"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="300000"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="600000"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="1800000"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="3600000"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-databroker",le="+Inf"} 6
+envoy_cluster_upstream_rq_time_sum{service="pomerium",envoy_cluster_name="pomerium-databroker"} 1.0500000000000000444089209850063
+envoy_cluster_upstream_rq_time_count{service="pomerium",envoy_cluster_name="pomerium-databroker"} 6
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="0.5"} 1
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1"} 1
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="5"} 3
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="10"} 4
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="25"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="50"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="100"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="250"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="500"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1000"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="2500"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="5000"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="10000"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="30000"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="60000"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="300000"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="600000"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="1800000"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="3600000"} 5
+envoy_cluster_upstream_rq_time_bucket{service="pomerium",envoy_cluster_name="pomerium-envoy-admin",le="+Inf"} 5
+envoy_cluster_upstream_rq_time_sum{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 22.6499999999999985789145284798
+envoy_cluster_upstream_rq_time_count{service="pomerium",envoy_cluster_name="pomerium-envoy-admin"} 5
+# TYPE envoy_cluster_manager_cds_update_duration histogram
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="0.5"} 0
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="1"} 0
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="5"} 0
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="10"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="25"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="50"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="100"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="250"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="500"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="1000"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="2500"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="5000"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="10000"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="30000"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="60000"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="300000"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="600000"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="1800000"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="3600000"} 1
+envoy_cluster_manager_cds_update_duration_bucket{service="pomerium",le="+Inf"} 1
+envoy_cluster_manager_cds_update_duration_sum{service="pomerium"} 6.049999999999999822364316059975
+envoy_cluster_manager_cds_update_duration_count{service="pomerium"} 1
+# TYPE envoy_http_downstream_cx_length_ms histogram
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="0.5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="1"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="10"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="25"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="50"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="100"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="250"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="1000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="2500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="5000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="10000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="30000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="60000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="300000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="600000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="1800000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="3600000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="+Inf"} 0
+envoy_http_downstream_cx_length_ms_sum{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_length_ms_count{service="pomerium",envoy_http_conn_manager_prefix="admin"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="0.5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="1"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="10"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="25"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="50"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="100"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="250"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="1000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="2500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="5000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="10000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="30000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="60000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="300000"} 1
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="600000"} 1
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="1800000"} 1
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="3600000"} 1
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="+Inf"} 1
+envoy_http_downstream_cx_length_ms_sum{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 67500
+envoy_http_downstream_cx_length_ms_count{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 1
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="0.5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="1"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="10"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="25"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="50"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="100"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="250"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="1000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="2500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="5000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="10000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="30000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="60000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="300000"} 5
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="600000"} 5
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="1800000"} 5
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="3600000"} 5
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="+Inf"} 5
+envoy_http_downstream_cx_length_ms_sum{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 625000
+envoy_http_downstream_cx_length_ms_count{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 5
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="0.5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="1"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="10"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="25"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="50"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="100"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="250"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="1000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="2500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="5000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="10000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="30000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="60000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="300000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="600000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="1800000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="3600000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="+Inf"} 0
+envoy_http_downstream_cx_length_ms_sum{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_length_ms_count{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="0.5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="1"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="10"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="25"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="50"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="100"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="250"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="1000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="2500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="5000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="10000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="30000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="60000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="300000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="600000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="1800000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="3600000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="+Inf"} 0
+envoy_http_downstream_cx_length_ms_sum{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_length_ms_count{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="0.5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="1"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="5"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="10"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="25"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="50"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="100"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="250"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="1000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="2500"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="5000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="10000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="30000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="60000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="300000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="600000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="1800000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="3600000"} 0
+envoy_http_downstream_cx_length_ms_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="+Inf"} 0
+envoy_http_downstream_cx_length_ms_sum{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+envoy_http_downstream_cx_length_ms_count{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_downstream_rq_time histogram
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="0.5"} 2
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="1"} 2
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="5"} 3
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="10"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="25"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="50"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="100"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="250"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="500"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="1000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="2500"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="5000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="10000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="30000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="60000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="300000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="600000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="1800000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="3600000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="admin",le="+Inf"} 5
+envoy_http_downstream_rq_time_sum{service="pomerium",envoy_http_conn_manager_prefix="admin"} 17.150000000000002131628207280301
+envoy_http_downstream_rq_time_count{service="pomerium",envoy_http_conn_manager_prefix="admin"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="0.5"} 1
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="1"} 1
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="5"} 3
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="10"} 4
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="25"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="50"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="100"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="250"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="500"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="1000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="2500"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="5000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="10000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="30000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="60000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="300000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="600000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="1800000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="3600000"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin",le="+Inf"} 5
+envoy_http_downstream_rq_time_sum{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 23.6499999999999985789145284798
+envoy_http_downstream_rq_time_count{service="pomerium",envoy_http_conn_manager_prefix="envoy-admin"} 5
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="0.5"} 1
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="1"} 1
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="5"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="10"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="25"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="50"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="100"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="250"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="500"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="1000"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="2500"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="5000"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="10000"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="30000"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="60000"} 6
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="300000"} 7
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="600000"} 7
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="1800000"} 7
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="3600000"} 7
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress",le="+Inf"} 7
+envoy_http_downstream_rq_time_sum{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 125007.25
+envoy_http_downstream_rq_time_count{service="pomerium",envoy_http_conn_manager_prefix="grpc_egress"} 7
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="0.5"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="1"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="5"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="10"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="25"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="50"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="100"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="250"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="500"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="1000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="2500"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="5000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="10000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="30000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="60000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="300000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="600000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="1800000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="3600000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress",le="+Inf"} 0
+envoy_http_downstream_rq_time_sum{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_time_count{service="pomerium",envoy_http_conn_manager_prefix="grpc_ingress"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="0.5"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="1"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="5"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="10"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="25"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="50"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="100"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="250"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="500"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="1000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="2500"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="5000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="10000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="30000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="60000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="300000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="600000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="1800000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="3600000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="ingress",le="+Inf"} 0
+envoy_http_downstream_rq_time_sum{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_time_count{service="pomerium",envoy_http_conn_manager_prefix="ingress"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="0.5"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="1"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="5"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="10"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="25"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="50"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="100"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="250"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="500"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="1000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="2500"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="5000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="10000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="30000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="60000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="300000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="600000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="1800000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="3600000"} 0
+envoy_http_downstream_rq_time_bucket{service="pomerium",envoy_http_conn_manager_prefix="metrics",le="+Inf"} 0
+envoy_http_downstream_rq_time_sum{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+envoy_http_downstream_rq_time_count{service="pomerium",envoy_http_conn_manager_prefix="metrics"} 0
+# TYPE envoy_http_rds_update_duration histogram
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="0.5"} 0
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="1"} 0
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="5"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="10"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="25"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="50"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="100"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="250"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="500"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="1000"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="2500"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="5000"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="10000"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="30000"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="60000"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="300000"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="600000"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="1800000"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="3600000"} 1
+envoy_http_rds_update_duration_bucket{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress",le="+Inf"} 1
+envoy_http_rds_update_duration_sum{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 4.049999999999999822364316059975
+envoy_http_rds_update_duration_count{service="pomerium",envoy_rds_route_config="main",envoy_http_conn_manager_prefix="ingress"} 1
+# TYPE envoy_listener_admin_connections_accepted_per_socket_event histogram
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="0.5"} 0
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="1"} 0
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="5"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="10"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="25"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="50"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="100"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="250"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="500"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="1000"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="2500"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="5000"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="10000"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="30000"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="60000"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="300000"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="600000"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="1800000"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="3600000"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_bucket{service="pomerium",le="+Inf"} 1
+envoy_listener_admin_connections_accepted_per_socket_event_sum{service="pomerium"} 1.0500000000000000444089209850063
+envoy_listener_admin_connections_accepted_per_socket_event_count{service="pomerium"} 1
+# TYPE envoy_listener_admin_downstream_cx_length_ms histogram
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="0.5"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="1"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="5"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="10"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="25"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="50"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="100"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="250"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="500"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="1000"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="2500"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="5000"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="10000"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="30000"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="60000"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="300000"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="600000"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="1800000"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="3600000"} 0
+envoy_listener_admin_downstream_cx_length_ms_bucket{service="pomerium",le="+Inf"} 0
+envoy_listener_admin_downstream_cx_length_ms_sum{service="pomerium"} 0
+envoy_listener_admin_downstream_cx_length_ms_count{service="pomerium"} 0
+# TYPE envoy_listener_connections_accepted_per_socket_event histogram
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="0.5"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="1"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="5"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="10"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="25"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="50"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="100"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="250"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="500"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="1000"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="2500"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="5000"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="10000"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="30000"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="60000"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="300000"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="600000"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="1800000"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="3600000"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="+Inf"} 5
+envoy_listener_connections_accepted_per_socket_event_sum{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 5.25
+envoy_listener_connections_accepted_per_socket_event_count{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 5
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="0.5"} 4
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="1"} 4
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="5"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="10"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="25"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="50"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="100"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="250"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="500"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="1000"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="2500"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="5000"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="10000"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="30000"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="60000"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="300000"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="600000"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="1800000"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="3600000"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="+Inf"} 6
+envoy_listener_connections_accepted_per_socket_event_sum{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 3.0999999999999996447286321199499
+envoy_listener_connections_accepted_per_socket_event_count{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 6
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="0.5"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="1"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="5"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="10"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="25"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="50"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="100"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="250"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="500"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="1000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="2500"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="5000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="10000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="30000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="60000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="300000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="600000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="1800000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="3600000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_443",le="+Inf"} 0
+envoy_listener_connections_accepted_per_socket_event_sum{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_connections_accepted_per_socket_event_count{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="0.5"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="1"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="5"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="10"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="25"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="50"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="100"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="250"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="500"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="1000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="2500"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="5000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="10000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="30000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="60000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="300000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="600000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="1800000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="3600000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="+Inf"} 0
+envoy_listener_connections_accepted_per_socket_event_sum{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_connections_accepted_per_socket_event_count{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="0.5"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="1"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="5"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="10"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="25"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="50"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="100"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="250"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="500"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="1000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="2500"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="5000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="10000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="30000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="60000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="300000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="600000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="1800000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="3600000"} 0
+envoy_listener_connections_accepted_per_socket_event_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="+Inf"} 0
+envoy_listener_connections_accepted_per_socket_event_sum{service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_connections_accepted_per_socket_event_count{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_downstream_cx_length_ms histogram
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="0.5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="1"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="10"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="25"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="50"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="100"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="250"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="1000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="2500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="5000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="10000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="30000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="60000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="300000"} 5
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="600000"} 5
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="1800000"} 5
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="3600000"} 5
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_52718",le="+Inf"} 5
+envoy_listener_downstream_cx_length_ms_sum{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 625000
+envoy_listener_downstream_cx_length_ms_count{service="pomerium",envoy_listener_address="127.0.0.1_52718"} 5
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="0.5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="1"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="10"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="25"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="50"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="100"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="250"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="1000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="2500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="5000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="10000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="30000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="60000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="300000"} 1
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="600000"} 1
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="1800000"} 1
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="3600000"} 1
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="127.0.0.1_9901",le="+Inf"} 1
+envoy_listener_downstream_cx_length_ms_sum{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 67500
+envoy_listener_downstream_cx_length_ms_count{service="pomerium",envoy_listener_address="127.0.0.1_9901"} 1
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="0.5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="1"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="10"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="25"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="50"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="100"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="250"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="1000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="2500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="5000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="10000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="30000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="60000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="300000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="600000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="1800000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="3600000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_443",le="+Inf"} 0
+envoy_listener_downstream_cx_length_ms_sum{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_cx_length_ms_count{service="pomerium",envoy_listener_address="[__]_443"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="0.5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="1"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="10"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="25"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="50"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="100"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="250"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="1000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="2500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="5000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="10000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="30000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="60000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="300000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="600000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="1800000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="3600000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_5443",le="+Inf"} 0
+envoy_listener_downstream_cx_length_ms_sum{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_cx_length_ms_count{service="pomerium",envoy_listener_address="[__]_5443"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="0.5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="1"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="5"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="10"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="25"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="50"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="100"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="250"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="1000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="2500"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="5000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="10000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="30000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="60000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="300000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="600000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="1800000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="3600000"} 0
+envoy_listener_downstream_cx_length_ms_bucket{service="pomerium",envoy_listener_address="[__]_9090",le="+Inf"} 0
+envoy_listener_downstream_cx_length_ms_sum{service="pomerium",envoy_listener_address="[__]_9090"} 0
+envoy_listener_downstream_cx_length_ms_count{service="pomerium",envoy_listener_address="[__]_9090"} 0
+# TYPE envoy_listener_manager_lds_update_duration histogram
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="0.5"} 0
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="1"} 0
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="5"} 0
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="10"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="25"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="50"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="100"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="250"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="500"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="1000"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="2500"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="5000"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="10000"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="30000"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="60000"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="300000"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="600000"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="1800000"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="3600000"} 1
+envoy_listener_manager_lds_update_duration_bucket{service="pomerium",le="+Inf"} 1
+envoy_listener_manager_lds_update_duration_sum{service="pomerium"} 7.049999999999999822364316059975
+envoy_listener_manager_lds_update_duration_count{service="pomerium"} 1
+# TYPE envoy_overload_refresh_interval_delay histogram
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="0.5"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="1"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="5"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="10"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="25"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="50"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="100"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="250"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="500"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="1000"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="2500"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="5000"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="10000"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="30000"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="60000"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="300000"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="600000"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="1800000"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="3600000"} 0
+envoy_overload_refresh_interval_delay_bucket{service="pomerium",le="+Inf"} 0
+envoy_overload_refresh_interval_delay_sum{service="pomerium"} 0
+envoy_overload_refresh_interval_delay_count{service="pomerium"} 0
+# TYPE envoy_server_initialization_time_ms histogram
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="0.5"} 0
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="1"} 0
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="5"} 0
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="10"} 0
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="25"} 0
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="50"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="100"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="250"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="500"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="1000"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="2500"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="5000"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="10000"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="30000"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="60000"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="300000"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="600000"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="1800000"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="3600000"} 1
+envoy_server_initialization_time_ms_bucket{service="pomerium",le="+Inf"} 1
+envoy_server_initialization_time_ms_sum{service="pomerium"} 31.5
+envoy_server_initialization_time_ms_count{service="pomerium"} 1
+# TYPE envoy_tls_inspector_bytes_processed histogram
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="0.5"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="1"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="5"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="10"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="25"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="50"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="100"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="250"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="500"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="1000"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="2500"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="5000"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="10000"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="30000"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="60000"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="300000"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="600000"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="1800000"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="3600000"} 0
+envoy_tls_inspector_bytes_processed_bucket{service="pomerium",le="+Inf"} 0
+envoy_tls_inspector_bytes_processed_sum{service="pomerium"} 0
+envoy_tls_inspector_bytes_processed_count{service="pomerium"} 0


### PR DESCRIPTION
## Summary

Improves memory usage when producing Prometheus metrics by performing streaming processing. Previously, the entire Envoy metrics dump was loaded into memory and parsed for relabeling purposes, which added GC pressure when a lot of routes were present. 


## Related issues

https://github.com/pomerium/internal/issues/2003

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
