### PR TITLE
ci: update mac build event type to match

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           repository: pomerium/mac-builds
           token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
-          event-type: pomerium-oss-release
+          event-type: pomerium-proxy-release
           client-payload: '{ "release": "${{ github.event.release.tag_name }}", "push": "true" }'
 
       - name: Get tag name


### PR DESCRIPTION
## Summary

The mac-builds repo has this workflow configured for the event type "pomerium-proxy-release" ([link](https://github.com/pomerium/mac-builds/blob/599f993e1a05dcd120ff3db6de638d97be4e5080/.github/workflows/pomerium-proxy-repo-dispatch.yaml#L4)).

## Related issues

https://linear.app/pomerium/issue/ENG-2548/core-release-workflow-does-not-trigger-mac-build-as-intended

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
