### PR TITLE
handle long names in the cards for route portal - ENG-2026

### DIFF
--- a/ui/src/components/RoutesPage.tsx
+++ b/ui/src/components/RoutesPage.tsx
@@ -34,8 +34,21 @@ const RouteCard: FC<RouteCardProps> = ({ route }) => {
   };
 
   return (
-    <Card raised={true}>
-      <CardActionArea href={route.from} target="_blank" onClick={handleClick}>
+    <Card
+      raised={true}
+      sx={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        justifyContent: "space-between",
+      }}
+    >
+      <CardActionArea
+        sx={{ height: "100%" }}
+        href={route.from}
+        target="_blank"
+        onClick={handleClick}
+      >
         <CardHeader
           avatar={
             route.logo_url ? (
@@ -67,7 +80,16 @@ const RouteCard: FC<RouteCardProps> = ({ route }) => {
               </IconButton>
             )
           }
-          title={route.name}
+          title={
+            <Box
+              component="span"
+              sx={{
+                wordBreak: "break-all",
+              }}
+            >
+              {route.name}
+            </Box>
+          }
         />
         <CardContent>
           {route.description && (


### PR DESCRIPTION
## Summary
Adds a box around the route name to add word wrap and padding.
Also changes the height of the card to account for multiple lines.

## Related issues
ENG-2026

## User Explanation
Handles long route names.

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
