### PR TITLE
config: preserve existing user when creating sessions from idp token

### DIFF
--- a/config/session.go
+++ b/config/session.go
@@ -213,7 +213,7 @@ func (c *incomingIDPTokenSessionCreator) createSessionAccessToken(
 		}
 
 		u, err := c.getUser(ctx, s.GetUserId())
-		if errors.Is(err, storage.ErrNotFound) {
+		if storage.IsNotFound(err) {
 			u = &user.User{Id: s.GetUserId()}
 		} else if err != nil {
 			return nil, fmt.Errorf("error retrieving existing user: %w", err)


### PR DESCRIPTION
## Summary
When we create a session for an IdP token we also create a `user.User` object. Currently if there is already a user object we would overwrite it. This PR instead merges the existing user record with claims from the access or identity token, so emails, names, etc should be preserved.

## Related issues
- [ENG-2062](https://linear.app/pomerium/issue/ENG-2062/core-users-created-from-idp-tokens-overwrite-existing-users)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
