### PR TITLE
proxy: fix routes portal error message

### DIFF
--- a/ui/src/components/RoutesPage.tsx
+++ b/ui/src/components/RoutesPage.tsx
@@ -125,7 +125,7 @@ const RoutesPage: FC<RoutesPageProps> = ({ data }) => {
   return (
     <SidebarPage>
       <Stack spacing={2}>
-        {data?.routes ? (
+        {data?.routes?.length > 0 ? (
           <>
             <RoutesSection
               type={"http"}


### PR DESCRIPTION
## Summary
Fix the error message that is displayed when there are no routes available for the routes portal.

## Related issues
- [ENG-1980](https://linear.app/pomerium/issue/ENG-1980/the-routes-portal-page-lacks-message-no-accessible-routes-found-when)

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
