### PR TITLE
testenv: add support for SSH routes/upstreams

### DIFF
--- a/internal/testenv/environment.go
+++ b/internal/testenv/environment.go
@@ -105,6 +105,8 @@ type Environment interface {
 	SharedSecret() []byte
 	CookieSecret() []byte
 
+	Config() *config.Config
+
 	// Add adds the given [Modifier] to the environment. All modifiers will be
 	// invoked upon calling Start() to apply individual modifications to the
 	// configuration before starting the Pomerium server.
@@ -414,7 +416,9 @@ func New(t testing.TB, opts ...EnvironmentOption) Environment {
 		ports: Ports{
 			ProxyHTTP:    values.Deferred[int](),
 			ProxyGRPC:    values.Deferred[int](),
+			ProxySSH:     values.Deferred[int](),
 			ProxyMetrics: values.Deferred[int](),
+			EnvoyAdmin:   values.Deferred[int](),
 			GRPC:         values.Deferred[int](),
 			HTTP:         values.Deferred[int](),
 			Outbound:     values.Deferred[int](),
@@ -481,7 +485,9 @@ type WithCaller[T any] struct {
 type Ports struct {
 	ProxyHTTP    values.MutableValue[int]
 	ProxyGRPC    values.MutableValue[int]
+	ProxySSH     values.MutableValue[int]
 	ProxyMetrics values.MutableValue[int]
+	EnvoyAdmin   values.MutableValue[int]
 	GRPC         values.MutableValue[int]
 	HTTP         values.MutableValue[int]
 	Outbound     values.MutableValue[int]
@@ -537,6 +543,10 @@ func (e *environment) Host() string {
 	return e.host
 }
 
+func (e *environment) Config() *config.Config {
+	return e.src.GetConfig()
+}
+
 func (e *environment) CACert() *tls.Certificate {
 	caCert, err := tls.LoadX509KeyPair(
 		filepath.Join(e.tempDir, "certs", "ca.pem"),
@@ -581,7 +591,7 @@ func (e *environment) Start() {
 	cfg := &config.Config{
 		Options: config.NewDefaultOptions(),
 	}
-	ports, err := netutil.AllocatePorts(9)
+	ports, err := netutil.AllocatePorts(11)
 	require.NoError(e.t, err)
 	atoi := func(str string) int {
 		p, err := strconv.Atoi(str)
@@ -592,14 +602,16 @@ func (e *environment) Start() {
 	}
 	e.ports.ProxyHTTP.Resolve(atoi(ports[0]))
 	e.ports.ProxyGRPC.Resolve(atoi(ports[1]))
-	e.ports.ProxyMetrics.Resolve(atoi(ports[2]))
-	e.ports.GRPC.Resolve(atoi(ports[3]))
-	e.ports.HTTP.Resolve(atoi(ports[4]))
-	e.ports.Outbound.Resolve(atoi(ports[5]))
-	e.ports.Metrics.Resolve(atoi(ports[6]))
-	e.ports.Debug.Resolve(atoi(ports[7]))
-	e.ports.ALPN.Resolve(atoi(ports[8]))
-	cfg.AllocatePorts(*(*[6]string)(ports[3:]))
+	e.ports.ProxySSH.Resolve(atoi(ports[2]))
+	e.ports.ProxyMetrics.Resolve(atoi(ports[3]))
+	e.ports.EnvoyAdmin.Resolve(atoi(ports[4]))
+	e.ports.GRPC.Resolve(atoi(ports[5]))
+	e.ports.HTTP.Resolve(atoi(ports[6]))
+	e.ports.Outbound.Resolve(atoi(ports[7]))
+	e.ports.Metrics.Resolve(atoi(ports[8]))
+	e.ports.Debug.Resolve(atoi(ports[9]))
+	e.ports.ALPN.Resolve(atoi(ports[10]))
+	cfg.AllocatePorts(*(*[6]string)(ports[5:]))
 
 	cfg.Options.AutocertOptions = config.AutocertOptions{Enable: false}
 	cfg.Options.Services = "all"
@@ -607,6 +619,8 @@ func (e *environment) Start() {
 	cfg.Options.ProxyLogLevel = config.LogLevelInfo
 	cfg.Options.Addr = fmt.Sprintf("%s:%d", e.host, e.ports.ProxyHTTP.Value())
 	cfg.Options.GRPCAddr = fmt.Sprintf("%s:%d", e.host, e.ports.ProxyGRPC.Value())
+	cfg.Options.SSHAddr = fmt.Sprintf("%s:%d", e.host, e.ports.ProxySSH.Value())
+	cfg.Options.EnvoyAdminAddress = fmt.Sprintf("%s:%d", e.host, e.ports.EnvoyAdmin.Value())
 	cfg.Options.MetricsAddr = fmt.Sprintf("%s:%d", e.host, e.ports.ProxyMetrics.Value())
 	cfg.Options.CAFile = filepath.Join(e.tempDir, "certs", "ca.pem")
 	cfg.Options.CertFile = filepath.Join(e.tempDir, "certs", "trusted.pem")
@@ -833,6 +847,34 @@ func (e *environment) Stop() {
 
 func (e *environment) Pause() {
 	e.t.Log("\x1b[31m*** test manually paused; continue with ctrl+c ***\x1b[0m")
+	e.debugf(`
+Host: %s
+Ports:
+  ProxyHTTP:    %d
+  ProxyGRPC:    %d
+  ProxySSH:     %d
+  ProxyMetrics: %d
+  EnvoyAdmin:   %d
+  GRPC:         %d
+  HTTP:         %d
+  Outbound:     %d
+  Metrics:      %d
+  Debug:        %d
+  ALPN:         %d
+  `,
+		e.host,
+		e.ports.ProxyHTTP.Value(),
+		e.ports.ProxyGRPC.Value(),
+		e.ports.ProxySSH.Value(),
+		e.ports.ProxyMetrics.Value(),
+		e.ports.EnvoyAdmin.Value(),
+		e.ports.GRPC.Value(),
+		e.ports.HTTP.Value(),
+		e.ports.Outbound.Value(),
+		e.ports.Metrics.Value(),
+		e.ports.Debug.Value(),
+		e.ports.ALPN.Value())
+
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGINT)
 	<-c

--- a/internal/testenv/scenarios/ssh.go
+++ b/internal/testenv/scenarios/ssh.go
@@ -1,0 +1,69 @@
+package scenarios
+
+import (
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	"encoding/pem"
+
+	"golang.org/x/crypto/ssh"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/pkg/slices"
+)
+
+type SSHConfig struct {
+	// Host key(s). An Ed25519 key will be generated if not set.
+	// Elements must be of a type supported by [ssh.NewSignerFromKey].
+	HostKeys []any
+
+	// User CA key, for signing SSH certificates used to authenticate to an
+	// upstream. An Ed25519 key will be generated if not set.
+	// Must be a type supported by [ssh.NewSignerFromKey].
+	UserCAKey any
+}
+
+func SSH(c SSHConfig) testenv.Modifier {
+	return testenv.ModifierFunc(func(ctx context.Context, cfg *config.Config) {
+		env := testenv.EnvFromContext(ctx)
+
+		if len(c.HostKeys) == 0 {
+			c.HostKeys = []any{newEd25519Key(env)}
+		}
+
+		if c.UserCAKey == nil {
+			c.UserCAKey = newEd25519Key(env)
+		}
+
+		marshalPrivateKey := func(key any) string {
+			p, err := ssh.MarshalPrivateKey(key.(crypto.PrivateKey), "")
+			env.Require().NoError(err)
+			return string(pem.EncodeToMemory(p))
+		}
+		configHostKeys := slices.Map(c.HostKeys, marshalPrivateKey)
+		cfg.Options.SSHHostKeys = &configHostKeys
+		cfg.Options.SSHUserCAKey = marshalPrivateKey(c.UserCAKey)
+	})
+}
+
+func newEd25519Key(env testenv.Environment) ed25519.PrivateKey {
+	_, priv, err := ed25519.GenerateKey(nil)
+	env.Require().NoError(err)
+	return priv
+}
+
+// EmptyKeyboardInteractiveChallenge responds to any keyboard-interactive
+// challenges with zero prompts, and fails otherwise.
+type EmptyKeyboardInteractiveChallenge struct {
+	testenv.DefaultAttach
+}
+
+func (c *EmptyKeyboardInteractiveChallenge) Do(
+	name, instruction string, questions []string, echos []bool,
+) (answers []string, err error) {
+	if len(questions) > 0 {
+		c.Env().Require().FailNow("unsupported keyboard-interactive challenge")
+	}
+	return nil, nil
+}

--- a/internal/testenv/types.go
+++ b/internal/testenv/types.go
@@ -69,6 +69,8 @@ func (d *DefaultAttach) RecordCaller() {
 	d.caller = getCaller(4)
 }
 
+func (d *DefaultAttach) Modify(*config.Config) {}
+
 // Aggregate should be embedded in types implementing [Modifier] when the type
 // contains other modifiers. Used as an alternative to [DefaultAttach].
 // Embedding this struct will properly keep track of when constituent modifiers

--- a/internal/testenv/upstreams/ssh.go
+++ b/internal/testenv/upstreams/ssh.go
@@ -1,0 +1,203 @@
+package upstreams
+
+import (
+	"context"
+	"fmt"
+	"net"
+
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/values"
+	"golang.org/x/crypto/ssh"
+)
+
+type SSHUpstreamOptions struct {
+	displayName    string
+	serverConfig   ssh.ServerConfig
+	authorizedKeys authorizedKeysChecker
+}
+
+type SSHUpstreamOption interface {
+	applySSH(*SSHUpstreamOptions)
+}
+
+type sshUpstreamOption func(o *SSHUpstreamOptions)
+
+func (s sshUpstreamOption) applySSH(o *SSHUpstreamOptions) { s(o) }
+
+func WithPublicKeyAuthAlgorithms(algs ...string) SSHUpstreamOption {
+	return sshUpstreamOption(func(o *SSHUpstreamOptions) {
+		o.serverConfig.PublicKeyAuthAlgorithms = algs
+	})
+}
+
+func WithHostKeys(keys ...ssh.Signer) SSHUpstreamOption {
+	return sshUpstreamOption(func(o *SSHUpstreamOptions) {
+		for _, key := range keys {
+			o.serverConfig.AddHostKey(key)
+		}
+	})
+}
+
+func WithBannerCallback(c func(ssh.ConnMetadata) string) SSHUpstreamOption {
+	return sshUpstreamOption(func(o *SSHUpstreamOptions) {
+		o.serverConfig.BannerCallback = c
+	})
+}
+
+// WithPublicKeyCallback sets a custom callback for the publickey authentication method.
+// This will override any previous [WithAuthorizedKey] option.
+func WithPublicKeyCallback(c func(ssh.ConnMetadata, ssh.PublicKey) (*ssh.Permissions, error)) SSHUpstreamOption {
+	return sshUpstreamOption(func(o *SSHUpstreamOptions) {
+		o.serverConfig.PublicKeyCallback = c
+	})
+}
+
+// WithAuthorizedKey allows the given key to be used to authenticate the given username,
+// enabling the publickey authentication method. This will override any previous
+// [WithPublicKeyCallback] option.
+func WithAuthorizedKey(key ssh.PublicKey, username string) SSHUpstreamOption {
+	return sshUpstreamOption(func(o *SSHUpstreamOptions) {
+		o.authorizedKeys.add(key, username)
+		o.serverConfig.PublicKeyCallback = o.authorizedKeys.check
+	})
+}
+
+type authorizedKeysChecker map[string]string // map from marshaled public key to corresponding username
+
+func (c *authorizedKeysChecker) add(key ssh.PublicKey, username string) {
+	if *c == nil {
+		*c = make(map[string]string)
+	}
+	(*c)[string(key.Marshal())] = username
+}
+
+func (c authorizedKeysChecker) check(conn ssh.ConnMetadata, key ssh.PublicKey) (*ssh.Permissions, error) {
+	if c[string(key.Marshal())] == conn.User() {
+		return &ssh.Permissions{}, nil
+	}
+	return nil, fmt.Errorf("not authorized")
+}
+
+type ServerConnCallback func(*ssh.ServerConn, <-chan ssh.NewChannel, <-chan *ssh.Request)
+
+var closeConnCallback ServerConnCallback = func(conn *ssh.ServerConn, ncc <-chan ssh.NewChannel, rq <-chan *ssh.Request) {
+	conn.Close()
+}
+
+// SSHUpstream represents an ssh server which can be used as the target for
+// one or more Pomerium routes in a test environment.
+//
+// Use SetServerConnCallback() to define the behavior of this server once
+// a connection is established.
+//
+// Dial() can be used to make a client-side connection through the Pomerium
+// route, while DirectDial() can be used to connect bypassing Pomerium.
+type SSHUpstream interface {
+	testenv.Upstream
+
+	SetServerConnCallback(callback ServerConnCallback)
+
+	Dial(r testenv.Route, config *ssh.ClientConfig) (*ssh.Client, error)
+	DirectDial(r testenv.Route, config *ssh.ClientConfig) (*ssh.Client, error)
+}
+
+type sshUpstream struct {
+	SSHUpstreamOptions
+	testenv.Aggregate
+	serverPort values.MutableValue[int]
+
+	serverConnCallback ServerConnCallback
+}
+
+var (
+	_ testenv.Upstream = (*sshUpstream)(nil)
+	_ SSHUpstream      = (*sshUpstream)(nil)
+)
+
+// SSH creates a new ssh upstream server.
+func SSH(opts ...SSHUpstreamOption) SSHUpstream {
+	options := SSHUpstreamOptions{
+		displayName: "SSH Upstream",
+	}
+	for _, op := range opts {
+		op.applySSH(&options)
+	}
+	up := &sshUpstream{
+		SSHUpstreamOptions: options,
+		serverPort:         values.Deferred[int](),
+		serverConnCallback: closeConnCallback, // default handler, to avoid hanging connections
+	}
+	up.RecordCaller()
+	return up
+}
+
+// Addr implements SSHUpstream.
+func (h *sshUpstream) Addr() values.Value[string] {
+	return values.Bind(h.serverPort, func(port int) string {
+		return fmt.Sprintf("%s:%d", h.Env().Host(), port)
+	})
+}
+
+// Router implements SSHUpstream.
+func (h *sshUpstream) SetServerConnCallback(callback ServerConnCallback) {
+	h.serverConnCallback = callback
+}
+
+// Route implements SSHUpstream.
+func (h *sshUpstream) Route() testenv.RouteStub {
+	r := &testenv.PolicyRoute{}
+	protocol := "ssh"
+	r.To(values.Bind(h.serverPort, func(port int) string {
+		return fmt.Sprintf("%s://%s:%d", protocol, h.Env().Host(), port)
+	}))
+	h.Add(r)
+	return r
+}
+
+// Run implements SSHUpstream.
+func (h *sshUpstream) Run(ctx context.Context) error {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return err
+	}
+	h.serverPort.Resolve(listener.Addr().(*net.TCPAddr).Port)
+
+	go func() {
+		<-ctx.Done()
+		listener.Close()
+	}()
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			// The testenv cleanup expects this function to return a "test cleanup" error,
+			// which propagates via the context.
+			if ctx.Err() != nil {
+				return context.Cause(ctx)
+			}
+			return err
+		}
+		go h.handleConnection(ctx, conn)
+	}
+}
+
+func (h *sshUpstream) handleConnection(ctx context.Context, conn net.Conn) {
+	serverConn, ncc, rc, err := ssh.NewServerConn(conn, &h.serverConfig)
+	h.Env().Require().NoError(err, "ssh connection handshake failed")
+	go func() {
+		<-ctx.Done()
+		conn.Close()
+	}()
+	h.serverConnCallback(serverConn, ncc, rc)
+}
+
+// Dial implements SSHUpstream.
+func (h *sshUpstream) Dial(r testenv.Route, config *ssh.ClientConfig) (*ssh.Client, error) {
+	return ssh.Dial("tcp", h.Env().Config().Options.SSHAddr, config)
+}
+
+// DirectDial implements SSHUpstream.
+func (h *sshUpstream) DirectDial(r testenv.Route, config *ssh.ClientConfig) (*ssh.Client, error) {
+	addr := fmt.Sprintf("127.0.0.1:%d", h.serverPort.Value())
+	return ssh.Dial("tcp", addr, config)
+}


### PR DESCRIPTION
## Summary

Add the new types `scenarios.SSH` for configuring Pomerium with the global SSH config options, and `upstreams.SSHUpstream` for configuring an individual SSH upstream/route.

Add barebones device auth flow support to the `testenv` mock IdP, for use with the SSH auth flow.

## Related issues

https://linear.app/pomerium/issue/ENG-2242/write-e2e-test-framework-for-pomerium-integration-with-ssh-network

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
