### PR TITLE
authenticate: cache authenticators

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -43,6 +43,8 @@ func ValidateOptions(o *config.Options) error {
 
 // Authenticate contains data required to run the authenticate service.
 type Authenticate struct {
+	backgroundCtx context.Context
+
 	accessTokenVerificationCount          metric.Int64Counter
 	accessTokenValidVerificationCount     metric.Int64Counter
 	accessTokenInvalidVerificationCount   metric.Int64Counter
@@ -67,6 +69,8 @@ func New(ctx context.Context, cfg *config.Config, options ...Option) (*Authentic
 	tracer := tracerProvider.Tracer(trace.PomeriumCoreTracer)
 
 	a := &Authenticate{
+		backgroundCtx: ctx,
+
 		accessTokenVerificationCount: metrics.Int64Counter("authenticate.idp_access_token.verifications",
 			metric.WithDescription("Number of IDP access token verifications."),
 			metric.WithUnit("{verification}")),

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -222,7 +222,7 @@ func (a *Authenticate) signOutRedirect(w http.ResponseWriter, r *http.Request) e
 	options := a.options.Load()
 	idpID := a.getIdentityProviderIDForRequest(r)
 
-	authenticator, err := a.cfg.getIdentityProvider(ctx, a.tracerProvider, options, idpID)
+	authenticator, err := a.cfg.getIdentityProvider(a.backgroundCtx, a.tracerProvider, options, idpID)
 	if err != nil {
 		return err
 	}
@@ -293,7 +293,7 @@ func (a *Authenticate) reauthenticateOrFail(w http.ResponseWriter, r *http.Reque
 	options := a.options.Load()
 	idpID := a.getIdentityProviderIDForRequest(r)
 
-	authenticator, err := a.cfg.getIdentityProvider(r.Context(), a.tracerProvider, options, idpID)
+	authenticator, err := a.cfg.getIdentityProvider(a.backgroundCtx, a.tracerProvider, options, idpID)
 	if err != nil {
 		return err
 	}
@@ -409,7 +409,7 @@ Or contact your administrator.
 
 	idpID := state.flow.GetIdentityProviderIDForURLValues(redirectURL.Query())
 
-	authenticator, err := a.cfg.getIdentityProvider(ctx, a.tracerProvider, options, idpID)
+	authenticator, err := a.cfg.getIdentityProvider(a.backgroundCtx, a.tracerProvider, options, idpID)
 	if err != nil {
 		return nil, err
 	}
@@ -513,7 +513,7 @@ func (a *Authenticate) revokeSession(ctx context.Context, w http.ResponseWriter,
 
 	idpID := r.FormValue(urlutil.QueryIdentityProviderID)
 
-	authenticator, err := a.cfg.getIdentityProvider(ctx, a.tracerProvider, options, idpID)
+	authenticator, err := a.cfg.getIdentityProvider(a.backgroundCtx, a.tracerProvider, options, idpID)
 	if err != nil {
 		return ""
 	}

--- a/authenticate/handlers_verify.go
+++ b/authenticate/handlers_verify.go
@@ -21,7 +21,7 @@ func (a *Authenticate) verifyAccessToken(w http.ResponseWriter, r *http.Request)
 		return httputil.NewError(http.StatusBadRequest, err)
 	}
 
-	authenticator, err := a.cfg.getIdentityProvider(r.Context(), a.tracerProvider, a.options.Load(), req.IdentityProviderID)
+	authenticator, err := a.cfg.getIdentityProvider(a.backgroundCtx, a.tracerProvider, a.options.Load(), req.IdentityProviderID)
 	if err != nil {
 		return err
 	}
@@ -62,7 +62,7 @@ func (a *Authenticate) verifyIdentityToken(w http.ResponseWriter, r *http.Reques
 		return httputil.NewError(http.StatusBadRequest, err)
 	}
 
-	authenticator, err := a.cfg.getIdentityProvider(r.Context(), a.tracerProvider, a.options.Load(), req.IdentityProviderID)
+	authenticator, err := a.cfg.getIdentityProvider(a.backgroundCtx, a.tracerProvider, a.options.Load(), req.IdentityProviderID)
 	if err != nil {
 		return err
 	}

--- a/authenticate/identity.go
+++ b/authenticate/identity.go
@@ -1,25 +1,93 @@
 package authenticate
 
 import (
+	"cmp"
 	"context"
+	"net/url"
+	"sync"
 
+	"github.com/google/btree"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/pomerium/pomerium/config"
+	identitypb "github.com/pomerium/pomerium/pkg/grpc/identity"
 	"github.com/pomerium/pomerium/pkg/identity"
 )
 
+type cachedAuthenticator struct {
+	redirectURL               *url.URL
+	idp                       *identitypb.Provider
+	overwriteIDTokenOnRefresh bool
+	authenticator             identity.Authenticator
+}
+
+var cachedAuthenticators = struct {
+	sync.Mutex
+	*btree.BTreeG[cachedAuthenticator]
+}{
+	BTreeG: btree.NewG(2, func(a, b cachedAuthenticator) bool {
+		return cmp.Or(
+			compareURLs(a.redirectURL, b.redirectURL),
+			cmp.Compare(a.idp.Hash(), b.idp.Hash()),
+			compareBools(a.overwriteIDTokenOnRefresh, b.overwriteIDTokenOnRefresh),
+		) < 0
+	}),
+}
+
 func defaultGetIdentityProvider(ctx context.Context, tracerProvider oteltrace.TracerProvider, options *config.Options, idpID string) (identity.Authenticator, error) {
-	redirectURL, err := options.GetAuthenticateRedirectURL()
+	var err error
+	key := cachedAuthenticator{}
+
+	key.redirectURL, err = options.GetAuthenticateRedirectURL()
 	if err != nil {
 		return nil, err
 	}
 
-	idp, err := options.GetIdentityProviderForID(idpID)
+	key.idp, err = options.GetIdentityProviderForID(idpID)
 	if err != nil {
 		return nil, err
 	}
 
-	return identity.GetIdentityProvider(ctx, tracerProvider, idp, redirectURL,
-		options.RuntimeFlags[config.RuntimeFlagRefreshSessionAtIDTokenExpiration])
+	key.overwriteIDTokenOnRefresh = options.RuntimeFlags[config.RuntimeFlagRefreshSessionAtIDTokenExpiration]
+
+	cachedAuthenticators.Lock()
+	defer cachedAuthenticators.Unlock()
+
+	value, ok := cachedAuthenticators.Get(key)
+	if ok {
+		return value.authenticator, nil
+	}
+
+	key.authenticator, err = identity.GetIdentityProvider(ctx, tracerProvider, key.idp, key.redirectURL, key.overwriteIDTokenOnRefresh)
+	if err != nil {
+		return nil, err
+	}
+
+	cachedAuthenticators.ReplaceOrInsert(key)
+
+	return key.authenticator, nil
+}
+
+func compareBools(a, b bool) int {
+	switch {
+	case a && !b:
+		return -1
+	case b && !a:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func compareURLs(a, b *url.URL) int {
+	switch {
+	case a == nil && b == nil:
+		return 0
+	case a == nil:
+		return 1
+	case b == nil:
+		return -1
+	}
+
+	return cmp.Compare(a.String(), b.String())
 }

--- a/internal/testenv/selftests/tracing_test.go
+++ b/internal/testenv/selftests/tracing_test.go
@@ -98,7 +98,7 @@ func TestOTLPTracing(t *testing.T) {
 			Exact:              true,
 			CheckDetachedSpans: true,
 		},
-		Match{Name: testEnvironmentLocalTest, TraceCount: 1, Services: []string{"Test Environment", "Control Plane", "Data Broker"}},
+		Match{Name: testEnvironmentLocalTest, TraceCount: 1, Services: []string{"Authenticate", "Test Environment", "Control Plane", "Data Broker", "IDP"}},
 		Match{Name: testEnvironmentAuthenticate, TraceCount: 1, Services: allServices},
 		Match{Name: authenticateOAuth2Client, TraceCount: Greater(0)},
 		Match{Name: idpServerGetUserinfo, TraceCount: EqualToMatch(authenticateOAuth2Client)},


### PR DESCRIPTION
## Summary
Currently we create a new authenticator on every request. When creating sessions from incoming IdP tokens this results in HTTP requests to the OIDC discovery document and JWKS keys every time. These are unnecessary HTTP requests and should be cached.

Update the `defaultGetIdentityProvider` so that it will cache authenticators and re-use them. We actually have very similar functionality in the identity manager, but I wanted to minimize the number of changes since this will need to be backported. Future improvements would be to unify this into a single authenticator cache and also handle frequent changes to IdP settings. (as of now they will just stay cached until restart)

A separate access token validator is now being used. This lets us properly trace the requests and adds a default 10 second timeout when fetching keys. Because of the way the OIDC `RemoteKeySet` works, it doesn't use the passed-in context, but rather uses a background context, which will never be cancelled. As a result, if an HTTP request for keys were to get stuck, we'd never be able to resolve. With a timeout we should be able to recover. A future improvement would be to implement a new custom `KeySet` that uses the passed-in context rather than a background context for fetching keys. This would allow the spans to occur in the proper trace.

## Related issues
- [ENG-2701](https://linear.app/pomerium/issue/ENG-2701/authenticate-idp-access-token-verification-always-retrieves-the-openid)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
