### PR TITLE
Fix trace client update

### DIFF
--- a/internal/telemetry/trace/client.go
+++ b/internal/telemetry/trace/client.go
@@ -30,6 +30,10 @@ var (
 type SyncClient interface {
 	otlptrace.Client
 
+	// Update safely replaces the current trace client with the one provided.
+	// The new client must be unstarted. The old client (if any) will be stopped.
+	//
+	// This function is NOT reentrant; callers must use appropriate locking.
 	Update(ctx context.Context, newClient otlptrace.Client) error
 }
 


### PR DESCRIPTION
## Summary

This adds the necessary locking to calls to trace/SyncClient.Update on config change.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
