### PR TITLE
authorize: cache warming

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -10,7 +10,10 @@ import (
 	"time"
 
 	"github.com/rs/zerolog"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
 
+	"github.com/pomerium/datasource/pkg/directory"
 	"github.com/pomerium/pomerium/authorize/evaluator"
 	"github.com/pomerium/pomerium/authorize/internal/store"
 	"github.com/pomerium/pomerium/config"
@@ -21,16 +24,16 @@ import (
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/storage"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // Authorize struct holds
 type Authorize struct {
-	state          *atomicutil.Value[*authorizeState]
-	store          *store.Store
-	currentOptions *atomicutil.Value[*config.Options]
-	accessTracker  *AccessTracker
-	globalCache    storage.Cache
+	state             *atomicutil.Value[*authorizeState]
+	store             *store.Store
+	currentOptions    *atomicutil.Value[*config.Options]
+	accessTracker     *AccessTracker
+	globalCache       storage.Cache
+	groupsCacheWarmer *cacheWarmer
 
 	// The stateLock prevents updating the evaluator store simultaneously with an evaluation.
 	// This should provide a consistent view of the data at a given server/record version and
@@ -60,6 +63,7 @@ func New(ctx context.Context, cfg *config.Config) (*Authorize, error) {
 	}
 	a.state = atomicutil.NewValue(state)
 
+	a.groupsCacheWarmer = newCacheWarmer(state.dataBrokerClientConnection, a.globalCache, directory.GroupRecordType)
 	return a, nil
 }
 
@@ -70,8 +74,16 @@ func (a *Authorize) GetDataBrokerServiceClient() databroker.DataBrokerServiceCli
 
 // Run runs the authorize service.
 func (a *Authorize) Run(ctx context.Context) error {
-	a.accessTracker.Run(ctx)
-	return nil
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		a.accessTracker.Run(ctx)
+		return nil
+	})
+	eg.Go(func() error {
+		a.groupsCacheWarmer.Run(ctx)
+		return nil
+	})
+	return eg.Wait()
 }
 
 func validateOptions(o *config.Options) error {
@@ -154,5 +166,6 @@ func (a *Authorize) OnConfigChange(ctx context.Context, cfg *config.Config) {
 		log.Ctx(ctx).Error().Err(err).Msg("authorize: error updating state")
 	} else {
 		a.state.Store(state)
+		a.groupsCacheWarmer.UpdateConn(state.dataBrokerClientConnection)
 	}
 }

--- a/authorize/cache_warmer.go
+++ b/authorize/cache_warmer.go
@@ -1,0 +1,124 @@
+package authorize
+
+import (
+	"context"
+	"time"
+
+	"google.golang.org/grpc"
+
+	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+type cacheWarmer struct {
+	cc      *grpc.ClientConn
+	cache   storage.Cache
+	typeURL string
+
+	updatedCC chan *grpc.ClientConn
+}
+
+func newCacheWarmer(
+	cc *grpc.ClientConn,
+	cache storage.Cache,
+	typeURL string,
+) *cacheWarmer {
+	return &cacheWarmer{
+		cc:      cc,
+		cache:   cache,
+		typeURL: typeURL,
+
+		updatedCC: make(chan *grpc.ClientConn, 1),
+	}
+}
+
+func (cw *cacheWarmer) UpdateConn(cc *grpc.ClientConn) {
+	for {
+		select {
+		case cw.updatedCC <- cc:
+			return
+		default:
+		}
+		select {
+		case <-cw.updatedCC:
+		default:
+		}
+	}
+}
+
+func (cw *cacheWarmer) Run(ctx context.Context) {
+	// Run a syncer for the cache warmer until the underlying databroker connection is changed.
+	// When that happens cancel the currently running syncer and start a new one.
+
+	runCtx, runCancel := context.WithCancel(ctx)
+	go cw.run(runCtx, cw.cc)
+
+	for {
+		select {
+		case <-ctx.Done():
+			runCancel()
+			return
+		case cc := <-cw.updatedCC:
+			if cc != cw.cc {
+				log.Ctx(ctx).Info().Msg("cache-warmer: received updated databroker client connection, restarting syncer")
+				cw.cc = cc
+				runCancel()
+				runCtx, runCancel = context.WithCancel(ctx)
+				go cw.run(runCtx, cw.cc)
+			}
+		}
+	}
+}
+
+func (cw *cacheWarmer) run(ctx context.Context, cc *grpc.ClientConn) {
+	log.Ctx(ctx).Debug().Str("type-url", cw.typeURL).Msg("cache-warmer: running databroker syncer to warm cache")
+	_ = databroker.NewSyncer(ctx, "cache-warmer", cacheWarmerSyncerHandler{
+		client: databroker.NewDataBrokerServiceClient(cc),
+		cache:  cw.cache,
+	}, databroker.WithTypeURL(cw.typeURL)).Run(ctx)
+}
+
+type cacheWarmerSyncerHandler struct {
+	client databroker.DataBrokerServiceClient
+	cache  storage.Cache
+}
+
+func (h cacheWarmerSyncerHandler) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	return h.client
+}
+
+func (h cacheWarmerSyncerHandler) ClearRecords(_ context.Context) {
+	h.cache.InvalidateAll()
+}
+
+func (h cacheWarmerSyncerHandler) UpdateRecords(ctx context.Context, serverVersion uint64, records []*databroker.Record) {
+	for _, record := range records {
+		req := &databroker.QueryRequest{
+			Type:  record.Type,
+			Limit: 1,
+		}
+		req.SetFilterByIDOrIndex(record.Id)
+
+		res := &databroker.QueryResponse{
+			Records:       []*databroker.Record{record},
+			TotalCount:    1,
+			ServerVersion: serverVersion,
+			RecordVersion: record.Version,
+		}
+
+		expiry := time.Now().Add(time.Hour * 24 * 365)
+		key, err := storage.MarshalQueryRequest(req)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("cache-warmer: failed to marshal query request")
+			continue
+		}
+		value, err := storage.MarshalQueryResponse(res)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("cache-warmer: failed to marshal query response")
+			continue
+		}
+
+		h.cache.Set(expiry, key, value)
+	}
+}

--- a/authorize/cache_warmer.go
+++ b/authorize/cache_warmer.go
@@ -60,13 +60,11 @@ func (cw *cacheWarmer) Run(ctx context.Context) {
 			runCancel()
 			return
 		case cc := <-cw.updatedCC:
-			if cc != cw.cc {
-				log.Ctx(ctx).Info().Msg("cache-warmer: received updated databroker client connection, restarting syncer")
-				cw.cc = cc
-				runCancel()
-				runCtx, runCancel = context.WithCancel(ctx)
-				go cw.run(runCtx, cw.cc)
-			}
+			log.Ctx(ctx).Info().Msg("cache-warmer: received updated databroker client connection, restarting syncer")
+			cw.cc = cc
+			runCancel()
+			runCtx, runCancel = context.WithCancel(ctx)
+			go cw.run(runCtx, cw.cc)
 		}
 	}
 }

--- a/authorize/cache_warmer_test.go
+++ b/authorize/cache_warmer_test.go
@@ -1,0 +1,52 @@
+package authorize
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+
+	"github.com/pomerium/pomerium/internal/databroker"
+	"github.com/pomerium/pomerium/internal/testutil"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+func TestCacheWarmer(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.GetContext(t, 10*time.Minute)
+	cc := testutil.NewGRPCServer(t, func(srv *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(srv, databroker.New(ctx, noop.NewTracerProvider()))
+	})
+	t.Cleanup(func() { cc.Close() })
+
+	client := databrokerpb.NewDataBrokerServiceClient(cc)
+	_, err := client.Put(ctx, &databrokerpb.PutRequest{
+		Records: []*databrokerpb.Record{
+			{Type: "example.com/record", Id: "e1", Data: protoutil.NewAnyBool(true)},
+			{Type: "example.com/record", Id: "e2", Data: protoutil.NewAnyBool(true)},
+		},
+	})
+	require.NoError(t, err)
+
+	cache := storage.NewGlobalCache(time.Minute)
+
+	cw := newCacheWarmer(cc, cache, "example.com/record")
+	go cw.Run(ctx)
+
+	assert.Eventually(t, func() bool {
+		req := &databrokerpb.QueryRequest{
+			Type:  "example.com/record",
+			Limit: 1,
+		}
+		req.SetFilterByIDOrIndex("e1")
+		res, err := storage.NewCachingQuerier(storage.NewStaticQuerier(), cache).Query(ctx, req)
+		require.NoError(t, err)
+		return len(res.GetRecords()) == 1
+	}, 10*time.Second, time.Millisecond*100)
+}

--- a/authorize/databroker_test.go
+++ b/authorize/databroker_test.go
@@ -37,10 +37,8 @@ func Test_getDataBrokerRecord(t *testing.T) {
 			s1 := &session.Session{Id: "s1", Version: fmt.Sprint(tc.recordVersion)}
 
 			sq := storage.NewStaticQuerier(s1)
-			tsq := storage.NewTracingQuerier(sq)
-			cq := storage.NewCachingQuerier(tsq, storage.NewGlobalCache(time.Minute))
-			tcq := storage.NewTracingQuerier(cq)
-			qctx := storage.WithQuerier(ctx, tcq)
+			cq := storage.NewCachingQuerier(sq, storage.NewGlobalCache(time.Minute))
+			qctx := storage.WithQuerier(ctx, cq)
 
 			s, err := getDataBrokerRecord(qctx, grpcutil.GetTypeURL(s1), s1.GetId(), tc.queryVersion)
 			assert.NoError(t, err)
@@ -49,11 +47,6 @@ func Test_getDataBrokerRecord(t *testing.T) {
 			s, err = getDataBrokerRecord(qctx, grpcutil.GetTypeURL(s1), s1.GetId(), tc.queryVersion)
 			assert.NoError(t, err)
 			assert.NotNil(t, s)
-
-			assert.Len(t, tsq.Traces(), tc.underlyingQueryCount,
-				"should have %d traces to the underlying querier", tc.underlyingQueryCount)
-			assert.Len(t, tcq.Traces(), tc.cachedQueryCount,
-				"should have %d traces to the cached querier", tc.cachedQueryCount)
 		})
 	}
 }

--- a/authorize/databroker_test.go
+++ b/authorize/databroker_test.go
@@ -38,7 +38,7 @@ func Test_getDataBrokerRecord(t *testing.T) {
 
 			sq := storage.NewStaticQuerier(s1)
 			tsq := storage.NewTracingQuerier(sq)
-			cq := storage.NewCachingQuerier(tsq, storage.NewLocalCache())
+			cq := storage.NewCachingQuerier(tsq, storage.NewGlobalCache(time.Minute))
 			tcq := storage.NewTracingQuerier(cq)
 			qctx := storage.WithQuerier(ctx, tcq)
 

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -33,11 +33,8 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 
 	querier := storage.NewTracingQuerier(
 		storage.NewCachingQuerier(
-			storage.NewCachingQuerier(
-				storage.NewQuerier(a.state.Load().dataBrokerClient),
-				a.globalCache,
-			),
-			storage.NewLocalCache(),
+			storage.NewQuerier(a.state.Load().dataBrokerClient),
+			a.globalCache,
 		),
 	)
 	ctx = storage.WithQuerier(ctx, querier)

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -31,11 +31,9 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 	ctx, span := a.tracer.Start(ctx, "authorize.grpc.Check")
 	defer span.End()
 
-	querier := storage.NewTracingQuerier(
-		storage.NewCachingQuerier(
-			storage.NewQuerier(a.state.Load().dataBrokerClient),
-			a.globalCache,
-		),
+	querier := storage.NewCachingQuerier(
+		storage.NewQuerier(a.state.Load().dataBrokerClient),
+		a.globalCache,
 	)
 	ctx = storage.WithQuerier(ctx, querier)
 

--- a/internal/testenv/selftests/tracing_test.go
+++ b/internal/testenv/selftests/tracing_test.go
@@ -12,13 +12,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/telemetry/trace"
-	"github.com/pomerium/pomerium/internal/testenv"
-	"github.com/pomerium/pomerium/internal/testenv/scenarios"
-	"github.com/pomerium/pomerium/internal/testenv/snippets"
-	"github.com/pomerium/pomerium/internal/testenv/upstreams"
-	. "github.com/pomerium/pomerium/internal/testutil/tracetest" //nolint:revive
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -27,6 +20,14 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/telemetry/trace"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/scenarios"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	. "github.com/pomerium/pomerium/internal/testutil/tracetest" //nolint:revive
 )
 
 func otlpTraceReceiverOrFromEnv(t *testing.T) (modifier testenv.Modifier, newRemoteClient func() otlptrace.Client, getResults func() *TraceResults) {
@@ -116,7 +117,7 @@ func TestOTLPTracing(t *testing.T) {
 				Exact:              true,
 				CheckDetachedSpans: true,
 			},
-			Match{Name: testEnvironmentLocalTest, TraceCount: 1, Services: []string{"Test Environment", "Control Plane", "Data Broker"}},
+			Match{Name: testEnvironmentLocalTest, TraceCount: 1, Services: []string{"Authorize", "Test Environment", "Control Plane", "Data Broker"}},
 			Match{Name: testEnvironmentAuthenticate, TraceCount: 1, Services: allServices},
 			Match{Name: authenticateOAuth2Client, TraceCount: Greater(0)},
 			Match{Name: idpServerGetUserinfo, TraceCount: EqualToMatch(authenticateOAuth2Client)},

--- a/pkg/storage/cache_test.go
+++ b/pkg/storage/cache_test.go
@@ -9,34 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestLocalCache(t *testing.T) {
-	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
-	defer clearTimeout()
-
-	callCount := 0
-	update := func(_ context.Context) ([]byte, error) {
-		callCount++
-		return []byte("v1"), nil
-	}
-	c := NewLocalCache()
-	v, err := c.GetOrUpdate(ctx, []byte("k1"), update)
-	assert.NoError(t, err)
-	assert.Equal(t, []byte("v1"), v)
-	assert.Equal(t, 1, callCount)
-
-	v, err = c.GetOrUpdate(ctx, []byte("k1"), update)
-	assert.NoError(t, err)
-	assert.Equal(t, []byte("v1"), v)
-	assert.Equal(t, 1, callCount)
-
-	c.Invalidate([]byte("k1"))
-
-	v, err = c.GetOrUpdate(ctx, []byte("k1"), update)
-	assert.NoError(t, err)
-	assert.Equal(t, []byte("v1"), v)
-	assert.Equal(t, 2, callCount)
-}
-
 func TestGlobalCache(t *testing.T) {
 	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
 	defer clearTimeout()
@@ -70,4 +42,10 @@ func TestGlobalCache(t *testing.T) {
 		})
 		return err != nil
 	}, time.Second, time.Millisecond*10, "should honor TTL")
+
+	c.Set(time.Now().Add(time.Hour), []byte("k2"), []byte("v2"))
+	v, err = c.GetOrUpdate(ctx, []byte("k2"), update)
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("v2"), v)
+	assert.Equal(t, 2, callCount)
 }

--- a/pkg/storage/querier.go
+++ b/pkg/storage/querier.go
@@ -240,9 +240,7 @@ func (q *cachingQuerier) InvalidateCache(ctx context.Context, in *databroker.Que
 }
 
 func (q *cachingQuerier) Query(ctx context.Context, in *databroker.QueryRequest, opts ...grpc.CallOption) (*databroker.QueryResponse, error) {
-	key, err := (&proto.MarshalOptions{
-		Deterministic: true,
-	}).Marshal(in)
+	key, err := MarshalQueryRequest(in)
 	if err != nil {
 		return nil, err
 	}
@@ -252,7 +250,7 @@ func (q *cachingQuerier) Query(ctx context.Context, in *databroker.QueryRequest,
 		if err != nil {
 			return nil, err
 		}
-		return proto.Marshal(res)
+		return MarshalQueryResponse(res)
 	})
 	if err != nil {
 		return nil, err
@@ -264,4 +262,18 @@ func (q *cachingQuerier) Query(ctx context.Context, in *databroker.QueryRequest,
 		return nil, err
 	}
 	return &res, nil
+}
+
+// MarshalQueryRequest marshales the query request.
+func MarshalQueryRequest(req *databroker.QueryRequest) ([]byte, error) {
+	return (&proto.MarshalOptions{
+		Deterministic: true,
+	}).Marshal(req)
+}
+
+// MarshalQueryResponse marshals the query response.
+func MarshalQueryResponse(res *databroker.QueryResponse) ([]byte, error) {
+	return (&proto.MarshalOptions{
+		Deterministic: true,
+	}).Marshal(res)
 }


### PR DESCRIPTION
## Summary
Add a cache warmer that will sync records from the databroker and add them to the cache. These records are set with a TTL a year in the future so they won't expire. 

## Related issues
- https://linear.app/pomerium/issue/ENG-1915/authorize-improve-group-query-performance


## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
