### PR TITLE
authorize: return 403 on invalid sessions

### DIFF
--- a/config/session.go
+++ b/config/session.go
@@ -202,7 +202,7 @@ func (c *incomingIDPTokenSessionCreator) createSessionAccessToken(
 		if err != nil {
 			return nil, fmt.Errorf("error verifying access token: %w", err)
 		} else if !res.Valid {
-			return nil, fmt.Errorf("invalid access token")
+			return nil, fmt.Errorf("%w: invalid access token", sessions.ErrInvalidSession)
 		}
 
 		s = c.newSessionFromIDPClaims(cfg, sessionID, res.Claims)
@@ -265,7 +265,7 @@ func (c *incomingIDPTokenSessionCreator) createSessionForIdentityToken(
 		if err != nil {
 			return nil, fmt.Errorf("error verifying identity token: %w", err)
 		} else if !res.Valid {
-			return nil, fmt.Errorf("invalid identity token")
+			return nil, fmt.Errorf("%w: invalid identity token", sessions.ErrInvalidSession)
 		}
 
 		s = c.newSessionFromIDPClaims(cfg, sessionID, res.Claims)

--- a/internal/sessions/errors.go
+++ b/internal/sessions/errors.go
@@ -8,6 +8,9 @@ var (
 	// ErrNoSessionFound is the error for when no session is found.
 	ErrNoSessionFound = errors.New("internal/sessions: session is not found")
 
+	// ErrInvalidSession is the error for when a session is invalid.
+	ErrInvalidSession = errors.New("internal/sessions: invalid session")
+
 	// ErrMalformed is the error for when a session is found but is malformed.
 	ErrMalformed = errors.New("internal/sessions: session is malformed")
 


### PR DESCRIPTION
## Summary
When loading sessions, if the reason a session failed to load is because the session is invalid, return a 403 instead of treating it like a missing session (resulting in a 302).

## Related issues
- [ENG-2172](https://linear.app/pomerium/issue/ENG-2172/core-failed-idp-token-audience-check-results-in-redirect)

## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
