### PR TITLE
metrics: add stats prefix to the listeners

### DIFF
--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -85,9 +85,10 @@ func (b *Builder) BuildListeners(
 }
 
 // newListener creates envoy listener with certain default values
-func newListener(name string) *envoy_config_listener_v3.Listener {
+func newListener(name, statPrefix string) *envoy_config_listener_v3.Listener {
 	return &envoy_config_listener_v3.Listener{
 		Name:                          name,
+		StatPrefix:                    statPrefix,
 		PerConnectionBufferLimitBytes: wrapperspb.UInt32(listenerBufferLimit),
 
 		// SO_REUSEPORT only works properly on linux and is force-disabled by
@@ -99,7 +100,7 @@ func newListener(name string) *envoy_config_listener_v3.Listener {
 
 // newQUICListener creates a new envoy listener that handles QUIC connections.
 func newQUICListener(name string, address *envoy_config_core_v3.Address) *envoy_config_listener_v3.Listener {
-	li := newListener(name)
+	li := newListener(name, name)
 	li.Address = address
 	li.UdpListenerConfig = &envoy_config_listener_v3.UdpListenerConfig{
 		QuicOptions: &envoy_config_listener_v3.QuicProtocolOptions{},
@@ -111,8 +112,8 @@ func newQUICListener(name string, address *envoy_config_core_v3.Address) *envoy_
 }
 
 // newTCPListener creates a new envoy listener that handles TCP connections.
-func newTCPListener(name string, address *envoy_config_core_v3.Address) *envoy_config_listener_v3.Listener {
-	li := newListener(name)
+func newTCPListener(name, statPrefix string, address *envoy_config_core_v3.Address) *envoy_config_listener_v3.Listener {
+	li := newListener(name, statPrefix)
 	li.Address = address
 	return li
 }

--- a/config/envoyconfig/listeners_envoy_admin.go
+++ b/config/envoyconfig/listeners_envoy_admin.go
@@ -25,7 +25,7 @@ func (b *Builder) buildEnvoyAdminListener(_ context.Context, cfg *config.Config)
 		return nil, fmt.Errorf("envoy_admin_addr %s: %w", cfg.Options.EnvoyAdminAddress, err)
 	}
 
-	li := newTCPListener("envoy-admin", addr)
+	li := newTCPListener("envoy-admin", "envoy-admin", addr)
 	li.FilterChains = []*envoy_config_listener_v3.FilterChain{filterChain}
 	return li, nil
 }

--- a/config/envoyconfig/listeners_grpc.go
+++ b/config/envoyconfig/listeners_grpc.go
@@ -28,7 +28,7 @@ func (b *Builder) buildGRPCListener(ctx context.Context, cfg *config.Config) (*e
 		address = buildTCPAddress(cfg.Options.GetGRPCAddr(), 443)
 	}
 
-	li := newTCPListener("grpc-ingress", address)
+	li := newTCPListener("grpc-ingress", "grpc-ingress", address)
 	li.FilterChains = []*envoy_config_listener_v3.FilterChain{&filterChain}
 
 	if cfg.Options.GetGRPCInsecure() {

--- a/config/envoyconfig/listeners_main.go
+++ b/config/envoyconfig/listeners_main.go
@@ -35,7 +35,7 @@ func (b *Builder) buildMainInsecureListener(
 	cfg *config.Config,
 	fullyStatic bool,
 ) (*envoy_config_listener_v3.Listener, error) {
-	li := newTCPListener("http-ingress", buildTCPAddress(cfg.Options.Addr, 80))
+	li := newTCPListener("http-ingress", "http-ingress", buildTCPAddress(cfg.Options.Addr, 80))
 
 	// listener filters
 	if cfg.Options.UseProxyProtocol {
@@ -91,7 +91,7 @@ func (b *Builder) buildMainTLSListener(
 	cfg *config.Config,
 	fullyStatic bool,
 ) (*envoy_config_listener_v3.Listener, error) {
-	li := newTCPListener("https-ingress", buildTCPAddress(cfg.Options.Addr, 443))
+	li := newTCPListener("https-ingress", "https-ingress", buildTCPAddress(cfg.Options.Addr, 443))
 
 	// listener filters
 	if cfg.Options.UseProxyProtocol {

--- a/config/envoyconfig/listeners_metrics.go
+++ b/config/envoyconfig/listeners_metrics.go
@@ -81,7 +81,7 @@ func (b *Builder) buildMetricsListener(cfg *config.Config) (*envoy_config_listen
 	}
 
 	addr := buildTCPAddress(net.JoinHostPort(host, port), 9902)
-	li := newTCPListener(fmt.Sprintf("metrics-ingress-%d", hashutil.MustHash(addr)), addr)
+	li := newTCPListener(fmt.Sprintf("metrics-ingress-%d", hashutil.MustHash(addr)), "metrics-ingress", addr)
 	li.FilterChains = []*envoy_config_listener_v3.FilterChain{filterChain}
 	return li, nil
 }

--- a/config/envoyconfig/outbound.go
+++ b/config/envoyconfig/outbound.go
@@ -22,7 +22,7 @@ func (b *Builder) buildOutboundListener(cfg *config.Config) (*envoy_config_liste
 
 	filter := b.buildOutboundHTTPConnectionManager()
 
-	li := newTCPListener("outbound-ingress", &envoy_config_core_v3.Address{
+	li := newTCPListener("grpc-egress", "grpc-egress", &envoy_config_core_v3.Address{
 		Address: &envoy_config_core_v3.Address_SocketAddress{
 			SocketAddress: &envoy_config_core_v3.SocketAddress{
 				Address: "127.0.0.1",

--- a/config/envoyconfig/testdata/metrics_http_connection_manager.json
+++ b/config/envoyconfig/testdata/metrics_http_connection_manager.json
@@ -1,5 +1,6 @@
 {
   "name": "metrics-ingress-2557141950503822122",
+  "statPrefix": "metrics-ingress",
   "perConnectionBufferLimitBytes": 32768,
   "address": {
     "socketAddress": {


### PR DESCRIPTION
## Summary

This PR updates stats prefix for the listeners, so that it would be easier to distinguish between their statistics. 

See also https://github.com/pomerium/documentation/pull/1942 

## Related issues

Fix https://linear.app/pomerium/issue/ENG-2643/set-stats-prefix-to-listeners

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
