### PR TITLE
remove debug log message for directories

### DIFF
--- a/internal/fileutil/directories.go
+++ b/internal/fileutil/directories.go
@@ -3,8 +3,6 @@ package fileutil
 import (
 	"os"
 	"path/filepath"
-
-	"github.com/rs/zerolog/log"
 )
 
 // CacheDir returns $XDG_CACHE_HOME/pomerium, or $HOME/.cache/pomerium, or /tmp/pomerium/cache
@@ -14,7 +12,6 @@ func CacheDir() string {
 		dir = filepath.Join(dir, "pomerium")
 	} else {
 		dir = filepath.Join(os.TempDir(), "pomerium", "cache")
-		log.Debug().Msgf("user cache directory not set, defaulting to %s", dir)
 	}
 	return dir
 }
@@ -30,7 +27,6 @@ func DataDir() string {
 		} else {
 			dir = filepath.Join(os.TempDir(), "pomerium", "data")
 		}
-		log.Debug().Msgf("user data directory not set, defaulting to %s", dir)
 	}
 	return dir
 }


### PR DESCRIPTION
## Summary
This log message ends up getting printed very early (during init in some places), so is difficult to remove by configuring the global logger. I'm not sure it's actually useful anyway, so we can just remove it.

## Related issues
- https://github.com/pomerium/cli/issues/509#issuecomment-2771809348
 

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
