### PR TITLE
ppl: add in string matcher

### DIFF
--- a/pkg/policy/criteria/matchers.go
+++ b/pkg/policy/criteria/matchers.go
@@ -69,31 +69,7 @@ func matchStringIn(dst *ast.Body, left *ast.Term, right parser.Value) error {
 	if !ok {
 		return fmt.Errorf("in matcher requires an array of strings")
 	}
-
-	var terms []*ast.Term
-	for _, v := range arr {
-		terms = append(terms, ast.NewTerm(v.RegoValue()))
-	}
-	arrayTerm := ast.NewTerm(ast.NewArray(terms...))
-
-	// Generate: count([true | some v; v = array[_]; v == left]) > 0
-	// This creates a comprehension that checks if the left value exists in the array
-	body := ast.Body{
-		ast.MustParseExpr("some v"),
-		ast.Equality.Expr(ast.VarTerm("v"), ast.RefTerm(arrayTerm, ast.VarTerm("_"))),
-		ast.Equal.Expr(ast.VarTerm("v"), left),
-	}
-
-	*dst = append(*dst, ast.GreaterThan.Expr(
-		ast.Count.Call(
-			ast.ArrayComprehensionTerm(
-				ast.BooleanTerm(true),
-				body,
-			),
-		),
-		ast.IntNumberTerm(0),
-	))
-
+	*dst = append(*dst, ast.Member.Expr(left, ast.NewTerm(arr.RegoValue())))
 	return nil
 }
 

--- a/pkg/policy/criteria/matchers_test.go
+++ b/pkg/policy/criteria/matchers_test.go
@@ -114,7 +114,7 @@ func TestStringMatcher(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		assert.Equal(t, `count([true | some v; v = ["value1", "value2", "value3"][_]; v == example]) > 0`, str(body))
+		assert.Equal(t, `example in ["value1", "value2", "value3"]`, str(body))
 	})
 	t.Run("in with object", func(t *testing.T) {
 		t.Parallel()
@@ -127,7 +127,7 @@ func TestStringMatcher(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		assert.Equal(t, `count([true | some v; v = ["admin", "user"][_]; v == example]) > 0`, str(body))
+		assert.Equal(t, `example in ["admin", "user"]`, str(body))
 	})
 	t.Run("in with non-array value", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/policy/criteria/matchers_test.go
+++ b/pkg/policy/criteria/matchers_test.go
@@ -102,6 +102,43 @@ func TestStringMatcher(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, `example == null`, str(body))
 	})
+	t.Run("in", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchString(&body, ast.VarTerm("example"), parser.Object{
+			"in": parser.Array{
+				parser.String("value1"),
+				parser.String("value2"),
+				parser.String("value3"),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, `count([true | some v; v = ["value1", "value2", "value3"][_]; v == example]) > 0`, str(body))
+	})
+	t.Run("in with object", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchString(&body, ast.VarTerm("example"), parser.Object{
+			"in": parser.Array{
+				parser.String("admin"),
+				parser.String("user"),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, `count([true | some v; v = ["admin", "user"][_]; v == example]) > 0`, str(body))
+	})
+	t.Run("in with non-array value", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchString(&body, ast.VarTerm("example"), parser.Object{
+			"in": parser.String("not-an-array"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "in matcher requires an array of strings")
+	})
 }
 
 func TestStringListMatcher(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `in` string matcher to PPL, that matches a string with an array of strings. 

## Related issues

Related: https://linear.app/pomerium/issue/ENG-2393

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
