### PR TITLE
log: separate grpc log level from pomerium log level

### DIFF
--- a/internal/log/grpc.go
+++ b/internal/log/grpc.go
@@ -15,90 +15,85 @@ func init() {
 	if level, ok := os.LookupEnv("GRPC_GO_LOG_VERBOSITY_LEVEL"); ok {
 		verbosityLevel, _ = strconv.Atoi(level) // default is 0
 	}
-	getLevel := GetLevel
-	// if the standard grpc severity level is set, it should take priority
+	logLevel := zerolog.Disabled
 	if severity, ok := os.LookupEnv("GRPC_GO_LOG_SEVERITY_LEVEL"); ok {
-		var severityOverride zerolog.Level
 		if level, err := zerolog.ParseLevel(severity); err == nil {
-			severityOverride = level
+			logLevel = level
 		} else {
 			// some non-standard but common values
 			switch strings.ToLower(strings.TrimSpace(severity)) {
 			case "off":
-				severityOverride = zerolog.Disabled
+				logLevel = zerolog.Disabled
 			case "err":
-				severityOverride = zerolog.ErrorLevel
+				logLevel = zerolog.ErrorLevel
 			case "warning": // zerolog only recognizes "warn"
-				severityOverride = zerolog.WarnLevel
+				logLevel = zerolog.WarnLevel
 			default:
-				severityOverride = zerolog.ErrorLevel
+				logLevel = zerolog.ErrorLevel
 			}
-		}
-		getLevel = func() zerolog.Level {
-			return severityOverride
 		}
 	}
 	grpclog.SetLoggerV2(&grpcLogger{
 		verbosityLevel: verbosityLevel,
-		getLevel:       getLevel,
+		logLevel:       logLevel,
 	})
 }
 
 type grpcLogger struct {
 	verbosityLevel int
-	getLevel       func() zerolog.Level
+	logLevel       zerolog.Level
 }
 
 func (c *grpcLogger) Info(args ...any) {
-	if c.getLevel() <= zerolog.DebugLevel {
+	if c.logLevel <= zerolog.DebugLevel {
 		Logger().Debug().Msg(fmt.Sprint(args...))
 	}
 }
 
 func (c *grpcLogger) Infoln(args ...any) {
-	if c.getLevel() <= zerolog.DebugLevel {
+	if c.logLevel <= zerolog.DebugLevel {
 		Logger().Debug().Msg(fmt.Sprintln(args...))
 	}
 }
 
 func (c *grpcLogger) Infof(format string, args ...any) {
-	if c.getLevel() <= zerolog.DebugLevel {
+	if c.logLevel <= zerolog.DebugLevel {
 		Logger().Debug().Msg(fmt.Sprintf(format, args...))
 	}
 }
 
 func (c *grpcLogger) Warning(args ...any) {
-	if c.getLevel() <= zerolog.DebugLevel {
+	if c.logLevel <= zerolog.DebugLevel {
 		Logger().Warn().Msg(fmt.Sprint(args...))
 	}
 }
 
 func (c *grpcLogger) Warningln(args ...any) {
-	if c.getLevel() <= zerolog.DebugLevel {
+	if c.logLevel <= zerolog.DebugLevel {
 		Logger().Warn().Msg(fmt.Sprintln(args...))
 	}
 }
 
 func (c *grpcLogger) Warningf(format string, args ...any) {
-	if c.getLevel() <= zerolog.DebugLevel {
+	if c.logLevel <= zerolog.DebugLevel {
 		Logger().Warn().Msg(fmt.Sprintf(format, args...))
 	}
 }
 
 func (c *grpcLogger) Error(args ...any) {
-	if c.getLevel() <= zerolog.DebugLevel {
+	if c.logLevel <= zerolog.DebugLevel {
 		Logger().Error().Msg(fmt.Sprint(args...))
 	}
 }
 
 func (c *grpcLogger) Errorln(args ...any) {
-	if c.getLevel() <= zerolog.DebugLevel {
+	if c.logLevel <= zerolog.DebugLevel {
 		Logger().Error().Msg(fmt.Sprintln(args...))
 	}
 }
 
 func (c *grpcLogger) Errorf(format string, args ...any) {
-	if c.getLevel() <= zerolog.DebugLevel {
+	if c.logLevel <= zerolog.DebugLevel {
 		Logger().Error().Msg(fmt.Sprintf(format, args...))
 	}
 }


### PR DESCRIPTION
The internal grpc logs are not very useful to us in most cases, and they are noisy at debug level. This keeps them disabled by default, using the standard grpc environment variables to control verbosity and severity, but still using the pomerium zerolog logger.