### PR TITLE
proxy: use querier cache for user info

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"slices"
-	"time"
 
 	"github.com/rs/zerolog"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -31,7 +30,6 @@ type Authorize struct {
 	store             *store.Store
 	currentConfig     *atomicutil.Value[*config.Config]
 	accessTracker     *AccessTracker
-	globalCache       storage.Cache
 	groupsCacheWarmer *cacheWarmer
 
 	tracerProvider oteltrace.TracerProvider
@@ -45,7 +43,6 @@ func New(ctx context.Context, cfg *config.Config) (*Authorize, error) {
 	a := &Authorize{
 		currentConfig:  atomicutil.NewValue(&config.Config{Options: new(config.Options)}),
 		store:          store.New(),
-		globalCache:    storage.NewGlobalCache(time.Minute),
 		tracerProvider: tracerProvider,
 		tracer:         tracer,
 	}
@@ -57,7 +54,7 @@ func New(ctx context.Context, cfg *config.Config) (*Authorize, error) {
 	}
 	a.state = atomicutil.NewValue(state)
 
-	a.groupsCacheWarmer = newCacheWarmer(state.dataBrokerClientConnection, a.globalCache, directory.GroupRecordType)
+	a.groupsCacheWarmer = newCacheWarmer(state.dataBrokerClientConnection, storage.GlobalCache, directory.GroupRecordType)
 	return a, nil
 }
 

--- a/authorize/databroker_test.go
+++ b/authorize/databroker_test.go
@@ -2,7 +2,6 @@ package authorize
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -12,44 +11,8 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
-	"github.com/pomerium/pomerium/pkg/grpcutil"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
-
-func Test_getDataBrokerRecord(t *testing.T) {
-	t.Parallel()
-
-	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
-	t.Cleanup(clearTimeout)
-
-	for _, tc := range []struct {
-		name                                   string
-		recordVersion, queryVersion            uint64
-		underlyingQueryCount, cachedQueryCount int
-	}{
-		{"cached", 1, 1, 1, 2},
-		{"invalidated", 1, 2, 3, 4},
-	} {
-		tc := tc
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			s1 := &session.Session{Id: "s1", Version: fmt.Sprint(tc.recordVersion)}
-
-			sq := storage.NewStaticQuerier(s1)
-			cq := storage.NewCachingQuerier(sq, storage.NewGlobalCache(time.Minute))
-			qctx := storage.WithQuerier(ctx, cq)
-
-			s, err := getDataBrokerRecord(qctx, grpcutil.GetTypeURL(s1), s1.GetId(), tc.queryVersion)
-			assert.NoError(t, err)
-			assert.NotNil(t, s)
-
-			s, err = getDataBrokerRecord(qctx, grpcutil.GetTypeURL(s1), s1.GetId(), tc.queryVersion)
-			assert.NoError(t, err)
-			assert.NotNil(t, s)
-		})
-	}
-}
 
 func TestAuthorize_getDataBrokerSessionOrServiceAccount(t *testing.T) {
 	t.Parallel()

--- a/pkg/grpc/databroker/databroker.go
+++ b/pkg/grpc/databroker/databroker.go
@@ -3,14 +3,12 @@ package databroker
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 
 	"google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
-	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 
@@ -51,34 +49,6 @@ func Get(ctx context.Context, client DataBrokerServiceClient, object recordObjec
 	}
 
 	return res.GetRecord().GetData().UnmarshalTo(object)
-}
-
-// GetViaJSON gets a record from the databroker, marshals it to JSON, and then unmarshals it to the given type.
-func GetViaJSON[T any](ctx context.Context, client DataBrokerServiceClient, recordType, recordID string) (*T, error) {
-	res, err := client.Get(ctx, &GetRequest{
-		Type: recordType,
-		Id:   recordID,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	msg, err := res.GetRecord().GetData().UnmarshalNew()
-	if err != nil {
-		return nil, err
-	}
-
-	bs, err := protojson.Marshal(msg)
-	if err != nil {
-		return nil, err
-	}
-
-	var obj T
-	err = json.Unmarshal(bs, &obj)
-	if err != nil {
-		return nil, err
-	}
-	return &obj, nil
 }
 
 // Put puts a record into the databroker.

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -107,3 +107,6 @@ func (cache *globalCache) set(expiry time.Time, key, value []byte) {
 	cache.fastcache.Set(key, item)
 	cache.mu.Unlock()
 }
+
+// GlobalCache is a global cache with a TTL of one minute.
+var GlobalCache = NewGlobalCache(time.Minute)

--- a/pkg/storage/querier_test.go
+++ b/pkg/storage/querier_test.go
@@ -1,0 +1,101 @@
+package storage_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/pomerium/datasource/pkg/directory"
+	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/grpcutil"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+func TestGetDataBrokerRecord(t *testing.T) {
+	t.Parallel()
+
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	t.Cleanup(clearTimeout)
+
+	for _, tc := range []struct {
+		name                                   string
+		recordVersion, queryVersion            uint64
+		underlyingQueryCount, cachedQueryCount int
+	}{
+		{"cached", 1, 1, 1, 2},
+		{"invalidated", 1, 2, 3, 4},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			s1 := &session.Session{Id: "s1", Version: fmt.Sprint(tc.recordVersion)}
+
+			sq := storage.NewStaticQuerier(s1)
+			cq := storage.NewCachingQuerier(sq, storage.NewGlobalCache(time.Minute))
+			qctx := storage.WithQuerier(ctx, cq)
+
+			s, err := storage.GetDataBrokerRecord(qctx, grpcutil.GetTypeURL(s1), s1.GetId(), tc.queryVersion)
+			assert.NoError(t, err)
+			assert.NotNil(t, s)
+
+			s, err = storage.GetDataBrokerRecord(qctx, grpcutil.GetTypeURL(s1), s1.GetId(), tc.queryVersion)
+			assert.NoError(t, err)
+			assert.NotNil(t, s)
+		})
+	}
+}
+
+func TestGetDataBrokerMessage(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.GetContext(t, time.Minute)
+
+	s1 := &session.Session{Id: "s1"}
+	sq := storage.NewStaticQuerier(s1)
+	cq := storage.NewCachingQuerier(sq, storage.NewGlobalCache(time.Minute))
+	qctx := storage.WithQuerier(ctx, cq)
+
+	s2, err := storage.GetDataBrokerMessage[session.Session](qctx, "s1", 0)
+	assert.NoError(t, err)
+	assert.Empty(t, cmp.Diff(s1, s2, protocmp.Transform()))
+
+	_, err = storage.GetDataBrokerMessage[session.Session](qctx, "s2", 0)
+	assert.ErrorIs(t, err, storage.ErrNotFound)
+}
+
+func TestGetDataBrokerObjectViaJSON(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.GetContext(t, time.Minute)
+
+	du1 := &directory.User{
+		ID:          "u1",
+		Email:       "u1@example.com",
+		DisplayName: "User 1!",
+	}
+	sq := storage.NewStaticQuerier(newDirectoryUserRecord(du1))
+	cq := storage.NewCachingQuerier(sq, storage.NewGlobalCache(time.Minute))
+	qctx := storage.WithQuerier(ctx, cq)
+
+	du2, err := storage.GetDataBrokerObjectViaJSON[directory.User](qctx, directory.UserRecordType, "u1", 0)
+	assert.NoError(t, err)
+	assert.Empty(t, cmp.Diff(du1, du2, protocmp.Transform()))
+}
+
+func newDirectoryUserRecord(directoryUser *directory.User) *databroker.Record {
+	m := map[string]any{}
+	bs, _ := json.Marshal(directoryUser)
+	_ = json.Unmarshal(bs, &m)
+	s, _ := structpb.NewStruct(m)
+	return storage.NewStaticRecord(directory.UserRecordType, s)
+}

--- a/proxy/data_test.go
+++ b/proxy/data_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/protoutil"
+	"github.com/pomerium/pomerium/pkg/storage"
 )
 
 func Test_getUserInfoData(t *testing.T) {
@@ -65,6 +66,7 @@ func Test_getUserInfoData(t *testing.T) {
 		proxy, err := New(ctx, &config.Config{Options: opts})
 		require.NoError(t, err)
 		proxy.state.Load().dataBrokerClient = client
+		ctx = storage.WithQuerier(ctx, storage.NewQuerier(client))
 
 		require.NoError(t, databrokerpb.PutMulti(ctx, client,
 			makeRecord(&session.Session{
@@ -81,7 +83,7 @@ func Test_getUserInfoData(t *testing.T) {
 				"group_ids": []any{"G1", "G2", "G3"},
 			})))
 
-		r := httptest.NewRequest(http.MethodGet, "/.pomerium/", nil)
+		r := httptest.NewRequestWithContext(ctx, http.MethodGet, "/.pomerium/", nil)
 		r.Header.Set("Authorization", "Bearer Pomerium-"+encodeSession(t, opts, &sessions.State{
 			ID: "S1",
 		}))
@@ -89,7 +91,9 @@ func Test_getUserInfoData(t *testing.T) {
 		assert.Equal(t, "S1", data.Session.Id)
 		assert.Equal(t, "U1", data.User.Id)
 		assert.True(t, data.IsEnterprise)
-		assert.Equal(t, []string{"G1", "G2", "G3"}, data.DirectoryUser.GroupIDs)
+		if assert.NotNil(t, data.DirectoryUser) {
+			assert.Equal(t, []string{"G1", "G2", "G3"}, data.DirectoryUser.GroupIDs)
+		}
 	})
 }
 

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 	"github.com/pomerium/pomerium/internal/telemetry/trace"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/storage"
 	"github.com/pomerium/pomerium/proxy/portal"
 )
 
@@ -124,6 +125,8 @@ func (p *Proxy) setHandlers(ctx context.Context, opts *config.Options) error {
 	r.StrictSlash(true)
 	// dashboard handlers are registered to all routes
 	r = p.registerDashboardHandlers(r, opts)
+	// attach the querier to the context
+	r.Use(p.querierMiddleware)
 	r.Use(trace.NewHTTPMiddleware(otelhttp.WithTracerProvider(p.tracerProvider)))
 
 	p.currentRouter.Store(r)
@@ -132,4 +135,17 @@ func (p *Proxy) setHandlers(ctx context.Context, opts *config.Options) error {
 
 func (p *Proxy) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	p.currentRouter.Load().ServeHTTP(w, r)
+}
+
+func (p *Proxy) querierMiddleware(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		ctx = storage.WithQuerier(ctx, storage.NewCachingQuerier(
+			storage.NewQuerier(p.state.Load().dataBrokerClient),
+			storage.GlobalCache,
+		))
+		r = r.WithContext(ctx)
+
+		h.ServeHTTP(w, r)
+	})
 }

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pomerium/pomerium/internal/authenticateflow"
 	"github.com/pomerium/pomerium/pkg/grpc"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/storage"
 )
 
 var outboundGRPCConnection = new(grpc.CachedOutboundGRPClientConn)
@@ -87,19 +88,16 @@ func newProxyStateFromConfig(ctx context.Context, tracerProvider oteltrace.Trace
 
 	state.incomingIDPTokenSessionCreator = config.NewIncomingIDPTokenSessionCreator(
 		func(ctx context.Context, recordType, recordID string) (*databroker.Record, error) {
-			res, err := state.dataBrokerClient.Get(ctx, &databroker.GetRequest{
-				Type: recordType,
-				Id:   recordID,
-			})
-			if err != nil {
-				return nil, err
-			}
-			return res.GetRecord(), nil
+			return storage.GetDataBrokerRecord(ctx, recordType, recordID, 0)
 		},
 		func(ctx context.Context, records []*databroker.Record) error {
 			_, err := state.dataBrokerClient.Put(ctx, &databroker.PutRequest{
 				Records: records,
 			})
+			if err != nil {
+				return err
+			}
+			storage.InvalidateCacheForDataBrokerRecords(ctx, records...)
 			return err
 		},
 	)


### PR DESCRIPTION
## Summary
Update the proxy service to use the same querier interface and cache as the authorize service. This should improve performance for redundant queries, like group information. In all-in-one mode it will also have the added benefit of using the same cached data that was used for authorization.

## Related issues
- [ENG-2160](https://linear.app/pomerium/issue/ENG-2160/core-inefficient-userinfo-groups)
 

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
