### PR TITLE
enable systemd health checks by default

### DIFF
--- a/ospkg/pomerium.service
+++ b/ospkg/pomerium.service
@@ -2,6 +2,8 @@
 Description=Pomerium
 
 [Service]
+Type=notify
+WatchdogSec=30s
 ExecStart=/usr/sbin/pomerium -config /etc/pomerium/config.yaml
 User=pomerium
 Group=pomerium


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
