### PR TITLE
testutil: use cmp.Diff in protobuf json assertion

### DIFF
--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -29,10 +29,18 @@ func AssertProtoEqual(t *testing.T, expected, actual any, msgAndArgs ...any) boo
 
 // AssertProtoJSONEqual asserts that a protobuf message matches the given JSON. The protoMsg can also be a slice
 // of protobuf messages.
-func AssertProtoJSONEqual(t *testing.T, expected string, protoMsg any, msgAndArgs ...any) bool {
+func AssertProtoJSONEqual(t *testing.T, expectedJSON string, protoMsg any, msgAndArgs ...any) bool {
 	t.Helper()
-	formattedJSON := formattedProtoJSON(protoMsg)
-	return assert.Equal(t, reformatJSON(json.RawMessage(expected)), formattedJSON, msgAndArgs...)
+	var expected any
+	err := json.Unmarshal([]byte(expectedJSON), &expected)
+	require.NoError(t, err)
+
+	var proto any
+	err = json.Unmarshal([]byte(formattedProtoJSON(protoMsg)), &proto)
+	require.NoError(t, err)
+
+	diff := cmp.Diff(expected, proto)
+	return assert.Empty(t, diff, msgAndArgs...)
 }
 
 func formattedProtoJSON(protoMsg any) string {


### PR DESCRIPTION
## Summary

use cmp.Diff in protojson comparisons that allows to see specifically which field doesn't match. 

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
