### PR TITLE
add ppl string operators

### DIFF
--- a/pkg/policy/criteria/matchers_test.go
+++ b/pkg/policy/criteria/matchers_test.go
@@ -50,6 +50,16 @@ func TestStringMatcher(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, `example == "test"`, str(body))
 	})
+	t.Run("not", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchString(&body, ast.VarTerm("example"), parser.Object{
+			"not": parser.String("test"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, `example != "test"`, str(body))
+	})
 	t.Run("starts_with", func(t *testing.T) {
 		t.Parallel()
 
@@ -117,6 +127,16 @@ func TestStringListMatcher(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, `count(example) == 1`+"\n"+`count([true | some v; v = example[_]; v == "test"]) > 0`, str(body))
+	})
+	t.Run("exclude", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchStringList(&body, ast.VarTerm("example"), parser.Object{
+			"exclude": parser.String("test"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, `count([true | some v; v = example[_]; v == "test"]) == 0`, str(body))
 	})
 	t.Run("string", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Summary
In PPL, add a `not` operator for the string matcher and an `exclude` operator for the string list matcher. This would allow you to do the following:

```yaml
allow:
  and:
    - domain:
        not: 'example.com'
    - groups:
        exclude: 'group1'
```

## Related issues
- [ENG-2030](https://linear.app/pomerium/issue/ENG-2030/core-more-flexible-ppl-logic)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
