### PR TITLE
add options to adjust databroker lease ttl, and retry initial interval

### DIFF
--- a/pkg/identity/legacymanager/config.go
+++ b/pkg/identity/legacymanager/config.go
@@ -10,6 +10,7 @@ import (
 var (
 	defaultSessionRefreshGracePeriod     = 1 * time.Minute
 	defaultSessionRefreshCoolOffDuration = 10 * time.Second
+	defaultLeaseTTL                      = 30 * time.Second
 )
 
 type config struct {
@@ -17,6 +18,7 @@ type config struct {
 	dataBrokerClient              databroker.DataBrokerServiceClient
 	sessionRefreshGracePeriod     time.Duration
 	sessionRefreshCoolOffDuration time.Duration
+	leaseTTL                      time.Duration
 	now                           func() time.Time
 	eventMgr                      *events.Manager
 	enabled                       bool
@@ -28,6 +30,7 @@ func newConfig(options ...Option) *config {
 	WithSessionRefreshCoolOffDuration(defaultSessionRefreshCoolOffDuration)(cfg)
 	WithNow(time.Now)(cfg)
 	WithEnabled(true)(cfg)
+	WithLeaseTTL(defaultLeaseTTL)(cfg)
 	for _, option := range options {
 		option(cfg)
 	}
@@ -83,5 +86,11 @@ func WithEventManager(mgr *events.Manager) Option {
 func WithEnabled(enabled bool) Option {
 	return func(cfg *config) {
 		cfg.enabled = enabled
+	}
+}
+
+func WithLeaseTTL(ttl time.Duration) Option {
+	return func(o *config) {
+		o.leaseTTL = ttl
 	}
 }

--- a/pkg/identity/legacymanager/manager.go
+++ b/pkg/identity/legacymanager/manager.go
@@ -88,7 +88,7 @@ func (mgr *Manager) UpdateConfig(options ...Option) {
 
 // RunEnabled runs the manager. This method blocks until an error occurs or the given context is canceled.
 func (mgr *Manager) RunEnabled(ctx context.Context) error {
-	leaser := databroker.NewLeaser("identity_manager", time.Second*30, mgr)
+	leaser := databroker.NewLeaser("identity_manager", mgr.cfg.Load().leaseTTL, mgr)
 	return leaser.Run(ctx)
 }
 

--- a/pkg/identity/manager/config.go
+++ b/pkg/identity/manager/config.go
@@ -11,6 +11,7 @@ var (
 	defaultSessionRefreshGracePeriod     = 1 * time.Minute
 	defaultSessionRefreshCoolOffDuration = 10 * time.Second
 	defaultUpdateUserInfoInterval        = 10 * time.Minute
+	defaultLeaseTTL                      = 30 * time.Second
 )
 
 type config struct {
@@ -19,6 +20,7 @@ type config struct {
 	sessionRefreshGracePeriod     time.Duration
 	sessionRefreshCoolOffDuration time.Duration
 	updateUserInfoInterval        time.Duration
+	leaseTTL                      time.Duration
 	now                           func() time.Time
 	eventMgr                      *events.Manager
 	enabled                       bool
@@ -31,6 +33,7 @@ func newConfig(options ...Option) *config {
 	WithNow(time.Now)(cfg)
 	WithUpdateUserInfoInterval(defaultUpdateUserInfoInterval)(cfg)
 	WithEnabled(true)(cfg)
+	WithLeaseTTL(defaultLeaseTTL)(cfg)
 	for _, option := range options {
 		option(cfg)
 	}
@@ -93,5 +96,12 @@ func WithEnabled(enabled bool) Option {
 func WithUpdateUserInfoInterval(dur time.Duration) Option {
 	return func(cfg *config) {
 		cfg.updateUserInfoInterval = dur
+	}
+}
+
+// WithLeaseTTL sets the TTL used by the leaser.
+func WithLeaseTTL(ttl time.Duration) Option {
+	return func(o *config) {
+		o.leaseTTL = ttl
 	}
 }

--- a/pkg/identity/manager/manager.go
+++ b/pkg/identity/manager/manager.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/rs/zerolog"
 	"golang.org/x/oauth2"
@@ -79,7 +78,7 @@ func (mgr *Manager) GetDataBrokerServiceClient() databroker.DataBrokerServiceCli
 
 // RunEnabled runs the manager. This method blocks until an error occurs or the given context is canceled.
 func (mgr *Manager) RunEnabled(ctx context.Context) error {
-	leaser := databroker.NewLeaser("identity_manager", time.Second*30, mgr)
+	leaser := databroker.NewLeaser("identity_manager", mgr.cfg.Load().leaseTTL, mgr)
 	return leaser.Run(ctx)
 }
 


### PR DESCRIPTION
## Summary

This adds the ability to adjust two previously hard coded durations - databroker lease TTL, and retry (package internal/retry) initial interval.

## Related issues

Cherry-picked from https://github.com/pomerium/pomerium/pull/5388

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
