### PR TITLE
ci: downgrade to ubuntu-22.04

### DIFF
--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       sha-tag: ${{ steps.metadata.outputs.sha-tag }}
       image: ${{ steps.metadata.outputs.image }}


### PR DESCRIPTION
## Summary

The Docker Main workflow has been failing nearly consistently recently. Let's try downgrading to 22.04.

## Related issues

- https://github.com/actions/runner-images/issues/11471

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
