### PR TITLE
config: support weighted URLs in To field (#5624)

### DIFF
--- a/config/policy.go
+++ b/config/policy.go
@@ -3,6 +3,7 @@ package config
 import (
 	"crypto/tls"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -365,19 +366,16 @@ func NewPolicyFromProto(pb *configpb.Route) (*Policy, error) {
 			Body:   pb.Response.GetBody(),
 		}
 	} else {
-		p.To = make(WeightedURLs, len(pb.To))
-		for i, u := range pb.To {
-			u, err := urlutil.ParseAndValidateURL(u)
-			if err != nil {
-				return nil, err
+		var err error
+		p.To, err = ParseWeightedUrls(pb.To...)
+		if err != nil && !errors.Is(err, errEmptyUrls) {
+			return nil, fmt.Errorf("error parsing to URLs: %w", err)
+		}
+
+		if len(pb.LoadBalancingWeights) == len(p.To) {
+			for i, w := range pb.LoadBalancingWeights {
+				p.To[i].LbWeight = w
 			}
-			w := WeightedURL{
-				URL: *u,
-			}
-			if len(pb.LoadBalancingWeights) == len(pb.To) {
-				w.LbWeight = pb.LoadBalancingWeights[i]
-			}
-			p.To[i] = w
 		}
 	}
 


### PR DESCRIPTION
Backport #5624 to 0.29.

Currently in core we support weighted URLs like this in the config file:

```yaml
to:
  - https://a.example.com,1
  - https://b.example.com,2
```

However in the protobuf we use a separate `load_balancing_weights` field:

```proto
message Route {
  repeated string to                     = 3;
  repeated uint32 load_balancing_weights = 37;
}
```

This PR updates the code to convert from protobuf so that it also supports weights directly in the `to` addresses. The existing `load_balancing_weights` behavior is preserved and will take precedence when provided.

- [ENG-2398](https://linear.app/pomerium/issue/ENG-2398/enterprise-api-upstream-weight-is-not-parsed)

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
