### PR TITLE
authorize: add client_cert_subject substitution

### DIFF
--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -3,6 +3,7 @@ package evaluator
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -54,6 +55,9 @@ type headersEvaluatorEvaluation struct {
 
 	gotSignedJWT    bool
 	cachedSignedJWT string
+
+	gotParsedClientCert    bool
+	cachedParsedClientCert *x509.Certificate
 }
 
 func newHeadersEvaluatorEvaluation(evaluator *HeadersEvaluator, request *Request, now time.Time) *headersEvaluatorEvaluation {
@@ -192,6 +196,8 @@ func (e *headersEvaluatorEvaluation) fillSetRequestHeaders(ctx context.Context) 
 				return s.GetOauthToken().GetAccessToken()
 			case slices.Equal(ref, []string{"pomerium", "client_cert_fingerprint"}):
 				return e.getClientCertFingerprint()
+			case slices.Equal(ref, []string{"pomerium", "client_cert_subject"}):
+				return e.getParsedClientCert().Subject.String()
 			case slices.Equal(ref, []string{"pomerium", "id_token"}):
 				s, _ := e.getSessionOrServiceAccount(ctx)
 				return s.GetIdToken().GetRaw()
@@ -256,9 +262,19 @@ func (e *headersEvaluatorEvaluation) getUser(ctx context.Context) *user.User {
 	return e.cachedUser
 }
 
+func (e *headersEvaluatorEvaluation) getParsedClientCert() *x509.Certificate {
+	if e.gotParsedClientCert {
+		return e.cachedParsedClientCert
+	}
+
+	e.gotParsedClientCert = true
+	e.cachedParsedClientCert, _ = cryptutil.ParsePEMCertificate([]byte(e.request.HTTP.ClientCertificate.Leaf))
+	return e.cachedParsedClientCert
+}
+
 func (e *headersEvaluatorEvaluation) getClientCertFingerprint() string {
-	cert, err := cryptutil.ParsePEMCertificate([]byte(e.request.HTTP.ClientCertificate.Leaf))
-	if err != nil {
+	cert := e.getParsedClientCert()
+	if cert == nil {
 		return ""
 	}
 	return cryptoSHA256(cert.Raw)

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -228,6 +228,7 @@ func TestHeadersEvaluator(t *testing.T) {
 						"X-ID-Token":               "${pomerium.id_token}",
 						"X-Access-Token":           "${pomerium.access_token}",
 						"Client-Cert-Fingerprint":  "${pomerium.client_cert_fingerprint}",
+						"Client-Cert-Subject":      "${pomerium.client_cert_subject}",
 						"Authorization":            "Bearer ${pomerium.jwt}",
 						"Foo":                      "escaped $$dollar sign",
 						"X-Incoming-Custom-Header": `From-Incoming ${pomerium.request.headers["X-Incoming-Header"]}`,
@@ -242,6 +243,7 @@ func TestHeadersEvaluator(t *testing.T) {
 		assert.Equal(t, "ACCESS_TOKEN", output.Headers.Get("X-Access-Token"))
 		assert.Equal(t, "3febe6467787e93f0a01030e0803072feaa710f724a9dc74de05cfba3d4a6d23",
 			output.Headers.Get("Client-Cert-Fingerprint"))
+		assert.Equal(t, "CN=trusted client cert", output.Headers.Get("Client-Cert-Subject"))
 		assert.Equal(t, "escaped $dollar sign", output.Headers.Get("Foo"))
 		assert.Equal(t, "From-Incoming INCOMING", output.Headers.Get("X-Incoming-Custom-Header"))
 		authHeader := output.Headers.Get("Authorization")


### PR DESCRIPTION
## Summary

Add a new request header substitution token `${pomerium.client_cert_subject}` that maps to a human-readable form of the client certificate Subject name.

## Related issues

https://linear.app/pomerium/issue/ENG-2691/support-extracting-downstream-cert-ou-and-pass-upstream-as-a-header

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
