### PR TITLE
ssh: add runtime flag for jump host mode

### DIFF
--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -33,7 +33,12 @@ var (
 	// RuntimeFlagMCP enables the MCP services for the authorize service
 	RuntimeFlagMCP = runtimeFlag("mcp", false)
 
+	// RuntimeFlagSSHRoutesPortal enables the SSH routes portal
 	RuntimeFlagSSHRoutesPortal = runtimeFlag("ssh_routes_portal", false)
+
+	// RuntimeFlagSSHAllowDirectTcpip allows downstream clients to open 'direct-tcpip'
+	// channels (jump host mode)
+	RuntimeFlagSSHAllowDirectTcpip = runtimeFlag("ssh_allow_direct_tcpip", false)
 )
 
 // RuntimeFlag is a runtime flag that can flip on/off certain features

--- a/internal/testenv/scenarios/ssh.go
+++ b/internal/testenv/scenarios/ssh.go
@@ -22,6 +22,12 @@ type SSHConfig struct {
 	// upstream. An Ed25519 key will be generated if not set.
 	// Must be a type supported by [ssh.NewSignerFromKey].
 	UserCAKey any
+
+	// If true, enables the 'ssh_allow_direct_tcpip' runtime flag
+	EnableDirectTcpip bool
+
+	// If true, enables the 'ssh_routes_portal' runtime flag
+	EnableRoutesPortal bool
 }
 
 func SSH(c SSHConfig) testenv.Modifier {
@@ -44,6 +50,8 @@ func SSH(c SSHConfig) testenv.Modifier {
 		configHostKeys := slices.Map(c.HostKeys, marshalPrivateKey)
 		cfg.Options.SSHHostKeys = &configHostKeys
 		cfg.Options.SSHUserCAKey = marshalPrivateKey(c.UserCAKey)
+		cfg.Options.RuntimeFlags[config.RuntimeFlagSSHAllowDirectTcpip] = c.EnableDirectTcpip
+		cfg.Options.RuntimeFlags[config.RuntimeFlagSSHRoutesPortal] = c.EnableRoutesPortal
 	})
 }
 

--- a/pkg/ssh/auth.go
+++ b/pkg/ssh/auth.go
@@ -351,7 +351,7 @@ func sessionIDFromFingerprint(sha256fingerprint []byte) (string, error) {
 	if len(sha256fingerprint) != sha256.Size {
 		return "", errInvalidFingerprint
 	}
-	return "sshkey-SHA256:" + base64.StdEncoding.EncodeToString(sha256fingerprint), nil
+	return "sshkey-SHA256:" + base64.RawStdEncoding.EncodeToString(sha256fingerprint), nil
 }
 
 var errPublicKeyAllowNil = errors.New("expected PublicKeyAllow message not to be nil")

--- a/pkg/ssh/auth_test.go
+++ b/pkg/ssh/auth_test.go
@@ -59,7 +59,7 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 				Username:  "username",
 				Hostname:  "hostname",
 				PublicKey: fakePublicKey,
-				SessionID: "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY=",
+				SessionID: "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
 			})
 			return &evaluator.Result{
 				Allow: evaluator.NewRuleResult(true),
@@ -278,7 +278,7 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 		assert.Equal(t, "fake.user@example.com", putRecords[0].Id)
 
 		assert.Equal(t, "type.googleapis.com/session.Session", putRecords[1].Type)
-		assert.Equal(t, "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY=", putRecords[1].Id)
+		assert.Equal(t, "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY", putRecords[1].Id)
 	})
 	t.Run("denied", func(t *testing.T) {
 		pe := func(_ context.Context, _ *Request) (*evaluator.Result, error) {
@@ -365,7 +365,7 @@ func TestFormatSession(t *testing.T) {
 			get: func(
 				_ context.Context, in *databroker.GetRequest, _ ...grpc.CallOption,
 			) (*databroker.GetResponse, error) {
-				const expectedID = "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY="
+				const expectedID = "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY"
 				assert.Equal(t, in.Type, "type.googleapis.com/session.Session")
 				assert.Equal(t, in.Id, expectedID)
 				claims := identity.FlattenedClaims{
@@ -394,7 +394,7 @@ func TestFormatSession(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, string(b), `
 User ID:    USER-ID
-Session ID: sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY=
+Session ID: sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY
 Expires at: 2025-06-26 19:15:58 +0000 UTC
 Claims:
   foo: [bar baz]
@@ -419,7 +419,7 @@ func TestDeleteSession(t *testing.T) {
 				_ context.Context, in *databroker.PutRequest, _ ...grpc.CallOption,
 			) (*databroker.PutResponse, error) {
 				require.Len(t, in.Records, 1)
-				assert.Equal(t, in.Records[0].Id, "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY=")
+				assert.Equal(t, in.Records[0].Id, "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY")
 				assert.NotNil(t, in.Records[0].DeletedAt)
 				return nil, putError
 			},


### PR DESCRIPTION
Adds a new runtime flag `ssh_allow_direct_tcpip` (default false) which enables the "jump-host mode". This is disabled by default since we are missing related config options/policy criteria.