### PR TITLE
ci: update build job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -51,8 +51,8 @@ jobs:
 
   build:
     strategy:
+      fail-fast: false
       matrix:
-        go-version: [1.23.x]
         node-version: [22.x]
         platform: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.platform }}


### PR DESCRIPTION
## Summary

Set `fail-fast: false` so that if one of these jobs fails it will not cancel the other. These have have unfortunately become very flaky, and the current behavior is not helpful.

Remove 'go-version' from the matrix as it is currently unused and it does not match the actual Go version in use.

## Related issues

## User Explanation

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
