### PR TITLE
return errors according to accept header

### DIFF
--- a/config/envoyconfig/http_connection_manager.go
+++ b/config/envoyconfig/http_connection_manager.go
@@ -1,6 +1,7 @@
 package envoyconfig
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -56,6 +57,15 @@ func (b *Builder) buildLocalReplyConfig(
 		headers = toEnvoyHeaders(options.GetSetResponseHeaders())
 	}
 
+	jsonBody, err := json.MarshalIndent(map[string]any{
+		"requestId":  "%STREAM_ID%",
+		"status":     "%RESPONSE_CODE%",
+		"statusText": "%RESPONSE_CODE_DETAILS%",
+	}, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("error rendering error json for local reply: %w", err)
+	}
+
 	data := make(map[string]any)
 	httputil.AddBrandingOptionsToMap(data, options.BrandingOptions)
 	for k, v := range data {
@@ -70,61 +80,120 @@ func (b *Builder) buildLocalReplyConfig(
 	data["requestId"] = "%STREAM_ID%"
 	data["responseFlags"] = "%RESPONSE_FLAGS%"
 
-	bs, err := ui.RenderPage("Error", "Error", data)
+	htmlBody, err := ui.RenderPage("Error", "Error", data)
 	if err != nil {
 		return nil, fmt.Errorf("error rendering error page for local reply: %w", err)
 	}
 
+	responseFlagFilter := &envoy_config_accesslog_v3.AccessLogFilter_ResponseFlagFilter{
+		ResponseFlagFilter: &envoy_config_accesslog_v3.ResponseFlagFilter{
+			Flags: []string{
+				"DC",
+				"DF",
+				"DI",
+				"DO",
+				"DPE",
+				"DT",
+				"FI",
+				"IH",
+				"LH",
+				"LR",
+				"NC",
+				"NFCF",
+				"NR",
+				"OM",
+				"RFCF",
+				"RL",
+				"RLSE",
+				"SI",
+				// "UAEX", // excluded because this response is handled in the authorize service
+				"UC",
+				"UF",
+				"UH",
+				"UMSDR",
+				"UO",
+				"UPE",
+				"UR",
+				"URX",
+				"UT",
+			},
+		},
+	}
+
 	return &envoy_http_connection_manager.LocalReplyConfig{
-		Mappers: []*envoy_http_connection_manager.ResponseMapper{{
-			Filter: &envoy_config_accesslog_v3.AccessLogFilter{
-				FilterSpecifier: &envoy_config_accesslog_v3.AccessLogFilter_ResponseFlagFilter{
-					ResponseFlagFilter: &envoy_config_accesslog_v3.ResponseFlagFilter{
-						Flags: []string{
-							"DC",
-							"DF",
-							"DI",
-							"DO",
-							"DPE",
-							"DT",
-							"FI",
-							"IH",
-							"LH",
-							"LR",
-							"NC",
-							"NFCF",
-							"NR",
-							"OM",
-							"RFCF",
-							"RL",
-							"RLSE",
-							"SI",
-							// "UAEX", // excluded because this response is handled in the authorize service
-							"UC",
-							"UF",
-							"UH",
-							"UMSDR",
-							"UO",
-							"UPE",
-							"UR",
-							"URX",
-							"UT",
+		Mappers: []*envoy_http_connection_manager.ResponseMapper{
+			{
+				Filter: &envoy_config_accesslog_v3.AccessLogFilter{
+					FilterSpecifier: &envoy_config_accesslog_v3.AccessLogFilter_AndFilter{
+						AndFilter: &envoy_config_accesslog_v3.AndFilter{
+							Filters: []*envoy_config_accesslog_v3.AccessLogFilter{
+								{FilterSpecifier: responseFlagFilter},
+								{FilterSpecifier: &envoy_config_accesslog_v3.AccessLogFilter_MetadataFilter{
+									MetadataFilter: &envoy_config_accesslog_v3.MetadataFilter{
+										Matcher: buildLocalReplyTypeMatcher("plain"),
+									},
+								}},
+							},
 						},
 					},
 				},
-			},
-			BodyFormatOverride: &envoy_config_core_v3.SubstitutionFormatString{
-				ContentType: "text/html; charset=UTF-8",
-				Format: &envoy_config_core_v3.SubstitutionFormatString_TextFormatSource{
-					TextFormatSource: &envoy_config_core_v3.DataSource{
-						Specifier: &envoy_config_core_v3.DataSource_InlineBytes{
-							InlineBytes: bs,
+				BodyFormatOverride: &envoy_config_core_v3.SubstitutionFormatString{
+					ContentType: "text/plain; charset=UTF-8",
+					Format: &envoy_config_core_v3.SubstitutionFormatString_TextFormatSource{
+						TextFormatSource: &envoy_config_core_v3.DataSource{
+							Specifier: &envoy_config_core_v3.DataSource_InlineBytes{
+								// just return the json body for plain text
+								InlineBytes: jsonBody,
+							},
 						},
 					},
 				},
+				HeadersToAdd: headers,
 			},
-			HeadersToAdd: headers,
-		}},
+			{
+				Filter: &envoy_config_accesslog_v3.AccessLogFilter{
+					FilterSpecifier: &envoy_config_accesslog_v3.AccessLogFilter_AndFilter{
+						AndFilter: &envoy_config_accesslog_v3.AndFilter{
+							Filters: []*envoy_config_accesslog_v3.AccessLogFilter{
+								{FilterSpecifier: responseFlagFilter},
+								{FilterSpecifier: &envoy_config_accesslog_v3.AccessLogFilter_MetadataFilter{
+									MetadataFilter: &envoy_config_accesslog_v3.MetadataFilter{
+										Matcher: buildLocalReplyTypeMatcher("json"),
+									},
+								}},
+							},
+						},
+					},
+				},
+				BodyFormatOverride: &envoy_config_core_v3.SubstitutionFormatString{
+					ContentType: "application/json; charset=UTF-8",
+					Format: &envoy_config_core_v3.SubstitutionFormatString_TextFormatSource{
+						TextFormatSource: &envoy_config_core_v3.DataSource{
+							Specifier: &envoy_config_core_v3.DataSource_InlineBytes{
+								InlineBytes: jsonBody,
+							},
+						},
+					},
+				},
+				HeadersToAdd: headers,
+			},
+			{
+				Filter: &envoy_config_accesslog_v3.AccessLogFilter{
+					FilterSpecifier: responseFlagFilter,
+				},
+				BodyFormatOverride: &envoy_config_core_v3.SubstitutionFormatString{
+					ContentType: "text/html; charset=UTF-8",
+					Format: &envoy_config_core_v3.SubstitutionFormatString_TextFormatSource{
+						TextFormatSource: &envoy_config_core_v3.DataSource{
+							Specifier: &envoy_config_core_v3.DataSource_InlineBytes{
+								InlineBytes: htmlBody,
+							},
+						},
+					},
+				},
+				HeadersToAdd: headers,
+			},
+		},
 	}, nil
 }
 

--- a/config/envoyconfig/http_connection_manager_test.go
+++ b/config/envoyconfig/http_connection_manager_test.go
@@ -21,6 +21,18 @@ func Test_buildLocalReplyConfig(t *testing.T) {
 	lrc, err := b.buildLocalReplyConfig(opts)
 	require.NoError(t, err)
 	tmpl := string(lrc.Mappers[0].GetBodyFormatOverride().GetTextFormatSource().GetInlineBytes())
+	assert.Equal(t, `{
+  "requestId": "%STREAM_ID%",
+  "status": "%RESPONSE_CODE%",
+  "statusText": "%RESPONSE_CODE_DETAILS%"
+}`, tmpl)
+	tmpl = string(lrc.Mappers[1].GetBodyFormatOverride().GetTextFormatSource().GetInlineBytes())
+	assert.Equal(t, `{
+  "requestId": "%STREAM_ID%",
+  "status": "%RESPONSE_CODE%",
+  "statusText": "%RESPONSE_CODE_DETAILS%"
+}`, tmpl)
+	tmpl = string(lrc.Mappers[2].GetBodyFormatOverride().GetTextFormatSource().GetInlineBytes())
 	assert.Equal(t, `<!DOCTYPE html>
 <html lang="en">
   <head>

--- a/config/envoyconfig/listeners_main.go
+++ b/config/envoyconfig/listeners_main.go
@@ -164,6 +164,7 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 		LuaFilter(luascripts.ExtAuthzSetCookie),
 		LuaFilter(luascripts.CleanUpstream),
 		LuaFilter(luascripts.RewriteHeaders),
+		LuaFilter(luascripts.LocalReplyType),
 	}
 	// if we support http3 and this is the non-quic listener, add an alt-svc header indicating h3 is available
 	if !useQUIC && cfg.Options.CodecType == config.CodecTypeHTTP3 {

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -103,7 +103,7 @@ func TestBuildListeners(t *testing.T) {
 							}]
 						}
 					}
-				}`, httpConfig.Get("httpFilters.6").String(),
+				}`, httpConfig.Get("httpFilters.7").String(),
 					"should add alt-svc header")
 			case "quic-ingress":
 				hasQUIC = true

--- a/config/envoyconfig/lua.go
+++ b/config/envoyconfig/lua.go
@@ -14,6 +14,7 @@ var luascripts struct {
 	RemoveImpersonateHeaders     string
 	RewriteHeaders               string
 	SetClientCertificateMetadata string
+	LocalReplyType               string
 }
 
 func init() {
@@ -23,6 +24,7 @@ func init() {
 		"luascripts/remove-impersonate-headers.lua":      &luascripts.RemoveImpersonateHeaders,
 		"luascripts/rewrite-headers.lua":                 &luascripts.RewriteHeaders,
 		"luascripts/set-client-certificate-metadata.lua": &luascripts.SetClientCertificateMetadata,
+		"luascripts/local-reply-type.lua":                &luascripts.LocalReplyType,
 	}
 
 	err := fs.WalkDir(luaFS, "luascripts", func(p string, d fs.DirEntry, err error) error {

--- a/config/envoyconfig/lua_test.go
+++ b/config/envoyconfig/lua_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 func TestLuaCleanUpstream(t *testing.T) {
-	L := lua.NewState()
-	defer L.Close()
+	t.Parallel()
+
+	L := newLua(t)
 
 	bs, err := luaFS.ReadFile("luascripts/clean-upstream.lua")
 	require.NoError(t, err)
@@ -46,9 +47,52 @@ func TestLuaCleanUpstream(t *testing.T) {
 	}, headers)
 }
 
+func TestLuaLocalReplyContentType(t *testing.T) {
+	t.Parallel()
+
+	L := newLua(t)
+
+	bs, err := luaFS.ReadFile("luascripts/local-reply-type.lua")
+	require.NoError(t, err)
+
+	err = L.DoString(string(bs))
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		accept string
+		expect string
+	}{
+		{"text/html", "html"},
+		{"application/json", "json"},
+		{"text/plain", "plain"},
+		{"text/plain,text/html", "plain"},
+		{"text/plain;q=0.8,text/html;q=0.9", "html"},
+		{"application/json;q=0.8,text/*;q=0.9", "html"},
+	} {
+		headers := map[string]string{
+			"accept": tc.accept,
+		}
+		dynamicMetadata := map[string]map[string]any{}
+		handle := newLuaRequestHandle(L, headers, dynamicMetadata)
+
+		err = L.CallByParam(lua.P{
+			Fn:      L.GetGlobal("envoy_on_request"),
+			NRet:    0,
+			Protect: true,
+		}, handle)
+		require.NoError(t, err)
+		assert.Equal(t, map[string]map[string]any{
+			"envoy.filters.http.lua": {
+				"pomerium_local_reply_type": tc.expect,
+			},
+		}, dynamicMetadata)
+	}
+}
+
 func TestLuaRewriteHeaders(t *testing.T) {
-	L := lua.NewState()
-	defer L.Close()
+	t.Parallel()
+
+	L := newLua(t)
 
 	bs, err := luaFS.ReadFile("luascripts/rewrite-headers.lua")
 	require.NoError(t, err)
@@ -83,6 +127,39 @@ func TestLuaRewriteHeaders(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, "https://frontend/one/some/uri/", headers["Location"])
+}
+
+func newLua(t *testing.T) *lua.LState {
+	L := lua.NewState()
+	t.Cleanup(L.Close)
+
+	L.SetGlobal("print", L.NewFunction(func(L *lua.LState) int {
+		var args []any
+		top := L.GetTop()
+		for i := 1; i <= top; i++ {
+			args = append(args, fromLua(L, L.Get(i)))
+		}
+		t.Log(args...)
+		return 0
+	}))
+
+	return L
+}
+
+func newLuaRequestHandle(L *lua.LState,
+	headers map[string]string,
+	dynamicMetadata map[string]map[string]any,
+) lua.LValue {
+	return newLuaType(L, map[string]lua.LGFunction{
+		"headers": func(L *lua.LState) int {
+			L.Push(newLuaHeaders(L, headers))
+			return 1
+		},
+		"streamInfo": func(L *lua.LState) int {
+			L.Push(newLuaStreamInfo(L, dynamicMetadata))
+			return 1
+		},
+	})
 }
 
 func newLuaResponseHandle(L *lua.LState,

--- a/config/envoyconfig/luascripts/local-reply-type.lua
+++ b/config/envoyconfig/luascripts/local-reply-type.lua
@@ -1,0 +1,76 @@
+-- This filter interprets the accept header of an incoming request and attempts to map it to
+-- a metadata value of either "html", "json" or "plain". This metadata value is used to format
+-- local replies in a format the client expects.
+
+function parse_accept_header(header_value)
+    -- returns a table with a type field, the table is sorted by position and weight
+    if header_value == nil then
+        return {}
+    end
+
+    local content_types = {}
+    local start_idx = 1
+    local position = 1
+    while true do
+        local end_idx = string.find(header_value, ",", start_idx)
+        local segment
+        if end_idx == nil then
+            segment = string.sub(header_value, start_idx)
+        else
+            segment = string.sub(header_value, start_idx, end_idx-1)
+        end
+
+        local mime_type = segment
+        local q = 1.0
+        local semicolon_idx = string.find(segment, ';')
+        if semicolon_idx ~= nil then
+            mime_type = string.sub(segment, 1, semicolon_idx-1)
+            q_idx = string.find(segment, "q=", semicolon_idx+1)
+            if q_idx ~= nil then
+                q_str = string.sub(segment, q_idx+2)
+                q = tonumber(q_str)
+            end
+        end
+
+        table.insert(content_types, { type=mime_type, q=q, position=position })
+        position = position+1
+
+        if end_idx == nil then
+            break
+        else
+            start_idx = end_idx+1
+        end
+    end
+    table.sort(content_types, function(a,b)
+        if a.q == b.q then
+            return a.position < b.position
+        end
+        return a.q > b.q
+    end)
+    return content_types
+end
+
+function envoy_on_request(request_handle)
+    local headers = request_handle:headers()
+    local dynamic_meta = request_handle:streamInfo():dynamicMetadata()
+
+    local content_types = parse_accept_header(headers:get("accept"))
+    for _, v in pairs(content_types) do
+        if v.type == "text/html" or v.type == "text/*"  then
+            dynamic_meta:set("envoy.filters.http.lua", "pomerium_local_reply_type", "html")
+            return
+        elseif v.type == "text/plain" then
+            dynamic_meta:set("envoy.filters.http.lua", "pomerium_local_reply_type", "plain")
+            return
+        elseif v.type == "application/json" or v.type == "application/*" then
+            dynamic_meta:set("envoy.filters.http.lua", "pomerium_local_reply_type", "json")
+            return
+        end
+    end
+    -- if nothing matched, just return html
+    dynamic_meta:set("envoy.filters.http.lua", "pomerium_local_reply_type", "html")
+end
+
+function envoy_on_response(response_handle)
+    -- unused
+end

--- a/config/envoyconfig/matchers.go
+++ b/config/envoyconfig/matchers.go
@@ -1,0 +1,23 @@
+package envoyconfig
+
+import envoy_type_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+
+func buildLocalReplyTypeMatcher(localReplyType string) *envoy_type_matcher_v3.MetadataMatcher {
+	return &envoy_type_matcher_v3.MetadataMatcher{
+		Filter: "envoy.filters.http.lua",
+		Path: []*envoy_type_matcher_v3.MetadataMatcher_PathSegment{{
+			Segment: &envoy_type_matcher_v3.MetadataMatcher_PathSegment_Key{
+				Key: "pomerium_local_reply_type",
+			},
+		}},
+		Value: &envoy_type_matcher_v3.ValueMatcher{
+			MatchPattern: &envoy_type_matcher_v3.ValueMatcher_StringMatch{
+				StringMatch: &envoy_type_matcher_v3.StringMatcher{
+					MatchPattern: &envoy_type_matcher_v3.StringMatcher_Exact{
+						Exact: localReplyType,
+					},
+				},
+			},
+		},
+	}
+}

--- a/config/envoyconfig/testdata/main_http_connection_manager_filter.json
+++ b/config/envoyconfig/testdata/main_http_connection_manager_filter.json
@@ -64,9 +64,7 @@
           "statusOnError": {
             "code": "InternalServerError"
           },
-          "metadataContextNamespaces": [
-            "com.pomerium.client-certificate-info"
-          ]
+          "metadataContextNamespaces": ["com.pomerium.client-certificate-info"]
         }
       },
       {
@@ -97,6 +95,15 @@
         }
       },
       {
+        "name": "envoy.filters.http.lua",
+        "typedConfig": {
+          "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua",
+          "defaultSourceCode": {
+            "inlineString": "-- This filter interprets the accept header of an incoming request and attempts to map it to\n-- a metadata value of either \"html\", \"json\" or \"plain\". This metadata value is used to format\n-- local replies in a format the client expects.\n\nfunction parse_accept_header(header_value)\n    -- returns a table with a type field, the table is sorted by position and weight\n    if header_value == nil then\n        return {}\n    end\n\n    local content_types = {}\n    local start_idx = 1\n    local position = 1\n    while true do\n        local end_idx = string.find(header_value, \",\", start_idx)\n        local segment\n        if end_idx == nil then\n            segment = string.sub(header_value, start_idx)\n        else\n            segment = string.sub(header_value, start_idx, end_idx-1)\n        end\n\n        local mime_type = segment\n        local q = 1.0\n        local semicolon_idx = string.find(segment, ';')\n        if semicolon_idx ~= nil then\n            mime_type = string.sub(segment, 1, semicolon_idx-1)\n            q_idx = string.find(segment, \"q=\", semicolon_idx+1)\n            if q_idx ~= nil then\n                q_str = string.sub(segment, q_idx+2)\n                q = tonumber(q_str)\n            end\n        end\n\n        table.insert(content_types, { type=mime_type, q=q, position=position })\n        position = position+1\n\n        if end_idx == nil then\n            break\n        else\n            start_idx = end_idx+1\n        end\n    end\n    table.sort(content_types, function(a,b)\n        if a.q == b.q then\n            return a.position < b.position\n        end\n        return a.q > b.q\n    end)\n    return content_types\nend\n\nfunction envoy_on_request(request_handle)\n    local headers = request_handle:headers()\n    local dynamic_meta = request_handle:streamInfo():dynamicMetadata()\n\n    local content_types = parse_accept_header(headers:get(\"accept\"))\n    for _, v in pairs(content_types) do\n        if v.type == \"text/html\" or v.type == \"text/*\"  then\n            dynamic_meta:set(\"envoy.filters.http.lua\", \"pomerium_local_reply_type\", \"html\")\n            return\n        elseif v.type == \"text/plain\" then\n            dynamic_meta:set(\"envoy.filters.http.lua\", \"pomerium_local_reply_type\", \"plain\")\n            return\n        elseif v.type == \"application/json\" or v.type == \"application/*\" then\n            dynamic_meta:set(\"envoy.filters.http.lua\", \"pomerium_local_reply_type\", \"json\")\n            return\n        end\n    end\n    -- if nothing matched, just return html\n    dynamic_meta:set(\"envoy.filters.http.lua\", \"pomerium_local_reply_type\", \"html\")\nend\n\nfunction envoy_on_response(response_handle)\n    -- unused\nend\n"
+          }
+        }
+      },
+      {
         "name": "envoy.filters.http.router",
         "typedConfig": {
           "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
@@ -115,6 +122,158 @@
     },
     "localReplyConfig": {
       "mappers": [
+        {
+          "filter": {
+            "andFilter": {
+              "filters": [
+                {
+                  "responseFlagFilter": {
+                    "flags": [
+                      "DC",
+                      "DF",
+                      "DI",
+                      "DO",
+                      "DPE",
+                      "DT",
+                      "FI",
+                      "IH",
+                      "LH",
+                      "LR",
+                      "NC",
+                      "NFCF",
+                      "NR",
+                      "OM",
+                      "RFCF",
+                      "RL",
+                      "RLSE",
+                      "SI",
+                      "UC",
+                      "UF",
+                      "UH",
+                      "UMSDR",
+                      "UO",
+                      "UPE",
+                      "UR",
+                      "URX",
+                      "UT"
+                    ]
+                  }
+                },
+                {
+                  "metadataFilter": {
+                    "matcher": {
+                      "filter": "envoy.filters.http.lua",
+                      "path": [{ "key": "pomerium_local_reply_type" }],
+                      "value": {
+                        "stringMatch": {
+                          "exact": "plain"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "bodyFormatOverride": {
+            "contentType": "text/plain; charset=UTF-8",
+            "textFormatSource": {
+              "inlineBytes": "ewogICJyZXF1ZXN0SWQiOiAiJVNUUkVBTV9JRCUiLAogICJzdGF0dXMiOiAiJVJFU1BPTlNFX0NPREUlIiwKICAic3RhdHVzVGV4dCI6ICIlUkVTUE9OU0VfQ09ERV9ERVRBSUxTJSIKfQ=="
+            }
+          },
+          "headersToAdd": [
+            {
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD",
+              "header": {
+                "key": "X-Frame-Options",
+                "value": "SAMEORIGIN"
+              }
+            },
+            {
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD",
+              "header": {
+                "key": "X-XSS-Protection",
+                "value": "1; mode=block"
+              }
+            }
+          ]
+        },
+        {
+          "filter": {
+            "andFilter": {
+              "filters": [
+                {
+                  "responseFlagFilter": {
+                    "flags": [
+                      "DC",
+                      "DF",
+                      "DI",
+                      "DO",
+                      "DPE",
+                      "DT",
+                      "FI",
+                      "IH",
+                      "LH",
+                      "LR",
+                      "NC",
+                      "NFCF",
+                      "NR",
+                      "OM",
+                      "RFCF",
+                      "RL",
+                      "RLSE",
+                      "SI",
+                      "UC",
+                      "UF",
+                      "UH",
+                      "UMSDR",
+                      "UO",
+                      "UPE",
+                      "UR",
+                      "URX",
+                      "UT"
+                    ]
+                  }
+                },
+                {
+                  "metadataFilter": {
+                    "matcher": {
+                      "filter": "envoy.filters.http.lua",
+                      "path": [{ "key": "pomerium_local_reply_type" }],
+                      "value": {
+                        "stringMatch": {
+                          "exact": "json"
+                        }
+                      }
+                    }
+                  }
+                }
+              ]
+            }
+          },
+          "bodyFormatOverride": {
+            "contentType": "application/json; charset=UTF-8",
+            "textFormatSource": {
+              "inlineBytes": "ewogICJyZXF1ZXN0SWQiOiAiJVNUUkVBTV9JRCUiLAogICJzdGF0dXMiOiAiJVJFU1BPTlNFX0NPREUlIiwKICAic3RhdHVzVGV4dCI6ICIlUkVTUE9OU0VfQ09ERV9ERVRBSUxTJSIKfQ=="
+            }
+          },
+          "headersToAdd": [
+            {
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD",
+              "header": {
+                "key": "X-Frame-Options",
+                "value": "SAMEORIGIN"
+              }
+            },
+            {
+              "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD",
+              "header": {
+                "key": "X-XSS-Protection",
+                "value": "1; mode=block"
+              }
+            }
+          ]
+        },
         {
           "bodyFormatOverride": {
             "contentType": "text/html; charset=UTF-8",


### PR DESCRIPTION
## Summary
For errors coming from Envoy we currently always return HTML. This PR updates the local reply configuration to return errors as JSON if the `Accept` header asks for it. The default is still HTML.

To do this we have to parse the `Accept` header in Lua. I attempted to follow the spec to do this correctly.

## Related issues
- [ENG-1651](https://linear.app/pomerium/issue/ENG-1651/error-responses-do-not-honor-accept-applicationjson-header)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
