### PR TITLE
envoyconfig: disable proxy protocol for the quic listener

### DIFF
--- a/config/envoyconfig/listeners_main.go
+++ b/config/envoyconfig/listeners_main.go
@@ -58,10 +58,6 @@ func (b *Builder) buildMainQUICListener(
 ) (*envoy_config_listener_v3.Listener, error) {
 	li := newQUICListener("quic-ingress", buildUDPAddress(cfg.Options.Addr, 443))
 
-	// listener filters
-	if cfg.Options.UseProxyProtocol {
-		li.ListenerFilters = append(li.ListenerFilters, ProxyProtocolFilter())
-	}
 	// access log
 	if cfg.Options.DownstreamMTLS.Enforcement == config.MTLSEnforcementRejectConnection {
 		li.AccessLog = append(li.AccessLog, newListenerAccessLog())

--- a/config/envoyconfig/listeners_main_test.go
+++ b/config/envoyconfig/listeners_main_test.go
@@ -7,11 +7,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
 	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
 func Test_requireProxyProtocol(t *testing.T) {
-	b := New("local-grpc", "local-http", "local-metrics", nil, nil, true)
+	b := New("local-grpc", "local-http", "local-metrics", filemgr.NewManager(), nil, true)
 	t.Run("required", func(t *testing.T) {
 		li, err := b.buildMainListener(t.Context(), &config.Config{Options: &config.Options{
 			UseProxyProtocol: true,
@@ -32,6 +34,15 @@ func Test_requireProxyProtocol(t *testing.T) {
 			UseProxyProtocol: false,
 			InsecureServer:   true,
 		}}, false, false)
+		require.NoError(t, err)
+		assert.Len(t, li.GetListenerFilters(), 0)
+	})
+	t.Run("disabled for quic", func(t *testing.T) {
+		li, err := b.buildMainListener(t.Context(), &config.Config{Options: &config.Options{
+			SharedKey:        cryptutil.NewBase64Key(),
+			UseProxyProtocol: true,
+			CodecType:        config.CodecTypeHTTP3,
+		}}, false, true)
 		require.NoError(t, err)
 		assert.Len(t, li.GetListenerFilters(), 0)
 	})


### PR DESCRIPTION
## Summary
Disable the proxy protocol for the QUIC listener. Envoy doesn't support this for UDP listeners. 

## Related issues
- [ENG-2855](https://linear.app/pomerium/issue/ENG-2855/http3-with-proxy-protocol)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
