### PR TITLE
[WIP] Migrate validation logic using cryptutil from databroker to configs

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -613,9 +613,12 @@ func (o *Options) Validate() error {
 		return errors.New("config: unknown databroker storage backend type")
 	}
 
-	_, err := o.GetSharedKey()
+	sharedKey, err := o.GetSharedKey()
 	if err != nil {
-		return fmt.Errorf("config: invalid shared secret: %w", err)
+		return fmt.Errorf("invalid 'SHARED_SECRET': %w", err)
+	}
+	if _, err := cryptutil.NewAEADCipher(sharedKey); err != nil {
+		return fmt.Errorf("invalid 'SHARED_SECRET': %w", err)
 	}
 
 	if o.AuthenticateURLString != "" {

--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pomerium/pomerium/internal/events"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/version"
-	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/envoy/files"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/registry"
@@ -172,7 +171,7 @@ func (c *DataBroker) Run(ctx context.Context) error {
 }
 
 func (c *DataBroker) update(_ context.Context, cfg *config.Config) error {
-	if err := validate(cfg.Options); err != nil {
+	if err := cfg.Options.Validate(); err != nil {
 		return fmt.Errorf("databroker: bad option: %w", err)
 	}
 
@@ -201,18 +200,5 @@ func (c *DataBroker) update(_ context.Context, cfg *config.Config) error {
 		c.manager.UpdateConfig(options...)
 	}
 
-	return nil
-}
-
-// validate checks that proper configuration settings are set to create
-// a databroker instance
-func validate(o *config.Options) error {
-	sharedKey, err := o.GetSharedKey()
-	if err != nil {
-		return fmt.Errorf("invalid 'SHARED_SECRET': %w", err)
-	}
-	if _, err := cryptutil.NewAEADCipher(sharedKey); err != nil {
-		return fmt.Errorf("invalid 'SHARED_SECRET': %w", err)
-	}
 	return nil
 }


### PR DESCRIPTION
## Summary

Data Broker had a private validation function used within its initialisation, but it was only used in one place. There was a separate validation function already defined within configs module, which didn't have the cryptutil usage. The current module import ballooning in each module is probably not ideal, especially considering there are various wrapper modules already in place (configs, cryptutil, etc.).

This may have some unintended consequences if the validation is more aggressive with the config module. In such case, we should split the validation logic into multiple functions, so that at least the consuming code (in this case databroker) should not need to know too much about the implementation logic, and only rely on the specific validation it needs.

## Related issues

N/A

## User Explanation

The config validation will be more strict and correct throughout the code base, not just data broker use cases.

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review