### PR TITLE
proxy: fix connect command in routes portal

### DIFF
--- a/proxy/portal/portal.go
+++ b/proxy/portal/portal.go
@@ -36,10 +36,19 @@ func RoutesFromConfigRoutes(routes []*config.Policy) []Route {
 		if err == nil {
 			if strings.HasPrefix(fromURL.Scheme, "tcp+") {
 				pr.Type = "tcp"
-				pr.ConnectCommand = "pomerium-cli tcp " + fromURL.Host
+				if len(fromURL.Path) > 1 {
+					pr.ConnectCommand = "pomerium-cli tcp " + fromURL.String()
+				} else {
+					pr.ConnectCommand = "pomerium-cli tcp " + fromURL.Host
+				}
 			} else if strings.HasPrefix(fromURL.Scheme, "udp+") {
 				pr.Type = "udp"
 				pr.ConnectCommand = "pomerium-cli udp " + fromURL.Host
+				if len(fromURL.Path) > 1 {
+					pr.ConnectCommand = "pomerium-cli udp " + fromURL.String()
+				} else {
+					pr.ConnectCommand = "pomerium-cli udp " + fromURL.Host
+				}
 			} else {
 				pr.Type = "http"
 			}

--- a/proxy/portal/portal_test.go
+++ b/proxy/portal/portal_test.go
@@ -17,6 +17,8 @@ func TestRouteFromConfigRoute(t *testing.T) {
 	require.NoError(t, err)
 	to2, err := config.ParseWeightedUrls("tcp://postgres:5432")
 	require.NoError(t, err)
+	to3, err := config.ParseWeightedUrls("tcp://redis:6379")
+	require.NoError(t, err)
 
 	assert.Equal(t, []portal.Route{
 		{
@@ -47,6 +49,13 @@ func TestRouteFromConfigRoute(t *testing.T) {
 			From:           "udp+https://dns.example.com:53",
 			ConnectCommand: "pomerium-cli udp dns.example.com:53",
 		},
+		{
+			ID:             "8544b096d71c5dfe",
+			Name:           "redis",
+			Type:           "tcp",
+			From:           "tcp+https://proxy.corp.example.com:8443/redis.internal.example.com:6379",
+			ConnectCommand: "pomerium-cli tcp tcp+https://proxy.corp.example.com:8443/redis.internal.example.com:6379",
+		},
 	}, portal.RoutesFromConfigRoutes([]*config.Policy{
 		{
 			From:        "https://from.example.com",
@@ -66,6 +75,11 @@ func TestRouteFromConfigRoute(t *testing.T) {
 		{
 			From: "udp+https://dns.example.com:53",
 			To:   to2,
+		},
+		{
+			Name: "redis",
+			From: "tcp+https://proxy.corp.example.com:8443/redis.internal.example.com:6379",
+			To:   to3,
 		},
 	}))
 }

--- a/ui/src/components/RoutesPage.tsx
+++ b/ui/src/components/RoutesPage.tsx
@@ -76,7 +76,11 @@ const RouteCard: FC<RouteCardProps> = ({ route }) => {
           {route.connect_command && (
             <Box
               component="span"
-              sx={{ fontFamily: '"DM Mono"', fontSize: "12px" }}
+              sx={{
+                fontFamily: '"DM Mono"',
+                fontSize: "12px",
+                wordBreak: "break-all",
+              }}
             >
               {route.connect_command}
             </Box>


### PR DESCRIPTION
## Summary
For extended TCP routes like `tcp+https://proxy.corp.example.com:8443/redis.internal.example.com:6379` the connect command was only showing `pomerium-cli tcp proxy.corp.example.com:8443`, but it should've used the whole URL.

## Related issues
- [ENG-1981](https://linear.app/pomerium/issue/ENG-1981/extended-tcp-routes-display-incorrectly-on-the-routes-portal-getting)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
