### PR TITLE
evaluator: halt on databroker errors during policy and header evaluation

### DIFF
--- a/pkg/policy/criteria/reasons.go
+++ b/pkg/policy/criteria/reasons.go
@@ -37,6 +37,7 @@ const (
 	ReasonUserUnauthenticated           = "user-unauthenticated" // user needs to log in
 	ReasonUserUnauthorized              = "user-unauthorized"    // user does not have access
 	ReasonValidClientCertificate        = "valid-client-certificate"
+	ReasonInternalServerError           = "internal-server-error"
 )
 
 // Reasons is a collection of reasons.


### PR DESCRIPTION
This updates the evaluator to handle all databroker client errors (previously they were ignored). If such an error is encountered, rego evaluation is immediately stopped and "internal-server-error" allow/deny reasons are returned. This allows us to treat the "databroker not ready" condition differently from the "user not found" condition - the latter of which will continue the auth process and start redirecting the user to sign in, which is not desirable if the databroker is not ready. This causes some confusion especially in cases where the databroker [client] comes online between the time that the user is redirected to sign in (not because the user was not found, but because the databroker was not ready) and the time that the user is redirected back after the oauth flow.

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
