### PR TITLE
ssh: terminate connection if corresponding session is revoked

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -63,7 +63,7 @@ func New(ctx context.Context, cfg *config.Config) (*Authorize, error) {
 	a.state = atomicutil.NewValue(state)
 
 	a.accessTracker = NewAccessTracker(a, accessTrackerMaxSize, accessTrackerDebouncePeriod)
-	a.ssh = ssh.NewStreamManager(ctx, ssh.NewAuth(ctx, a, a.currentConfig, a.tracerProvider), cfg)
+	a.ssh = ssh.NewStreamManager(ssh.NewAuth(a, a.currentConfig, a.tracerProvider), cfg)
 	a.ssh.Start(ctx)
 	return a, nil
 }

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -56,15 +56,15 @@ func New(ctx context.Context, cfg *config.Config) (*Authorize, error) {
 		tracerProvider: tracerProvider,
 		tracer:         tracer,
 	}
-	a.accessTracker = NewAccessTracker(a, accessTrackerMaxSize, accessTrackerDebouncePeriod)
-	a.ssh = ssh.NewStreamManager(ctx, ssh.NewAuth(a, a.currentConfig, a.tracerProvider), cfg)
-
 	state, err := newAuthorizeStateFromConfig(ctx, nil, tracerProvider, cfg, a.store, &a.outboundGrpcConn)
 	if err != nil {
 		return nil, err
 	}
 	a.state = atomicutil.NewValue(state)
 
+	a.accessTracker = NewAccessTracker(a, accessTrackerMaxSize, accessTrackerDebouncePeriod)
+	a.ssh = ssh.NewStreamManager(ctx, ssh.NewAuth(ctx, a, a.currentConfig, a.tracerProvider), cfg)
+	a.ssh.Start(ctx)
 	return a, nil
 }
 

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -64,7 +64,6 @@ func New(ctx context.Context, cfg *config.Config) (*Authorize, error) {
 
 	a.accessTracker = NewAccessTracker(a, accessTrackerMaxSize, accessTrackerDebouncePeriod)
 	a.ssh = ssh.NewStreamManager(ssh.NewAuth(a, a.currentConfig, a.tracerProvider), cfg)
-	a.ssh.Start(ctx)
 	return a, nil
 }
 
@@ -76,6 +75,9 @@ func (a *Authorize) GetDataBrokerServiceClient() databroker.DataBrokerServiceCli
 // Run runs the authorize service.
 func (a *Authorize) Run(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return a.ssh.Run(ctx)
+	})
 	eg.Go(func() error {
 		a.accessTracker.Run(ctx)
 		return nil

--- a/authorize/ssh_grpc.go
+++ b/authorize/ssh_grpc.go
@@ -94,7 +94,7 @@ func (a *Authorize) ServeChannel(stream extensions_ssh.StreamManagement_ServeCha
 	return handler.ServeChannel(stream)
 }
 
-func (a *Authorize) EvaluateSSH(ctx context.Context, streamId uint64, req *ssh.Request) (*evaluator.Result, error) {
+func (a *Authorize) EvaluateSSH(ctx context.Context, streamID uint64, req *ssh.Request) (*evaluator.Result, error) {
 	ctx = a.withQuerierForCheckRequest(ctx)
 
 	evalreq := evaluator.Request{
@@ -125,7 +125,7 @@ func (a *Authorize) EvaluateSSH(ctx context.Context, streamId uint64, req *ssh.R
 	allowed := res.Allow.Value && !res.Deny.Value
 
 	if allowed {
-		if err := a.ssh.SetSessionIDForStream(streamId, req.SessionID); err != nil {
+		if err := a.ssh.SetSessionIDForStream(streamID, req.SessionID); err != nil {
 			log.Ctx(ctx).Error().Err(err).Msg("failed to set session id for stream")
 			return nil, err
 		}

--- a/authorize/ssh_grpc.go
+++ b/authorize/ssh_grpc.go
@@ -94,7 +94,7 @@ func (a *Authorize) ServeChannel(stream extensions_ssh.StreamManagement_ServeCha
 	return handler.ServeChannel(stream)
 }
 
-func (a *Authorize) EvaluateSSH(ctx context.Context, req *ssh.Request) (*evaluator.Result, error) {
+func (a *Authorize) EvaluateSSH(ctx context.Context, streamId uint64, req *ssh.Request) (*evaluator.Result, error) {
 	ctx = a.withQuerierForCheckRequest(ctx)
 
 	evalreq := evaluator.Request{
@@ -122,7 +122,16 @@ func (a *Authorize) EvaluateSSH(ctx context.Context, req *ssh.Request) (*evaluat
 		return nil, err
 	}
 
-	skipLogging := req.LogOnlyIfDenied && res.Allow.Value && !res.Deny.Value
+	allowed := res.Allow.Value && !res.Deny.Value
+
+	if allowed {
+		if err := a.ssh.SetSessionIDForStream(streamId, req.SessionID); err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("failed to set session id for stream")
+			return nil, err
+		}
+	}
+
+	skipLogging := req.LogOnlyIfDenied && allowed
 	if !skipLogging {
 		s, _ := a.getDataBrokerSessionOrServiceAccount(ctx, req.SessionID, 0)
 

--- a/internal/testenv/environment.go
+++ b/internal/testenv/environment.go
@@ -52,6 +52,7 @@ import (
 	"github.com/pomerium/pomerium/internal/version"
 	"github.com/pomerium/pomerium/pkg/cmd/pomerium"
 	"github.com/pomerium/pomerium/pkg/envoy"
+	"github.com/pomerium/pomerium/pkg/grpc"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/health"
 	"github.com/pomerium/pomerium/pkg/identity/manager"
@@ -104,6 +105,8 @@ type Environment interface {
 	Host() string
 	SharedSecret() []byte
 	CookieSecret() []byte
+
+	NewDataBrokerServiceClient() databroker.DataBrokerServiceClient
 
 	Config() *config.Config
 
@@ -838,6 +841,15 @@ func (e *environment) SharedSecret() []byte {
 
 func (e *environment) CookieSecret() []byte {
 	return bytes.Clone(e.cookieSecret[:])
+}
+
+func (e *environment) NewDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	cc, err := grpc.NewGRPCClientConn(e.ctx, &grpc.Options{
+		Address:      fmt.Sprintf("%s:%d", e.host, e.ports.Outbound.Value()),
+		SignedJWTKey: e.sharedSecret[:],
+	})
+	e.require.NoError(err)
+	return databroker.NewDataBrokerServiceClient(cc)
 }
 
 func (e *environment) Stop() {

--- a/internal/testenv/selftests/tracing_test.go
+++ b/internal/testenv/selftests/tracing_test.go
@@ -98,7 +98,7 @@ func TestOTLPTracing(t *testing.T) {
 			Exact:              true,
 			CheckDetachedSpans: true,
 		},
-		Match{Name: testEnvironmentLocalTest, TraceCount: 1, Services: []string{"Authenticate", "Test Environment", "Control Plane", "Data Broker", "IDP"}},
+		Match{Name: testEnvironmentLocalTest, TraceCount: 1, Services: []string{"Authenticate", "Authorize", "Test Environment", "Control Plane", "Data Broker", "IDP"}},
 		Match{Name: testEnvironmentAuthenticate, TraceCount: 1, Services: allServices},
 		Match{Name: authenticateOAuth2Client, TraceCount: Greater(0)},
 		Match{Name: idpServerGetUserinfo, TraceCount: EqualToMatch(authenticateOAuth2Client)},

--- a/internal/testutil/tracetest/tracing.go
+++ b/internal/testutil/tracetest/tracing.go
@@ -438,7 +438,13 @@ func (tr *TraceResults) MatchTraces(t testing.TB, opts MatchOptions, matches ...
 
 				if m.Services != nil {
 					for _, trace := range traceDetails {
-						assert.ElementsMatch(t, m.Services, trace.Services)
+						ok := assert.ElementsMatch(t, m.Services, trace.Services)
+						if !ok {
+							t.Logf("trace details: %s", trace.Name)
+							for i, span := range trace.Spans {
+								t.Logf("  span %d: [%s] %s", i, span.Service, span.Raw.Name)
+							}
+						}
 					}
 				}
 			} else if _, ok := m.TraceCount.(Any); !ok {

--- a/pkg/ssh/auth.go
+++ b/pkg/ssh/auth.go
@@ -32,7 +32,7 @@ import (
 )
 
 type Evaluator interface {
-	EvaluateSSH(ctx context.Context, streamId uint64, req *Request) (*evaluator.Result, error)
+	EvaluateSSH(ctx context.Context, streamID uint64, req *Request) (*evaluator.Result, error)
 	GetDataBrokerServiceClient() databroker.DataBrokerServiceClient
 	InvalidateCacheForRecords(context.Context, ...*databroker.Record)
 }
@@ -53,7 +53,6 @@ type Auth struct {
 }
 
 func NewAuth(
-	ctx context.Context,
 	evaluator Evaluator,
 	currentConfig *atomicutil.Value[*config.Config],
 	tracerProvider oteltrace.TracerProvider,

--- a/pkg/ssh/auth.go
+++ b/pkg/ssh/auth.go
@@ -32,7 +32,7 @@ import (
 )
 
 type Evaluator interface {
-	EvaluateSSH(context.Context, *Request) (*evaluator.Result, error)
+	EvaluateSSH(ctx context.Context, streamId uint64, req *Request) (*evaluator.Result, error)
 	GetDataBrokerServiceClient() databroker.DataBrokerServiceClient
 	InvalidateCacheForRecords(context.Context, ...*databroker.Record)
 }
@@ -53,11 +53,22 @@ type Auth struct {
 }
 
 func NewAuth(
+	ctx context.Context,
 	evaluator Evaluator,
 	currentConfig *atomicutil.Value[*config.Config],
 	tracerProvider oteltrace.TracerProvider,
 ) *Auth {
-	return &Auth{evaluator, currentConfig, tracerProvider}
+	auth := &Auth{
+		evaluator:      evaluator,
+		currentConfig:  currentConfig,
+		tracerProvider: tracerProvider,
+	}
+	return auth
+}
+
+// GetDataBrokerServiceClient implements AuthInterface.
+func (a *Auth) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	return a.evaluator.GetDataBrokerServiceClient()
 }
 
 func (a *Auth) HandlePublicKeyMethodRequest(
@@ -108,7 +119,7 @@ func (a *Auth) handlePublicKeyMethodRequest(
 		}
 	}
 
-	res, err := a.evaluator.EvaluateSSH(ctx, sshreq)
+	res, err := a.evaluator.EvaluateSSH(ctx, info.StreamID, sshreq)
 	if err != nil {
 		return PublicKeyAuthMethodResponse{}, err
 	}
@@ -239,7 +250,7 @@ func (a *Auth) EvaluateDelayed(ctx context.Context, info StreamAuthInfo) error {
 	if err != nil {
 		return err
 	}
-	res, err := a.evaluator.EvaluateSSH(ctx, req)
+	res, err := a.evaluator.EvaluateSSH(ctx, info.StreamID, req)
 	if err != nil {
 		return err
 	}

--- a/pkg/ssh/auth_test.go
+++ b/pkg/ssh/auth_test.go
@@ -43,7 +43,7 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 		pe := func(context.Context, uint64, *ssh.Request) (*evaluator.Result, error) {
 			return nil, errors.New("error evaluating policy")
 		}
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{evaluateSSH: pe}, nil, nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe}, nil, nil)
 		_, err := a.UnexportedHandlePublicKeyMethodRequest(t.Context(), info, &req)
 		assert.ErrorContains(t, err, "error evaluating policy")
 	})
@@ -68,7 +68,7 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 				Deny:  evaluator.NewRuleResult(false),
 			}, nil
 		}
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{evaluateSSH: pe}, nil, nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe}, nil, nil)
 		res, err := a.HandlePublicKeyMethodRequest(t.Context(), info, &req)
 		assert.NoError(t, err)
 		assert.Empty(t, res.RequireAdditionalMethods)
@@ -88,7 +88,7 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 				Deny:  evaluator.NewRuleResult(true),
 			}, nil
 		}
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{evaluateSSH: pe}, nil, nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe}, nil, nil)
 		res, err := a.HandlePublicKeyMethodRequest(t.Context(), info, &req)
 		assert.NoError(t, err)
 		assert.Nil(t, res.Allow)
@@ -107,7 +107,7 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 				Deny:  evaluator.NewRuleResult(false),
 			}, nil
 		}
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{evaluateSSH: pe}, nil, nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe}, nil, nil)
 		res, err := a.HandlePublicKeyMethodRequest(t.Context(), info, &req)
 		assert.NoError(t, err)
 		assert.Nil(t, res.Allow)
@@ -126,7 +126,7 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 				Deny:  evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
 			}, nil
 		}
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{evaluateSSH: pe}, nil, nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe}, nil, nil)
 		res, err := a.HandlePublicKeyMethodRequest(t.Context(), info, &req)
 		assert.NoError(t, err)
 		assert.NotNil(t, res.Allow)
@@ -152,7 +152,7 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 				Deny:  evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
 			}, nil
 		}
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{pe, client}, nil, nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{pe, client}, nil, nil)
 		res, err := a.HandlePublicKeyMethodRequest(t.Context(), info, &req)
 		assert.NoError(t, err)
 		assert.NotNil(t, res.Allow)
@@ -187,7 +187,7 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 				Deny:  evaluator.NewRuleResult(false),
 			}, nil
 		}
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{pe, client}, nil, nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{pe, client}, nil, nil)
 		res, err := a.HandlePublicKeyMethodRequest(t.Context(), info, &req)
 		assert.NoError(t, err)
 		assert.NotNil(t, res.Allow)
@@ -213,7 +213,7 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 				Deny:  evaluator.NewRuleResult(false),
 			}, nil
 		}
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{pe, client}, nil, nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{pe, client}, nil, nil)
 		_, err := a.HandlePublicKeyMethodRequest(t.Context(), info, &req)
 		assert.ErrorContains(t, err, "internal error")
 	})
@@ -257,7 +257,7 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 		cfg.Options.ProviderURL = idpURL
 		cfg.Options.ClientID = "client-id"
 		cfg.Options.ClientSecret = "client-secret"
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{pe, client}, atomicutil.NewValue(&cfg), nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{pe, client}, atomicutil.NewValue(&cfg), nil)
 		info := ssh.StreamAuthInfo{
 			Username: ptr("username"),
 			Hostname: ptr("hostname"),
@@ -312,7 +312,7 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 		cfg.Options.ProviderURL = idpURL
 		cfg.Options.ClientID = "client-id"
 		cfg.Options.ClientSecret = "client-secret"
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{pe, client}, atomicutil.NewValue(&cfg), nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{pe, client}, atomicutil.NewValue(&cfg), nil)
 		info := ssh.StreamAuthInfo{
 			Username: ptr("username"),
 			Hostname: ptr("hostname"),
@@ -338,7 +338,7 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 		cfg.Options.ProviderURL = idpURL
 		cfg.Options.ClientID = "client-id"
 		cfg.Options.ClientSecret = "client-secret"
-		a := ssh.NewAuth(t.Context(), nil, atomicutil.NewValue(&cfg), nil)
+		a := ssh.NewAuth(nil, atomicutil.NewValue(&cfg), nil)
 		info := ssh.StreamAuthInfo{
 			Username: ptr("username"),
 			Hostname: ptr("hostname"),
@@ -389,7 +389,7 @@ func TestFormatSession(t *testing.T) {
 				}, nil
 			},
 		}
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{client: client}, nil, nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{client: client}, nil, nil)
 		info := ssh.StreamAuthInfo{
 			PublicKeyFingerprintSha256: []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
 		}
@@ -427,7 +427,7 @@ func TestDeleteSession(t *testing.T) {
 				return nil, putError
 			},
 		}
-		a := ssh.NewAuth(t.Context(), fakePolicyEvaluator{client: client}, nil, nil)
+		a := ssh.NewAuth(fakePolicyEvaluator{client: client}, nil, nil)
 		info := ssh.StreamAuthInfo{
 			PublicKeyFingerprintSha256: []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
 		}
@@ -441,8 +441,8 @@ type fakePolicyEvaluator struct {
 	client      databroker.DataBrokerServiceClient
 }
 
-func (f fakePolicyEvaluator) EvaluateSSH(ctx context.Context, streamId uint64, req *ssh.Request) (*evaluator.Result, error) {
-	return f.evaluateSSH(ctx, streamId, req)
+func (f fakePolicyEvaluator) EvaluateSSH(ctx context.Context, streamID uint64, req *ssh.Request) (*evaluator.Result, error) {
+	return f.evaluateSSH(ctx, streamID, req)
 }
 
 func (f fakePolicyEvaluator) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {

--- a/pkg/ssh/cli.go
+++ b/pkg/ssh/cli.go
@@ -67,7 +67,7 @@ func NewCLI(
 	return cli
 }
 
-func (cli *CLI) AddLogoutCommand(ctrl ChannelControlInterface) {
+func (cli *CLI) AddLogoutCommand(_ ChannelControlInterface) {
 	cli.AddCommand(&cobra.Command{
 		Use:           "logout",
 		Short:         "Log out",

--- a/pkg/ssh/cli.go
+++ b/pkg/ssh/cli.go
@@ -69,15 +69,12 @@ func NewCLI(
 
 func (cli *CLI) AddLogoutCommand(ctrl ChannelControlInterface) {
 	cli.AddCommand(&cobra.Command{
-		Use:   "logout",
-		Short: "Log out",
+		Use:           "logout",
+		Short:         "Log out",
+		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			err := ctrl.DeleteSession(cmd.Context())
-			if err != nil {
-				return fmt.Errorf("failed to delete session: %w\r", err)
-			}
 			_, _ = cmd.OutOrStdout().Write([]byte("Logged out successfully\r\n"))
-			return nil
+			return ErrDeleteSessionOnExit
 		},
 	})
 }
@@ -100,6 +97,10 @@ func (cli *CLI) AddWhoamiCommand(ctrl ChannelControlInterface) {
 // ErrHandoff is a sentinel error to indicate that the command triggered a handoff,
 // and we should not automatically disconnect
 var ErrHandoff = errors.New("handoff")
+
+// ErrDeleteSessionOnExit is a sentinel error to indicate that the authorized
+// session should be deleted once the SSH connection ends.
+var ErrDeleteSessionOnExit = errors.New("delete_session_on_exit")
 
 func (cli *CLI) AddPortalCommand(ctrl ChannelControlInterface) {
 	cli.AddCommand(&cobra.Command{

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -2,30 +2,119 @@ package ssh
 
 import (
 	"context"
+	"errors"
 	"sync"
+	"time"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type StreamManager struct {
-	auth    AuthInterface
-	reauthC chan struct{}
+	auth               AuthInterface
+	reauthC            chan struct{}
+	initialSyncDone    bool
+	waitForInitialSync chan struct{}
 
 	mu            sync.Mutex
 	cfg           *config.Config
 	activeStreams map[uint64]*StreamHandler
+	// Tracks session IDs for active streams
+	activeStreamSessions map[uint64]string
+	// Tracks stream IDs for active sessions
+	sessionStreams map[string]map[uint64]struct{}
+}
+
+// ClearRecords implements databroker.SyncerHandler.
+func (sm *StreamManager) ClearRecords(ctx context.Context) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	if !sm.initialSyncDone {
+		sm.initialSyncDone = true
+		close(sm.waitForInitialSync)
+		log.Ctx(ctx).Debug().
+			Msg("ssh stream manager: initial sync done")
+		return
+	}
+	for sessionID, streamIDs := range sm.sessionStreams {
+		for streamID := range streamIDs {
+			log.Ctx(ctx).Debug().
+				Str("session-id", sessionID).
+				Uint64("stream-id", streamID).
+				Msg("terminating stream: databroker sync reset")
+			sm.terminateStreamLocked(streamID)
+		}
+	}
+	clear(sm.sessionStreams)
+}
+
+// GetDataBrokerServiceClient implements databroker.SyncerHandler.
+func (sm *StreamManager) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	return sm.auth.GetDataBrokerServiceClient()
+}
+
+// UpdateRecords implements databroker.SyncerHandler.
+func (sm *StreamManager) UpdateRecords(ctx context.Context, serverVersion uint64, records []*databroker.Record) {
+	sm.mu.Lock()
+	defer sm.mu.Unlock()
+	for _, record := range records {
+		if record.DeletedAt == nil {
+			continue
+		}
+		// a session was deleted; terminate all of its associated streams
+		for streamID := range sm.sessionStreams[record.Id] {
+			log.Ctx(ctx).Debug().
+				Str("session-id", record.Id).
+				Uint64("stream-id", streamID).
+				Msg("terminating stream: session revoked")
+			sm.terminateStreamLocked(streamID)
+		}
+		delete(sm.sessionStreams, record.Id)
+	}
+}
+
+func (sm *StreamManager) SetSessionIDForStream(streamID uint64, sessionID string) error {
+	sm.mu.Lock()
+	for !sm.initialSyncDone {
+		sm.mu.Unlock()
+		select {
+		case <-sm.waitForInitialSync:
+		case <-time.After(10 * time.Second):
+			return errors.New("timed out waiting for initial sync")
+		}
+		sm.mu.Lock()
+	}
+	defer sm.mu.Unlock()
+	if sm.sessionStreams[sessionID] == nil {
+		sm.sessionStreams[sessionID] = map[uint64]struct{}{}
+	}
+	sm.sessionStreams[sessionID][streamID] = struct{}{}
+	sm.activeStreamSessions[streamID] = sessionID
+	return nil
 }
 
 func NewStreamManager(ctx context.Context, auth AuthInterface, cfg *config.Config) *StreamManager {
 	sm := &StreamManager{
-		auth:          auth,
-		reauthC:       make(chan struct{}, 1),
-		cfg:           cfg,
-		activeStreams: map[uint64]*StreamHandler{},
+		auth:                 auth,
+		waitForInitialSync:   make(chan struct{}),
+		reauthC:              make(chan struct{}, 1),
+		cfg:                  cfg,
+		activeStreams:        map[uint64]*StreamHandler{},
+		activeStreamSessions: map[uint64]string{},
+		sessionStreams:       map[string]map[uint64]struct{}{},
 	}
-	go sm.reauthLoop(ctx)
 	return sm
+}
+
+func (sm *StreamManager) Start(ctx context.Context) {
+	syncer := databroker.NewSyncer(ctx, "ssh-auth-session-sync", sm,
+		databroker.WithTypeURL("type.googleapis.com/session.Session"))
+	go syncer.Run(ctx)
+	go sm.reauthLoop(ctx)
 }
 
 func (sm *StreamManager) OnConfigChange(cfg *config.Config) {
@@ -59,10 +148,18 @@ func (sm *StreamManager) NewStreamHandler(
 		readC:      make(chan *extensions_ssh.ClientMessage, 32),
 		writeC:     writeC,
 		reauthC:    make(chan struct{}),
+		terminateC: make(chan error, 1),
 		close: func() {
 			sm.mu.Lock()
 			defer sm.mu.Unlock()
 			delete(sm.activeStreams, streamID)
+			if sessionID, ok := sm.activeStreamSessions[streamID]; ok {
+				delete(sm.sessionStreams[sessionID], streamID)
+				if len(sm.sessionStreams[sessionID]) == 0 {
+					delete(sm.sessionStreams, sessionID)
+				}
+			}
+			delete(sm.activeStreamSessions, streamID)
 			close(writeC)
 		},
 	}
@@ -87,5 +184,11 @@ func (sm *StreamManager) reauthLoop(ctx context.Context) {
 				s.Reauth()
 			}
 		}
+	}
+}
+
+func (sm *StreamManager) terminateStreamLocked(streamID uint64) {
+	if sh, ok := sm.activeStreams[streamID]; ok {
+		sh.Terminate(status.Errorf(codes.PermissionDenied, "no longer authorized"))
 	}
 }

--- a/pkg/ssh/manager_test.go
+++ b/pkg/ssh/manager_test.go
@@ -36,7 +36,7 @@ func TestStreamManager(t *testing.T) {
 		{From: "ssh://host2", To: mustParseWeightedURLs(t, "ssh://dest2:22")},
 	}
 	m := ssh.NewStreamManager(auth, cfg)
-	// intentionally don't call m.Start() - simulate initial sync completing
+	// intentionally don't call m.Run() - simulate initial sync completing
 	m.ClearRecords(t.Context())
 	t.Run("LookupStream", func(t *testing.T) {
 		assert.Nil(t, m.LookupStream(1234))

--- a/pkg/ssh/manager_test.go
+++ b/pkg/ssh/manager_test.go
@@ -1,14 +1,21 @@
 package ssh_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/ssh"
 	mock_ssh "github.com/pomerium/pomerium/pkg/ssh/mock"
 )
@@ -29,12 +36,118 @@ func TestStreamManager(t *testing.T) {
 		{From: "ssh://host2", To: mustParseWeightedURLs(t, "ssh://dest2:22")},
 	}
 	m := ssh.NewStreamManager(t.Context(), auth, cfg)
-
+	// intentionally don't call m.Start() - simulate initial sync completing
+	m.ClearRecords(context.Background())
 	t.Run("LookupStream", func(t *testing.T) {
 		assert.Nil(t, m.LookupStream(1234))
 		sh := m.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 1234})
+		done := make(chan error)
+		ctx, ca := context.WithCancel(t.Context())
+		go func() {
+			done <- sh.Run(ctx)
+		}()
 		assert.Equal(t, sh, m.LookupStream(1234))
 		sh.Close()
 		assert.Nil(t, m.LookupStream(1234))
+		ca()
+		err := <-done
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("TerminateStreamOnSessionDelete", func(t *testing.T) {
+		sh := m.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 1234})
+		done := make(chan error)
+		go func() {
+			done <- sh.Run(t.Context())
+		}()
+
+		m.SetSessionIDForStream(1234, "test-id-1")
+		m.UpdateRecords(context.Background(), 0, []*databroker.Record{
+			{
+				Type: "type.googleapis.com/session.Session",
+				Id:   "test-id-1",
+				Data: marshalAny(&session.Session{}),
+			},
+			{
+				Type:      "type.googleapis.com/session.Session",
+				Id:        "test-id-1",
+				Data:      marshalAny(&session.Session{}),
+				DeletedAt: timestamppb.Now(),
+			},
+		})
+		select {
+		case err := <-done:
+			assert.ErrorIs(t, err, status.Errorf(codes.PermissionDenied, "no longer authorized"))
+		case <-time.After(1 * time.Second):
+			t.Fail()
+		}
+	})
+
+	t.Run("TerminateMultipleStreamsForSession", func(t *testing.T) {
+		sh1 := m.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 1})
+		done1 := make(chan error)
+		go func() {
+			done1 <- sh1.Run(t.Context())
+		}()
+		sh2 := m.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 2})
+		done2 := make(chan error)
+		go func() {
+			done2 <- sh2.Run(t.Context())
+		}()
+		m.SetSessionIDForStream(1, "test-id-1")
+		m.SetSessionIDForStream(2, "test-id-1")
+		m.UpdateRecords(context.Background(), 0, []*databroker.Record{
+			{
+				Type: "type.googleapis.com/session.Session",
+				Id:   "test-id-1",
+				Data: marshalAny(&session.Session{}),
+			},
+			{
+				Type:      "type.googleapis.com/session.Session",
+				Id:        "test-id-1",
+				Data:      marshalAny(&session.Session{}),
+				DeletedAt: timestamppb.Now(),
+			},
+		})
+		select {
+		case err := <-done1:
+			assert.ErrorIs(t, err, status.Errorf(codes.PermissionDenied, "no longer authorized"))
+		case <-time.After(1 * time.Second):
+			t.Fail()
+		}
+		select {
+		case err := <-done2:
+			assert.ErrorIs(t, err, status.Errorf(codes.PermissionDenied, "no longer authorized"))
+		case <-time.After(1 * time.Second):
+			t.Fail()
+		}
+	})
+
+	t.Run("ClearRecords", func(t *testing.T) {
+		sh1 := m.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 1})
+		done1 := make(chan error)
+		go func() {
+			done1 <- sh1.Run(t.Context())
+		}()
+		sh2 := m.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 2})
+		done2 := make(chan error)
+		go func() {
+			done2 <- sh2.Run(t.Context())
+		}()
+		m.SetSessionIDForStream(1, "test-id-1")
+		m.SetSessionIDForStream(2, "test-id-2")
+		m.ClearRecords(context.Background())
+		select {
+		case err := <-done1:
+			assert.ErrorIs(t, err, status.Errorf(codes.PermissionDenied, "no longer authorized"))
+		case <-time.After(1 * time.Second):
+			t.Fail()
+		}
+		select {
+		case err := <-done2:
+			assert.ErrorIs(t, err, status.Errorf(codes.PermissionDenied, "no longer authorized"))
+		case <-time.After(1 * time.Second):
+			t.Fail()
+		}
 	})
 }

--- a/pkg/ssh/manager_test.go
+++ b/pkg/ssh/manager_test.go
@@ -35,9 +35,9 @@ func TestStreamManager(t *testing.T) {
 		{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://dest1:22")},
 		{From: "ssh://host2", To: mustParseWeightedURLs(t, "ssh://dest2:22")},
 	}
-	m := ssh.NewStreamManager(t.Context(), auth, cfg)
+	m := ssh.NewStreamManager(auth, cfg)
 	// intentionally don't call m.Start() - simulate initial sync completing
-	m.ClearRecords(context.Background())
+	m.ClearRecords(t.Context())
 	t.Run("LookupStream", func(t *testing.T) {
 		assert.Nil(t, m.LookupStream(1234))
 		sh := m.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: 1234})
@@ -62,7 +62,7 @@ func TestStreamManager(t *testing.T) {
 		}()
 
 		m.SetSessionIDForStream(1234, "test-id-1")
-		m.UpdateRecords(context.Background(), 0, []*databroker.Record{
+		m.UpdateRecords(t.Context(), 0, []*databroker.Record{
 			{
 				Type: "type.googleapis.com/session.Session",
 				Id:   "test-id-1",
@@ -96,7 +96,7 @@ func TestStreamManager(t *testing.T) {
 		}()
 		m.SetSessionIDForStream(1, "test-id-1")
 		m.SetSessionIDForStream(2, "test-id-1")
-		m.UpdateRecords(context.Background(), 0, []*databroker.Record{
+		m.UpdateRecords(t.Context(), 0, []*databroker.Record{
 			{
 				Type: "type.googleapis.com/session.Session",
 				Id:   "test-id-1",
@@ -136,7 +136,7 @@ func TestStreamManager(t *testing.T) {
 		}()
 		m.SetSessionIDForStream(1, "test-id-1")
 		m.SetSessionIDForStream(2, "test-id-2")
-		m.ClearRecords(context.Background())
+		m.ClearRecords(t.Context())
 		select {
 		case err := <-done1:
 			assert.ErrorIs(t, err, status.Errorf(codes.PermissionDenied, "no longer authorized"))

--- a/pkg/ssh/mock/mock_auth_interface.go
+++ b/pkg/ssh/mock/mock_auth_interface.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
+	databroker "github.com/pomerium/pomerium/pkg/grpc/databroker"
 	ssh0 "github.com/pomerium/pomerium/pkg/ssh"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -153,6 +154,44 @@ func (c *MockAuthInterfaceFormatSessionCall) Do(f func(context.Context, ssh0.Str
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockAuthInterfaceFormatSessionCall) DoAndReturn(f func(context.Context, ssh0.StreamAuthInfo) ([]byte, error)) *MockAuthInterfaceFormatSessionCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// GetDataBrokerServiceClient mocks base method.
+func (m *MockAuthInterface) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDataBrokerServiceClient")
+	ret0, _ := ret[0].(databroker.DataBrokerServiceClient)
+	return ret0
+}
+
+// GetDataBrokerServiceClient indicates an expected call of GetDataBrokerServiceClient.
+func (mr *MockAuthInterfaceMockRecorder) GetDataBrokerServiceClient() *MockAuthInterfaceGetDataBrokerServiceClientCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataBrokerServiceClient", reflect.TypeOf((*MockAuthInterface)(nil).GetDataBrokerServiceClient))
+	return &MockAuthInterfaceGetDataBrokerServiceClientCall{Call: call}
+}
+
+// MockAuthInterfaceGetDataBrokerServiceClientCall wrap *gomock.Call
+type MockAuthInterfaceGetDataBrokerServiceClientCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAuthInterfaceGetDataBrokerServiceClientCall) Return(arg0 databroker.DataBrokerServiceClient) *MockAuthInterfaceGetDataBrokerServiceClientCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAuthInterfaceGetDataBrokerServiceClientCall) Do(f func() databroker.DataBrokerServiceClient) *MockAuthInterfaceGetDataBrokerServiceClientCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAuthInterfaceGetDataBrokerServiceClientCall) DoAndReturn(f func() databroker.DataBrokerServiceClient) *MockAuthInterfaceGetDataBrokerServiceClientCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/pkg/ssh/ssh_export_test.go
+++ b/pkg/ssh/ssh_export_test.go
@@ -1,0 +1,23 @@
+package ssh
+
+import (
+	"context"
+
+	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
+)
+
+func (a *Auth) UnexportedHandlePublicKeyMethodRequest(
+	ctx context.Context,
+	info StreamAuthInfo,
+	req *extensions_ssh.PublicKeyMethodRequest,
+) (PublicKeyAuthMethodResponse, error) {
+	return a.handlePublicKeyMethodRequest(ctx, info, req)
+}
+
+func (a *Auth) UnexportedHandleKeyboardInteractiveMethodRequest(
+	ctx context.Context,
+	info StreamAuthInfo,
+	querier KeyboardInteractiveQuerier,
+) (KeyboardInteractiveAuthMethodResponse, error) {
+	return a.handleKeyboardInteractiveMethodRequest(ctx, info, querier)
+}

--- a/pkg/ssh/stream_test.go
+++ b/pkg/ssh/stream_test.go
@@ -135,7 +135,7 @@ func (s *StreamHandlerSuite) SetupTest() {
 	}
 
 	s.mgr = ssh.NewStreamManager(s.mockAuth, s.cfg)
-	// intentionally don't call m.Start() - simulate initial sync completing
+	// intentionally don't call m.Run() - simulate initial sync completing
 	s.mgr.ClearRecords(context.Background())
 }
 

--- a/pkg/ssh/stream_test.go
+++ b/pkg/ssh/stream_test.go
@@ -134,7 +134,7 @@ func (s *StreamHandlerSuite) SetupTest() {
 		f(s.cfg)
 	}
 
-	s.mgr = ssh.NewStreamManager(context.Background(), s.mockAuth, s.cfg)
+	s.mgr = ssh.NewStreamManager(s.mockAuth, s.cfg)
 	// intentionally don't call m.Start() - simulate initial sync completing
 	s.mgr.ClearRecords(context.Background())
 }

--- a/pkg/ssh/stream_test.go
+++ b/pkg/ssh/stream_test.go
@@ -135,6 +135,8 @@ func (s *StreamHandlerSuite) SetupTest() {
 	}
 
 	s.mgr = ssh.NewStreamManager(context.Background(), s.mockAuth, s.cfg)
+	// intentionally don't call m.Start() - simulate initial sync completing
+	s.mgr.ClearRecords(context.Background())
 }
 
 func (s *StreamHandlerSuite) TearDownTest() {

--- a/pkg/ssh/stream_test.go
+++ b/pkg/ssh/stream_test.go
@@ -1212,7 +1212,7 @@ func init() {
 	StreamHandlerSuiteBeforeTestHooks["TestServeChannel_Session_Exec_Whoami"] = HookWithArgs(hook, Eq(status.Errorf(codes.Canceled, "channel closed")))
 	StreamHandlerSuiteBeforeTestHooks["TestServeChannel_Session_Exec_WhoamiError"] = HookWithArgs(hook, Eq(status.Errorf(codes.Canceled, "channel closed")))
 	StreamHandlerSuiteBeforeTestHooks["TestServeChannel_Session_Exec_Logout"] = HookWithArgs(hook, Eq(status.Errorf(codes.Canceled, "channel closed")))
-	StreamHandlerSuiteBeforeTestHooks["TestServeChannel_Session_Exec_LogoutError"] = HookWithArgs(hook, Eq(status.Errorf(codes.Canceled, "channel closed")))
+	StreamHandlerSuiteBeforeTestHooks["TestServeChannel_Session_Exec_LogoutError"] = HookWithArgs(hook, Eq(status.Errorf(codes.Aborted, "failed to delete session")))
 	StreamHandlerSuiteBeforeTestHooks["TestServeChannel_Session_RoutesPortal_NonInteractiveError"] = HookWithArgs(hook, Eq(status.Errorf(codes.Canceled, "channel closed")))
 	StreamHandlerSuiteBeforeTestHooks["TestServeChannel_Session_RoutesPortalDisabled_NoArgs"] = RuntimeFlagDependentHookWithArgs(hook,
 		config.RuntimeFlagSSHRoutesPortal, []any{Not(Nil())}, []any{Eq(status.Errorf(codes.Canceled, "channel closed"))})
@@ -1927,7 +1927,7 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_LogoutError() {
 
 	s.mockAuth.EXPECT().
 		DeleteSession(Any(), Any()).
-		Return(errors.New("test error"))
+		Return(status.Errorf(codes.Aborted, "failed to delete session"))
 
 	stream.SendClientToServer(channelMsg(ssh.ChannelRequestMsg{
 		PeersID:   peerID,
@@ -1939,8 +1939,10 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_LogoutError() {
 	}))
 	recvChannelMsg[ssh.ChannelRequestSuccessMsg](s, stream)
 
-	channelData := s.channelDataLoop(peerID, stream, 1)
-	s.Equal("Error: failed to delete session: test error\r\n", channelData.String())
+	channelData := s.channelDataLoop(peerID, stream, 0)
+	// The user will see this, but the error is propagated internally
+	s.Equal("Logged out successfully\r\n", channelData.String())
+	// error checked in cleanup
 }
 
 func (s *StreamHandlerSuite) TestServeChannel_DirectTcpip_NoSubMsg() {


### PR DESCRIPTION
If an SSH session record is deleted from the databroker, any active connections for that session will be closed. 