### PR TITLE
storage: invalidate sync querier when records are updated

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -140,13 +140,13 @@ func (a *Authorize) maybeGetSessionFromRequest(
 			return storage.GetDataBrokerRecord(ctx, recordType, recordID, 0)
 		},
 		func(ctx context.Context, records []*databroker.Record) error {
-			_, err := a.state.Load().dataBrokerClient.Put(ctx, &databroker.PutRequest{
+			res, err := a.state.Load().dataBrokerClient.Put(ctx, &databroker.PutRequest{
 				Records: records,
 			})
 			if err != nil {
 				return err
 			}
-			storage.InvalidateCacheForDataBrokerRecords(ctx, records...)
+			storage.InvalidateCacheForDataBrokerRecords(ctx, res.Records...)
 			return nil
 		},
 	).CreateSession(ctx, a.currentConfig.Load(), policy, hreq)

--- a/pkg/storage/querier.go
+++ b/pkg/storage/querier.go
@@ -155,8 +155,9 @@ func InvalidateCacheForDataBrokerRecords(
 ) {
 	for _, record := range records {
 		q := &databroker.QueryRequest{
-			Type:  record.GetType(),
-			Limit: 1,
+			Type:                     record.GetType(),
+			Limit:                    1,
+			MinimumRecordVersionHint: proto.Uint64(record.GetVersion()),
 		}
 		q.SetFilterByIDOrIndex(record.GetId())
 		GetQuerier(ctx).InvalidateCache(ctx, q)


### PR DESCRIPTION
## Summary
Invalidate the sync querier when records are updated so that we fallback to databroker querying until the sync is complete.

## Related issues
For [ENG-2377](https://linear.app/pomerium/issue/ENG-2377/core-initial-access-with-idp-accessidentity-tokens-sometimes-fails)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
