### PR TITLE
config: fix JWT groups filter option

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -1512,7 +1512,9 @@ func (o *Options) ApplySettings(ctx context.Context, certsIndex *cryptutil.Certi
 	set(&o.SigningKey, settings.SigningKey)
 	setMap(&o.SetResponseHeaders, settings.SetResponseHeaders)
 	setMap(&o.JWTClaimsHeaders, settings.JwtClaimsHeaders)
-	o.JWTGroupsFilter = NewJWTGroupsFilter(settings.JwtGroupsFilter)
+	if len(settings.JwtGroupsFilter) > 0 {
+		o.JWTGroupsFilter = NewJWTGroupsFilter(settings.JwtGroupsFilter)
+	}
 	setDuration(&o.DefaultUpstreamTimeout, settings.DefaultUpstreamTimeout)
 	set(&o.MetricsAddr, settings.MetricsAddress)
 	set(&o.MetricsBasicAuth, settings.MetricsBasicAuth)

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -976,6 +976,19 @@ func TestOptions_ApplySettings(t *testing.T) {
 		})
 		assert.Equal(t, "#333333", options.BrandingOptions.GetPrimaryColor())
 	})
+
+	t.Run("jwt_groups_filter", func(t *testing.T) {
+		options := NewDefaultOptions()
+		options.ApplySettings(ctx, nil, &configpb.Settings{
+			JwtGroupsFilter: []string{"foo", "bar", "baz"},
+		})
+		options.ApplySettings(ctx, nil, &configpb.Settings{})
+		assert.Equal(t, NewJWTGroupsFilter([]string{"foo", "bar", "baz"}), options.JWTGroupsFilter)
+		options.ApplySettings(ctx, nil, &configpb.Settings{
+			JwtGroupsFilter: []string{"quux", "zulu"},
+		})
+		assert.Equal(t, NewJWTGroupsFilter([]string{"quux", "zulu"}), options.JWTGroupsFilter)
+	})
 }
 
 func TestOptions_GetSetResponseHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

When applying the settings proto, update the JWT groups filter option only if the filter set is non-empty.

This is important when Pomerium via the Ingress Controller in combination with Pomerium Enterprise. In this scenario there is a settings proto applied from both Ingress Controller and the Enterprise console, and we want to make sure the one from Ingress Controller does not overwrite the filter settings from Enterprise.

(This is the same kind of issue and the same kind of fix as in https://github.com/pomerium/pomerium/pull/5401.)

## Related issues

https://linear.app/pomerium/issue/ENG-1802/add-support-for-jwt-groups-filtering

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
