### PR TITLE
only support loading idp tokens via bearer tokens

### DIFF
--- a/config/session.go
+++ b/config/session.go
@@ -405,22 +405,8 @@ func (cfg *Config) GetIncomingIDPAccessTokenForPolicy(policy *Policy, r *http.Re
 		bearerTokenFormat = *policy.BearerTokenFormat
 	}
 
-	if token := r.Header.Get(httputil.HeaderPomeriumIDPAccessToken); token != "" {
-		return token, true
-	}
-
 	if auth := r.Header.Get(httputil.HeaderAuthorization); auth != "" {
-		prefix := httputil.AuthorizationTypePomeriumIDPAccessToken + " "
-		if strings.HasPrefix(strings.ToLower(auth), strings.ToLower(prefix)) {
-			return auth[len(prefix):], true
-		}
-
-		prefix = "Bearer " + httputil.AuthorizationTypePomeriumIDPAccessToken + "-"
-		if strings.HasPrefix(strings.ToLower(auth), strings.ToLower(prefix)) {
-			return auth[len(prefix):], true
-		}
-
-		prefix = "Bearer "
+		prefix := "Bearer "
 		if strings.HasPrefix(strings.ToLower(auth), strings.ToLower(prefix)) &&
 			bearerTokenFormat == BearerTokenFormatIDPAccessToken {
 			return auth[len(prefix):], true
@@ -440,22 +426,8 @@ func (cfg *Config) GetIncomingIDPIdentityTokenForPolicy(policy *Policy, r *http.
 		bearerTokenFormat = *policy.BearerTokenFormat
 	}
 
-	if token := r.Header.Get(httputil.HeaderPomeriumIDPIdentityToken); token != "" {
-		return token, true
-	}
-
 	if auth := r.Header.Get(httputil.HeaderAuthorization); auth != "" {
-		prefix := httputil.AuthorizationTypePomeriumIDPIdentityToken + " "
-		if strings.HasPrefix(strings.ToLower(auth), strings.ToLower(prefix)) {
-			return auth[len(prefix):], true
-		}
-
-		prefix = "Bearer " + httputil.AuthorizationTypePomeriumIDPIdentityToken + "-"
-		if strings.HasPrefix(strings.ToLower(auth), strings.ToLower(prefix)) {
-			return auth[len(prefix):], true
-		}
-
-		prefix = "Bearer "
+		prefix := "Bearer "
 		if strings.HasPrefix(strings.ToLower(auth), strings.ToLower(prefix)) &&
 			bearerTokenFormat == BearerTokenFormatIDPIdentityToken {
 			return auth[len(prefix):], true

--- a/config/session_test.go
+++ b/config/session_test.go
@@ -207,24 +207,6 @@ func TestGetIncomingIDPAccessTokenForPolicy(t *testing.T) {
 			expectedOK: false,
 		},
 		{
-			name:          "custom header",
-			headers:       http.Header{"X-Pomerium-Idp-Access-Token": {"access token via custom header"}},
-			expectedOK:    true,
-			expectedToken: "access token via custom header",
-		},
-		{
-			name:          "custom authorization",
-			headers:       http.Header{"Authorization": {"Pomerium-Idp-Access-Token access token via custom authorization"}},
-			expectedOK:    true,
-			expectedToken: "access token via custom authorization",
-		},
-		{
-			name:          "custom bearer",
-			headers:       http.Header{"Authorization": {"Bearer Pomerium-Idp-Access-Token-access token via custom bearer"}},
-			expectedOK:    true,
-			expectedToken: "access token via custom bearer",
-		},
-		{
 			name:       "bearer disabled",
 			headers:    http.Header{"Authorization": {"Bearer access token via bearer"}},
 			expectedOK: false,
@@ -288,24 +270,6 @@ func TestGetIncomingIDPIdentityTokenForPolicy(t *testing.T) {
 		{
 			name:       "empty headers",
 			expectedOK: false,
-		},
-		{
-			name:          "custom header",
-			headers:       http.Header{"X-Pomerium-Idp-Identity-Token": {"identity token via custom header"}},
-			expectedOK:    true,
-			expectedToken: "identity token via custom header",
-		},
-		{
-			name:          "custom authorization",
-			headers:       http.Header{"Authorization": {"Pomerium-Idp-Identity-Token identity token via custom authorization"}},
-			expectedOK:    true,
-			expectedToken: "identity token via custom authorization",
-		},
-		{
-			name:          "custom bearer",
-			headers:       http.Header{"Authorization": {"Bearer Pomerium-Idp-Identity-Token-identity token via custom bearer"}},
-			expectedOK:    true,
-			expectedToken: "identity token via custom bearer",
 		},
 		{
 			name:       "bearer disabled",
@@ -496,12 +460,14 @@ func TestIncomingIDPTokenSessionCreator_CreateSession(t *testing.T) {
 		cfg.Options.AuthenticateURLString = srv.URL
 		cfg.Options.ClientSecret = "CLIENT_SECRET_1"
 		cfg.Options.ClientID = "CLIENT_ID_1"
+		bearerTokenFormatIDPAccessToken := BearerTokenFormatIDPAccessToken
+		cfg.Options.BearerTokenFormat = &bearerTokenFormatIDPAccessToken
 		route := &Policy{}
 		route.IDPClientSecret = "CLIENT_SECRET_2"
 		route.IDPClientID = "CLIENT_ID_2"
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.example.com", nil)
 		require.NoError(t, err)
-		req.Header.Set(httputil.HeaderPomeriumIDPAccessToken, "ACCESS_TOKEN")
+		req.Header.Set("Authorization", "Bearer ACCESS_TOKEN")
 		c := NewIncomingIDPTokenSessionCreator(
 			func(_ context.Context, _, _ string) (*databroker.Record, error) {
 				return nil, storage.ErrNotFound
@@ -537,12 +503,14 @@ func TestIncomingIDPTokenSessionCreator_CreateSession(t *testing.T) {
 		cfg.Options.AuthenticateURLString = srv.URL
 		cfg.Options.ClientSecret = "CLIENT_SECRET_1"
 		cfg.Options.ClientID = "CLIENT_ID_1"
+		bearerTokenFormatIDPIdentityToken := BearerTokenFormatIDPIdentityToken
+		cfg.Options.BearerTokenFormat = &bearerTokenFormatIDPIdentityToken
 		route := &Policy{}
 		route.IDPClientSecret = "CLIENT_SECRET_2"
 		route.IDPClientID = "CLIENT_ID_2"
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.example.com", nil)
 		require.NoError(t, err)
-		req.Header.Set(httputil.HeaderPomeriumIDPIdentityToken, "IDENTITY_TOKEN")
+		req.Header.Set("Authorization", "Bearer IDENTITY_TOKEN")
 		c := NewIncomingIDPTokenSessionCreator(
 			func(_ context.Context, _, _ string) (*databroker.Record, error) {
 				return nil, storage.ErrNotFound

--- a/internal/httputil/headers.go
+++ b/internal/httputil/headers.go
@@ -21,9 +21,7 @@ const (
 	// HeaderPomeriumAuthorization is the header key for a pomerium authorization JWT. It
 	// can be used in place of the standard authorization header if that header is being
 	// used by upstream applications.
-	HeaderPomeriumAuthorization    = "x-pomerium-authorization"
-	HeaderPomeriumIDPAccessToken   = "x-pomerium-idp-access-token"   //nolint: gosec
-	HeaderPomeriumIDPIdentityToken = "x-pomerium-idp-identity-token" //nolint: gosec
+	HeaderPomeriumAuthorization = "x-pomerium-authorization"
 	// HeaderPomeriumResponse is set when pomerium itself creates a response,
 	// as opposed to the upstream application and can be used to distinguish
 	// between an application error, and a pomerium related error when debugging.

--- a/proxy/data_test.go
+++ b/proxy/data_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pomerium/datasource/pkg/directory"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/databroker"
-	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/sessions"
 	"github.com/pomerium/pomerium/internal/testutil"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
@@ -48,7 +47,7 @@ func Test_getUserInfoData(t *testing.T) {
 		proxy.state.Load().dataBrokerClient = client
 
 		r := httptest.NewRequest(http.MethodGet, "/.pomerium/", nil)
-		r.Header.Set(httputil.HeaderPomeriumIDPAccessToken, "ACCESS_TOKEN")
+		r.Header.Set("Authorization", "Bearer ACCESS_TOKEN")
 		data := proxy.getUserInfoData(r)
 		assert.NotNil(t, data.Session)
 		assert.NotNil(t, data.User)

--- a/proxy/proxy_test.go
+++ b/proxy/proxy_test.go
@@ -30,6 +30,8 @@ func testOptions(t *testing.T) *config.Options {
 	opts.Services = config.ServiceAll
 	opts.SharedKey = "80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ="
 	opts.CookieSecret = "OromP1gurwGWjQPYb1nNgSxtbVB5NnLzX6z5WOKr0Yw="
+	bearerTokenFormatIDPAccessToken := config.BearerTokenFormatIDPAccessToken
+	opts.BearerTokenFormat = &bearerTokenFormatIDPAccessToken
 
 	hpkePrivateKey, err := opts.GetHPKEPrivateKey()
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
Instead of 

```
X-Pomerium-IDP-Access-Token: <TOKEN>
Authorization: Pomerium-IDP-Access-Token <TOKEN>
Authorization: Bearer Pomerium-IDP-Access-Token-<TOKEN>
X-Pomerium-IDP-Identity-Token: <TOKEN>
Authorization: Pomerium-IDP-Identity-Token <TOKEN>
Authorization: Bearer Pomerium-IDP-Identity-Token-<TOKEN>
```
Only support:

```
Authorization: Bearer Token
```

With the corresponding bearer token format option set.


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
