### PR TITLE
config: migrate deprecated cluster DNS settings

### DIFF
--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -66,8 +66,6 @@ func (e Endpoint) TransportSocketName() string {
 func newDefaultEnvoyClusterConfig() *envoy_config_cluster_v3.Cluster {
 	return &envoy_config_cluster_v3.Cluster{
 		ConnectTimeout:                defaultConnectionTimeout,
-		RespectDnsTtl:                 true,
-		DnsLookupFamily:               envoy_config_cluster_v3.Cluster_V4_PREFERRED,
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(connectionBufferLimit),
 	}
 }

--- a/config/envoyconfig/testdata/clusters.json
+++ b/config/envoyconfig/testdata/clusters.json
@@ -33,7 +33,14 @@
         }
       ]
     },
-    "dnsLookupFamily": "V4_PREFERRED",
+    "clusterType": {
+      "name": "envoy.clusters.dns",
+      "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster",
+        "dnsLookupFamily": "V4_PREFERRED",
+        "respectDnsTtl": true
+      }
+    },
     "loadAssignment": {
       "clusterName": "pomerium-control-plane-grpc",
       "endpoints": [
@@ -57,8 +64,6 @@
     },
     "name": "pomerium-control-plane-grpc",
     "perConnectionBufferLimitBytes": 32768,
-    "respectDnsTtl": true,
-    "type": "STRICT_DNS",
     "typedExtensionProtocolOptions": {
       "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
         "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
@@ -81,6 +86,14 @@
   },
   {
     "connectTimeout": "10s",
+    "clusterType": {
+      "name": "envoy.clusters.dns",
+      "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster",
+        "dnsLookupFamily": "V4_PREFERRED",
+        "respectDnsTtl": true
+      }
+    },
     "circuitBreakers": {
       "thresholds": [
         {
@@ -91,7 +104,6 @@
         }
       ]
     },
-    "dnsLookupFamily": "V4_PREFERRED",
     "loadAssignment": {
       "clusterName": "pomerium-control-plane-http",
       "endpoints": [
@@ -115,8 +127,6 @@
     },
     "name": "pomerium-control-plane-http",
     "perConnectionBufferLimitBytes": 32768,
-    "respectDnsTtl": true,
-    "type": "STRICT_DNS",
     "typedExtensionProtocolOptions": {
       "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
         "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
@@ -143,6 +153,14 @@
   },
   {
     "connectTimeout": "10s",
+    "clusterType": {
+      "name": "envoy.clusters.dns",
+      "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster",
+        "dnsLookupFamily": "V4_PREFERRED",
+        "respectDnsTtl": true
+      }
+    },
     "circuitBreakers": {
       "thresholds": [
         {
@@ -153,7 +171,6 @@
         }
       ]
     },
-    "dnsLookupFamily": "V4_PREFERRED",
     "loadAssignment": {
       "clusterName": "pomerium-control-plane-metrics",
       "endpoints": [
@@ -177,8 +194,6 @@
     },
     "name": "pomerium-control-plane-metrics",
     "perConnectionBufferLimitBytes": 32768,
-    "respectDnsTtl": true,
-    "type": "STRICT_DNS",
     "typedExtensionProtocolOptions": {
       "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
         "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
@@ -205,6 +220,14 @@
   },
   {
     "connectTimeout": "10s",
+    "clusterType": {
+      "name": "envoy.clusters.dns",
+      "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster",
+        "dnsLookupFamily": "V4_PREFERRED",
+        "respectDnsTtl": true
+      }
+    },
     "circuitBreakers": {
       "thresholds": [
         {
@@ -215,7 +238,6 @@
         }
       ]
     },
-    "dnsLookupFamily": "V4_PREFERRED",
     "loadAssignment": {
       "clusterName": "pomerium-authorize",
       "endpoints": [
@@ -239,8 +261,6 @@
     },
     "name": "pomerium-authorize",
     "perConnectionBufferLimitBytes": 32768,
-    "respectDnsTtl": true,
-    "type": "STRICT_DNS",
     "typedExtensionProtocolOptions": {
       "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
         "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",
@@ -263,6 +283,14 @@
   },
   {
     "connectTimeout": "10s",
+    "clusterType": {
+      "name": "envoy.clusters.dns",
+      "typedConfig": {
+        "@type": "type.googleapis.com/envoy.extensions.clusters.dns.v3.DnsCluster",
+        "dnsLookupFamily": "V4_PREFERRED",
+        "respectDnsTtl": true
+      }
+    },
     "circuitBreakers": {
       "thresholds": [
         {
@@ -273,7 +301,6 @@
         }
       ]
     },
-    "dnsLookupFamily": "V4_PREFERRED",
     "loadAssignment": {
       "clusterName": "pomerium-databroker",
       "endpoints": [
@@ -297,8 +324,6 @@
     },
     "name": "pomerium-databroker",
     "perConnectionBufferLimitBytes": 32768,
-    "respectDnsTtl": true,
-    "type": "STRICT_DNS",
     "typedExtensionProtocolOptions": {
       "envoy.extensions.upstreams.http.v3.HttpProtocolOptions": {
         "@type": "type.googleapis.com/envoy.extensions.upstreams.http.v3.HttpProtocolOptions",

--- a/config/validate.go
+++ b/config/validate.go
@@ -6,7 +6,7 @@ import (
 	"strconv"
 	"strings"
 
-	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	envoy_extensions_clusters_common_dns_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/clusters/common/dns/v3"
 )
 
 // DNSLookupFamily values.
@@ -53,22 +53,22 @@ func ValidateCookieSameSite(value string) error {
 }
 
 // GetEnvoyDNSLookupFamily gets the envoy DNS lookup family.
-func GetEnvoyDNSLookupFamily(value string) envoy_config_cluster_v3.Cluster_DnsLookupFamily {
+func GetEnvoyDNSLookupFamily(value string) envoy_extensions_clusters_common_dns_v3.DnsLookupFamily {
 	switch value {
 	case DNSLookupFamilyAuto:
-		return envoy_config_cluster_v3.Cluster_AUTO
+		return envoy_extensions_clusters_common_dns_v3.DnsLookupFamily_AUTO
 	case DNSLookupFamilyV4Only:
-		return envoy_config_cluster_v3.Cluster_V4_ONLY
+		return envoy_extensions_clusters_common_dns_v3.DnsLookupFamily_V4_ONLY
 	case DNSLookupFamilyV6Only:
-		return envoy_config_cluster_v3.Cluster_V6_ONLY
+		return envoy_extensions_clusters_common_dns_v3.DnsLookupFamily_V6_ONLY
 	case DNSLookupFamilyV4Preferred:
-		return envoy_config_cluster_v3.Cluster_V4_PREFERRED
+		return envoy_extensions_clusters_common_dns_v3.DnsLookupFamily_V4_PREFERRED
 	case DNSLookupFamilyAll:
-		return envoy_config_cluster_v3.Cluster_ALL
+		return envoy_extensions_clusters_common_dns_v3.DnsLookupFamily_ALL
 	}
 
 	// default
-	return envoy_config_cluster_v3.Cluster_V4_PREFERRED
+	return envoy_extensions_clusters_common_dns_v3.DnsLookupFamily_V4_PREFERRED
 }
 
 // ValidateMetricsAddress validates address for the metrics


### PR DESCRIPTION
## Summary

Address the deprecation warnings for `respect_dns_ttl` by migrating to the newer CustomClusterType config proto.

## Related issues

https://linear.app/pomerium/issue/ENG-2503/address-envoy-deprecation-warning-for-respect-dns-ttl

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
