### PR TITLE
cleanup logs

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -109,7 +109,7 @@ func New(
 ) (*Evaluator, error) {
 	cfg := getConfig(options...)
 
-	err := updateStore(ctx, store, cfg)
+	err := updateStore(store, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -321,8 +321,8 @@ func (e *Evaluator) getClientCA(policy *config.Policy) (string, error) {
 	return string(e.clientCA), nil
 }
 
-func updateStore(ctx context.Context, store *store.Store, cfg *evaluatorConfig) error {
-	jwk, err := getJWK(ctx, cfg)
+func updateStore(store *store.Store, cfg *evaluatorConfig) error {
+	jwk, err := getJWK(cfg)
 	if err != nil {
 		return fmt.Errorf("authorize: couldn't create signer: %w", err)
 	}
@@ -339,7 +339,7 @@ func updateStore(ctx context.Context, store *store.Store, cfg *evaluatorConfig) 
 	return nil
 }
 
-func getJWK(ctx context.Context, cfg *evaluatorConfig) (*jose.JSONWebKey, error) {
+func getJWK(cfg *evaluatorConfig) (*jose.JSONWebKey, error) {
 	var decodedCert []byte
 	// if we don't have a signing key, generate one
 	if len(cfg.SigningKey) == 0 {
@@ -359,10 +359,6 @@ func getJWK(ctx context.Context, cfg *evaluatorConfig) (*jose.JSONWebKey, error)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't generate signing key: %w", err)
 	}
-	log.Ctx(ctx).Info().Str("Algorithm", jwk.Algorithm).
-		Str("KeyID", jwk.KeyID).
-		Interface("Public Key", jwk.Public()).
-		Msg("authorize: signing key")
 
 	return jwk, nil
 }

--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -53,10 +53,6 @@ func main() {
 }
 
 func run(ctx context.Context, configFile string) error {
-	ctx = log.WithContext(ctx, func(c zerolog.Context) zerolog.Context {
-		return c.Str("config_file_source", configFile).Bool("bootstrap", true)
-	})
-
 	var src config.Source
 
 	src, err := config.NewFileOrEnvironmentSource(ctx, configFile, files.FullVersion())

--- a/config/config_source.go
+++ b/config/config_source.go
@@ -108,10 +108,6 @@ func NewFileOrEnvironmentSource(
 	ctx context.Context,
 	configFile, envoyVersion string,
 ) (*FileOrEnvironmentSource, error) {
-	ctx = log.WithContext(ctx, func(c zerolog.Context) zerolog.Context {
-		return c.Str("config_file_source", configFile)
-	})
-
 	options, err := newOptionsFromConfig(configFile)
 	if err != nil {
 		return nil, err
@@ -254,7 +250,7 @@ func (src *FileWatcherSource) onConfigChange(ctx context.Context, cfg *Config) {
 	// store the config and trigger an update
 	src.cfg = cfg.Clone()
 	src.hash = getAllConfigFilePathsHash(src.cfg)
-	log.Ctx(ctx).Info().Uint64("hash", src.hash).Msg("config/filewatchersource: underlying config change, triggering update")
+	log.Ctx(ctx).Debug().Uint64("hash", src.hash).Msg("config/filewatchersource: underlying config change, triggering update")
 	src.Trigger(ctx, src.cfg)
 }
 

--- a/config/metrics.go
+++ b/config/metrics.go
@@ -93,7 +93,6 @@ func (mgr *MetricsManager) updateServer(ctx context.Context, cfg *Config) {
 	mgr.handler = nil
 
 	if mgr.addr == "" {
-		log.Ctx(ctx).Info().Msg("metrics: http server disabled")
 		return
 	}
 

--- a/config/options.go
+++ b/config/options.go
@@ -655,14 +655,11 @@ func (o *Options) Validate() error {
 		return fmt.Errorf("config: failed to parse headers: %w", err)
 	}
 
-	hasCert := false
-
 	if o.Cert != "" || o.Key != "" {
 		_, err := cryptutil.CertificateFromBase64(o.Cert, o.Key)
 		if err != nil {
 			return fmt.Errorf("config: bad cert base64 %w", err)
 		}
-		hasCert = true
 	}
 
 	for _, c := range o.CertificateData {
@@ -670,7 +667,6 @@ func (o *Options) Validate() error {
 		if err != nil {
 			return fmt.Errorf("config: bad cert entry, cert is invalid: %w", err)
 		}
-		hasCert = true
 	}
 
 	for _, c := range o.CertificateFiles {
@@ -678,7 +674,6 @@ func (o *Options) Validate() error {
 		if err != nil {
 			return fmt.Errorf("config: bad cert entry, file reference invalid. %w", err)
 		}
-		hasCert = true
 	}
 
 	if o.CertFile != "" || o.KeyFile != "" {
@@ -686,7 +681,6 @@ func (o *Options) Validate() error {
 		if err != nil {
 			return fmt.Errorf("config: bad cert file %w", err)
 		}
-		hasCert = true
 	}
 
 	if err := o.DownstreamMTLS.validate(); err != nil {
@@ -695,11 +689,6 @@ func (o *Options) Validate() error {
 
 	// strip quotes from redirect address (#811)
 	o.HTTPRedirectAddr = strings.Trim(o.HTTPRedirectAddr, `"'`)
-
-	if !o.InsecureServer && !hasCert && !o.AutocertOptions.Enable {
-		log.Ctx(ctx).Info().Msg("neither `autocert`, " +
-			"`insecure_server` or manually provided certificates were provided, server will be using a self-signed certificate")
-	}
 
 	if err := ValidateDNSLookupFamily(o.DNSLookupFamily); err != nil {
 		return fmt.Errorf("config: %w", err)

--- a/internal/log/grpc.go
+++ b/internal/log/grpc.go
@@ -51,19 +51,19 @@ type grpcLogger struct {
 
 func (c *grpcLogger) Info(args ...any) {
 	if c.getLevel() <= zerolog.DebugLevel {
-		Logger().Info().Msg(fmt.Sprint(args...))
+		Logger().Debug().Msg(fmt.Sprint(args...))
 	}
 }
 
 func (c *grpcLogger) Infoln(args ...any) {
 	if c.getLevel() <= zerolog.DebugLevel {
-		Logger().Info().Msg(fmt.Sprintln(args...))
+		Logger().Debug().Msg(fmt.Sprintln(args...))
 	}
 }
 
 func (c *grpcLogger) Infof(format string, args ...any) {
 	if c.getLevel() <= zerolog.DebugLevel {
-		Logger().Info().Msg(fmt.Sprintf(format, args...))
+		Logger().Debug().Msg(fmt.Sprintf(format, args...))
 	}
 }
 

--- a/pkg/envoy/resource_monitor_linux.go
+++ b/pkg/envoy/resource_monitor_linux.go
@@ -283,7 +283,7 @@ func (s *sharedResourceMonitor) Run(ctx context.Context, envoyPid int) error {
 	if envoyCgroup != s.cgroup {
 		return fmt.Errorf("envoy process is not in the expected cgroup: %s", envoyCgroup)
 	}
-	log.Ctx(ctx).Info().Str("service", "envoy").Str("cgroup", s.cgroup).Msg("starting resource monitor")
+	log.Ctx(ctx).Debug().Str("service", "envoy").Str("cgroup", s.cgroup).Msg("starting resource monitor")
 
 	ctx, ca := context.WithCancelCause(ctx)
 


### PR DESCRIPTION
## Summary
Cleanup some logs:

- remove the authorize signing key log message
- remove the `config_file_source` and `bootstrap` fields added to every log line. It's unclear what these fields were intended to mean, but they don't appear to be updated depending on the configuration source.
- change the file watcher underlying config change message to `debug`
- remove the message about metrics being disabled
- remove the `server will be using a self-signed certificate` message. The ask was to remove it only for zero, enterprise or the ingress controller, but the way pomerium works is by loading an initial config, and then the subsequent configs come in via the databroker, so it will start with a self-signed certificate regardless (in other words this log message is accurate)
- change default gRPC levels to debug instead of info
- change resource monitor message to debug
- remove the log ctx for syncer and set the fields explicitly, we don't want `syncer_id` and `syncer_type` being added to all the subsequent log messages, just the messages directly related to syncing

## Related issues
- [ENG-1890](https://linear.app/pomerium/issue/ENG-1890/remove-any-spurious-logs-warnings-from-core-when-running-with-ingress)

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
