### PR TITLE
envoyconfig: do not set freebind option if null

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -177,9 +177,9 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 
 	options := cfg.Options
 
-	if options.EnvoyBindConfigFreebind.IsSet() || options.EnvoyBindConfigSourceAddress != "" {
+	if options.EnvoyBindConfigFreebind.IsValid() || options.EnvoyBindConfigSourceAddress != "" {
 		cluster.UpstreamBindConfig = new(envoy_config_core_v3.BindConfig)
-		if options.EnvoyBindConfigFreebind.IsSet() {
+		if options.EnvoyBindConfigFreebind.IsValid() {
 			cluster.UpstreamBindConfig.Freebind = wrapperspb.Bool(options.EnvoyBindConfigFreebind.Bool)
 		}
 		if options.EnvoyBindConfigSourceAddress != "" {

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -1056,6 +1056,16 @@ func Test_bindConfig(t *testing.T) {
 			}
 		`, cluster.UpstreamBindConfig)
 	})
+	t.Run("freebind_set_but_null", func(t *testing.T) {
+		cluster, err := b.buildPolicyCluster(ctx, &config.Config{Options: &config.Options{
+			EnvoyBindConfigFreebind: null.BoolFromPtr(nil),
+		}}, &config.Policy{
+			From: "https://from.example.com",
+			To:   mustParseWeightedURLs(t, "https://to.example.com"),
+		})
+		assert.NoError(t, err)
+		assert.Nil(t, cluster.UpstreamBindConfig)
+	})
 	t.Run("source address", func(t *testing.T) {
 		cluster, err := b.buildPolicyCluster(ctx, &config.Config{Options: &config.Options{
 			EnvoyBindConfigSourceAddress: "192.168.0.1",


### PR DESCRIPTION
## Summary

When applying the EnvoyBindConfigFreebind option, change the check from IsSet() to IsValid(). This way, if the option is null, it won't affect the UpstreamBindConfig.

## Related issues

https://linear.app/pomerium/issue/ENG-2606/core-applying-empty-settings-protobuf-should-not-modify-configuration

## User Explanation

Fixes a bug where the source address for upstream connections was explicitly bound to 0.0.0.0:0, even if no source address was configured, when using Pomerium Enterprise or the Pomerium Ingress Controller. This bug would result in errors like `failed_to_bind_to_0.0.0.0:0:_Address_family_not_supported_by_protocol_family` or `failed_to_bind_to_0.0.0.0:0:_Invalid_argument` when attempting to connect to an upstream server using IPv6.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
