### PR TITLE
authorize: log JWT groups filtering

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -84,10 +84,11 @@ type RequestSession struct {
 
 // Result is the result of evaluation.
 type Result struct {
-	Allow   RuleResult
-	Deny    RuleResult
-	Headers http.Header
-	Traces  []contextutil.PolicyEvaluationTrace
+	Allow               RuleResult
+	Deny                RuleResult
+	Headers             http.Header
+	Traces              []contextutil.PolicyEvaluationTrace
+	AdditionalLogFields map[log.AuthorizeLogField]any
 }
 
 // An Evaluator evaluates policies.
@@ -228,10 +229,11 @@ func (e *Evaluator) Evaluate(ctx context.Context, req *Request) (*Result, error)
 	}
 
 	res := &Result{
-		Allow:   policyOutput.Allow,
-		Deny:    policyOutput.Deny,
-		Headers: headersOutput.Headers,
-		Traces:  policyOutput.Traces,
+		Allow:               policyOutput.Allow,
+		Deny:                policyOutput.Deny,
+		Headers:             headersOutput.Headers,
+		Traces:              policyOutput.Traces,
+		AdditionalLogFields: headersOutput.AdditionalLogFields,
 	}
 	return res, nil
 }

--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -8,12 +8,14 @@ import (
 	"github.com/open-policy-agent/opa/rego"
 
 	"github.com/pomerium/pomerium/authorize/internal/store"
+	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
 )
 
 // HeadersResponse is the output from the headers.rego script.
 type HeadersResponse struct {
-	Headers http.Header
+	Headers             http.Header
+	AdditionalLogFields map[log.AuthorizeLogField]any
 }
 
 // A HeadersEvaluator evaluates the headers.rego script.

--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -381,7 +381,8 @@ func (e *headersEvaluatorEvaluation) filterGroups(ctx context.Context, groups []
 	if removedCount := len(groups) - len(included); removedCount > 0 {
 		log.Ctx(ctx).Debug().
 			Str("request-id", requestid.FromContext(ctx)).
-			Array("removed-groups-ids", excluded).
+			Array("removed-group-ids", excluded).
+			Strs("remaining-group-ids", included).
 			Msg("JWT group filtering removed groups")
 		e.response.AdditionalLogFields[log.AuthorizeLogFieldRemovedGroupsCount] = removedCount
 	}

--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -15,6 +15,7 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"github.com/go-jose/go-jose/v3"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pomerium/datasource/pkg/directory"
@@ -23,7 +24,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
-	"github.com/pomerium/pomerium/pkg/slices"
+	"github.com/pomerium/pomerium/pkg/telemetry/requestid"
 )
 
 // A headersEvaluatorEvaluation is a single evaluation of the headers evaluator.
@@ -57,8 +58,11 @@ func newHeadersEvaluatorEvaluation(evaluator *HeadersEvaluator, request *Request
 	return &headersEvaluatorEvaluation{
 		evaluator: evaluator,
 		request:   request,
-		response:  &HeadersResponse{Headers: make(http.Header)},
-		now:       now,
+		response: &HeadersResponse{
+			Headers:             make(http.Header),
+			AdditionalLogFields: make(map[log.AuthorizeLogField]any),
+		},
+		now: now,
 	}
 }
 
@@ -325,7 +329,7 @@ func (e *headersEvaluatorEvaluation) getJWTPayloadGroups(ctx context.Context) []
 func (e *headersEvaluatorEvaluation) getGroups(ctx context.Context) []string {
 	groupIDs := e.getGroupIDs(ctx)
 	if len(groupIDs) > 0 {
-		groupIDs = e.filterGroups(groupIDs)
+		groupIDs = e.filterGroups(ctx, groupIDs)
 		groups := make([]string, 0, len(groupIDs)*2)
 		groups = append(groups, groupIDs...)
 		groups = append(groups, e.getDataBrokerGroupNames(ctx, groupIDs)...)
@@ -337,7 +341,7 @@ func (e *headersEvaluatorEvaluation) getGroups(ctx context.Context) []string {
 	return groups
 }
 
-func (e *headersEvaluatorEvaluation) filterGroups(groups []string) []string {
+func (e *headersEvaluatorEvaluation) filterGroups(ctx context.Context, groups []string) []string {
 	// Apply the global groups filter or the per-route groups filter, if either is enabled.
 	filters := make([]config.JWTGroupsFilter, 0, 2)
 	if f := e.evaluator.store.GetJWTGroupsFilter(); f.Enabled() {
@@ -349,7 +353,8 @@ func (e *headersEvaluatorEvaluation) filterGroups(groups []string) []string {
 	if len(filters) == 0 {
 		return groups
 	}
-	return slices.Filter(groups, func(g string) bool {
+
+	filterFn := func(g string) bool {
 		// A group should be included if it appears in either the global or the route-level filter list.
 		for _, f := range filters {
 			if f.IsAllowed(g) {
@@ -357,7 +362,30 @@ func (e *headersEvaluatorEvaluation) filterGroups(groups []string) []string {
 			}
 		}
 		return false
-	})
+	}
+	var included []string
+
+	// Log the specifics of which groups were filtered out at Debug level.
+	var excluded *zerolog.Array
+	if log.Ctx(ctx).GetLevel() <= zerolog.DebugLevel {
+		excluded = zerolog.Arr()
+	}
+
+	for _, g := range groups {
+		if filterFn(g) {
+			included = append(included, g)
+		} else if excluded != nil {
+			excluded.Str(g)
+		}
+	}
+	if removedCount := len(groups) - len(included); removedCount > 0 {
+		log.Ctx(ctx).Debug().
+			Str("request-id", requestid.FromContext(ctx)).
+			Array("removed-groups-ids", excluded).
+			Msg("JWT group filtering removed groups")
+		e.response.AdditionalLogFields[log.AuthorizeLogFieldRemovedGroupsCount] = removedCount
+	}
+	return included
 }
 
 func (e *headersEvaluatorEvaluation) getJWTPayloadSID() string {

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -517,7 +517,8 @@ func TestHeadersEvaluator_JWTGroupsFilter(t *testing.T) {
 		{"empty route filter", []string{"1", "2", "3"}, []string{}, "SESSION-1", []any{"1", "2", "3", "GROUP-1", "GROUP-2", "GROUP-3"}, 47},
 		{
 			"no filtering", nil, nil, "SESSION-10",
-			[]any{"10", "20", "30", "40", "50", "GROUP-10", "GROUP-20", "GROUP-30", "GROUP-40", "GROUP-50"}, 0,
+			[]any{"10", "20", "30", "40", "50", "GROUP-10", "GROUP-20", "GROUP-30", "GROUP-40", "GROUP-50"},
+			0,
 		},
 		// filtering has no effect on groups from an IdP "groups" claim
 		{"groups claim", []string{"foo", "quux"}, nil, "SESSION-11", []any{"foo", "bar", "baz"}, 0},

--- a/authorize/log.go
+++ b/authorize/log.go
@@ -33,7 +33,7 @@ func (a *Authorize) logAuthorizeCheck(
 	evt := log.Ctx(ctx).Info().Str("service", "authorize")
 	fields := a.currentOptions.Load().GetAuthorizeLogFields()
 	for _, field := range fields {
-		evt = populateLogEvent(ctx, field, evt, in, s, u, hdrs, impersonateDetails)
+		evt = populateLogEvent(ctx, field, evt, in, s, u, hdrs, impersonateDetails, res)
 	}
 	evt = log.HTTPHeaders(evt, fields, hdrs)
 
@@ -139,6 +139,7 @@ func populateLogEvent(
 	u *user.User,
 	hdrs map[string]string,
 	impersonateDetails *impersonateDetails,
+	res *evaluator.Result,
 ) *zerolog.Event {
 	path, query, _ := strings.Cut(in.GetAttributes().GetRequest().GetHttp().GetPath(), "?")
 
@@ -205,6 +206,11 @@ func populateLogEvent(
 		}
 		return evt.Str(string(field), userID)
 	default:
+		if res != nil {
+			if v, ok := res.AdditionalLogFields[field]; ok {
+				evt = evt.Interface(string(field), v)
+			}
+		}
 		return evt
 	}
 }

--- a/internal/log/authorize.go
+++ b/internal/log/authorize.go
@@ -23,6 +23,7 @@ const (
 	AuthorizeLogFieldMethod               AuthorizeLogField = "method"
 	AuthorizeLogFieldPath                 AuthorizeLogField = "path"
 	AuthorizeLogFieldQuery                AuthorizeLogField = "query"
+	AuthorizeLogFieldRemovedGroupsCount   AuthorizeLogField = "removed-groups-count"
 	AuthorizeLogFieldRequestID            AuthorizeLogField = "request-id"
 	AuthorizeLogFieldServiceAccountID     AuthorizeLogField = "service-account-id"
 	AuthorizeLogFieldSessionID            AuthorizeLogField = "session-id"
@@ -41,6 +42,7 @@ var DefaultAuthorizeLogFields = []AuthorizeLogField{
 	AuthorizeLogFieldImpersonateSessionID,
 	AuthorizeLogFieldImpersonateUserID,
 	AuthorizeLogFieldImpersonateEmail,
+	AuthorizeLogFieldRemovedGroupsCount,
 	AuthorizeLogFieldServiceAccountID,
 	AuthorizeLogFieldUser,
 	AuthorizeLogFieldEmail,
@@ -63,6 +65,7 @@ var authorizeLogFieldLookup = map[AuthorizeLogField]struct{}{
 	AuthorizeLogFieldMethod:               {},
 	AuthorizeLogFieldPath:                 {},
 	AuthorizeLogFieldQuery:                {},
+	AuthorizeLogFieldRemovedGroupsCount:   {},
 	AuthorizeLogFieldRequestID:            {},
 	AuthorizeLogFieldServiceAccountID:     {},
 	AuthorizeLogFieldSessionID:            {},


### PR DESCRIPTION
## Summary

Add a new mechanism for passing additional authorize log fields back from the authorize `Evaluator`. Use this mechanism to pass back the count of groups removed due to the JWT groups filter option as the new log field `removed-groups-count`.

Also add a separate debug-level log entry with the specific IDs of any removed groups.

## Related issues

https://linear.app/pomerium/issue/ENG-1802/add-support-for-jwt-groups-filtering

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
