### PR TITLE
mcp: fix upstream client access token

### DIFF
--- a/config/policy.go
+++ b/config/policy.go
@@ -224,7 +224,7 @@ func (p *MCP) HasUpstreamOAuth2() bool {
 
 // IsUpstreamClientNeedsAccessToken checks if the route is for the MCP Client and if it needs to pass the upstream access token
 func (p *MCP) IsUpstreamClientNeedsAccessToken() bool {
-	return p != nil && p.UpstreamOAuth2 != nil && p.PassUpstreamAccessToken
+	return p != nil && p.PassUpstreamAccessToken
 }
 
 type UpstreamOAuth2 struct {


### PR DESCRIPTION
## Summary

the `mcp: pass_upstream_access_token` option should take effect even if no upstream oauth config is set.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
