### PR TITLE
mcp: ignore unknown fields in the client registration request

### DIFF
--- a/internal/mcp/handler_register_client.go
+++ b/internal/mcp/handler_register_client.go
@@ -35,7 +35,7 @@ func (srv *Handler) RegisterClient(w http.ResponseWriter, r *http.Request) {
 	}
 
 	v := new(rfc7591v1.ClientMetadata)
-	err = protojson.Unmarshal(data, v)
+	err = protojson.UnmarshalOptions{DiscardUnknown: true}.Unmarshal(data, v)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("failed to unmarshal request body")
 		http.Error(w, "failed to unmarshal request body", http.StatusBadRequest)


### PR DESCRIPTION
## Summary

Some clients may send RFC7591 Client Registration Request with extra fields that are not part of the spec, and we used too restrictive decoder for that. This PR ignores the unknown fields. 

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
