### PR TITLE
config: fix lost branding settings when there are multiple configuration sources

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -1550,7 +1550,9 @@ func (o *Options) ApplySettings(ctx context.Context, certsIndex *cryptutil.Certi
 	setSlice(&o.ProgrammaticRedirectDomainWhitelist, settings.ProgrammaticRedirectDomainWhitelist)
 	setCodecType(&o.CodecType, settings.CodecType)
 	setOptional(&o.PassIdentityHeaders, settings.PassIdentityHeaders)
-	o.BrandingOptions = settings
+	if settings.HasBrandingOptions() {
+		o.BrandingOptions = settings
+	}
 	copyMap(&o.RuntimeFlags, settings.RuntimeFlags, func(k string, v bool) (RuntimeFlag, bool) {
 		return RuntimeFlag(k), v
 	})

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -963,6 +963,19 @@ func TestOptions_ApplySettings(t *testing.T) {
 		})
 		assert.Equal(t, proto.Bool(true), options.PassIdentityHeaders)
 	})
+
+	t.Run("branding", func(t *testing.T) {
+		options := NewDefaultOptions()
+		options.ApplySettings(ctx, nil, &configpb.Settings{
+			PrimaryColor: proto.String("#FFFFFF"),
+		})
+		options.ApplySettings(ctx, nil, &configpb.Settings{})
+		assert.Equal(t, "#FFFFFF", options.BrandingOptions.GetPrimaryColor())
+		options.ApplySettings(ctx, nil, &configpb.Settings{
+			PrimaryColor: proto.String("#333333"),
+		})
+		assert.Equal(t, "#333333", options.BrandingOptions.GetPrimaryColor())
+	})
 }
 
 func TestXXX(t *testing.T) {

--- a/pkg/grpc/config/config.go
+++ b/pkg/grpc/config/config.go
@@ -20,3 +20,13 @@ func (rr *RouteRedirect) IsSet() bool {
 func (x *Config) GetId() string { //nolint
 	return x.Name
 }
+
+func (x *Settings) HasBrandingOptions() bool {
+	return x.GetPrimaryColor() != "" ||
+		x.GetSecondaryColor() != "" ||
+		x.GetDarkmodePrimaryColor() != "" ||
+		x.GetDarkmodeSecondaryColor() != "" ||
+		x.GetLogoUrl() != "" ||
+		x.GetFaviconUrl() != "" ||
+		x.GetErrorMessageFirstParagraph() != ""
+}


### PR DESCRIPTION
## Summary
Because of the way we set branding settings if there were multiple settings in the databroker the last one would always win, even if no branding settings were set in it. This updates the code to only update the branding settings if at least one of the branding settings in the protobuf are set.

## Related issues
- https://linear.app/pomerium/issue/ENG-1766/branding-not-applied-to-core-pages-when-using-ingress-controller

 

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
