### PR TITLE
Increase some test timeouts

### DIFF
--- a/internal/telemetry/trace/debug_test.go
+++ b/internal/telemetry/trace/debug_test.go
@@ -74,7 +74,7 @@ func TestSpanObserver(t *testing.T) {
 
 		waitOkToExit.Store(true)
 		obs.Observe(Span(5).ID())
-		assert.Eventually(t, waitExited.Load, 10*time.Millisecond, 1*time.Millisecond)
+		assert.Eventually(t, waitExited.Load, 100*time.Millisecond, 10*time.Millisecond)
 	})
 
 	t.Run("new references observed during wait", func(t *testing.T) {
@@ -122,7 +122,7 @@ func TestSpanObserver(t *testing.T) {
 		waitOkToExit.Store(true)
 		obs.Observe(Span(7).ID())
 		assert.Equal(t, []oteltrace.SpanID{}, obs.XUnobservedIDs())
-		assert.Eventually(t, waitExited.Load, 10*time.Millisecond, 1*time.Millisecond)
+		assert.Eventually(t, waitExited.Load, 100*time.Millisecond, 10*time.Millisecond)
 	})
 
 	t.Run("multiple waiters", func(t *testing.T) {
@@ -147,7 +147,7 @@ func TestSpanObserver(t *testing.T) {
 
 		assert.Eventually(t, func() bool {
 			return waitersExited.Load() == 10
-		}, 10*time.Millisecond, 1*time.Millisecond)
+		}, 100*time.Millisecond, 10*time.Millisecond)
 	})
 }
 


### PR DESCRIPTION
## Summary

Should fix these test flakes:
```
--- FAIL: TestSpanObserver (0.12s)
    --- FAIL: TestSpanObserver/new_references_observed_during_wait (0.08s)
        debug_test.go:125: 
            	Error Trace:	/Users/runner/work/pomerium/pomerium/internal/telemetry/trace/debug_test.go:125
            	Error:      	Condition never satisfied
            	Test:       	TestSpanObserver/new_references_observed_during_wait
    --- FAIL: TestSpanObserver/multiple_waiters (0.02s)
        debug_test.go:148: 
            	Error Trace:	/Users/runner/work/pomerium/pomerium/internal/telemetry/trace/debug_test.go:148
            	Error:      	Condition never satisfied
            	Test:       	TestSpanObserver/multiple_waiters
```

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
