### PR TITLE
authenticate: remove /.pomerium/callback handler

### DIFF
--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -694,14 +694,6 @@ func (m mockDataBrokerServiceClient) Put(ctx context.Context, in *databroker.Put
 	return m.put(ctx, in, opts...)
 }
 
-func mustParseURL(rawurl string) *url.URL {
-	u, err := url.Parse(rawurl)
-	if err != nil {
-		panic(err)
-	}
-	return u
-}
-
 // stubFlow is a stub implementation of the flow interface.
 type stubFlow struct {
 	verifySignatureErr error

--- a/authenticate/middleware.go
+++ b/authenticate/middleware.go
@@ -20,14 +20,3 @@ func (a *Authenticate) requireValidSignatureOnRedirect(next httputil.HandlerFunc
 		return next(w, r)
 	})
 }
-
-// requireValidSignature validates the pomerium_signature.
-func (a *Authenticate) requireValidSignature(next httputil.HandlerFunc) http.Handler {
-	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		err := a.state.Load().flow.VerifyAuthenticateSignature(r)
-		if err != nil {
-			return err
-		}
-		return next(w, r)
-	})
-}


### PR DESCRIPTION
## Summary
Remove the `/.pomerium/callback` handler in the authenticate service. This appears to have been added to allow using webauthn devices in the authenticate service, but this is no longer allowed (the webauthn registration and creation options are only passed on the proxy service), so this code appears to be unnecessary.

Currently this function is called instead of the proxy service's `/.pomerium/callback` function. As a result the pomerium session cookie is not being written in a way that the authorize service can read. We are writing `_pomerium_authenticate` in the authenticate service, and `_pomerium` in the proxy service. Because the cookie isn't written properly, the next call to the authorize service fails, resulting in an infinite redirect loop.

By removing this function, the proxy service's `/.pomerium/callback` handler will now be called instead. This handler writes the cookie properly.

## Related issues
- #5549 


## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
