### PR TITLE
allow access to the routes portal without logging in, change status code

### DIFF
--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -537,7 +537,7 @@ func TestAuthenticate_userInfo(t *testing.T) {
 			"/",
 			true,
 			&mstore.Store{Encrypted: true, Session: &sessions.State{ID: "SESSION_ID", IssuedAt: jwt.NewNumericDate(now)}},
-			http.StatusOK,
+			http.StatusUnauthorized,
 		},
 		{
 			"signed redirect",

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -389,7 +389,11 @@ func TestAuthorize_deniedResponse(t *testing.T) {
 				"headers": [
 					{
 						"appendAction": "OVERWRITE_IF_EXISTS_OR_ADD",
-						"header": { "key": "Content-Type", "value": "text/html; charset=UTF-8" }
+						"header": { "key": "Cache-Control", "value": "no-cache, must-revalidate" }
+					},
+					{
+						"appendAction": "OVERWRITE_IF_EXISTS_OR_ADD",
+						"header": { "key": "Content-Type", "value": "text/html; charset=utf-8" }
 					},
 					{
 						"appendAction": "OVERWRITE_IF_EXISTS_OR_ADD",

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -243,8 +243,6 @@ var internalPathsNeedingLogin = set.From([]string{
 	"/.pomerium/jwt",
 	"/.pomerium/user",
 	"/.pomerium/webauthn",
-	"/.pomerium/routes",
-	"/.pomerium/api/v1/routes",
 })
 
 func (e *Evaluator) evaluateInternal(_ context.Context, req *Request) (*PolicyResponse, error) {

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -243,6 +243,7 @@ var internalPathsNeedingLogin = set.From([]string{
 	"/.pomerium/jwt",
 	"/.pomerium/user",
 	"/.pomerium/webauthn",
+	"/.pomerium/api/v1/routes",
 })
 
 func (e *Evaluator) evaluateInternal(_ context.Context, req *Request) (*PolicyResponse, error) {

--- a/internal/handlers/device-enrolled.go
+++ b/internal/handlers/device-enrolled.go
@@ -10,6 +10,6 @@ import (
 // DeviceEnrolled displays an HTML page informing the user that they've successfully enrolled a device.
 func DeviceEnrolled(data UserInfoData) http.Handler {
 	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		return ui.ServePage(w, r, "DeviceEnrolled", "Device Enrolled", data.ToJSON())
+		return ui.ServePage(w, r, http.StatusOK, "DeviceEnrolled", "Device Enrolled", data.ToJSON())
 	})
 }

--- a/internal/handlers/signedout.go
+++ b/internal/handlers/signedout.go
@@ -28,6 +28,6 @@ func SignedOut(data SignedOutData) http.Handler {
 		}
 
 		// otherwise show the signed-out page
-		return ui.ServePage(w, r, "SignedOut", "Signed Out", data.ToJSON())
+		return ui.ServePage(w, r, http.StatusOK, "SignedOut", "Signed Out", data.ToJSON())
 	})
 }

--- a/internal/handlers/signout.go
+++ b/internal/handlers/signout.go
@@ -25,6 +25,6 @@ func (data SignOutConfirmData) ToJSON() map[string]any {
 // SignOutConfirm returns a handler that renders the sign out confirm page.
 func SignOutConfirm(data SignOutConfirmData) http.Handler {
 	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		return ui.ServePage(w, r, "SignOutConfirm", "Confirm Sign Out", data.ToJSON())
+		return ui.ServePage(w, r, http.StatusOK, "SignOutConfirm", "Confirm Sign Out", data.ToJSON())
 	})
 }

--- a/internal/handlers/userinfo.go
+++ b/internal/handlers/userinfo.go
@@ -108,6 +108,10 @@ func (data UserInfoData) userJSON() map[string]any {
 // UserInfo returns a handler that renders the user info page.
 func UserInfo(data UserInfoData) http.Handler {
 	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		return ui.ServePage(w, r, "UserInfo", "User Info Dashboard", data.ToJSON())
+		statusCode := http.StatusOK
+		if data.Session == nil {
+			statusCode = http.StatusUnauthorized
+		}
+		return ui.ServePage(w, r, statusCode, "UserInfo", "User Info Dashboard", data.ToJSON())
 	})
 }

--- a/internal/handlers/webauthn/webauthn.go
+++ b/internal/handlers/webauthn/webauthn.go
@@ -402,7 +402,7 @@ func (h *Handler) handleView(w http.ResponseWriter, r *http.Request, state *Stat
 		"selfUrl":         r.URL.String(),
 	}
 	httputil.AddBrandingOptionsToMap(m, state.BrandingOptions)
-	return ui.ServePage(w, r, "WebAuthnRegistration", "Device Registration", m)
+	return ui.ServePage(w, r, http.StatusOK, "WebAuthnRegistration", "Device Registration", m)
 }
 
 func (h *Handler) saveSessionAndRedirect(w http.ResponseWriter, r *http.Request, state *State, rawRedirectURI string) error {

--- a/internal/httputil/errors.go
+++ b/internal/httputil/errors.go
@@ -100,9 +100,7 @@ func (e *HTTPError) ErrorResponse(ctx context.Context, w http.ResponseWriter, r 
 	}
 	AddBrandingOptionsToMap(m, e.BrandingOptions)
 
-	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
-	w.WriteHeader(response.Status)
-	if err := ui.ServePage(w, r, "Error", fmt.Sprintf("%d %s", response.Status, response.StatusText), m); err != nil {
+	if err := ui.ServePage(w, r, response.Status, "Error", fmt.Sprintf("%d %s", response.Status, response.StatusText), m); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/proxy/handlers_portal.go
+++ b/proxy/handlers_portal.go
@@ -20,7 +20,11 @@ func (p *Proxy) routesPortalHTML(w http.ResponseWriter, r *http.Request) error {
 	rs := p.getPortalRoutes(r.Context(), u)
 	m := u.ToJSON()
 	m["routes"] = rs
-	return ui.ServePage(w, r, "Routes", "Routes Portal", m)
+	statusCode := http.StatusOK
+	if u.Session == nil {
+		statusCode = http.StatusUnauthorized
+	}
+	return ui.ServePage(w, r, statusCode, "Routes", "Routes Portal", m)
 }
 
 func (p *Proxy) routesPortalJSON(w http.ResponseWriter, r *http.Request) error {

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -277,7 +277,7 @@ func TestLoadSessionState(t *testing.T) {
 		w := httptest.NewRecorder()
 		proxy.ServeHTTP(w, r)
 
-		assert.Equal(t, http.StatusOK, w.Code)
+		assert.Equal(t, http.StatusUnauthorized, w.Code)
 		assert.Contains(t, w.Body.String(), "window.POMERIUM_DATA")
 		assert.NotContains(t, w.Body.String(), "___SESSION_ID___")
 	})

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -41,7 +41,7 @@ func RenderPage(page, title string, data map[string]any) ([]byte, error) {
 }
 
 // ServePage serves the index.html page.
-func ServePage(w http.ResponseWriter, r *http.Request, page, title string, data map[string]any) error {
+func ServePage(w http.ResponseWriter, r *http.Request, statusCode int, page, title string, data map[string]any) error {
 	if data == nil {
 		data = make(map[string]any)
 	}
@@ -53,7 +53,9 @@ func ServePage(w http.ResponseWriter, r *http.Request, page, title string, data 
 	}
 
 	w.Header().Set("Cache-Control", "no-cache, must-revalidate")
-	http.ServeContent(w, r, "index.html", time.Time{}, bytes.NewReader(bs))
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(statusCode)
+	_, _ = w.Write(bs)
 	return nil
 }
 

--- a/ui/src/components/RoutesPage.tsx
+++ b/ui/src/components/RoutesPage.tsx
@@ -1,4 +1,6 @@
 import {
+  Alert,
+  AlertTitle,
   Avatar,
   Box,
   Card,
@@ -151,6 +153,13 @@ const RoutesPage: FC<RoutesPageProps> = ({ data }) => {
   return (
     <SidebarPage>
       <Stack spacing={2}>
+        {!data?.session?.id && (
+          <Alert severity="warning">
+            <AlertTitle>User Details Not Available</AlertTitle>
+            Have you signed in yet? <br />
+            <a href="/">{location.origin}</a>.
+          </Alert>
+        )}
         {data?.routes?.length > 0 ? (
           <>
             <RoutesSection


### PR DESCRIPTION
## Summary
Make it so that if you want to get to the routes portal you no longer need to be logged in. Instead you will see a warning box, just like the user info page.

Also update the status codes so that when not logged in these pages return a 401.

## Related issues
- [ENG-2199](https://linear.app/pomerium/issue/ENG-2199/core-user-info-endpoint-should-return-401-when-not-logged-in)
- #5549 


## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
