### PR TITLE
fix pem normalization when file has no trailing newline

### DIFF
--- a/pkg/cryptutil/pem.go
+++ b/pkg/cryptutil/pem.go
@@ -14,6 +14,11 @@ import (
 // If the PEM data contains multiple certificates, signing certificates
 // will be moved after the things they sign.
 func NormalizePEM(data []byte) []byte {
+	// make sure the file has a trailing newline
+	if len(data) > 0 && !bytes.HasSuffix(data, []byte{'\n'}) {
+		data = append(data, '\n')
+	}
+
 	type Segment struct {
 		ID   int
 		Data []byte

--- a/pkg/cryptutil/pem_test.go
+++ b/pkg/cryptutil/pem_test.go
@@ -1,6 +1,7 @@
 package cryptutil_test
 
 import (
+	"bytes"
 	"slices"
 	"testing"
 
@@ -22,6 +23,11 @@ func TestNormalizePEM(t *testing.T) {
 		{
 			input:  slices.Concat(rootCA.PublicPEM, intermediateCA.PublicPEM, cert.PublicPEM, cert.PrivateKeyPEM),
 			expect: slices.Concat(cert.PublicPEM, cert.PrivateKeyPEM, intermediateCA.PublicPEM, rootCA.PublicPEM),
+		},
+		{
+			// make sure we handle a file without a trailing newline
+			input:  slices.Concat(intermediateCA.PublicPEM, bytes.TrimRight(cert.PublicPEM, "\n")),
+			expect: slices.Concat(cert.PublicPEM, intermediateCA.PublicPEM),
 		},
 		{
 			input:  slices.Concat(cert.PublicPEM, cert.PrivateKeyPEM, intermediateCA.PublicPEM, rootCA.PublicPEM),


### PR DESCRIPTION
## Summary
Fix for an issue with #5642 . If a file didn't end in a newline it was possible for blocks to be concatenated like this:

```
-----END CERTIFICATE----------BEGIN CERTIFICATE-----
```

This would only happen if the last certificate was moved forward. (Technically the spec requires a newline, but a trimmed input would be missing it, so we should tolerate that)

## Related issues
#5642


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
