### PR TITLE
storage: use a fake DNS server in TestLookup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,6 +42,7 @@ require (
 	github.com/klauspost/compress v1.18.0
 	github.com/martinlindhe/base36 v1.1.1
 	github.com/mholt/acmez/v3 v3.1.1
+	github.com/miekg/dns v1.1.63
 	github.com/minio/minio-go/v7 v7.0.89
 	github.com/mitchellh/hashstructure/v2 v2.0.2
 	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
@@ -185,7 +186,6 @@ require (
 	github.com/magiconair/properties v1.8.9 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
-	github.com/miekg/dns v1.1.63 // indirect
 	github.com/minio/crc64nvme v1.0.1 // indirect
 	github.com/minio/md5-simd v1.1.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect

--- a/pkg/storage/postgres/backend_test.go
+++ b/pkg/storage/postgres/backend_test.go
@@ -3,13 +3,16 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"net"
 	"os"
 	"runtime"
 	"testing"
 	"time"
 
+	"github.com/miekg/dns"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -201,15 +204,40 @@ func TestBackend(t *testing.T) {
 }
 
 func TestLookup(t *testing.T) {
-	t.Parallel()
+	originalDefaultResolver := net.DefaultResolver
+	net.DefaultResolver = stubResolver(t)
+	t.Cleanup(func() { net.DefaultResolver = originalDefaultResolver })
 
-	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*1000)
 	t.Cleanup(clearTimeout)
 
 	cfg, err := ParseConfig("host=localhost")
 	assert.NoError(t, err)
 
-	addrs, err := cfg.ConnConfig.LookupFunc(ctx, "test.unknown")
+	addrs, err := cfg.ConnConfig.LookupFunc(ctx, "www.example.com")
 	assert.NoError(t, err)
 	assert.Empty(t, addrs)
+}
+
+// stubResolver returns a fake DNS resolver that always responds with NXDOMAIN.
+func stubResolver(t *testing.T) *net.Resolver {
+	stubListener := bufconn.Listen(1500)
+	stubDNS := &dns.Server{
+		Listener: stubListener,
+		Handler: dns.HandlerFunc(func(w dns.ResponseWriter, r *dns.Msg) {
+			m := &dns.Msg{}
+			m.SetRcode(r, dns.RcodeNameError)
+			w.WriteMsg(m)
+		}),
+	}
+
+	go stubDNS.ActivateAndServe()
+	t.Cleanup(func() { stubDNS.Shutdown() })
+
+	return &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return stubListener.DialContext(ctx)
+		},
+	}
 }

--- a/pkg/storage/postgres/backend_test.go
+++ b/pkg/storage/postgres/backend_test.go
@@ -208,7 +208,7 @@ func TestLookup(t *testing.T) {
 	net.DefaultResolver = stubResolver(t)
 	t.Cleanup(func() { net.DefaultResolver = originalDefaultResolver })
 
-	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*1000)
+	ctx, clearTimeout := context.WithTimeout(context.Background(), time.Second*10)
 	t.Cleanup(clearTimeout)
 
 	cfg, err := ParseConfig("host=localhost")


### PR DESCRIPTION
## Summary

@wasaga reports that there have been some recent test failures in `TestLookup` with the error message "i/o timeout". It looks like this test does a real DNS lookup, and so depends on a working DNS server and reliable network connectivity. Let's swap in a fake in-memory DNS server instead.

## Related issues

https://linear.app/pomerium/issue/ENG-2352/core-test-flake-in-pkgstoragepostgresbackend-testgo

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
