### PR TITLE
ssh: always set non-nil args list for internal cli

### DIFF
--- a/pkg/ssh/cli.go
+++ b/pkg/ssh/cli.go
@@ -44,6 +44,8 @@ func NewCLI(
 	}
 
 	cmd.CompletionOptions.DisableDefaultCmd = true
+	// set a non-nil args list, otherwise it will read from os.Args by default
+	cmd.SetArgs([]string{})
 	cmd.SetIn(stdin)
 	cmd.SetOut(stdout)
 	cmd.SetErr(stdout)


### PR DESCRIPTION
When accessing the internal CLI with no arguments, the cobra CLI defaults its args to os.Argv, which are most likely going to be `--config /some/config/file.yaml`, resulting in a cryptic error if the internal CLI is accessed with no args (and the portal is disabled). This defaults the internal CLI's args to a non-nil empty string list, so that it does not default to argv.