### PR TITLE
fix: health checks should reflect clustered databroker member health

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -396,6 +396,7 @@ func (srv *Server) getExpectedHealthChecks(cfg *config.Config) (ret []health.Che
 			health.StorageBackend,
 			health.DatabrokerInitialSync,
 			health.DatabrokerBuildConfig,
+			health.DatabrokerCluster,
 		)
 		if cfg.Options.DataBroker.StorageType == config.StoragePostgresName {
 			ret = append(

--- a/internal/databroker/server_clustered_leader.go
+++ b/internal/databroker/server_clustered_leader.go
@@ -1,5 +1,7 @@
 package databroker
 
+import "github.com/pomerium/pomerium/pkg/health"
+
 type clusteredLeaderServer struct {
 	Server
 }
@@ -8,6 +10,7 @@ type clusteredLeaderServer struct {
 // A clustered leader server implements the server interface via a local
 // backend server.
 func NewClusteredLeaderServer(local Server) Server {
+	health.ReportRunning(health.DatabrokerCluster, health.StrAttr("member", "leader"))
 	return &clusteredLeaderServer{local}
 }
 

--- a/internal/databroker/server_erroring.go
+++ b/internal/databroker/server_erroring.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
 	registrypb "github.com/pomerium/pomerium/pkg/grpc/registry"
+	"github.com/pomerium/pomerium/pkg/health"
 )
 
 type erroringServer struct {
@@ -17,6 +18,7 @@ type erroringServer struct {
 
 // NewErroringServer creates a new Server that returns an error for all databroker and registry methods.
 func NewErroringServer(err error) Server {
+	health.ReportError(health.DatabrokerCluster, err, health.StrAttr("member", "unknown"))
 	return &erroringServer{err: err}
 }
 

--- a/pkg/health/check.go
+++ b/pkg/health/check.go
@@ -18,6 +18,9 @@ const (
 	DatabrokerBuildConfig = Check("config.databroker.build")
 	// DatabrokerInitialSync checks whether the initial sync was successful
 	DatabrokerInitialSync = Check("databroker.sync.initial")
+	// DatabrokerCluster checks whether members of the databroker cluster are healthy
+	DatabrokerCluster = Check("databroker.cluster")
+
 	// StorageBackend checks whether the storage backend is healthy
 	StorageBackend = Check("storage.backend")
 	// StorageBackendCleanup checks the storage backend cleanup tasks are healthy


### PR DESCRIPTION
## Summary

When pomerium is started the startup, health and readiness checks will now appropriately reflect the status of clustered-mode.

When members of the cluster are leaders , the default checks are used to evaluate startup, health, and readiness.

When members of the cluster are followers, they must receive sync messages from the leader, otherwise startup will not succeed, and they will be marked unhealthy/unready.

When members cannot join the cluster, due to incorrect configuration, they are marked as unhealthy.

## Related issues

[ENG-2885](https://linear.app/pomerium/issue/ENG-2885/health-check-when-cluster-databroker-leader-is-inaccessible-health)

## User Explanation

Clustered mode member health is now reflected in health checks.

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] ready for review
