### PR TITLE
envoyconfig: add test for local reply

### DIFF
--- a/config/envoyconfig/listeners_main.go
+++ b/config/envoyconfig/listeners_main.go
@@ -177,7 +177,7 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 		maxStreamDuration = durationpb.New(cfg.Options.WriteTimeout)
 	}
 
-	localReply, err := b.buildLocalReplyConfig(cfg.Options)
+	localReply, err := b.BuildLocalReplyConfig(cfg.Options)
 	if err != nil {
 		return nil, err
 	}

--- a/config/envoyconfig/local_reply.go
+++ b/config/envoyconfig/local_reply.go
@@ -56,9 +56,9 @@ var responseFlags = []ResponseFlag{
 	{"UT", "UpstreamRequestTimeout", "Upstream request timeout in addition to 504 response code.", codes.DeadlineExceeded},
 }
 
-// buildLocalReplyConfig builds the local reply config: the config used to modify "local" replies, that is replies
+// BuildLocalReplyConfig builds the local reply config: the config used to modify "local" replies, that is replies
 // coming directly from envoy
-func (b *Builder) buildLocalReplyConfig(
+func (b *Builder) BuildLocalReplyConfig(
 	options *config.Options,
 ) (*envoy_http_connection_manager.LocalReplyConfig, error) {
 	// add global headers for HSTS headers (#2110)

--- a/config/envoyconfig/local_reply_test.go
+++ b/config/envoyconfig/local_reply_test.go
@@ -1,24 +1,39 @@
-package envoyconfig
+package envoyconfig_test
 
 import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/interop"
+	"google.golang.org/grpc/interop/grpc_testing"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/config/envoyconfig"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 )
 
-func Test_buildLocalReplyConfig(t *testing.T) {
-	b := Builder{}
+func Test_BuildLocalReplyConfig(t *testing.T) {
+	b := envoyconfig.Builder{}
 	opts := config.NewDefaultOptions()
 	opts.BrandingOptions = &configpb.Settings{
 		LogoUrl:                    proto.String("http://example.com/my%20branding%20logo.png"),
 		ErrorMessageFirstParagraph: proto.String("It's 100% broken."),
 	}
-	lrc, err := b.buildLocalReplyConfig(opts)
+	lrc, err := b.BuildLocalReplyConfig(opts)
 	require.NoError(t, err)
 	tmpl := string(lrc.Mappers[0].GetBodyFormatOverride().GetTextFormatSource().GetInlineBytes())
 	assert.Equal(t, `{
@@ -73,4 +88,80 @@ func Test_buildLocalReplyConfig(t *testing.T) {
   </body>
 </html>
 `, tmpl)
+}
+
+func TestLocalReply(t *testing.T) {
+	env := testenv.New(t)
+
+	httpUpstream := upstreams.HTTP(nil)
+	httpRoute := httpUpstream.Route().From(env.SubdomainURL("http1")).Policy(func(p *config.Policy) { p.AllowPublicUnauthenticatedAccess = true })
+	env.AddUpstream(httpUpstream)
+
+	grpcUpstream := upstreams.GRPC(insecure.NewCredentials())
+	grpc_testing.RegisterTestServiceServer(grpcUpstream, interop.NewTestServer())
+	grpcRoute := grpcUpstream.Route().
+		From(env.SubdomainURL("grpc1")).
+		Policy(func(p *config.Policy) { p.AllowPublicUnauthenticatedAccess = true })
+
+	env.AddUpstream(grpcUpstream)
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	t.Run("grpc", func(t *testing.T) {
+		// connect to an invalid from URL so that we get a 404 error
+		cc, err := grpc.NewClient(strings.TrimPrefix(strings.Replace(grpcRoute.URL().Value(), "grpc1", "grpc2", -1), "https://"),
+			grpc.WithTransportCredentials(credentials.NewClientTLSFromCert(env.ServerCAs(), "")))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = cc.Close() })
+
+		client := grpc_testing.NewTestServiceClient(cc)
+		_, err = client.EmptyCall(env.Context(), &grpc_testing.Empty{})
+		s, ok := status.FromError(err)
+		if assert.True(t, ok) {
+			assert.Equal(t, codes.NotFound, s.Code())
+
+			var details struct {
+				RequestID  string `json:"requestId"`
+				Status     string `json:"status"`
+				StatusText string `json:"statusText"`
+			}
+			err = json.Unmarshal([]byte(s.Message()), &details)
+			assert.NoError(t, err)
+			assert.Equal(t, "404", details.Status)
+			assert.Equal(t, "route_not_found", details.StatusText)
+		}
+	})
+	t.Run("http", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, strings.Replace(httpRoute.URL().Value(), "http1", "http2", -1), nil)
+		require.NoError(t, err)
+
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNotFound, res.StatusCode)
+
+		bs, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		assert.Contains(t, string(bs), "<!DOCTYPE html>")
+	})
+	t.Run("json", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, strings.Replace(httpRoute.URL().Value(), "http1", "http2", -1), nil)
+		require.NoError(t, err)
+		req.Header.Set("Accept", "application/json")
+
+		res, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusNotFound, res.StatusCode)
+
+		bs, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		var details struct {
+			RequestID  string `json:"requestId"`
+			Status     string `json:"status"`
+			StatusText string `json:"statusText"`
+		}
+		err = json.Unmarshal(bs, &details)
+		assert.NoError(t, err)
+		assert.Equal(t, "404", details.Status)
+		assert.Equal(t, "route_not_found", details.StatusText)
+	})
 }


### PR DESCRIPTION
## Summary
Add a test to ensure the local reply config results in errors in the right format.

## Related issues
- [ENG-2470](https://linear.app/pomerium/issue/ENG-2470/core-add-test-for-grpc-error-formatting)

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
