### PR TITLE
metrics: fix an apparent metric setup error

### DIFF
--- a/internal/telemetry/metrics/info.go
+++ b/internal/telemetry/metrics/info.go
@@ -240,11 +240,11 @@ var (
 		Measure:     identityManagerLastSessionRefreshSuccess,
 		Aggregation: view.Count(),
 	}
-	// IdentityManagerLastSessionRefreshErrorView contains user refresh errors counter
+	// IdentityManagerLastSessionRefreshErrorView contains session refresh errors counter
 	IdentityManagerLastSessionRefreshErrorView = &view.View{
-		Name:        identityManagerLastUserRefreshError.Name(),
-		Description: identityManagerLastUserRefreshError.Description(),
-		Measure:     identityManagerLastUserRefreshError,
+		Name:        identityManagerLastSessionRefreshError.Name(),
+		Description: identityManagerLastSessionRefreshError.Description(),
+		Measure:     identityManagerLastSessionRefreshError,
 		Aggregation: view.Count(),
 	}
 	// IdentityManagerLastSessionRefreshSuccessTimestampView contains successful session refresh counter


### PR DESCRIPTION
## Summary

The IdentityManagerLastSessionRefreshErrorView appears to be a duplicate of IdentityManagerLastUserRefreshErrorView. Adjust it to use the matching identityManagerLastSessionRefreshError instead.

## Related issues

https://linear.app/pomerium/issue/ENG-2190/core-identitymanagerlastsessionrefresherrorview-appears-to-be

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
