### PR TITLE
mcp: add list-routes client helper

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -293,6 +293,8 @@ var internalPathsNeedingLogin = set.From([]string{
 	"/.pomerium/routes",
 	"/.pomerium/api/v1/routes",
 	"/.pomerium/mcp/authorize",
+	"/.pomerium/mcp/routes",
+	"/.pomerium/mcp/connect",
 })
 
 func (e *Evaluator) evaluateInternal(_ context.Context, req *Request) (*PolicyResponse, error) {

--- a/config/policy.go
+++ b/config/policy.go
@@ -29,7 +29,7 @@ import (
 // Policy contains route specific configuration and access settings.
 type Policy struct {
 	ID          string `mapstructure:"-" yaml:"-" json:"-"`
-	Name        string `mapstructure:"-" yaml:"-" json:"-"`
+	Name        string `mapstructure:"name" yaml:"-" json:"name,omitempty"`
 	Description string `mapstructure:"description" yaml:"description,omitempty" json:"description,omitempty"`
 	LogoURL     string `mapstructure:"logo_url" yaml:"logo_url,omitempty" json:"logo_url,omitempty"`
 

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -27,6 +27,8 @@ const (
 	registerEndpoint      = "/register"
 	revocationEndpoint    = "/revoke"
 	tokenEndpoint         = "/token"
+	listRoutesEndpoint    = "/routes"
+	connectEndpoint       = "/connect"
 )
 
 type Handler struct {
@@ -78,6 +80,8 @@ func (srv *Handler) HandlerFunc() http.HandlerFunc {
 	r.Path(path.Join(srv.prefix, authorizationEndpoint)).Methods(http.MethodGet).HandlerFunc(srv.Authorize)
 	r.Path(path.Join(srv.prefix, oauthCallbackEndpoint)).Methods(http.MethodGet).HandlerFunc(srv.OAuthCallback)
 	r.Path(path.Join(srv.prefix, tokenEndpoint)).Methods(http.MethodPost).HandlerFunc(srv.Token)
+	r.Path(path.Join(srv.prefix, listRoutesEndpoint)).Methods(http.MethodGet).HandlerFunc(srv.ListRoutes)
+	r.Path(path.Join(srv.prefix, connectEndpoint)).Methods(http.MethodGet).HandlerFunc(srv.Connect)
 
 	return r.ServeHTTP
 }

--- a/internal/mcp/handler_authorization.go
+++ b/internal/mcp/handler_authorization.go
@@ -82,7 +82,7 @@ func (srv *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	requiresUpstreamOAuth2Token := srv.relyingParties.HasConfigForHost(r.Host)
+	requiresUpstreamOAuth2Token := srv.relyingParties.HasOAuth2ConfigForHost(r.Host)
 	var authReqID string
 	var hasUpstreamOAuth2Token bool
 	{

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -1,0 +1,11 @@
+package mcp
+
+import (
+	"net/http"
+)
+
+// Connect is a helper method for MCP clients to ensure that the current user
+// has an active upstream Oauth2 session for the route.
+func (srv *Handler) Connect(w http.ResponseWriter, _ *http.Request) {
+	http.Error(w, "not implemented", http.StatusNotImplemented)
+}

--- a/internal/mcp/handler_list_routes.go
+++ b/internal/mcp/handler_list_routes.go
@@ -1,0 +1,110 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+// ListMCPServers returns a list of MCP servers that are registered,
+// and whether the current user has access to them.
+func (srv *Handler) ListRoutes(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "invalid method", http.StatusMethodNotAllowed)
+		return
+	}
+
+	err := srv.listMCPServers(w, r)
+	if err != nil {
+		log.Ctx(r.Context()).Error().Err(err).Msg("failed to list MCP servers")
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+func (srv *Handler) listMCPServers(w http.ResponseWriter, r *http.Request) error {
+	claims, err := getClaimsFromRequest(r)
+	if err != nil {
+		return fmt.Errorf("failed to get claims from request: %w", err)
+	}
+
+	userID, ok := getUserIDFromClaims(claims)
+	if !ok {
+		return fmt.Errorf("user id is not present in claims")
+	}
+
+	var servers []serverInfo
+	for v := range srv.relyingParties.All() {
+		servers = append(servers, serverInfo{
+			Name:        v.Name,
+			Description: v.Description,
+			LogoURL:     v.LogoURL,
+			URL:         v.URL,
+			needsOauth:  v.Config != nil,
+		})
+	}
+
+	servers, err = srv.checkHostsConnectedForUser(r.Context(), userID, servers)
+	if err != nil {
+		return fmt.Errorf("failed to check hosts connected for user %s: %w", userID, err)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Cache-Control", "no-store, no-cache, must-revalidate, max-age=0")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
+
+	type response struct {
+		Servers []serverInfo `json:"servers"`
+	}
+
+	return json.NewEncoder(w).Encode(response{
+		Servers: servers,
+	})
+}
+
+func (srv *Handler) checkHostsConnectedForUser(
+	ctx context.Context,
+	userID string,
+	servers []serverInfo,
+) ([]serverInfo, error) {
+	eg, ctx := errgroup.WithContext(ctx)
+	for i := range servers {
+		if !servers[i].needsOauth {
+			servers[i].Connected = true
+			continue
+		}
+		eg.Go(func() error {
+			_, err := srv.storage.GetUpstreamOAuth2Token(ctx, servers[i].host, userID)
+			if err != nil && status.Code(err) != codes.NotFound {
+				return fmt.Errorf("failed to get oauth2 token for user %s: %w", userID, err)
+			}
+			servers[i].Connected = err == nil
+			return nil
+		})
+	}
+
+	err := eg.Wait()
+	if err != nil {
+		return nil, fmt.Errorf("failed to check hosts connected for user %s: %w", userID, err)
+	}
+	return servers, nil
+}
+
+type serverInfo struct {
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+	LogoURL     string `json:"logo_url,omitempty"`
+	URL         string `json:"url"`
+	Connected   bool   `json:"connected"`
+	needsOauth  bool   `json:"-"`
+	host        string `json:"-"`
+}

--- a/internal/mcp/host_info_test.go
+++ b/internal/mcp/host_info_test.go
@@ -17,13 +17,18 @@ func TestBuildOAuthConfig(t *testing.T) {
 		Options: &config.Options{
 			Policies: []config.Policy{
 				{
+					Name: "test",
 					From: "https://regular.example.com",
 				},
 				{
-					From: "https://mcp1.example.com",
-					MCP:  &config.MCP{},
+					Name:        "mcp-1",
+					Description: "description-1",
+					LogoURL:     "https://logo.example.com",
+					From:        "https://mcp1.example.com",
+					MCP:         &config.MCP{},
 				},
 				{
+					Name: "mcp-2",
 					From: "https://mcp2.example.com",
 					MCP: &config.MCP{
 						UpstreamOAuth2: &config.UpstreamOAuth2{
@@ -40,17 +45,29 @@ func TestBuildOAuthConfig(t *testing.T) {
 			},
 		},
 	}
-	got := mcp.BuildOAuthConfig(cfg, "/prefix")
-	diff := cmp.Diff(got, map[string]*oauth2.Config{
+	got := mcp.BuildHostInfo(cfg, "/prefix")
+	diff := cmp.Diff(got, map[string]mcp.HostInfo{
+		"mcp1.example.com": {
+			Name:        "mcp-1",
+			Host:        "mcp1.example.com",
+			URL:         "https://mcp1.example.com",
+			Description: "description-1",
+			LogoURL:     "https://logo.example.com",
+		},
 		"mcp2.example.com": {
-			ClientID:     "client_id",
-			ClientSecret: "client_secret",
-			Endpoint: oauth2.Endpoint{
-				AuthURL:   "https://auth.example.com/auth",
-				TokenURL:  "https://auth.example.com/token",
-				AuthStyle: oauth2.AuthStyleInParams,
+			Name: "mcp-2",
+			Host: "mcp2.example.com",
+			URL:  "https://mcp2.example.com",
+			Config: &oauth2.Config{
+				ClientID:     "client_id",
+				ClientSecret: "client_secret",
+				Endpoint: oauth2.Endpoint{
+					AuthURL:   "https://auth.example.com/auth",
+					TokenURL:  "https://auth.example.com/token",
+					AuthStyle: oauth2.AuthStyleInParams,
+				},
+				RedirectURL: "https://mcp2.example.com/prefix/oauth/callback",
 			},
-			RedirectURL: "https://mcp2.example.com/prefix/oauth/callback",
 		},
 	}, cmpopts.IgnoreUnexported(oauth2.Config{}))
 	require.Empty(t, diff)


### PR DESCRIPTION
## Summary

For MCP clients behind Pomerium, add a helper `/.pomerium/mcp/routes` that returns list of MCP servers this user is able to access.

See https://github.com/wasaga/mcp-client-pom for usage example. 

## Related issues

Ref: https://linear.app/pomerium/issue/ENG-2336/draft-mcp-clients-support-passing-access-tokens

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
