### PR TITLE
Fix comment grammar

### DIFF
--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -54,7 +54,7 @@ func (b *Builder) buildPomeriumHTTPRoutes(
 ) ([]*envoy_config_route_v3.Route, error) {
 	var routes []*envoy_config_route_v3.Route
 
-	// if this is the pomerium proxy in front of the the authenticate service, don't add
+	// if this is the pomerium proxy in front of the authenticate service, don't add
 	// these routes since they will be handled by authenticate
 	isFrontingAuthenticate, err := isProxyFrontingAuthenticate(options, host)
 	if err != nil {


### PR DESCRIPTION
## Summary
- fix wording in routes.go comment referencing authenticate service

## Testing
- `go vet ./...`
- `go test ./config/...` *(fails: connect: no route to host)*