### PR TITLE
roll back to using ubuntu-22.04 images

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     name: Backport
     steps:
       - name: Generate token

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         go-version: [1.23.x]
         node-version: [16.x]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-22.04]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -14,7 +14,7 @@ jobs:
     #   - https://gh.io/supported-runners-and-hardware-resources
     #   - https://gh.io/using-larger-runners (GitHub.com only)
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
-    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-22.04' }}
     permissions:
       # required for all workflows
       security-events: write

--- a/.github/workflows/docker-main.yaml
+++ b/.github/workflows/docker-main.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       sha-tag: ${{ steps.metadata.outputs.sha-tag }}
       image: ${{ steps.metadata.outputs.image }}
@@ -71,7 +71,7 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: publish
     steps:
       - name: Checkout Gitops Repo

--- a/.github/workflows/docker-version-branches.yaml
+++ b/.github/workflows/docker-version-branches.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 

--- a/.github/workflows/needs-data.yaml
+++ b/.github/workflows/needs-data.yaml
@@ -11,7 +11,7 @@ jobs:
     permissions:
       issues: write # for actions/stale to close stale issues
       pull-requests: write # for actions/stale to close stale PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/stale@28ca1036281a5e5922ead5184a1bbf96e5fc984e
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       contents: write
       issues: read
       pull-requests: read
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       DOCKER_CLI_EXPERIMENTAL: "enabled"
     outputs:
@@ -117,7 +117,7 @@ jobs:
           docker manifest push pomerium/pomerium:debug-nonroot
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: goreleaser
     steps:
       - name: Checkout Gitops Repo

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         go-version: [1.23.x]
         node-version: [16.x]
-        platform: [ubuntu-latest]
+        platform: [ubuntu-22.04]
         deployment: [multi, single]
         authenticate-flow: [stateful, stateless]
     runs-on: ${{ matrix.platform }}
@@ -55,7 +55,7 @@ jobs:
       matrix:
         go-version: [1.23.x]
         node-version: [16.x]
-        platform: [ubuntu-latest, macos-latest]
+        platform: [ubuntu-22.04, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -86,7 +86,7 @@ jobs:
         run: make cover
 
       - uses: jandelgado/gcov2lcov-action@4e1989767862652e6ca8d3e2e61aabe6d43be28b
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.platform == 'ubuntu-22.04'
         name: convert coverage to lcov
         with:
           infile: coverage.txt
@@ -94,13 +94,13 @@ jobs:
 
       - name: upload to coveralls
         uses: coverallsapp/github-action@cfd0633edbd2411b532b808ba7a8b5e04f76d2c8
-        if: matrix.platform == 'ubuntu-latest'
+        if: matrix.platform == 'ubuntu-22.04'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: coverage.lcov
 
   build-docker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
@@ -117,7 +117,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   precommit:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
@@ -142,7 +142,7 @@ jobs:
           SKIP: lint
 
   check-docker-images:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         go-version: [1.23.x]
         node-version: [16.x]
-        platform: [ubuntu-22.04, macos-latest]
+        platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683


### PR DESCRIPTION
pending https://github.com/actions/runner-images/issues/11471 resolution, this moves us back to images that were working.

## Summary

There is a recent issue with the image used to run github actions that results in odd errors and segmentation faults on arm64/aarch64 platforms.  

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

https://github.com/pomerium/pomerium/pull/new/rsmith/downgrade-22.04
<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
