### PR TITLE
postgres: drop redundant indices

### DIFF
--- a/pkg/storage/postgres/migrate.go
+++ b/pkg/storage/postgres/migrate.go
@@ -158,6 +158,21 @@ var migrations = []func(context.Context, pgx.Tx) error{
 
 		return nil
 	},
+	6: func(ctx context.Context, tx pgx.Tx) error {
+		// these indices are redundant
+		for _, q := range []string{
+			`DROP INDEX ` + schemaName + `.` + recordsTableName + `_type_idx`,
+			`DROP INDEX ` + schemaName + `.` + recordChangesTableName + `_version_idx`,
+			`DROP INDEX ` + schemaName + `.` + recordChangesTableName + `_type_idx`,
+		} {
+			_, err := tx.Exec(ctx, q)
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	},
 }
 
 func migrate(ctx context.Context, tx pgx.Tx) (serverVersion uint64, err error) {


### PR DESCRIPTION
## Summary
There are 3 indices in the postgres storage driver that are redundant. This PR drops them.

## Related issues
- [ENG-2560](https://linear.app/pomerium/issue/ENG-2560/request-remove-redundant-database-indexes)

## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
