### PR TITLE
metrics: reduce gc pressure

### DIFF
--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -22,6 +22,9 @@ var (
 	// is deprecated pending removal in a future release, but this flag allows a temporary
 	// opt-out from the deprecation.
 	RuntimeFlagPomeriumJWTEndpoint = runtimeFlag("pomerium_jwt_endpoint", false)
+
+	// RuntimeFlagAddExtraMetricsLabels enables adding extra labels to metrics (host and installation id)
+	RuntimeFlagAddExtraMetricsLabels = runtimeFlag("add_extra_metrics_labels", true)
 )
 
 // RuntimeFlag is a runtime flag that can flip on/off certain features

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	github.com/tniswong/go.rfcx v0.0.0-20181019234604-07783c52761f
 	github.com/volatiletech/null/v9 v9.0.0
 	github.com/yuin/gopher-lua v1.1.1
+	github.com/zeebo/assert v1.3.1
 	github.com/zeebo/xxh3 v1.0.2
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0
@@ -227,7 +228,6 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
-	github.com/zeebo/assert v1.3.1 // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.34.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,6 @@ require (
 	github.com/tniswong/go.rfcx v0.0.0-20181019234604-07783c52761f
 	github.com/volatiletech/null/v9 v9.0.0
 	github.com/yuin/gopher-lua v1.1.1
-	github.com/zeebo/assert v1.3.1
 	github.com/zeebo/xxh3 v1.0.2
 	go.opencensus.io v0.24.0
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.59.0
@@ -228,6 +227,7 @@ require (
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/yashtewari/glob-intersection v0.2.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
+	github.com/zeebo/assert v1.3.1 // indirect
 	github.com/zeebo/blake3 v0.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/contrib/detectors/gcp v1.34.0 // indirect

--- a/internal/telemetry/metrics/bench_test.go
+++ b/internal/telemetry/metrics/bench_test.go
@@ -1,0 +1,115 @@
+package metrics_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	"github.com/zeebo/assert"
+)
+
+func TestScrapeMetricsEndpoint(t *testing.T) {
+	t.Skip("this test is for profiling purposes only")
+
+	env := testenv.New(t, testenv.WithTraceDebugFlags(testenv.StandardTraceDebugFlags))
+	upstream := upstreams.HTTP(nil)
+	upstream.Handle("/test", func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte("OK"))
+	})
+
+	routes := []testenv.Route{}
+	for i := range 10 {
+		routes = append(routes, upstream.Route().
+			From(env.SubdomainURL(fmt.Sprintf("test-%d", i))).
+			Policy(func(p *config.Policy) { p.AllowPublicUnauthenticatedAccess = true }))
+	}
+	env.AddUpstream(upstream)
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	for _, r := range routes {
+		resp, err := upstream.Get(r, upstreams.Path("/test"))
+		assert.NoError(t, err)
+		data, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		resp.Body.Close()
+		assert.Equal(t, "OK", string(data))
+	}
+
+	metricsURL := fmt.Sprintf("http://localhost:%d/metrics", env.Ports().Metrics.Value())
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	var durations []time.Duration
+	var totalBytes int64
+	var errors int
+
+	pct := 0
+	niter := 200
+	for i := 0; i < niter; i++ {
+		pct = i * 100 / niter
+		if pct%10 == 0 {
+			t.Log(pct, "%")
+		}
+
+		start := time.Now()
+		resp, err := client.Get(metricsURL)
+		elapsed := time.Since(start)
+
+		if err != nil {
+			t.Logf("Request %d failed: %v", i, err)
+			errors++
+			continue
+		}
+
+		nb, err := io.Copy(io.Discard, resp.Body)
+		if err != nil {
+			resp.Body.Close()
+			errors++
+			continue
+		}
+		resp.Body.Close()
+
+		durations = append(durations, elapsed)
+		totalBytes += nb
+	}
+
+	if len(durations) > 0 {
+		sort.Slice(durations, func(i, j int) bool {
+			return durations[i] < durations[j]
+		})
+
+		var total time.Duration
+		for _, d := range durations {
+			total += d
+		}
+
+		t.Logf("Metrics scraping statistics:")
+		t.Logf("  Successful requests: %d", len(durations))
+		t.Logf("  Failed requests: %d", errors)
+		t.Logf("  Total bytes: %d", totalBytes)
+		t.Logf("  Avg bytes per request: %.2f", float64(totalBytes)/float64(len(durations)))
+		t.Logf("  Min: %v", durations[0])
+		t.Logf("  Max: %v", durations[len(durations)-1])
+		t.Logf("  Avg: %v", total/time.Duration(len(durations)))
+		t.Logf("  p50: %v", durations[len(durations)*50/100])
+		t.Logf("  p90: %v", durations[len(durations)*90/100])
+		t.Logf("  p95: %v", durations[len(durations)*95/100])
+		t.Logf("  p99: %v", durations[len(durations)*99/100])
+	} else {
+		t.Logf("No successful requests made")
+	}
+
+	t.Logf("metrics endpoint: %s", metricsURL)
+
+	env.Stop()
+}

--- a/internal/telemetry/metrics/bench_test.go
+++ b/internal/telemetry/metrics/bench_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pomerium/pomerium/internal/testenv"
 	"github.com/pomerium/pomerium/internal/testenv/snippets"
 	"github.com/pomerium/pomerium/internal/testenv/upstreams"
-	"github.com/zeebo/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestScrapeMetricsEndpoint(t *testing.T) {

--- a/internal/telemetry/metrics/providers_test.go
+++ b/internal/telemetry/metrics/providers_test.go
@@ -29,7 +29,7 @@ envoy_server_initialization_time_ms_bucket{le="1000"} 1
 }
 
 func getMetrics(t *testing.T, envoyURL *url.URL, header http.Header) []byte {
-	h, err := PrometheusHandler([]ScrapeEndpoint{{Name: "envoy", URL: *envoyURL}}, "test_installation_id", time.Second*20)
+	h, err := PrometheusHandler([]ScrapeEndpoint{{Name: "envoy", URL: *envoyURL}}, time.Second*20, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/telemetry/prometheus/relabel_text_stream.go
+++ b/internal/telemetry/prometheus/relabel_text_stream.go
@@ -46,6 +46,9 @@ func RelabelTextStream(dst io.Writer, src io.Reader, addLabels map[string]string
 		if errors.Is(err, io.EOF) {
 			break
 		}
+		if err != nil {
+			return err
+		}
 
 		if len(line) == 0 || line[0] == '#' {
 			if _, err := dst.Write(line); err != nil {

--- a/internal/telemetry/prometheus/relabel_text_stream.go
+++ b/internal/telemetry/prometheus/relabel_text_stream.go
@@ -1,0 +1,97 @@
+package prometheus
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"strings"
+)
+
+func writeMulti(dst io.Writer, b ...[]byte) error {
+	for _, buf := range b {
+		if _, err := dst.Write(buf); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// RelabelTextStream relabels a prometheus text stream by adding additional labels to each metric.
+func RelabelTextStream(dst io.Writer, src io.Reader, addLabels map[string]string) error {
+	if len(addLabels) == 0 {
+		_, err := io.Copy(dst, src)
+		return err
+	}
+
+	var additionalLabelsBuilder strings.Builder
+	for k, v := range addLabels {
+		if additionalLabelsBuilder.Len() > 0 {
+			additionalLabelsBuilder.WriteByte(',')
+		}
+		additionalLabelsBuilder.WriteString(k)
+		additionalLabelsBuilder.WriteString("=\"")
+		additionalLabelsBuilder.WriteString(v)
+		additionalLabelsBuilder.WriteString("\"")
+	}
+	additionalLabels := []byte(additionalLabelsBuilder.String())
+
+	scanner := bufio.NewReader(src)
+
+	for {
+		line, err := scanner.ReadSlice('\n')
+		if errors.Is(err, io.EOF) {
+			break
+		}
+
+		if len(line) == 0 || line[0] == '#' {
+			if _, err := dst.Write(line); err != nil {
+				return err
+			}
+			continue
+		}
+
+		spaceIdx := bytes.IndexByte(line, ' ')
+		if spaceIdx == -1 {
+			if _, err := dst.Write(line); err != nil {
+				return err
+			}
+			continue
+		}
+
+		metricWithLabels := line[:spaceIdx]
+		value := line[spaceIdx:]
+
+		openBraceIdx := bytes.IndexByte(metricWithLabels, '{')
+		if openBraceIdx == -1 { // no labels
+			if err := writeMulti(dst, metricWithLabels, []byte("{"), additionalLabels, []byte("}"), value); err != nil {
+				return err
+			}
+			continue
+		}
+
+		metricName := metricWithLabels[:openBraceIdx]
+
+		closeBraceIdx := bytes.LastIndexByte(metricWithLabels, '}')
+		if closeBraceIdx == -1 || closeBraceIdx <= openBraceIdx {
+			if _, err := dst.Write(line); err != nil {
+				return err
+			}
+			continue
+		}
+
+		existingLabels := metricWithLabels[openBraceIdx+1 : closeBraceIdx]
+
+		if len(existingLabels) > 0 {
+			if err := writeMulti(dst, metricName, []byte("{"), existingLabels, []byte(","), additionalLabels, []byte("}"), value); err != nil {
+				return err
+			}
+		} else {
+			if err := writeMulti(dst, metricName, []byte("{"), additionalLabels, []byte("}"), value); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/telemetry/prometheus/relabel_text_stream_test.go
+++ b/internal/telemetry/prometheus/relabel_text_stream_test.go
@@ -1,0 +1,121 @@
+package prometheus_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/pomerium/pomerium/internal/telemetry/prometheus"
+	"github.com/stretchr/testify/require"
+)
+
+// RepeatingReader repeats reading from the beginning after EOF for a specified number of times
+type RepeatingReader struct {
+	reader    *bytes.Reader
+	resets    int
+	maxResets int
+}
+
+// NewRepeatingReader creates a new reader that will reset up to maxResets times
+func NewRepeatingReader(data []byte, maxResets int) *RepeatingReader {
+	return &RepeatingReader{
+		reader:    bytes.NewReader(data),
+		resets:    0,
+		maxResets: maxResets,
+	}
+}
+
+// Read implements io.Reader
+func (r *RepeatingReader) Read(p []byte) (n int, err error) {
+	n, err = r.reader.Read(p)
+	if err == io.EOF && r.resets < r.maxResets {
+		r.reader.Seek(0, io.SeekStart)
+		r.resets++
+		return r.Read(p)
+	}
+	return
+}
+
+func TestRelabelTextStream(t *testing.T) {
+	testCases := []struct {
+		name      string
+		input     string
+		addLabels map[string]string
+		expected  string
+	}{
+		{
+			name:      "empty input",
+			input:     "",
+			addLabels: map[string]string{"instance": "localhost:9090"},
+			expected:  "",
+		},
+		{
+			name:      "no labels to add",
+			input:     "metric 42\n",
+			addLabels: map[string]string{},
+			expected:  "metric 42\n",
+		},
+		{
+			name:      "comment lines",
+			input:     "# HELP metric_name Help text\n# TYPE metric_name counter\n",
+			addLabels: map[string]string{"instance": "localhost:9090"},
+			expected:  "# HELP metric_name Help text\n# TYPE metric_name counter\n",
+		},
+		{
+			name:      "metric without labels",
+			input:     "http_requests_total 42\n",
+			addLabels: map[string]string{"instance": "localhost:9090"},
+			expected:  "http_requests_total{instance=\"localhost:9090\"} 42\n",
+		},
+		{
+			name:      "metric with existing labels",
+			input:     "http_requests_total{method=\"GET\"} 42\n",
+			addLabels: map[string]string{"instance": "localhost:9090"},
+			expected:  "http_requests_total{method=\"GET\",instance=\"localhost:9090\"} 42\n",
+		},
+		{
+			name:      "multiple labels to add",
+			input:     "http_requests_total 42\n",
+			addLabels: map[string]string{"instance": "localhost:9090", "job": "prometheus"},
+			expected:  "http_requests_total{instance=\"localhost:9090\",job=\"prometheus\"} 42\n",
+		},
+		{
+			name:      "malformed metric (no space)",
+			input:     "invalid_metric\n",
+			addLabels: map[string]string{"instance": "localhost:9090"},
+			expected:  "invalid_metric\n",
+		},
+		{
+			name:      "malformed metric (no closing brace)",
+			input:     "invalid_metric{label=\"value\" 42\n",
+			addLabels: map[string]string{"instance": "localhost:9090"},
+			expected:  "invalid_metric{label=\"value\" 42\n",
+		},
+		{
+			name:      "empty labels",
+			input:     "http_requests_total{} 42\n",
+			addLabels: map[string]string{"instance": "localhost:9090"},
+			expected:  "http_requests_total{instance=\"localhost:9090\"} 42\n",
+		},
+		{
+			name:      "multiple metrics",
+			input:     "metric1 10\nmetric2{label=\"value\"} 20\n# COMMENT\nmetric3 30\n",
+			addLabels: map[string]string{"instance": "localhost:9090"},
+			expected:  "metric1{instance=\"localhost:9090\"} 10\nmetric2{label=\"value\",instance=\"localhost:9090\"} 20\n# COMMENT\nmetric3{instance=\"localhost:9090\"} 30\n",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			inputReader := strings.NewReader(tc.input)
+			outputBuffer := &bytes.Buffer{}
+
+			err := prometheus.RelabelTextStream(outputBuffer, inputReader, tc.addLabels)
+			require.NoError(t, err)
+
+			actual := outputBuffer.String()
+			require.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

We add extra labels (hostname and installation id) to the Prometheus metrics output.
Previously we were parsing the incoming streams (from Envoy and internal ones) with `expfmt` prometheus library, updated each entry with extra labels and encoded back.

Unfortunately in a large streams that creates a significant GC pressure as a lot of small objects are created and destroyed.

This PR tries to do metric label augmentation with minimal GC allocations. It also adds a runtime flag `add_extra_metrics_labels` that would disable adding extra labels entirely, if they are not explicitly used during queries. 

## Related issues

Ref: https://linear.app/pomerium/issue/ENG-2117
Ref: https://github.com/pomerium/pomerium/issues/5378

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
