### PR TITLE
Fix typo, add more test cases for atomicutil, and mention about atomic.Pointer migration

### DIFF
--- a/internal/atomicutil/value.go
+++ b/internal/atomicutil/value.go
@@ -40,7 +40,8 @@ func (v *Value[T]) Swap(val T) T {
 	return old
 }
 
-// Swap swaps the value atomically.
+// CompareAndSwap swaps the value atomically, and returns true if the swap
+// was executed.
 func (v *Value[T]) CompareAndSwap(old, n T) bool {
 	return v.value.CompareAndSwap(old, n)
 }

--- a/internal/atomicutil/value_test.go
+++ b/internal/atomicutil/value_test.go
@@ -1,6 +1,7 @@
 package atomicutil
 
 import (
+	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,4 +19,40 @@ func TestValue(t *testing.T) {
 		var v Value[int]
 		assert.Equal(t, 0, v.Load())
 	})
+}
+
+func TestStore(t *testing.T) {
+	v := NewValue(5)
+	v.Store(42)
+	assert.Equal(t, 42, v.Load())
+}
+
+func TestSwap(t *testing.T) {
+	v := NewValue(42)
+	v.Swap(33)
+	assert.Equal(t, 33, v.Load())
+}
+
+func TestCompareAndSwap(t *testing.T) {
+	v := NewValue(42)
+
+	swapped := v.CompareAndSwap(42, 33)
+	assert.Equal(t, true, swapped)
+	assert.Equal(t, 33, v.Load())
+
+	swapped = v.CompareAndSwap(42, 33)
+	assert.Equal(t, false, swapped)
+	assert.Equal(t, 33, v.Load())
+}
+
+// This is just to illustrate how we should use atomic.Pointer[T] instead.
+func TestWithPointer(t *testing.T) {
+	var withUtil *Value[int]
+	var withPointer atomic.Pointer[int]
+
+	// This becomes the zero value.
+	assert.NotNil(t, withUtil.Load())
+
+	// This is nil.
+	assert.Nil(t, withPointer.Load())
 }


### PR DESCRIPTION
## Summary

I found the `atomicutil` package used throughout the code base, but it seems to predate the addition of `atomic.Pointer[T]`. Potentially this should allow us to remove the package altogether and use stdlib directly instead. But I went ahead with starting with adding simple test cases first, so that we have better test coverage across the code base.

Also, I added an example of how `atomicutil` usage may be problematic in some specific scenario compared to how it's implemented with `atomic.Pointer[T]`. Not to mention, there is some performance gain of not using the direct casting with its generic support. (Though this is probably a minor one and the code clarity is a benefit we may want to keep rather than using other atomic values such as `atomic.Bool`.)

## Related issues

N/A

## User Explanation

This only touches the function documentation and test cases, and should not have any impact for users.

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review