### PR TITLE
tracing: adjust envoy otel trace batching settings to match go sdk

### DIFF
--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -51,7 +51,7 @@ func TestBuilder_BuildBootstrapLayeredRuntime(t *testing.T) {
 				"tracing": {
 					"opentelemetry": {
 						"flush_interval_ms": 5000,
-						"min_flush_spans": 3
+						"min_flush_spans": 512
 					}
 				}
 			}

--- a/internal/telemetry/trace/global.go
+++ b/internal/telemetry/trace/global.go
@@ -2,9 +2,12 @@ package trace
 
 import (
 	"context"
+	"os"
+	"strconv"
 
 	"go.opentelemetry.io/contrib/propagators/autoprop"
 	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/embedded"
 )
@@ -43,4 +46,26 @@ var _ trace.Tracer = panicTracer{}
 // Start implements trace.Tracer.
 func (p panicTracer) Start(context.Context, string, ...trace.SpanStartOption) (context.Context, trace.Span) {
 	panic("global tracer used")
+}
+
+// functions below mimic those with the same name in otel/sdk/internal/env/env.go
+
+func BatchSpanProcessorScheduleDelay() int {
+	const defaultValue = sdktrace.DefaultScheduleDelay
+	if v, ok := os.LookupEnv("OTEL_BSP_SCHEDULE_DELAY"); ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return defaultValue
+}
+
+func BatchSpanProcessorMaxExportBatchSize() int {
+	const defaultValue = sdktrace.DefaultMaxExportBatchSize
+	if v, ok := os.LookupEnv("OTEL_BSP_MAX_EXPORT_BATCH_SIZE"); ok {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return defaultValue
 }

--- a/internal/telemetry/trace/server.go
+++ b/internal/telemetry/trace/server.go
@@ -50,7 +50,7 @@ func NewServer(ctx context.Context) *ExporterServer {
 }
 
 func (srv *ExporterServer) Start(ctx context.Context) {
-	lis := bufconn.Listen(4096)
+	lis := bufconn.Listen(2 * 1024 * 1024)
 	go func() {
 		if err := srv.remoteClient.Start(ctx); err != nil {
 			panic(err)
@@ -95,5 +95,6 @@ func (srv *ExporterServer) Shutdown(ctx context.Context) error {
 	if err := srv.remoteClient.Stop(ctx); err != nil {
 		errs = append(errs, err)
 	}
+	srv.cc.Close()
 	return errors.Join(errs...)
 }

--- a/internal/testenv/scenarios/trace_receiver.go
+++ b/internal/testenv/scenarios/trace_receiver.go
@@ -75,7 +75,10 @@ func (rec *OTLPTraceReceiver) Attach(ctx context.Context) {
 }
 
 // Modify implements testenv.Modifier.
-func (rec *OTLPTraceReceiver) Modify(*config.Config) {}
+func (rec *OTLPTraceReceiver) Modify(cfg *config.Config) {
+	cfg.Options.TracingProvider = "otlp"
+	cfg.Options.TracingOTLPEndpoint = rec.GRPCEndpointURL().Value()
+}
 
 func (rec *OTLPTraceReceiver) handleV1Traces(w http.ResponseWriter, r *http.Request) {
 	if r.Header.Get("Content-Type") != "application/x-protobuf" {


### PR DESCRIPTION
## Summary

Update envoy otel flush interval and span batch size parameters to match the same values from the go sdk. The go defaults are 5000ms and 512 spans respectively.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
