### PR TITLE
feat: health check CLI

### DIFF
--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/cmd/pomerium"
 	"github.com/pomerium/pomerium/pkg/contextutil"
 	"github.com/pomerium/pomerium/pkg/envoy/files"
+	"github.com/pomerium/pomerium/pkg/health"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
@@ -31,6 +32,7 @@ func main() {
 		SilenceUsage: true,
 	}
 	root.AddCommand(zero_cmd.BuildRootCmd())
+	root.AddCommand(health.BuildHealthCommand())
 	root.PersistentFlags().StringVar(&configFile, "config", "", "Specify configuration file location")
 	log.SetLevel(zerolog.InfoLevel)
 

--- a/integration/clusters/multi-stateful/compose.yml
+++ b/integration/clusters/multi-stateful/compose.yml
@@ -184,6 +184,14 @@ services:
       SHARED_SECRET: UYgnt8bxxK5G2sFaNzyqi5Z+OgF8m2akNc0xdQx718w=
       SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVBSR1d3TGg3NW5OWG5razM3ekRmTjhvbkx3ZkNpYUxQVEQrbmM4THg1aGNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFa3BCa08wVEttaDRKZFFmTE9lZU1kNTNLbmdhMVdkUVhyNUZjZXBrK2RMVktkVkt4WENHcQpoMW9qdWh1VzExR0lvT3pTOUdvU0tsTlZTUkZXVkVXRHZ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
       SIGNING_KEY_ALGORITHM: ES256
+    healthcheck:
+      interval: 1s
+      retries: 2
+      test:
+      - CMD
+      - pomerium
+      - health
+      timeout: 1s
     image: pomerium/pomerium:${POMERIUM_TAG:-main}
     networks:
       main:
@@ -246,6 +254,14 @@ services:
       SHARED_SECRET: UYgnt8bxxK5G2sFaNzyqi5Z+OgF8m2akNc0xdQx718w=
       SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVBSR1d3TGg3NW5OWG5razM3ekRmTjhvbkx3ZkNpYUxQVEQrbmM4THg1aGNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFa3BCa08wVEttaDRKZFFmTE9lZU1kNTNLbmdhMVdkUVhyNUZjZXBrK2RMVktkVkt4WENHcQpoMW9qdWh1VzExR0lvT3pTOUdvU0tsTlZTUkZXVkVXRHZ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
       SIGNING_KEY_ALGORITHM: ES256
+    healthcheck:
+      interval: 1s
+      retries: 2
+      test:
+      - CMD
+      - pomerium
+      - health
+      timeout: 1s
     image: pomerium/pomerium:${POMERIUM_TAG:-main}
     networks:
       main:
@@ -307,6 +323,14 @@ services:
       SHARED_SECRET: UYgnt8bxxK5G2sFaNzyqi5Z+OgF8m2akNc0xdQx718w=
       SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVBSR1d3TGg3NW5OWG5razM3ekRmTjhvbkx3ZkNpYUxQVEQrbmM4THg1aGNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFa3BCa08wVEttaDRKZFFmTE9lZU1kNTNLbmdhMVdkUVhyNUZjZXBrK2RMVktkVkt4WENHcQpoMW9qdWh1VzExR0lvT3pTOUdvU0tsTlZTUkZXVkVXRHZ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
       SIGNING_KEY_ALGORITHM: ES256
+    healthcheck:
+      interval: 1s
+      retries: 2
+      test:
+      - CMD
+      - pomerium
+      - health
+      timeout: 1s
     image: pomerium/pomerium:${POMERIUM_TAG:-main}
     networks:
       main:
@@ -368,6 +392,14 @@ services:
       SHARED_SECRET: UYgnt8bxxK5G2sFaNzyqi5Z+OgF8m2akNc0xdQx718w=
       SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVBSR1d3TGg3NW5OWG5razM3ekRmTjhvbkx3ZkNpYUxQVEQrbmM4THg1aGNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFa3BCa08wVEttaDRKZFFmTE9lZU1kNTNLbmdhMVdkUVhyNUZjZXBrK2RMVktkVkt4WENHcQpoMW9qdWh1VzExR0lvT3pTOUdvU0tsTlZTUkZXVkVXRHZ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
       SIGNING_KEY_ALGORITHM: ES256
+    healthcheck:
+      interval: 1s
+      retries: 2
+      test:
+      - CMD
+      - pomerium
+      - health
+      timeout: 1s
     image: pomerium/pomerium:${POMERIUM_TAG:-main}
     networks:
       main:

--- a/integration/clusters/multi-stateless/compose.yml
+++ b/integration/clusters/multi-stateless/compose.yml
@@ -185,6 +185,14 @@ services:
       SHARED_SECRET: UYgnt8bxxK5G2sFaNzyqi5Z+OgF8m2akNc0xdQx718w=
       SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVBSR1d3TGg3NW5OWG5razM3ekRmTjhvbkx3ZkNpYUxQVEQrbmM4THg1aGNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFa3BCa08wVEttaDRKZFFmTE9lZU1kNTNLbmdhMVdkUVhyNUZjZXBrK2RMVktkVkt4WENHcQpoMW9qdWh1VzExR0lvT3pTOUdvU0tsTlZTUkZXVkVXRHZ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
       SIGNING_KEY_ALGORITHM: ES256
+    healthcheck:
+      interval: 1s
+      retries: 2
+      test:
+      - CMD
+      - pomerium
+      - health
+      timeout: 1s
     image: pomerium/pomerium:${POMERIUM_TAG:-main}
     networks:
       main:
@@ -248,6 +256,14 @@ services:
       SHARED_SECRET: UYgnt8bxxK5G2sFaNzyqi5Z+OgF8m2akNc0xdQx718w=
       SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVBSR1d3TGg3NW5OWG5razM3ekRmTjhvbkx3ZkNpYUxQVEQrbmM4THg1aGNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFa3BCa08wVEttaDRKZFFmTE9lZU1kNTNLbmdhMVdkUVhyNUZjZXBrK2RMVktkVkt4WENHcQpoMW9qdWh1VzExR0lvT3pTOUdvU0tsTlZTUkZXVkVXRHZ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
       SIGNING_KEY_ALGORITHM: ES256
+    healthcheck:
+      interval: 1s
+      retries: 2
+      test:
+      - CMD
+      - pomerium
+      - health
+      timeout: 1s
     image: pomerium/pomerium:${POMERIUM_TAG:-main}
     networks:
       main:
@@ -310,6 +326,14 @@ services:
       SHARED_SECRET: UYgnt8bxxK5G2sFaNzyqi5Z+OgF8m2akNc0xdQx718w=
       SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVBSR1d3TGg3NW5OWG5razM3ekRmTjhvbkx3ZkNpYUxQVEQrbmM4THg1aGNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFa3BCa08wVEttaDRKZFFmTE9lZU1kNTNLbmdhMVdkUVhyNUZjZXBrK2RMVktkVkt4WENHcQpoMW9qdWh1VzExR0lvT3pTOUdvU0tsTlZTUkZXVkVXRHZ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
       SIGNING_KEY_ALGORITHM: ES256
+    healthcheck:
+      interval: 1s
+      retries: 2
+      test:
+      - CMD
+      - pomerium
+      - health
+      timeout: 1s
     image: pomerium/pomerium:${POMERIUM_TAG:-main}
     networks:
       main:
@@ -372,6 +396,14 @@ services:
       SHARED_SECRET: UYgnt8bxxK5G2sFaNzyqi5Z+OgF8m2akNc0xdQx718w=
       SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVBSR1d3TGg3NW5OWG5razM3ekRmTjhvbkx3ZkNpYUxQVEQrbmM4THg1aGNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFa3BCa08wVEttaDRKZFFmTE9lZU1kNTNLbmdhMVdkUVhyNUZjZXBrK2RMVktkVkt4WENHcQpoMW9qdWh1VzExR0lvT3pTOUdvU0tsTlZTUkZXVkVXRHZ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
       SIGNING_KEY_ALGORITHM: ES256
+    healthcheck:
+      interval: 1s
+      retries: 2
+      test:
+      - CMD
+      - pomerium
+      - health
+      timeout: 1s
     image: pomerium/pomerium:${POMERIUM_TAG:-main}
     networks:
       main:

--- a/integration/clusters/single-stateful/compose.yml
+++ b/integration/clusters/single-stateful/compose.yml
@@ -178,6 +178,14 @@ services:
       SHARED_SECRET: UYgnt8bxxK5G2sFaNzyqi5Z+OgF8m2akNc0xdQx718w=
       SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVBSR1d3TGg3NW5OWG5razM3ekRmTjhvbkx3ZkNpYUxQVEQrbmM4THg1aGNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFa3BCa08wVEttaDRKZFFmTE9lZU1kNTNLbmdhMVdkUVhyNUZjZXBrK2RMVktkVkt4WENHcQpoMW9qdWh1VzExR0lvT3pTOUdvU0tsTlZTUkZXVkVXRHZ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
       SIGNING_KEY_ALGORITHM: ES256
+    healthcheck:
+      interval: 1s
+      retries: 2
+      test:
+      - CMD
+      - poemrium
+      - health
+      timeout: 1s
     image: pomerium/pomerium:${POMERIUM_TAG:-main}
     networks:
       main:

--- a/integration/clusters/single-stateless/compose.yml
+++ b/integration/clusters/single-stateless/compose.yml
@@ -179,6 +179,14 @@ services:
       SHARED_SECRET: UYgnt8bxxK5G2sFaNzyqi5Z+OgF8m2akNc0xdQx718w=
       SIGNING_KEY: LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSVBSR1d3TGg3NW5OWG5razM3ekRmTjhvbkx3ZkNpYUxQVEQrbmM4THg1aGNvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFa3BCa08wVEttaDRKZFFmTE9lZU1kNTNLbmdhMVdkUVhyNUZjZXBrK2RMVktkVkt4WENHcQpoMW9qdWh1VzExR0lvT3pTOUdvU0tsTlZTUkZXVkVXRHZ3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=
       SIGNING_KEY_ALGORITHM: ES256
+    healthcheck:
+      interval: 1s
+      retries: 2
+      test:
+      - CMD
+      - poemrium
+      - health
+      timeout: 1s
     image: pomerium/pomerium:${POMERIUM_TAG:-main}
     networks:
       main:

--- a/integration/tpl/backends/pomerium.libsonnet
+++ b/integration/tpl/backends/pomerium.libsonnet
@@ -152,6 +152,12 @@ function(mode, idp, authentication_flow, dns_suffix='') {
           CERTIFICATE: std.base64(importstr '../files/pomerium-authorize.pem'),
           CERTIFICATE_KEY: std.base64(importstr '../files/pomerium-authorize-key.pem'),
         },
+        healthcheck: {
+          test: ["CMD", "pomerium", "health"] ,
+          interval: "1s",
+          timeout: "1s",
+          retries: 2,
+        },
         ports: [
           '9904:9901/tcp',
           '5446:5443/tcp',
@@ -161,6 +167,12 @@ function(mode, idp, authentication_flow, dns_suffix='') {
         image: image,
         environment: environment {
           SERVICES: 'authenticate',
+        },
+        healthcheck: {
+          test: ["CMD", "pomerium", "health"] ,
+          interval: "1s",
+          timeout: "1s",
+          retries: 2,
         },
         ports: [
           '9903:9901/tcp',
@@ -174,6 +186,12 @@ function(mode, idp, authentication_flow, dns_suffix='') {
           CERTIFICATE: std.base64(importstr '../files/pomerium-databroker.pem'),
           CERTIFICATE_KEY: std.base64(importstr '../files/pomerium-databroker-key.pem'),
         },
+        healthcheck: {
+          test: ["CMD", "pomerium", "health"] ,
+          interval: "1s",
+          timeout: "1s",
+          retries: 2,
+        },
         ports: [
           '9902:9901/tcp',
           '5444:5443/tcp',
@@ -183,6 +201,12 @@ function(mode, idp, authentication_flow, dns_suffix='') {
         image: image,
         environment: environment {
           SERVICES: 'proxy',
+        },
+        healthcheck: {
+          test: ["CMD", "pomerium", "health"] ,
+          interval: "1s",
+          timeout: "1s",
+          retries: 2,
         },
         ports: [
           '80:80/tcp',
@@ -196,6 +220,12 @@ function(mode, idp, authentication_flow, dns_suffix='') {
       ComposeService(name, {
         image: image,
         environment: environment,
+        healthcheck: {
+          test: ["CMD", "poemrium", "health"] ,
+          interval: "1s",
+          timeout: "1s",
+          retries: 2,
+        },
         ports: [
           '80:80/tcp',
           '443:443/tcp',

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -186,6 +186,14 @@ func NewServer(
 	srv.MetricsRouter.Handle("/metrics", srv.metricsMgr)
 
 	// health
+	srv.HealthCheckRouter.Path("/status").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := srv.ProbeProvider.Load()
+		if p != nil {
+			http.HandlerFunc(p.Status).ServeHTTP(w, r)
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	})
 	srv.HealthCheckRouter.Path("/startupz").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p := srv.ProbeProvider.Load()
 		if p != nil {

--- a/pkg/health/cli.go
+++ b/pkg/health/cli.go
@@ -1,0 +1,111 @@
+package health
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	stdslices "slices"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pomerium/pomerium/pkg/slices"
+)
+
+var ErrUnhealthy = errors.New("status unhealthy")
+
+func getHTTPStatus(
+	client *http.Client,
+	req *http.Request,
+	// expectedChecks []Check,
+	filter Filter,
+) (string, error) {
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("got unexpected status code %d : %w", resp.StatusCode, ErrUnhealthy)
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	msg := &httpStatusPayload{}
+
+	if err := json.Unmarshal(data, msg); err != nil {
+		return "", err
+	}
+
+	errs := []error{}
+	requiredChecks := map[Check]struct{}{}
+	for _, check := range msg.Required {
+		requiredChecks[check] = struct{}{}
+	}
+
+	for check, status := range msg.Statuses {
+		delete(requiredChecks, Check(check))
+		if stdslices.Contains(filter.Exclude, Check(check)) {
+			continue
+		}
+		if status.Err != "" {
+			errs = append(errs, err)
+			continue
+		}
+		if status.Status != StatusRunning.String() {
+			errs = append(errs, fmt.Errorf("unhealthy status : %s", status.Status))
+		}
+	}
+
+	if len(requiredChecks) > 0 || len(errs) > 0 {
+		errs = append(errs, ErrUnhealthy)
+	}
+
+	return string(data), errors.Join(errs...)
+}
+
+func BuildHealthCommand() *cobra.Command {
+	var addr string
+	var excludeFilters []string
+	var verbose bool
+	cmd := &cobra.Command{
+		Use: "health",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			client := http.DefaultClient
+
+			req, err := http.NewRequestWithContext(cmd.Context(), http.MethodGet, fmt.Sprintf("http://%s/status", addr), nil)
+			if err != nil {
+				return err
+			}
+
+			raw, err := getHTTPStatus(client, req, Filter{Exclude: slices.Map(excludeFilters, func(e string) Check {
+				return Check(e)
+			})})
+			if verbose && raw != "" {
+				cmd.Println(raw)
+			}
+			return err
+		},
+	}
+
+	cmd.Flags().StringVarP(
+		&addr,
+		"health-addr",
+		"a",
+		"127.0.0.1:28080",
+		"port of the pomerium health check service",
+	)
+
+	cmd.Flags().StringArrayVarP(
+		&excludeFilters,
+		"exclude",
+		"e",
+		[]string{},
+		"list of health checks to exclude from consideration",
+	)
+	cmd.Flags().BoolVarP(&verbose, "verbose", "v", false, "prints extra health information")
+	return cmd
+}

--- a/pkg/health/cli_test.go
+++ b/pkg/health/cli_test.go
@@ -1,0 +1,59 @@
+package health
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCLI(t *testing.T) {
+	assert := assert.New(t)
+	mgr := NewManager()
+	c1, c2, c3 := Check("check1"), Check("check2"), Check("check3")
+	hP := NewHTTPProvider(mgr, WithExpectedChecks(c1, c2, c3))
+	status := http.HandlerFunc(hP.Status)
+	server := httptest.NewServer(status)
+
+	req, _ := http.NewRequest(http.MethodGet, server.URL+"/status", nil)
+	type testcase struct {
+		filter Filter
+		err    error
+	}
+	tcs1 := []testcase{
+		{
+			err: ErrUnhealthy,
+			filter: Filter{
+				Exclude: []Check{},
+			},
+		},
+		{
+			err: nil,
+			filter: Filter{
+				Exclude: []Check{c3},
+			},
+		},
+	}
+	mgr.ReportStatus(c1, StatusRunning)
+	mgr.ReportStatus(c2, StatusRunning)
+	mgr.ReportError(c3, fmt.Errorf("some error"))
+	for _, tc := range tcs1 {
+		_, err := getHTTPStatus(server.Client(), req, tc.filter)
+		if err != nil {
+			assert.True(errors.Is(err, ErrUnhealthy))
+			assert.ErrorIs(err, tc.err)
+		} else {
+			assert.Nil(tc.err, "expected an error but got nonde")
+		}
+
+	}
+
+	mgr.ReportStatus(c1, StatusTerminating)
+	_, err := getHTTPStatus(server.Client(), req, Filter{
+		Exclude: []Check{c3},
+	})
+	assert.ErrorIs(err, ErrUnhealthy)
+}


### PR DESCRIPTION
## Summary

Requires https://github.com/pomerium/pomerium/pull/5822

Adds a sub-command to the pomerium binary to provide health checking in container environments like docker compose or amazon ECS.

The command runs a http client against the http health check server and exits with 0 on success and 1 on failure.

## Related issues

[ENG-1895](https://linear.app/pomerium/issue/ENG-1895/feature-request-cli-health-command)

## User Explanation

Users can now enable health checks in their docker compose environments using:
```yaml
services:
  pomerium:
    # pomerium service details
    healthcheck:
      test: ["CMD", "pomerium", "health"]
      interval: 1m30s
      timeout: 10s
      retries: 3
      start_period: 40s
      start_interval: 5s
  ```

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] ready for review
