### PR TITLE
mcp: if upstream oauth does not return a refresh token, keep previous

### DIFF
--- a/internal/mcp/token.go
+++ b/internal/mcp/token.go
@@ -65,6 +65,11 @@ func (srv *Handler) GetUpstreamOAuth2Token(
 		if err != nil {
 			return "", fmt.Errorf("failed to get OAuth2 token: %w", err)
 		}
+
+		if token.RefreshToken == "" {
+			token.RefreshToken = tokenPB.GetRefreshToken()
+		}
+
 		if token.AccessToken != tokenPB.GetAccessToken() ||
 			token.RefreshToken != tokenPB.GetRefreshToken() {
 			err = srv.storage.StoreUpstreamOAuth2Token(ctx, host, userID, OAuth2TokenToPB(token))


### PR DESCRIPTION
## Summary

Upstream OAuth2 providers may not return the refresh token at every access token renewal request, 
this PR ensures we do not accidentally overwrite the refresh token at hand with an empty string. 

## Related issues

Fix https://linear.app/pomerium/issue/ENG-2619/mcp-upstream-oauth2-google-drive-did-not-return-refresh-token

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
