### PR TITLE
Fix small timeout causing test flake

### DIFF
--- a/internal/telemetry/trace/debug_test.go
+++ b/internal/telemetry/trace/debug_test.go
@@ -145,13 +145,9 @@ func TestSpanObserver(t *testing.T) {
 
 		obs.Observe(Span(1).ID())
 
-		startTime := time.Now()
-		for waitersExited.Load() != 10 {
-			if time.Since(startTime) > 1*time.Millisecond {
-				t.Fatal("timed out")
-			}
-			runtime.Gosched()
-		}
+		assert.Eventually(t, func() bool {
+			return waitersExited.Load() == 10
+		}, 10*time.Millisecond, 1*time.Millisecond)
 	})
 }
 


### PR DESCRIPTION
## Summary

Fix test flake seen in https://github.com/pomerium/pomerium/actions/runs/12893427421/job/35949817188

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
