### PR TITLE
databroker/file: enforce strict permissions on files (0600) and directories (0700)

### DIFF
--- a/pkg/pebbleutil/pebbleutil.go
+++ b/pkg/pebbleutil/pebbleutil.go
@@ -2,7 +2,9 @@ package pebbleutil
 
 import (
 	"context"
+	"fmt"
 	"iter"
+	"os"
 	"slices"
 
 	"github.com/cockroachdb/pebble/v2"
@@ -90,6 +92,9 @@ func Open(dirname string, options *pebble.Options) (*pebble.DB, error) {
 		options = new(pebble.Options)
 	}
 	options.LoggerAndTracer = pebbleLogger{}
+	if options.FS == nil {
+		options.FS = secureFS{FS: vfs.Default}
+	}
 	if options.Levels == nil {
 		options.Levels = []pebble.LevelOptions{{Compression: func() pebble.Compression {
 			return pebble.NoCompression
@@ -118,3 +123,37 @@ func (pebbleLogger) Errorf(_ string, _ ...any)                    {}
 func (pebbleLogger) Fatalf(_ string, _ ...any)                    {}
 func (pebbleLogger) Eventf(_ context.Context, _ string, _ ...any) {}
 func (pebbleLogger) IsTracingEnabled(_ context.Context) bool      { return false }
+
+// enforce strict permissions on files (0600) and directories (0700)
+type secureFS struct{ vfs.FS }
+
+func (s secureFS) Create(name string, category vfs.DiskWriteCategory) (vfs.File, error) {
+	f, err := s.FS.Create(name, category)
+	if err != nil {
+		return nil, fmt.Errorf("create %q: %w", name, err)
+	}
+	err = os.Chmod(name, 0o600)
+	if err != nil {
+		_ = f.Close()
+		_ = os.Remove(name)
+		return nil, fmt.Errorf("chmod %q: %w", name, err)
+	}
+	return f, nil
+}
+
+func (s secureFS) MkdirAll(path string, _ os.FileMode) error {
+	return s.FS.MkdirAll(path, 0o700)
+}
+
+func (s secureFS) ReuseForWrite(name, oldname string, category vfs.DiskWriteCategory) (vfs.File, error) {
+	f, err := s.FS.ReuseForWrite(name, oldname, category)
+	if err != nil {
+		return nil, err
+	}
+	err = os.Chmod(name, 0o600)
+	if err != nil {
+		_ = f.Close()
+		return nil, fmt.Errorf("chmod %q: %w", name, err)
+	}
+	return f, nil
+}

--- a/pkg/pebbleutil/pebbleutil_test.go
+++ b/pkg/pebbleutil/pebbleutil_test.go
@@ -1,0 +1,77 @@
+package pebbleutil
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/pebble/v2"
+)
+
+func TestSecureFSFileAndDirPerms(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	dbDir := filepath.Join(dir, "db")
+	db, err := Open(dbDir, nil)
+	if err != nil {
+		t.Fatalf("open pebble: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	wo := &pebble.WriteOptions{Sync: true}
+	val := bytes.Repeat([]byte{'v'}, 4096)
+	for i := 0; i < 200; i++ {
+		k := []byte(fmt.Sprintf("k%06d", i))
+		if err := db.Set(k, val, wo); err != nil {
+			t.Fatalf("set: %v", err)
+		}
+	}
+	if err := db.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	var foundFile bool
+	err = filepath.Walk(dbDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		mode := info.Mode().Perm()
+		if info.IsDir() {
+			if mode != 0o700 {
+				t.Errorf("dir %s mode = %o, want 0700", path, mode)
+			}
+			return nil
+		}
+		base := filepath.Base(path)
+		if base == "LOCK" {
+			// Pebble seems to manage LOCK file separately
+			return nil
+		}
+		foundFile = true
+		if mode != 0o600 {
+			t.Errorf("file %s mode = %o, want 0600", path, mode)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk: %v", err)
+	}
+	if !foundFile {
+		t.Fatalf("no files found in pebble dir; test invalid")
+	}
+}
+
+func TestMustOpenMemoryUnchanged(t *testing.T) {
+	t.Parallel()
+	db := MustOpenMemory(nil)
+	t.Cleanup(func() { _ = db.Close() })
+	wo := &pebble.WriteOptions{Sync: true}
+	if err := db.Set([]byte("k"), []byte("v"), wo); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	if err := db.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Enforce strict permissions on files (0600) and directories (0700) created by the `file` databroker. 

## Related issues

Fix #5832

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
