### PR TITLE
databroker: add erroring server, update imports

### DIFF
--- a/internal/databroker/config_source_test.go
+++ b/internal/databroker/config_source_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
@@ -47,7 +47,7 @@ func TestConfigSource(t *testing.T) {
 	t.Cleanup(srv.Stop)
 
 	s := grpc.NewServer()
-	databroker.RegisterDataBrokerServiceServer(s, srv)
+	databrokerpb.RegisterDataBrokerServiceServer(s, srv)
 	go func() { _ = s.Serve(li) }()
 
 	cfgs := make(chan *config.Config, 10)
@@ -87,8 +87,8 @@ func TestConfigSource(t *testing.T) {
 			Certificates: []*configpb.Settings_Certificate{cert},
 		},
 	})
-	_, _ = srv.Put(ctx, &databroker.PutRequest{
-		Records: []*databroker.Record{{
+	_, _ = srv.Put(ctx, &databrokerpb.PutRequest{
+		Records: []*databrokerpb.Record{{
 			Type: data.TypeUrl,
 			Id:   "1",
 			Data: data,

--- a/internal/databroker/server_backend.go
+++ b/internal/databroker/server_backend.go
@@ -17,7 +17,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/registry"
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/storage"
 	"github.com/pomerium/pomerium/pkg/storage/file"
 	"github.com/pomerium/pomerium/pkg/storage/inmemory"
@@ -59,7 +59,7 @@ func NewBackendServer(tracerProvider oteltrace.TracerProvider) Server {
 }
 
 // AcquireLease acquires a lease.
-func (srv *backendServer) AcquireLease(ctx context.Context, req *databroker.AcquireLeaseRequest) (*databroker.AcquireLeaseResponse, error) {
+func (srv *backendServer) AcquireLease(ctx context.Context, req *databrokerpb.AcquireLeaseRequest) (*databrokerpb.AcquireLeaseResponse, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.AcquireLease")
 	defer span.End()
 	log.Ctx(ctx).Debug().
@@ -80,12 +80,12 @@ func (srv *backendServer) AcquireLease(ctx context.Context, req *databroker.Acqu
 		return nil, status.Error(codes.AlreadyExists, "lease is already taken")
 	}
 
-	return &databroker.AcquireLeaseResponse{
+	return &databrokerpb.AcquireLeaseResponse{
 		Id: leaseID,
 	}, nil
 }
 
-func (srv *backendServer) Clear(ctx context.Context, _ *emptypb.Empty) (*databroker.ClearResponse, error) {
+func (srv *backendServer) Clear(ctx context.Context, _ *emptypb.Empty) (*databrokerpb.ClearResponse, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.Clear")
 	defer span.End()
 	log.Ctx(ctx).Debug().
@@ -111,14 +111,14 @@ func (srv *backendServer) Clear(ctx context.Context, _ *emptypb.Empty) (*databro
 		return nil, err
 	}
 
-	return &databroker.ClearResponse{
+	return &databrokerpb.ClearResponse{
 		OldServerVersion: oldServerVersion,
 		NewServerVersion: newServerVersion,
 	}, nil
 }
 
 // Get gets a record from the in-memory list.
-func (srv *backendServer) Get(ctx context.Context, req *databroker.GetRequest) (*databroker.GetResponse, error) {
+func (srv *backendServer) Get(ctx context.Context, req *databrokerpb.GetRequest) (*databrokerpb.GetResponse, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.Get")
 	defer span.End()
 	log.Ctx(ctx).Debug().
@@ -139,13 +139,13 @@ func (srv *backendServer) Get(ctx context.Context, req *databroker.GetRequest) (
 	case record.DeletedAt != nil:
 		return nil, status.Error(codes.NotFound, "record not found")
 	}
-	return &databroker.GetResponse{
+	return &databrokerpb.GetResponse{
 		Record: record,
 	}, nil
 }
 
 // ListTypes lists all the record types.
-func (srv *backendServer) ListTypes(ctx context.Context, _ *emptypb.Empty) (*databroker.ListTypesResponse, error) {
+func (srv *backendServer) ListTypes(ctx context.Context, _ *emptypb.Empty) (*databrokerpb.ListTypesResponse, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.ListTypes")
 	defer span.End()
 	log.Ctx(ctx).Debug().Msg("list types")
@@ -158,11 +158,11 @@ func (srv *backendServer) ListTypes(ctx context.Context, _ *emptypb.Empty) (*dat
 	if err != nil {
 		return nil, err
 	}
-	return &databroker.ListTypesResponse{Types: types}, nil
+	return &databrokerpb.ListTypesResponse{Types: types}, nil
 }
 
 // Query queries for records.
-func (srv *backendServer) Query(ctx context.Context, req *databroker.QueryRequest) (*databroker.QueryResponse, error) {
+func (srv *backendServer) Query(ctx context.Context, req *databrokerpb.QueryRequest) (*databrokerpb.QueryResponse, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.Query")
 	defer span.End()
 	log.Ctx(ctx).Debug().
@@ -190,7 +190,7 @@ func (srv *backendServer) Query(ctx context.Context, req *databroker.QueryReques
 		return nil, err
 	}
 
-	var filtered []*databroker.Record
+	var filtered []*databrokerpb.Record
 	for record, err := range seq {
 		if err != nil {
 			return nil, err
@@ -203,8 +203,8 @@ func (srv *backendServer) Query(ctx context.Context, req *databroker.QueryReques
 		filtered = append(filtered, record)
 	}
 
-	records, totalCount := databroker.ApplyOffsetAndLimit(filtered, int(req.GetOffset()), int(req.GetLimit()))
-	return &databroker.QueryResponse{
+	records, totalCount := databrokerpb.ApplyOffsetAndLimit(filtered, int(req.GetOffset()), int(req.GetLimit()))
+	return &databrokerpb.QueryResponse{
 		Records:       records,
 		TotalCount:    int64(totalCount),
 		ServerVersion: serverVersion,
@@ -213,7 +213,7 @@ func (srv *backendServer) Query(ctx context.Context, req *databroker.QueryReques
 }
 
 // Put updates an existing record or adds a new one.
-func (srv *backendServer) Put(ctx context.Context, req *databroker.PutRequest) (*databroker.PutResponse, error) {
+func (srv *backendServer) Put(ctx context.Context, req *databrokerpb.PutRequest) (*databrokerpb.PutResponse, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.Put")
 	defer span.End()
 
@@ -243,7 +243,7 @@ func (srv *backendServer) Put(ctx context.Context, req *databroker.PutRequest) (
 	if err != nil {
 		return nil, err
 	}
-	res := &databroker.PutResponse{
+	res := &databrokerpb.PutResponse{
 		ServerVersion: serverVersion,
 		Records:       records,
 	}
@@ -252,7 +252,7 @@ func (srv *backendServer) Put(ctx context.Context, req *databroker.PutRequest) (
 }
 
 // Patch updates specific fields of an existing record.
-func (srv *backendServer) Patch(ctx context.Context, req *databroker.PatchRequest) (*databroker.PatchResponse, error) {
+func (srv *backendServer) Patch(ctx context.Context, req *databrokerpb.PatchRequest) (*databrokerpb.PatchResponse, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.Patch")
 	defer span.End()
 
@@ -282,7 +282,7 @@ func (srv *backendServer) Patch(ctx context.Context, req *databroker.PatchReques
 	if err != nil {
 		return nil, err
 	}
-	res := &databroker.PatchResponse{
+	res := &databrokerpb.PatchResponse{
 		ServerVersion: serverVersion,
 		Records:       patchedRecords,
 	}
@@ -291,7 +291,7 @@ func (srv *backendServer) Patch(ctx context.Context, req *databroker.PatchReques
 }
 
 // ReleaseLease releases a lease.
-func (srv *backendServer) ReleaseLease(ctx context.Context, req *databroker.ReleaseLeaseRequest) (*emptypb.Empty, error) {
+func (srv *backendServer) ReleaseLease(ctx context.Context, req *databrokerpb.ReleaseLeaseRequest) (*emptypb.Empty, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.ReleaseLease")
 	defer span.End()
 	log.Ctx(ctx).Trace().
@@ -313,7 +313,7 @@ func (srv *backendServer) ReleaseLease(ctx context.Context, req *databroker.Rele
 }
 
 // RenewLease releases a lease.
-func (srv *backendServer) RenewLease(ctx context.Context, req *databroker.RenewLeaseRequest) (*emptypb.Empty, error) {
+func (srv *backendServer) RenewLease(ctx context.Context, req *databrokerpb.RenewLeaseRequest) (*emptypb.Empty, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.RenewLease")
 	defer span.End()
 	log.Ctx(ctx).Trace().
@@ -338,7 +338,7 @@ func (srv *backendServer) RenewLease(ctx context.Context, req *databroker.RenewL
 }
 
 // ServerInfo returns info about the databroker server.
-func (srv *backendServer) ServerInfo(ctx context.Context, _ *emptypb.Empty) (*databroker.ServerInfoResponse, error) {
+func (srv *backendServer) ServerInfo(ctx context.Context, _ *emptypb.Empty) (*databrokerpb.ServerInfoResponse, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.ServerInfo")
 	defer span.End()
 
@@ -352,7 +352,7 @@ func (srv *backendServer) ServerInfo(ctx context.Context, _ *emptypb.Empty) (*da
 		return nil, err
 	}
 
-	res := new(databroker.ServerInfoResponse)
+	res := new(databrokerpb.ServerInfoResponse)
 	res.ServerVersion = serverVersion
 	res.EarliestRecordVersion = earliestRecordVersion
 	res.LatestRecordVersion = latestRecordVersion
@@ -360,7 +360,7 @@ func (srv *backendServer) ServerInfo(ctx context.Context, _ *emptypb.Empty) (*da
 }
 
 // SetOptions sets options for a type in the databroker.
-func (srv *backendServer) SetOptions(ctx context.Context, req *databroker.SetOptionsRequest) (*databroker.SetOptionsResponse, error) {
+func (srv *backendServer) SetOptions(ctx context.Context, req *databrokerpb.SetOptionsRequest) (*databrokerpb.SetOptionsResponse, error) {
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.SetOptions")
 	defer span.End()
 
@@ -376,13 +376,13 @@ func (srv *backendServer) SetOptions(ctx context.Context, req *databroker.SetOpt
 	if err != nil {
 		return nil, err
 	}
-	return &databroker.SetOptionsResponse{
+	return &databrokerpb.SetOptionsResponse{
 		Options: options,
 	}, nil
 }
 
 // Sync streams updates for the given record type.
-func (srv *backendServer) Sync(req *databroker.SyncRequest, stream databroker.DataBrokerService_SyncServer) error {
+func (srv *backendServer) Sync(req *databrokerpb.SyncRequest, stream databrokerpb.DataBrokerService_SyncServer) error {
 	ctx := stream.Context()
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.Sync")
 	defer span.End()
@@ -410,7 +410,7 @@ func (srv *backendServer) Sync(req *databroker.SyncRequest, stream databroker.Da
 		if err != nil {
 			return err
 		}
-		err = stream.Send(&databroker.SyncResponse{
+		err = stream.Send(&databrokerpb.SyncResponse{
 			Record: record,
 		})
 		if err != nil {
@@ -422,7 +422,7 @@ func (srv *backendServer) Sync(req *databroker.SyncRequest, stream databroker.Da
 }
 
 // SyncLatest returns the latest value of every record in the databroker as a stream of records.
-func (srv *backendServer) SyncLatest(req *databroker.SyncLatestRequest, stream databroker.DataBrokerService_SyncLatestServer) error {
+func (srv *backendServer) SyncLatest(req *databrokerpb.SyncLatestRequest, stream databrokerpb.DataBrokerService_SyncLatestServer) error {
 	ctx := stream.Context()
 	ctx, span := srv.tracer.Start(ctx, "databroker.grpc.SyncLatest")
 	defer span.End()
@@ -450,8 +450,8 @@ func (srv *backendServer) SyncLatest(req *databroker.SyncLatestRequest, stream d
 		}
 
 		if req.GetType() == "" || req.GetType() == record.GetType() {
-			err = stream.Send(&databroker.SyncLatestResponse{
-				Response: &databroker.SyncLatestResponse_Record{
+			err = stream.Send(&databrokerpb.SyncLatestResponse{
+				Response: &databrokerpb.SyncLatestResponse_Record{
 					Record: record,
 				},
 			})
@@ -462,9 +462,9 @@ func (srv *backendServer) SyncLatest(req *databroker.SyncLatestRequest, stream d
 	}
 
 	// always send the server version last in case there are no records
-	return stream.Send(&databroker.SyncLatestResponse{
-		Response: &databroker.SyncLatestResponse_Versions{
-			Versions: &databroker.Versions{
+	return stream.Send(&databrokerpb.SyncLatestResponse{
+		Response: &databrokerpb.SyncLatestResponse_Versions{
+			Versions: &databrokerpb.Versions{
 				ServerVersion:       serverVersion,
 				LatestRecordVersion: recordVersion,
 			},

--- a/internal/databroker/server_backend_test.go
+++ b/internal/databroker/server_backend_test.go
@@ -28,18 +28,18 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
-	"github.com/pomerium/pomerium/pkg/grpc/session"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	sessionpb "github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 type testSyncerHandler struct {
-	getDataBrokerServiceClient func() databroker.DataBrokerServiceClient
+	getDataBrokerServiceClient func() databrokerpb.DataBrokerServiceClient
 	clearRecords               func(ctx context.Context)
-	updateRecords              func(ctx context.Context, serverVersion uint64, records []*databroker.Record)
+	updateRecords              func(ctx context.Context, serverVersion uint64, records []*databrokerpb.Record)
 }
 
-func (h testSyncerHandler) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+func (h testSyncerHandler) GetDataBrokerServiceClient() databrokerpb.DataBrokerServiceClient {
 	return h.getDataBrokerServiceClient()
 }
 
@@ -47,7 +47,7 @@ func (h testSyncerHandler) ClearRecords(ctx context.Context) {
 	h.clearRecords(ctx)
 }
 
-func (h testSyncerHandler) UpdateRecords(ctx context.Context, serverVersion uint64, records []*databroker.Record) {
+func (h testSyncerHandler) UpdateRecords(ctx context.Context, serverVersion uint64, records []*databrokerpb.Record) {
 	h.updateRecords(ctx, serverVersion, records)
 }
 
@@ -69,26 +69,26 @@ func TestServer_Get(t *testing.T) {
 	t.Run("ignore deleted", func(t *testing.T) {
 		srv := newServer(t)
 
-		s := new(session.Session)
+		s := new(sessionpb.Session)
 		s.Id = "1"
 		data := protoutil.NewAny(s)
-		_, err := srv.Put(t.Context(), &databroker.PutRequest{
-			Records: []*databroker.Record{{
+		_, err := srv.Put(t.Context(), &databrokerpb.PutRequest{
+			Records: []*databrokerpb.Record{{
 				Type: data.TypeUrl,
 				Id:   s.Id,
 				Data: data,
 			}},
 		})
 		assert.NoError(t, err)
-		_, err = srv.Put(t.Context(), &databroker.PutRequest{
-			Records: []*databroker.Record{{
+		_, err = srv.Put(t.Context(), &databrokerpb.PutRequest{
+			Records: []*databrokerpb.Record{{
 				Type:      data.TypeUrl,
 				Id:        s.Id,
 				DeletedAt: timestamppb.Now(),
 			}},
 		})
 		assert.NoError(t, err)
-		_, err = srv.Get(t.Context(), &databroker.GetRequest{
+		_, err = srv.Get(t.Context(), &databrokerpb.GetRequest{
 			Type: data.TypeUrl,
 			Id:   s.Id,
 		})
@@ -100,13 +100,13 @@ func TestServer_Get(t *testing.T) {
 func TestServer_Patch(t *testing.T) {
 	srv := newServer(t)
 
-	s := &session.Session{
+	s := &sessionpb.Session{
 		Id:         "1",
-		OauthToken: &session.OAuthToken{AccessToken: "access-token"},
+		OauthToken: &sessionpb.OAuthToken{AccessToken: "access-token"},
 	}
 	data := protoutil.NewAny(s)
-	_, err := srv.Put(t.Context(), &databroker.PutRequest{
-		Records: []*databroker.Record{{
+	_, err := srv.Put(t.Context(), &databrokerpb.PutRequest{
+		Records: []*databrokerpb.Record{{
 			Type: data.TypeUrl,
 			Id:   s.Id,
 			Data: data,
@@ -121,8 +121,8 @@ func TestServer_Patch(t *testing.T) {
 	s.AccessedAt = now
 	s.OauthToken.AccessToken = "access-token-field-ignored"
 	data = protoutil.NewAny(s)
-	patchResponse, err := srv.Patch(t.Context(), &databroker.PatchRequest{
-		Records: []*databroker.Record{{
+	patchResponse, err := srv.Patch(t.Context(), &databrokerpb.PatchRequest{
+		Records: []*databrokerpb.Record{{
 			Type: data.TypeUrl,
 			Id:   s.Id,
 			Data: data,
@@ -130,41 +130,41 @@ func TestServer_Patch(t *testing.T) {
 		FieldMask: fm,
 	})
 	require.NoError(t, err)
-	testutil.AssertProtoEqual(t, protoutil.NewAny(&session.Session{
+	testutil.AssertProtoEqual(t, protoutil.NewAny(&sessionpb.Session{
 		Id:         "1",
 		AccessedAt: now,
-		OauthToken: &session.OAuthToken{AccessToken: "access-token"},
+		OauthToken: &sessionpb.OAuthToken{AccessToken: "access-token"},
 	}), patchResponse.GetRecord().GetData())
 
-	getResponse, err := srv.Get(t.Context(), &databroker.GetRequest{
+	getResponse, err := srv.Get(t.Context(), &databrokerpb.GetRequest{
 		Type: data.TypeUrl,
 		Id:   s.Id,
 	})
 	require.NoError(t, err)
-	testutil.AssertProtoEqual(t, protoutil.NewAny(&session.Session{
+	testutil.AssertProtoEqual(t, protoutil.NewAny(&sessionpb.Session{
 		Id:         "1",
 		AccessedAt: now,
-		OauthToken: &session.OAuthToken{AccessToken: "access-token"},
+		OauthToken: &sessionpb.OAuthToken{AccessToken: "access-token"},
 	}), getResponse.GetRecord().GetData())
 }
 
 func TestServer_Options(t *testing.T) {
 	srv := newServer(t)
 
-	s := new(session.Session)
+	s := new(sessionpb.Session)
 	s.Id = "1"
 	data := protoutil.NewAny(s)
-	_, err := srv.Put(t.Context(), &databroker.PutRequest{
-		Records: []*databroker.Record{{
+	_, err := srv.Put(t.Context(), &databrokerpb.PutRequest{
+		Records: []*databrokerpb.Record{{
 			Type: data.TypeUrl,
 			Id:   s.Id,
 			Data: data,
 		}},
 	})
 	assert.NoError(t, err)
-	_, err = srv.SetOptions(t.Context(), &databroker.SetOptionsRequest{
+	_, err = srv.SetOptions(t.Context(), &databrokerpb.SetOptionsRequest{
 		Type: data.TypeUrl,
-		Options: &databroker.Options{
+		Options: &databrokerpb.Options{
 			Capacity: proto.Uint64(1),
 		},
 	})
@@ -174,21 +174,21 @@ func TestServer_Options(t *testing.T) {
 func TestServer_Lease(t *testing.T) {
 	srv := newServer(t)
 
-	res, err := srv.AcquireLease(t.Context(), &databroker.AcquireLeaseRequest{
+	res, err := srv.AcquireLease(t.Context(), &databrokerpb.AcquireLeaseRequest{
 		Name:     "TEST",
 		Duration: durationpb.New(time.Second * 10),
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, res.GetId())
 
-	_, err = srv.RenewLease(t.Context(), &databroker.RenewLeaseRequest{
+	_, err = srv.RenewLease(t.Context(), &databrokerpb.RenewLeaseRequest{
 		Name:     "TEST",
 		Id:       res.GetId(),
 		Duration: durationpb.New(time.Second * 10),
 	})
 	assert.NoError(t, err)
 
-	_, err = srv.ReleaseLease(t.Context(), &databroker.ReleaseLeaseRequest{
+	_, err = srv.ReleaseLease(t.Context(), &databrokerpb.ReleaseLeaseRequest{
 		Name: "TEST",
 		Id:   res.GetId(),
 	})
@@ -199,11 +199,11 @@ func TestServer_Query(t *testing.T) {
 	srv := newServer(t)
 
 	for i := 0; i < 10; i++ {
-		s := new(session.Session)
+		s := new(sessionpb.Session)
 		s.Id = fmt.Sprint(i)
 		data := protoutil.NewAny(s)
-		_, err := srv.Put(t.Context(), &databroker.PutRequest{
-			Records: []*databroker.Record{{
+		_, err := srv.Put(t.Context(), &databrokerpb.PutRequest{
+			Records: []*databrokerpb.Record{{
 				Type: data.TypeUrl,
 				Id:   s.Id,
 				Data: data,
@@ -211,8 +211,8 @@ func TestServer_Query(t *testing.T) {
 		})
 		assert.NoError(t, err)
 	}
-	res, err := srv.Query(t.Context(), &databroker.QueryRequest{
-		Type: protoutil.GetTypeURL(new(session.Session)),
+	res, err := srv.Query(t.Context(), &databrokerpb.QueryRequest{
+		Type: protoutil.GetTypeURL(new(sessionpb.Session)),
 		Filter: &structpb.Struct{
 			Fields: map[string]*structpb.Value{
 				"$or": structpb.NewListValue(&structpb.ListValue{Values: []*structpb.Value{
@@ -249,11 +249,11 @@ func TestServer_Query(t *testing.T) {
 func TestServer_Sync(t *testing.T) {
 	srv := newServer(t)
 
-	s := new(session.Session)
+	s := new(sessionpb.Session)
 	s.Id = "1"
 	data := protoutil.NewAny(s)
-	_, err := srv.Put(t.Context(), &databroker.PutRequest{
-		Records: []*databroker.Record{{
+	_, err := srv.Put(t.Context(), &databrokerpb.PutRequest{
+		Records: []*databrokerpb.Record{{
 			Type: data.TypeUrl,
 			Id:   s.Id,
 			Data: data,
@@ -262,7 +262,7 @@ func TestServer_Sync(t *testing.T) {
 	assert.NoError(t, err)
 
 	gs := grpc.NewServer()
-	databroker.RegisterDataBrokerServiceServer(gs, srv)
+	databrokerpb.RegisterDataBrokerServiceServer(gs, srv)
 	li, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err)
 	defer li.Close()
@@ -283,15 +283,15 @@ func TestServer_Sync(t *testing.T) {
 		clearRecords := make(chan struct{}, 10)
 		updateRecords := make(chan uint64, 10)
 
-		client := databroker.NewDataBrokerServiceClient(cc)
-		syncer := databroker.NewSyncer(ctx, "TEST", testSyncerHandler{
-			getDataBrokerServiceClient: func() databroker.DataBrokerServiceClient {
+		client := databrokerpb.NewDataBrokerServiceClient(cc)
+		syncer := databrokerpb.NewSyncer(ctx, "TEST", testSyncerHandler{
+			getDataBrokerServiceClient: func() databrokerpb.DataBrokerServiceClient {
 				return client
 			},
 			clearRecords: func(_ context.Context) {
 				clearRecords <- struct{}{}
 			},
-			updateRecords: func(_ context.Context, recordVersion uint64, _ []*databroker.Record) {
+			updateRecords: func(_ context.Context, recordVersion uint64, _ []*databrokerpb.Record) {
 				updateRecords <- recordVersion
 			},
 		})
@@ -308,8 +308,8 @@ func TestServer_Sync(t *testing.T) {
 
 		}
 
-		_, err = srv.Put(t.Context(), &databroker.PutRequest{
-			Records: []*databroker.Record{{
+		_, err = srv.Put(t.Context(), &databrokerpb.PutRequest{
+			Records: []*databrokerpb.Record{{
 				Type: data.TypeUrl,
 				Id:   s.Id,
 				Data: data,
@@ -336,11 +336,11 @@ func TestServerInvalidStorage(t *testing.T) {
 		},
 	})
 
-	s := new(session.Session)
+	s := new(sessionpb.Session)
 	s.Id = "1"
 	data := protoutil.NewAny(s)
-	_, err := srv.Put(t.Context(), &databroker.PutRequest{
-		Records: []*databroker.Record{{
+	_, err := srv.Put(t.Context(), &databrokerpb.PutRequest{
+		Records: []*databrokerpb.Record{{
 			Type: data.TypeUrl,
 			Id:   s.Id,
 			Data: data,
@@ -367,11 +367,11 @@ func TestServerPostgres(t *testing.T) {
 			},
 		})
 
-		s := new(session.Session)
+		s := new(sessionpb.Session)
 		s.Id = "1"
 		data := protoutil.NewAny(s)
-		_, err := srv.Put(t.Context(), &databroker.PutRequest{
-			Records: []*databroker.Record{{
+		_, err := srv.Put(t.Context(), &databrokerpb.PutRequest{
+			Records: []*databrokerpb.Record{{
 				Type: data.TypeUrl,
 				Id:   s.Id,
 				Data: data,
@@ -380,7 +380,7 @@ func TestServerPostgres(t *testing.T) {
 		assert.NoError(t, err)
 
 		gs := grpc.NewServer()
-		databroker.RegisterDataBrokerServiceServer(gs, srv)
+		databrokerpb.RegisterDataBrokerServiceServer(gs, srv)
 		li, err := net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 		defer li.Close()
@@ -398,8 +398,8 @@ func TestServerPostgres(t *testing.T) {
 			}
 			defer cc.Close()
 
-			client := databroker.NewDataBrokerServiceClient(cc)
-			stream, err := client.SyncLatest(ctx, &databroker.SyncLatestRequest{
+			client := databrokerpb.NewDataBrokerServiceClient(cc)
+			stream, err := client.SyncLatest(ctx, &databrokerpb.SyncLatestRequest{
 				Type: data.TypeUrl,
 			})
 			if err != nil {

--- a/internal/databroker/server_erroring.go
+++ b/internal/databroker/server_erroring.go
@@ -1,0 +1,88 @@
+package databroker
+
+import (
+	"context"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/pomerium/pomerium/config"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	registrypb "github.com/pomerium/pomerium/pkg/grpc/registry"
+)
+
+type erroringServer struct {
+	err error
+}
+
+// NewErroringServer creates a new Server that returns an error for all databroker and registry methods.
+func NewErroringServer(err error) Server {
+	return &erroringServer{err: err}
+}
+
+func (srv *erroringServer) AcquireLease(_ context.Context, _ *databrokerpb.AcquireLeaseRequest) (*databrokerpb.AcquireLeaseResponse, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) Clear(_ context.Context, _ *emptypb.Empty) (*databrokerpb.ClearResponse, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) Get(_ context.Context, _ *databrokerpb.GetRequest) (*databrokerpb.GetResponse, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) List(_ context.Context, _ *registrypb.ListRequest) (*registrypb.ServiceList, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) ListTypes(_ context.Context, _ *emptypb.Empty) (*databrokerpb.ListTypesResponse, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) Patch(_ context.Context, _ *databrokerpb.PatchRequest) (*databrokerpb.PatchResponse, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) Put(_ context.Context, _ *databrokerpb.PutRequest) (*databrokerpb.PutResponse, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) Query(_ context.Context, _ *databrokerpb.QueryRequest) (*databrokerpb.QueryResponse, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) ReleaseLease(_ context.Context, _ *databrokerpb.ReleaseLeaseRequest) (*emptypb.Empty, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) RenewLease(_ context.Context, _ *databrokerpb.RenewLeaseRequest) (*emptypb.Empty, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) Report(_ context.Context, _ *registrypb.RegisterRequest) (*registrypb.RegisterResponse, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) ServerInfo(_ context.Context, _ *emptypb.Empty) (*databrokerpb.ServerInfoResponse, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) SetOptions(_ context.Context, _ *databrokerpb.SetOptionsRequest) (*databrokerpb.SetOptionsResponse, error) {
+	return nil, srv.err
+}
+
+func (srv *erroringServer) Sync(_ *databrokerpb.SyncRequest, _ grpc.ServerStreamingServer[databrokerpb.SyncResponse]) error {
+	return srv.err
+}
+
+func (srv *erroringServer) SyncLatest(_ *databrokerpb.SyncLatestRequest, _ grpc.ServerStreamingServer[databrokerpb.SyncLatestResponse]) error {
+	return srv.err
+}
+
+func (srv *erroringServer) Watch(_ *registrypb.ListRequest, _ grpc.ServerStreamingServer[registrypb.ServiceList]) error {
+	return srv.err
+}
+
+func (srv *erroringServer) Stop()                                              {}
+func (srv *erroringServer) OnConfigChange(_ context.Context, _ *config.Config) {}

--- a/internal/databroker/server_erroring_test.go
+++ b/internal/databroker/server_erroring_test.go
@@ -1,0 +1,28 @@
+package databroker_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/pomerium/pomerium/internal/databroker"
+	"github.com/pomerium/pomerium/internal/testutil"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+func TestErroringServer(t *testing.T) {
+	t.Parallel()
+
+	erroring := databroker.NewErroringServer(errors.New("TEST ERROR"))
+
+	cc := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(s, erroring)
+	})
+
+	res, err := databrokerpb.NewDataBrokerServiceClient(cc).ServerInfo(t.Context(), new(emptypb.Empty))
+	assert.ErrorContains(t, err, "TEST ERROR")
+	assert.Nil(t, res)
+}

--- a/internal/databroker/server_secured.go
+++ b/internal/databroker/server_secured.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
-	"github.com/pomerium/pomerium/pkg/grpc/databroker"
-	"github.com/pomerium/pomerium/pkg/grpc/registry"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	registrypb "github.com/pomerium/pomerium/pkg/grpc/registry"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
 )
 
@@ -30,112 +30,112 @@ func NewSecuredServer(underlying Server) Server {
 	return srv
 }
 
-func (srv *securedServer) AcquireLease(ctx context.Context, req *databroker.AcquireLeaseRequest) (*databroker.AcquireLeaseResponse, error) {
+func (srv *securedServer) AcquireLease(ctx context.Context, req *databrokerpb.AcquireLeaseRequest) (*databrokerpb.AcquireLeaseResponse, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.AcquireLease(ctx, req)
 }
 
-func (srv *securedServer) Clear(ctx context.Context, req *emptypb.Empty) (*databroker.ClearResponse, error) {
+func (srv *securedServer) Clear(ctx context.Context, req *emptypb.Empty) (*databrokerpb.ClearResponse, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.Clear(ctx, req)
 }
 
-func (srv *securedServer) Get(ctx context.Context, req *databroker.GetRequest) (*databroker.GetResponse, error) {
+func (srv *securedServer) Get(ctx context.Context, req *databrokerpb.GetRequest) (*databrokerpb.GetResponse, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.Get(ctx, req)
 }
 
-func (srv *securedServer) List(ctx context.Context, req *registry.ListRequest) (*registry.ServiceList, error) {
+func (srv *securedServer) List(ctx context.Context, req *registrypb.ListRequest) (*registrypb.ServiceList, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.List(ctx, req)
 }
 
-func (srv *securedServer) ListTypes(ctx context.Context, req *emptypb.Empty) (*databroker.ListTypesResponse, error) {
+func (srv *securedServer) ListTypes(ctx context.Context, req *emptypb.Empty) (*databrokerpb.ListTypesResponse, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.ListTypes(ctx, req)
 }
 
-func (srv *securedServer) Patch(ctx context.Context, req *databroker.PatchRequest) (*databroker.PatchResponse, error) {
+func (srv *securedServer) Patch(ctx context.Context, req *databrokerpb.PatchRequest) (*databrokerpb.PatchResponse, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.Patch(ctx, req)
 }
 
-func (srv *securedServer) Put(ctx context.Context, req *databroker.PutRequest) (*databroker.PutResponse, error) {
+func (srv *securedServer) Put(ctx context.Context, req *databrokerpb.PutRequest) (*databrokerpb.PutResponse, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.Put(ctx, req)
 }
 
-func (srv *securedServer) Query(ctx context.Context, req *databroker.QueryRequest) (*databroker.QueryResponse, error) {
+func (srv *securedServer) Query(ctx context.Context, req *databrokerpb.QueryRequest) (*databrokerpb.QueryResponse, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.Query(ctx, req)
 }
 
-func (srv *securedServer) ReleaseLease(ctx context.Context, req *databroker.ReleaseLeaseRequest) (*emptypb.Empty, error) {
+func (srv *securedServer) ReleaseLease(ctx context.Context, req *databrokerpb.ReleaseLeaseRequest) (*emptypb.Empty, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.ReleaseLease(ctx, req)
 }
 
-func (srv *securedServer) RenewLease(ctx context.Context, req *databroker.RenewLeaseRequest) (*emptypb.Empty, error) {
+func (srv *securedServer) RenewLease(ctx context.Context, req *databrokerpb.RenewLeaseRequest) (*emptypb.Empty, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.RenewLease(ctx, req)
 }
 
-func (srv *securedServer) Report(ctx context.Context, req *registry.RegisterRequest) (*registry.RegisterResponse, error) {
+func (srv *securedServer) Report(ctx context.Context, req *registrypb.RegisterRequest) (*registrypb.RegisterResponse, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.Report(ctx, req)
 }
 
-func (srv *securedServer) ServerInfo(ctx context.Context, req *emptypb.Empty) (*databroker.ServerInfoResponse, error) {
+func (srv *securedServer) ServerInfo(ctx context.Context, req *emptypb.Empty) (*databrokerpb.ServerInfoResponse, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.ServerInfo(ctx, req)
 }
 
-func (srv *securedServer) SetOptions(ctx context.Context, req *databroker.SetOptionsRequest) (*databroker.SetOptionsResponse, error) {
+func (srv *securedServer) SetOptions(ctx context.Context, req *databrokerpb.SetOptionsRequest) (*databrokerpb.SetOptionsResponse, error) {
 	if err := srv.authorize(ctx); err != nil {
 		return nil, err
 	}
 	return srv.underlying.SetOptions(ctx, req)
 }
 
-func (srv *securedServer) Sync(req *databroker.SyncRequest, stream grpc.ServerStreamingServer[databroker.SyncResponse]) error {
+func (srv *securedServer) Sync(req *databrokerpb.SyncRequest, stream grpc.ServerStreamingServer[databrokerpb.SyncResponse]) error {
 	if err := srv.authorize(stream.Context()); err != nil {
 		return err
 	}
 	return srv.underlying.Sync(req, stream)
 }
 
-func (srv *securedServer) SyncLatest(req *databroker.SyncLatestRequest, stream grpc.ServerStreamingServer[databroker.SyncLatestResponse]) error {
+func (srv *securedServer) SyncLatest(req *databrokerpb.SyncLatestRequest, stream grpc.ServerStreamingServer[databrokerpb.SyncLatestResponse]) error {
 	if err := srv.authorize(stream.Context()); err != nil {
 		return err
 	}
 	return srv.underlying.SyncLatest(req, stream)
 }
 
-func (srv *securedServer) Watch(req *registry.ListRequest, stream grpc.ServerStreamingServer[registry.ServiceList]) error {
+func (srv *securedServer) Watch(req *registrypb.ListRequest, stream grpc.ServerStreamingServer[registrypb.ServiceList]) error {
 	if err := srv.authorize(stream.Context()); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
Add a new `erroringServer` that always returns errors for all databroker and registry methods.

This server will be used by a `clusteredServer` that will use it if configuration is invalid.

Also update imports to be consistent. We have multiple packages named `databroker` which can be confusing. When the `internal/databroker` uses `grpc/databroker` it should always use the `databrokerpb` name now.

## Related issues
- [ENG-2823](https://linear.app/pomerium/issue/ENG-2823/databroker-add-erroring-server)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
