### PR TITLE
ssh: improve 'whoami' format

### DIFF
--- a/internal/testutil/mockidp/mockidp.go
+++ b/internal/testutil/mockidp/mockidp.go
@@ -337,7 +337,7 @@ func (state state) GetUserInfo(users map[string]*User) *userInfo {
 	for _, u := range users {
 		if u.Email == state.Email {
 			userInfo.Subject = u.ID
-			userInfo.Name = u.FirstName + " " + u.LastName
+			userInfo.Name = strings.TrimSpace(u.FirstName + " " + u.LastName)
 			userInfo.FamilyName = u.LastName
 			userInfo.GivenName = u.FirstName
 		}

--- a/pkg/ssh/ssh_int_test.go
+++ b/pkg/ssh/ssh_int_test.go
@@ -331,18 +331,18 @@ func (s *SSHTestSuite) TestWhoami() {
 	s.Regexp(s.executeTemplate(`
 User ID:    .*
 Session ID: sshkey-{{.PublicKeyFingerprint | quoteMeta}}
-Expires at: .*
+Expires at: .* \(in \d+h\d+m\d+s\)
 Claims:
-  aud: \[CLIENT_ID\]
-  email: \[{{.Email | quoteMeta}}\]
-  exp: \[.*\]
-  family_name: \[\]
-  given_name: \[\]
-  iat: \[.*\]
-  iss: \[https://mock-idp\..*\]
-  name: \[ \]
-  sub: \[.*\]
-`), string(output))
+  aud: "CLIENT_ID"
+  email: "{{.Email | quoteMeta}}"
+  exp: .* \(in \d+h\d+m\d+s\)
+  family_name: ""
+  given_name: ""
+  iat: .* \(\d+s ago\)
+  iss: "https://mock-idp\..*"
+  name: ""
+  sub: ".*"
+`[1:]), string(output))
 }
 
 func TestSSH(t *testing.T) {


### PR DESCRIPTION
Old:
```
User ID:    xxx
Session ID: xxx
Expires at: 2025-07-10 08:39:40.64992461 +0000 UTC
Claims:
  aud: [xxx]
  email: [foo@bar.com]
  email_verified: [true]
  exp: [1.75212238e+09]
  family_name: [bar]
  given_name: [foo]
  iat: [1.75208638e+09]
  iss: [https://example.com]
  name: [Foo Bar]
  nickname: [foobar]
  picture: [https://example.com]
  sub: [xxx]
  updated_at: [2025-07-09T18:12:15.226Z]
```

New:
```
User ID:    xxx
Session ID: xxx
Expires at: 2025-07-10 11:23:27.641004885 +0000 UTC (in 13h59m57s)
Claims:
  aud: "xxx"
  email: "foo@bar.com"
  email_verified: true
  exp: 2025-07-10 07:23:27 +0000 UTC (in 9h59m56s)
  family_name: "bar"
  given_name: "foo"
  iat: 2025-07-09 21:23:27 +0000 UTC (4s ago)
  iss: "https://example.com"
  name: "Foo Bar"
  nickname: "foobar"
  picture: "https://example.com"
  sub: "xxx"
  updated_at: "2025-07-09T18:12:15.226Z"

```