### PR TITLE
config: fix layered bearer_token_format and idp_access_token_allowed_audiences

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -1509,8 +1509,6 @@ func (o *Options) ApplySettings(ctx context.Context, certsIndex *cryptutil.Certi
 	if settings.IdpAccessTokenAllowedAudiences != nil {
 		values := slices.Clone(settings.IdpAccessTokenAllowedAudiences.Values)
 		o.IDPAccessTokenAllowedAudiences = &values
-	} else {
-		o.IDPAccessTokenAllowedAudiences = nil
 	}
 	setSlice(&o.AuthorizeURLStrings, settings.AuthorizeServiceUrls)
 	set(&o.AuthorizeInternalURLString, settings.AuthorizeInternalServiceUrl)
@@ -1520,7 +1518,7 @@ func (o *Options) ApplySettings(ctx context.Context, certsIndex *cryptutil.Certi
 	set(&o.SigningKey, settings.SigningKey)
 	setMap(&o.SetResponseHeaders, settings.SetResponseHeaders)
 	setMap(&o.JWTClaimsHeaders, settings.JwtClaimsHeaders)
-	o.BearerTokenFormat = BearerTokenFormatFromPB(settings.BearerTokenFormat)
+	setOptional(&o.BearerTokenFormat, BearerTokenFormatFromPB(settings.BearerTokenFormat))
 	if len(settings.JwtGroupsFilter) > 0 {
 		o.JWTGroupsFilter = NewJWTGroupsFilter(settings.JwtGroupsFilter)
 	}


### PR DESCRIPTION
## Summary
The `bearer_token_format` and `idp_access_token_allowed_audiences` options are currently always being overwritten when applying protobuf config. When there are two sources of configuration (for example the ingress controller and the enterprise console), the last applied configuration should take precedence, but since these fields are optional, they should only overwrite the existing configuration option if they are set, otherwise the current value should be preserved.


## Related issues
- [ENG-2171](https://linear.app/pomerium/issue/ENG-2171/idp-token-configuration-issue)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
