### PR TITLE
authorize: change handling of empty groups claim

### DIFF
--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -280,6 +280,12 @@ func (e *headersEvaluatorEvaluation) getJWTPayloadGroups(ctx context.Context) []
 
 	s, _ := e.getSessionOrServiceAccount(ctx)
 	groups, _ := getClaimStringSlice(s, "groups")
+	if groups == nil {
+		// If there are no groups, marshal this claim as an empty list rather than a JSON null,
+		// for better compatibility with third-party libraries.
+		// See https://github.com/pomerium/pomerium/issues/5393 for one example.
+		groups = []string{}
+	}
 	return groups
 }
 


### PR DESCRIPTION
## Summary

Make sure to serialize the JWT "groups" claim as an empty list rather than a JSON null. This matches the behavior of Pomerium v0.27.2 and earlier, and should provide better compatibility with some third-party libraries.

## Related issues

- https://github.com/pomerium/pomerium/issues/5393

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
