### PR TITLE
config: fix jwt_issuer_format conversion

### DIFF
--- a/config/options_test.go
+++ b/config/options_test.go
@@ -989,6 +989,20 @@ func TestOptions_ApplySettings(t *testing.T) {
 		})
 		assert.Equal(t, NewJWTGroupsFilter([]string{"quux", "zulu"}), options.JWTGroupsFilter)
 	})
+
+	t.Run("jwt_issuer_format", func(t *testing.T) {
+		options := NewDefaultOptions()
+		assert.Equal(t, JWTIssuerFormatUnset, options.JWTIssuerFormat)
+		options.ApplySettings(ctx, nil, &configpb.Settings{
+			JwtIssuerFormat: configpb.IssuerFormat_IssuerURI.Enum(),
+		})
+		options.ApplySettings(ctx, nil, &configpb.Settings{})
+		assert.Equal(t, JWTIssuerFormatURI, options.JWTIssuerFormat)
+		options.ApplySettings(ctx, nil, &configpb.Settings{
+			JwtIssuerFormat: configpb.IssuerFormat_IssuerHostOnly.Enum(),
+		})
+		assert.Equal(t, JWTIssuerFormatHostOnly, options.JWTIssuerFormat)
+	})
 }
 
 func TestOptions_GetSetResponseHeaders(t *testing.T) {

--- a/config/policy.go
+++ b/config/policy.go
@@ -389,13 +389,6 @@ func NewPolicyFromProto(pb *configpb.Route) (*Policy, error) {
 		p.EnvoyOpts.Name = pb.Name
 	}
 
-	switch pb.GetJwtIssuerFormat() {
-	case configpb.IssuerFormat_IssuerHostOnly:
-		p.JWTIssuerFormat = JWTIssuerFormatHostOnly
-	case configpb.IssuerFormat_IssuerURI:
-		p.JWTIssuerFormat = JWTIssuerFormatURI
-	}
-
 	p.BearerTokenFormat = BearerTokenFormatFromPB(pb.BearerTokenFormat)
 
 	for _, rwh := range pb.RewriteResponseHeaders {

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -292,6 +292,22 @@ func TestPolicy_FromToPb(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, p.Redirect.HTTPSRedirect, policyFromProto.Redirect.HTTPSRedirect)
 	})
+
+	t.Run("JWT issuer format", func(t *testing.T) {
+		for f := range knownJWTIssuerFormats {
+			p := &Policy{
+				From:            "https://pomerium.io",
+				To:              mustParseWeightedURLs(t, "http://localhost"),
+				JWTIssuerFormat: f,
+			}
+			pbPolicy, err := p.ToProto()
+			require.NoError(t, err)
+
+			policyFromPb, err := NewPolicyFromProto(pbPolicy)
+			assert.NoError(t, err)
+			assert.Equal(t, f, policyFromPb.JWTIssuerFormat)
+		}
+	})
 }
 
 func TestPolicy_Matches(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix a bug from https://github.com/pomerium/pomerium/pull/5508: remove the previous conversion logic in `NewPolicyFromProto()` for the `jwt_issuer_format` field. This would prevent the new "unset" state from working correctly. Add a unit test to verify that all three values (unset, "hostOnly" and "uri") will successfully round trip to the proto format and back again.

Also add a test case for the `Options.ApplySettings()` method to verify that an unset `jwt_issuer_format` will not overwrite the existing value (if any) in the settings.

## Related issues

https://linear.app/pomerium/issue/ENG-2072/config-jwt-issuer-format-should-also-be-support-at-the-global-level

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
