### PR TITLE
grpc: refactor databroker errors

### DIFF
--- a/authorize/access_tracker.go
+++ b/authorize/access_tracker.go
@@ -2,12 +2,11 @@ package authorize
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -138,7 +137,7 @@ func (tracker *AccessTracker) updateServiceAccount(
 	defer clearTimeout()
 
 	sa, err := user.GetServiceAccount(ctx, client, serviceAccountID)
-	if status.Code(err) == codes.NotFound {
+	if errors.Is(err, databroker.ErrRecordNotFound) {
 		return nil
 	} else if err != nil {
 		return err

--- a/authorize/access_tracker_test.go
+++ b/authorize/access_tracker_test.go
@@ -63,7 +63,7 @@ func TestAccessTracker(t *testing.T) {
 				case "type.googleapis.com/session.Session":
 					s, ok := sessions[in.GetId()]
 					if !ok {
-						return nil, status.Errorf(codes.NotFound, "unknown session")
+						return nil, databroker.ErrRecordNotFound
 					}
 					return &databroker.GetResponse{
 						Record: &databroker.Record{
@@ -75,7 +75,7 @@ func TestAccessTracker(t *testing.T) {
 				case "type.googleapis.com/user.ServiceAccount":
 					sa, ok := serviceAccounts[in.GetId()]
 					if !ok {
-						return nil, status.Errorf(codes.NotFound, "unknown service account")
+						return nil, databroker.ErrRecordNotFound
 					}
 					return &databroker.GetResponse{
 						Record: &databroker.Record{

--- a/authorize/databroker.go
+++ b/authorize/databroker.go
@@ -2,7 +2,9 @@ package authorize
 
 import (
 	"context"
+	"errors"
 
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
@@ -24,7 +26,7 @@ func (a *Authorize) getDataBrokerSessionOrServiceAccount(
 	defer span.End()
 
 	record, err := storage.GetDataBrokerRecord(ctx, grpcutil.GetTypeURL(new(session.Session)), sessionID, dataBrokerRecordVersion)
-	if storage.IsNotFound(err) {
+	if errors.Is(err, databroker.ErrRecordNotFound) {
 		record, err = storage.GetDataBrokerRecord(ctx, grpcutil.GetTypeURL(new(user.ServiceAccount)), sessionID, dataBrokerRecordVersion)
 	}
 	if err != nil {

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pomerium/pomerium/internal/mcp"
 	"github.com/pomerium/pomerium/internal/sessions"
 	"github.com/pomerium/pomerium/pkg/contextutil"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
@@ -184,7 +185,7 @@ func (a *Authorize) getMCPSession(
 	}
 
 	record, err := storage.GetDataBrokerRecord(ctx, grpcutil.GetTypeURL(new(session.Session)), sessionID, 0)
-	if storage.IsNotFound(err) {
+	if errors.Is(err, databroker.ErrRecordNotFound) {
 		return nil, fmt.Errorf("session databroker record not found: %w", sessions.ErrNoSessionFound)
 	}
 

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -2,6 +2,7 @@ package authorize
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"testing"
@@ -244,7 +245,7 @@ func (m mockDataBrokerServiceClient) Patch(ctx context.Context, in *databroker.P
 			Type: record.GetType(),
 			Id:   record.GetId(),
 		}, opts...)
-		if storage.IsNotFound(err) {
+		if errors.Is(err, databroker.ErrRecordNotFound) {
 			continue
 		} else if err != nil {
 			return nil, err

--- a/config/session_test.go
+++ b/config/session_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/identity"
-	"github.com/pomerium/pomerium/pkg/storage"
 )
 
 func TestSessionStore_LoadSessionState(t *testing.T) {
@@ -472,7 +471,7 @@ func TestIncomingIDPTokenSessionCreator_CreateSession(t *testing.T) {
 		c := NewIncomingIDPTokenSessionCreator(
 			noop.NewTracerProvider(),
 			func(_ context.Context, _, _ string) (*databroker.Record, error) {
-				return nil, storage.ErrNotFound
+				return nil, databroker.ErrRecordNotFound
 			},
 			func(_ context.Context, records []*databroker.Record) error {
 				if assert.Len(t, records, 2, "should put session and user") {
@@ -516,7 +515,7 @@ func TestIncomingIDPTokenSessionCreator_CreateSession(t *testing.T) {
 		c := NewIncomingIDPTokenSessionCreator(
 			noop.NewTracerProvider(),
 			func(_ context.Context, _, _ string) (*databroker.Record, error) {
-				return nil, storage.ErrNotFound
+				return nil, databroker.ErrRecordNotFound
 			},
 			func(_ context.Context, records []*databroker.Record) error {
 				if assert.Len(t, records, 2, "should put session and user") {

--- a/databroker/databroker_test.go
+++ b/databroker/databroker_test.go
@@ -9,8 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/databroker"
@@ -101,8 +99,7 @@ func TestServerSync(t *testing.T) {
 		})
 		require.NoError(t, err)
 		_, err = client.Recv()
-		require.Error(t, err)
-		assert.Equal(t, codes.Aborted.String(), status.Code(err).String())
+		assert.ErrorIs(t, err, databrokerpb.ErrInvalidServerVersion)
 	})
 }
 

--- a/internal/zero/telemetry/sessions/collector.go
+++ b/internal/zero/telemetry/sessions/collector.go
@@ -3,6 +3,7 @@ package sessions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -52,7 +53,7 @@ func (c *collector) loadCounters(ctx context.Context) error {
 		"dau": ResetDailyUTC,
 	} {
 		state, err := LoadMetricState(ctx, c.client, key)
-		if err != nil && !databroker.IsNotFound(err) {
+		if err != nil && !errors.Is(err, databroker.ErrRecordNotFound) {
 			return err
 		}
 		if state == nil {

--- a/pkg/grpc/databroker/databroker.go
+++ b/pkg/grpc/databroker/databroker.go
@@ -7,8 +7,6 @@ import (
 	"fmt"
 	"io"
 
-	"google.golang.org/grpc/codes"
-	status "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	structpb "google.golang.org/protobuf/types/known/structpb"
 
@@ -31,11 +29,6 @@ func NewRecord(object recordObject) *Record {
 		Id:   object.GetId(),
 		Data: protoutil.NewAny(object),
 	}
-}
-
-// IsNotFound returns true if the error is a not found error.
-func IsNotFound(err error) bool {
-	return status.Code(err) == codes.NotFound
 }
 
 // Get gets a record from the databroker and unmarshals it into the object.

--- a/pkg/grpc/databroker/errors.go
+++ b/pkg/grpc/databroker/errors.go
@@ -1,0 +1,17 @@
+package databroker
+
+import (
+	"google.golang.org/grpc/codes"
+
+	"github.com/pomerium/pomerium/pkg/grpcutil"
+)
+
+// known errors
+var (
+	ErrInvalidQueryFilter   = grpcutil.NewError(codes.InvalidArgument, "INVALID_QUERY_FILTER", "invalid query filter")
+	ErrInvalidRecordVersion = grpcutil.NewError(codes.Aborted, "INVALID_RECORD_VERSION", "invalid record version")
+	ErrInvalidServerVersion = grpcutil.NewError(codes.Aborted, "INVALID_SERVER_VERSION", "invalid server version")
+	ErrLeaseAlreadyTaken    = grpcutil.NewError(codes.AlreadyExists, "LEASE_ALREADY_TAKEN", "lease is already taken")
+	ErrLeaseLost            = grpcutil.NewError(codes.AlreadyExists, "LEASE_LOST", "lease lost")
+	ErrRecordNotFound       = grpcutil.NewError(codes.NotFound, "RECORD_NOT_FOUND", "record not found")
+)

--- a/pkg/grpc/databroker/syncer.go
+++ b/pkg/grpc/databroker/syncer.go
@@ -2,6 +2,7 @@ package databroker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -197,7 +198,7 @@ func (syncer *Syncer) sync(ctx context.Context) error {
 
 	for {
 		res, err := stream.Recv()
-		if status.Code(err) == codes.Aborted {
+		if errors.Is(err, ErrInvalidRecordVersion) || errors.Is(err, ErrInvalidServerVersion) {
 			log.Ctx(ctx).Error().Err(err).
 				Str("syncer-id", syncer.id).
 				Str("syncer-type", syncer.cfg.typeURL).

--- a/pkg/grpc/databroker/syncer_test.go
+++ b/pkg/grpc/databroker/syncer_test.go
@@ -72,7 +72,7 @@ func TestSyncer(t *testing.T) {
 			case 1:
 				return status.Error(codes.Internal, "SOME INTERNAL ERROR")
 			case 2:
-				return status.Error(codes.Aborted, "ABORTED")
+				return ErrInvalidServerVersion
 			case 3:
 				_ = server.Send(&SyncResponse{
 					Record: r3,

--- a/pkg/grpcutil/errors.go
+++ b/pkg/grpcutil/errors.go
@@ -1,0 +1,31 @@
+package grpcutil
+
+import (
+	"fmt"
+
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// NewError creates a new error for use with gRPC.
+func NewError(code codes.Code, reason, message string, pairs ...string) error {
+	ei := &errdetails.ErrorInfo{
+		Domain: "pomerium.com",
+		Reason: reason,
+	}
+
+	// add metadata
+	for i := 1; i < len(pairs); i += 2 {
+		if ei.Metadata == nil {
+			ei.Metadata = make(map[string]string)
+		}
+		ei.Metadata[pairs[i-1]] = pairs[i]
+	}
+
+	s, err := status.New(code, fmt.Sprintf("%s: %s", reason, message)).WithDetails(ei)
+	if err != nil {
+		return err
+	}
+	return s.Err()
+}

--- a/pkg/grpcutil/errors_test.go
+++ b/pkg/grpcutil/errors_test.go
@@ -1,0 +1,103 @@
+package grpcutil_test
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/genproto/googleapis/rpc/errdetails"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/status"
+
+	"github.com/pomerium/pomerium/pkg/grpcutil"
+)
+
+type testHealthServer struct {
+	check func(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error)
+	grpc_health_v1.UnimplementedHealthServer
+}
+
+func (s testHealthServer) Check(ctx context.Context, req *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+	return s.check(ctx, req)
+}
+
+func TestErrors(t *testing.T) {
+	t.Parallel()
+
+	li, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = li.Close() })
+
+	var checkErr error
+
+	s := grpc.NewServer()
+	grpc_health_v1.RegisterHealthServer(s, testHealthServer{
+		check: func(_ context.Context, _ *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
+			return nil, checkErr
+		},
+	})
+	go s.Serve(li)
+
+	cc, err := grpc.NewClient(li.Addr().String(), grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	c := grpc_health_v1.NewHealthClient(cc)
+
+	for _, tc := range []struct {
+		err1, err2 error
+		matches    bool
+	}{
+		{
+			grpcutil.NewError(codes.DataLoss, "A", "message 1"),
+			grpcutil.NewError(codes.DataLoss, "A", "message 1"),
+			true,
+		},
+		{
+			grpcutil.NewError(codes.DataLoss, "A", "message 1"),
+			must(status.New(codes.DataLoss, "A: message 1").WithDetails(&errdetails.ErrorInfo{
+				Domain: "pomerium.com",
+				Reason: "A",
+			})).Err(),
+			true,
+		},
+		{
+			grpcutil.NewError(codes.DataLoss, "A", "message 1"),
+			grpcutil.NewError(codes.DataLoss, "A", "message 2"),
+			false,
+		},
+		{
+			grpcutil.NewError(codes.DataLoss, "A", "message 1", "a", "b"),
+			grpcutil.NewError(codes.DataLoss, "A", "message 1", "x", "y"),
+			false,
+		},
+		{
+			grpcutil.NewError(codes.NotFound, "A", "message 1"),
+			grpcutil.NewError(codes.DataLoss, "A", "message 1"),
+			false,
+		},
+		{
+			grpcutil.NewError(codes.DataLoss, "A", "message 1"),
+			grpcutil.NewError(codes.DataLoss, "B", "message 1"),
+			false,
+		},
+	} {
+		checkErr = tc.err1
+		_, err = c.Check(t.Context(), new(grpc_health_v1.HealthCheckRequest))
+		if tc.matches {
+			assert.ErrorIs(t, err, tc.err2, "errors should be equal")
+		} else {
+			assert.NotErrorIs(t, err, tc.err2, "errors should not be equal")
+		}
+	}
+}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}

--- a/pkg/identity/manager/manager.go
+++ b/pkg/identity/manager/manager.go
@@ -3,14 +3,13 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 
 	"github.com/rs/zerolog"
 	"golang.org/x/oauth2"
 	"golang.org/x/sync/errgroup"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -342,7 +341,7 @@ func (mgr *Manager) deleteSession(ctx context.Context, sessionID string) {
 		Type: grpcutil.GetTypeURL(new(session.Session)),
 		Id:   sessionID,
 	})
-	if status.Code(err) == codes.NotFound {
+	if errors.Is(err, databroker.ErrRecordNotFound) {
 		return
 	} else if err != nil {
 		log.Ctx(ctx).Error().Err(err).

--- a/pkg/storage/file/backend.go
+++ b/pkg/storage/file/backend.go
@@ -337,7 +337,7 @@ func (backend *Backend) getRecordLocked(
 ) (*databrokerpb.Record, error) {
 	record, err := recordKeySpace.get(r, recordType, recordID)
 	if isNotFound(err) {
-		err = storage.ErrNotFound
+		err = databrokerpb.ErrRecordNotFound
 	} else if err != nil {
 		err = fmt.Errorf("pebble: error getting record: %w", err)
 	}

--- a/pkg/storage/file/iterate.go
+++ b/pkg/storage/file/iterate.go
@@ -38,10 +38,10 @@ func (backend *Backend) iterateChangedRecords(
 		}
 
 		if serverVersion != currentServerVersion {
-			yield(nil, storage.ErrInvalidServerVersion)
+			yield(nil, databrokerpb.ErrInvalidServerVersion)
 			return
 		} else if earliestRecordVersion > 0 && afterRecordVersion < (earliestRecordVersion-1) {
-			yield(nil, storage.ErrInvalidRecordVersion)
+			yield(nil, databrokerpb.ErrInvalidRecordVersion)
 			return
 		}
 

--- a/pkg/storage/inmemory/backend_test.go
+++ b/pkg/storage/inmemory/backend_test.go
@@ -56,7 +56,7 @@ func TestExpiry(t *testing.T) {
 
 	cnt := 0
 	for _, err := range backend.Sync(ctx, "", backend.serverVersion, 0, false) {
-		assert.ErrorIs(t, err, storage.ErrInvalidRecordVersion)
+		assert.ErrorIs(t, err, databroker.ErrInvalidRecordVersion)
 		cnt++
 	}
 	assert.Greater(t, cnt, 0)

--- a/pkg/storage/inmemory/iterate.go
+++ b/pkg/storage/inmemory/iterate.go
@@ -25,10 +25,10 @@ func (backend *Backend) iterateChangedRecords(
 		currentServerVersion := backend.serverVersion
 		backend.mu.RUnlock()
 		if serverVersion != currentServerVersion {
-			yield(nil, storage.ErrInvalidServerVersion)
+			yield(nil, databroker.ErrInvalidServerVersion)
 			return
 		} else if earliestRecordVersion > 0 && afterRecordVersion < (earliestRecordVersion-1) {
-			yield(nil, storage.ErrInvalidRecordVersion)
+			yield(nil, databroker.ErrInvalidRecordVersion)
 			return
 		}
 

--- a/pkg/storage/postgres/backend.go
+++ b/pkg/storage/postgres/backend.go
@@ -247,7 +247,7 @@ func (backend *Backend) Patch(
 		record = dup(record)
 		record.ModifiedAt = now
 		err := patchRecord(ctx, pool, record, fields)
-		if storage.IsNotFound(err) {
+		if errors.Is(err, databroker.ErrRecordNotFound) {
 			continue
 		} else if err != nil {
 			err = fmt.Errorf("storage/postgres: error patching record %q of type %q: %w",

--- a/pkg/storage/postgres/backend_test.go
+++ b/pkg/storage/postgres/backend_test.go
@@ -14,8 +14,8 @@ import (
 	"google.golang.org/grpc/test/bufconn"
 
 	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/iterutil"
-	"github.com/pomerium/pomerium/pkg/storage"
 	"github.com/pomerium/pomerium/pkg/storage/storagetest"
 )
 
@@ -47,7 +47,7 @@ func TestBackend(t *testing.T) {
 			assert.NoError(t, err)
 
 			_, err = backend.Get(t.Context(), "unknown", "1")
-			assert.ErrorIs(t, err, storage.ErrNotFound)
+			assert.ErrorIs(t, err, databroker.ErrRecordNotFound)
 
 			_, _, seq, err := backend.SyncLatest(t.Context(), "unknown", nil)
 			if assert.NoError(t, err) {

--- a/pkg/storage/postgres/iterate.go
+++ b/pkg/storage/postgres/iterate.go
@@ -23,7 +23,7 @@ func (backend *Backend) iterateChangedRecords(
 			yield(nil, err)
 			return
 		} else if currentServerVersion != serverVersion {
-			yield(nil, storage.ErrInvalidServerVersion)
+			yield(nil, databroker.ErrInvalidServerVersion)
 			return
 		}
 
@@ -33,7 +33,7 @@ func (backend *Backend) iterateChangedRecords(
 			return
 		}
 		if earliestRecordVersion > 0 && afterRecordVersion < (earliestRecordVersion-1) {
-			yield(nil, storage.ErrInvalidRecordVersion)
+			yield(nil, databroker.ErrInvalidRecordVersion)
 			return
 		}
 

--- a/pkg/storage/postgres/postgres.go
+++ b/pkg/storage/postgres/postgres.go
@@ -159,14 +159,14 @@ func getRecord(
 		 WHERE type=$1 AND id=$2 `+string(lockMode),
 		recordType, recordID).Scan(&version, &data, &modifiedAt)
 	if isNotFound(err) {
-		return nil, storage.ErrNotFound
+		return nil, databroker.ErrRecordNotFound
 	} else if err != nil {
 		return nil, fmt.Errorf("postgres: failed to execute query: %w", err)
 	}
 
 	a, err := protoutil.UnmarshalAnyJSON(data)
 	if isUnknownType(err) {
-		return nil, storage.ErrNotFound
+		return nil, databroker.ErrRecordNotFound
 	} else if err != nil {
 		return nil, fmt.Errorf("postgres: failed to unmarshal data: %w", err)
 	}
@@ -366,7 +366,7 @@ func patchRecord(
 
 	existing, err := getRecord(ctx, tx, record.GetType(), record.GetId(), lockModeUpdate)
 	if isNotFound(err) {
-		return storage.ErrNotFound
+		return databroker.ErrRecordNotFound
 	} else if err != nil {
 		return err
 	}
@@ -442,7 +442,7 @@ func timestamptzFromTimestamppb(ts *timestamppb.Timestamp) pgtype.Timestamptz {
 }
 
 func isNotFound(err error) bool {
-	return errors.Is(err, pgx.ErrNoRows) || errors.Is(err, storage.ErrNotFound)
+	return errors.Is(err, pgx.ErrNoRows) || errors.Is(err, databroker.ErrRecordNotFound)
 }
 
 func isUnknownType(err error) bool {

--- a/pkg/storage/querier.go
+++ b/pkg/storage/querier.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 
 	grpc "google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
-	status "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
 
@@ -31,7 +29,7 @@ type nilQuerier struct{}
 func (nilQuerier) InvalidateCache(_ context.Context, _ *databroker.QueryRequest) {}
 
 func (nilQuerier) Query(_ context.Context, _ *databroker.QueryRequest, _ ...grpc.CallOption) (*databroker.QueryResponse, error) {
-	return nil, errors.Join(ErrUnavailable, status.Error(codes.NotFound, "not found"))
+	return nil, errors.Join(ErrUnavailable, databroker.ErrRecordNotFound)
 }
 
 func (nilQuerier) Stop() {}
@@ -89,7 +87,7 @@ func GetDataBrokerRecord(
 		return nil, err
 	}
 	if len(res.GetRecords()) == 0 {
-		return nil, ErrNotFound
+		return nil, databroker.ErrRecordNotFound
 	}
 	return res.GetRecords()[0], nil
 }

--- a/pkg/storage/querier_sync.go
+++ b/pkg/storage/querier_sync.go
@@ -185,14 +185,14 @@ func (q *syncQuerier) sync(ctx context.Context) error {
 
 	for {
 		res, err := stream.Recv()
-		if status.Code(err) == codes.Aborted {
+		if errors.Is(err, databroker.ErrInvalidRecordVersion) || errors.Is(err, databroker.ErrInvalidServerVersion) {
 			// this indicates the server version changed, so we need to reset
 			q.mu.Lock()
 			q.serverVersion = 0
 			q.latestRecordVersion = 0
 			q.minimumRecordVersion = 0
 			q.mu.Unlock()
-			return fmt.Errorf("stream was aborted due to mismatched server versions: %w", err)
+			return fmt.Errorf("stream was aborted due to mismatched versions: %w", err)
 		} else if err != nil {
 			return fmt.Errorf("error receiving sync message: %w", err)
 		}

--- a/pkg/storage/querier_test.go
+++ b/pkg/storage/querier_test.go
@@ -69,7 +69,7 @@ func TestGetDataBrokerMessage(t *testing.T) {
 	assert.Empty(t, cmp.Diff(s1, s2, protocmp.Transform()))
 
 	_, err = storage.GetDataBrokerMessage[session.Session](qctx, "s2", 0)
-	assert.ErrorIs(t, err, storage.ErrNotFound)
+	assert.ErrorIs(t, err, databroker.ErrRecordNotFound)
 }
 
 func TestGetDataBrokerObjectViaJSON(t *testing.T) {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -3,26 +3,15 @@ package storage
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"time"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
-)
-
-// Errors
-var (
-	ErrNotFound             = status.Error(codes.NotFound, "record not found")
-	ErrStreamDone           = errors.New("record stream done")
-	ErrInvalidServerVersion = status.Error(codes.Aborted, "invalid server version")
-	ErrInvalidRecordVersion = status.Error(codes.Aborted, "invalid record version")
 )
 
 // Backend is the interface required for a storage backend.
@@ -129,9 +118,4 @@ func matchProtoMapValue(fd protoreflect.FieldDescriptor, m protoreflect.Map, que
 		return !matches
 	})
 	return matches
-}
-
-// IsNotFound returns true if the error is because a record was not found.
-func IsNotFound(err error) bool {
-	return errors.Is(err, ErrNotFound) || status.Code(err) == codes.NotFound
 }

--- a/pkg/storage/storagetest/storagetest.go
+++ b/pkg/storage/storagetest/storagetest.go
@@ -607,7 +607,7 @@ func TestSyncOldRecords(t *testing.T, backend storage.Backend) {
 
 	ids, err = sync(serverVersion, rs1[0].Version)
 	assert.Len(t, ids, 0)
-	assert.ErrorIs(t, err, storage.ErrInvalidRecordVersion)
+	assert.ErrorIs(t, err, databroker.ErrInvalidRecordVersion)
 }
 
 type mockRegistryWatchServer struct {

--- a/pkg/synccache/sync_cache.go
+++ b/pkg/synccache/sync_cache.go
@@ -10,8 +10,6 @@ import (
 
 	pebble "github.com/cockroachdb/pebble/v2"
 	"github.com/google/uuid"
-	"google.golang.org/grpc/codes"
-	status "google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -157,7 +155,7 @@ func (c *syncCache) sync(ctx context.Context, client databroker.DataBrokerServic
 		res, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
 			break
-		} else if status.Code(err) == codes.Aborted {
+		} else if errors.Is(err, databroker.ErrInvalidRecordVersion) || errors.Is(err, databroker.ErrInvalidServerVersion) {
 			cancel()
 			// the server version changed, so use sync latest
 			return c.syncLatest(ctx, client, recordType)


### PR DESCRIPTION
## Summary
Refactor the way databroker errors are returned to use `errors.Is` instead of `status.Code`. This is so that we have a more precise definition of whether or not the error we are searching for is the one we expected.

For example, we might see a `codes.NotFound` error because a route doesn't exist, but previously we assumed this meant a record didn't exist (since it's the same code), so the check was too broad.

In practice this rarely mattered, but it will become more important with some new errors that are being added (and use the same status codes).

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
