### PR TITLE
feat: handle signals to better gracefully drain/terminate envoy

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -17,6 +17,7 @@ import (
 	_ "github.com/pomerium/pomerium/internal/zero/bootstrap/writers/k8s"
 	zero_cmd "github.com/pomerium/pomerium/internal/zero/cmd"
 	"github.com/pomerium/pomerium/pkg/cmd/pomerium"
+	"github.com/pomerium/pomerium/pkg/contextutil"
 	"github.com/pomerium/pomerium/pkg/envoy/files"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
@@ -32,7 +33,9 @@ func main() {
 	root.AddCommand(zero_cmd.BuildRootCmd())
 	root.PersistentFlags().StringVar(&configFile, "config", "", "Specify configuration file location")
 	log.SetLevel(zerolog.InfoLevel)
-	ctx := trace.NewContext(context.Background(), trace.NewSyncClient(nil))
+
+	sigCtx := contextutil.SetupSignals(context.Background())
+	ctx := trace.NewContext(sigCtx, trace.NewSyncClient(nil))
 	defer func() {
 		if err := trace.ShutdownContext(ctx); err != nil {
 			log.Error().Err(err).Send()

--- a/pkg/contextutil/signals.go
+++ b/pkg/contextutil/signals.go
@@ -1,0 +1,29 @@
+package contextutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+var ErrShutdown = errors.New("pomerium shutdown requested")
+
+func SetupSignals(ctx context.Context) context.Context {
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	ctxCa, ca := context.WithCancelCause(ctx)
+	go func() {
+		defer ca(fmt.Errorf("signal received : %w", ErrShutdown))
+		select {
+		case <-sig:
+			log.Logger().Trace().Msg("interrupt received")
+		case <-ctxCa.Done():
+		}
+	}()
+	return ctxCa
+}


### PR DESCRIPTION
## Summary

Right now we explicitly do not handle OS signals in pomerium - this has the side effect of not necessarily running shutdown phases of pomerium, e.g. things that are supposed to run after a context is done, for example `context.AfterFunc(ctx, ...)`.

It works mostly as expected right now since when container orchestration frameworks like Kubernetes pass a SIGTERM to the process, any sub-processes spawned with exec.Command will inherit those signals and get sent SIGTERM as well, which according to the envoy docs will result in draining listeners according to `--drain-time` which defaults to 600s.

However, right now the pomerium.Shutdown is a utility function explicitly used by our test environment, our current pomerium.Wait doesn't handle graceful shutdown correctly, it has been amended to:
- wait for envoy server to close (either successfully or unsuccessfully)
- return errors to the parent command if and only if the first error was not surfaced via pomerium.Shutdown() or by one of the valid interrupt signals. Not handling these errors means that systemd, will handle graceful shutdown as well since it expects a zero return code on successful shutdown, which the previous iteration did not have.


An unintended side effect of catching signals is the envoy server gracePeriodSeconds on is always set to 0 (in non-test env settings) -- causing the envoy process to be SIGKILLED inadvertently by the old code. This has been fixed by respecting the default `--drain-time`.

<hr/>
In addition, we make a best effort to post an explicit graceful drain request to envoy during shutdown.

<hr/>

Some testing utilities I used to verify different termination sceanrios:
- `strace -p $(pidof pomerium) -e signal`
- `strace -p $(pidof envoy) -e signal`

should always receive SIGTERM/SIGINT and exit with status code 0. 

<hr/>

Ref:
- https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/operations/draining
- https://www.envoyproxy.io/docs/envoy/latest/operations/cli#cmdoption-drain-time-s

## Related issues

https://linear.app/pomerium/project/healthcheck-with-graceful-teardown-e5428048d59e/overview
https://linear.app/pomerium/issue/ENG-2847/health-check-graceful-termination

## User Explanation

Users can expect that envoy's connections will be drained before the pomerium-proxy exits when it terminates gracefully, i.e. receives SIGINT/SIGTERM.
 
## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
