### PR TITLE
support loading idp token sessions in the proxy service

### DIFF
--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -78,7 +78,7 @@ func (p *Proxy) SignOut(w http.ResponseWriter, r *http.Request) error {
 	state := p.state.Load()
 
 	var redirectURL *url.URL
-	signOutURL, err := p.currentOptions.Load().GetSignOutRedirectURL()
+	signOutURL, err := p.currentConfig.Load().Options.GetSignOutRedirectURL()
 	if err != nil {
 		return httputil.NewError(http.StatusInternalServerError, err)
 	}
@@ -126,7 +126,7 @@ func (p *Proxy) Callback(w http.ResponseWriter, r *http.Request) error {
 // using the authenticate service.
 func (p *Proxy) ProgrammaticLogin(w http.ResponseWriter, r *http.Request) error {
 	state := p.state.Load()
-	options := p.currentOptions.Load()
+	options := p.currentConfig.Load().Options
 
 	redirectURI, err := urlutil.ParseAndValidateURL(r.FormValue(urlutil.QueryRedirectURI))
 	if err != nil {

--- a/proxy/handlers_portal.go
+++ b/proxy/handlers_portal.go
@@ -40,7 +40,7 @@ func (p *Proxy) routesPortalJSON(w http.ResponseWriter, r *http.Request) error {
 }
 
 func (p *Proxy) getPortalRoutes(ctx context.Context, u handlers.UserInfoData) []portal.Route {
-	options := p.currentOptions.Load()
+	options := p.currentConfig.Load().Options
 	pu := p.getPortalUser(u)
 	var routes []*config.Policy
 	for route := range options.GetAllPolicies() {


### PR DESCRIPTION
## Summary
Creating sessions for IdP tokens was implemented in #5484 . This adds the same functionality to the proxy service.

## Related issues
- [ENG-2017](https://linear.app/pomerium/issue/ENG-2017/proxy-add-support-for-loading-sessions-via-idp-access-and-identity)

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
