### PR TITLE
fix(metrics): enforce prometheus legacy scheme on client side exporter

### DIFF
--- a/internal/telemetry/metrics/otel.go
+++ b/internal/telemetry/metrics/otel.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"github.com/prometheus/common/model"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/prometheus"
 	"go.opentelemetry.io/otel/metric"
@@ -11,6 +12,7 @@ import (
 var Meter metric.Meter
 
 func init() {
+	model.NameValidationScheme = model.LegacyValidation
 	e, err := prometheus.New(
 		prometheus.WithNamespace("pomerium"),
 		prometheus.WithoutUnits(),


### PR DESCRIPTION
## Summary

This is related to prometheus 3.X  changing the behaviour of valid metric names, now any string is technically a valid metric name. 

In prometheus 2.X, metric names were strictly enforced with something like ([a-z][0-9]|_)+

Since OpenTelemetry conventions already accepted non-prometheus strings as metric names, when they made the move to update the prometheus exporter to Prometheus 3 they carelessly introducing breaking changes to how exposed metric naming works (breaking dashboards and alerts for downstream consumers of said metrics)…


Their move to consolidate metric translation between the two formats (following best practice) in https://github.com/prometheus/otlptranslator, still seems to have introduced inconsistent behavior.
## Related issues

<!-- For example...
- #159
-->
[ENG-2726](https://linear.app/pomerium/issue/ENG-2726/prometheus-metrics-names-altered-after-scrape)

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
