### PR TITLE
core/authz: remove unused mutex

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"sync"
 	"time"
 
 	"github.com/rs/zerolog"
@@ -34,11 +33,6 @@ type Authorize struct {
 	accessTracker     *AccessTracker
 	globalCache       storage.Cache
 	groupsCacheWarmer *cacheWarmer
-
-	// The stateLock prevents updating the evaluator store simultaneously with an evaluation.
-	// This should provide a consistent view of the data at a given server/record version and
-	// avoid partial updates.
-	stateLock sync.RWMutex
 
 	tracerProvider oteltrace.TracerProvider
 	tracer         oteltrace.Tracer

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -69,10 +69,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 		return nil, err
 	}
 
-	// take the state lock here so we don't update while evaluating
-	a.stateLock.RLock()
 	res, err := state.evaluator.Evaluate(ctx, req)
-	a.stateLock.RUnlock()
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Str("request-id", requestID).Msg("error during OPA evaluation")
 		return nil, err


### PR DESCRIPTION
## Summary

Removes `Authorize.stateLock` mutex as it's currently not guarding anything. 

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
