### PR TITLE
Fix typo in Seal comment

### DIFF
--- a/pkg/hpke/hpke.go
+++ b/pkg/hpke/hpke.go
@@ -177,7 +177,7 @@ func (key *PublicKey) String() string {
 	return encode(bs)
 }
 
-// Seal seales a message using HPKE.
+// Seal seals a message using HPKE.
 func Seal(
 	senderPrivateKey *PrivateKey,
 	receiverPublicKey *PublicKey,


### PR DESCRIPTION
## Summary
- fix a typo in `pkg/hpke/hpke.go` comment

## Testing
- `go vet` *(fails: module download timed out)*
- `go test ./...` *(fails: module download timed out)*

[n.b. this was an experiment using codex]