### PR TITLE
authorize: add request body logging

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -56,6 +56,7 @@ type RequestHTTP struct {
 	Headers           map[string]string     `json:"headers"`
 	ClientCertificate ClientCertificateInfo `json:"client_certificate"`
 	IP                string                `json:"ip"`
+	Body              string                `json:"body"`
 }
 
 // RequestHTTPFromCheckRequest populates a RequestHTTP from an Envoy CheckRequest proto.
@@ -78,6 +79,7 @@ func RequestHTTPFromCheckRequest(
 		Headers:           checkrequest.GetHeaders(in),
 		ClientCertificate: getClientCertificateInfo(ctx, clientCertMetadata),
 		IP:                attrs.GetSource().GetAddress().GetSocketAddress().GetAddress(),
+		Body:              attrs.GetRequest().GetHttp().GetBody(),
 	}
 }
 

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -109,7 +109,8 @@ func Test_getEvaluatorRequest(t *testing.T) {
 				Leaf:          certPEM[1:] + "\n",
 				Intermediates: "",
 			},
-			IP: "",
+			IP:   "",
+			Body: "BODY",
 		},
 	}
 	assert.Equal(t, expect, actual)
@@ -164,6 +165,7 @@ func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 			},
 			ClientCertificate: evaluator.ClientCertificateInfo{},
 			IP:                "",
+			Body:              "BODY",
 		},
 	}
 	assert.Equal(t, expect, actual)

--- a/authorize/log.go
+++ b/authorize/log.go
@@ -145,6 +145,11 @@ func populateLogEvent(
 	switch field {
 	case log.AuthorizeLogFieldCheckRequestID:
 		return evt.Str(string(field), req.HTTP.Headers["X-Request-Id"])
+	case log.AuthorizeLogFieldBody:
+		if req.HTTP.Body == "" {
+			return evt
+		}
+		return evt.Str(string(field), req.HTTP.Body)
 	case log.AuthorizeLogFieldEmail:
 		return evt.Str(string(field), u.GetEmail())
 	case log.AuthorizeLogFieldEnvoyRouteChecksum:

--- a/authorize/log_test.go
+++ b/authorize/log_test.go
@@ -30,6 +30,7 @@ func Test_populateLogEvent(t *testing.T) {
 			RawQuery: "a=b",
 			Headers:  map[string]string{"X-Request-Id": "CHECK-REQUEST-ID"},
 			IP:       "127.0.0.1",
+			Body:     `{"test":"request body"}`,
 		},
 		MCP: evaluator.RequestMCP{
 			Method: "tools/call",
@@ -75,6 +76,7 @@ func Test_populateLogEvent(t *testing.T) {
 		s      sessionOrServiceAccount
 		expect string
 	}{
+		{log.AuthorizeLogFieldBody, s, `{"body":"{\"test\":\"request body\"}"}`},
 		{log.AuthorizeLogFieldCheckRequestID, s, `{"check-request-id":"CHECK-REQUEST-ID"}`},
 		{log.AuthorizeLogFieldEmail, s, `{"email":"EMAIL"}`},
 		{log.AuthorizeLogFieldEnvoyRouteChecksum, s, `{"envoy-route-checksum":1234}`},

--- a/internal/log/authorize.go
+++ b/internal/log/authorize.go
@@ -11,6 +11,7 @@ type AuthorizeLogField string
 // known authorize log fields
 const (
 	AuthorizeLogFieldCheckRequestID       AuthorizeLogField = "check-request-id"
+	AuthorizeLogFieldBody                 AuthorizeLogField = "body"
 	AuthorizeLogFieldEmail                AuthorizeLogField = "email"
 	AuthorizeLogFieldEnvoyRouteChecksum   AuthorizeLogField = "envoy-route-checksum"
 	AuthorizeLogFieldEnvoyRouteID         AuthorizeLogField = "envoy-route-id"
@@ -64,6 +65,7 @@ var ErrUnknownAuthorizeLogField = errors.New("unknown authorize log field")
 
 var authorizeLogFieldLookup = map[AuthorizeLogField]struct{}{
 	AuthorizeLogFieldCheckRequestID:       {},
+	AuthorizeLogFieldBody:                 {},
 	AuthorizeLogFieldEmail:                {},
 	AuthorizeLogFieldEnvoyRouteChecksum:   {},
 	AuthorizeLogFieldEnvoyRouteID:         {},


### PR DESCRIPTION
## Summary

Adds an option to log request body for protocols that perform request inspection, such as MCP. 

## Related issues

Fix https://linear.app/pomerium/issue/ENG-2544/authorize-request-body-logging

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
