### PR TITLE
mcp: add oauth metadata endpoint

### DIFF
--- a/config/envoyconfig/http_connection_manager.go
+++ b/config/envoyconfig/http_connection_manager.go
@@ -20,6 +20,7 @@ func (b *Builder) buildVirtualHost(
 	options *config.Options,
 	name string,
 	host string,
+	hasMCPPolicy bool,
 ) (*envoy_config_route_v3.VirtualHost, error) {
 	vh := &envoy_config_route_v3.VirtualHost{
 		Name:    name,
@@ -36,7 +37,7 @@ func (b *Builder) buildVirtualHost(
 	}
 
 	// these routes match /.pomerium/... and similar paths
-	rs, err := b.buildPomeriumHTTPRoutes(options, host)
+	rs, err := b.buildPomeriumHTTPRoutes(options, host, hasMCPPolicy)
 	if err != nil {
 		return nil, err
 	}

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -195,7 +195,7 @@ func Test_getAllDomains(t *testing.T) {
 	}
 	t.Run("routable", func(t *testing.T) {
 		t.Run("http", func(t *testing.T) {
-			actual, err := getAllRouteableHosts(options, "127.0.0.1:9000")
+			actual, _, err := getAllRouteableHosts(options, "127.0.0.1:9000")
 			require.NoError(t, err)
 			expect := []string{
 				"a.example.com",
@@ -214,7 +214,7 @@ func Test_getAllDomains(t *testing.T) {
 			assert.Equal(t, expect, actual)
 		})
 		t.Run("grpc", func(t *testing.T) {
-			actual, err := getAllRouteableHosts(options, "127.0.0.1:9001")
+			actual, _, err := getAllRouteableHosts(options, "127.0.0.1:9001")
 			require.NoError(t, err)
 			expect := []string{
 				"authorize.example.com:9001",
@@ -225,7 +225,7 @@ func Test_getAllDomains(t *testing.T) {
 		t.Run("both", func(t *testing.T) {
 			newOptions := *options
 			newOptions.GRPCAddr = newOptions.Addr
-			actual, err := getAllRouteableHosts(&newOptions, "127.0.0.1:9000")
+			actual, _, err := getAllRouteableHosts(&newOptions, "127.0.0.1:9000")
 			require.NoError(t, err)
 			expect := []string{
 				"a.example.com",
@@ -252,7 +252,7 @@ func Test_getAllDomains(t *testing.T) {
 		options.Policies = []config.Policy{
 			{From: "https://a.example.com"},
 		}
-		actual, err := getAllRouteableHosts(options, ":443")
+		actual, _, err := getAllRouteableHosts(options, ":443")
 		require.NoError(t, err)
 		assert.Equal(t, []string{"a.example.com"}, actual)
 	})

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -60,6 +60,7 @@ func (b *Builder) buildPomeriumHTTPRoutes(
 		return nil, err
 	}
 	if !isFrontingAuthenticate {
+		// Add common routes
 		routes = append(routes,
 			b.buildControlPlanePathRoute(options, "/ping"),
 			b.buildControlPlanePathRoute(options, "/healthz"),
@@ -68,6 +69,18 @@ func (b *Builder) buildPomeriumHTTPRoutes(
 			b.buildControlPlanePathRoute(options, "/.well-known/pomerium"),
 			b.buildControlPlanePrefixRoute(options, "/.well-known/pomerium/"),
 		)
+
+		// Only add oauth-authorization-server route if there's an MCP policy
+		hasMCPPolicy := false
+		for _, policy := range options.GetAllPoliciesIndexed() {
+			if policy.IsMCP() {
+				hasMCPPolicy = true
+				break
+			}
+		}
+		if hasMCPPolicy {
+			routes = append(routes, b.buildControlPlanePathRoute(options, "/.well-known/oauth-authorization-server"))
+		}
 	}
 
 	authRoutes, err := b.buildPomeriumAuthenticateHTTPRoutes(options, host)

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -50,6 +50,7 @@ func (b *Builder) buildGRPCRoutes() ([]*envoy_config_route_v3.Route, error) {
 func (b *Builder) buildPomeriumHTTPRoutes(
 	options *config.Options,
 	host string,
+	isMCPHost bool,
 ) ([]*envoy_config_route_v3.Route, error) {
 	var routes []*envoy_config_route_v3.Route
 
@@ -70,15 +71,8 @@ func (b *Builder) buildPomeriumHTTPRoutes(
 			b.buildControlPlanePrefixRoute(options, "/.well-known/pomerium/"),
 		)
 
-		// Only add oauth-authorization-server route if there's an MCP policy
-		hasMCPPolicy := false
-		for _, policy := range options.GetAllPoliciesIndexed() {
-			if policy.IsMCP() {
-				hasMCPPolicy = true
-				break
-			}
-		}
-		if hasMCPPolicy {
+		// Only add oauth-authorization-server route if there's an MCP policy for this host
+		if isMCPHost {
 			routes = append(routes, b.buildControlPlanePathRoute(options, "/.well-known/oauth-authorization-server"))
 		}
 	}

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -104,7 +104,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 			AuthenticateURLString:    "https://authenticate.example.com",
 			AuthenticateCallbackPath: "/oauth2/callback",
 		}
-		routes, err := b.buildPomeriumHTTPRoutes(options, "authenticate.example.com")
+		routes, err := b.buildPomeriumHTTPRoutes(options, "authenticate.example.com", false)
 		require.NoError(t, err)
 
 		testutil.AssertProtoJSONEqual(t, `[
@@ -125,7 +125,7 @@ func Test_buildPomeriumHTTPRoutes(t *testing.T) {
 			AuthenticateURLString:    "https://authenticate.example.com",
 			AuthenticateCallbackPath: "/oauth2/callback",
 		}
-		routes, err := b.buildPomeriumHTTPRoutes(options, "authenticate.example.com")
+		routes, err := b.buildPomeriumHTTPRoutes(options, "authenticate.example.com", false)
 		require.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, "null", routes)
 	})
@@ -2302,23 +2302,16 @@ func Test_buildPomeriumHTTPRoutesWithMCP(t *testing.T) {
 			},
 		}
 
-		routes, err := b.buildPomeriumHTTPRoutes(options, "example.com")
+		routes, err := b.buildPomeriumHTTPRoutes(options, "example.com", false)
 		require.NoError(t, err)
 
-		// Check routes for well-known endpoints
 		hasOAuthServer := false
-		hasPomerium := false
 		for _, route := range routes {
 			if route.GetMatch().GetPath() == "/.well-known/oauth-authorization-server" {
 				hasOAuthServer = true
 			}
-			if route.GetMatch().GetPath() == "/.well-known/pomerium" {
-				hasPomerium = true
-			}
 		}
 
-		// Verify oauth-authorization-server route is NOT present
-		assert.True(t, hasPomerium, "/.well-known/pomerium route should be present")
 		assert.False(t, hasOAuthServer, "/.well-known/oauth-authorization-server route should NOT be present")
 	})
 
@@ -2340,24 +2333,8 @@ func Test_buildPomeriumHTTPRoutesWithMCP(t *testing.T) {
 			},
 		}
 
-		routes, err := b.buildPomeriumHTTPRoutes(options, "example.com")
+		routes, err := b.buildPomeriumHTTPRoutes(options, "example.com", true)
 		require.NoError(t, err)
-
-		// Check routes for well-known endpoints
-		hasOAuthServer := false
-		hasPomerium := false
-		for _, route := range routes {
-			if route.GetMatch().GetPath() == "/.well-known/oauth-authorization-server" {
-				hasOAuthServer = true
-			}
-			if route.GetMatch().GetPath() == "/.well-known/pomerium" {
-				hasPomerium = true
-			}
-		}
-
-		// Verify oauth-authorization-server route IS present
-		assert.True(t, hasPomerium, "/.well-known/pomerium route should be present")
-		assert.True(t, hasOAuthServer, "/.well-known/oauth-authorization-server route should be present")
 
 		// Verify the expected route structures
 		testutil.AssertProtoJSONEqual(t, `[

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -15,6 +15,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/handlers"
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/mcp"
 	"github.com/pomerium/pomerium/internal/middleware"
 	"github.com/pomerium/pomerium/internal/telemetry"
 	"github.com/pomerium/pomerium/internal/urlutil"
@@ -79,5 +80,10 @@ func (srv *Server) mountCommonEndpoints(root *mux.Router, cfg *config.Config) er
 	root.Handle("/.well-known/pomerium/", traceHandler(handlers.WellKnownPomerium(authenticateURL)))
 	root.Path("/.well-known/pomerium/jwks.json").Methods(http.MethodGet).Handler(traceHandler(handlers.JWKSHandler(signingKey)))
 	root.Path(urlutil.HPKEPublicKeyPath).Methods(http.MethodGet).Handler(traceHandler(hpke_handlers.HPKEPublicKeyHandler(hpkePublicKey)))
+
+	root.Path("/.well-known/oauth-authorization-server").
+		Methods(http.MethodGet, http.MethodOptions).
+		Handler(mcp.AuthorizationServerMetadataHandler(mcp.DefaultPrefix))
+
 	return nil
 }

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -1,0 +1,11 @@
+package mcp
+
+const (
+	DefaultPrefix = "/.pomerium/mcp"
+
+	authorizationEndpoint = "/authorize"
+	oauthCallbackEndpoint = "/oauth/callback"
+	registerEndpoint      = "/register"
+	revocationEndpoint    = "/revoke"
+	tokenEndpoint         = "/token"
+)

--- a/internal/mcp/handler_metadata.go
+++ b/internal/mcp/handler_metadata.go
@@ -1,0 +1,129 @@
+package mcp
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"path"
+
+	"github.com/gorilla/mux"
+	"github.com/rs/cors"
+)
+
+// AuthorizationServerMetadata represents the OAuth 2.0 Authorization Server Metadata (RFC 8414).
+// https://datatracker.ietf.org/doc/html/rfc8414#section-2
+type AuthorizationServerMetadata struct {
+	// Issuer is REQUIRED. The authorization server's issuer identifier, a URL using the "https" scheme with no query or fragment.
+	Issuer string `json:"issuer"`
+
+	// AuthorizationEndpoint is the URL of the authorization server's authorization endpoint. REQUIRED unless no grant types use the authorization endpoint.
+	AuthorizationEndpoint string `json:"authorization_endpoint,omitempty"`
+
+	// TokenEndpoint is the URL of the authorization server's token endpoint. REQUIRED unless only the implicit grant type is supported.
+	TokenEndpoint string `json:"token_endpoint,omitempty"`
+
+	// JwksURI is OPTIONAL. URL of the authorization server's JWK Set document.
+	JwksURI string `json:"jwks_uri,omitempty"`
+
+	// RegistrationEndpoint is OPTIONAL. URL of the authorization server's OAuth 2.0 Dynamic Client Registration endpoint.
+	RegistrationEndpoint string `json:"registration_endpoint,omitempty"`
+
+	// ScopesSupported is RECOMMENDED. JSON array of supported OAuth 2.0 "scope" values.
+	ScopesSupported []string `json:"scopes_supported,omitempty"`
+
+	// ResponseTypesSupported is REQUIRED. JSON array of supported OAuth 2.0 "response_type" values.
+	ResponseTypesSupported []string `json:"response_types_supported"`
+
+	// ResponseModesSupported is OPTIONAL. JSON array of supported OAuth 2.0 "response_mode" values. Default: ["query", "fragment"].
+	ResponseModesSupported []string `json:"response_modes_supported,omitempty"`
+
+	// GrantTypesSupported is OPTIONAL. JSON array of supported OAuth 2.0 grant type values. Default: ["authorization_code", "implicit"].
+	GrantTypesSupported []string `json:"grant_types_supported,omitempty"`
+
+	// TokenEndpointAuthMethodsSupported is OPTIONAL. JSON array of client authentication methods supported by the token endpoint. Default: "client_secret_basic".
+	TokenEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+
+	// TokenEndpointAuthSigningAlgValuesSupported is OPTIONAL. JSON array of JWS signing algorithms supported by the token endpoint for JWT client authentication.
+	TokenEndpointAuthSigningAlgValuesSupported []string `json:"token_endpoint_auth_signing_alg_values_supported,omitempty"`
+
+	// ServiceDocumentation is OPTIONAL. URL of a page with human-readable information for developers.
+	ServiceDocumentation string `json:"service_documentation,omitempty"`
+
+	// UILocalesSupported is OPTIONAL. JSON array of supported languages and scripts for the UI, as BCP 47 language tags.
+	UILocalesSupported []string `json:"ui_locales_supported,omitempty"`
+
+	// OpPolicyURI is OPTIONAL. URL for the authorization server's policy on client data usage.
+	OpPolicyURI string `json:"op_policy_uri,omitempty"`
+
+	// OpTosURI is OPTIONAL. URL for the authorization server's terms of service.
+	OpTosURI string `json:"op_tos_uri,omitempty"`
+
+	// RevocationEndpoint is OPTIONAL. URL of the authorization server's OAuth 2.0 revocation endpoint.
+	RevocationEndpoint string `json:"revocation_endpoint,omitempty"`
+
+	// RevocationEndpointAuthMethodsSupported is OPTIONAL. JSON array of client authentication methods supported by the revocation endpoint. Default: "client_secret_basic".
+	RevocationEndpointAuthMethodsSupported []string `json:"revocation_endpoint_auth_methods_supported,omitempty"`
+
+	// RevocationEndpointAuthSigningAlgValuesSupported is OPTIONAL. JSON array of JWS signing algorithms supported by the revocation endpoint for JWT client authentication.
+	RevocationEndpointAuthSigningAlgValuesSupported []string `json:"revocation_endpoint_auth_signing_alg_values_supported,omitempty"`
+
+	// IntrospectionEndpoint is OPTIONAL. URL of the authorization server's OAuth 2.0 introspection endpoint.
+	IntrospectionEndpoint string `json:"introspection_endpoint,omitempty"`
+
+	// IntrospectionEndpointAuthMethodsSupported is OPTIONAL. JSON array of client authentication methods supported by the introspection endpoint.
+	IntrospectionEndpointAuthMethodsSupported []string `json:"introspection_endpoint_auth_methods_supported,omitempty"`
+
+	// IntrospectionEndpointAuthSigningAlgValuesSupported is OPTIONAL. JSON array of JWS signing algorithms supported by the introspection endpoint for JWT client authentication.
+	IntrospectionEndpointAuthSigningAlgValuesSupported []string `json:"introspection_endpoint_auth_signing_alg_values_supported,omitempty"`
+
+	// CodeChallengeMethodsSupported is OPTIONAL. JSON array of PKCE code challenge methods supported by this authorization server.
+	CodeChallengeMethodsSupported []string `json:"code_challenge_methods_supported,omitempty"`
+}
+
+func AuthorizationServerMetadataHandler(prefix string) http.HandlerFunc {
+	c := cors.New(cors.Options{
+		AllowedMethods: []string{http.MethodGet, http.MethodOptions},
+		AllowedOrigins: []string{"*"},
+		AllowedHeaders: []string{"mcp-protocol-version"},
+	})
+	r := mux.NewRouter()
+	r.Use(c.Handler)
+	r.Methods(http.MethodGet).HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		meta := getAuthorizationServerMetadata(r.Host, prefix)
+		_ = json.NewEncoder(w).Encode(meta)
+	})
+	r.Methods(http.MethodOptions).HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	})
+	return http.HandlerFunc(r.ServeHTTP)
+}
+
+func getAuthorizationServerMetadata(host, prefix string) AuthorizationServerMetadata {
+	baseURL := url.URL{
+		Scheme: "https",
+		Host:   host,
+	}
+	P := func(path string) string {
+		u := baseURL
+		u.Path = path
+		return u.String()
+	}
+
+	return AuthorizationServerMetadata{
+		Issuer:                                 P("/"),
+		ServiceDocumentation:                   "https://pomerium.com/docs",
+		AuthorizationEndpoint:                  P(path.Join(prefix, authorizationEndpoint)),
+		ResponseTypesSupported:                 []string{"code"},
+		CodeChallengeMethodsSupported:          []string{"S256"},
+		TokenEndpoint:                          P(path.Join(prefix, tokenEndpoint)),
+		TokenEndpointAuthMethodsSupported:      []string{"none"},
+		GrantTypesSupported:                    []string{"authorization_code", "refresh_token"},
+		RevocationEndpoint:                     P(path.Join(prefix, revocationEndpoint)),
+		RevocationEndpointAuthMethodsSupported: []string{"client_secret_post"},
+		RegistrationEndpoint:                   P(path.Join(prefix, registerEndpoint)),
+		ScopesSupported:                        []string{"openid", "offline"},
+	}
+}


### PR DESCRIPTION
## Summary

For MCP routes, serve `/.well-known/oauth-authorization-server` according to OAuth 2.0 Authorization Server Metadata (RFC8414). 

## Related issues

Fixes: https://linear.app/pomerium/issue/ENG-2318/mcp-authorization-server-metadata

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
