### PR TITLE
envoyconfig: make source_address independent of freebind

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -189,13 +189,6 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 					PortValue: 0,
 				},
 			}
-		} else {
-			cluster.UpstreamBindConfig.SourceAddress = &envoy_config_core_v3.SocketAddress{
-				Address: "0.0.0.0",
-				PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{
-					PortValue: 0,
-				},
-			}
 		}
 	}
 

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -1048,13 +1048,19 @@ func Test_bindConfig(t *testing.T) {
 		assert.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{
-				"freebind": true,
-				"sourceAddress": {
-					"address": "0.0.0.0",
-					"portValue": 0
-				}
+				"freebind": true
 			}
 		`, cluster.UpstreamBindConfig)
+	})
+	t.Run("freebind set but null", func(t *testing.T) {
+		cluster, err := b.buildPolicyCluster(ctx, &config.Config{Options: &config.Options{
+			EnvoyBindConfigFreebind: null.BoolFromPtr(nil),
+		}}, &config.Policy{
+			From: "https://from.example.com",
+			To:   mustParseWeightedURLs(t, "https://to.example.com"),
+		})
+		assert.NoError(t, err)
+		assert.Nil(t, cluster.UpstreamBindConfig.GetSourceAddress())
 	})
 	t.Run("source address", func(t *testing.T) {
 		cluster, err := b.buildPolicyCluster(ctx, &config.Config{Options: &config.Options{


### PR DESCRIPTION
## Summary

Do not automatically set an upstream source address if the freebind option is set. It looks like Envoy can apply the freebind option whether or not a source address is set, and if we set 0.0.0.0:0 as the default this will cause errors with IPv6 upstream connections.

## Related issues

https://linear.app/pomerium/issue/ENG-2606/core-applying-empty-settings-protobuf-should-not-modify-configuration
https://linear.app/pomerium/issue/ENG-2637/core-allow-freebind-and-source-address-settings-to-be-completely

## User Explanation

Fixes a bug where the source address for upstream connections was explicitly bound to 0.0.0.0:0, even if no source address was configured, when using Pomerium Enterprise or the Pomerium Ingress Controller. This bug would result in errors like `failed_to_bind_to_0.0.0.0:0:_Address_family_not_supported_by_protocol_family` or `failed_to_bind_to_0.0.0.0:0:_Invalid_argument` when attempting to connect to an upstream server using IPv6.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
