### PR TITLE
tracing: add missing check for otel_exporter_otlp_endpoint in envoy trace config

### DIFF
--- a/config/envoyconfig/tracing.go
+++ b/config/envoyconfig/tracing.go
@@ -33,7 +33,7 @@ func isTracingEnabled(cfg *otelconfig.Config) bool {
 	case "none", "noop", "":
 		return false
 	default:
-		return cfg.OtelExporterOtlpTracesEndpoint != nil
+		return cfg.OtelExporterOtlpTracesEndpoint != nil || cfg.OtelExporterOtlpEndpoint != nil
 	}
 }
 


### PR DESCRIPTION
https://linear.app/pomerium/issue/ENG-1960

## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
