### PR TITLE
testenv: avoid dns lookups for *.localhost.pomerium.io

### DIFF
--- a/internal/testenv/dns.go
+++ b/internal/testenv/dns.go
@@ -1,0 +1,64 @@
+package testenv
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+const localDomainName = "localhost.pomerium.io"
+
+type DialContextFunc = func(ctx context.Context, network string, addr string) (net.Conn, error)
+
+var defaultDialer = &net.Dialer{
+	Timeout:   30 * time.Second,
+	KeepAlive: 30 * time.Second,
+	Resolver: &net.Resolver{
+		PreferGo: true,
+	},
+}
+
+func init() {
+	http.DefaultTransport.(*http.Transport).DialContext = OverrideDialContext(defaultDialer.DialContext)
+}
+
+func OverrideDialContext(defaultDialContext DialContextFunc) DialContextFunc {
+	return func(ctx context.Context, network, addr string) (net.Conn, error) {
+		host, port, err := maybeSplitHostPort(addr)
+		if err != nil {
+			return nil, err
+		}
+		if strings.HasSuffix(host, localDomainName) {
+			switch network {
+			case "tcp", "tcp4", "udp", "udp4":
+				host = "127.0.0.1"
+			case "tcp6", "udp6":
+				host = "::1"
+			}
+		}
+		return defaultDialContext(ctx, network, net.JoinHostPort(host, port))
+	}
+}
+
+func maybeSplitHostPort(s string) (string, string, error) {
+	if strings.Contains(s, ":") {
+		return net.SplitHostPort(s)
+	}
+	return s, "", nil
+}
+
+func GRPCContextDialer(ctx context.Context, target string) (net.Conn, error) {
+	if strings.HasPrefix(target, "unix") {
+		return defaultDialer.DialContext(ctx, "tcp", target)
+	}
+	host, port, err := net.SplitHostPort(target)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasSuffix(host, localDomainName) {
+		return defaultDialer.DialContext(ctx, "tcp", "127.0.0.1:"+port)
+	}
+	return defaultDialer.DialContext(ctx, "tcp", target)
+}

--- a/internal/testenv/selftests/dns_test.go
+++ b/internal/testenv/selftests/dns_test.go
@@ -1,0 +1,55 @@
+package selftests_test
+
+import (
+	"net"
+	"net/http"
+	"net/http/httptrace"
+	"testing"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDNSOverrides(t *testing.T) {
+	env := testenv.New(t)
+	h := upstreams.HTTP(nil)
+	h.Handle("/", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("OK"))
+	})
+	route := h.Route().From(env.SubdomainURL("foo")).Policy(func(p *config.Policy) {
+		p.AllowPublicUnauthenticatedAccess = true
+	})
+	env.AddUpstream(h)
+
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	var traceHostPort, traceRemoteAddr string
+	var dnsStartCalled, dnsEndCalled bool
+	trace := httptrace.ClientTrace{
+		DNSStart: func(di httptrace.DNSStartInfo) {
+			dnsStartCalled = true
+		},
+		DNSDone: func(di httptrace.DNSDoneInfo) {
+			dnsEndCalled = true
+		},
+		GetConn: func(hostPort string) {
+			traceHostPort = hostPort
+		},
+		GotConn: func(gci httptrace.GotConnInfo) {
+			traceRemoteAddr = gci.Conn.RemoteAddr().String()
+		},
+	}
+	resp, err := h.Get(route, upstreams.WithClientTrace(&trace))
+	require.NoError(t, err)
+	require.False(t, dnsStartCalled)
+	require.False(t, dnsEndCalled)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.Equal(t, route.URL().Value(), "https://"+traceHostPort)
+	host, _, err := net.SplitHostPort(traceRemoteAddr)
+	require.NoError(t, err)
+	require.True(t, net.ParseIP(host).IsLoopback())
+}

--- a/internal/testenv/selftests/dns_test.go
+++ b/internal/testenv/selftests/dns_test.go
@@ -16,7 +16,7 @@ import (
 func TestDNSOverrides(t *testing.T) {
 	env := testenv.New(t)
 	h := upstreams.HTTP(nil)
-	h.Handle("/", func(w http.ResponseWriter, r *http.Request) {
+	h.Handle("/", func(w http.ResponseWriter, _ *http.Request) {
 		w.Write([]byte("OK"))
 	})
 	route := h.Route().From(env.SubdomainURL("foo")).Policy(func(p *config.Policy) {
@@ -30,10 +30,10 @@ func TestDNSOverrides(t *testing.T) {
 	var traceHostPort, traceRemoteAddr string
 	var dnsStartCalled, dnsEndCalled bool
 	trace := httptrace.ClientTrace{
-		DNSStart: func(di httptrace.DNSStartInfo) {
+		DNSStart: func(_ httptrace.DNSStartInfo) {
 			dnsStartCalled = true
 		},
-		DNSDone: func(di httptrace.DNSDoneInfo) {
+		DNSDone: func(_ httptrace.DNSDoneInfo) {
 			dnsEndCalled = true
 		},
 		GetConn: func(hostPort string) {

--- a/internal/testenv/upstreams/grpc.go
+++ b/internal/testenv/upstreams/grpc.go
@@ -128,6 +128,7 @@ func (g *grpcUpstream) Run(ctx context.Context) error {
 
 func (g *grpcUpstream) Dial(r testenv.Route, dialOpts ...grpc.DialOption) *grpc.ClientConn {
 	dialOpts = append(dialOpts,
+		grpc.WithContextDialer(testenv.GRPCContextDialer),
 		grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(g.Env().ServerCAs(), "")),
 		grpc.WithDefaultCallOptions(grpc.WaitForReady(true)),
 	)


### PR DESCRIPTION
## Summary

This adds a custom dialer that prevents lookups for `localhost.pomerium.io` and any subdomains to avoid flooding DNS servers with requests during benchmarks (and influencing benchmark results)

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
