### PR TITLE
config: escape % signs in local reply format string

### DIFF
--- a/config/envoyconfig/http_connection_manager.go
+++ b/config/envoyconfig/http_connection_manager.go
@@ -56,13 +56,19 @@ func (b *Builder) buildLocalReplyConfig(
 		headers = toEnvoyHeaders(options.GetSetResponseHeaders())
 	}
 
-	data := map[string]any{
-		"status":        "%RESPONSE_CODE%",
-		"statusText":    "%RESPONSE_CODE_DETAILS%",
-		"requestId":     "%STREAM_ID%",
-		"responseFlags": "%RESPONSE_FLAGS%",
-	}
+	data := make(map[string]any)
 	httputil.AddBrandingOptionsToMap(data, options.BrandingOptions)
+	for k, v := range data {
+		// Escape any % signs in the branding options data, as Envoy will
+		// interpret the page output as a substitution format string.
+		if s, ok := v.(string); ok {
+			data[k] = strings.ReplaceAll(s, "%", "%%")
+		}
+	}
+	data["status"] = "%RESPONSE_CODE%"
+	data["statusText"] = "%RESPONSE_CODE_DETAILS%"
+	data["requestId"] = "%STREAM_ID%"
+	data["responseFlags"] = "%RESPONSE_FLAGS%"
 
 	bs, err := ui.RenderPage("Error", "Error", data)
 	if err != nil {

--- a/config/envoyconfig/http_connection_manager_test.go
+++ b/config/envoyconfig/http_connection_manager_test.go
@@ -1,0 +1,64 @@
+package envoyconfig
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/config"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+)
+
+func Test_buildLocalReplyConfig(t *testing.T) {
+	b := Builder{}
+	opts := config.NewDefaultOptions()
+	opts.BrandingOptions = &configpb.Settings{
+		LogoUrl:                    proto.String("http://example.com/my%20branding%20logo.png"),
+		ErrorMessageFirstParagraph: proto.String("It's 100% broken."),
+	}
+	lrc, err := b.buildLocalReplyConfig(opts)
+	require.NoError(t, err)
+	tmpl := string(lrc.Mappers[0].GetBodyFormatOverride().GetTextFormatSource().GetInlineBytes())
+	assert.Equal(t, `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <link id="favicon" rel="shortcut icon" href="/.pomerium/favicon.ico?v=2" />
+    <link
+      class="pomerium_favicon"
+      rel="apple-touch-icon"
+      sizes="180x180"
+      href="/.pomerium/apple-touch-icon.png"
+    />
+    <link
+      class="pomerium_favicon"
+      rel="icon"
+      sizes="32x32"
+      href="/.pomerium/favicon-32x32.png"
+    />
+    <link
+      class="pomerium_favicon"
+      rel="icon"
+      sizes="16x16"
+      href="/.pomerium/favicon-16x16.png"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>Error</title>
+    <link rel="stylesheet" href="/.pomerium/index.css" />
+  </head>
+  <body>
+    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <div id="root"></div>
+    <script>
+      window.POMERIUM_DATA = {"errorMessageFirstParagraph":"It's 100%% broken.","logoUrl":"http://example.com/my%%20branding%%20logo.png","page":"Error","requestId":"%STREAM_ID%","responseFlags":"%RESPONSE_FLAGS%","status":"%RESPONSE_CODE%","statusText":"%RESPONSE_CODE_DETAILS%"};
+    </script>
+    <script src="/.pomerium/index.js"></script>
+  </body>
+</html>
+`, tmpl)
+}


### PR DESCRIPTION
## Summary

Since v0.26, Pomerium configures Envoy to use a custom HTML error page format string for most errors served by Envoy itself. This format string uses %COMMAND% directives to include details about the error.

The HTML error page template also includes any branding options set via the corresponding Enterprise settings. We need to ensure that any % signs in the branding options strings are escaped to %% so that Envoy will not interpret them as the start of a %COMMAND% directive, which could lead to Envoy rejecting the format string as invalid.

## Related issues

https://linear.app/pomerium/issue/ENG-1958/some-logo-url-values-may-result-in-bad-envoy-config

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
