### PR TITLE
postgres: ignore canceled context when reporting health for flaky test

### DIFF
--- a/pkg/storage/postgres/backend.go
+++ b/pkg/storage/postgres/backend.go
@@ -73,6 +73,11 @@ func New(ctx context.Context, dsn string, options ...Option) *Backend {
 
 	go backend.doPeriodically(func(ctx context.Context) error {
 		err := backend.ping(ctx)
+		// ignore canceled errors
+		if errors.Is(err, context.Canceled) {
+			return nil
+		}
+
 		if err != nil {
 			health.ReportError(health.StorageBackend, err, health.StrAttr("backend", "postgres"))
 		} else {


### PR DESCRIPTION
## Summary
Postgres tests have been failing when the context is canceled. This appears to happen when health is reported. So we can just ignore that error and skip reporting health if it happens.


## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
