### PR TITLE
add runtime flag for session refresh change

### DIFF
--- a/authenticate/identity.go
+++ b/authenticate/identity.go
@@ -20,5 +20,6 @@ func defaultGetIdentityProvider(ctx context.Context, tracerProvider oteltrace.Tr
 		return nil, err
 	}
 
-	return identity.GetIdentityProvider(ctx, tracerProvider, idp, redirectURL)
+	return identity.GetIdentityProvider(ctx, tracerProvider, idp, redirectURL,
+		options.RuntimeFlags[config.RuntimeFlagRefreshSessionAtIDTokenExpiration])
 }

--- a/config/identity.go
+++ b/config/identity.go
@@ -98,5 +98,6 @@ func (o *Options) GetAuthenticator(ctx context.Context, tracerProvider oteltrace
 		return nil, err
 	}
 
-	return identity.GetIdentityProvider(ctx, tracerProvider, idp, redirectURL)
+	return identity.GetIdentityProvider(ctx, tracerProvider, idp, redirectURL,
+		o.RuntimeFlags[RuntimeFlagRefreshSessionAtIDTokenExpiration])
 }

--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -33,6 +33,10 @@ var (
 	// opt-out from the deprecation.
 	RuntimeFlagPomeriumJWTEndpoint = runtimeFlag("pomerium_jwt_endpoint", false)
 
+	// RuntimeFlagRefreshSessionAtIDTokenExpiration changes the identity manager session refresh
+	// timing to also take into account the ID token expiration time.
+	RuntimeFlagRefreshSessionAtIDTokenExpiration = runtimeFlag("refresh_session_at_id_token_expiration", true)
+
 	// RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs sets the envoy concurrency option to GOMAXPROCS.
 	RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs = runtimeFlag("set_envoy_concurrency_to_go_max_procs", true)
 

--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -3,6 +3,13 @@ package config
 import "maps"
 
 var (
+	// RuntimeFlagAddExtraMetricsLabels enables adding extra labels to metrics (host and installation id)
+	RuntimeFlagAddExtraMetricsLabels = runtimeFlag("add_extra_metrics_labels", true)
+
+	// RuntimeFlagAuthorizeUseSyncedData enables synced data for querying the databroker for
+	// certain types of data.
+	RuntimeFlagAuthorizeUseSyncedData = runtimeFlag("authorize_use_synced_data", true)
+
 	// RuntimeFlagConfigHotReload enables the hot-reloading mechanism for the config file
 	// and any other files referenced within it
 	RuntimeFlagConfigHotReload = runtimeFlag("config_hot_reload", true)
@@ -17,31 +24,24 @@ var (
 	// RuntimeFlagMatchAnyIncomingPort enables ignoring the incoming port when matching routes
 	RuntimeFlagMatchAnyIncomingPort = runtimeFlag("match_any_incoming_port", true)
 
+	// RuntimeFlagMCP enables the MCP services for the authorize service
+	RuntimeFlagMCP = runtimeFlag("mcp", false)
+
 	// RuntimeFlagPomeriumJWTEndpoint enables the /.pomerium/jwt endpoint, for retrieving
 	// signed user info claims from an upstream single-page web application. This endpoint
 	// is deprecated pending removal in a future release, but this flag allows a temporary
 	// opt-out from the deprecation.
 	RuntimeFlagPomeriumJWTEndpoint = runtimeFlag("pomerium_jwt_endpoint", false)
 
-	// RuntimeFlagAddExtraMetricsLabels enables adding extra labels to metrics (host and installation id)
-	RuntimeFlagAddExtraMetricsLabels = runtimeFlag("add_extra_metrics_labels", true)
-
-	// RuntimeFlagAuthorizeUseSyncedData enables synced data for querying the databroker for
-	// certain types of data.
-	RuntimeFlagAuthorizeUseSyncedData = runtimeFlag("authorize_use_synced_data", true)
-
-	// RuntimeFlagMCP enables the MCP services for the authorize service
-	RuntimeFlagMCP = runtimeFlag("mcp", false)
-
-	// RuntimeFlagSSHRoutesPortal enables the SSH routes portal
-	RuntimeFlagSSHRoutesPortal = runtimeFlag("ssh_routes_portal", false)
+	// RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs sets the envoy concurrency option to GOMAXPROCS.
+	RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs = runtimeFlag("set_envoy_concurrency_to_go_max_procs", true)
 
 	// RuntimeFlagSSHAllowDirectTcpip allows downstream clients to open 'direct-tcpip'
 	// channels (jump host mode)
 	RuntimeFlagSSHAllowDirectTcpip = runtimeFlag("ssh_allow_direct_tcpip", false)
 
-	// RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs sets the envoy concurrency option to GOMAXPROCS.
-	RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs = runtimeFlag("set_envoy_concurrency_to_go_max_procs", true)
+	// RuntimeFlagSSHRoutesPortal enables the SSH routes portal
+	RuntimeFlagSSHRoutesPortal = runtimeFlag("ssh_routes_portal", false)
 )
 
 // RuntimeFlag is a runtime flag that can flip on/off certain features

--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -193,6 +193,8 @@ func (c *DataBroker) update(_ context.Context, cfg *config.Config) error {
 			}
 			return cfg.Options.GetAuthenticator(ctx, c.tracerProvider, idpID)
 		}),
+		manager.WithRefreshSessionAtIDTokenExpiration(manager.RefreshSessionAtIDTokenExpiration(
+			cfg.Options.RuntimeFlags[config.RuntimeFlagRefreshSessionAtIDTokenExpiration])),
 	}, c.managerOptions...)
 
 	if c.manager == nil {

--- a/pkg/identity/manager/config.go
+++ b/pkg/identity/manager/config.go
@@ -19,14 +19,15 @@ var (
 )
 
 type config struct {
-	dataBrokerClient              databroker.DataBrokerServiceClient
-	sessionRefreshGracePeriod     time.Duration
-	sessionRefreshCoolOffDuration time.Duration
-	updateUserInfoInterval        time.Duration
-	leaseTTL                      time.Duration
-	now                           func() time.Time
-	eventMgr                      *events.Manager
-	getAuthenticator              func(ctx context.Context, idpID string) (identity.Authenticator, error)
+	dataBrokerClient                  databroker.DataBrokerServiceClient
+	sessionRefreshGracePeriod         time.Duration
+	sessionRefreshCoolOffDuration     time.Duration
+	refreshSessionAtIDTokenExpiration RefreshSessionAtIDTokenExpiration
+	updateUserInfoInterval            time.Duration
+	leaseTTL                          time.Duration
+	now                               func() time.Time
+	eventMgr                          *events.Manager
+	getAuthenticator                  func(ctx context.Context, idpID string) (identity.Authenticator, error)
 }
 
 func newConfig(options ...Option) *config {
@@ -97,6 +98,14 @@ func WithSessionRefreshGracePeriod(dur time.Duration) Option {
 func WithSessionRefreshCoolOffDuration(dur time.Duration) Option {
 	return func(cfg *config) {
 		cfg.sessionRefreshCoolOffDuration = dur
+	}
+}
+
+// RefreshSessionAtIDTokenExpiration sets whether to incorporate ID token
+// expiration time into the session refresh schedule.
+func WithRefreshSessionAtIDTokenExpiration(r RefreshSessionAtIDTokenExpiration) Option {
+	return func(cfg *config) {
+		cfg.refreshSessionAtIDTokenExpiration = r
 	}
 }
 

--- a/pkg/identity/manager/data.go
+++ b/pkg/identity/manager/data.go
@@ -10,11 +10,16 @@ import (
 	"github.com/pomerium/pomerium/pkg/identity"
 )
 
+// RefreshSessionAtIDTokenExpiration indicates whether a session refresh should be
+// scheduled at the expiration time of the ID token.
+type RefreshSessionAtIDTokenExpiration bool
+
 func nextSessionRefresh(
 	s *session.Session,
 	lastRefresh time.Time,
 	gracePeriod time.Duration,
 	coolOffDuration time.Duration,
+	refreshAtIDTokenExpiration RefreshSessionAtIDTokenExpiration,
 ) time.Time {
 	var tm time.Time
 
@@ -28,7 +33,7 @@ func nextSessionRefresh(
 		}
 	}
 
-	if s.GetIdToken().GetExpiresAt() != nil {
+	if refreshAtIDTokenExpiration && s.GetIdToken().GetExpiresAt() != nil {
 		expiry := s.GetIdToken().GetExpiresAt().AsTime()
 		if s.GetIdToken().GetExpiresAt().IsValid() && !expiry.IsZero() {
 			expiry = expiry.Add(-gracePeriod)

--- a/pkg/identity/manager/manager.go
+++ b/pkg/identity/manager/manager.go
@@ -153,6 +153,7 @@ func (mgr *Manager) onUpdateSession(ctx context.Context, s *session.Session) {
 			mgr.cfg.Load().now,
 			mgr.cfg.Load().sessionRefreshGracePeriod,
 			mgr.cfg.Load().sessionRefreshCoolOffDuration,
+			mgr.cfg.Load().refreshSessionAtIDTokenExpiration,
 			mgr.refreshSession,
 			s.GetId(),
 		)

--- a/pkg/identity/manager/schedulers.go
+++ b/pkg/identity/manager/schedulers.go
@@ -73,6 +73,7 @@ type refreshSessionScheduler struct {
 	sessionRefreshCoolOffDuration time.Duration
 	refreshSession                func(ctx context.Context, sesionID string)
 	sessionID                     string
+	refreshAtIDTokenExpiration    RefreshSessionAtIDTokenExpiration
 
 	lastRefresh atomic.Pointer[time.Time]
 	next        chan time.Time
@@ -84,6 +85,7 @@ func newRefreshSessionScheduler(
 	now func() time.Time,
 	sessionRefreshGracePeriod time.Duration,
 	sessionRefreshCoolOffDuration time.Duration,
+	refreshAtIDTokenExpiration RefreshSessionAtIDTokenExpiration,
 	refreshSession func(ctx context.Context, sesionID string),
 	sessionID string,
 ) *refreshSessionScheduler {
@@ -92,6 +94,7 @@ func newRefreshSessionScheduler(
 		now:                           now,
 		sessionRefreshGracePeriod:     sessionRefreshGracePeriod,
 		sessionRefreshCoolOffDuration: sessionRefreshCoolOffDuration,
+		refreshAtIDTokenExpiration:    refreshAtIDTokenExpiration,
 		refreshSession:                refreshSession,
 		sessionID:                     sessionID,
 		next:                          make(chan time.Time, 1),
@@ -109,6 +112,7 @@ func (rss *refreshSessionScheduler) Update(s *session.Session) {
 		*rss.lastRefresh.Load(),
 		rss.sessionRefreshGracePeriod,
 		rss.sessionRefreshCoolOffDuration,
+		rss.refreshAtIDTokenExpiration,
 	)
 	for {
 		select {

--- a/pkg/identity/manager/schedulers_test.go
+++ b/pkg/identity/manager/schedulers_test.go
@@ -24,6 +24,7 @@ func TestRefreshSessionScheduler_OverallExpiration(t *testing.T) {
 			time.Now,
 			defaultSessionRefreshGracePeriod,
 			defaultSessionRefreshCoolOffDuration,
+			RefreshSessionAtIDTokenExpiration(true),
 			func(_ context.Context, _ string) {
 				calls = append(calls, time.Now())
 			},
@@ -72,6 +73,7 @@ func TestRefreshSessionScheduler_AccessTokenExpiration(t *testing.T) {
 			time.Now,
 			1*time.Minute,  // how long before expiration to attempt refresh
 			10*time.Second, // cool off duration
+			RefreshSessionAtIDTokenExpiration(true),
 			refresh,
 			"S1",
 		)
@@ -151,6 +153,7 @@ func TestRefreshSessionScheduler_IDTokenExpiresBeforeAccessToken(t *testing.T) {
 			time.Now,
 			1*time.Minute, // how long before expiration to attempt refresh
 			defaultSessionRefreshCoolOffDuration,
+			RefreshSessionAtIDTokenExpiration(true),
 			refresh,
 			"S1",
 		)
@@ -223,6 +226,7 @@ func TestRefreshSessionScheduler_IDTokenNotRefreshed(t *testing.T) {
 			time.Now,
 			1*time.Minute, // how long before expiration to attempt refresh
 			defaultSessionRefreshCoolOffDuration,
+			RefreshSessionAtIDTokenExpiration(true),
 			refresh,
 			"S1",
 		)

--- a/pkg/identity/oauth/options.go
+++ b/pkg/identity/oauth/options.go
@@ -34,4 +34,8 @@ type Options struct {
 
 	// When set validates the audience in access tokens.
 	AccessTokenAllowedAudiences *[]string
+
+	// When set to true, any existing ID token will always be overwritten
+	// (replaced or cleared) after a successful session refresh.
+	OverwriteIDTokenOnRefresh bool
 }

--- a/pkg/identity/providers.go
+++ b/pkg/identity/providers.go
@@ -100,15 +100,17 @@ func GetIdentityProvider(
 	tracerProvider oteltrace.TracerProvider,
 	idp *identitypb.Provider,
 	redirectURL *url.URL,
+	overwriteIDTokenOnRefresh bool,
 ) (Authenticator, error) {
 	o := oauth.Options{
-		RedirectURL:     redirectURL,
-		ProviderName:    idp.GetType(),
-		ProviderURL:     idp.GetUrl(),
-		ClientID:        idp.GetClientId(),
-		ClientSecret:    idp.GetClientSecret(),
-		Scopes:          idp.GetScopes(),
-		AuthCodeOptions: idp.GetRequestParams(),
+		RedirectURL:               redirectURL,
+		ProviderName:              idp.GetType(),
+		ProviderURL:               idp.GetUrl(),
+		ClientID:                  idp.GetClientId(),
+		ClientSecret:              idp.GetClientSecret(),
+		Scopes:                    idp.GetScopes(),
+		AuthCodeOptions:           idp.GetRequestParams(),
+		OverwriteIDTokenOnRefresh: overwriteIDTokenOnRefresh,
 	}
 	if v := idp.GetAccessTokenAllowedAudiences(); v != nil {
 		o.AccessTokenAllowedAudiences = &v.Values

--- a/pkg/ssh/auth.go
+++ b/pkg/ssh/auth.go
@@ -380,7 +380,8 @@ func (a *Auth) getAuthenticator(ctx context.Context, hostname string) (*identity
 		return nil, nil, err
 	}
 
-	authenticator, err := identity.GetIdentityProvider(ctx, a.tracerProvider, idp, redirectURL)
+	authenticator, err := identity.GetIdentityProvider(ctx, a.tracerProvider, idp, redirectURL,
+		opts.RuntimeFlags[config.RuntimeFlagRefreshSessionAtIDTokenExpiration])
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
## Summary

Add a new runtime flag `refresh_session_at_id_token_expiration` to guard the two changes introduced by https://github.com/pomerium/pomerium/pull/5727, which are:
1. schedule session refresh based on ID token expiration (in addition to access token expiration and overall session lifetime)
2. always overwrite an existing ID token upon successful session refresh

This requires a bit of refactoring to make the runtime flag setting available in the identity manager and OIDC code:
- add a new `WithRefreshSessionAtIDTokenExpiration(bool)` option to the identity manager config
- add a new `OverwriteIDTokenOnRefresh bool` field to the oauth.Options struct

## Related issues

https://linear.app/pomerium/issue/ENG-2588/support-configuring-earlier-token-refresh-and-id-token-expiration

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
