### PR TITLE
policy: add source_ip PPL criteria

### DIFF
--- a/pkg/policy/criteria/criteria_test.go
+++ b/pkg/policy/criteria/criteria_test.go
@@ -41,6 +41,7 @@ type (
 		Path              string                `json:"path"`
 		Headers           map[string][]string   `json:"headers"`
 		ClientCertificate ClientCertificateInfo `json:"client_certificate"`
+		IP                string                `json:"ip"`
 	}
 	InputSSH struct {
 		Username  string `json:"username"`

--- a/pkg/policy/criteria/reasons.go
+++ b/pkg/policy/criteria/reasons.go
@@ -45,6 +45,8 @@ const (
 	ReasonUserUnauthenticated           = "user-unauthenticated" // user needs to log in
 	ReasonUserUnauthorized              = "user-unauthorized"    // user does not have access
 	ReasonValidClientCertificate        = "valid-client-certificate"
+	ReasonSourceIPOK                    = "source-ip-ok"
+	ReasonSourceIPUnauthorized          = "source-ip-unauthorized"
 )
 
 // Reasons is a collection of reasons.

--- a/pkg/policy/criteria/source_ip.go
+++ b/pkg/policy/criteria/source_ip.go
@@ -1,0 +1,39 @@
+package criteria
+
+import (
+	"github.com/open-policy-agent/opa/ast"
+
+	"github.com/pomerium/pomerium/pkg/policy/parser"
+)
+
+type sourceIPCriterion struct {
+	g *Generator
+}
+
+func (c sourceIPCriterion) DataType() CriterionDataType { return CriterionDataTypeStringMatcher }
+
+func (c sourceIPCriterion) Name() string { return "source_ip" }
+
+func (c sourceIPCriterion) GenerateRule(_ string, data parser.Value) (*ast.Rule, []*ast.Rule, error) {
+	var body ast.Body
+	ref := ast.RefTerm(ast.VarTerm("input"), ast.VarTerm("http"), ast.VarTerm("ip"))
+	err := matchString(&body, ref, data)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rule := NewCriterionRule(c.g, c.Name(),
+		ReasonSourceIPOK, ReasonSourceIPUnauthorized,
+		body)
+
+	return rule, nil, nil
+}
+
+// SourceIP returns a Criterion which matches source IP address.
+func SourceIP(generator *Generator) Criterion {
+	return sourceIPCriterion{g: generator}
+}
+
+func init() {
+	Register(SourceIP)
+}

--- a/pkg/policy/criteria/source_ip_test.go
+++ b/pkg/policy/criteria/source_ip_test.go
@@ -1,0 +1,34 @@
+package criteria
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+func TestSourceIPs(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		res, err := evaluate(t, `
+allow:
+  and:
+    - source_ip:
+        is: "127.0.0.1"
+`, []*databroker.Record{}, Input{HTTP: InputHTTP{IP: "127.0.0.1"}})
+		require.NoError(t, err)
+		require.Equal(t, A{true, A{ReasonSourceIPOK}, M{}}, res["allow"])
+		require.Equal(t, A{false, A{}}, res["deny"])
+	})
+	t.Run("unauthorized", func(t *testing.T) {
+		res, err := evaluate(t, `
+allow:
+  and:
+    - source_ip:
+        is: "127.0.0.1"
+`, []*databroker.Record{}, Input{HTTP: InputHTTP{IP: "192.168.1.1"}})
+		require.NoError(t, err)
+		require.Equal(t, A{false, A{ReasonSourceIPUnauthorized}, M{}}, res["allow"])
+		require.Equal(t, A{false, A{}}, res["deny"])
+	})
+}


### PR DESCRIPTION
Allow to write policies using client IP address.

## Summary

Example use case: Allow to access a web service only from a specific IP address.

Example config:

```yaml
authenticate_service_url: https://authenticate.pomerium.app

routes:
  - from: https://httpbin.localhost.pomerium.io
    to: https://httpbin.dev/headers
    policy:
      - allow:
          and:
            - source_ip:
                in: ["127.0.0.1", "192.168.100.102"]
```

I understand that this use-case is already supported by writing custom rego, but found it to be cumbersome to do it that way.

Note: Initially I want the `source_ip` criteria to work for both HTTP and SSH. But then I'm not sure if it is possible because:
- There is no IP address in `RequestSSH` struct
- The GenerateRule function could not know if it is being used in an HTTP or an SSH route to generate the appropiate Rego policy.

I can rename the criteria to `http_ip` if you think it is a better name. I will also create another PR for updating documentation if this PR is accepted.

## Related issues

- #1943

## User Explanation

The user will be able to use source_ip matcher criteria when writing policies.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
