### PR TITLE
feat: report pomerium health to systemd

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -302,7 +302,7 @@ type Options struct {
 	CircuitBreakerThresholds *CircuitBreakerThresholds `mapstructure:"circuit_breaker_thresholds" yaml:"circuit_breaker_thresholds" json:"circuit_breaker_thresholds"`
 	// Address/Port to bind to for health check http probes
 	HealthCheckAddr string `mapstructure:"health_check_addr" yaml:"health_check_addr,omitempty"`
-	// Forcibly disables systemd health checks. They are typically run if the environment detects if it is running via systemd
+	// Forcibly disables systemd health checks. Systemd health checks are run automatically based on auto-detection
 	HealthCheckSystemdDisabled bool `mapstructure:"health_check_systemd_disabled" yaml:"health_check_systemd_disabled"`
 }
 

--- a/config/options.go
+++ b/config/options.go
@@ -302,6 +302,8 @@ type Options struct {
 	CircuitBreakerThresholds *CircuitBreakerThresholds `mapstructure:"circuit_breaker_thresholds" yaml:"circuit_breaker_thresholds" json:"circuit_breaker_thresholds"`
 	// Address/Port to bind to for health check http probes
 	HealthCheckAddr string `mapstructure:"health_check_addr" yaml:"health_check_addr,omitempty"`
+	// Forcibly disables systemd health checks. They are typically run if the environment detects if it is running via systemd
+	HealthCheckSystemdDisabled bool `mapstructure:"health_check_systemd_disabled" yaml:"health_check_systemd_disabled"`
 }
 
 type certificateFilePair struct {
@@ -338,6 +340,7 @@ var defaultOptions = Options{
 	EnvoyAdminProfilePath:               os.DevNull,
 	ProgrammaticRedirectDomainWhitelist: []string{"localhost"},
 	HealthCheckAddr:                     "127.0.0.1:28080",
+	HealthCheckSystemdDisabled:          false,
 }
 
 // IsRuntimeFlagSet returns true if the runtime flag is sets

--- a/internal/controlplane/health_linux.go
+++ b/internal/controlplane/health_linux.go
@@ -1,0 +1,88 @@
+//go:build linux
+
+package controlplane
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/pkg/health"
+)
+
+func (srv *Server) configureExtraProviders(
+	ctx context.Context,
+	cfg *config.Config,
+	mgr health.ProviderManager,
+	checks []health.Check,
+) {
+	srv.configureSdNotify(ctx, cfg, mgr, checks)
+}
+
+func (srv *Server) configureSdNotify(
+	ctx context.Context,
+	cfg *config.Config,
+	mgr health.ProviderManager,
+	checks []health.Check,
+) {
+	// if it already exists stop it
+	existing := srv.SystemdProvider.Load()
+	if existing != nil {
+		existing.Shutdown()
+	}
+	srv.SystemdProvider.Store(nil)
+	mgr.Deregister(health.ProviderSystemd)
+	// https: //www.freedesktop.org/software/systemd/man/latest/sd_notify.html#Notes
+	sock := os.Getenv("NOTIFY_SOCKET")
+	if sock == "" {
+		log.Info().Msg("sd_notify notifications disabled, no socket available")
+		return
+	}
+	if cfg.Options.HealthCheckSystemdDisabled {
+		log.Info().Msg("sd_notify_notifications disabled")
+		return
+	}
+	log.Info().Str("sock-addr", sock).Msg("sd_notify notifications enabled")
+	enabled, dur := srv.watchdogEnabled()
+	wconf := health.SystemdWatchdogConf{
+		Enabled:  enabled,
+		Interval: dur,
+	}
+	provider, err := health.NewSystemDProvider(ctx, mgr, sock, wconf, health.WithExpectedChecks(checks...))
+	if err != nil {
+		log.Error().Msg("failed to start sd_notify health checks")
+		srv.SystemdProvider.Store(nil)
+		return
+	}
+	log.Info().Bool("watchdog", enabled).Float64("intervalSeconds", wconf.Interval.Seconds()).Msg("started sd_notify health checks")
+	mgr.Register(health.ProviderSystemd, provider)
+	provider.Start()
+	srv.SystemdProvider.Store(provider)
+}
+
+func (srv *Server) watchdogEnabled() (enabled bool, interval time.Duration) {
+	// https://www.freedesktop.org/software/systemd/man/latest/sd_watchdog_enabled.html#Environment
+	wusec := os.Getenv("WATCHDOG_USEC")
+	wpid := os.Getenv("WATCHDOG_PID")
+
+	if wusec == "" || wpid == "" {
+		return false, 0
+	}
+
+	durMicroSeconds, err := strconv.Atoi(wusec)
+	if err != nil {
+		return false, 0
+	}
+	p, err := strconv.Atoi(wpid)
+	if err != nil {
+		return false, 0
+	}
+
+	if os.Getpid() != p {
+		return false, 0
+	}
+	return true, time.Duration(durMicroSeconds) * time.Microsecond
+}

--- a/internal/controlplane/health_other.go
+++ b/internal/controlplane/health_other.go
@@ -1,0 +1,18 @@
+//go:build !linux
+
+package controlplane
+
+import (
+	"context"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/health"
+)
+
+func (srv *Server) configureExtraProviders(
+	ctx context.Context,
+	cfg *config.Config,
+	mgr health.ProviderManager,
+	checks []health.Check,
+) {
+}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -6,8 +6,6 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"net/url"
-	"os"
-	"strconv"
 	"time"
 
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
@@ -385,73 +383,7 @@ func (srv *Server) updateHealthProviders(ctx context.Context, cfg *config.Config
 	srv.ProbeProvider.Store(httpProvider)
 	mgr.Register(health.ProviderHTTP, httpProvider)
 
-	// sd_notify configurations
-	srv.configureSdNotify(ctx, cfg, mgr, checks)
-}
-
-func (srv *Server) configureSdNotify(
-	ctx context.Context,
-	cfg *config.Config,
-	mgr health.ProviderManager,
-	checks []health.Check,
-) {
-	// if it already exists stop it
-	existing := srv.SystemdProvider.Load()
-	if existing != nil {
-		existing.Shutdown()
-	}
-	srv.SystemdProvider.Store(nil)
-	mgr.Deregister(health.ProviderSystemd)
-	// https: //www.freedesktop.org/software/systemd/man/latest/sd_notify.html#Notes
-	sock := os.Getenv("NOTIFY_SOCKET")
-	if sock == "" {
-		log.Info().Msg("sd_notify notifications disabled, no socket available")
-		return
-	}
-	if cfg.Options.HealthCheckSystemdDisabled {
-		log.Info().Msg("sd_notify_notifications disabled")
-		return
-	}
-	log.Info().Str("sock-addr", sock).Msg("sd_notify notifications enabled")
-	enabled, dur := srv.watchdogEnabled()
-	wconf := health.SystemdWatchdogConf{
-		Enabled:  enabled,
-		Interval: dur,
-	}
-	provider, err := health.NewSystemDProvider(ctx, mgr, sock, wconf, health.WithExpectedChecks(checks...))
-	if err != nil {
-		log.Error().Msg("failed to start sd_notify health checks")
-		srv.SystemdProvider.Store(nil)
-		return
-	}
-	log.Info().Bool("watchdog", enabled).Float64("intervalSeconds", wconf.Interval.Seconds()).Msg("started sd_notify health checks")
-	mgr.Register(health.ProviderSystemd, provider)
-	provider.Start()
-	srv.SystemdProvider.Store(provider)
-}
-
-func (srv *Server) watchdogEnabled() (enabled bool, interval time.Duration) {
-	// https://www.freedesktop.org/software/systemd/man/latest/sd_watchdog_enabled.html#Environment
-	wusec := os.Getenv("WATCHDOG_USEC")
-	wpid := os.Getenv("WATCHDOG_PID")
-
-	if wusec == "" || wpid == "" {
-		return false, 0
-	}
-
-	durMicroSeconds, err := strconv.Atoi(wusec)
-	if err != nil {
-		return false, 0
-	}
-	p, err := strconv.Atoi(wpid)
-	if err != nil {
-		return false, 0
-	}
-
-	if os.Getpid() != p {
-		return false, 0
-	}
-	return true, time.Duration(durMicroSeconds) * time.Microsecond
+	srv.configureExtraProviders(ctx, cfg, mgr, checks)
 }
 
 func (srv *Server) getExpectedHealthChecks(cfg *config.Config) (ret []health.Check) {

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -428,7 +428,6 @@ func (srv *Server) configureSdNotify(
 	mgr.Register(health.ProviderSystemd, provider)
 	provider.Start()
 	srv.SystemdProvider.Store(provider)
-
 }
 
 func (srv *Server) watchdogEnabled() (enabled bool, interval time.Duration) {

--- a/pkg/health/deduplicate_test.go
+++ b/pkg/health/deduplicate_test.go
@@ -13,8 +13,10 @@ import (
 
 func TestDeduplicate(t *testing.T) {
 	t.Parallel()
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
-	p1 := NewMockProvider(gomock.NewController(t))
+	p1 := NewMockProvider(ctrl)
 	dp := health.NewDeduplicator()
 	dp.SetProvider(p1)
 
@@ -41,7 +43,7 @@ func TestDeduplicate(t *testing.T) {
 	dp.ReportStatus(check1, health.StatusRunning, health.StrAttr("k1", "v1"))
 
 	// after setting new provider, current state should be reported
-	p2 := NewMockProvider(gomock.NewController(t))
+	p2 := NewMockProvider(ctrl)
 	p2.EXPECT().ReportStatus(check1, health.StatusRunning, health.StrAttr("k1", "v1")).Times(1)
 	p2.EXPECT().ReportStatus(check2, health.StatusRunning).Times(1)
 	p2.EXPECT().ReportError(check3, errors.New("error-3")).Times(1)

--- a/pkg/health/manager.go
+++ b/pkg/health/manager.go
@@ -12,8 +12,9 @@ var (
 type ProviderID string
 
 const (
-	ProviderHTTP = "ProviderHTTP"
-	ProviderZero = "ProviderZero"
+	ProviderSystemd = "ProviderSystemd"
+	ProviderHTTP    = "ProviderHTTP"
+	ProviderZero    = "ProviderZero"
 )
 
 var defaultProviderManager = NewManager()

--- a/pkg/health/manager_test.go
+++ b/pkg/health/manager_test.go
@@ -37,6 +37,7 @@ func TestManagerReplay(t *testing.T) {
 	assert := assert.New(t)
 	mgr := health.NewManager()
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	id1, id2, id3 := health.ProviderID("id1"), health.ProviderID("id2"), health.ProviderID("id3")
 	p1 := NewMockProvider(ctrl)
 	p2 := NewMockProvider(ctrl)
@@ -71,6 +72,7 @@ func TestManagerDeduplication(t *testing.T) {
 	mgr := health.NewManager()
 
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	p1 := NewMockProvider(ctrl)
 	p2 := NewMockProvider(ctrl)
 
@@ -120,6 +122,7 @@ func TestManagerDeduplication(t *testing.T) {
 func TestDefaultManager(t *testing.T) {
 	t.Parallel()
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 
 	p1 := NewMockProvider(ctrl)
 	p2 := NewMockProvider(ctrl)

--- a/pkg/health/systemd.go
+++ b/pkg/health/systemd.go
@@ -1,0 +1,232 @@
+package health
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync/atomic"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/rs/zerolog"
+
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+const (
+	// sdNotifyReady tells the service manager that service startup is finished
+	// or the service finished loading its configuration.
+	sdNotifyReady = "READY=1"
+
+	// SdNotifyStopping tells the service manager that the service is beginning
+	// its shutdown.
+	sdNotifyStopping = "STOPPING=1"
+
+	// SdNotifyWatchdog tells the service manager to update the watchdog
+	// timestamp for the service.
+	sdNotifyWatchdog = "WATCHDOG=1"
+)
+
+var (
+	SdNotifyStatus = func(st string) string {
+		return "STATUS=" + st
+	}
+)
+
+// SystemdProvider provides health reports to sd_notify, which is the protocol consumed by
+// systemd & systemctl.
+// Reference : https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html#Description
+type SystemdProvider struct {
+	ctx context.Context
+	ca  context.CancelFunc
+
+	log zerolog.Logger
+
+	conn      *net.UnixConn
+	watchConf SystemdWatchdogConf
+
+	expectedChecks map[Check]struct{}
+	tr             Tracker
+
+	notifiedReady    *atomic.Bool
+	notifiedStopping *atomic.Bool
+	done             chan struct{}
+}
+
+type SystemdWatchdogConf struct {
+	Enabled  bool
+	Interval time.Duration
+}
+
+var _ Provider = (*SystemdProvider)(nil)
+
+func NewSystemDProvider(
+	parentCtx context.Context,
+	tr Tracker,
+	addr string,
+	watchConf SystemdWatchdogConf,
+	opts ...CheckOption,
+) (*SystemdProvider, error) {
+	options := CheckOptions{}
+	options.Apply(opts...)
+
+	sockAddr := &net.UnixAddr{
+		Name: addr,
+		Net:  "unixgram",
+	}
+	conn, err := net.DialUnix(sockAddr.Net, nil, sockAddr)
+	if err != nil {
+		return nil, err
+	}
+	ready, stopping := &atomic.Bool{}, &atomic.Bool{}
+	ready.Store(false)
+	stopping.Store(false)
+
+	ctx := context.WithoutCancel(parentCtx)
+	ctxca, ca := context.WithCancel(ctx)
+	logger := log.With().Str("component", "sd_notify").Bool("watchdog", watchConf.Enabled).Logger()
+
+	s := &SystemdProvider{
+		log:              logger,
+		ctx:              ctxca,
+		ca:               ca,
+		conn:             conn,
+		tr:               tr,
+		watchConf:        watchConf,
+		expectedChecks:   options.expected,
+		notifiedReady:    ready,
+		notifiedStopping: stopping,
+		done:             make(chan struct{}, 1),
+	}
+
+	return s, nil
+}
+
+func (s *SystemdProvider) Start() {
+	if s.watchConf.Enabled {
+		s.log.Info().Msg("starting watchdog")
+		go s.runWatchdog()
+	}
+}
+
+func (s *SystemdProvider) Shutdown() {
+	s.log.Info().Msg("shutting down")
+	defer s.ca()
+	close(s.done)
+}
+
+func (s *SystemdProvider) runWatchdog() error {
+	t := time.NewTicker(s.watchConf.Interval / 2)
+	defer t.Stop()
+	for {
+		select {
+		case <-t.C:
+			s.log.Debug().Msg("pushing heartbeat to watchdog...")
+			_, err := s.conn.Write([]byte(sdNotifyWatchdog))
+			if err != nil {
+				s.log.Error().Err(err).Msg("failed to hearbeat to watchdog")
+			}
+		case <-s.done:
+			return nil
+		case <-s.ctx.Done():
+			return nil
+		}
+
+	}
+}
+
+func (s *SystemdProvider) isStarted() bool {
+	recs := s.tr.GetRecords()
+	for check := range s.expectedChecks {
+		rec, ok := recs[check]
+		if !ok {
+			return false
+		}
+		if rec.status != StatusRunning {
+			return false
+		}
+	}
+	return true
+}
+
+func (s *SystemdProvider) ReportStatus(Check, Status, ...Attr) {
+	s.reportStarted()
+	s.reportStopping()
+}
+
+func (s *SystemdProvider) reportStarted() {
+	if s.notifiedReady.Load() {
+		return
+	}
+	if !s.isStarted() {
+		return
+	}
+	s.notifiedReady.Store(true)
+	go func() {
+		retrier := backoff.WithContext(backoff.NewExponentialBackOff(
+			backoff.WithInitialInterval(time.Second),
+			backoff.WithMaxInterval(time.Second*5),
+		), s.ctx)
+
+		backoff.Retry(func() error {
+			_, err := s.conn.Write([]byte(sdNotifyReady))
+			if err != nil {
+				s.log.Error().Msg("failed to report ready")
+			}
+			return err
+		}, retrier)
+		s.log.Info().Msg("reported ready")
+	}()
+}
+
+func (s *SystemdProvider) isStopping() bool {
+	recs := s.tr.GetRecords()
+	for _, rec := range recs {
+		if rec.status == StatusTerminating {
+			return true
+		}
+	}
+	return false
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
+}
+
+func (s *SystemdProvider) reportStopping() {
+	if s.notifiedStopping.Load() {
+		return
+	}
+	if !s.isStopping() {
+		return
+	}
+	s.notifiedStopping.Store(true)
+	go func() {
+		retrier := backoff.WithContext(backoff.NewExponentialBackOff(
+			backoff.WithInitialInterval(time.Second),
+			backoff.WithMaxInterval(time.Second*5),
+		), s.ctx)
+
+		backoff.Retry(func() error {
+			_, err := s.conn.Write([]byte(sdNotifyStopping))
+			if err != nil {
+				s.log.Error().Msg("failed to report stopping")
+			}
+			return err
+		}, retrier)
+		s.log.Info().Msg("reported stopping")
+	}()
+}
+
+func (s *SystemdProvider) ReportError(check Check, err error, _ ...Attr) {
+	// while sd_notify can accept up to 64Kb, 80 characters is readable from
+	// the terminal
+	stStr := truncate(SdNotifyStatus(fmt.Sprintf("Error in %s: %s", check, err.Error())), 80)
+	// this doesn't block
+	if _, err := s.conn.Write([]byte(stStr)); err != nil {
+		s.log.Error().Msg("failed to report error status")
+	}
+}

--- a/pkg/health/systemd_test.go
+++ b/pkg/health/systemd_test.go
@@ -53,6 +53,7 @@ func TestSystemdProvider(t *testing.T) {
 
 	mgr.ReportError(c3, fmt.Errorf("some newer error"))
 	n, oobN, _, _, err = serveConn.ReadMsgUnix(b2, oob)
+	assert.NoError(err)
 	assert.Equal(0, oobN)
 	assert.Equal(35, n)
 	assert.Equal("STATUS=Error in c: some newer error", string(b2[:n]))
@@ -73,7 +74,6 @@ func TestSystemdProvider(t *testing.T) {
 	assert.Equal(0, oobN)
 	assert.Equal(10, n)
 	assert.Equal("STOPPING=1", string(b4[:n]))
-
 }
 
 func TestSystemdWatchDog(t *testing.T) {
@@ -139,5 +139,4 @@ func TestSystemdWatchDog(t *testing.T) {
 		assert.Equal(-1, n)
 		assert.ErrorIs(err, os.ErrDeadlineExceeded)
 	})
-
 }

--- a/pkg/health/systemd_test.go
+++ b/pkg/health/systemd_test.go
@@ -1,3 +1,5 @@
+//go:build linux
+
 package health
 
 import (

--- a/pkg/health/systemd_test.go
+++ b/pkg/health/systemd_test.go
@@ -1,0 +1,143 @@
+package health
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSystemdProvider(t *testing.T) {
+	assert := assert.New(t)
+	c1, c2, c3 := Check("a"), Check("b"), Check("c")
+	sockDir := t.TempDir()
+
+	sock := sockDir + "/notify-socket.sock"
+	laddr := net.UnixAddr{
+		Name: sock,
+		Net:  "unixgram",
+	}
+	serveConn, err := net.ListenUnixgram("unixgram", &laddr)
+	assert.NoError(err)
+	mgr := NewManager()
+	sysd, err := NewSystemDProvider(t.Context(), mgr, sock, SystemdWatchdogConf{
+		Enabled:  false,
+		Interval: 0,
+	}, WithExpectedChecks(
+		c1,
+		c2,
+		c3,
+	))
+	assert.NoError(err)
+	mgr.Register(ProviderSystemd, sysd)
+	mgr.ReportStatus(c1, StatusRunning)
+	b1 := []byte{}
+	oob := []byte{}
+	serveConn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	n, oobN, _, _, err := serveConn.ReadMsgUnix(b1, oob)
+	assert.ErrorIs(err, os.ErrDeadlineExceeded)
+	assert.Equal(-1, n)
+	assert.Equal(0, oobN)
+	mgr.ReportError(c2, fmt.Errorf("some error"))
+	serveConn.SetReadDeadline(time.Now().Add(30 * time.Second))
+	b2 := make([]byte, 100)
+	n, oobN, _, _, err = serveConn.ReadMsgUnix(b2, oob)
+	assert.NoError(err)
+	assert.Equal(0, oobN)
+	assert.Equal(29, n)
+	assert.Equal("STATUS=Error in b: some error", string(b2[:n]))
+
+	mgr.ReportError(c3, fmt.Errorf("some newer error"))
+	n, oobN, _, _, err = serveConn.ReadMsgUnix(b2, oob)
+	assert.Equal(0, oobN)
+	assert.Equal(35, n)
+	assert.Equal("STATUS=Error in c: some newer error", string(b2[:n]))
+
+	mgr.ReportStatus(c2, StatusRunning)
+	mgr.ReportStatus(c3, StatusRunning)
+	b3 := make([]byte, 100)
+	n, oobN, _, _, err = serveConn.ReadMsgUnix(b3, oob)
+	assert.NoError(err)
+	assert.Equal(0, oobN)
+	assert.Equal(7, n)
+	assert.Equal("READY=1", string(b3[:n]))
+
+	mgr.ReportStatus(c1, StatusTerminating)
+	b4 := make([]byte, 100)
+	n, oobN, _, _, err = serveConn.ReadMsgUnix(b4, oob)
+	assert.NoError(err)
+	assert.Equal(0, oobN)
+	assert.Equal(10, n)
+	assert.Equal("STOPPING=1", string(b4[:n]))
+
+}
+
+func TestSystemdWatchDog(t *testing.T) {
+	assert := assert.New(t)
+	sockDir := t.TempDir()
+	sock := sockDir + "/notify-socket.sock"
+	laddr := net.UnixAddr{
+		Name: sock,
+		Net:  "unixgram",
+	}
+	serveConn, err := net.ListenUnixgram("unixgram", &laddr)
+	assert.NoError(err)
+	mgr := NewManager()
+	watchConf := SystemdWatchdogConf{
+		Enabled:  true,
+		Interval: time.Millisecond * 50,
+	}
+	sysd, err := NewSystemDProvider(t.Context(), mgr, sock, watchConf)
+	assert.NoError(err)
+	sysd.Start()
+	synctest.Run(func() {
+		start := time.Now()
+		serveConn.SetReadDeadline(time.Now().Add(3 * watchConf.Interval))
+		go func() {
+			time.Sleep(2 * watchConf.Interval)
+		}()
+		synctest.Wait()
+		b := make([]byte, 100)
+		oob := make([]byte, 1000)
+		n, oobN, _, _, err := serveConn.ReadMsgUnix(b, oob)
+		assert.NoError(err)
+		assert.Equal(0, oobN)
+		assert.Equal(10, n)
+		assert.Equal("WATCHDOG=1", string(b[:n]))
+		t.Logf("%v", time.Since(start))
+		synctest.Wait()
+		n, oobN, _, _, err = serveConn.ReadMsgUnix(b, oob)
+		assert.NoError(err)
+		assert.Equal(0, oobN)
+		assert.Equal(10, n)
+		assert.Equal("WATCHDOG=1", string(b[:n]))
+		t.Logf("%v", time.Since(start))
+		synctest.Wait()
+		n, oobN, _, _, err = serveConn.ReadMsgUnix(b, oob)
+		assert.NoError(err)
+		assert.Equal(0, oobN)
+		assert.Equal(10, n)
+		assert.Equal("WATCHDOG=1", string(b[:n]))
+		t.Logf("%v", time.Since(start))
+		synctest.Wait()
+		n, oobN, _, _, err = serveConn.ReadMsgUnix(b, oob)
+		assert.NoError(err)
+		assert.Equal(0, oobN)
+		assert.Equal(10, n)
+		assert.Equal("WATCHDOG=1", string(b[:n]))
+		t.Logf("%v", time.Since(start))
+		synctest.Wait()
+		sysd.Shutdown()
+		synctest.Wait()
+		t.Logf("%v", time.Since(start))
+		n, oobN, _, _, err = serveConn.ReadMsgUnix(b, oob)
+		assert.Equal(0, oobN)
+		assert.Equal(-1, n)
+		assert.ErrorIs(err, os.ErrDeadlineExceeded)
+	})
+
+}


### PR DESCRIPTION
## Summary

This PR adds systemd as a valid integration for internal pomerium health checks.

When all expected checks have started, report READY to systemd. 

When any component enters the terminating state, report STOPPING to systemd.

When any component reports an error, the latest error reported gets surfaced to systemd's status so that `sudo systemctl status pomerium.service` reflects the last error

References (sd_notify & sd_watchdog_enabled man pages), convenient web links here:
- https://www.freedesktop.org/software/systemd/man/latest/sd_notify.html
- https://www.freedesktop.org/software/systemd/man/latest/sd_watchdog_enabled.html#

To have a startup probe based on the sd_notify protocol the systemd configuration should have:
```
[Service]
#...
Type=notify
```

The sd_notify health checker also implements the watchdog part of the systemd configuration:

```
[Service]
# ....
WatchdogSec=30s
```

Currently watchdog heartbeats regularly trivially as long as the process (and sd_notify goroutine) is up and running. 

This could be extended in the future to have the equivalent of a liveness probe via the watchdog messages, where the sd_notify health checker will no longer send watchdog messages if it is unhealthy.


## Related issues

[ENG-2902](https://linear.app/pomerium/issue/ENG-2902/systemd-sd-notify-health-check-implementation)


## User Explanation

Users installing pomerium via systemd now benefit from pomerium's internal health checks being integrated with `systemd` via `sd_notify`.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
