### PR TITLE
ci: remove 'brews' configuration from GoReleaser

### DIFF
--- a/.github/goreleaser-mac.yaml
+++ b/.github/goreleaser-mac.yaml
@@ -61,30 +61,3 @@ checksum:
 
 snapshot:
   name_template: "{{ .Version }}+next+{{ .ShortCommit }}"
-
-brews:
-  - # Name template of the recipe
-    name: pomerium
-    # IDs of the archives to use.
-    ids:
-      - pomerium
-    tap:
-      owner: pomerium
-      name: homebrew-tap
-      # Optionally a token can be provided, if it differs from the token provided to GoReleaser
-      token: "{{ .Env.APPARITOR_GITHUB_TOKEN }}"
-    # Git author used to commit to the repository.
-    # Defaults are shown.
-    commit_author:
-      name: apparitor
-      email: apparitor@users.noreply.github.com
-    folder: Formula
-    install: |
-      bin.install "pomerium"
-    pull_request:
-      enabled: true
-      draft: true
-      base:
-        owner: pomerium
-        name: homebrew-tap
-        branch: main

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -243,37 +243,6 @@ docker_manifests:
       - pomerium/pomerium:debug-nonroot-arm64v8-v{{ .Major }}.{{ .Minor }}
       - pomerium/pomerium:debug-nonroot-amd64-v{{ .Major }}.{{ .Minor }}
 
-brews:
-  - # Name template of the recipe
-    name: pomerium
-    # IDs of the archives to use.
-    ids:
-      - pomerium
-    # GOARM to specify which 32-bit arm version to use if there are multiple versions
-    # from the build section. Brew formulas support atm only one 32-bit version.
-    # Default is 6 for all artifacts or each id if there a multiple versions.
-    goarm: 6
-    tap:
-      owner: pomerium
-      name: homebrew-tap
-      # Optionally a token can be provided, if it differs from the token provided to GoReleaser
-      token: "{{ .Env.APPARITOR_GITHUB_TOKEN }}"
-    # Git author used to commit to the repository.
-    # Defaults are shown.
-    commit_author:
-      name: apparitor
-      email: apparitor@users.noreply.github.com
-    folder: Formula
-    install: |
-      bin.install "pomerium"
-    pull_request:
-      enabled: true
-      draft: true
-      base:
-        owner: pomerium
-        name: homebrew-tap
-        branch: main
-
 nfpms:
   - id: pomerium
 


### PR DESCRIPTION
## Summary

Instead, we'll generate Homebrew formula updates from a workflow triggered after the macOS builds finish. See https://github.com/pomerium/homebrew-tap/pull/26 and https://github.com/pomerium/mac-builds/pull/6.

## Related issues

https://linear.app/pomerium/issue/ENG-2546/core-release-fails-due-to-unsupported-goreleaser-homebrew-option

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
