### PR TITLE
identity: add IdP access and identity token verification for OIDC

### DIFF
--- a/pkg/identity/oidc/azure/microsoft_test.go
+++ b/pkg/identity/oidc/azure/microsoft_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/internal/testutil"
-	"github.com/pomerium/pomerium/pkg/identity/identity"
 	"github.com/pomerium/pomerium/pkg/identity/oauth"
 )
 
@@ -109,25 +108,4 @@ func TestVerifyAccessToken(t *testing.T) {
 
 	_, err = p.VerifyAccessToken(ctx, rawAccessToken2)
 	assert.ErrorContains(t, err, "invalid audience")
-}
-
-func TestVerifyIdentityToken(t *testing.T) {
-	t.Parallel()
-
-	ctx := testutil.GetContext(t, time.Minute)
-
-	mux := http.NewServeMux()
-	srv := httptest.NewServer(mux)
-
-	p, err := New(ctx, &oauth.Options{
-		ProviderName: Name,
-		ProviderURL:  srv.URL,
-		ClientID:     "CLIENT_ID",
-		ClientSecret: "CLIENT_SECRET",
-	})
-	require.NoError(t, err)
-
-	claims, err := p.VerifyIdentityToken(ctx, "RAW IDENTITY TOKEN")
-	assert.ErrorIs(t, identity.ErrVerifyIdentityTokenNotSupported, err)
-	assert.Nil(t, claims)
 }

--- a/pkg/identity/oidc/oidc.go
+++ b/pkg/identity/oidc/oidc.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"sync"
 
 	go_oidc "github.com/coreos/go-oidc/v3/oidc"
@@ -49,6 +50,8 @@ type Provider struct {
 	// AuthCodeOptions specifies additional key value pairs query params to add
 	// to the request flow signin url.
 	AuthCodeOptions map[string]string
+
+	accessTokenAllowedAudiences *[]string
 
 	mu       sync.Mutex
 	provider *go_oidc.Provider
@@ -95,6 +98,7 @@ func New(ctx context.Context, o *oauth.Options, options ...Option) (*Provider, e
 			return provider.Verifier(&go_oidc.Config{ClientID: o.ClientID})
 		}),
 	}, options...)...)
+	p.accessTokenAllowedAudiences = o.AccessTokenAllowedAudiences
 	return p, nil
 }
 
@@ -363,8 +367,34 @@ func (p *Provider) SignOut(w http.ResponseWriter, r *http.Request, idTokenHint, 
 }
 
 // VerifyAccessToken verifies an access token.
-func (p *Provider) VerifyAccessToken(_ context.Context, _ string) (claims map[string]any, err error) {
-	return nil, identity.ErrVerifyAccessTokenNotSupported
+func (p *Provider) VerifyAccessToken(ctx context.Context, rawAccessToken string) (claims map[string]any, err error) {
+	pp, err := p.GetProvider()
+	if err != nil {
+		return nil, fmt.Errorf("error getting oauth provider: %w", err)
+	}
+
+	// use the access token to call the user info endpoint
+	userInfo, err := pp.UserInfo(ctx, oauth2.StaticTokenSource(&oauth2.Token{
+		TokenType:   "Bearer",
+		AccessToken: rawAccessToken,
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving user info with access token: %w", err)
+	}
+
+	claims = jwtutil.Claims(map[string]any{})
+	err = userInfo.Claims(&claims)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshaling access token claims: %w", err)
+	}
+
+	if p.accessTokenAllowedAudiences != nil {
+		if audience, ok := claims["aud"].(string); !ok || !slices.Contains(*p.accessTokenAllowedAudiences, audience) {
+			return nil, fmt.Errorf("error verifying access token audience claim, invalid audience")
+		}
+	}
+
+	return claims, nil
 }
 
 // VerifyIdentityToken verifies an identity token.


### PR DESCRIPTION
## Summary
For the generic `oidc` provider, used by `auth0`, `cognito`, `gitlab`, `google`, `oidc`, `okta`, `onelogin` and `ping`, add support for direct access and identity token verification. Because Keycloak uses `oidc` this also adds support for Keycloak.

Access tokens are verified by using the user info endpoint. If a call to this endpoint succeeds using the access token, that access token is considered valid and the user info claims will be returned.

Identity tokens are verified by using the jwks endpoint to retrieve the signing key, and verifying that the identity token was signed with that key. If the identity token is valid the claims in the JWT will be returned.

## Related issues
- [ENG-2312](https://linear.app/pomerium/issue/ENG-2312/core-implement-token-validation-for-keycloak)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
