### PR TITLE
metrics: restore global registry in unit tests

### DIFF
--- a/internal/telemetry/metrics/info_test.go
+++ b/internal/telemetry/metrics/info_test.go
@@ -65,7 +65,7 @@ func Test_SetDBConfigInfo(t *testing.T) {
 }
 
 func Test_SetBuildInfo(t *testing.T) {
-	registry = newMetricRegistry()
+	initTemporaryMetricsRegistry(t)
 
 	version.Version = "v0.0.1"
 	version.GitCommit = "deadbeef"
@@ -84,7 +84,7 @@ func Test_SetBuildInfo(t *testing.T) {
 }
 
 func Test_AddPolicyCountCallback(t *testing.T) {
-	registry = newMetricRegistry()
+	initTemporaryMetricsRegistry(t)
 
 	wantValue := int64(42)
 	wantLabels := []metricdata.LabelValue{
@@ -105,4 +105,10 @@ func Test_RegisterInfoMetrics(t *testing.T) {
 	if len(r) != 2 {
 		t.Error("Did not find enough registries")
 	}
+}
+
+func initTemporaryMetricsRegistry(t *testing.T) {
+	original := registry
+	registry = newMetricRegistry()
+	t.Cleanup(func() { registry = original })
 }


### PR DESCRIPTION
## Summary

Currently there appears to be a test order dependency between a couple of the info_test.go test cases and the `Test_PrometheusHandler` test. This can be exposed by running:

    go test -count 2 ./internal/telemetry/metrics

The test cases in info_test.go overwrite the global 'registry' variable, which seems to prevent `Test_PrometheusHandler` from being able to export the internal Go metrics. Add a helper method to restore the original registry after these test cases.


## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
