### PR TITLE
multi-domain login redirects

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -235,8 +235,12 @@ func (a *Authorize) requireLoginResponse(
 		signInURLQuery = url.Values{}
 		signInURLQuery.Add("pomerium_traceparent", id)
 	}
+	var additionalHosts []string
+	if request.Policy != nil {
+		additionalHosts = request.Policy.DependsOn
+	}
 	redirectTo, err := state.authenticateFlow.AuthenticateSignInURL(
-		ctx, signInURLQuery, &checkRequestURL, idp.GetId())
+		ctx, signInURLQuery, &checkRequestURL, idp.GetId(), additionalHosts)
 	if err != nil {
 		return nil, err
 	}

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -20,7 +20,7 @@ import (
 var outboundGRPCConnection = new(grpc.CachedOutboundGRPClientConn)
 
 type authenticateFlow interface {
-	AuthenticateSignInURL(ctx context.Context, queryParams url.Values, redirectURL *url.URL, idpID string) (string, error)
+	AuthenticateSignInURL(ctx context.Context, queryParams url.Values, redirectURL *url.URL, idpID string, additionalLoginHosts []string) (string, error)
 }
 
 type authorizeState struct {

--- a/config/options.go
+++ b/config/options.go
@@ -1984,16 +1984,3 @@ func setCertificate(
 		*dstCertificateKey = base64.StdEncoding.EncodeToString(src.GetKeyBytes())
 	}
 }
-
-func (o *Options) GetRouteForHost(host string) *Policy {
-	for _, r := range o.Routes {
-		u, err := url.Parse(r.From)
-		if err != nil {
-			continue
-		}
-		if u.Host == host {
-			return &r
-		}
-	}
-	return nil
-}

--- a/config/options.go
+++ b/config/options.go
@@ -1984,3 +1984,16 @@ func setCertificate(
 		*dstCertificateKey = base64.StdEncoding.EncodeToString(src.GetKeyBytes())
 	}
 }
+
+func (o *Options) GetRouteForHost(host string) *Policy {
+	for _, r := range o.Routes {
+		u, err := url.Parse(r.From)
+		if err != nil {
+			continue
+		}
+		if u.Host == host {
+			return &r
+		}
+	}
+	return nil
+}

--- a/config/policy.go
+++ b/config/policy.go
@@ -200,6 +200,8 @@ type Policy struct {
 	ShowErrorDetails bool `mapstructure:"show_error_details" yaml:"show_error_details" json:"show_error_details"`
 
 	Policy *PPLPolicy `mapstructure:"policy" yaml:"policy,omitempty" json:"policy,omitempty"`
+
+	DependsOn []string `mapstructure:"depends_on" yaml:"depends_on,omitempty" json:"depends_on,omitempty"`
 }
 
 // RewriteHeader is a policy configuration option to rewrite an HTTP header.

--- a/config/policy.go
+++ b/config/policy.go
@@ -692,6 +692,10 @@ func (p *Policy) Validate() error {
 		return fmt.Errorf("config: unsupported jwt_issuer_format value %q", p.JWTIssuerFormat)
 	}
 
+	if len(p.DependsOn) > 5 {
+		return fmt.Errorf("config: depends_on is limited to 5 additional redirect hosts, got %v", p.DependsOn)
+	}
+
 	return nil
 }
 

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -56,6 +56,7 @@ func Test_PolicyValidate(t *testing.T) {
 		{"TCP To URLs", Policy{From: "tcp+https://httpbin.corp.example:4000", To: mustParseWeightedURLs(t, "tcp://one.example.com:5000", "tcp://two.example.com:5000")}, false},
 		{"mix of TCP and non-TCP To URLs", Policy{From: "tcp+https://httpbin.corp.example:4000", To: mustParseWeightedURLs(t, "https://example.com", "tcp://example.com:5000")}, true},
 		{"UDP To URLs", Policy{From: "udp+https://httpbin.corp.example:4000", To: mustParseWeightedURLs(t, "udp://one.example.com:5000", "udp://two.example.com:5000")}, false},
+		{"too many depends_on hosts", Policy{From: "https://httpbin.corp.example", To: mustParseWeightedURLs(t, "https://httpbin.corp.notatld"), DependsOn: []string{"a", "b", "c", "d", "e", "f"}}, true},
 	}
 
 	for _, tt := range tests {

--- a/internal/authenticateflow/authenticateflow_int_test.go
+++ b/internal/authenticateflow/authenticateflow_int_test.go
@@ -1,0 +1,98 @@
+package authenticateflow_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/cookiejar"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/scenarios"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	"github.com/pomerium/pomerium/internal/testenv/values"
+)
+
+func newHttpUpstream(
+	env testenv.Environment, subdomain string,
+) (upstreams.HTTPUpstream, testenv.Route) {
+	up := upstreams.HTTP(nil)
+	up.Handle("/", func(w http.ResponseWriter, r *http.Request) { fmt.Fprintln(w, "hello world") })
+	route := up.Route().
+		From(env.SubdomainURL(subdomain)).
+		To(values.Bind(up.Addr(), func(addr string) string {
+			// override the target protocol to use http://
+			return fmt.Sprintf("http://%s", addr)
+		})).
+		Policy(func(p *config.Policy) { p.AllowAnyAuthenticatedUser = true })
+	env.AddUpstream(up)
+	return up, route
+}
+
+func TestMultiDomainLogin(t *testing.T) {
+	env := testenv.New(t)
+
+	env.Add(scenarios.NewIDP([]*scenarios.User{{Email: "test@example.com"}}))
+
+	// Create three routes to be linked via multi-domain login...
+	upstreamA, routeA := newHttpUpstream(env, "a")
+	upstreamB, routeB := newHttpUpstream(env, "b")
+	upstreamC, routeC := newHttpUpstream(env, "c")
+	// ...and one route that will not be involved.
+	upstreamD, routeD := newHttpUpstream(env, "d")
+
+	// Configure route A to redirect through routes B and C on login.
+	routeA.Policy(func(p *config.Policy) {
+		p.DependsOn = []string{
+			strings.TrimPrefix(routeB.URL().Value(), "https://"),
+			strings.TrimPrefix(routeC.URL().Value(), "https://"),
+		}
+	})
+
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	// By default the testenv code will use a separate http.Client for each
+	// separate route. Instead we specifically want to test the cross-route
+	// behavior for a single client.
+	cj, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	sharedClient := http.Client{Jar: cj}
+	withSharedClient := upstreams.ClientHook(
+		func(c *http.Client) *http.Client { return &sharedClient })
+
+	assertResponseOK := func(resp *http.Response, err error) {
+		t.Helper()
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		io.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
+	assertRedirect := func(resp *http.Response, err error) {
+		t.Helper()
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusFound, resp.StatusCode)
+		io.ReadAll(resp.Body)
+		resp.Body.Close()
+	}
+
+	// Log in to the first route.
+	assertResponseOK(upstreamA.Get(routeA, withSharedClient, upstreams.AuthenticateAs("test@example.com")))
+
+	// The client should also be authenticated for routes B and C without any
+	// additional login redirects.
+	sharedClient.CheckRedirect = func(req *http.Request, via []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	assertResponseOK(upstreamB.Get(routeB, withSharedClient))
+	assertResponseOK(upstreamC.Get(routeC, withSharedClient))
+
+	// The client should not be authenticated for route D.
+	assertRedirect(upstreamD.Get(routeD, withSharedClient))
+}

--- a/internal/authenticateflow/stateful_test.go
+++ b/internal/authenticateflow/stateful_test.go
@@ -128,7 +128,7 @@ func TestStatefulAuthenticateSignInURL(t *testing.T) {
 
 	t.Run("NilQueryParams", func(t *testing.T) {
 		redirectURL := &url.URL{Scheme: "https", Host: "example.com"}
-		u, err := flow.AuthenticateSignInURL(context.Background(), nil, redirectURL, "fake-idp-id")
+		u, err := flow.AuthenticateSignInURL(context.Background(), nil, redirectURL, "fake-idp-id", nil)
 		assert.NoError(t, err)
 		parsed, _ := url.Parse(u)
 		assert.NoError(t, urlutil.NewSignedURL(key, parsed).Validate())
@@ -143,7 +143,7 @@ func TestStatefulAuthenticateSignInURL(t *testing.T) {
 		redirectURL := &url.URL{Scheme: "https", Host: "example.com"}
 		q := url.Values{}
 		q.Set("foo", "bar")
-		u, err := flow.AuthenticateSignInURL(context.Background(), q, redirectURL, "fake-idp-id")
+		u, err := flow.AuthenticateSignInURL(context.Background(), q, redirectURL, "fake-idp-id", nil)
 		assert.NoError(t, err)
 		parsed, _ := url.Parse(u)
 		assert.NoError(t, urlutil.NewSignedURL(key, parsed).Validate())
@@ -270,7 +270,7 @@ func TestStatefulCallback(t *testing.T) {
 			r.Header.Set("Accept", "application/json")
 
 			w := httptest.NewRecorder()
-			err = flow.Callback(w, r, nil)
+			err = flow.Callback(w, r)
 			if tt.wantErrorMsg == "" {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)

--- a/internal/authenticateflow/stateful_test.go
+++ b/internal/authenticateflow/stateful_test.go
@@ -155,6 +155,21 @@ func TestStatefulAuthenticateSignInURL(t *testing.T) {
 		assert.Equal(t, "fake-idp-id", q.Get("pomerium_idp_id"))
 		assert.Equal(t, "bar", q.Get("foo"))
 	})
+	t.Run("AdditionalHosts", func(t *testing.T) {
+		redirectURL := &url.URL{Scheme: "https", Host: "example.com"}
+		additionalHosts := []string{"foo.example.com", "bar.example.com:1234"}
+		u, err := flow.AuthenticateSignInURL(context.Background(), nil, redirectURL, "fake-idp-id", additionalHosts)
+		assert.NoError(t, err)
+		parsed, _ := url.Parse(u)
+		assert.NoError(t, urlutil.NewSignedURL(key, parsed).Validate())
+		assert.Equal(t, "https", parsed.Scheme)
+		assert.Equal(t, "authenticate.example.com", parsed.Host)
+		assert.Equal(t, "/.pomerium/sign_in", parsed.Path)
+		q := parsed.Query()
+		assert.Equal(t, "https://example.com", parsed.Query().Get("pomerium_redirect_uri"))
+		assert.Equal(t, "fake-idp-id", q.Get("pomerium_idp_id"))
+		assert.Equal(t, "foo.example.com,bar.example.com:1234", q.Get("pomerium_additional_hosts"))
+	})
 }
 
 func TestStatefulGetIdentityProviderIDForURLValues(t *testing.T) {
@@ -277,6 +292,7 @@ func TestStatefulCallback(t *testing.T) {
 				}
 				location, _ := url.Parse(w.Result().Header.Get("Location"))
 				assert.Equal(t, "example.com", location.Host)
+				assert.Equal(t, "/", location.Path)
 				assert.Equal(t, "ok", location.Query().Get("pomerium_callback_uri"))
 			} else {
 				if err == nil || !strings.Contains(err.Error(), tt.wantErrorMsg) {
@@ -285,6 +301,60 @@ func TestStatefulCallback(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestStatefulCallback_AdditionalHosts(t *testing.T) {
+	opts := config.NewDefaultOptions()
+	opts.SharedKey = "80ldlrU2d7w+wVpKNfevk6fmb8otEx6CqOfshj2LwhQ="
+	sharedKey, _ := opts.GetSharedKey()
+
+	flow, err := NewStateful(
+		context.Background(),
+		trace.NewNoopTracerProvider(),
+		&config.Config{Options: opts},
+		&mstore.Store{Session: &sessions.State{}},
+	)
+	require.NoError(t, err)
+
+	redirectURI := "https://route.example.com/"
+	callbackURI := &url.URL{
+		Scheme: "https",
+		Host:   "route.example.com",
+		Path:   "/.pomerium/callback",
+		RawQuery: url.Values{
+			urlutil.QuerySessionEncrypted: []string{goodEncryptionString},
+			urlutil.QueryRedirectURI:      []string{redirectURI},
+			urlutil.QueryAdditionalHosts:  []string{"foo.example.com,bar.example.com"},
+		}.Encode(),
+	}
+	signedCallbackURI := urlutil.NewSignedURL(sharedKey, callbackURI)
+
+	doCallback := func(uri string) *http.Response {
+		t.Helper()
+		r := httptest.NewRequest(http.MethodGet, uri, nil)
+		r.Host = r.URL.Host
+
+		w := httptest.NewRecorder()
+		err = flow.Callback(w, r)
+		require.NoError(t, err)
+		return w.Result()
+	}
+
+	// Callback() should serve redirects to the additional hosts before the final redirect URI.
+	res := doCallback(signedCallbackURI.String())
+	location, _ := url.Parse(res.Header.Get("Location"))
+	assert.Equal(t, "foo.example.com", location.Host)
+	assert.Equal(t, "/.pomerium/callback/", location.Path)
+
+	res = doCallback(location.String())
+	location, _ = url.Parse(res.Header.Get("Location"))
+	assert.Equal(t, "bar.example.com", location.Host)
+	assert.Equal(t, "/.pomerium/callback/", location.Path)
+
+	res = doCallback(location.String())
+	location, _ = url.Parse(res.Header.Get("Location"))
+	assert.Equal(t, "route.example.com", location.Host)
+	assert.Equal(t, "/", location.Path)
 }
 
 func TestStatefulRevokeSession(t *testing.T) {

--- a/internal/authenticateflow/stateful_test.go
+++ b/internal/authenticateflow/stateful_test.go
@@ -270,7 +270,7 @@ func TestStatefulCallback(t *testing.T) {
 			r.Header.Set("Accept", "application/json")
 
 			w := httptest.NewRecorder()
-			err = flow.Callback(w, r)
+			err = flow.Callback(w, r, nil)
 			if tt.wantErrorMsg == "" {
 				if err != nil {
 					t.Errorf("unexpected error: %v", err)

--- a/internal/authenticateflow/stateless.go
+++ b/internal/authenticateflow/stateless.go
@@ -359,7 +359,7 @@ func (s *Stateless) AuthenticateSignInURL(
 	queryParams url.Values,
 	redirectURL *url.URL,
 	idpID string,
-	additionalHosts []string,
+	_ []string,
 ) (string, error) {
 	authenticateHPKEPublicKey, err := s.authenticateKeyFetcher.FetchPublicKey(ctx)
 	if err != nil {

--- a/internal/authenticateflow/stateless.go
+++ b/internal/authenticateflow/stateless.go
@@ -355,7 +355,11 @@ func getUserClaim(profile *identitypb.Profile, field string) *string {
 // AuthenticateSignInURL returns a URL to redirect the user to the authenticate
 // domain.
 func (s *Stateless) AuthenticateSignInURL(
-	ctx context.Context, queryParams url.Values, redirectURL *url.URL, idpID string,
+	ctx context.Context,
+	queryParams url.Values,
+	redirectURL *url.URL,
+	idpID string,
+	additionalHosts []string,
 ) (string, error) {
 	authenticateHPKEPublicKey, err := s.authenticateKeyFetcher.FetchPublicKey(ctx)
 	if err != nil {
@@ -380,7 +384,7 @@ func (s *Stateless) AuthenticateSignInURL(
 }
 
 // Callback handles a redirect to a route domain once signed in.
-func (s *Stateless) Callback(w http.ResponseWriter, r *http.Request, route *config.Policy) error {
+func (s *Stateless) Callback(w http.ResponseWriter, r *http.Request) error {
 	if err := r.ParseForm(); err != nil {
 		return httputil.NewError(http.StatusBadRequest, err)
 	}

--- a/internal/authenticateflow/stateless.go
+++ b/internal/authenticateflow/stateless.go
@@ -380,7 +380,7 @@ func (s *Stateless) AuthenticateSignInURL(
 }
 
 // Callback handles a redirect to a route domain once signed in.
-func (s *Stateless) Callback(w http.ResponseWriter, r *http.Request) error {
+func (s *Stateless) Callback(w http.ResponseWriter, r *http.Request, route *config.Policy) error {
 	if err := r.ParseForm(); err != nil {
 		return httputil.NewError(http.StatusBadRequest, err)
 	}

--- a/internal/urlutil/proxy.go
+++ b/internal/urlutil/proxy.go
@@ -4,19 +4,15 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 // ErrMissingRedirectURI indicates the pomerium_redirect_uri was missing from the query string.
 var ErrMissingRedirectURI = errors.New("missing " + QueryRedirectURI)
 
 // GetCallbackURL gets the proxy's callback URL from a request and a base64url encoded + encrypted session state JWT.
-func GetCallbackURL(r *http.Request, encodedSessionJWT string) (*url.URL, error) {
-	return GetCallbackURLForRedirectURI(r, encodedSessionJWT, r.FormValue(QueryRedirectURI))
-}
-
-// GetCallbackURLForRedirectURI gets the proxy's callback URL from a request and a base64url encoded + encrypted session
-// state JWT.
-func GetCallbackURLForRedirectURI(r *http.Request, encodedSessionJWT, rawRedirectURI string) (*url.URL, error) {
+func GetCallbackURL(r *http.Request, encodedSessionJWT string, additionalHosts []string) (*url.URL, error) {
+	rawRedirectURI := r.FormValue(QueryRedirectURI)
 	if rawRedirectURI == "" {
 		return nil, ErrMissingRedirectURI
 	}
@@ -53,6 +49,10 @@ func GetCallbackURLForRedirectURI(r *http.Request, encodedSessionJWT, rawRedirec
 	}
 	if tracestate := r.FormValue(QueryTracestate); tracestate != "" {
 		callbackParams.Set(QueryTracestate, tracestate)
+	}
+
+	if additionalHosts != nil {
+		callbackParams.Set(QueryAdditionalHosts, strings.Join(additionalHosts, ","))
 	}
 
 	// add our encoded and encrypted route-session JWT to a query param

--- a/internal/urlutil/proxy.go
+++ b/internal/urlutil/proxy.go
@@ -51,7 +51,7 @@ func GetCallbackURL(r *http.Request, encodedSessionJWT string, additionalHosts [
 		callbackParams.Set(QueryTracestate, tracestate)
 	}
 
-	if additionalHosts != nil {
+	if len(additionalHosts) > 0 {
 		callbackParams.Set(QueryAdditionalHosts, strings.Join(additionalHosts, ","))
 	}
 

--- a/internal/urlutil/query_params.go
+++ b/internal/urlutil/query_params.go
@@ -4,6 +4,7 @@ package urlutil
 // services over HTTP calls and redirects. They are typically used in
 // conjunction with a HMAC to ensure authenticity.
 const (
+	QueryAdditionalHosts    = "pomerium_additional_hosts"
 	QueryCallbackURI        = "pomerium_callback_uri"
 	QueryDeviceCredentialID = "pomerium_device_credential_id"
 	QueryDeviceType         = "pomerium_device_type"

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -119,9 +119,7 @@ func (p *Proxy) deviceEnrolled(w http.ResponseWriter, r *http.Request) error {
 // Callback handles the result of a successful call to the authenticate service
 // and is responsible setting per-route sessions.
 func (p *Proxy) Callback(w http.ResponseWriter, r *http.Request) error {
-	// XXX: need a better way to match request to route
-	route := p.currentOptions.Load().GetRouteForHost(r.Host)
-	return p.state.Load().authenticateFlow.Callback(w, r, route)
+	return p.state.Load().authenticateFlow.Callback(w, r)
 }
 
 // ProgrammaticLogin returns a signed url that can be used to login
@@ -151,7 +149,7 @@ func (p *Proxy) ProgrammaticLogin(w http.ResponseWriter, r *http.Request) error 
 	q.Set(urlutil.QueryIsProgrammatic, "true")
 
 	rawURL, err := state.authenticateFlow.AuthenticateSignInURL(
-		r.Context(), q, redirectURI, idp.GetId())
+		r.Context(), q, redirectURI, idp.GetId(), nil)
 	if err != nil {
 		return httputil.NewError(http.StatusInternalServerError, err)
 	}

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -119,7 +119,9 @@ func (p *Proxy) deviceEnrolled(w http.ResponseWriter, r *http.Request) error {
 // Callback handles the result of a successful call to the authenticate service
 // and is responsible setting per-route sessions.
 func (p *Proxy) Callback(w http.ResponseWriter, r *http.Request) error {
-	return p.state.Load().authenticateFlow.Callback(w, r)
+	// XXX: need a better way to match request to route
+	route := p.currentOptions.Load().GetRouteForHost(r.Host)
+	return p.state.Load().authenticateFlow.Callback(w, r, route)
 }
 
 // ProgrammaticLogin returns a signed url that can be used to login

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -20,7 +20,7 @@ var outboundGRPCConnection = new(grpc.CachedOutboundGRPClientConn)
 
 type authenticateFlow interface {
 	AuthenticateSignInURL(ctx context.Context, queryParams url.Values, redirectURL *url.URL, idpID string) (string, error)
-	Callback(w http.ResponseWriter, r *http.Request) error
+	Callback(w http.ResponseWriter, r *http.Request, route *config.Policy) error
 }
 
 type proxyState struct {

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -19,8 +19,8 @@ import (
 var outboundGRPCConnection = new(grpc.CachedOutboundGRPClientConn)
 
 type authenticateFlow interface {
-	AuthenticateSignInURL(ctx context.Context, queryParams url.Values, redirectURL *url.URL, idpID string) (string, error)
-	Callback(w http.ResponseWriter, r *http.Request, route *config.Policy) error
+	AuthenticateSignInURL(ctx context.Context, queryParams url.Values, redirectURL *url.URL, idpID string, additionalHosts []string) (string, error)
+	Callback(w http.ResponseWriter, r *http.Request) error
 }
 
 type proxyState struct {


### PR DESCRIPTION
## Summary

Add support for redirecting through multiple domains upon initial login to a Pomerium route. This may be useful for resolving CORS issues in certain circumstances (e.g. single-page applications that host resources on different sub-domains).

Add a new `depends_on` route setting that accepts a list of additional hosts to redirect through.

Add an integration test using the `testenv` framework.

Caveats:
- This feature is not available for Pomerium deployments using the Hosted Authenticate Service.
- This feature is not available for programmatic login.
- There is a limit of 5 additional hosts for a particular route.
- All of the additional hosts must resolve to the same Pomerium deployment.

## Related issues

https://linear.app/pomerium/issue/ENG-1710/better-support-for-cross-domain-requests

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
