### PR TITLE
importutil: refactor GenerateRouteNames to allow for protobuf or config routes

### DIFF
--- a/config/policy.go
+++ b/config/policy.go
@@ -869,6 +869,26 @@ func (p *Policy) GetPassIdentityHeaders(options *Options) bool {
 	return false
 }
 
+// GetFrom gets the from URL.
+func (p *Policy) GetFrom() string {
+	return p.From
+}
+
+// GetPath gets the path.
+func (p *Policy) GetPath() string {
+	return p.Path
+}
+
+// GetPrefix gets the prefix.
+func (p *Policy) GetPrefix() string {
+	return p.Prefix
+}
+
+// GetRegex gets the regex.
+func (p *Policy) GetRegex() string {
+	return p.Regex
+}
+
 /*
 SortPolicies sorts policies to match the following SQL order:
 

--- a/pkg/zero/importutil/namegen_test.go
+++ b/pkg/zero/importutil/namegen_test.go
@@ -391,16 +391,11 @@ func TestGenerateRouteNames(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, importutil.GenerateRouteNames(tc.input))
+			policies := make([]*config.Policy, len(tc.input))
+			for i := range tc.input {
+				policies[i], _ = config.NewPolicyFromProto(tc.input[i])
+			}
+			assert.Equal(t, tc.expected, importutil.GenerateRouteNames(policies))
 		})
 	}
-}
-
-func TestGenerateRouteNamesForPolicy(t *testing.T) {
-	t.Parallel()
-
-	names := importutil.GenerateRouteNames([]*config.Policy{
-		{From: "https://from.example.com", Path: "/"},
-		{From: "https://from.example.com", Path: "/path"},
-	})
-	assert.Equal(t, []string{"from", "from-path"}, names)
 }

--- a/pkg/zero/importutil/namegen_test.go
+++ b/pkg/zero/importutil/namegen_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/config"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/pkg/zero/importutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestGenerateCertName(t *testing.T) {
@@ -391,4 +393,14 @@ func TestGenerateRouteNames(t *testing.T) {
 			assert.Equal(t, tc.expected, importutil.GenerateRouteNames(tc.input))
 		})
 	}
+}
+
+func TestGenerateRouteNamesForPolicy(t *testing.T) {
+	t.Parallel()
+
+	names := importutil.GenerateRouteNames([]*config.Policy{
+		{From: "https://from.example.com", Path: "/"},
+		{From: "https://from.example.com", Path: "/path"},
+	})
+	assert.Equal(t, []string{"from", "from-path"}, names)
 }


### PR DESCRIPTION
## Summary
Make the `GenerateRouteNames` function generic so it can work with protobuf Routes or config Routes. This is done by adding some getters to `config.Policy`.

## Related issues
- https://github.com/pomerium/pomerium/pull/5424#discussion_r1915429150


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
