### PR TITLE
mcp: add global runtime flag

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/pomerium/pomerium/authorize/checkrequest"
 	"github.com/pomerium/pomerium/authorize/evaluator"
+	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/urlutil"
@@ -358,8 +359,10 @@ func (a *Authorize) userInfoEndpointURL(in *envoy_service_auth_v3.CheckRequest) 
 }
 
 func (a *Authorize) shouldRedirect(in *envoy_service_auth_v3.CheckRequest, request *evaluator.Request) bool {
-	if request.Policy.IsMCPServer() {
-		return false
+	if a.currentConfig.Load().Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
+		if request.Policy.IsMCPServer() {
+			return false
+		}
 	}
 
 	requestHeaders := in.GetAttributes().GetRequest().GetHttp().GetHeaders()

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -113,7 +113,8 @@ func TestAuthorize_handleResult(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 495, int(res.GetDeniedResponse().GetStatus().GetCode()))
 	})
-	t.Run("mcp-route-unauthenticated", func(t *testing.T) {
+	t.Run("mcp-route-unauthenticated, mcp flag is on", func(t *testing.T) {
+		opt.RuntimeFlags[config.RuntimeFlagMCP] = true
 		res, err := a.handleResult(context.Background(),
 			&envoy_service_auth_v3.CheckRequest{},
 			&evaluator.Request{
@@ -124,6 +125,19 @@ func TestAuthorize_handleResult(t *testing.T) {
 			})
 		assert.NoError(t, err)
 		assert.Equal(t, 401, int(res.GetDeniedResponse().GetStatus().GetCode()))
+	})
+	t.Run("mcp-route-unauthenticated, mcp flag is off", func(t *testing.T) {
+		opt.RuntimeFlags[config.RuntimeFlagMCP] = false
+		res, err := a.handleResult(context.Background(),
+			&envoy_service_auth_v3.CheckRequest{},
+			&evaluator.Request{
+				Policy: &config.Policy{MCP: &config.MCP{}},
+			},
+			&evaluator.Result{
+				Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+			})
+		assert.NoError(t, err)
+		assert.Equal(t, 302, int(res.GetDeniedResponse().GetStatus().GetCode()))
 	})
 }
 

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -123,13 +123,15 @@ func (a *Authorize) maybeGetSessionFromRequest(
 	hreq *http.Request,
 	policy *config.Policy,
 ) (*session.Session, error) {
-	if policy.IsMCPServer() {
-		s, err := a.getMCPSession(ctx, hreq)
-		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msg("error getting mcp session")
-			return nil, err
+	if a.currentConfig.Load().Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
+		if policy.IsMCPServer() {
+			s, err := a.getMCPSession(ctx, hreq)
+			if err != nil {
+				log.Ctx(ctx).Error().Err(err).Msg("error getting mcp session")
+				return nil, err
+			}
+			return s, nil
 		}
-		return s, nil
 	}
 
 	// attempt to create a session from an incoming idp token

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -72,7 +72,7 @@ func (b *Builder) buildPomeriumHTTPRoutes(
 		)
 
 		// Only add oauth-authorization-server route if there's an MCP policy for this host
-		if isMCPHost {
+		if options.IsRuntimeFlagSet(config.RuntimeFlagMCP) && isMCPHost {
 			routes = append(routes, b.buildControlPlanePathRoute(options, "/.well-known/oauth-authorization-server"))
 		}
 	}

--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -29,6 +29,9 @@ var (
 	// RuntimeFlagAuthorizeUseSyncedData enables synced data for querying the databroker for
 	// certain types of data.
 	RuntimeFlagAuthorizeUseSyncedData = runtimeFlag("authorize_use_synced_data", true)
+
+	// RuntimeFlagMCP enables the MCP services for the authorize service
+	RuntimeFlagMCP = runtimeFlag("mcp", false)
 )
 
 // RuntimeFlag is a runtime flag that can flip on/off certain features

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -81,9 +81,11 @@ func (srv *Server) mountCommonEndpoints(root *mux.Router, cfg *config.Config) er
 	root.Path("/.well-known/pomerium/jwks.json").Methods(http.MethodGet).Handler(traceHandler(handlers.JWKSHandler(signingKey)))
 	root.Path(urlutil.HPKEPublicKeyPath).Methods(http.MethodGet).Handler(traceHandler(hpke_handlers.HPKEPublicKeyHandler(hpkePublicKey)))
 
-	root.Path("/.well-known/oauth-authorization-server").
-		Methods(http.MethodGet, http.MethodOptions).
-		Handler(mcp.AuthorizationServerMetadataHandler(mcp.DefaultPrefix))
+	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
+		root.Path("/.well-known/oauth-authorization-server").
+			Methods(http.MethodGet, http.MethodOptions).
+			Handler(mcp.AuthorizationServerMetadataHandler(mcp.DefaultPrefix))
+	}
 
 	return nil
 }

--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -24,8 +24,10 @@ func (p *Proxy) registerDashboardHandlers(r *mux.Router, opts *config.Options) *
 	h := httputil.DashboardSubrouter(r)
 	h.Use(middleware.SetHeaders(httputil.HeadersContentSecurityPolicy))
 
-	// model context protocol
-	h.PathPrefix("/mcp").Handler(p.mcp.Load().HandlerFunc())
+	if opts.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
+		// model context protocol
+		h.PathPrefix("/mcp").Handler(p.mcp.Load().HandlerFunc())
+	}
 
 	// special pomerium endpoints for users to view their session
 	h.Path("/").Handler(httputil.HandlerFunc(p.userInfo)).Methods(http.MethodGet)


### PR DESCRIPTION
## Summary

Adds global runtime flag to enable/disable MCP support. 

```yaml
runtime_flags:
  mcp: true
```

## Related issues

Fix: https://linear.app/pomerium/issue/ENG-2367/place-mcp-support-behind-a-runtime-flag

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
