### PR TITLE
upgrade to go v1.24

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,12 +15,12 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
           cache: false
 
       - run: make deps-build
 
       - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
         with:
-          version: v1.60.1
+          version: v1.64.8
           args: --timeout=10m

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
           cache: false
 
       - name: Set up Docker
@@ -99,7 +99,7 @@ jobs:
           echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
 
       - name: Publish latest tag
-        if: "steps.latestTag.outputs.tag == steps.tagName.outputs.tag"
+        if: steps.latestTag.outputs.tag == steps.tagName.outputs.tag
         run: |
           docker manifest create -a pomerium/pomerium:latest pomerium/pomerium:amd64-${{ steps.tagName.outputs.tag }} pomerium/pomerium:arm64v8-${{ steps.tagName.outputs.tag }}
           docker manifest push pomerium/pomerium:latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [1.23.x]
         node-version: [22.x]
         platform: [ubuntu-22.04]
         deployment: [multi, single]
@@ -23,7 +22,7 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.24.x
           cache: false
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
@@ -62,7 +61,7 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: 1.24.x
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e
         with:
@@ -126,7 +125,7 @@ jobs:
 
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b
         with:
-          go-version: 1.23.x
+          go-version: 1.24.x
           cache: false
 
       - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,11 +11,11 @@ linters:
   enable:
     - asasalint
     - bodyclose
+    - copyloopvar
     - dogsled
     - errcheck
     - errorlint
-    - exportloopref
-    # - gci # https://github.com/daixiang0/gci/issues/209
+    - gci
     - gocheckcompilerdirectives
     - gofumpt
     - goimports
@@ -30,10 +30,10 @@ linters:
     - revive
     - staticcheck
     - stylecheck
-    - tenv
     - unconvert
     - unused
     - usestdlibvars
+    - usetesting
 
 issues:
   # List of regexps of issue texts to exclude, empty list by default.

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-golang 1.23.0
-golangci-lint 1.60.1

--- a/Makefile
+++ b/Makefile
@@ -90,9 +90,10 @@ build-ui: yarn
 	@cd ui; yarn build
 
 .PHONY: lint
-lint: ## Verifies `golint` passes.
-	@echo "==> $@"
-	@go run github.com/golangci/golangci-lint/cmd/golangci-lint@v1.60.1 run ./... --fix
+lint:
+	@echo "@==> $@"
+	@VERSION=$$(go run github.com/mikefarah/yq/v4@v4.34.1 '.jobs.lint.steps[] | select(.uses == "golangci/golangci-lint-action*") | .with.version' .github/workflows/lint.yaml) && \
+	go run github.com/golangci/golangci-lint/cmd/golangci-lint@$$VERSION run ./... --fix
 
 .PHONY: test
 test: get-envoy ## Runs the go tests.

--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 	"fmt"
 
+	oteltrace "go.opentelemetry.io/otel/trace"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/atomicutil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // ValidateOptions checks that configuration are complete and valid.

--- a/authenticate/authenticate_test.go
+++ b/authenticate/authenticate_test.go
@@ -58,7 +58,6 @@ func TestOptions_Validate(t *testing.T) {
 		{"empty callback path", badCallbackPath, true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if err := ValidateOptions(tt.o); (err != nil) != tt.wantErr {
 				t.Errorf("Options.Validate() error = %v, wantErr %v", err, tt.wantErr)
@@ -105,7 +104,6 @@ func TestNew(t *testing.T) {
 		{"bad signing key", badSigningKey, true},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			_, err := New(context.Background(), &config.Config{Options: tt.opts})
 			if (err != nil) != tt.wantErr {

--- a/authenticate/config.go
+++ b/authenticate/config.go
@@ -3,11 +3,12 @@ package authenticate
 import (
 	"context"
 
+	oteltrace "go.opentelemetry.io/otel/trace"
+
 	"github.com/pomerium/pomerium/authenticate/events"
 	"github.com/pomerium/pomerium/config"
 	identitypb "github.com/pomerium/pomerium/pkg/grpc/identity"
 	"github.com/pomerium/pomerium/pkg/identity"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 type authenticateConfig struct {

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -219,7 +219,6 @@ func TestAuthenticate_SignOut(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -343,7 +342,6 @@ func TestAuthenticate_OAuthCallback(t *testing.T) {
 		{"bad hmac", http.MethodGet, time.Now().Unix(), base64.URLEncoding.EncodeToString([]byte("malformed_state")), "", "", "", "code", "https://corp.pomerium.io", "https://authenticate.pomerium.io", &mstore.Store{}, identity.MockProvider{AuthenticateResponse: oauth2.Token{}}, "https://corp.pomerium.io", http.StatusBadRequest},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
@@ -449,7 +447,6 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()

--- a/authorize/authorize_test.go
+++ b/authorize/authorize_test.go
@@ -79,7 +79,6 @@ func TestNew(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			_, err := New(context.Background(), &config.Config{Options: &tt.config})
@@ -104,7 +103,6 @@ func TestAuthorize_OnConfigChange(t *testing.T) {
 		{"bad option", "gXK6ggrlIW2HyKyUF9rUO4azrDgxhDPWqw9y+lJU7B8=", policies, false},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			o := &config.Options{

--- a/authorize/evaluator/google_cloud_serverless_test.go
+++ b/authorize/evaluator/google_cloud_serverless_test.go
@@ -44,6 +44,8 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 }
 
 func Test_normalizeServiceAccount(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name                   string
 		serviceAccount         string
@@ -59,7 +61,6 @@ func Test_normalizeServiceAccount(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			gotServiceAccount, err := normalizeServiceAccount(tc.serviceAccount)

--- a/authorize/log_test.go
+++ b/authorize/log_test.go
@@ -96,8 +96,6 @@ func Test_populateLogEvent(t *testing.T) {
 		{log.AuthorizeLogFieldUser, sa, `{"user":"SERVICE-ACCOUNT-USER-ID"}`},
 		{log.AuthorizeLogFieldUser, nil, `{"user":""}`},
 	} {
-
-		tc := tc
 		t.Run(string(tc.field), func(t *testing.T) {
 			t.Parallel()
 

--- a/config/autocert_test.go
+++ b/config/autocert_test.go
@@ -90,7 +90,7 @@ func TestAutocertOptions_Validate(t *testing.T) {
 			}
 		},
 		"ok/trusted-ca-file": func(t *testing.T) test {
-			f, err := os.CreateTemp("", "pomerium-test-ca")
+			f, err := os.CreateTemp(t.TempDir(), "pomerium-test-ca")
 			require.NoError(t, err)
 			n, err := f.Write(certPEM)
 			require.NoError(t, err)
@@ -128,7 +128,7 @@ func TestAutocertOptions_Validate(t *testing.T) {
 			}
 		},
 		"fail/trusted-ca-combined": func(t *testing.T) test {
-			f, err := os.CreateTemp("", "pomerium-test-ca")
+			f, err := os.CreateTemp(t.TempDir(), "pomerium-test-ca")
 			require.NoError(t, err)
 			n, err := f.Write(certPEM)
 			require.NoError(t, err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,10 +6,11 @@ import (
 	"encoding/pem"
 	"testing"
 
-	"github.com/pomerium/pomerium/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/config"
 )
 
 func TestGenerateCatchAllCertificate(t *testing.T) {

--- a/config/envoyconfig/bootstrap.go
+++ b/config/envoyconfig/bootstrap.go
@@ -16,12 +16,13 @@ import (
 	envoy_config_overload_v3 "github.com/envoyproxy/go-control-plane/envoy/config/overload/v3"
 	envoy_extensions_access_loggers_file_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/file/v3"
 	envoy_extensions_resource_monitors_downstream_connections_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/resource_monitors/downstream_connections/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/otelconfig"
 	"github.com/pomerium/pomerium/internal/telemetry"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/structpb"
 )
 
 const maxActiveDownstreamConnections = 50000

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -216,7 +216,6 @@ func (b *Builder) buildPolicyEndpoints(
 ) ([]Endpoint, error) {
 	var endpoints []Endpoint
 	for _, dst := range policy.To {
-		dst := dst
 		ts, err := b.buildPolicyTransportSocket(ctx, cfg, policy, dst.URL)
 		if err != nil {
 			return nil, err

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -275,7 +275,6 @@ func Test_urlMatchesHost(t *testing.T) {
 		{"non standard port", "http://example.com:81", "example.com", false},
 		{"non standard host port", "http://example.com:81", "example.com:80", false},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/config/envoyconfig/tracing.go
+++ b/config/envoyconfig/tracing.go
@@ -13,13 +13,14 @@ import (
 	metadatav3 "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
 	envoy_tracing_v3 "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
 	extensions_trace_context "github.com/pomerium/envoy-custom/api/extensions/http/early_header_mutation/trace_context"
 	extensions_uuidx "github.com/pomerium/envoy-custom/api/extensions/request_id/uuidx"
 	extensions_pomerium_otel "github.com/pomerium/envoy-custom/api/extensions/tracers/pomerium_otel"
 	"github.com/pomerium/pomerium/config/otelconfig"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 func isTracingEnabled(cfg *otelconfig.Config) bool {

--- a/config/options.go
+++ b/config/options.go
@@ -1871,13 +1871,6 @@ func compareByteSliceSlice(a, b [][]byte) int {
 	}
 }
 
-func min(x, y int) int {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // NewAtomicOptions creates a new AtomicOptions.
 func NewAtomicOptions() *atomicutil.Value[*Options] {
 	return atomicutil.NewValue(new(Options))

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -331,7 +331,7 @@ func Test_parsePolicyFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tempFile, _ := os.CreateTemp("", "*.json")
+			tempFile, _ := os.CreateTemp(t.TempDir(), "*.json")
 			defer tempFile.Close()
 			defer os.Remove(tempFile.Name())
 			tempFile.Write(tt.policyBytes)
@@ -462,7 +462,7 @@ func TestOptionsFromViper(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tempFile, _ := os.CreateTemp("", "*.json")
+			tempFile, _ := os.CreateTemp(t.TempDir(), "*.json")
 			defer tempFile.Close()
 			defer os.Remove(tempFile.Name())
 			tempFile.Write(tt.configBytes)
@@ -506,8 +506,7 @@ func Test_NewOptionsFromConfigEnvVar(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for k, v := range tt.envKeyPairs {
-				os.Setenv(k, v)
-				defer os.Unsetenv(k)
+				t.Setenv(k, v)
 			}
 			_, err := newOptionsFromConfig("")
 			if (err != nil) != tt.wantErr {
@@ -578,7 +577,7 @@ func Test_AutoCertOptionsFromEnvVar(t *testing.T) {
 		"ok/custom-ca-file": func(t *testing.T) test {
 			certPEM, err := newCACertPEM()
 			require.NoError(t, err)
-			f, err := os.CreateTemp("", "pomerium-test-ca")
+			f, err := os.CreateTemp(t.TempDir(), "pomerium-test-ca")
 			require.NoError(t, err)
 			n, err := f.Write(certPEM)
 			require.NoError(t, err)
@@ -617,8 +616,7 @@ func Test_AutoCertOptionsFromEnvVar(t *testing.T) {
 		tc := run(t)
 		t.Run(name, func(t *testing.T) {
 			for k, v := range tc.envs {
-				os.Setenv(k, v)
-				defer os.Unsetenv(k)
+				t.Setenv(k, v)
 			}
 			o, err := newOptionsFromConfig("")
 			if err != nil {
@@ -658,7 +656,6 @@ func TestCertificatesArrayParsing(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -827,7 +824,6 @@ func TestOptions_DefaultURL(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			u, err := tc.f()
@@ -1235,7 +1231,6 @@ LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IUUNBUUVFSUdHaDZGbEJlOHl5OWRSSmdtKzM1
 			0x49, 0x56, 0x41, 0x54, 0x45, 0x20, 0x4b, 0x45, 0x59, 0x2d, 0x2d, 0x2d, 0x2d, 0x2d,
 		}, nil},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1285,7 +1280,6 @@ func TestOptions_GetCookieSameSite(t *testing.T) {
 		{"none", http.SameSiteNoneMode},
 		{"UnKnOwN", http.SameSiteDefaultMode},
 	} {
-		tc := tc
 		t.Run(tc.input, func(t *testing.T) {
 			t.Parallel()
 
@@ -1314,7 +1308,6 @@ func TestOptions_GetCSRFSameSite(t *testing.T) {
 		{"UnKnOwN", "", csrf.SameSiteDefaultMode},
 		{"", apple.Name, csrf.SameSiteNoneMode},
 	} {
-		tc := tc
 		t.Run(tc.cookieSameSite, func(t *testing.T) {
 			t.Parallel()
 

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -176,7 +176,6 @@ func Test_PolicyRouteID(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			assert.NoError(t, tt.basePolicy.Validate())

--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -28,7 +29,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/identity"
 	"github.com/pomerium/pomerium/pkg/identity/manager"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // DataBroker represents the databroker service. The databroker service is a simple interface

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/pomerium/pomerium
 
 go 1.23.6
 
-toolchain go1.23.7
-
 require (
 	cloud.google.com/go/storage v1.50.0
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2

--- a/integration/control_plane_test.go
+++ b/integration/control_plane_test.go
@@ -63,9 +63,7 @@ func TestHealth(t *testing.T) {
 	endpoints := []string{"healthz", "ping"}
 
 	for _, route := range pomeriumRoutes {
-		route := route
 		for _, endpoint := range endpoints {
-			endpoint := endpoint
 			routeToCheck := fmt.Sprintf("%s/%s", route, endpoint)
 			t.Run(routeToCheck, func(t *testing.T) {
 				req, err := http.NewRequestWithContext(ctx, http.MethodGet, routeToCheck, nil)

--- a/internal/atomicutil/value.go
+++ b/internal/atomicutil/value.go
@@ -41,6 +41,6 @@ func (v *Value[T]) Swap(val T) T {
 }
 
 // Swap swaps the value atomically.
-func (v *Value[T]) CompareAndSwap(old, new T) bool {
-	return v.value.CompareAndSwap(old, new)
+func (v *Value[T]) CompareAndSwap(old, n T) bool {
+	return v.value.CompareAndSwap(old, n)
 }

--- a/internal/authenticateflow/stateful_test.go
+++ b/internal/authenticateflow/stateful_test.go
@@ -67,7 +67,6 @@ func TestStatefulSignIn(t *testing.T) {
 		{"good programmatic request", "corp.example.example", map[string]string{urlutil.QueryIsProgrammatic: "true", urlutil.QueryRedirectURI: "https://dst.some.example/"}, true, &sessions.State{}, &mock.Encoder{}, nil, "", "https://dst.some.example/.pomerium/callback/"},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			sessionStore := &mstore.Store{SaveError: tt.saveError}
 			flow, err := NewStateful(context.Background(), trace.NewNoopTracerProvider(), &config.Config{Options: opts}, sessionStore)

--- a/internal/authenticateflow/stateless.go
+++ b/internal/authenticateflow/stateless.go
@@ -9,6 +9,9 @@ import (
 	"net/url"
 
 	"github.com/go-jose/go-jose/v3"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/oauth2"
 	googlegrpc "google.golang.org/grpc"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -31,9 +34,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/hpke"
 	"github.com/pomerium/pomerium/pkg/identity"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	"go.opentelemetry.io/otel"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // Stateless implements the stateless authentication flow. In this flow, the

--- a/internal/autocert/manager_test.go
+++ b/internal/autocert/manager_test.go
@@ -551,7 +551,7 @@ func Test_configureTrustedRoots(t *testing.T) {
 			require.NoError(t, err)
 			ok := roots.AppendCertsFromPEM(ca.certPEM)
 			require.Equal(t, true, ok)
-			f, err := os.CreateTemp("", "pomerium-test-ca")
+			f, err := os.CreateTemp(t.TempDir(), "pomerium-test-ca")
 			require.NoError(t, err)
 			n, err := f.Write(ca.certPEM)
 			require.NoError(t, err)

--- a/internal/benchmarks/latency_bench_test.go
+++ b/internal/benchmarks/latency_bench_test.go
@@ -9,13 +9,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/testenv"
 	"github.com/pomerium/pomerium/internal/testenv/envutil"
 	"github.com/pomerium/pomerium/internal/testenv/scenarios"
 	"github.com/pomerium/pomerium/internal/testenv/snippets"
 	"github.com/pomerium/pomerium/internal/testenv/upstreams"
-	"github.com/stretchr/testify/assert"
 )
 
 var (

--- a/internal/controlplane/grpc_accesslog_test.go
+++ b/internal/controlplane/grpc_accesslog_test.go
@@ -66,7 +66,6 @@ func Test_populateLogEvent(t *testing.T) {
 		{log.AccessLogFieldUpstreamCluster, `{"upstream-cluster":"UPSTREAM-CLUSTER"}`},
 		{log.AccessLogFieldUserAgent, `{"user-agent":"USER-AGENT"}`},
 	} {
-		tc := tc
 		t.Run(string(tc.field), func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"golang.org/x/net/nettest"
 	"golang.org/x/sync/errgroup"
@@ -36,7 +37,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/httputil"
 	"github.com/pomerium/pomerium/pkg/telemetry/requestid"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // A Service can be mounted on the control plane.
@@ -222,8 +222,6 @@ func (srv *Server) Run(ctx context.Context) error {
 		{"debug", srv.DebugListener, srv.DebugRouter},
 		{"metrics", srv.MetricsListener, srv.MetricsRouter},
 	} {
-		entry := entry
-
 		// start the HTTP server
 		eg.Go(func() error {
 			log.Ctx(ctx).Debug().

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -8,7 +8,10 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
+	googlegrpc "google.golang.org/grpc"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/errgrouputil"
@@ -22,9 +25,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpcutil"
 	"github.com/pomerium/pomerium/pkg/health"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	oteltrace "go.opentelemetry.io/otel/trace"
-	googlegrpc "google.golang.org/grpc"
 )
 
 // ConfigSource provides a new Config source that decorates an underlying config with
@@ -136,7 +136,6 @@ func (src *ConfigSource) buildNewConfigLocked(ctx context.Context, cfg *config.C
 	var policyBuilders []errgrouputil.BuilderFunc[config.Policy]
 	for _, cfgpb := range src.dbConfigs {
 		for _, routepb := range cfgpb.GetRoutes() {
-			routepb := routepb
 			policyBuilders = append(policyBuilders, func(ctx context.Context) (*config.Policy, error) {
 				p, err := src.buildPolicyFromProto(ctx, routepb)
 				if err != nil {

--- a/internal/databroker/server.go
+++ b/internal/databroker/server.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
@@ -22,7 +23,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/storage/inmemory"
 	"github.com/pomerium/pomerium/pkg/storage/postgres"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 // Server implements the databroker service using an in memory database.

--- a/internal/httputil/router.go
+++ b/internal/httputil/router.go
@@ -34,7 +34,6 @@ func DashboardSubrouter(parent *mux.Router) *mux.Router {
 		"index.css",
 		"index.js",
 	} {
-		fileName := fileName
 		r.Path("/" + fileName).Handler(HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 			return ui.ServeFile(w, r, fileName)
 		}))

--- a/internal/log/middleware.go
+++ b/internal/log/middleware.go
@@ -6,12 +6,12 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/pomerium/protoutil/streams"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc"
 
 	"github.com/pomerium/pomerium/internal/middleware/responsewriter"
 	"github.com/pomerium/pomerium/pkg/telemetry/requestid"
+	"github.com/pomerium/protoutil/streams"
 )
 
 // NewHandler injects log into requests context.

--- a/internal/registry/reporter.go
+++ b/internal/registry/reporter.go
@@ -10,14 +10,14 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	googlegrpc "google.golang.org/grpc"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc"
 	pb "github.com/pomerium/pomerium/pkg/grpc/registry"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
-	oteltrace "go.opentelemetry.io/otel/trace"
-	googlegrpc "google.golang.org/grpc"
 )
 
 // Reporter periodically submits a list of services available on this instance to the service registry

--- a/internal/telemetry/metrics/bench_test.go
+++ b/internal/telemetry/metrics/bench_test.go
@@ -8,11 +8,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/testenv"
 	"github.com/pomerium/pomerium/internal/testenv/snippets"
 	"github.com/pomerium/pomerium/internal/testenv/upstreams"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestScrapeMetricsEndpoint(t *testing.T) {

--- a/internal/telemetry/metrics/providers.go
+++ b/internal/telemetry/metrics/providers.go
@@ -184,12 +184,12 @@ func ocExport(name string, exporter *ocprom.Exporter, r *http.Request, labels ma
 		exporter.ServeHTTP(rec, r)
 
 		if rec.Code/100 != 2 {
-			return promProducerResult{name: name, err: errors.New(rec.Result().Status)} //nolint
+			return promProducerResult{name: name, err: errors.New(rec.Result().Status)}
 		}
 
 		return promProducerResult{
 			name:   name,
-			src:    rec.Result().Body, //nolint
+			src:    rec.Result().Body,
 			labels: labels,
 		}
 	}

--- a/internal/telemetry/prometheus/relabel.go
+++ b/internal/telemetry/prometheus/relabel.go
@@ -12,7 +12,6 @@ func AddLabels(
 ) iter.Seq2[*dto.MetricFamily, error] {
 	var extra []*dto.LabelPair
 	for k, v := range addLabels {
-		k, v := k, v
 		extra = append(extra, &dto.LabelPair{
 			Name:  &k,
 			Value: &v,

--- a/internal/telemetry/prometheus/relabel_text_stream_test.go
+++ b/internal/telemetry/prometheus/relabel_text_stream_test.go
@@ -6,8 +6,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/pomerium/pomerium/internal/telemetry/prometheus"
 	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/internal/telemetry/prometheus"
 )
 
 // RepeatingReader repeats reading from the beginning after EOF for a specified number of times

--- a/internal/testenv/environment.go
+++ b/internal/testenv/environment.go
@@ -33,6 +33,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/grpclog"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
 	"github.com/pomerium/pomerium/config/otelconfig"
@@ -49,14 +58,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/netutil"
 	"github.com/pomerium/pomerium/pkg/slices"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	"github.com/rs/zerolog"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-	oteltrace "go.opentelemetry.io/otel/trace"
-	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/grpclog"
 )
 
 // Environment is a lightweight integration test fixture that runs Pomerium
@@ -1083,7 +1084,7 @@ func (src *configSource) ModifyConfig(ctx context.Context, m Modifier) {
 }
 
 func newOtelConfigFromEnv(t testing.TB) otelconfig.Config {
-	f, err := os.CreateTemp("", "tmp-config-*.yaml")
+	f, err := os.CreateTemp(t.TempDir(), "tmp-config-*.yaml")
 	require.NoError(t, err)
 	defer os.Remove(f.Name())
 	f.Close()

--- a/internal/testenv/scenarios/mock_idp.go
+++ b/internal/testenv/scenarios/mock_idp.go
@@ -23,6 +23,7 @@ import (
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
 	"github.com/google/uuid"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/encoding"
 	"github.com/pomerium/pomerium/internal/encoding/jws"

--- a/internal/testenv/scenarios/trace_receiver.go
+++ b/internal/testenv/scenarios/trace_receiver.go
@@ -9,11 +9,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pomerium/pomerium/config"
-	"github.com/pomerium/pomerium/internal/testenv"
-	"github.com/pomerium/pomerium/internal/testenv/upstreams"
-	"github.com/pomerium/pomerium/internal/testenv/values"
-	"github.com/pomerium/pomerium/internal/testutil/tracetest"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
@@ -21,6 +16,12 @@ import (
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	"github.com/pomerium/pomerium/internal/testenv/values"
+	"github.com/pomerium/pomerium/internal/testutil/tracetest"
 )
 
 type RecordedExportRequest struct {

--- a/internal/testenv/selftests/dns_test.go
+++ b/internal/testenv/selftests/dns_test.go
@@ -6,11 +6,12 @@ import (
 	"net/http/httptrace"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/testenv"
 	"github.com/pomerium/pomerium/internal/testenv/snippets"
 	"github.com/pomerium/pomerium/internal/testenv/upstreams"
-	"github.com/stretchr/testify/require"
 )
 
 func TestDNSOverrides(t *testing.T) {

--- a/internal/testenv/snippets/wait.go
+++ b/internal/testenv/snippets/wait.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/pomerium/pomerium/internal/testenv"
-	"github.com/pomerium/pomerium/pkg/grpcutil"
-	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/pkg/grpcutil"
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 func WaitStartupComplete(env testenv.Environment, timeout ...time.Duration) time.Duration {

--- a/internal/testenv/temp_darwin.go
+++ b/internal/testenv/temp_darwin.go
@@ -10,7 +10,7 @@ import (
 // macos temp directory names are too long
 // https://github.com/golang/go/issues/62614
 func tempDir(t testing.TB) string {
-	dir, err := os.MkdirTemp("", "test")
+	dir, err := os.MkdirTemp("", "test") //nolint:usetesting
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/testenv/upstreams/grpc.go
+++ b/internal/testenv/upstreams/grpc.go
@@ -6,15 +6,16 @@ import (
 	"net"
 	"strings"
 
-	"github.com/pomerium/pomerium/internal/testenv"
-	"github.com/pomerium/pomerium/internal/testenv/snippets"
-	"github.com/pomerium/pomerium/internal/testenv/values"
-	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/values"
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 type GRPCUpstreamOptions struct {

--- a/internal/testenv/upstreams/http.go
+++ b/internal/testenv/upstreams/http.go
@@ -17,15 +17,15 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
+
 	"github.com/pomerium/pomerium/internal/testenv"
 	"github.com/pomerium/pomerium/internal/testenv/snippets"
 	"github.com/pomerium/pomerium/internal/testenv/values"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
-
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/codes"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 type Protocol string

--- a/internal/testenv/upstreams/tcp.go
+++ b/internal/testenv/upstreams/tcp.go
@@ -13,12 +13,13 @@ import (
 	"net/url"
 	"sync"
 
-	"github.com/pomerium/pomerium/internal/testenv"
-	"github.com/pomerium/pomerium/internal/testenv/values"
-	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/net/http2"
+
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/values"
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 type TCPUpstream interface {

--- a/internal/testenv/upstreams/util.go
+++ b/internal/testenv/upstreams/util.go
@@ -14,13 +14,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pomerium/pomerium/integration/forms"
-	"github.com/pomerium/pomerium/internal/retry"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/integration/forms"
+	"github.com/pomerium/pomerium/internal/retry"
 )
 
 var ErrRetry = errors.New("error")

--- a/internal/testutil/minio.go
+++ b/internal/testutil/minio.go
@@ -6,10 +6,11 @@ import (
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
-	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 // WithTestMinIO starts a test MinIO server

--- a/internal/testutil/postgres.go
+++ b/internal/testutil/postgres.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5"
-	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
 	oteltrace "go.opentelemetry.io/otel/trace"
+
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 // WithTestPostgres starts a postgres database.

--- a/internal/testutil/tracetest/buffer_test.go
+++ b/internal/testutil/tracetest/buffer_test.go
@@ -3,9 +3,10 @@ package tracetest
 import (
 	"testing"
 
-	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/stretchr/testify/assert"
 	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"github.com/pomerium/pomerium/internal/testutil"
 )
 
 func TestBuffer(t *testing.T) {

--- a/internal/testutil/tracetest/tracing.go
+++ b/internal/testutil/tracetest/tracing.go
@@ -16,7 +16,6 @@ import (
 	"unique"
 
 	gocmp "github.com/google/go-cmp/cmp"
-	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -27,6 +26,8 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 type (

--- a/internal/urlutil/time_test.go
+++ b/internal/urlutil/time_test.go
@@ -48,7 +48,6 @@ func TestValidateTimeParameters(t *testing.T) {
 			QueryExpiry: {fmt.Sprint(msNow)},
 		}, ""},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/urlutil/url_test.go
+++ b/internal/urlutil/url_test.go
@@ -150,7 +150,6 @@ func TestGetServerNamesForURL(t *testing.T) {
 		{"tcp", &url.URL{Scheme: "tcp+https", Host: "example.com:1234"}, []string{"example.com"}},
 		{"tcp with path", &url.URL{Scheme: "tcp+https", Host: "proxy.example.com", Path: "/ssh.example.com:1234"}, []string{"proxy.example.com"}},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := GetServerNamesForURL(tc.u)
@@ -176,7 +175,6 @@ func TestGetDomainsForURL(t *testing.T) {
 		{"tcp with path", &url.URL{Scheme: "tcp+https", Host: "proxy.example.com", Path: "/ssh.example.com:1234"}, []string{"ssh.example.com:1234"}},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			got := GetDomainsForURL(tc.u, true)

--- a/internal/zero/cmd/command_import.go
+++ b/internal/zero/cmd/command_import.go
@@ -9,13 +9,14 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/envoy/files"
 	"github.com/pomerium/pomerium/pkg/zero/cluster"
 	"github.com/pomerium/pomerium/pkg/zero/importutil"
-	"github.com/rs/zerolog"
-	"github.com/spf13/cobra"
 )
 
 func BuildImportCmd() *cobra.Command {

--- a/internal/zero/cmd/command_root.go
+++ b/internal/zero/cmd/command_root.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 
-	zero "github.com/pomerium/pomerium/internal/zero/api"
 	"github.com/spf13/cobra"
+
+	zero "github.com/pomerium/pomerium/internal/zero/api"
 )
 
 type zeroClientContextKeyType struct{}

--- a/internal/zero/connect-mux/messages.go
+++ b/internal/zero/connect-mux/messages.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/rs/zerolog/log"
 	"google.golang.org/protobuf/encoding/protojson"
 
 	"github.com/pomerium/pomerium/internal/zero/apierror"
 	"github.com/pomerium/pomerium/pkg/zero/connect"
-	"github.com/rs/zerolog/log"
 )
 
 // Watch watches for changes to the config until either context is canceled,

--- a/internal/zero/controller/leaser.go
+++ b/internal/zero/controller/leaser.go
@@ -24,7 +24,6 @@ func (c *leaser) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient
 func (c *leaser) RunLeased(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, fn := range c.funcs {
-		fn := fn
 		eg.Go(func() error { return fn(ctx, c.client) })
 	}
 	err := eg.Wait()

--- a/internal/zero/grpcconn/client_test.go
+++ b/internal/zero/grpcconn/client_test.go
@@ -30,7 +30,6 @@ func TestConfig(t *testing.T) {
 		{endpoint: "http://localhost:8721/path", expectError: true},
 		{endpoint: "https://localhost:8721/path", expectError: true},
 	} {
-		tc := tc
 		t.Run(tc.endpoint, func(t *testing.T) {
 			t.Parallel()
 			cfg, err := getConfig(tc.endpoint)

--- a/internal/zero/reconciler/download_cache.go
+++ b/internal/zero/reconciler/download_cache.go
@@ -110,9 +110,9 @@ func (r *BundleCacheEntry) ToAny() (*anypb.Any, error) {
 }
 
 // FromAny unmarshals an anypb.Any into a BundleCacheEntry
-func (r *BundleCacheEntry) FromAny(any *anypb.Any) error {
+func (r *BundleCacheEntry) FromAny(a *anypb.Any) error {
 	var s structpb.Struct
-	err := any.UnmarshalTo(&s)
+	err := a.UnmarshalTo(&s)
 	if err != nil {
 		return fmt.Errorf("unmarshal struct: %w", err)
 	}

--- a/internal/zero/telemetry/opencensus/opencensus.go
+++ b/internal/zero/telemetry/opencensus/opencensus.go
@@ -5,11 +5,10 @@ import (
 	"context"
 	"sync/atomic"
 
+	"github.com/hashicorp/go-set/v3"
 	"go.opentelemetry.io/otel/bridge/opencensus"
 	"go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
-
-	"github.com/hashicorp/go-set/v3"
 )
 
 type Producer struct {

--- a/internal/zero/telemetry/sessions/producer.go
+++ b/internal/zero/telemetry/sessions/producer.go
@@ -41,7 +41,6 @@ func (p *Producer) Produce(ctx context.Context) ([]metricdata.ScopeMetrics, erro
 	metrics := make([]metricdata.Metrics, len(ids))
 	eg, ctx := errgroup.WithContext(ctx)
 	for i := 0; i < len(ids); i++ {
-		i := i
 		eg.Go(func() error {
 			state, err := LoadMetricState(ctx, client, ids[i])
 			if err != nil {

--- a/internal/zero/telemetry/sessions/storage.go
+++ b/internal/zero/telemetry/sessions/storage.go
@@ -86,9 +86,9 @@ func (r *MetricState) ToAny() *anypb.Any {
 }
 
 // FromAny unmarshals an anypb.Any into a MetricState
-func (r *MetricState) FromAny(any *anypb.Any) error {
+func (r *MetricState) FromAny(a *anypb.Any) error {
 	var s structpb.Struct
-	err := any.UnmarshalTo(&s)
+	err := a.UnmarshalTo(&s)
 	if err != nil {
 		return fmt.Errorf("unmarshal struct: %w", err)
 	}

--- a/pkg/cmd/pomerium/pomerium.go
+++ b/pkg/cmd/pomerium/pomerium.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.uber.org/automaxprocs/maxprocs"
 	"golang.org/x/sync/errgroup"
 
@@ -29,7 +30,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/envoy/files"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"github.com/pomerium/pomerium/proxy"
-	oteltrace "go.opentelemetry.io/otel/trace"
 )
 
 type Options struct {

--- a/pkg/counter/counter.go
+++ b/pkg/counter/counter.go
@@ -21,11 +21,11 @@ type Counter struct {
 }
 
 // New creates a counter for the maximum amount unique elements provided
-func New(cap uint) *Counter {
+func New(capacity uint) *Counter {
 	return &Counter{
 		// from paper: a load factor (number of unique values/hash table size) much larger
 		// than 1.0 (e.g., 12) can be used for accurate estimation (e.g., 1% of error)
-		Bits: bitset.New(cap / loadFactor),
+		Bits: bitset.New(capacity / loadFactor),
 	}
 }
 

--- a/pkg/envoy/extract_test.go
+++ b/pkg/envoy/extract_test.go
@@ -13,11 +13,11 @@ func TestClean(t *testing.T) {
 	t.Parallel()
 
 	tmpDir := t.TempDir()
-	d1, err := os.MkdirTemp(tmpDir, envoyPrefix)
+	d1, err := os.MkdirTemp(tmpDir, envoyPrefix) //nolint:usetesting
 	require.NoError(t, err)
-	d2, err := os.MkdirTemp(tmpDir, envoyPrefix)
+	d2, err := os.MkdirTemp(tmpDir, envoyPrefix) //nolint:usetesting
 	require.NoError(t, err)
-	d3, err := os.MkdirTemp(tmpDir, envoyPrefix)
+	d3, err := os.MkdirTemp(tmpDir, envoyPrefix) //nolint:usetesting
 	require.NoError(t, err)
 
 	cleanTempDir(tmpDir)

--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -57,7 +57,7 @@ func run(ctx context.Context, args []string) error {
 func runAll(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	for _, target := range targets {
-		target := target
+
 		eg.Go(func() error {
 			return download(ctx, "./envoy-"+target, baseURL+"/envoy-"+target)
 		})

--- a/pkg/envoy/resource_monitor_linux.go
+++ b/pkg/envoy/resource_monitor_linux.go
@@ -293,6 +293,7 @@ func (s *sharedResourceMonitor) Run(ctx context.Context, envoyPid int) error {
 
 	watcherExited := make(chan struct{})
 	if err := limitWatcher.Watch(ctx); err != nil {
+		ca(nil)
 		return fmt.Errorf("failed to start watch on cgroup memory limit: %w", err)
 	}
 	go func() {
@@ -455,11 +456,11 @@ func (d *cgroupV2Driver) MemoryLimit(cgroup string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	max := strings.TrimSpace(string(data))
-	if max == "max" {
+	v := strings.TrimSpace(string(data))
+	if v == "max" {
 		return 0, nil
 	}
-	return strconv.ParseUint(max, 10, 64)
+	return strconv.ParseUint(v, 10, 64)
 }
 
 // Validate implements CgroupDriver.
@@ -570,11 +571,11 @@ func (d *cgroupV1Driver) MemoryLimit(cgroup string) (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	max := strings.TrimSpace(string(data))
-	if max == "max" {
+	v := strings.TrimSpace(string(data))
+	if v == "max" {
 		return 0, nil
 	}
-	return strconv.ParseUint(max, 10, 64)
+	return strconv.ParseUint(v, 10, 64)
 }
 
 // Validate implements CgroupDriver.
@@ -680,11 +681,11 @@ func (w *memoryLimitWatcher) readValue() (uint64, error) {
 	if err != nil {
 		return 0, err
 	}
-	max := strings.TrimSpace(string(data))
-	if max == "max" {
+	v := strings.TrimSpace(string(data))
+	if v == "max" {
 		return 0, nil
 	}
-	return strconv.ParseUint(max, 10, 64)
+	return strconv.ParseUint(v, 10, 64)
 }
 
 func (w *memoryLimitWatcher) Watch(ctx context.Context) error {

--- a/pkg/grpc/session/session_test.go
+++ b/pkg/grpc/session/session_test.go
@@ -187,7 +187,6 @@ func TestSession_Validate(t *testing.T) {
 		// Expiry of the ID token does not indicate expiry of the underlying session.
 		{"expired id token ok", &Session{IdToken: &IDToken{ExpiresAt: t0}}, nil},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/grpc/user/user_test.go
+++ b/pkg/grpc/user/user_test.go
@@ -20,7 +20,6 @@ func TestServiceAccount_Validate(t *testing.T) {
 		{"valid", &ServiceAccount{}, nil},
 		{"expired", &ServiceAccount{ExpiresAt: t0}, ErrServiceAccountExpired},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/grpcutil/options.go
+++ b/pkg/grpcutil/options.go
@@ -8,10 +8,11 @@ import (
 
 	"github.com/go-jose/go-jose/v3"
 	"github.com/go-jose/go-jose/v3/jwt"
-	"github.com/pomerium/pomerium/internal/log"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 // WithStreamSignedJWT returns a StreamClientInterceptor that adds a JWT to requests.

--- a/pkg/identity/manager/data.go
+++ b/pkg/identity/manager/data.go
@@ -38,9 +38,9 @@ func nextSessionRefresh(
 	}
 
 	// don't refresh any quicker than the cool-off duration
-	min := lastRefresh.Add(coolOffDuration)
-	if tm.Before(min) {
-		tm = min
+	v := lastRefresh.Add(coolOffDuration)
+	if tm.Before(v) {
+		tm = v
 	}
 
 	return tm

--- a/pkg/protoutil/any_test.go
+++ b/pkg/protoutil/any_test.go
@@ -78,7 +78,6 @@ func TestToAny(t *testing.T) {
 		}`},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			actual := ToAny(tc.value)
 			testutil.AssertProtoJSONEqual(t, tc.expect, actual)

--- a/pkg/protoutil/struct_test.go
+++ b/pkg/protoutil/struct_test.go
@@ -33,7 +33,6 @@ func TestToValue(t *testing.T) {
 		{"Message", &apipb.Method{Name: "example"}, `{"name": "example"}`},
 	}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			actual := ToStruct(tc.value)
 			testutil.AssertProtoJSONEqual(t, tc.expect, actual)

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -458,12 +458,12 @@ func signalServiceChange(ctx context.Context, q querier) error {
 	return err
 }
 
-func jsonbFromAny(any *anypb.Any) ([]byte, error) {
-	if any == nil {
+func jsonbFromAny(a *anypb.Any) ([]byte, error) {
+	if a == nil {
 		return nil, nil
 	}
 
-	return protojson.Marshal(any)
+	return protojson.Marshal(a)
 }
 
 func timestamppbFromTimestamptz(ts pgtype.Timestamptz) *timestamppb.Timestamp {

--- a/pkg/storage/postgres/tracing_test.go
+++ b/pkg/storage/postgres/tracing_test.go
@@ -8,6 +8,9 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/testenv"
 	"github.com/pomerium/pomerium/internal/testenv/scenarios"
@@ -15,8 +18,6 @@ import (
 	"github.com/pomerium/pomerium/internal/testenv/upstreams"
 	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/internal/testutil/tracetest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestQueryTracing(t *testing.T) {

--- a/pkg/storage/querier_test.go
+++ b/pkg/storage/querier_test.go
@@ -34,7 +34,6 @@ func TestGetDataBrokerRecord(t *testing.T) {
 		{"cached", 1, 1, 1, 2},
 		{"invalidated", 1, 2, 3, 4},
 	} {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -49,12 +49,12 @@ type Backend interface {
 }
 
 // MatchAny searches any data with a query.
-func MatchAny(any *anypb.Any, query string) bool {
-	if any == nil {
+func MatchAny(a *anypb.Any, query string) bool {
+	if a == nil {
 		return false
 	}
 
-	msg, err := any.UnmarshalNew()
+	msg, err := a.UnmarshalNew()
 	if err != nil {
 		// ignore invalid any types
 		log.Error().Err(err).Msg("storage: invalid any type")

--- a/pkg/telemetry/trace/carriers_test.go
+++ b/pkg/telemetry/trace/carriers_test.go
@@ -4,8 +4,9 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 func TestPomeriumURLQueryCarrier(t *testing.T) {

--- a/pkg/telemetry/trace/client.go
+++ b/pkg/telemetry/trace/client.go
@@ -10,13 +10,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pomerium/pomerium/config/otelconfig"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
+
+	"github.com/pomerium/pomerium/config/otelconfig"
 )
 
 var (

--- a/pkg/telemetry/trace/client_test.go
+++ b/pkg/telemetry/trace/client_test.go
@@ -11,6 +11,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
+	"go.uber.org/mock/gomock"
+
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/testenv"
@@ -20,11 +26,6 @@ import (
 	"github.com/pomerium/pomerium/internal/testutil/tracetest/mock_otlptrace"
 	"github.com/pomerium/pomerium/internal/version"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel"
-	tracev1 "go.opentelemetry.io/proto/otlp/trace/v1"
-	"go.uber.org/mock/gomock"
 )
 
 func TestSyncClient(t *testing.T) {

--- a/pkg/telemetry/trace/debug_test.go
+++ b/pkg/telemetry/trace/debug_test.go
@@ -9,11 +9,12 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/pomerium/pomerium/internal/testutil/tracetest" //nolint:revive
-	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"github.com/stretchr/testify/assert"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
+
+	. "github.com/pomerium/pomerium/internal/testutil/tracetest" //nolint:revive
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 func TestSpanObserver(t *testing.T) {

--- a/pkg/telemetry/trace/global_test.go
+++ b/pkg/telemetry/trace/global_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 func TestUseGlobalPanicTracer(t *testing.T) {

--- a/pkg/telemetry/trace/middleware_test.go
+++ b/pkg/telemetry/trace/middleware_test.go
@@ -9,13 +9,14 @@ import (
 	"time"
 
 	"github.com/gorilla/mux"
-	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
+
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 func TestHTTPMiddleware(t *testing.T) {

--- a/pkg/telemetry/trace/server.go
+++ b/pkg/telemetry/trace/server.go
@@ -7,14 +7,14 @@ import (
 	"net"
 	"time"
 
-	"github.com/pomerium/pomerium/internal/log"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	coltracepb "go.opentelemetry.io/proto/otlp/collector/trace/v1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
 
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
-	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 const localExporterMetadataKey = "x-local-exporter"

--- a/pkg/webauthnutil/webauthnutil_test.go
+++ b/pkg/webauthnutil/webauthnutil_test.go
@@ -19,7 +19,6 @@ func TestGetEffectiveDomain(t *testing.T) {
 		{"https://www.subdomain.example.com/some/path", "example.com"},
 		{"https://example.com/some/path", "example.com"},
 	} {
-		tc := tc
 		t.Run(tc.expect, func(t *testing.T) {
 			t.Parallel()
 


### PR DESCRIPTION
## Summary
Upgrade go to v1.24. Also upgrade golangci-lint v1.64.8 and fix a bunch of linting issues.

## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
