### PR TITLE
ssh: continuous authorization

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/ssh"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
@@ -31,6 +32,7 @@ type Authorize struct {
 	store         *store.Store
 	currentConfig *atomicutil.Value[*config.Config]
 	accessTracker *AccessTracker
+	ssh           *ssh.StreamManager
 
 	tracerProvider oteltrace.TracerProvider
 	tracer         oteltrace.Tracer
@@ -48,6 +50,7 @@ func New(ctx context.Context, cfg *config.Config) (*Authorize, error) {
 
 		currentConfig:  atomicutil.NewValue(cfg),
 		store:          store.New(),
+		ssh:            ssh.NewStreamManager(ctx, cfg),
 		tracerProvider: tracerProvider,
 		tracer:         tracer,
 	}
@@ -161,4 +164,5 @@ func (a *Authorize) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	} else {
 		a.state.Store(newState)
 	}
+	a.ssh.OnConfigChange(cfg)
 }

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -50,11 +50,11 @@ func New(ctx context.Context, cfg *config.Config) (*Authorize, error) {
 
 		currentConfig:  atomicutil.NewValue(cfg),
 		store:          store.New(),
-		ssh:            ssh.NewStreamManager(ctx, cfg),
 		tracerProvider: tracerProvider,
 		tracer:         tracer,
 	}
 	a.accessTracker = NewAccessTracker(a, accessTrackerMaxSize, accessTrackerDebouncePeriod)
+	a.ssh = ssh.NewStreamManager(ctx, ssh.NewAuth(a, a.currentConfig, a.tracerProvider), cfg)
 
 	state, err := newAuthorizeStateFromConfig(ctx, nil, tracerProvider, cfg, a.store)
 	if err != nil {

--- a/authorize/ssh_grpc.go
+++ b/authorize/ssh_grpc.go
@@ -28,8 +28,7 @@ func (a *Authorize) ManageStream(stream extensions_ssh.StreamManagement_ManageSt
 	}
 
 	state := a.state.Load()
-	handler := state.ssh.NewStreamHandler(
-		a.currentConfig.Load(),
+	handler := a.ssh.NewStreamHandler(
 		ssh.NewAuth(a, state.dataBrokerClient, a.currentConfig, a.tracerProvider),
 		downstream,
 	)
@@ -85,7 +84,7 @@ func (a *Authorize) ServeChannel(stream extensions_ssh.StreamManagement_ServeCha
 	} else {
 		return status.Errorf(codes.Internal, "first message was not metadata")
 	}
-	handler := a.state.Load().ssh.LookupStream(streamID)
+	handler := a.ssh.LookupStream(streamID)
 	if handler == nil || !handler.IsExpectingInternalChannel() {
 		return status.Errorf(codes.InvalidArgument, "stream not found")
 	}

--- a/authorize/ssh_grpc.go
+++ b/authorize/ssh_grpc.go
@@ -121,13 +121,16 @@ func (a *Authorize) EvaluateSSH(ctx context.Context, req *ssh.Request) (*evaluat
 		return nil, err
 	}
 
-	s, _ := a.getDataBrokerSessionOrServiceAccount(ctx, req.SessionID, 0)
+	skipLogging := req.LogOnlyIfDenied && res.Allow.Value && !res.Deny.Value
+	if !skipLogging {
+		s, _ := a.getDataBrokerSessionOrServiceAccount(ctx, req.SessionID, 0)
 
-	var u *user.User
-	if s != nil {
-		u, _ = a.getDataBrokerUser(ctx, s.GetUserId())
+		var u *user.User
+		if s != nil {
+			u, _ = a.getDataBrokerUser(ctx, s.GetUserId())
+		}
+		a.logAuthorizeCheck(ctx, &evalreq, res, s, u)
 	}
-	a.logAuthorizeCheck(ctx, &evalreq, res, s, u)
 
 	return res, nil
 }

--- a/authorize/ssh_grpc.go
+++ b/authorize/ssh_grpc.go
@@ -27,11 +27,7 @@ func (a *Authorize) ManageStream(stream extensions_ssh.StreamManagement_ManageSt
 		return status.Errorf(codes.Internal, "first message was not a downstream connected event")
 	}
 
-	state := a.state.Load()
-	handler := a.ssh.NewStreamHandler(
-		ssh.NewAuth(a, state.dataBrokerClient, a.currentConfig, a.tracerProvider),
-		downstream,
-	)
+	handler := a.ssh.NewStreamHandler(downstream)
 	defer handler.Close()
 
 	eg, ctx := errgroup.WithContext(stream.Context())

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
-	"github.com/pomerium/pomerium/pkg/ssh"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
 
@@ -40,7 +39,6 @@ type authorizeState struct {
 	authenticateFlow           authenticateFlow
 	syncQueriers               map[string]storage.Querier
 	mcp                        *mcp.Handler
-	ssh                        *ssh.StreamManager
 }
 
 func newAuthorizeStateFromConfig(
@@ -71,8 +69,6 @@ func newAuthorizeStateFromConfig(
 		state.mcp = mcp
 		evaluatorOptions = append(evaluatorOptions, evaluator.WithMCPAccessTokenProvider(mcp))
 	}
-
-	state.ssh = ssh.NewStreamManager()
 
 	state.evaluator, err = newPolicyEvaluator(ctx, cfg.Options, store, previousEvaluator, evaluatorOptions...)
 	if err != nil {

--- a/pkg/ssh/auth.go
+++ b/pkg/ssh/auth.go
@@ -39,6 +39,8 @@ type Request struct {
 	Hostname  string
 	PublicKey []byte
 	SessionID string
+
+	LogOnlyIfDenied bool
 }
 
 type Auth struct {
@@ -229,7 +231,7 @@ func (a *Auth) handleLogin(
 	return a.saveSession(ctx, sessionID, &sessionClaims, token)
 }
 
-var errAccessDenied = errors.New("access denied")
+var errAccessDenied = status.Error(codes.PermissionDenied, "access denied")
 
 func (a *Auth) EvaluateDelayed(ctx context.Context, info StreamAuthInfo) error {
 	req, err := sshRequestFromStreamAuthInfo(info)
@@ -375,6 +377,8 @@ func sshRequestFromStreamAuthInfo(info StreamAuthInfo) (*Request, error) {
 		Hostname:  *info.Hostname,
 		PublicKey: info.PublicKeyAllow.Value.PublicKey,
 		SessionID: sessionID,
+
+		LogOnlyIfDenied: info.InitialAuthComplete,
 	}, nil
 }
 

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -1,6 +1,7 @@
 package ssh
 
 import (
+	"context"
 	"sync"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
@@ -8,28 +9,45 @@ import (
 )
 
 type StreamManager struct {
+	reauth chan []*StreamHandler
+
 	mu            sync.Mutex
+	cfg           *config.Config
 	activeStreams map[uint64]*StreamHandler
 }
 
-func NewStreamManager() *StreamManager {
-	return &StreamManager{
+func NewStreamManager(ctx context.Context, cfg *config.Config) *StreamManager {
+	sm := &StreamManager{
+		reauth:        make(chan []*StreamHandler, 1),
+		cfg:           cfg,
 		activeStreams: map[uint64]*StreamHandler{},
+	}
+	go sm.reauthLoop(ctx)
+	return sm
+}
+
+func (sm *StreamManager) OnConfigChange(cfg *config.Config) {
+	sm.mu.Lock()
+	sm.cfg = cfg
+	snapshot := make([]*StreamHandler, 0, len(sm.activeStreams))
+	for _, s := range sm.activeStreams {
+		snapshot = append(snapshot, s)
+	}
+	sm.mu.Unlock()
+
+	select {
+	case sm.reauth <- snapshot:
+	default:
 	}
 }
 
 func (sm *StreamManager) LookupStream(streamID uint64) *StreamHandler {
 	sm.mu.Lock()
 	defer sm.mu.Unlock()
-	stream := sm.activeStreams[streamID]
-	if stream == nil {
-		return nil
-	}
-	return stream
+	return sm.activeStreams[streamID]
 }
 
 func (sm *StreamManager) NewStreamHandler(
-	cfg *config.Config,
 	auth AuthInterface,
 	downstream *extensions_ssh.DownstreamConnectEvent,
 ) *StreamHandler {
@@ -39,10 +57,11 @@ func (sm *StreamManager) NewStreamHandler(
 	writeC := make(chan *extensions_ssh.ServerMessage, 32)
 	sh := &StreamHandler{
 		auth:       auth,
-		config:     cfg,
+		config:     sm.cfg,
 		downstream: downstream,
 		readC:      make(chan *extensions_ssh.ClientMessage, 32),
 		writeC:     writeC,
+		reauthC:    make(chan struct{}),
 		close: func() {
 			sm.mu.Lock()
 			defer sm.mu.Unlock()
@@ -52,4 +71,17 @@ func (sm *StreamManager) NewStreamHandler(
 	}
 	sm.activeStreams[streamID] = sh
 	return sh
+}
+
+func (sm *StreamManager) reauthLoop(ctx context.Context) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case streams := <-sm.reauth:
+			for _, s := range streams {
+				s.Reauth()
+			}
+		}
+	}
 }

--- a/pkg/ssh/manager_test.go
+++ b/pkg/ssh/manager_test.go
@@ -22,17 +22,17 @@ func mustParseWeightedURLs(t *testing.T, urls ...string) []config.WeightedURL {
 func TestStreamManager(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	auth := mock_ssh.NewMockAuthInterface(ctrl)
-	m := ssh.NewStreamManager()
 
 	cfg := &config.Config{Options: config.NewDefaultOptions()}
 	cfg.Options.Policies = []config.Policy{
 		{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://dest1:22")},
 		{From: "ssh://host2", To: mustParseWeightedURLs(t, "ssh://dest2:22")},
 	}
+	m := ssh.NewStreamManager(t.Context(), cfg)
 
 	t.Run("LookupStream", func(t *testing.T) {
 		assert.Nil(t, m.LookupStream(1234))
-		sh := m.NewStreamHandler(cfg, auth, &extensions_ssh.DownstreamConnectEvent{StreamId: 1234})
+		sh := m.NewStreamHandler(auth, &extensions_ssh.DownstreamConnectEvent{StreamId: 1234})
 		assert.Equal(t, sh, m.LookupStream(1234))
 		sh.Close()
 		assert.Nil(t, m.LookupStream(1234))

--- a/pkg/ssh/manager_test.go
+++ b/pkg/ssh/manager_test.go
@@ -28,11 +28,11 @@ func TestStreamManager(t *testing.T) {
 		{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://dest1:22")},
 		{From: "ssh://host2", To: mustParseWeightedURLs(t, "ssh://dest2:22")},
 	}
-	m := ssh.NewStreamManager(t.Context(), cfg)
+	m := ssh.NewStreamManager(t.Context(), auth, cfg)
 
 	t.Run("LookupStream", func(t *testing.T) {
 		assert.Nil(t, m.LookupStream(1234))
-		sh := m.NewStreamHandler(auth, &extensions_ssh.DownstreamConnectEvent{StreamId: 1234})
+		sh := m.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 1234})
 		assert.Equal(t, sh, m.LookupStream(1234))
 		sh.Close()
 		assert.Nil(t, m.LookupStream(1234))

--- a/pkg/ssh/stream_test.go
+++ b/pkg/ssh/stream_test.go
@@ -123,7 +123,7 @@ func (s *StreamHandlerSuite) SetupTest() {
 		f(s.cfg)
 	}
 
-	s.mgr = ssh.NewStreamManager(context.Background(), s.cfg)
+	s.mgr = ssh.NewStreamManager(context.Background(), s.mockAuth, s.cfg)
 }
 
 func (s *StreamHandlerSuite) TearDownTest() {
@@ -163,8 +163,7 @@ func (s *StreamHandlerSuite) expectError(fn func(), msg string) {
 }
 
 func (s *StreamHandlerSuite) startStreamHandler(streamID uint64) *ssh.StreamHandler {
-	sh := s.mgr.NewStreamHandler(
-		s.mockAuth, &extensions_ssh.DownstreamConnectEvent{StreamId: streamID})
+	sh := s.mgr.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: streamID})
 	s.errC = make(chan error, 1)
 	ctx, ca := context.WithCancel(s.T().Context())
 	go func() {
@@ -1998,8 +1997,7 @@ func (s *StreamHandlerSuite) TestFormatSession() {
 	s.mockAuth.EXPECT().
 		FormatSession(Any(), Any()).
 		Return([]byte("example"), nil)
-	sh := s.mgr.NewStreamHandler(
-		s.mockAuth, &extensions_ssh.DownstreamConnectEvent{StreamId: 1})
+	sh := s.mgr.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 1})
 	ctx, ca := context.WithCancel(context.Background())
 	ca()
 	// this will exit immediately, but it will have a state, which is only
@@ -2015,8 +2013,7 @@ func (s *StreamHandlerSuite) TestDeleteSession() {
 	s.mockAuth.EXPECT().
 		DeleteSession(Any(), Any()).
 		Return(nil)
-	sh := s.mgr.NewStreamHandler(
-		s.mockAuth, &extensions_ssh.DownstreamConnectEvent{StreamId: 1})
+	sh := s.mgr.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 1})
 	ctx, ca := context.WithCancel(context.Background())
 	ca()
 	// this will exit immediately, but it will have a state, which is only
@@ -2028,8 +2025,7 @@ func (s *StreamHandlerSuite) TestDeleteSession() {
 }
 
 func (s *StreamHandlerSuite) TestRunCalledTwice() {
-	sh := s.mgr.NewStreamHandler(
-		s.mockAuth, &extensions_ssh.DownstreamConnectEvent{StreamId: 1})
+	sh := s.mgr.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 1})
 	ctx, ca := context.WithCancel(context.Background())
 	ca()
 	sh.Run(ctx)
@@ -2039,8 +2035,7 @@ func (s *StreamHandlerSuite) TestRunCalledTwice() {
 }
 
 func (s *StreamHandlerSuite) TestAllSSHRoutes() {
-	sh := s.mgr.NewStreamHandler(
-		s.mockAuth, &extensions_ssh.DownstreamConnectEvent{StreamId: 1})
+	sh := s.mgr.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 1})
 	routes := slices.Collect(sh.AllSSHRoutes())
 	s.Len(routes, 2)
 	s.Equal("ssh://host1", routes[0].From)


### PR DESCRIPTION
## Summary

Re-evaluate ssh authorization decision on a fixed interval. If access is no longer allowed, log a new `authorize check` message and disconnect.

## Related issues

https://linear.app/pomerium/issue/ENG-2044/support-continuous-verification-with-ssh-proxying

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
