### PR TITLE
proxy: add short timeout for logo discovery

### DIFF
--- a/proxy/handlers_portal.go
+++ b/proxy/handlers_portal.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"sync"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/handlers"
@@ -49,23 +50,31 @@ func (p *Proxy) getPortalRoutes(ctx context.Context, u handlers.UserInfoData) []
 		}
 	}
 	portalRoutes := portal.RoutesFromConfigRoutes(routes)
+
+	var wg sync.WaitGroup
 	for i, pr := range portalRoutes {
-		r := routes[i]
-		for _, to := range r.To {
-			if pr.LogoURL == "" {
-				var err error
-				pr.LogoURL, err = p.logoProvider.GetLogoURL(ctx, pr.From, to.URL.String())
-				if err != nil && !errors.Is(err, portal.ErrLogoNotFound) {
-					log.Ctx(ctx).Error().
-						Err(err).
-						Str("from", pr.From).
-						Str("to", to.URL.String()).
-						Msg("error retrieving logo for route")
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			r := routes[i]
+			for _, to := range r.To {
+				if pr.LogoURL == "" {
+					var err error
+					pr.LogoURL, err = p.logoProvider.GetLogoURL(ctx, pr.From, to.URL.String())
+					if err != nil && !errors.Is(err, portal.ErrLogoNotFound) {
+						log.Ctx(ctx).Error().
+							Err(err).
+							Str("from", pr.From).
+							Str("to", to.URL.String()).
+							Msg("error retrieving logo for route")
+					}
 				}
 			}
-		}
-		portalRoutes[i] = pr
+			portalRoutes[i] = pr
+		}()
 	}
+	wg.Wait()
 	return portalRoutes
 }
 

--- a/proxy/portal/logo_provider_test.go
+++ b/proxy/portal/logo_provider_test.go
@@ -1,6 +1,7 @@
-package portal_test
+package portal
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pomerium/pomerium/internal/testutil"
-	"github.com/pomerium/pomerium/proxy/portal"
 )
 
 func TestLogoProvider(t *testing.T) {
@@ -30,8 +30,27 @@ func TestLogoProvider(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	ctx := testutil.GetContext(t, time.Minute)
-	p := portal.NewLogoProvider()
+	p := NewLogoProvider()
 	u, err := p.GetLogoURL(ctx, "", srv.URL)
 	assert.NoError(t, err)
 	assert.Equal(t, "data:image/vnd.microsoft.icon;base64,Tk9UIEFDVFVBTExZIEFOIElDT04=", u)
+}
+
+func TestLogoProvider_Timeout(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-r.Context().Done():
+		case <-time.After(time.Second):
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	ctx := testutil.GetContext(t, time.Minute)
+	p := newFaviconDiscoveryLogoProvider()
+	p.discoveryTimeout = time.Millisecond
+	_, err := p.GetLogoURL(ctx, "", srv.URL)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }


### PR DESCRIPTION
## Summary
Add a short `500ms` timeout on the logo discovery request for the routes portal to prevent the page from timing out on misbehaving upstream services.

## Related issues
- [ENG-2071](https://linear.app/pomerium/issue/ENG-2071/routes-portal-often-times-out-in-master-pgsql-env)
 
## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
