### PR TITLE
core: improve tracing

### DIFF
--- a/authorize/state.go
+++ b/authorize/state.go
@@ -102,6 +102,7 @@ func newAuthorizeStateFromConfig(
 		return nil, fmt.Errorf("authorize: invalid session store: %w", err)
 	}
 	state.idpTokenSessionCreator = config.NewIncomingIDPTokenSessionCreator(
+		tracerProvider,
 		func(ctx context.Context, recordType, recordID string) (*databroker.Record, error) {
 			return storage.GetDataBrokerRecord(ctx, recordType, recordID, 0)
 		},

--- a/config/config.go
+++ b/config/config.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+
 	"github.com/pomerium/pomerium/internal/fileutil"
 	"github.com/pomerium/pomerium/internal/hashutil"
 	"github.com/pomerium/pomerium/internal/httputil"
@@ -225,7 +227,7 @@ func (cfg *Config) GetAuthenticateKeyFetcher() (hpke.KeyFetcher, error) {
 	return hpke.NewKeyFetcher(hpkeURL, transport), nil
 }
 
-func (cfg *Config) resolveAuthenticateURL() (*url.URL, *http.Transport, error) {
+func (cfg *Config) resolveAuthenticateURL() (*url.URL, http.RoundTripper, error) {
 	authenticateURL, err := cfg.Options.GetInternalAuthenticateURL()
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid authenticate service url: %w", err)
@@ -243,5 +245,6 @@ func (cfg *Config) resolveAuthenticateURL() (*url.URL, *http.Transport, error) {
 		return nil, nil, fmt.Errorf("get tls client config: %w", err)
 	}
 
+	transport = otelhttp.NewTransport(transport)
 	return authenticateURL, transport, nil
 }

--- a/config/http.go
+++ b/config/http.go
@@ -119,7 +119,7 @@ func NewPolicyHTTPTransport(options *Options, policy *Policy, disableHTTP2 bool)
 }
 
 // GetTLSClientTransport returns http transport accounting for custom CAs from config
-func GetTLSClientTransport(cfg *Config) (*http.Transport, error) {
+func GetTLSClientTransport(cfg *Config) (http.RoundTripper, error) {
 	tlsConfig, err := cfg.GetTLSClientConfig()
 	if err != nil {
 		return nil, err

--- a/config/session_test.go
+++ b/config/session_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -469,6 +470,7 @@ func TestIncomingIDPTokenSessionCreator_CreateSession(t *testing.T) {
 		require.NoError(t, err)
 		req.Header.Set("Authorization", "Bearer ACCESS_TOKEN")
 		c := NewIncomingIDPTokenSessionCreator(
+			noop.NewTracerProvider(),
 			func(_ context.Context, _, _ string) (*databroker.Record, error) {
 				return nil, storage.ErrNotFound
 			},
@@ -512,6 +514,7 @@ func TestIncomingIDPTokenSessionCreator_CreateSession(t *testing.T) {
 		require.NoError(t, err)
 		req.Header.Set("Authorization", "Bearer IDENTITY_TOKEN")
 		c := NewIncomingIDPTokenSessionCreator(
+			noop.NewTracerProvider(),
 			func(_ context.Context, _, _ string) (*databroker.Record, error) {
 				return nil, storage.ErrNotFound
 			},

--- a/databroker/cache.go
+++ b/databroker/cache.go
@@ -195,6 +195,7 @@ func (c *DataBroker) update(_ context.Context, cfg *config.Config) error {
 		}),
 		manager.WithRefreshSessionAtIDTokenExpiration(manager.RefreshSessionAtIDTokenExpiration(
 			cfg.Options.RuntimeFlags[config.RuntimeFlagRefreshSessionAtIDTokenExpiration])),
+		manager.WithTracerProvider(c.tracerProvider),
 	}, c.managerOptions...)
 
 	if c.manager == nil {

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -277,7 +277,8 @@ func (src *ConfigSource) runUpdater(ctx context.Context, cfg *config.Config) {
 		client: client,
 		src:    src,
 	}, databroker.WithTypeURL(grpcutil.GetTypeURL(new(configpb.Config))),
-		databroker.WithFastForward())
+		databroker.WithFastForward(),
+		databroker.WithSyncerTracerProvider(src.tracerProvider))
 	go func() {
 		log.Ctx(ctx).Debug().
 			Str("outbound-port", cfg.OutboundPort).

--- a/internal/telemetry/component.go
+++ b/internal/telemetry/component.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
@@ -26,8 +25,7 @@ type Component struct {
 }
 
 // NewComponent creates a new Component.
-func NewComponent(logLevel zerolog.Level, component string, attributes ...attribute.KeyValue) *Component {
-	tracerProvider := otel.GetTracerProvider()
+func NewComponent(tracerProvider oteltrace.TracerProvider, logLevel zerolog.Level, component string, attributes ...attribute.KeyValue) *Component {
 	tracer := tracerProvider.Tracer(trace.PomeriumCoreTracer)
 
 	c := &Component{

--- a/internal/zero/cmd/run.go
+++ b/internal/zero/cmd/run.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/zero/controller"
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
 // Run runs the pomerium zero command.
@@ -32,6 +33,7 @@ func Run(ctx context.Context, configFile string) error {
 		controller.WithClusterAPIEndpoint(getClusterAPIEndpoint()),
 		controller.WithConnectAPIEndpoint(getConnectAPIEndpoint()),
 		controller.WithOTELAPIEndpoint(getOTELAPIEndpoint()),
+		controller.WithTracerProvider(trace.NewTracerProvider(ctx, "Zero")),
 	}
 
 	bootstrapConfigFileName, err := getBootstrapConfigFileName()

--- a/internal/zero/controller/config.go
+++ b/internal/zero/controller/config.go
@@ -1,6 +1,11 @@
 package controller
 
-import "time"
+import (
+	"time"
+
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+)
 
 // Option configures a controller.
 type Option func(*controllerConfig)
@@ -18,6 +23,7 @@ type controllerConfig struct {
 	reconcilerLeaseDuration  time.Duration
 	databrokerRequestTimeout time.Duration
 	shutdownTimeout          time.Duration
+	tracerProvider           oteltrace.TracerProvider
 }
 
 // WithTmpDir sets the temporary directory to use.
@@ -118,6 +124,13 @@ func WithShutdownTimeout(timeout time.Duration) Option {
 	}
 }
 
+// WithTracerProvider sets the tracer provider in the config.
+func WithTracerProvider(tracerProvider oteltrace.TracerProvider) Option {
+	return func(cfg *controllerConfig) {
+		cfg.tracerProvider = tracerProvider
+	}
+}
+
 func newControllerConfig(opts ...Option) *controllerConfig {
 	c := new(controllerConfig)
 
@@ -127,6 +140,7 @@ func newControllerConfig(opts ...Option) *controllerConfig {
 		WithDatabrokerLeaseDuration(time.Second * 30),
 		WithDatabrokerRequestTimeout(time.Second * 30),
 		WithShutdownTimeout(time.Second * 10),
+		WithTracerProvider(noop.NewTracerProvider()),
 	} {
 		opt(c)
 	}

--- a/internal/zero/controller/controller.go
+++ b/internal/zero/controller/controller.go
@@ -186,6 +186,7 @@ func (c *controller) runReconcilerLeased(ctx context.Context, client databroker.
 		return reconciler.Run(ctx,
 			reconciler.WithAPI(c.api),
 			reconciler.WithDataBrokerClient(client),
+			reconciler.WithTracerProvider(c.cfg.tracerProvider),
 		)
 	})
 }

--- a/internal/zero/reconciler/config.go
+++ b/internal/zero/reconciler/config.go
@@ -6,6 +6,9 @@ import (
 	"os"
 	"time"
 
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
 	sdk "github.com/pomerium/pomerium/internal/zero/api"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
@@ -25,6 +28,7 @@ type reconcilerConfig struct {
 	checkForUpdateIntervalWhenConnected    time.Duration
 
 	syncBackoffMaxInterval time.Duration
+	tracerProvider         oteltrace.TracerProvider
 }
 
 // Option configures the resource bundles reconciler
@@ -89,6 +93,13 @@ func WithSyncBackoffMaxInterval(interval time.Duration) Option {
 	}
 }
 
+// WithTracerProvider sets the tracer provider in the config.
+func WithTracerProvider(tracerProvider oteltrace.TracerProvider) Option {
+	return func(cfg *reconcilerConfig) {
+		cfg.tracerProvider = tracerProvider
+	}
+}
+
 func newConfig(opts ...Option) *reconcilerConfig {
 	cfg := &reconcilerConfig{}
 	for _, opt := range []Option{
@@ -98,6 +109,7 @@ func newConfig(opts ...Option) *reconcilerConfig {
 		WithCheckForUpdateIntervalWhenDisconnected(time.Minute * 5),
 		WithCheckForUpdateIntervalWhenConnected(time.Hour),
 		WithSyncBackoffMaxInterval(time.Minute),
+		WithTracerProvider(noop.NewTracerProvider()),
 	} {
 		opt(cfg)
 	}

--- a/internal/zero/reconciler/sync.go
+++ b/internal/zero/reconciler/sync.go
@@ -271,6 +271,7 @@ func (c *service) syncBundleToDatabroker(ctx context.Context, key string, src io
 		},
 		func(_ []*databroker.Record) {},
 		EqualRecord,
+		databroker.WithReconcilerTracerProvider(c.config.tracerProvider),
 	).Reconcile(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("reconcile databroker records: %w", err)

--- a/pkg/grpc/databroker/fast_forward.go
+++ b/pkg/grpc/databroker/fast_forward.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry"
@@ -33,12 +34,12 @@ type ffCmd struct {
 	records       []*Record
 }
 
-func newFastForwardHandler(ctx context.Context, id string, handler SyncerHandler) SyncerHandler {
+func newFastForwardHandler(ctx context.Context, tracerProvider oteltrace.TracerProvider, id string, handler SyncerHandler) SyncerHandler {
 	ff := &fastForwardHandler{
 		id:      id,
 		handler: handler,
 		pending: make(chan ffCmd, 1),
-		c:       telemetry.NewComponent(zerolog.DebugLevel, "databroker.fastforward", attribute.String(metrics.SyncerIDLabel, id)),
+		c:       telemetry.NewComponent(tracerProvider, zerolog.DebugLevel, "databroker.fastforward", attribute.String(metrics.SyncerIDLabel, id)),
 	}
 	go ff.run(ctx)
 	return ff

--- a/pkg/grpc/databroker/fast_forward_test.go
+++ b/pkg/grpc/databroker/fast_forward_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 )
 
 type mockFF struct {
@@ -46,7 +47,7 @@ func TestFastForward(t *testing.T) {
 		update: make(chan uint64),
 	}
 
-	f := newFastForwardHandler(ctx, "test", m)
+	f := newFastForwardHandler(ctx, noop.NewTracerProvider(), "test", m)
 
 	for x := 0; x < 100; x++ {
 		n := rand.Intn(100) + 1

--- a/pkg/grpc/databroker/syncer.go
+++ b/pkg/grpc/databroker/syncer.go
@@ -8,6 +8,8 @@ import (
 
 	backoff "github.com/cenkalti/backoff/v4"
 	"github.com/rs/zerolog"
+	oteltrace "go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -16,6 +18,7 @@ import (
 )
 
 type syncerConfig struct {
+	tracerProvider  oteltrace.TracerProvider
 	typeURL         string
 	withFastForward bool
 }
@@ -25,10 +28,18 @@ type SyncerOption func(cfg *syncerConfig)
 
 func getSyncerConfig(options ...SyncerOption) *syncerConfig {
 	cfg := new(syncerConfig)
+	WithSyncerTracerProvider(noop.NewTracerProvider())(cfg)
 	for _, option := range options {
 		option(cfg)
 	}
 	return cfg
+}
+
+// WithSyncerTracerProvider sets the tracer provider for the syncer.
+func WithSyncerTracerProvider(tracerProvider oteltrace.TracerProvider) SyncerOption {
+	return func(cfg *syncerConfig) {
+		cfg.tracerProvider = tracerProvider
+	}
 }
 
 // WithTypeURL restricts the sync'd results to the given type.
@@ -101,7 +112,7 @@ func NewSyncer(ctx context.Context, id string, handler SyncerHandler, options ..
 		id: id,
 	}
 	if s.cfg.withFastForward {
-		s.handler = newFastForwardHandler(closeCtx, id, handler)
+		s.handler = newFastForwardHandler(closeCtx, s.cfg.tracerProvider, id, handler)
 	}
 	return s
 }

--- a/pkg/identity/manager/sync.go
+++ b/pkg/identity/manager/sync.go
@@ -17,7 +17,8 @@ type sessionSyncerHandler struct {
 
 func newSessionSyncer(ctx context.Context, mgr *Manager) *databroker.Syncer {
 	return databroker.NewSyncer(ctx, "identity_manager/sessions", sessionSyncerHandler{baseCtx: ctx, mgr: mgr},
-		databroker.WithTypeURL(grpcutil.GetTypeURL(new(session.Session))))
+		databroker.WithTypeURL(grpcutil.GetTypeURL(new(session.Session))),
+		databroker.WithSyncerTracerProvider(mgr.cfg.Load().tracerProvider))
 }
 
 func (h sessionSyncerHandler) ClearRecords(ctx context.Context) {
@@ -51,7 +52,8 @@ type userSyncerHandler struct {
 
 func newUserSyncer(ctx context.Context, mgr *Manager) *databroker.Syncer {
 	return databroker.NewSyncer(ctx, "identity_manager/users", userSyncerHandler{baseCtx: ctx, mgr: mgr},
-		databroker.WithTypeURL(grpcutil.GetTypeURL(new(user.User))))
+		databroker.WithTypeURL(grpcutil.GetTypeURL(new(user.User))),
+		databroker.WithSyncerTracerProvider(mgr.cfg.Load().tracerProvider))
 }
 
 func (h userSyncerHandler) ClearRecords(ctx context.Context) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -19,7 +19,7 @@ import (
 
 // Errors
 var (
-	ErrNotFound             = errors.New("record not found")
+	ErrNotFound             = status.Error(codes.NotFound, "record not found")
 	ErrStreamDone           = errors.New("record stream done")
 	ErrInvalidServerVersion = status.Error(codes.Aborted, "invalid server version")
 	ErrInvalidRecordVersion = status.Error(codes.Aborted, "invalid record version")

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -87,6 +87,7 @@ func newProxyStateFromConfig(ctx context.Context, tracerProvider oteltrace.Trace
 	}
 
 	state.incomingIDPTokenSessionCreator = config.NewIncomingIDPTokenSessionCreator(
+		tracerProvider,
 		func(ctx context.Context, recordType, recordID string) (*databroker.Record, error) {
 			return storage.GetDataBrokerRecord(ctx, recordType, recordID, 0)
 		},


### PR DESCRIPTION
## Summary
Improve tracing:

1. Add a telemetry component to the idp token session creator and pass a tracing provider to it.
2. Wrap the http transport used to make requests to the authenticate service with an otelhttp transport so that the tracing context is preserved and the spans are joined together
3. Pass the tracer provider in several other places

## Related issues
- [ENG-2693](https://linear.app/pomerium/issue/ENG-2693/authorize-add-additional-tracing-to-the-incomingidptokensessioncreator)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
