### PR TITLE
Add websocket denial test

### DIFF
--- a/config/envoyconfig/protocols_int_test.go
+++ b/config/envoyconfig/protocols_int_test.go
@@ -321,54 +321,17 @@ func TestHttp1Websocket(t *testing.T) {
 		}
 	})
 
-	route := up.Route().
+	// Two routes share the same upstream and websocket handler and differ only
+	// in whether the policy allows websockets. That isolates the denial to the
+	// AllowWebsockets flag: a failure on the denied route can't be blamed on a
+	// misconfigured upstream, since the allowed route proves the upstream works.
+	allowed := up.Route().
 		From(env.SubdomainURL("ws-test")).
 		Policy(func(p *config.Policy) {
 			p.AllowPublicUnauthenticatedAccess = true
 			p.AllowWebsockets = true
 		})
-
-	env.AddUpstream(up)
-	env.Start()
-	snippets.WaitStartupComplete(env)
-
-	assert.NoError(t, up.DialWS(route, func(conn *websocket.Conn) error {
-		if err := conn.SetWriteDeadline(time.Now().Add(1 * time.Second)); err != nil {
-			return err
-		}
-		if err := conn.WriteMessage(websocket.TextMessage, []byte("hello world")); err != nil {
-			return err
-		}
-		if err := conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
-			return err
-		}
-		mt, bytes, err := conn.ReadMessage()
-		if err != nil {
-			return err
-		}
-		assert.Equal(t, websocket.TextMessage, mt)
-		assert.Equal(t, "hello world", string(bytes))
-		return nil
-	}, upstreams.Path("/ws")))
-}
-
-func TestHttp1WebsocketDenied(t *testing.T) {
-	env := testenv.New(t)
-
-	up := upstreams.HTTP(nil)
-	up.HandleWS("/ws", websocket.Upgrader{}, func(conn *websocket.Conn) error {
-		for {
-			mt, message, err := conn.ReadMessage()
-			if err != nil {
-				return err
-			}
-			if err := conn.WriteMessage(mt, message); err != nil {
-				return err
-			}
-		}
-	})
-
-	route := up.Route().
+	denied := up.Route().
 		From(env.SubdomainURL("ws-test-denied")).
 		Policy(func(p *config.Policy) {
 			p.AllowPublicUnauthenticatedAccess = true
@@ -378,8 +341,34 @@ func TestHttp1WebsocketDenied(t *testing.T) {
 	env.Start()
 	snippets.WaitStartupComplete(env)
 
-	err := up.DialWS(route, func(_ *websocket.Conn) error { return nil }, upstreams.Path("/ws"))
-	require.Error(t, err)
+	t.Run("allowed", func(t *testing.T) {
+		assert.NoError(t, up.DialWS(allowed, func(conn *websocket.Conn) error {
+			if err := conn.SetWriteDeadline(time.Now().Add(1 * time.Second)); err != nil {
+				return err
+			}
+			if err := conn.WriteMessage(websocket.TextMessage, []byte("hello world")); err != nil {
+				return err
+			}
+			if err := conn.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
+				return err
+			}
+			mt, bytes, err := conn.ReadMessage()
+			if err != nil {
+				return err
+			}
+			assert.Equal(t, websocket.TextMessage, mt)
+			assert.Equal(t, "hello world", string(bytes))
+			return nil
+		}, upstreams.Path("/ws")))
+	})
+
+	t.Run("denied", func(t *testing.T) {
+		// Without AllowWebsockets the upgrade is rejected with a non-101
+		// response, which surfaces as ErrBadHandshake. Asserting the specific
+		// error keeps the test from passing on an unrelated dial failure.
+		err := up.DialWS(denied, func(_ *websocket.Conn) error { return nil }, upstreams.Path("/ws"))
+		require.ErrorIs(t, err, websocket.ErrBadHandshake)
+	})
 }
 
 func TestClientCert(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix err variable check in websocket message read
- add `TestHttp1WebsocketDenied` to ensure websockets are rejected when not allowed

## Related issues

## User Explanation
Adds a regression test verifying that routes without `AllowWebsockets` return an error when establishing websocket connections.

## Checklist
- [ ] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review