### PR TITLE
remove noisy logs

### DIFF
--- a/internal/fileutil/directories.go
+++ b/internal/fileutil/directories.go
@@ -14,7 +14,7 @@ func CacheDir() string {
 		dir = filepath.Join(dir, "pomerium")
 	} else {
 		dir = filepath.Join(os.TempDir(), "pomerium", "cache")
-		log.Error().Msgf("user cache directory not set, defaulting to %s", dir)
+		log.Debug().Msgf("user cache directory not set, defaulting to %s", dir)
 	}
 	return dir
 }
@@ -30,7 +30,7 @@ func DataDir() string {
 		} else {
 			dir = filepath.Join(os.TempDir(), "pomerium", "data")
 		}
-		log.Error().Msgf("user data directory not set, defaulting to %s", dir)
+		log.Debug().Msgf("user data directory not set, defaulting to %s", dir)
 	}
 	return dir
 }

--- a/internal/telemetry/trace/trace.go
+++ b/internal/telemetry/trace/trace.go
@@ -139,7 +139,7 @@ func ShutdownContext(ctx context.Context) error {
 	if err := sys.tpm.ShutdownAll(context.Background()); err != nil {
 		errs = append(errs, fmt.Errorf("error shutting down tracer providers: %w", err))
 	}
-	if err := sys.exporterServer.Shutdown(context.Background()); err != nil {
+	if err := sys.exporterServer.Shutdown(context.Background()); err != nil && !errors.Is(err, ErrNoClient) {
 		errs = append(errs, fmt.Errorf("error shutting down trace exporter: %w", err))
 	}
 	return errors.Join(errs...)


### PR DESCRIPTION
## Summary
Remove some noisy logs.

## Related issues
- [ENG-1982](https://linear.app/pomerium/issue/ENG-1982/core-version-command-output-includes-error-log-entry)
 

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
