### PR TITLE
oauth: add minimal device auth support for ssh

### DIFF
--- a/pkg/identity/mock_provider.go
+++ b/pkg/identity/mock_provider.go
@@ -12,14 +12,18 @@ import (
 
 // MockProvider provides a mocked implementation of the providers interface.
 type MockProvider struct {
-	AuthenticateResponse oauth2.Token
-	AuthenticateError    error
-	RefreshResponse      oauth2.Token
-	RefreshError         error
-	RevokeError          error
-	UpdateUserInfoError  error
-	SignInError          error
-	SignOutError         error
+	AuthenticateResponse      oauth2.Token
+	AuthenticateError         error
+	RefreshResponse           oauth2.Token
+	RefreshError              error
+	RevokeError               error
+	UpdateUserInfoError       error
+	SignInError               error
+	SignOutError              error
+	DeviceAuthResponse        oauth2.DeviceAuthResponse
+	DeviceAuthError           error
+	DeviceAccessTokenResponse oauth2.Token
+	DeviceAccessTokenError    error
 }
 
 // Authenticate is a mocked providers function.
@@ -55,6 +59,16 @@ func (mp MockProvider) SignOut(_ http.ResponseWriter, _ *http.Request, _, _, _ s
 // SignIn is a mocked providers function.
 func (mp MockProvider) SignIn(_ http.ResponseWriter, _ *http.Request, _ string) error {
 	return mp.SignInError
+}
+
+// DeviceAuth implements Authenticator.
+func (mp MockProvider) DeviceAuth(_ context.Context) (*oauth2.DeviceAuthResponse, error) {
+	return &mp.DeviceAuthResponse, mp.DeviceAuthError
+}
+
+// DeviceAccessToken implements Authenticator.
+func (mp MockProvider) DeviceAccessToken(_ context.Context, _ *oauth2.DeviceAuthResponse, _ identity.State) (*oauth2.Token, error) {
+	return &mp.DeviceAccessTokenResponse, mp.DeviceAccessTokenError
 }
 
 // VerifyAccessToken verifies an access token.

--- a/pkg/identity/oauth/apple/apple.go
+++ b/pkg/identity/oauth/apple/apple.go
@@ -188,6 +188,14 @@ func (p *Provider) SignOut(_ http.ResponseWriter, _ *http.Request, _, _, _ strin
 	return oidc.ErrSignoutNotImplemented
 }
 
+func (p *Provider) DeviceAuth(_ context.Context) (*oauth2.DeviceAuthResponse, error) {
+	return nil, oidc.ErrDeviceAuthNotImplemented
+}
+
+func (p *Provider) DeviceAccessToken(_ context.Context, _ *oauth2.DeviceAuthResponse, _ identity.State) (*oauth2.Token, error) {
+	return nil, oidc.ErrDeviceAuthNotImplemented
+}
+
 // VerifyAccessToken verifies an access token.
 func (p *Provider) VerifyAccessToken(_ context.Context, _ string) (claims map[string]any, err error) {
 	// apple does not appear to have any way of verifying access tokens

--- a/pkg/identity/oauth/github/github.go
+++ b/pkg/identity/oauth/github/github.go
@@ -258,6 +258,14 @@ func (p *Provider) SignOut(_ http.ResponseWriter, _ *http.Request, _, _, _ strin
 	return oidc.ErrSignoutNotImplemented
 }
 
+func (p *Provider) DeviceAuth(_ context.Context) (*oauth2.DeviceAuthResponse, error) {
+	return nil, oidc.ErrDeviceAuthNotImplemented
+}
+
+func (p *Provider) DeviceAccessToken(_ context.Context, _ *oauth2.DeviceAuthResponse, _ identity.State) (*oauth2.Token, error) {
+	return nil, oidc.ErrDeviceAuthNotImplemented
+}
+
 // VerifyAccessToken verifies an access token.
 func (p *Provider) VerifyAccessToken(ctx context.Context, rawAccessToken string) (claims map[string]any, err error) {
 	claims = jwtutil.Claims(map[string]any{})

--- a/pkg/identity/oidc/errors.go
+++ b/pkg/identity/oidc/errors.go
@@ -13,6 +13,10 @@ var ErrRevokeNotImplemented = errors.New("identity/oidc: revoke not implemented"
 // https://openid.net/specs/openid-connect-frontchannel-1_0.html#RPInitiated
 var ErrSignoutNotImplemented = errors.New("identity/oidc: end session not implemented")
 
+// ErrDeviceAuthNotImplemented is returned when device auth is not implemented
+// by an identity provider.
+var ErrDeviceAuthNotImplemented = errors.New("identity/oidc: device auth not implemented")
+
 // ErrMissingProviderURL is returned when an identity provider requires a provider url
 // does not receive one.
 var ErrMissingProviderURL = errors.New("identity/oidc: missing provider url")

--- a/pkg/identity/providers.go
+++ b/pkg/identity/providers.go
@@ -41,6 +41,9 @@ type Authenticator interface {
 
 	SignIn(w http.ResponseWriter, r *http.Request, state string) error
 	SignOut(w http.ResponseWriter, r *http.Request, idTokenHint, authenticateSignedOutURL, redirectToURL string) error
+
+	DeviceAuth(ctx context.Context) (*oauth2.DeviceAuthResponse, error)
+	DeviceAccessToken(ctx context.Context, r *oauth2.DeviceAuthResponse, state State) (*oauth2.Token, error)
 }
 
 // AuthenticatorConstructor makes an Authenticator from the given options.


### PR DESCRIPTION
## Summary

This adds the necessary logic needed for device auth flow in ssh. The code is not used currently; will follow up with testenv updates that can let us test this with the mock idp.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
