### PR TITLE
fix: race condition with mcp server handler loading

### DIFF
--- a/proxy/handlers.go
+++ b/proxy/handlers.go
@@ -26,7 +26,14 @@ func (p *Proxy) registerDashboardHandlers(r *mux.Router, opts *config.Options) *
 
 	if opts.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
 		// model context protocol
-		h.PathPrefix("/mcp").Handler(p.mcp.Load().HandlerFunc())
+		h.PathPrefix("/mcp").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			srv := p.mcp.Load()
+			if srv == nil {
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+			srv.HandlerFunc().ServeHTTP(w, r)
+		})
 	}
 
 	// special pomerium endpoints for users to view their session

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -86,6 +86,7 @@ func New(ctx context.Context, cfg *config.Config) (*Proxy, error) {
 		currentRouter:    atomicutil.NewValue(httputil.NewRouter()),
 		logoProvider:     portal.NewLogoProvider(),
 		outboundGrpcConn: outboundGrpcConn,
+		mcp:              atomicutil.NewValue[*mcp.Handler](nil),
 	}
 	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
 		mcp, err := mcp.New(ctx, mcp.DefaultPrefix, cfg, outboundGrpcConn)


### PR DESCRIPTION
## Summary

mcp handler is not atomically set in the constructor so race condition can occur when a configuration is updated, trying to load the mcp handler.

If the mcp handler has not been set, while trying to serving traffic, it will serve a 503 Service Unavailable code.
<details>
<summary>Stack trace</summary>
<pre><code>
pomerium-1  | panic: runtime error: invalid memory address or nil pointer dereference
pomerium-1  | [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2868806]
pomerium-1  |
pomerium-1  | goroutine 213 [running]:
pomerium-1  | github.com/pomerium/pomerium/internal/atomicutil.(*Value[...]).Store(...)
pomerium-1  |   /go/src/github.com/pomerium/pomerium/internal/atomicutil/value.go:34
pomerium-1  | github.com/pomerium/pomerium/proxy.(*Proxy).OnConfigChange(0xc0009b9900, {0x3c5c1f0, 0xc0013626c0}, 0xc000df6120)
pomerium-1  |   /go/src/github.com/pomerium/pomerium/proxy/proxy.go:123 +0x106
pomerium-1  | github.com/pomerium/pomerium/internal/autocert.(*Manager).OnConfigChange.(*ChangeDispatcher).OnConfigChange.func1({0x3c5c1f0?, 0xc0013626c0?}, {0x0?})
pomerium-1  |   /go/src/github.com/pomerium/pomerium/config/config_source.go:46 +0x22
pomerium-1  | github.com/pomerium/pomerium/internal/events.targetListener[...].run(0xc000da7ef0?)
pomerium-1  |   /go/src/github.com/pomerium/pomerium/internal/events/target.go:148 +0x58
pomerium-1  | created by github.com/pomerium/pomerium/internal/events.newTargetListener[...] in goroutine 91
pomerium-1  |   /go/src/github.com/pomerium/pomerium/internal/events/target.go:127 +0x15c
pomerium-1 exited with code 2 (restarting)
</code></pre>
</details>

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
