### PR TITLE
identity manager: attempt to refresh ID token too

### DIFF
--- a/pkg/identity/manager/data.go
+++ b/pkg/identity/manager/data.go
@@ -28,6 +28,16 @@ func nextSessionRefresh(
 		}
 	}
 
+	if s.GetIdToken().GetExpiresAt() != nil {
+		expiry := s.GetIdToken().GetExpiresAt().AsTime()
+		if s.GetIdToken().GetExpiresAt().IsValid() && !expiry.IsZero() {
+			expiry = expiry.Add(-gracePeriod)
+			if tm.IsZero() || expiry.Before(tm) {
+				tm = expiry
+			}
+		}
+	}
+
 	if s.GetExpiresAt() != nil {
 		expiry := s.GetExpiresAt().AsTime()
 		if s.GetExpiresAt().IsValid() && !expiry.IsZero() {

--- a/pkg/identity/manager/data_test.go
+++ b/pkg/identity/manager/data_test.go
@@ -50,9 +50,15 @@ func TestSession_NextRefresh(t *testing.T) {
 	}
 	assert.Equal(t, tm2.Add(-time.Second*10), nextSessionRefresh(s, tm1, gracePeriod, coolOffDuration))
 
-	tm3 := time.Date(2020, 6, 5, 12, 15, 0, 0, time.UTC)
-	s.ExpiresAt = timestamppb.New(tm3)
-	assert.Equal(t, tm3, nextSessionRefresh(s, tm1, gracePeriod, coolOffDuration))
+	tm3 := time.Date(2020, 6, 5, 12, 30, 0, 0, time.UTC)
+	s.IdToken = &session.IDToken{
+		ExpiresAt: timestamppb.New(tm3),
+	}
+	assert.Equal(t, tm3.Add(-time.Second*10), nextSessionRefresh(s, tm1, gracePeriod, coolOffDuration))
+
+	tm4 := time.Date(2020, 6, 5, 12, 15, 0, 0, time.UTC)
+	s.ExpiresAt = timestamppb.New(tm4)
+	assert.Equal(t, tm4, nextSessionRefresh(s, tm1, gracePeriod, coolOffDuration))
 }
 
 func TestSession_UnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

Incorporate ID token expiration into the session refresh scheduling calculation. This should allow Pomerium to keep a valid ID token for IdPs that support ID token refresh (not all IdPs do).

## Related issues

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
