### PR TITLE
config: minor cleanup in GenerateCatchAllCertificate

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -155,38 +155,13 @@ func (cfg *Config) GetTLSClientConfig() (*tls.Config, error) {
 	}, nil
 }
 
-// GenerateCatchAllCertificate generates a catch-all certificate. If no derived CA is defined a
-// self-signed certificate will be generated.
+// GenerateCatchAllCertificate generates a catch-all certificate from a CA
+// derived from the shared secret.
 func (cfg *Config) GenerateCatchAllCertificate() (*tls.Certificate, error) {
-	if cfg.Options.DeriveInternalDomainCert != nil {
-		sharedKey, err := cfg.Options.GetSharedKey()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate cert, invalid shared key: %w", err)
-		}
-
-		ca, err := derivecert.NewCA(sharedKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate cert, invalid derived CA: %w", err)
-		}
-
-		pem, err := ca.NewServerCert([]string{"*"})
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate cert, error creating server certificate: %w", err)
-		}
-
-		cert, err := pem.TLS()
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate cert, error converting generated certificate into TLS certificate: %w", err)
-		}
-		return &cert, nil
-	}
-
 	sharedKey, err := cfg.Options.GetSharedKey()
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate cert, invalid shared key: %w", err)
 	}
-
-	// finally fall back to a generated, self-signed certificate
 	return cryptutil.GenerateCertificate(sharedKey, "*")
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,51 @@
+package config_test
+
+import (
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/pem"
+	"testing"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestGenerateCatchAllCertificate(t *testing.T) {
+	expected := `-----BEGIN CERTIFICATE-----
+MIIBlzCCAT2gAwIBAgIRAPmKEV01Qa1gBWn9yUQPCFgwCgYIKoZIzj0EAwIwLTER
+MA8GA1UEChMIUG9tZXJpdW0xGDAWBgNVBAMTD1BvbWVyaXVtIFBTSyBDQTAgFw0y
+MjEyMDEwMDAwMDBaGA8yMDUwMTIwMTAwMDAwMFowEzERMA8GA1UEChMIUG9tZXJp
+dW0wWTATBgcqhkjOPQIBBggqhkjOPQMBBwNCAASkOynLyo4bsBFKiTN87zqoGe4x
+62tdRaE+g5Trxqqv8qWwhb4q9fUWI+pNQigBe2HsGJFsneA2M0S11RXVG2ffo1Yw
+VDAOBgNVHQ8BAf8EBAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwEwHwYDVR0jBBgw
+FoAU384OyoQVoqmKbzZbfHny25RhyqcwDAYDVR0RBAUwA4IBKjAKBggqhkjOPQQD
+AgNIADBFAiEAitjxkg8yM/OWXGrzdUOA0gAh/c53/+7Gr45XEFCBMNQCIB3OzfDM
+z/tcTCNUHYSh638283eNtxzfadbEhEjJ1Bpe
+-----END CERTIFICATE-----
+`
+	cfg := &config.Config{Options: &config.Options{
+		SharedKey: base64.StdEncoding.EncodeToString([]byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")),
+	}}
+	cert, err := cfg.GenerateCatchAllCertificate()
+	require.NoError(t, err)
+	assertCertPEM(t, []string{expected}, cert)
+
+	cfg.Options.DeriveInternalDomainCert = proto.String("example.com")
+	cert, err = cfg.GenerateCatchAllCertificate()
+	require.NoError(t, err)
+	assertCertPEM(t, []string{expected}, cert)
+}
+
+func assertCertPEM(t *testing.T, expected []string, cert *tls.Certificate) {
+	if assert.Len(t, cert.Certificate, len(expected)) {
+		for i := range cert.Certificate {
+			certPEM := pem.EncodeToMemory(&pem.Block{
+				Type:  "CERTIFICATE",
+				Bytes: cert.Certificate[i],
+			})
+			assert.Equal(t, expected[i], string(certPEM))
+		}
+	}
+}


### PR DESCRIPTION
## Summary

GenerateCatchAllCertificate() currently returns the same result whether or not DeriveInternalDomainCert is nil. Let's remove this conditional.

Also update the comment (currently the generated certificate is never a self-signed certificate) and add a unit test for this method.

## Related issues

n/a

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
