### PR TITLE
oauth21: more verbose error

### DIFF
--- a/internal/oauth21/error.go
+++ b/internal/oauth21/error.go
@@ -2,6 +2,7 @@ package oauth21
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 )
 
@@ -29,7 +30,7 @@ type Error struct {
 }
 
 func (e Error) Error() string {
-	return string(e.Code)
+	return fmt.Sprintf("[%s] %s", e.Code, e.Description)
 }
 
 // ErrorResponse writes an error response according to https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12#section-3.2.4


### PR DESCRIPTION
## Summary

Print more verbose OAuth2.1 error message to internal log. 

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
