### PR TITLE
raft: skip TestStreamLayer on macOS for now

### DIFF
--- a/internal/databroker/raft/stream_layer_test.go
+++ b/internal/databroker/raft/stream_layer_test.go
@@ -1,6 +1,7 @@
 package raft_test
 
 import (
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -25,6 +26,10 @@ func TestStreamLayer(t *testing.T) {
 		_, err = l.Dial("127.0.0.100:9001", time.Second)
 		assert.ErrorIs(t, err, raft.ErrDialerNotAvailable)
 	})
+
+	if runtime.GOOS == "darwin" {
+		t.Skip("skipping because 127.0.0.100 is not routed by default on macOS")
+	}
 
 	cfg := &config.Config{
 		Options: &config.Options{


### PR DESCRIPTION
## Summary

TestStreamLayer is consistently failing on macOS. Let's skip it for now until we can figure out how best to fix it.

## Related issues

n/a

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
