### PR TITLE
databroker: move gc to public interface, abort sync calls with invalid record versions

### DIFF
--- a/pkg/grpc/databroker/syncer.go
+++ b/pkg/grpc/databroker/syncer.go
@@ -190,8 +190,8 @@ func (syncer *Syncer) sync(ctx context.Context) error {
 			log.Ctx(ctx).Error().Err(err).
 				Str("syncer-id", syncer.id).
 				Str("syncer-type", syncer.cfg.typeURL).
-				Msg("aborted sync due to mismatched server version")
-			// server version changed, so re-init
+				Msg("aborted sync due to mismatched versions")
+			// server version may have changed, so re-init
 			syncer.serverVersion = 0
 			return nil
 		} else if err != nil {

--- a/pkg/storage/inmemory/config.go
+++ b/pkg/storage/inmemory/config.go
@@ -1,10 +1,7 @@
 package inmemory
 
-import "time"
-
 type config struct {
 	degree int
-	expiry time.Duration
 }
 
 // An Option customizes the in-memory backend.
@@ -13,7 +10,6 @@ type Option func(cfg *config)
 func getConfig(options ...Option) *config {
 	cfg := &config{
 		degree: 16,
-		expiry: time.Hour,
 	}
 	for _, option := range options {
 		option(cfg)
@@ -25,12 +21,5 @@ func getConfig(options ...Option) *config {
 func WithBTreeDegree(degree int) Option {
 	return func(cfg *config) {
 		cfg.degree = degree
-	}
-}
-
-// WithExpiry sets the expiry for changes.
-func WithExpiry(expiry time.Duration) Option {
-	return func(cfg *config) {
-		cfg.expiry = expiry
 	}
 }

--- a/pkg/storage/postgres/backend_test.go
+++ b/pkg/storage/postgres/backend_test.go
@@ -51,6 +51,21 @@ func TestBackend(t *testing.T) {
 	})
 }
 
+func TestSyncOldRecords(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("GITHUB_ACTION") != "" && runtime.GOOS == "darwin" {
+		t.Skip("Github action can not run docker on MacOS")
+	}
+
+	testutil.WithTestPostgres(t, func(dsn string) {
+		backend := New(t.Context(), dsn)
+		defer backend.Close()
+
+		storagetest.TestSyncOldRecords(t, backend)
+	})
+}
+
 func TestLookup(t *testing.T) {
 	originalDefaultResolver := net.DefaultResolver
 	net.DefaultResolver = stubResolver(t)

--- a/pkg/storage/postgres/option.go
+++ b/pkg/storage/postgres/option.go
@@ -7,25 +7,16 @@ import (
 )
 
 const (
-	defaultExpiry      = time.Hour
 	defaultRegistryTTL = time.Second * 30
 )
 
 type config struct {
-	expiry         time.Duration
 	registryTTL    time.Duration
 	tracerProvider oteltrace.TracerProvider
 }
 
 // Option customizes a Backend.
 type Option func(*config)
-
-// WithExpiry sets the expiry for changes.
-func WithExpiry(expiry time.Duration) Option {
-	return func(cfg *config) {
-		cfg.expiry = expiry
-	}
-}
 
 // WithRegistryTTL sets the default registry TTL.
 func WithRegistryTTL(ttl time.Duration) Option {
@@ -42,7 +33,6 @@ func WithTracerProvider(tracerProvider oteltrace.TracerProvider) Option {
 
 func getConfig(options ...Option) *config {
 	cfg := new(config)
-	WithExpiry(defaultExpiry)(cfg)
 	WithRegistryTTL(defaultRegistryTTL)(cfg)
 	for _, o := range options {
 		o(cfg)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -22,12 +22,15 @@ var (
 	ErrNotFound             = errors.New("record not found")
 	ErrStreamDone           = errors.New("record stream done")
 	ErrInvalidServerVersion = status.Error(codes.Aborted, "invalid server version")
+	ErrInvalidRecordVersion = status.Error(codes.Aborted, "invalid record version")
 )
 
 // Backend is the interface required for a storage backend.
 type Backend interface {
 	// Close closes the backend.
 	Close() error
+	// Clean removes old data.
+	Clean(ctx context.Context, options CleanOptions) error
 	// Get is used to retrieve a record.
 	Get(ctx context.Context, recordType, id string) (*databroker.Record, error)
 	// GetOptions gets the options for a type.
@@ -46,6 +49,11 @@ type Backend interface {
 	Sync(ctx context.Context, recordType string, serverVersion, recordVersion uint64) (RecordStream, error)
 	// SyncLatest syncs all the records.
 	SyncLatest(ctx context.Context, recordType string, filter FilterExpression) (serverVersion, recordVersion uint64, stream RecordStream, err error)
+}
+
+// CleanOptions are the options used for cleaning the storage backend.
+type CleanOptions struct {
+	RemoveRecordChangesBefore time.Time
 }
 
 // MatchAny searches any data with a query.

--- a/pkg/storage/storagetest/storagetest.go
+++ b/pkg/storage/storagetest/storagetest.go
@@ -409,6 +409,76 @@ func TestBackend(t *testing.T, backend storage.Backend) {
 	})
 }
 
+func TestSyncOldRecords(t *testing.T, backend storage.Backend) {
+	t.Helper()
+
+	sync := func(serverVersion, afterRecordVersion uint64) ([]string, error) {
+		stream, err := backend.Sync(t.Context(), "", serverVersion, afterRecordVersion)
+		if err != nil {
+			return nil, err
+		}
+		defer stream.Close()
+
+		var ids []string
+		for stream.Next(false) {
+			ids = append(ids, stream.Record().GetId())
+		}
+		return ids, nil
+	}
+	syncLatest := func() (serverVersion, latestRecordVersion uint64, ids []string, err error) {
+		serverVersion, latestRecordVersion, stream, err := backend.SyncLatest(t.Context(), "", nil)
+		if err != nil {
+			return 0, 0, nil, err
+		}
+		defer stream.Close()
+
+		for stream.Next(false) {
+			ids = append(ids, stream.Record().GetId())
+		}
+		return serverVersion, latestRecordVersion, ids, nil
+	}
+
+	serverVersion, recordVersion, ids, err := syncLatest()
+	assert.NotZero(t, serverVersion)
+	assert.Empty(t, ids)
+	assert.NoError(t, err)
+
+	ids, err = sync(serverVersion, recordVersion)
+	assert.Empty(t, ids)
+	assert.NoError(t, err)
+
+	rs1 := []*databroker.Record{{Type: "example", Id: "r1", Data: protoutil.NewAnyString("r1")}}
+	rs2 := []*databroker.Record{{Type: "example", Id: "r2", Data: protoutil.NewAnyString("r2")}}
+	rs3 := []*databroker.Record{{Type: "example", Id: "r3", Data: protoutil.NewAnyString("r3")}}
+
+	_, err = backend.Put(t.Context(), rs1)
+	require.NoError(t, err)
+	time.Sleep(time.Millisecond)
+	_, err = backend.Put(t.Context(), rs2)
+	require.NoError(t, err)
+	time.Sleep(time.Millisecond)
+	tm3 := time.Now()
+	_, err = backend.Put(t.Context(), rs3)
+	require.NoError(t, err)
+	time.Sleep(time.Millisecond)
+
+	_, recordVersion, ids, err = syncLatest()
+	assert.Equal(t, rs3[0].Version, recordVersion)
+	assert.Len(t, ids, 3)
+	assert.NoError(t, err)
+
+	ids, err = sync(serverVersion, rs1[0].Version)
+	assert.Len(t, ids, 2)
+	assert.NoError(t, err)
+
+	err = backend.Clean(t.Context(), storage.CleanOptions{RemoveRecordChangesBefore: tm3})
+	require.NoError(t, err)
+
+	ids, err = sync(serverVersion, rs1[0].Version)
+	assert.Len(t, ids, 0)
+	assert.ErrorIs(t, err, storage.ErrInvalidRecordVersion)
+}
+
 type mockRegistryWatchServer struct {
 	registry.Registry_WatchServer
 	context context.Context


### PR DESCRIPTION
## Summary
The databroker maintains a list of record changes over time. Those changes are retrieved via the databroker `Sync` call. Both the in-memory and postgres storage backends periodically remove old changes.

Since this logic is necessary for any storage backend, add a `Clean` method to the public interface and start the background cleaner in the databroker server rather than the storage backend itself. This makes it easier to test.

Currently if a client attempts to `Sync` changes, but they've fallen too far behind, we would not detect this and the client would never receive the missing changes. The correct behavior is to abort the `Sync`, which signals the client to do a full re-sync via `SyncLatest`. This PR attempts to implement that behavior.

There is some risk with this change. If the assumptions I'm making about how clients work turn out not to be true, we could end up with clients continuously attempting to call `Sync` and never recovering.

## Related issues
- [ENG-2640](https://linear.app/pomerium/issue/ENG-2640/core-databroker-sync-may-miss-changes)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
