### PR TITLE
get-envoy: allow downloading a specific os/arch

### DIFF
--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"runtime"
+	"slices"
 	"time"
 
 	"golang.org/x/sync/errgroup"
@@ -44,6 +45,10 @@ func run(ctx context.Context, args []string) error {
 		return runAll(ctx)
 	case "current":
 		return runCurrent(ctx)
+	default:
+		if slices.Contains(targets, mode) {
+			return runArch(ctx, mode)
+		}
 	}
 
 	return fmt.Errorf("unknown mode: %s", mode)
@@ -67,7 +72,11 @@ func runAll(ctx context.Context) error {
 }
 
 func runCurrent(ctx context.Context) error {
-	err := download(ctx, "./envoy", baseURL+"/envoy-"+runtime.GOOS+"-"+runtime.GOARCH)
+	return runArch(ctx, runtime.GOOS+"-"+runtime.GOARCH)
+}
+
+func runArch(ctx context.Context, arch string) error {
+	err := download(ctx, "./envoy", baseURL+"/envoy-"+arch)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
