### PR TITLE
fix: handle os.Interrupt for shutdown

### DIFF
--- a/pkg/contextutil/signals.go
+++ b/pkg/contextutil/signals.go
@@ -15,7 +15,7 @@ var ErrShutdown = errors.New("pomerium shutdown requested")
 
 func SetupSignals(ctx context.Context) context.Context {
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT)
+	signal.Notify(sig, syscall.SIGTERM, syscall.SIGINT, os.Interrupt)
 	ctxCa, ca := context.WithCancelCause(ctx)
 	go func() {
 		defer ca(fmt.Errorf("signal received : %w", ErrShutdown))

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -210,7 +210,7 @@ func (srv *Server) Close() error {
 		}
 		log.Debug().Int("exit-grace-period-seconds", int(srv.exitGracePeriod.Seconds())).Msg("requesting envoy to shutdown gracefully")
 		if srv.exitGracePeriodOrDefault() > 0 {
-			_ = srv.cmd.Process.Signal(syscall.SIGTERM)
+			_ = srv.cmd.Process.Signal(shutdownSignal)
 			select {
 			case <-srv.cmdExited:
 				return nil

--- a/pkg/envoy/signal_linux.go
+++ b/pkg/envoy/signal_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package envoy
+
+import "syscall"
+
+var shutdownSignal = syscall.SIGTERM

--- a/pkg/envoy/signal_other.go
+++ b/pkg/envoy/signal_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package envoy
+
+import "os"
+
+var shutdownSignal = os.Interrupt


### PR DESCRIPTION
## Summary

Handles os.Interrupt signals as shutdown signals for non-linux environments.


## Related issues

N/A

## User Explanation

Graceful shutdown will work on darwin environments.

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] ready for review
