### PR TITLE
envoyconfig: set IP_BIND_ADDRESS_NO_PORT on Linux

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -189,6 +189,7 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 					PortValue: 0,
 				},
 			}
+			addIPBindAddressNoPortSocketOption(&cluster.UpstreamBindConfig.SocketOptions)
 		}
 	}
 

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -1070,14 +1071,32 @@ func Test_bindConfig(t *testing.T) {
 			To:   mustParseWeightedURLs(t, "https://to.example.com"),
 		})
 		assert.NoError(t, err)
-		testutil.AssertProtoJSONEqual(t, `
-			{
-				"sourceAddress": {
-					"address": "192.168.0.1",
-					"portValue": 0
+		if runtime.GOOS == "linux" {
+			testutil.AssertProtoJSONEqual(t, `
+				{
+					"sourceAddress": {
+						"address": "192.168.0.1",
+						"portValue": 0
+					},
+					"socketOptions": [
+						{
+							"description": "IP_BIND_ADDRESS_NO_PORT",
+							"name": "24",
+							"intValue": "1"
+						}
+					]
 				}
-			}
-		`, cluster.UpstreamBindConfig)
+			`, cluster.UpstreamBindConfig)
+		} else {
+			testutil.AssertProtoJSONEqual(t, `
+				{
+					"sourceAddress": {
+						"address": "192.168.0.1",
+						"portValue": 0
+					}
+				}
+			`, cluster.UpstreamBindConfig)
+		}
 	})
 }
 

--- a/config/envoyconfig/sockopts_linux.go
+++ b/config/envoyconfig/sockopts_linux.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package envoyconfig
+
+import (
+	"syscall"
+
+	"golang.org/x/sys/unix"
+
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+)
+
+func addIPBindAddressNoPortSocketOption(opts *[]*envoy_config_core_v3.SocketOption) {
+	*opts = append(*opts, &envoy_config_core_v3.SocketOption{
+		Description: "IP_BIND_ADDRESS_NO_PORT",
+		Level:       syscall.IPPROTO_IP,
+		Name:        unix.IP_BIND_ADDRESS_NO_PORT,
+		Value:       &envoy_config_core_v3.SocketOption_IntValue{IntValue: 1},
+		State:       envoy_config_core_v3.SocketOption_STATE_PREBIND,
+	})
+}

--- a/config/envoyconfig/sockopts_other.go
+++ b/config/envoyconfig/sockopts_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package envoyconfig
+
+import (
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+)
+
+func addIPBindAddressNoPortSocketOption(_ *[]*envoy_config_core_v3.SocketOption) {
+	// This socket option is supported only on Linux.
+}


### PR DESCRIPTION
## Summary

When using an explicit upstream source address, there is greater potential for ephemeral port exhaustion. On Linux, let's set the IP_BIND_ADDRESS_NO_PORT option in this case. This should defer the ephemeral port assignment until the actual connection to the upstream, so that one ephemeral port can be used by multiple different connections.

## Related issues

https://linear.app/pomerium/issue/ENG-2636/investigate-ip-bind-address-no-port-socket-option-to-improve-ephemeral

## User Explanation

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
