### PR TITLE
telemetry: instrument databroker reconciler, fix attributes

### DIFF
--- a/pkg/grpc/databroker/reconciler.go
+++ b/pkg/grpc/databroker/reconciler.go
@@ -113,6 +113,9 @@ func (r *Reconciler) RunLeased(ctx context.Context) error {
 }
 
 func (r *Reconciler) reconcileLoop(ctx context.Context) error {
+	ctx, g := r.telemetry.Active(ctx, "ReconcileLoop")
+	defer g.Done()
+
 	for {
 		err := r.Reconcile(ctx)
 		if err != nil {


### PR DESCRIPTION
## Summary

1. add instrumentation to the databroker reconciler
2. fix attributes not passed in the telemetry.Component to individual counters
3. add a new `Running` method to `telemetry.Component` to indicate a long-running operation such as a certain control loop is live.

## Related issues

Ref: https://linear.app/pomerium/issue/ENG-2656

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
