### PR TITLE
policy: support emails from directory user

### DIFF
--- a/config/policy_ppl_test.go
+++ b/config/policy_ppl_test.go
@@ -85,7 +85,8 @@ else := [false, {"user-unauthenticated"}]
 domain_0 := [true, {"domain-ok"}] if {
 	session := get_session(input.session.id)
 	user := get_user(session)
-	domain := split(get_user_email(session, user), "@")[1]
+	directory_user := get_directory_user(session)
+	domain := split(get_user_email(session, user, directory_user), "@")[1]
 	domain == "a.example.com"
 }
 
@@ -99,7 +100,8 @@ else := [false, {"user-unauthenticated"}]
 domain_1 := [true, {"domain-ok"}] if {
 	session := get_session(input.session.id)
 	user := get_user(session)
-	domain := split(get_user_email(session, user), "@")[1]
+	directory_user := get_directory_user(session)
+	domain := split(get_user_email(session, user, directory_user), "@")[1]
 	domain == "b.example.com"
 }
 
@@ -113,7 +115,8 @@ else := [false, {"user-unauthenticated"}]
 domain_2 := [true, {"domain-ok"}] if {
 	session := get_session(input.session.id)
 	user := get_user(session)
-	domain := split(get_user_email(session, user), "@")[1]
+	directory_user := get_directory_user(session)
+	domain := split(get_user_email(session, user, directory_user), "@")[1]
 	domain == "c.example.com"
 }
 
@@ -127,7 +130,8 @@ else := [false, {"user-unauthenticated"}]
 domain_3 := [true, {"domain-ok"}] if {
 	session := get_session(input.session.id)
 	user := get_user(session)
-	domain := split(get_user_email(session, user), "@")[1]
+	directory_user := get_directory_user(session)
+	domain := split(get_user_email(session, user, directory_user), "@")[1]
 	domain == "d.example.com"
 }
 
@@ -141,7 +145,8 @@ else := [false, {"user-unauthenticated"}]
 domain_4 := [true, {"domain-ok"}] if {
 	session := get_session(input.session.id)
 	user := get_user(session)
-	domain := split(get_user_email(session, user), "@")[1]
+	directory_user := get_directory_user(session)
+	domain := split(get_user_email(session, user, directory_user), "@")[1]
 	domain == "e.example.com"
 }
 
@@ -240,7 +245,8 @@ else := [false, {"user-unauthenticated"}]
 email_0 := [true, {"email-ok"}] if {
 	session := get_session(input.session.id)
 	user := get_user(session)
-	email := get_user_email(session, user)
+	directory_user := get_directory_user(session)
+	email := get_user_email(session, user, directory_user)
 	email == "user1"
 }
 
@@ -267,7 +273,8 @@ else := [false, {"user-unauthenticated"}]
 email_1 := [true, {"email-ok"}] if {
 	session := get_session(input.session.id)
 	user := get_user(session)
-	email := get_user_email(session, user)
+	directory_user := get_directory_user(session)
+	email := get_user_email(session, user, directory_user)
 	email == "user2"
 }
 
@@ -294,7 +301,8 @@ else := [false, {"user-unauthenticated"}]
 email_2 := [true, {"email-ok"}] if {
 	session := get_session(input.session.id)
 	user := get_user(session)
-	email := get_user_email(session, user)
+	directory_user := get_directory_user(session)
+	email := get_user_email(session, user, directory_user)
 	email == "user3"
 }
 
@@ -321,7 +329,8 @@ else := [false, {"user-unauthenticated"}]
 email_3 := [true, {"email-ok"}] if {
 	session := get_session(input.session.id)
 	user := get_user(session)
-	email := get_user_email(session, user)
+	directory_user := get_directory_user(session)
+	email := get_user_email(session, user, directory_user)
 	email == "user4"
 }
 
@@ -348,7 +357,8 @@ else := [false, {"user-unauthenticated"}]
 email_4 := [true, {"email-ok"}] if {
 	session := get_session(input.session.id)
 	user := get_user(session)
-	email := get_user_email(session, user)
+	directory_user := get_directory_user(session)
+	email := get_user_email(session, user, directory_user)
 	email == "user5"
 }
 
@@ -478,7 +488,19 @@ get_user(session) := v if {
 
 else := {}
 
-get_user_email(session, user) := v if {
+get_directory_user(session) := v if {
+	v = get_databroker_record("pomerium.io/DirectoryUser", session.user_id)
+	v != null
+}
+
+else := {}
+
+get_user_email(session, user, directory_user) := v if {
+	v = object.get(directory_user, "email", "")
+	v != ""
+}
+
+else := v if {
 	v = user.email
 }
 

--- a/pkg/policy/criteria/domain.go
+++ b/pkg/policy/criteria/domain.go
@@ -15,7 +15,10 @@ var domainBody = ast.Body{
 		user := get_user(session)
 	`),
 	ast.MustParseExpr(`
-		domain := split(get_user_email(session, user), "@")[1]
+		directory_user := get_directory_user(session)
+	`),
+	ast.MustParseExpr(`
+		domain := split(get_user_email(session, user, directory_user), "@")[1]
 	`),
 }
 
@@ -48,6 +51,7 @@ func (c domainCriterion) GenerateRule(_ string, data parser.Value) (*ast.Rule, [
 		rules.GetSession(),
 		rules.GetUser(),
 		rules.GetUserEmail(),
+		rules.GetDirectoryUser(),
 	}, nil
 }
 

--- a/pkg/policy/criteria/domain_test.go
+++ b/pkg/policy/criteria/domain_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/pomerium/datasource/pkg/directory"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
@@ -59,6 +60,27 @@ allow:
 				makeRecord(&user.User{
 					Id:    "USER_ID",
 					Email: "test1@example.com",
+				}),
+			},
+			Input{Session: InputSession{ID: "SESSION_ID"}})
+		require.NoError(t, err)
+		require.Equal(t, A{true, A{ReasonDomainOK}, M{}}, res["allow"])
+		require.Equal(t, A{false, A{}}, res["deny"])
+	})
+	t.Run("by directory user", func(t *testing.T) {
+		res, err := evaluate(t, `
+allow:
+  and:
+    - domain:
+        is: example.com
+`,
+			[]*databroker.Record{
+				makeRecord(&session.Session{
+					Id:     "SESSION_ID",
+					UserId: "USER_ID",
+				}),
+				makeStructRecord(directory.UserRecordType, "USER_ID", map[string]any{
+					"email": "user@example.com",
 				}),
 			},
 			Input{Session: InputSession{ID: "SESSION_ID"}})

--- a/pkg/policy/criteria/email.go
+++ b/pkg/policy/criteria/email.go
@@ -16,7 +16,10 @@ var emailBody = ast.Body{
 		user := get_user(session)
 	`),
 	ast.MustParseExpr(`
-		email := get_user_email(session, user)
+		directory_user := get_directory_user(session)
+	`),
+	ast.MustParseExpr(`
+		email := get_user_email(session, user, directory_user)
 	`),
 }
 
@@ -49,6 +52,7 @@ func (c emailCriterion) GenerateRule(_ string, data parser.Value) (*ast.Rule, []
 		rules.GetSession(),
 		rules.GetUser(),
 		rules.GetUserEmail(),
+		rules.GetDirectoryUser(),
 	}, nil
 }
 

--- a/pkg/policy/criteria/email_test.go
+++ b/pkg/policy/criteria/email_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/pomerium/datasource/pkg/directory"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
@@ -72,6 +73,27 @@ allow:
 				}),
 			},
 			Input{Session: InputSession{ID: "SESSION1"}})
+		require.NoError(t, err)
+		require.Equal(t, A{true, A{ReasonEmailOK}, M{}}, res["allow"])
+		require.Equal(t, A{false, A{}}, res["deny"])
+	})
+	t.Run("by directory user", func(t *testing.T) {
+		res, err := evaluate(t, `
+allow:
+  and:
+    - email:
+        is: test@example.com
+`,
+			[]*databroker.Record{
+				makeRecord(&session.Session{
+					Id:     "SESSION_ID",
+					UserId: "USER_ID",
+				}),
+				makeStructRecord(directory.UserRecordType, "USER_ID", map[string]any{
+					"email": "test@example.com",
+				}),
+			},
+			Input{Session: InputSession{ID: "SESSION_ID"}})
 		require.NoError(t, err)
 		require.Equal(t, A{true, A{ReasonEmailOK}, M{}}, res["allow"])
 		require.Equal(t, A{false, A{}}, res["deny"])


### PR DESCRIPTION
## Summary
Update policy evaluation of `email` and `domain` to support retrieving a user's email address from the `DirectoryUser` in addition to the `User` record in the databroker.

We already do this when evaluating headers, so this seems like an oversight of the current implementation.

## Related issues
- #5503 


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
