### PR TITLE
websockets: disable http2 connect

### DIFF
--- a/config/envoyconfig/listeners_main.go
+++ b/config/envoyconfig/listeners_main.go
@@ -207,9 +207,6 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 		mgr.CodecType = envoy_extensions_filters_network_http_connection_manager.HttpConnectionManager_AUTO
 	} else if cfg.Options.GetCodecType() == config.CodecTypeAuto || cfg.Options.GetCodecType() == config.CodecTypeHTTP2 {
 		mgr.CodecType = cfg.Options.GetCodecType().ToEnvoy()
-		mgr.Http2ProtocolOptions = &envoy_config_core_v3.Http2ProtocolOptions{
-			AllowConnect: true,
-		}
 	} else {
 		mgr.CodecType = cfg.Options.GetCodecType().ToEnvoy()
 	}

--- a/config/envoyconfig/testdata/main_http_connection_manager_filter.json
+++ b/config/envoyconfig/testdata/main_http_connection_manager_filter.json
@@ -113,9 +113,6 @@
         }
       }
     },
-    "http2ProtocolOptions": {
-      "allowConnect": true
-    },
     "localReplyConfig": {
       "mappers": [
         {


### PR DESCRIPTION
## Summary

Disable HTTP2/Connect that seems to break websocket protocol upgrade in #5387

## Related issues

Fix https://github.com/pomerium/pomerium/issues/5431

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
