### PR TITLE
databroker: move gc to public interface, abort sync calls with invalid record versions (#5753)

### DIFF
--- a/pkg/grpc/databroker/syncer.go
+++ b/pkg/grpc/databroker/syncer.go
@@ -190,8 +190,8 @@ func (syncer *Syncer) sync(ctx context.Context) error {
 			log.Ctx(ctx).Error().Err(err).
 				Str("syncer-id", syncer.id).
 				Str("syncer-type", syncer.cfg.typeURL).
-				Msg("aborted sync due to mismatched server version")
-			// server version changed, so re-init
+				Msg("aborted sync due to mismatched versions")
+			// server version may have changed, so re-init
 			syncer.serverVersion = 0
 			return nil
 		} else if err != nil {

--- a/pkg/storage/inmemory/config.go
+++ b/pkg/storage/inmemory/config.go
@@ -1,10 +1,7 @@
 package inmemory
 
-import "time"
-
 type config struct {
 	degree int
-	expiry time.Duration
 }
 
 // An Option customizes the in-memory backend.
@@ -13,7 +10,6 @@ type Option func(cfg *config)
 func getConfig(options ...Option) *config {
 	cfg := &config{
 		degree: 16,
-		expiry: time.Hour,
 	}
 	for _, option := range options {
 		option(cfg)
@@ -25,12 +21,5 @@ func getConfig(options ...Option) *config {
 func WithBTreeDegree(degree int) Option {
 	return func(cfg *config) {
 		cfg.degree = degree
-	}
-}
-
-// WithExpiry sets the expiry for changes.
-func WithExpiry(expiry time.Duration) Option {
-	return func(cfg *config) {
-		cfg.expiry = expiry
 	}
 }

--- a/pkg/storage/postgres/backend_test.go
+++ b/pkg/storage/postgres/backend_test.go
@@ -203,6 +203,21 @@ func TestBackend(t *testing.T) {
 	})
 }
 
+func TestSyncOldRecords(t *testing.T) {
+	t.Parallel()
+
+	if os.Getenv("GITHUB_ACTION") != "" && runtime.GOOS == "darwin" {
+		t.Skip("Github action can not run docker on MacOS")
+	}
+
+	testutil.WithTestPostgres(t, func(dsn string) {
+		backend := New(t.Context(), dsn)
+		defer backend.Close()
+
+		storagetest.TestSyncOldRecords(t, backend)
+	})
+}
+
 func TestLookup(t *testing.T) {
 	originalDefaultResolver := net.DefaultResolver
 	net.DefaultResolver = stubResolver(t)

--- a/pkg/storage/postgres/option.go
+++ b/pkg/storage/postgres/option.go
@@ -7,25 +7,16 @@ import (
 )
 
 const (
-	defaultExpiry      = time.Hour
 	defaultRegistryTTL = time.Second * 30
 )
 
 type config struct {
-	expiry         time.Duration
 	registryTTL    time.Duration
 	tracerProvider oteltrace.TracerProvider
 }
 
 // Option customizes a Backend.
 type Option func(*config)
-
-// WithExpiry sets the expiry for changes.
-func WithExpiry(expiry time.Duration) Option {
-	return func(cfg *config) {
-		cfg.expiry = expiry
-	}
-}
 
 // WithRegistryTTL sets the default registry TTL.
 func WithRegistryTTL(ttl time.Duration) Option {
@@ -42,7 +33,6 @@ func WithTracerProvider(tracerProvider oteltrace.TracerProvider) Option {
 
 func getConfig(options ...Option) *config {
 	cfg := new(config)
-	WithExpiry(defaultExpiry)(cfg)
 	WithRegistryTTL(defaultRegistryTTL)(cfg)
 	for _, o := range options {
 		o(cfg)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -22,12 +22,15 @@ var (
 	ErrNotFound             = errors.New("record not found")
 	ErrStreamDone           = errors.New("record stream done")
 	ErrInvalidServerVersion = status.Error(codes.Aborted, "invalid server version")
+	ErrInvalidRecordVersion = status.Error(codes.Aborted, "invalid record version")
 )
 
 // Backend is the interface required for a storage backend.
 type Backend interface {
 	// Close closes the backend.
 	Close() error
+	// Clean removes old data.
+	Clean(ctx context.Context, options CleanOptions) error
 	// Get is used to retrieve a record.
 	Get(ctx context.Context, recordType, id string) (*databroker.Record, error)
 	// GetOptions gets the options for a type.
@@ -46,6 +49,11 @@ type Backend interface {
 	Sync(ctx context.Context, recordType string, serverVersion, recordVersion uint64) (RecordStream, error)
 	// SyncLatest syncs all the records.
 	SyncLatest(ctx context.Context, recordType string, filter FilterExpression) (serverVersion, recordVersion uint64, stream RecordStream, err error)
+}
+
+// CleanOptions are the options used for cleaning the storage backend.
+type CleanOptions struct {
+	RemoveRecordChangesBefore time.Time
 }
 
 // MatchAny searches any data with a query.


### PR DESCRIPTION
Backport #5753 to v0.30.