### PR TITLE
identity manager: use synctest for scheduler tests

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,6 +21,8 @@ jobs:
       - run: make deps-build
 
       - uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
+        env:
+          GOEXPERIMENT: synctest
         with:
           version: v1.64.8
           args: --timeout=10m

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ BUILDDIR := ${PREFIX}/dist
 BINDIR := ${PREFIX}/bin
 GO111MODULE=on
 CGO_ENABLED := 0
+export GOEXPERIMENT=synctest
 # Set any default go build tags
 BUILDTAGS :=
 
@@ -98,7 +99,7 @@ lint:
 .PHONY: test
 test: get-envoy ## Runs the go tests.
 	@echo "==> $@"
-	@GOEXPERIMENT=synctest $(GO) test -race -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration)
+	@$(GO) test -race -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration)
 
 .PHONY: cover
 cover: get-envoy ## Runs go test with coverage

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ lint:
 .PHONY: test
 test: get-envoy ## Runs the go tests.
 	@echo "==> $@"
-	@$(GO) test -race -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration)
+	@GOEXPERIMENT=synctest $(GO) test -race -tags "$(BUILDTAGS)" $(shell $(GO) list ./... | grep -v vendor | grep -v github.com/pomerium/pomerium/integration)
 
 .PHONY: cover
 cover: get-envoy ## Runs go test with coverage

--- a/pkg/identity/manager/schedulers_test.go
+++ b/pkg/identity/manager/schedulers_test.go
@@ -42,7 +42,6 @@ func TestRefreshSessionScheduler_OverallExpiration(t *testing.T) {
 		synctest.Wait()
 		assert.Len(t, calls, 2)
 		assert.Equal(t, time.Now(), calls[1])
-
 	})
 }
 


### PR DESCRIPTION
## Summary

Rework the existing identity manager scheduler tests to use the new [testing/synctest](https://go.dev/blog/synctest) package. This should let us test the timing more precisely, and make it easier to exercise more complex scenarios.

Add a new test to exercise the session refresh scheduling behavior around the OAuth access token expiration time.

## Related issues

In preparation for https://linear.app/pomerium/issue/ENG-2588/support-configuring-earlier-token-refresh-and-id-token-expiration.

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
