### PR TITLE
config: support multiple running services in addition to all-in-one mode

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -42,13 +42,18 @@ func (b *Builder) BuildClusters(ctx context.Context, cfg *config.Config) ([]*env
 		Host:   b.localMetricsAddress,
 	}
 
-	authorizeURLs, databrokerURLs := grpcURLs, grpcURLs
-	if !config.IsAll(cfg.Options.Services) {
+	authorizeURLs := grpcURLs
+	if !config.IsAuthorize(cfg.Options.Services) {
 		var err error
 		authorizeURLs, err = cfg.Options.GetInternalAuthorizeURLs()
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	databrokerURLs := grpcURLs
+	if !config.IsDataBroker(cfg.Options.Services) {
+		var err error
 		databrokerURLs, err = cfg.Options.GetDataBrokerURLs()
 		if err != nil {
 			return nil, err

--- a/config/helpers.go
+++ b/config/helpers.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"slices"
 	"strings"
 )
 
@@ -24,6 +23,73 @@ const (
 	StorageInMemoryName = "memory"
 )
 
+// IsAll checks to see if we should be running all services
+func IsAll(services string) bool {
+	var isAuthenticate, isAuthorize, isDataBroker, isProxy bool
+	for _, svc := range splitServices(services) {
+		switch svc {
+		case ServiceAll:
+			isAuthenticate = true
+			isAuthorize = true
+			isDataBroker = true
+			isProxy = true
+		case ServiceAuthenticate:
+			isAuthenticate = true
+		case ServiceAuthorize:
+			isAuthorize = true
+		case ServiceCache, ServiceDataBroker:
+			isDataBroker = true
+		case ServiceProxy:
+			isProxy = true
+		}
+	}
+	return isAuthenticate && isAuthorize && isDataBroker && isProxy
+}
+
+// IsAuthenticate checks to see if we should be running the authenticate service
+func IsAuthenticate(services string) bool {
+	for _, svc := range splitServices(services) {
+		switch svc {
+		case ServiceAll, ServiceAuthenticate:
+			return true
+		}
+	}
+	return false
+}
+
+// IsAuthorize checks to see if we should be running the authorize service
+func IsAuthorize(services string) bool {
+	for _, svc := range splitServices(services) {
+		switch svc {
+		case ServiceAll, ServiceAuthorize:
+			return true
+		}
+	}
+	return false
+}
+
+// IsDataBroker checks to see if we should be running the databroker service
+func IsDataBroker(services string) bool {
+	for _, svc := range splitServices(services) {
+		switch svc {
+		case ServiceAll, ServiceCache, ServiceDataBroker:
+			return true
+		}
+	}
+	return false
+}
+
+// IsProxy checks to see if we should be running the proxy service
+func IsProxy(services string) bool {
+	for _, svc := range splitServices(services) {
+		switch svc {
+		case ServiceAll, ServiceProxy:
+			return true
+		}
+	}
+	return false
+}
+
 // IsValidService checks to see if a service is a valid service mode
 func IsValidService(services string) bool {
 	svcs := splitServices(services)
@@ -42,36 +108,6 @@ func IsValidService(services string) bool {
 		}
 	}
 	return len(svcs) > 0
-}
-
-// IsAuthenticate checks to see if we should be running the authenticate service
-func IsAuthenticate(services string) bool {
-	return slices.Contains(splitServices(services), ServiceAll) ||
-		slices.Contains(splitServices(services), ServiceAuthenticate)
-}
-
-// IsAuthorize checks to see if we should be running the authorize service
-func IsAuthorize(services string) bool {
-	return slices.Contains(splitServices(services), ServiceAll) ||
-		slices.Contains(splitServices(services), ServiceAuthorize)
-}
-
-// IsProxy checks to see if we should be running the proxy service
-func IsProxy(services string) bool {
-	return slices.Contains(splitServices(services), ServiceAll) ||
-		slices.Contains(splitServices(services), ServiceProxy)
-}
-
-// IsDataBroker checks to see if we should be running the databroker service
-func IsDataBroker(services string) bool {
-	return slices.Contains(splitServices(services), ServiceAll) ||
-		slices.Contains(splitServices(services), ServiceCache) ||
-		slices.Contains(splitServices(services), ServiceDataBroker)
-}
-
-// IsAll checks to see if we should be running all services
-func IsAll(services string) bool {
-	return slices.Contains(splitServices(services), ServiceAll)
 }
 
 func splitServices(raw string) []string {

--- a/config/helpers.go
+++ b/config/helpers.go
@@ -1,5 +1,10 @@
 package config
 
+import (
+	"slices"
+	"strings"
+)
+
 const (
 	// ServiceAll represents running all services in "all-in-one" mode
 	ServiceAll = "all"
@@ -20,65 +25,62 @@ const (
 )
 
 // IsValidService checks to see if a service is a valid service mode
-func IsValidService(s string) bool {
-	switch s {
-	case
-		ServiceAll,
-		ServiceAuthenticate,
-		ServiceAuthorize,
-		ServiceCache,
-		ServiceDataBroker,
-		ServiceProxy:
-		return true
+func IsValidService(services string) bool {
+	svcs := splitServices(services)
+	for _, svc := range svcs {
+		switch svc {
+		case
+			ServiceAll,
+			ServiceAuthenticate,
+			ServiceAuthorize,
+			ServiceCache,
+			ServiceDataBroker,
+			ServiceProxy:
+			// valid
+		default:
+			return false
+		}
 	}
-	return false
+	return len(svcs) > 0
 }
 
 // IsAuthenticate checks to see if we should be running the authenticate service
-func IsAuthenticate(s string) bool {
-	switch s {
-	case ServiceAll, ServiceAuthenticate:
-		return true
-	}
-	return false
+func IsAuthenticate(services string) bool {
+	return slices.Contains(splitServices(services), ServiceAll) ||
+		slices.Contains(splitServices(services), ServiceAuthenticate)
 }
 
 // IsAuthorize checks to see if we should be running the authorize service
-func IsAuthorize(s string) bool {
-	switch s {
-	case ServiceAll, ServiceAuthorize:
-		return true
-	}
-	return false
+func IsAuthorize(services string) bool {
+	return slices.Contains(splitServices(services), ServiceAll) ||
+		slices.Contains(splitServices(services), ServiceAuthorize)
 }
 
 // IsProxy checks to see if we should be running the proxy service
-func IsProxy(s string) bool {
-	switch s {
-	case ServiceAll, ServiceProxy:
-		return true
-	}
-	return false
+func IsProxy(services string) bool {
+	return slices.Contains(splitServices(services), ServiceAll) ||
+		slices.Contains(splitServices(services), ServiceProxy)
 }
 
 // IsDataBroker checks to see if we should be running the databroker service
-func IsDataBroker(s string) bool {
-	switch s {
-	case
-		ServiceAll,
-		ServiceCache,
-		ServiceDataBroker:
-		return true
-	}
-	return false
-}
-
-// IsRegistry checks if this node should run the registry service
-func IsRegistry(s string) bool {
-	return IsDataBroker(s)
+func IsDataBroker(services string) bool {
+	return slices.Contains(splitServices(services), ServiceAll) ||
+		slices.Contains(splitServices(services), ServiceCache) ||
+		slices.Contains(splitServices(services), ServiceDataBroker)
 }
 
 // IsAll checks to see if we should be running all services
-func IsAll(s string) bool {
-	return s == ServiceAll
+func IsAll(services string) bool {
+	return slices.Contains(splitServices(services), ServiceAll)
+}
+
+func splitServices(raw string) []string {
+	var svcs []string
+	for _, s := range strings.Split(raw, ",") {
+		s = strings.TrimSpace(strings.ToLower(s))
+		if s != "" {
+			svcs = append(svcs, s)
+		}
+	}
+	return svcs
 }

--- a/config/helpers_test.go
+++ b/config/helpers_test.go
@@ -112,3 +112,23 @@ func Test_IsDataBroker(t *testing.T) {
 		})
 	}
 }
+
+func Test_IsAll(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		service string
+		want    bool
+	}{
+		{"proxy", "proxy", false},
+		{"all", "all", true},
+		{"separate", "authenticate,authorize,databroker,proxy", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsDataBroker(tt.service); got != tt.want {
+				t.Errorf("IsAll() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/config/helpers_test.go
+++ b/config/helpers_test.go
@@ -13,7 +13,6 @@ func Test_isValidService(t *testing.T) {
 		{"proxy", "proxy", true},
 		{"all", "all", true},
 		{"authenticate", "authenticate", true},
-		{"authenticate bad case", "AuThenticate", false},
 		{"authorize implemented", "authorize", true},
 		{"jiberish", "xd23", false},
 		{"databroker", "databroker", true},
@@ -37,7 +36,6 @@ func Test_isAuthenticate(t *testing.T) {
 		{"proxy", "proxy", false},
 		{"all", "all", true},
 		{"authenticate", "authenticate", true},
-		{"authenticate bad case", "AuThenticate", false},
 		{"authorize implemented", "authorize", false},
 		{"jiberish", "xd23", false},
 	}
@@ -60,7 +58,6 @@ func Test_isAuthorize(t *testing.T) {
 		{"proxy", "proxy", false},
 		{"all", "all", true},
 		{"authorize", "authorize", true},
-		{"authorize bad case", "AuThorize", false},
 		{"authenticate implemented", "authenticate", false},
 		{"jiberish", "xd23", false},
 	}
@@ -82,7 +79,6 @@ func Test_IsProxy(t *testing.T) {
 		{"proxy", "proxy", true},
 		{"all", "all", true},
 		{"authorize", "authorize", false},
-		{"proxy bad case", "PrOxY", false},
 		{"jiberish", "xd23", false},
 	}
 	for _, tt := range tests {
@@ -104,7 +100,6 @@ func Test_IsDataBroker(t *testing.T) {
 		{"proxy", "proxy", false},
 		{"all", "all", true},
 		{"authorize", "authorize", false},
-		{"proxy bad case", "PrOxY", false},
 		{"jiberish", "xd23", false},
 		{"cache", "cache", true},
 		{"databroker", "databroker", true},

--- a/config/options.go
+++ b/config/options.go
@@ -829,7 +829,7 @@ func (o *Options) SupportsUserRefresh() bool {
 
 // GetAuthorizeURLs returns the AuthorizeURLs in the options or 127.0.0.1:5443.
 func (o *Options) GetAuthorizeURLs() ([]*url.URL, error) {
-	if IsAll(o.Services) && o.AuthorizeURLString == "" && len(o.AuthorizeURLStrings) == 0 {
+	if (IsAuthenticate(o.Services) || IsProxy(o.Services)) && o.AuthorizeURLString == "" && len(o.AuthorizeURLStrings) == 0 {
 		u, err := urlutil.ParseAndValidateURL("http://127.0.0.1" + DefaultAlternativeAddr)
 		if err != nil {
 			return nil, err
@@ -850,7 +850,7 @@ func (o *Options) GetInternalAuthorizeURLs() ([]*url.URL, error) {
 
 // GetDataBrokerURLs returns the DataBrokerURLs in the options or 127.0.0.1:5443.
 func (o *Options) GetDataBrokerURLs() ([]*url.URL, error) {
-	if IsAll(o.Services) && o.DataBrokerURLString == "" && len(o.DataBrokerURLStrings) == 0 {
+	if (IsAuthenticate(o.Services) || IsProxy(o.Services)) && o.DataBrokerURLString == "" && len(o.DataBrokerURLStrings) == 0 {
 		u, err := urlutil.ParseAndValidateURL("http://127.0.0.1" + DefaultAlternativeAddr)
 		if err != nil {
 			return nil, err
@@ -893,7 +893,7 @@ func (o *Options) getURLs(strs ...string) ([]*url.URL, error) {
 // GetGRPCAddr gets the gRPC address.
 func (o *Options) GetGRPCAddr() string {
 	// to avoid port collision when running on localhost
-	if IsAll(o.Services) && o.GRPCAddr == defaultOptions.GRPCAddr {
+	if (IsAuthenticate(o.Services) || IsProxy(o.Services)) && o.GRPCAddr == defaultOptions.GRPCAddr {
 		return DefaultAlternativeAddr
 	}
 	return o.GRPCAddr
@@ -904,7 +904,7 @@ func (o *Options) GetGRPCInsecure() bool {
 	if o.GRPCInsecure != nil {
 		return *o.GRPCInsecure
 	}
-	if IsAll(o.Services) {
+	if IsAuthenticate(o.Services) || IsProxy(o.Services) {
 		return true
 	}
 	return false

--- a/internal/telemetry/util.go
+++ b/internal/telemetry/util.go
@@ -1,15 +1,15 @@
 package telemetry
 
+import "strings"
+
 // ServiceName turns a pomerium service option into the appropriate external label for telemetry purposes
 //
 // Ex:
 // service 'all' -> 'pomerium'
 // service 'proxy' -> 'pomerium-proxy'
 func ServiceName(service string) string {
-	switch service {
-	case "all", "":
+	if strings.Count(service, ",") > 0 || service == "all" || service == "" {
 		return "pomerium"
-	default:
-		return "pomerium-" + service
 	}
+	return "pomerium-" + service
 }

--- a/internal/telemetry/util_test.go
+++ b/internal/telemetry/util_test.go
@@ -16,6 +16,7 @@ func Test_ServiceName(t *testing.T) {
 		{"all", "all", "pomerium"},
 		{"proxy", "proxy", "pomerium-proxy"},
 		{"missing", "", "pomerium"},
+		{"multiple", "authorize,proxy", "pomerium"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
Currently you can either run a single service or all-in-one mode. This PR adds support for running any 2 or 3 services together. For example `services: authorize,proxy`.

I think I updated the conditions to make sense, but there's some risk here as there may have been some assumptions in places I'm overlooking.

## Related issues
- [ENG-2485](https://linear.app/pomerium/issue/ENG-2485/core-support-running-multiple-but-not-all-services)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
