### PR TITLE
config: allow URLs in depends_on

### DIFF
--- a/config/policy.go
+++ b/config/policy.go
@@ -761,6 +761,16 @@ func (p *Policy) Validate() error {
 	if len(p.DependsOn) > 5 {
 		return fmt.Errorf("config: depends_on is limited to 5 additional redirect hosts, got %v", p.DependsOn)
 	}
+	for i, v := range p.DependsOn {
+		if strings.Contains(v, "/") {
+			u, err := url.Parse(v)
+			if err == nil && u.Scheme != "" && u.Host != "" {
+				p.DependsOn[i] = u.Host
+			} else {
+				return fmt.Errorf("config: unsupported depends_on value %q", p.DependsOn[i])
+			}
+		}
+	}
 
 	if p.MCP != nil && p.MCP.Server == nil && p.MCP.Client == nil {
 		return fmt.Errorf("config: mcp must have either server or client set")


### PR DESCRIPTION
## Summary

Normalize URLs in the depends_on hosts list to extract just the host, so that 'from' URL values can be used directly with this option.

## Related issues

https://linear.app/pomerium/issue/ENG-2376/error-when-hosts-include-scheme-https

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
