### PR TITLE
telemetry: rm non-static labels

### DIFF
--- a/pkg/grpc/databroker/fast_forward.go
+++ b/pkg/grpc/databroker/fast_forward.go
@@ -99,9 +99,7 @@ func (ff *fastForwardHandler) ClearRecords(ctx context.Context) {
 }
 
 func (ff *fastForwardHandler) UpdateRecords(ctx context.Context, serverVersion uint64, records []*Record) {
-	ctx, op := ff.c.Start(ctx, "Enqueue/UpdateRecords",
-		attribute.Int("records-in", len(records)),
-	)
+	ctx, op := ff.c.Start(ctx, "Enqueue/UpdateRecords")
 	defer op.Complete()
 
 	ff.mu.Lock()
@@ -144,9 +142,6 @@ func (ff *fastForwardHandler) UpdateRecords(ctx context.Context, serverVersion u
 	case <-ctx.Done():
 		_ = op.Failure(errors.New("cancelled"))
 	case ff.pending <- cmd:
-		op.Complete(
-			attribute.Int("records-enqueued", len(records)),
-			attribute.Int("records-dropped", dropped),
-		)
+		op.Complete()
 	}
 }


### PR DESCRIPTION
## Summary

Removes non-static metric/trace labels from databroker fast-forward component.

## Related issues

Fix: https://linear.app/pomerium/issue/ENG-2727/databrokerfast-forward-rm-metric-attributes

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
