### PR TITLE
config: applying empty Settings should be a no-op

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -1651,7 +1651,9 @@ func (o *Options) ApplySettings(ctx context.Context, certsIndex *cryptutil.Certi
 	set(&o.EnvoyAdminProfilePath, settings.EnvoyAdminProfilePath)
 	set(&o.EnvoyAdminAddress, settings.EnvoyAdminAddress)
 	set(&o.EnvoyBindConfigSourceAddress, settings.EnvoyBindConfigSourceAddress)
-	o.EnvoyBindConfigFreebind = null.BoolFromPtr(settings.EnvoyBindConfigFreebind)
+	if settings.EnvoyBindConfigFreebind != nil {
+		o.EnvoyBindConfigFreebind = null.BoolFrom(*settings.EnvoyBindConfigFreebind)
+	}
 	setSlice(&o.ProgrammaticRedirectDomainWhitelist, settings.ProgrammaticRedirectDomainWhitelist)
 	setCodecType(&o.CodecType, settings.CodecType)
 	setOptional(&o.PassIdentityHeaders, settings.PassIdentityHeaders)
@@ -1661,7 +1663,9 @@ func (o *Options) ApplySettings(ctx context.Context, certsIndex *cryptutil.Certi
 	copyMap(&o.RuntimeFlags, settings.RuntimeFlags, func(k string, v bool) (RuntimeFlag, bool) {
 		return RuntimeFlag(k), v
 	})
-	o.HTTP3AdvertisePort = null.Uint32FromPtr(settings.Http3AdvertisePort)
+	if settings.Http3AdvertisePort != nil {
+		o.HTTP3AdvertisePort = null.Uint32From(*settings.Http3AdvertisePort)
+	}
 	if settings.CircuitBreakerThresholds != nil {
 		o.CircuitBreakerThresholds = CircuitBreakerThresholdsFromPB(settings.CircuitBreakerThresholds)
 	}

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1127,6 +1127,20 @@ func TestOptions_ApplySettings(t *testing.T) {
 		assert.Equal(t, "SSH_USER_CA_KEY_FILE", options.SSHUserCAKeyFile)
 		assert.Equal(t, "SSH_USER_CA_KEY", options.SSHUserCAKey)
 	})
+
+	t.Run("empty", func(t *testing.T) {
+		opts := NewDefaultOptions()
+		// set a few non-default options too
+		opts.DownstreamMTLS.CA = "client CA"
+		opts.InstallationID = "installation ID"
+		opts.RuntimeFlags[RuntimeFlagMCP] = true
+		opts.SSHAddr = "ssh address"
+		expected := *opts
+
+		// Applying an empty Settings protobuf should be a no-op.
+		opts.ApplySettings(t.Context(), nil, &configpb.Settings{})
+		assert.Equal(t, &expected, opts)
+	})
 }
 
 func TestOptions_GetSetResponseHeaders(t *testing.T) {


### PR DESCRIPTION
## Summary

Add a test case that calling ApplySettings() with an empty Settings proto should not result in any change to an existing Options struct. Fix two fields that do not currently behave this way.

## Related issues

https://linear.app/pomerium/issue/ENG-2606/core-applying-empty-settings-protobuf-should-not-modify-configuration

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
