### PR TITLE
envoy: set concurrency to GOMAXPROCS

### DIFF
--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -39,6 +39,9 @@ var (
 	// RuntimeFlagSSHAllowDirectTcpip allows downstream clients to open 'direct-tcpip'
 	// channels (jump host mode)
 	RuntimeFlagSSHAllowDirectTcpip = runtimeFlag("ssh_allow_direct_tcpip", false)
+
+	// RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs sets the envoy concurrency option to GOMAXPROCS.
+	RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs = runtimeFlag("set_envoy_concurrency_to_go_max_procs", true)
 )
 
 // RuntimeFlag is a runtime flag that can flip on/off certain features

--- a/pkg/envoy/resource_monitor_linux.go
+++ b/pkg/envoy/resource_monitor_linux.go
@@ -43,6 +43,7 @@ const (
 
 type CgroupDriver interface {
 	CgroupForPid(pid int) (string, error)
+	CPULimit(cgroup string) (float64, bool, error)
 	Path(cgroup string, kind CgroupFilePath) string
 	Validate(cgroup string) error
 	MemoryUsage(cgroup string) (uint64, error)
@@ -98,6 +99,8 @@ var (
 	}
 	recordActionThresholdsOnce sync.Once
 	computedActionThresholds   = make(map[string]float64)
+
+	errMalformedFile = errors.New("malformed file")
 )
 
 func init() {
@@ -441,6 +444,35 @@ func (d *cgroupV2Driver) CgroupForPid(pid int) (string, error) {
 	return parseCgroupName(data)
 }
 
+func (d *cgroupV2Driver) CPULimit(cgroup string) (float64, bool, error) {
+	current, err := fs.ReadFile(d.fs, filepath.Join(d.root, cgroup, "cpu.max"))
+	if err != nil {
+		return 0, false, err
+	}
+
+	parts := strings.Fields(string(current))
+	if len(parts) != 2 {
+		return 0, false, errMalformedFile
+	}
+
+	// no limit
+	if parts[0] == "max" {
+		return 0, false, nil
+	}
+
+	quota, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0, false, errors.Join(errMalformedFile, err)
+	}
+
+	period, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		return 0, false, errors.Join(errMalformedFile, err)
+	}
+
+	return float64(quota) / float64(period), true, nil
+}
+
 // MemoryUsage implements CgroupDriver.
 func (d *cgroupV2Driver) MemoryUsage(cgroup string) (uint64, error) {
 	current, err := fs.ReadFile(d.fs, d.Path(cgroup, MemoryUsagePath))
@@ -554,6 +586,10 @@ func (d *cgroupV1Driver) CgroupForPid(pid int) (string, error) {
 		}
 	}
 	return "", errors.New("cgroup not found")
+}
+
+func (d *cgroupV1Driver) CPULimit(_ string) (float64, bool, error) {
+	return 0, false, fmt.Errorf("not implemented")
 }
 
 // MemoryUsage implements CgroupDriver.


### PR DESCRIPTION
## Summary
Explicitly set the `concurrency` option for envoy to match `GOMAXPROCS`. In v1.25 the default behavior of `GOMAXPROCS` will change:

> On Linux, the runtime considers the CPU bandwidth limit of the cgroup containing the process, if any. If the CPU bandwidth limit is lower than the number of logical CPUs available, GOMAXPROCS will default to the lower limit. In container runtime systems like Kubernetes, cgroup CPU bandwidth limits generally correspond to the “CPU limit” option.

However we use [github.com/uber-go/automaxprocs](https://github.com/uber-go/automaxprocs) so we already have this behavior.

This behavior is enabled by default but can be disabled by setting the runtime flag `set_envoy_concurrency_to_go_max_procs` to false. 

This change will be backported to v0.30 and v0.29, though with v0.29 the default will be off so as not to change the current behavior.

I also looked into the `--cpuset-threads` option, but it only applies when cpusets are used explicitly and most containers use `cpu.cfs_quota_us` or `cpu.max` instead.

## Related issues
- [ENG-2549](https://linear.app/pomerium/issue/ENG-2549/core-set-cpuset-threads-envoy-option-to-detected-cpu-quota)

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
