### PR TITLE
databroker: add clustered leader server

### DIFF
--- a/internal/databroker/server_clustered_leader.go
+++ b/internal/databroker/server_clustered_leader.go
@@ -1,0 +1,12 @@
+package databroker
+
+type clusteredLeaderServer struct {
+	Server
+}
+
+// NewClusteredLeaderServer creates a new clustered leader databroker server.
+// A clustered leader server implements the server interface via a local
+// backend server.
+func NewClusteredLeaderServer(local Server) Server {
+	return &clusteredLeaderServer{local}
+}

--- a/internal/databroker/server_clustered_leader_test.go
+++ b/internal/databroker/server_clustered_leader_test.go
@@ -1,0 +1,34 @@
+package databroker_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/pomerium/pomerium/internal/databroker"
+	"github.com/pomerium/pomerium/internal/testutil"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+func TestClusteredLeaderServer(t *testing.T) {
+	t.Parallel()
+
+	local := databroker.NewBackendServer(noop.NewTracerProvider())
+	leader := databroker.NewClusteredLeaderServer(local)
+
+	cc := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(s, leader)
+	})
+
+	res1, err := local.ServerInfo(t.Context(), new(emptypb.Empty))
+	assert.NoError(t, err)
+	res2, err := databrokerpb.NewDataBrokerServiceClient(cc).ServerInfo(t.Context(), new(emptypb.Empty))
+	assert.NoError(t, err)
+
+	assert.Empty(t, cmp.Diff(res1, res2, protocmp.Transform()))
+}


### PR DESCRIPTION
## Summary
Add the clustered leader server for the databroker. It just wraps a local server instance. See #5815.

## Related issues
- [ENG-2722](https://linear.app/pomerium/issue/ENG-2722/databroker-add-clustered-server)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
