### PR TITLE
registry: fix reporter client context on config change

### DIFF
--- a/internal/registry/reporter.go
+++ b/internal/registry/reporter.go
@@ -59,7 +59,7 @@ func (r *Reporter) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	}
 
 	if len(services) > 0 {
-		ctx, cancel := context.WithCancel(context.TODO())
+		ctx, cancel := context.WithCancel(ctx)
 		go runReporter(ctx, pb.NewRegistryClient(registryConn), services)
 		r.cancel = cancel
 	}


### PR DESCRIPTION
## Summary

This allows the reporter to shut down cleanly if the underlying context is canceled. It was previously only shut down when restarting.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
