### PR TITLE
tracing: expand environment variables in the otlp endpoint options

### DIFF
--- a/pkg/telemetry/trace/client.go
+++ b/pkg/telemetry/trace/client.go
@@ -156,10 +156,10 @@ func NewTraceClientFromConfig(opts otelconfig.Config) (otlptrace.Client, error) 
 		var signalSpecificEndpoint bool
 
 		if opts.OtelExporterOtlpTracesEndpoint != nil {
-			endpoint = *opts.OtelExporterOtlpTracesEndpoint
+			endpoint = os.ExpandEnv(*opts.OtelExporterOtlpTracesEndpoint)
 			signalSpecificEndpoint = true
 		} else if opts.OtelExporterOtlpEndpoint != nil {
-			endpoint = *opts.OtelExporterOtlpEndpoint
+			endpoint = os.ExpandEnv(*opts.OtelExporterOtlpEndpoint)
 			signalSpecificEndpoint = false
 		}
 		if opts.OtelExporterOtlpTracesProtocol != nil {


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
