### PR TITLE
envoy: add internal_address_config to address deprecation warning

### DIFF
--- a/config/envoyconfig/filters.go
+++ b/config/envoyconfig/filters.go
@@ -47,6 +47,7 @@ func ExtAuthzFilter(grpcClientTimeout *durationpb.Duration) *envoy_extensions_fi
 func HTTPConnectionManagerFilter(
 	httpConnectionManager *envoy_extensions_filters_network_http_connection_manager.HttpConnectionManager,
 ) *envoy_config_listener_v3.Filter {
+	applyGlobalHTTPConnectionManagerOptions(httpConnectionManager)
 	return &envoy_config_listener_v3.Filter{
 		Name: "envoy.filters.network.http_connection_manager",
 		ConfigType: &envoy_config_listener_v3.Filter_TypedConfig{

--- a/config/envoyconfig/outbound.go
+++ b/config/envoyconfig/outbound.go
@@ -42,7 +42,7 @@ func (b *Builder) buildOutboundListener(cfg *config.Config) (*envoy_config_liste
 func (b *Builder) buildOutboundHTTPConnectionManager() *envoy_config_listener_v3.Filter {
 	rc := b.buildOutboundRouteConfiguration()
 
-	tc := marshalAny(&envoy_http_connection_manager.HttpConnectionManager{
+	return HTTPConnectionManagerFilter(&envoy_http_connection_manager.HttpConnectionManager{
 		CodecType:  envoy_http_connection_manager.HttpConnectionManager_AUTO,
 		StatPrefix: "grpc_egress",
 		// limit request first byte to last byte time
@@ -56,13 +56,6 @@ func (b *Builder) buildOutboundHTTPConnectionManager() *envoy_config_listener_v3
 			HTTPRouterFilter(),
 		},
 	})
-
-	return &envoy_config_listener_v3.Filter{
-		Name: "envoy.filters.network.http_connection_manager",
-		ConfigType: &envoy_config_listener_v3.Filter_TypedConfig{
-			TypedConfig: tc,
-		},
-	}
 }
 
 func (b *Builder) buildOutboundRouteConfiguration() *envoy_config_route_v3.RouteConfiguration {

--- a/config/envoyconfig/testdata/main_http_connection_manager_filter.json
+++ b/config/envoyconfig/testdata/main_http_connection_manager_filter.json
@@ -186,6 +186,34 @@
       }
     },
     "useRemoteAddress": true,
-    "xffNumTrustedHops": 1
+    "xffNumTrustedHops": 1,
+    "internalAddressConfig": {
+      "cidrRanges": [
+        {
+          "addressPrefix": "127.0.0.1",
+          "prefixLen": 32
+        },
+        {
+          "addressPrefix": "::1",
+          "prefixLen": 128
+        },
+        {
+          "addressPrefix": "10.0.0.0",
+          "prefixLen": 8
+        },
+        {
+          "addressPrefix": "192.168.0.0",
+          "prefixLen": 16
+        },
+        {
+          "addressPrefix": "172.16.0.0",
+          "prefixLen": 12
+        },
+        {
+          "addressPrefix": "fd00::",
+          "prefixLen": 8
+        }
+      ]
+    }
   }
 }

--- a/config/envoyconfig/testdata/metrics_http_connection_manager.json
+++ b/config/envoyconfig/testdata/metrics_http_connection_manager.json
@@ -54,7 +54,35 @@
                 }
               ]
             },
-            "statPrefix": "metrics"
+            "statPrefix": "metrics",
+            "internalAddressConfig": {
+              "cidrRanges": [
+                {
+                  "addressPrefix": "127.0.0.1",
+                  "prefixLen": 32
+                },
+                {
+                  "addressPrefix": "::1",
+                  "prefixLen": 128
+                },
+                {
+                  "addressPrefix": "10.0.0.0",
+                  "prefixLen": 8
+                },
+                {
+                  "addressPrefix": "192.168.0.0",
+                  "prefixLen": 16
+                },
+                {
+                  "addressPrefix": "172.16.0.0",
+                  "prefixLen": 12
+                },
+                {
+                  "addressPrefix": "fd00::",
+                  "prefixLen": 8
+                }
+              ]
+            }
           }
         }
       ],


### PR DESCRIPTION
## Summary

See docs: https://www.envoyproxy.io/docs/envoy/v1.32.3/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto.html#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-internal-address-config
## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
