### PR TITLE
migrate to filippo.io/csrf

### DIFF
--- a/authenticate/csrf.go
+++ b/authenticate/csrf.go
@@ -1,0 +1,121 @@
+package authenticate
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/securecookie"
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+const (
+	csrfTokenLength  = 32
+	csrfCookieMaxAge = 12 * 3600 // 12 hours
+)
+
+var (
+	errNoCSRFCookie = errors.New("no CSRF cookie")
+)
+
+type csrfCookieValidation struct {
+	sc       *securecookie.SecureCookie
+	name     string
+	sameSite http.SameSite
+}
+
+func NewCSRFCookieValidation(
+	authKey []byte, name string, sameSite http.SameSite,
+) *csrfCookieValidation {
+	sc := securecookie.New(authKey, nil)
+	sc.SetSerializer(securecookie.JSONEncoder{})
+	sc.MaxAge(csrfCookieMaxAge)
+
+	return &csrfCookieValidation{
+		sc:       sc,
+		name:     name,
+		sameSite: sameSite,
+	}
+}
+
+// getTokenFromCookie returns the CSRF token stored in the cookie, or nil if no such cookie.
+// Returns a non-nil error if a cookie exists but could not be decoded.
+func (c *csrfCookieValidation) getTokenFromCookie(r *http.Request) ([]byte, error) {
+	cookie, err := r.Cookie(c.name)
+	if err != nil {
+		return nil, errNoCSRFCookie
+	}
+
+	// TODO: check cookie is not just about to expire?
+
+	var token []byte
+	err = c.sc.Decode(c.name, cookie.Value, &token)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(token) != csrfTokenLength {
+		return nil, fmt.Errorf("unexpected length (want %d, got %d)", csrfTokenLength, len(token))
+	}
+
+	return token, nil
+}
+
+func (c *csrfCookieValidation) setNewCookie(w http.ResponseWriter, token []byte) error {
+	encoded, err := c.sc.Encode(c.name, token)
+	if err != nil {
+		return err
+	}
+
+	cookie := &http.Cookie{
+		Name:     c.name,
+		Value:    encoded,
+		MaxAge:   csrfCookieMaxAge,
+		HttpOnly: true,
+		Secure:   true,
+		SameSite: c.sameSite,
+		Path:     "/",
+		Expires:  time.Now().Add(time.Duration(csrfCookieMaxAge) * time.Second),
+	}
+	http.SetCookie(w, cookie)
+	return nil
+}
+
+// EnsureCookieSet will set a CSRF cookie on the response if one is not already
+// present on the request, and return the new or existing CSRF token (base64-encoded).
+func (c *csrfCookieValidation) EnsureCookieSet(w http.ResponseWriter, r *http.Request) string {
+	token, err := c.getTokenFromCookie(r)
+	if err != nil {
+		if err != errNoCSRFCookie {
+			log.Ctx(r.Context()).Info().Err(err).Msg("malformed CSRF token")
+		}
+
+		token = make([]byte, csrfTokenLength)
+		rand.Read(token) // as of Go 1.24.0 this cannot return an error
+
+		err = c.setNewCookie(w, token)
+		if err != nil {
+			log.Ctx(r.Context()).Error().Err(err).Msg("couldn't set CSRF cookie")
+		}
+	}
+
+	return base64.StdEncoding.EncodeToString(token)
+}
+
+func (c *csrfCookieValidation) ValidateToken(r *http.Request, expected string) error {
+	decoded, err := base64.StdEncoding.DecodeString(expected)
+	if err != nil {
+		return err
+	}
+	token, err := c.getTokenFromCookie(r)
+	if err != nil {
+		return err
+	} else if !bytes.Equal(token, decoded) {
+		return errors.New("invalid CSRF token")
+	}
+	return nil
+}

--- a/authenticate/csrf_test.go
+++ b/authenticate/csrf_test.go
@@ -1,0 +1,95 @@
+package authenticate
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+)
+
+func TestEnsureTokenSet(t *testing.T) {
+	csrf := NewCSRFCookieValidation(cryptutil.NewKey(), "_csrf", http.SameSiteLaxMode)
+
+	verifyCookie := func(t *testing.T, rec *httptest.ResponseRecorder) string {
+		cookies := rec.Result().Cookies()
+		require.Len(t, cookies, 1)
+		cookie := cookies[0]
+		assert.Equal(t, "_csrf", cookie.Name)
+		assert.Empty(t, cookie.Domain)
+		assert.True(t, cookie.Secure)
+		assert.True(t, cookie.HttpOnly)
+		assert.Equal(t, http.SameSiteLaxMode, cookie.SameSite)
+		assert.Equal(t, "/", cookie.Path)
+		return cookies[0].Value
+	}
+
+	t.Run("no cookie", func(t *testing.T) {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/example/path", nil)
+
+		csrf.EnsureCookieSet(rec, req)
+
+		// A cookie should be set.
+		verifyCookie(t, rec)
+	})
+	t.Run("valid cookie", func(t *testing.T) {
+		existingCookie, existingToken := getCSRFCookieAndTokenForTest(t, csrf)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/example/path", nil)
+		req.AddCookie(existingCookie)
+
+		token := csrf.EnsureCookieSet(rec, req)
+
+		// The existing cookie should not be modified.
+		assert.Empty(t, rec.Result().Cookies())
+		assert.Equal(t, existingToken, token)
+	})
+	t.Run("invalid cookie", func(t *testing.T) {
+		// Generate a cookie with a token of the wrong length.
+		wrongTokenLength := []byte("abcdefg")
+		value, err := csrf.sc.Encode("_csrf", wrongTokenLength)
+		require.NoError(t, err)
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/example/path", nil)
+
+		req.AddCookie(&http.Cookie{
+			Name:  "_csrf",
+			Value: value,
+		})
+
+		csrf.EnsureCookieSet(rec, req)
+
+		// The invalid cookie should be overwritten.
+		verifyCookie(t, rec)
+	})
+}
+
+func TestValidateToken(t *testing.T) {
+	csrf := NewCSRFCookieValidation(cryptutil.NewKey(), "_csrf", http.SameSiteLaxMode)
+
+	cookie, token := getCSRFCookieAndTokenForTest(t, csrf)
+	req := httptest.NewRequest(http.MethodGet, "/example/path", nil)
+	req.AddCookie(cookie)
+
+	assert.NoError(t, csrf.ValidateToken(req, token))
+	assert.ErrorContains(t, csrf.ValidateToken(req, ""), "invalid CSRF token")
+	assert.ErrorContains(t, csrf.ValidateToken(req, "AAA="), "invalid CSRF token")
+	assert.ErrorContains(t, csrf.ValidateToken(&http.Request{}, token), "no CSRF cookie")
+	assert.ErrorContains(t, csrf.ValidateToken(&http.Request{}, ""), "no CSRF cookie")
+}
+
+func getCSRFCookieAndTokenForTest(t *testing.T, csrf *csrfCookieValidation) (*http.Cookie, string) {
+	t.Helper()
+	rec := httptest.NewRecorder()
+	token := csrf.EnsureCookieSet(rec, &http.Request{})
+	cookies := rec.Result().Cookies()
+	require.Len(t, cookies, 1, "test bug: expected CSRF cookie not set")
+	require.Equal(t, csrf.name, cookies[0].Name, "test bug: expected CSRF cookie not set")
+	return cookies[0], token
+}

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -47,30 +47,18 @@ func (a *Authenticate) Mount(r *mux.Router) {
 	r.Use(func(h http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/.pomerium/verify-access-token" ||
-				r.URL.Path == "/.pomerium/verify-identity-token" {
+				r.URL.Path == "/.pomerium/verify-identity-token" ||
+				r.URL.Path == "/oauth2/callback" { // protected by separate CSRF token
 				r = csrf.UnsafeSkipCheck(r)
 			}
 			h.ServeHTTP(w, r)
 		})
 	})
 	r.Use(func(h http.Handler) http.Handler {
-		options := a.options.Load()
-		state := a.state.Load()
-		csrfKey := fmt.Sprintf("%s_csrf", options.CookieName)
 		csrfOptions := []csrf.Option{
-			csrf.Secure(true),
-			csrf.Path("/"),
-			csrf.UnsafePaths(
-				[]string{
-					"/oauth2/callback", // rfc6749#section-10.12 accepts GET
-				}),
-			csrf.FormValueName("state"), // rfc6749#section-10.12
-			csrf.CookieName(csrfKey),
-			csrf.FieldName(csrfKey),
 			csrf.ErrorHandler(httputil.HandlerFunc(httputil.CSRFFailureHandler)),
-			csrf.SameSite(options.GetCSRFSameSite()),
 		}
-		return csrf.Protect(state.cookieSecret, csrfOptions...)(h)
+		return csrf.Protect(nil, csrfOptions...)(h)
 	})
 	r.Use(trace.NewHTTPMiddleware(otelhttp.WithTracerProvider(a.tracerProvider)))
 
@@ -313,9 +301,9 @@ func (a *Authenticate) reauthenticateOrFail(w http.ResponseWriter, r *http.Reque
 			traceID = base64.RawURLEncoding.EncodeToString(append(traceIDBytes, traceFlags[0]))
 		}
 	}
-	nonce := csrf.Token(r)
+	token := state.csrf.EnsureCookieSet(w, r)
 	now := time.Now().Unix()
-	b := []byte(fmt.Sprintf("%s|%d|%s|", nonce, now, traceID))
+	b := []byte(fmt.Sprintf("%s|%d|%s|", token, now, traceID))
 	enc := cryptutil.Encrypt(state.cookieCipher, []byte(redirectURL.String()), b)
 	b = append(b, enc...)
 	encodedState := base64.URLEncoding.EncodeToString(b)
@@ -370,21 +358,21 @@ func (a *Authenticate) getOAuthCallback(w http.ResponseWriter, r *http.Request) 
 		return nil, httputil.NewError(http.StatusBadRequest, fmt.Errorf("identity provider returned empty code"))
 	}
 
-	// state includes a csrf nonce (validated by middleware) and redirect uri
+	// state includes a csrf token and redirect uri
 	bytes, err := base64.URLEncoding.DecodeString(r.FormValue("state"))
 	if err != nil {
 		return nil, httputil.NewError(http.StatusBadRequest, fmt.Errorf("bad bytes: %w", err))
 	}
 
 	// split state into concat'd components
-	// (nonce|timestamp|trace_id+flags|encrypted_data(redirect_url)+mac(nonce,ts))
+	// (token|timestamp|trace_id+flags|encrypted_data(redirect_url)+mac(token|timestamp|trace_id+flags|))
 	statePayload := strings.SplitN(string(bytes), "|", 4)
 	if len(statePayload) != 4 {
 		return nil, httputil.NewError(http.StatusBadRequest, fmt.Errorf("state malformed, size: %d", len(statePayload)))
 	}
 
 	// Use our AEAD construct to enforce secrecy and authenticity:
-	// mac: to validate the nonce again, and above timestamp
+	// mac: to validate the token/timestamp/trace_id+flags
 	// decrypt: to prevent leaking 'redirect_uri' to IdP or logs
 	b := []byte(fmt.Sprint(statePayload[0], "|", statePayload[1], "|", statePayload[2], "|"))
 	redirectString, err := cryptutil.Decrypt(state.cookieCipher, []byte(statePayload[3]), b)
@@ -394,6 +382,11 @@ func (a *Authenticate) getOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	redirectURL, err := urlutil.ParseAndValidateURL(string(redirectString))
 	if err != nil {
 		return nil, httputil.NewError(http.StatusBadRequest, err)
+	}
+
+	// Validate the token against the value stored in the CSRF cookie.
+	if state.csrf.ValidateToken(r, statePayload[0]) != nil {
+		return nil, httputil.NewError(http.StatusBadRequest, fmt.Errorf("invalid CSRF token"))
 	}
 
 	// verify that the returned timestamp is valid
@@ -496,7 +489,6 @@ func (a *Authenticate) getUserInfoData(r *http.Request) handlers.UserInfoData {
 	}
 
 	data := state.flow.GetUserInfoData(r, s)
-	data.CSRFToken = csrf.Token(r)
 	data.BrandingOptions = a.options.Load().BrandingOptions
 	return data
 }

--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	csrf "filippo.io/csrf/gorilla"
 	"github.com/google/uuid"
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
@@ -18,7 +19,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
-	"github.com/pomerium/csrf"
 	"github.com/pomerium/pomerium/internal/authenticateflow"
 	"github.com/pomerium/pomerium/internal/handlers"
 	"github.com/pomerium/pomerium/internal/httputil"

--- a/authenticate/handlers_test.go
+++ b/authenticate/handlers_test.go
@@ -2,6 +2,7 @@ package authenticate
 
 import (
 	"context"
+	"crypto/cipher"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -353,10 +354,12 @@ func TestAuthenticate_OAuthCallback(t *testing.T) {
 			a.cfg = getAuthenticateConfig(WithGetIdentityProvider(func(_ context.Context, _ oteltrace.TracerProvider, _ *config.Options, _ string) (identity.Authenticator, error) {
 				return tt.provider, nil
 			}))
+			csrf := NewCSRFCookieValidation(cryptutil.NewKey(), "_csrf", http.SameSiteLaxMode)
 			a.state.Store(&authenticateState{
 				redirectURL:  authURL,
 				sessionStore: tt.session,
 				cookieCipher: aead,
+				csrf:         csrf,
 				flow:         new(stubFlow),
 			})
 			a.options.Store(new(config.Options))
@@ -364,12 +367,13 @@ func TestAuthenticate_OAuthCallback(t *testing.T) {
 			params, _ := url.ParseQuery(u.RawQuery)
 			params.Add("error", tt.paramErr)
 			params.Add("code", tt.code)
-			nonce := cryptutil.NewBase64Key() // mock csrf
-			// (nonce|timestamp|trace_id+flags|encrypt(redirect_url),mac(nonce,ts))
-			b := []byte(fmt.Sprintf("%s|%d||%s", nonce, tt.ts, tt.extraMac))
-			enc := cryptutil.Encrypt(a.state.Load().cookieCipher, []byte(tt.redirectURI), b)
-			b = append(b, enc...)
-			encodedState := base64.URLEncoding.EncodeToString(b)
+			csrfCookie, token := getCSRFCookieAndTokenForTest(t, csrf)
+			encodedState := testOAuthState{
+				Token:       token,
+				Timestamp:   tt.ts,
+				ExtraMac:    tt.extraMac,
+				RedirectURI: tt.redirectURI,
+			}.Encode(a.state.Load().cookieCipher)
 			if tt.extraState != "" {
 				encodedState += tt.extraState
 			}
@@ -382,12 +386,100 @@ func TestAuthenticate_OAuthCallback(t *testing.T) {
 
 			r := httptest.NewRequest(tt.method, u.String(), nil)
 			r.Header.Set("Accept", "application/json")
+			r.AddCookie(csrfCookie)
 			w := httptest.NewRecorder()
 			httputil.HandlerFunc(a.OAuthCallback).ServeHTTP(w, r)
 			if w.Result().StatusCode != tt.wantCode {
 				t.Errorf("Authenticate.OAuthCallback() error = %v, wantErr %v\n%v", w.Result().StatusCode, tt.wantCode, w.Body.String())
 				return
 			}
+		})
+	}
+}
+
+type testOAuthState struct {
+	Token       string
+	Timestamp   int64
+	ExtraMac    string
+	RedirectURI string
+}
+
+func (s testOAuthState) Encode(cc cipher.AEAD) string {
+	// (token|timestamp|trace_id+flags|encrypt(redirect_url),mac(token|timestamp|trace_id+flags|))
+	b := []byte(fmt.Sprintf("%s|%d||%s", s.Token, s.Timestamp, s.ExtraMac))
+	enc := cryptutil.Encrypt(cc, []byte(s.RedirectURI), b)
+	b = append(b, enc...)
+	return base64.URLEncoding.EncodeToString(b)
+}
+
+func TestAuthenticate_OAuthCallback_CSRF(t *testing.T) {
+	t.Parallel()
+
+	aead, err := chacha20poly1305.NewX(cryptutil.NewKey())
+	require.NoError(t, err)
+	authURL, _ := url.Parse("https://authenticate.pomerium.io")
+	a := testAuthenticate(t)
+	a.cfg = getAuthenticateConfig(WithGetIdentityProvider(func(_ context.Context, _ oteltrace.TracerProvider, _ *config.Options, _ string) (identity.Authenticator, error) {
+		return identity.MockProvider{AuthenticateResponse: oauth2.Token{}}, nil
+	}))
+	csrf := NewCSRFCookieValidation(cryptutil.NewKey(), "_csrf", http.SameSiteLaxMode)
+	a.state.Store(&authenticateState{
+		redirectURL:  authURL,
+		sessionStore: &mstore.Store{},
+		cookieCipher: aead,
+		csrf:         csrf,
+		flow:         new(stubFlow),
+	})
+	a.options.Store(new(config.Options))
+
+	csrfCookie, token := getCSRFCookieAndTokenForTest(t, csrf)
+
+	newReq := func(cookie *http.Cookie, token string) *http.Request {
+		encodedState := testOAuthState{
+			Token:       token,
+			Timestamp:   time.Now().Unix(),
+			RedirectURI: "https://corp.pomerium.io",
+		}.Encode(aead)
+		u, _ := url.Parse("/oauthGet")
+		u.RawQuery = url.Values{
+			"code":  []string{"code"},
+			"state": []string{encodedState},
+		}.Encode()
+		r := httptest.NewRequest(http.MethodGet, u.String(), nil)
+		if cookie != nil {
+			r.AddCookie(cookie)
+		}
+		return r
+	}
+
+	// Set up a few mismatched/invalid values too.
+	otherCookie, otherToken := getCSRFCookieAndTokenForTest(t, csrf)
+	invalidCookie := *otherCookie
+	invalidCookie.Value = "invalid-cookie-format"
+
+	cases := []struct {
+		name           string
+		cookie         *http.Cookie
+		token          string
+		expectedStatus int
+	}{
+		{"ok", csrfCookie, token, http.StatusFound},
+		{"no cookie", nil, token, http.StatusBadRequest},
+		{"mismatched cookie", otherCookie, token, http.StatusBadRequest},
+		{"invalid cookie", &invalidCookie, token, http.StatusBadRequest},
+		{"empty token", csrfCookie, "", http.StatusBadRequest},
+		{"mismatched token", csrfCookie, otherToken, http.StatusBadRequest},
+		{"invalid token", &invalidCookie, "not-a-valid-token", http.StatusBadRequest},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			r := newReq(c.cookie, c.token)
+			w := httptest.NewRecorder()
+
+			httputil.HandlerFunc(a.OAuthCallback).ServeHTTP(w, r)
+
+			result := w.Result()
+			assert.Equal(t, c.expectedStatus, result.StatusCode)
 		})
 	}
 }
@@ -469,6 +561,7 @@ func TestAuthenticate_SessionValidatorMiddleware(t *testing.T) {
 				cookieCipher:  aead,
 				sharedEncoder: signer,
 				flow:          new(stubFlow),
+				csrf:          NewCSRFCookieValidation(cryptutil.NewKey(), "_csrf", http.SameSiteLaxMode),
 			})
 			a.options.Store(new(config.Options))
 			r := httptest.NewRequest(http.MethodGet, "/", nil)

--- a/authenticate/state.go
+++ b/authenticate/state.go
@@ -56,6 +56,8 @@ type authenticateState struct {
 	// a user's session state from
 	sessionLoader sessions.SessionLoader
 
+	csrf *csrfCookieValidation
+
 	jwk *jose.JSONWebKeySet
 }
 
@@ -126,6 +128,12 @@ func newAuthenticateStateFromConfig(
 	if err != nil {
 		return nil, err
 	}
+
+	state.csrf = NewCSRFCookieValidation(
+		state.cookieSecret,
+		fmt.Sprintf("%s_csrf", cfg.Options.CookieName),
+		cfg.Options.GetCSRFSameSite(),
+	)
 
 	state.sessionStore = cookieStore
 	state.sessionLoader = cookieStore

--- a/config/options.go
+++ b/config/options.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 	"time"
 
-	csrf "filippo.io/csrf/gorilla"
 	envoy_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/go-viper/mapstructure/v2"
 	goset "github.com/hashicorp/go-set/v3"
@@ -1430,24 +1429,14 @@ func (o *Options) GetCookieSameSite() http.SameSite {
 }
 
 // GetCSRFSameSite gets the csrf same site option.
-func (o *Options) GetCSRFSameSite() csrf.SameSiteMode {
+func (o *Options) GetCSRFSameSite() http.SameSite {
 	if o.Provider == apple.Name {
-		// csrf.SameSiteLaxMode will cause browsers to reset
-		// the session on POST. This breaks Appleid being able
-		// to verify the csrf token.
-		return csrf.SameSiteNoneMode
+		// "Sign in with Apple" uses a POST request for the OAuth callback,
+		// which will cause the browser not to send our CSRF cookie unless
+		// the cookie was set with SameSite=none.
+		return http.SameSiteNoneMode
 	}
-
-	str := strings.ToLower(o.CookieSameSite)
-	switch str {
-	case "strict":
-		return csrf.SameSiteStrictMode
-	case "lax":
-		return csrf.SameSiteLaxMode
-	case "none":
-		return csrf.SameSiteNoneMode
-	}
-	return csrf.SameSiteDefaultMode
+	return o.GetCookieSameSite()
 }
 
 // GetSigningKey gets the signing key.

--- a/config/options.go
+++ b/config/options.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	csrf "filippo.io/csrf/gorilla"
 	envoy_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"github.com/go-viper/mapstructure/v2"
 	goset "github.com/hashicorp/go-set/v3"
@@ -26,7 +27,6 @@ import (
 	"github.com/volatiletech/null/v9"
 	"google.golang.org/protobuf/types/known/durationpb"
 
-	"github.com/pomerium/csrf"
 	"github.com/pomerium/pomerium/config/otelconfig"
 	"github.com/pomerium/pomerium/internal/fileutil"
 	"github.com/pomerium/pomerium/internal/hashutil"

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -26,7 +26,6 @@ import (
 	"testing"
 	"time"
 
-	csrf "filippo.io/csrf/gorilla"
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -1412,17 +1411,17 @@ func TestOptions_GetCSRFSameSite(t *testing.T) {
 	for _, tc := range []struct {
 		cookieSameSite string
 		provider       string
-		expected       csrf.SameSiteMode
+		expected       http.SameSite
 	}{
-		{"", "", csrf.SameSiteDefaultMode},
-		{"Lax", "", csrf.SameSiteLaxMode},
-		{"lax", "", csrf.SameSiteLaxMode},
-		{"Strict", "", csrf.SameSiteStrictMode},
-		{"strict", "", csrf.SameSiteStrictMode},
-		{"None", "", csrf.SameSiteNoneMode},
-		{"none", "", csrf.SameSiteNoneMode},
-		{"UnKnOwN", "", csrf.SameSiteDefaultMode},
-		{"", apple.Name, csrf.SameSiteNoneMode},
+		{"", "", http.SameSiteDefaultMode},
+		{"Lax", "", http.SameSiteLaxMode},
+		{"lax", "", http.SameSiteLaxMode},
+		{"Strict", "", http.SameSiteStrictMode},
+		{"strict", "", http.SameSiteStrictMode},
+		{"None", "", http.SameSiteNoneMode},
+		{"none", "", http.SameSiteNoneMode},
+		{"UnKnOwN", "", http.SameSiteDefaultMode},
+		{"", apple.Name, http.SameSiteNoneMode},
 	} {
 		t.Run(tc.cookieSameSite, func(t *testing.T) {
 			t.Parallel()

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 	"time"
 
+	csrf "filippo.io/csrf/gorilla"
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -37,7 +38,6 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
-	"github.com/pomerium/csrf"
 	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	buf.build/go/protovalidate v0.14.0
 	cloud.google.com/go/storage v1.56.1
 	contrib.go.opencensus.io/exporter/prometheus v0.4.2
+	filippo.io/csrf v0.2.1
 	filippo.io/keygen v0.0.0-20250626140535-790df0a991a0
 	github.com/CAFxX/httpcompression v0.0.9
 	github.com/VictoriaMetrics/fastcache v1.13.0
@@ -60,7 +61,6 @@ require (
 	github.com/open-policy-agent/opa v1.8.0
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.8.1
-	github.com/pomerium/csrf v1.7.0
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524
 	github.com/pomerium/envoy-custom v1.35.3-rc2
 	github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46
@@ -205,7 +205,6 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
-	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -205,6 +205,7 @@ require (
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.6 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
+	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,6 +63,8 @@ dario.cat/mergo v1.0.1/go.mod h1:uNxQE+84aUszobStD9th8a29P2fMDhsBdgRYvZOxGmk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 filippo.io/bigmod v0.0.3 h1:qmdCFHmEMS+PRwzrW6eUrgA4Q3T8D6bRcjsypDMtWHM=
 filippo.io/bigmod v0.0.3/go.mod h1:WxGvOYE0OUaBC2N112Dflb3CjOnMBuNRA2UWZc2UbPE=
+filippo.io/csrf v0.2.1 h1:MdV/y9xOECwJko48lPkH9NaYNpZ6kYfaNlgnZk4k6Uo=
+filippo.io/csrf v0.2.1/go.mod h1:eVfdeENlqr/ErpNx4E5I6a11I1aP0WL/PPkzKD1d960=
 filippo.io/keygen v0.0.0-20250626140535-790df0a991a0 h1:SwGfqr/8gvAcvfGe8QQEV4ul3Tww7jEpo2QJ3v51kgg=
 filippo.io/keygen v0.0.0-20250626140535-790df0a991a0/go.mod h1:nAs0+DyACEQGudhkTwlPC9atyqDYC7ZotgZR7D8OwXM=
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
@@ -448,8 +450,6 @@ github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
-github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=
@@ -670,8 +670,6 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pomerium/csrf v1.7.0 h1:Qp4t6oyEod3svQtKfJZs589mdUTWKVf7q0PgCKYCshY=
-github.com/pomerium/csrf v1.7.0/go.mod h1:hAPZV47mEj2T9xFs+ysbum4l7SF1IdrryYaY6PdoIqw=
 github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 h1:3YQY1sb54tEEbr0L73rjHkpLB0IB6qh3zl1+XQbMLis=
 github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524/go.mod h1:7fGbUYJnU8RcxZJvUvhukOIBv1G7LWDAHMfDxAf5+Y0=
 github.com/pomerium/envoy-custom v1.35.3-rc2 h1:jSMBR8zWk2OhNJ7CPP3xDZzQRMAFimsEumUXtE0o6xg=

--- a/go.sum
+++ b/go.sum
@@ -450,6 +450,8 @@ github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
+github.com/gorilla/securecookie v1.1.2 h1:YCIWL56dvtr73r6715mJs5ZvhtnY73hBvEF8kXD8ePA=
+github.com/gorilla/securecookie v1.1.2/go.mod h1:NfCASbcHqRSY+3a8tlWJwsQap2VX5pwzwo4h3eOamfo=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc h1:GN2Lv3MGO7AS6PrRoT6yV5+wkrOpcszoIsO4+4ds248=

--- a/internal/handlers/userinfo.go
+++ b/internal/handlers/userinfo.go
@@ -14,7 +14,6 @@ import (
 
 // UserInfoData is the data for the UserInfo page.
 type UserInfoData struct {
-	CSRFToken      string
 	IsImpersonated bool
 	Session        *session.Session
 	User           *user.User
@@ -34,7 +33,6 @@ type UserInfoData struct {
 // ToJSON converts the data into a JSON map.
 func (data UserInfoData) ToJSON() map[string]any {
 	m := map[string]any{}
-	m["csrfToken"] = data.CSRFToken
 	m["isImpersonated"] = data.IsImpersonated
 	m["session"] = data.sessionJSON()
 	m["user"] = data.userJSON()

--- a/internal/handlers/userinfo_test.go
+++ b/internal/handlers/userinfo_test.go
@@ -22,7 +22,6 @@ func TestUserInfoData(t *testing.T) {
 	bs, err := json.Marshal(m)
 	assert.NoError(t, err)
 	assert.JSONEq(t, `{
-		"csrfToken": "",
 		"isEnterprise": false,
 		"isImpersonated": false,
 		"profile": {

--- a/internal/handlers/well_known_pomerium.go
+++ b/internal/handlers/well_known_pomerium.go
@@ -4,9 +4,9 @@ import (
 	"net/http"
 	"net/url"
 
+	csrf "filippo.io/csrf/gorilla"
 	"github.com/rs/cors"
 
-	"github.com/pomerium/csrf"
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/urlutil"
 )

--- a/internal/handlers/well_known_pomerium.go
+++ b/internal/handlers/well_known_pomerium.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 	"net/url"
 
-	csrf "filippo.io/csrf/gorilla"
 	"github.com/rs/cors"
 
 	"github.com/pomerium/pomerium/internal/httputil"
@@ -25,7 +24,6 @@ func WellKnownPomerium(authenticateURL *url.URL) http.Handler {
 			urlutil.GetAbsoluteURL(r).ResolveReference(&url.URL{Path: "/.well-known/pomerium/jwks.json"}).String(),
 			urlutil.GetAbsoluteURL(r).ResolveReference(&url.URL{Path: "/.pomerium/sign_out"}).String(),
 		}
-		w.Header().Set("X-CSRF-Token", csrf.Token(r))
 		httputil.RenderJSON(w, http.StatusOK, wellKnownURLs)
 		return nil
 	}))

--- a/internal/httputil/router.go
+++ b/internal/httputil/router.go
@@ -3,9 +3,9 @@ package httputil
 import (
 	"net/http"
 
+	csrf "filippo.io/csrf/gorilla"
 	"github.com/gorilla/mux"
 
-	"github.com/pomerium/csrf"
 	"github.com/pomerium/pomerium/ui"
 )
 

--- a/proxy/data.go
+++ b/proxy/data.go
@@ -4,7 +4,8 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/pomerium/csrf"
+	csrf "filippo.io/csrf/gorilla"
+
 	"github.com/pomerium/datasource/pkg/directory"
 	"github.com/pomerium/pomerium/internal/handlers"
 	"github.com/pomerium/pomerium/internal/handlers/webauthn"

--- a/proxy/data.go
+++ b/proxy/data.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	csrf "filippo.io/csrf/gorilla"
-
 	"github.com/pomerium/datasource/pkg/directory"
 	"github.com/pomerium/pomerium/internal/handlers"
 	"github.com/pomerium/pomerium/internal/handlers/webauthn"
@@ -35,7 +33,6 @@ func (p *Proxy) getUserInfoData(r *http.Request) handlers.UserInfoData {
 	state := p.state.Load()
 
 	data := handlers.UserInfoData{
-		CSRFToken:       csrf.Token(r),
 		BrandingOptions: cfg.Options.BrandingOptions,
 	}
 

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -10,8 +10,6 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
-
-	csrf "filippo.io/csrf/gorilla"
 )
 
 // ServeFile serves a file.
@@ -45,7 +43,6 @@ func ServePage(w http.ResponseWriter, r *http.Request, page, title string, data 
 	if data == nil {
 		data = make(map[string]any)
 	}
-	data["csrfToken"] = csrf.Token(r)
 
 	bs, err := RenderPage(page, title, data)
 	if err != nil {

--- a/ui/embed.go
+++ b/ui/embed.go
@@ -11,7 +11,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/pomerium/csrf"
+	csrf "filippo.io/csrf/gorilla"
 )
 
 // ServeFile serves a file.

--- a/ui/src/components/CsrfInput.tsx
+++ b/ui/src/components/CsrfInput.tsx
@@ -1,9 +1,0 @@
-import React, { FC } from "react";
-
-export type CsrfInputProps = {
-  csrfToken: string;
-};
-export const CsrfInput: FC<CsrfInputProps> = ({ csrfToken }) => {
-  return <input type="hidden" name="_pomerium_csrf" value={csrfToken} />;
-};
-export default CsrfInput;

--- a/ui/src/components/DeviceCredentialsTable.tsx
+++ b/ui/src/components/DeviceCredentialsTable.tsx
@@ -13,12 +13,10 @@ import React, { FC } from "react";
 import IDField from "./IDField";
 
 export type DeviceCredentialsTableProps = {
-  csrfToken: string;
   ids: string[];
   webAuthnUrl: string;
 };
 export const DeviceCredentialsTable: FC<DeviceCredentialsTableProps> = ({
-  csrfToken,
   ids,
   webAuthnUrl,
 }) => {
@@ -40,11 +38,6 @@ export const DeviceCredentialsTable: FC<DeviceCredentialsTableProps> = ({
                 </TableCell>
                 <TableCell>
                   <form action={webAuthnUrl} method="POST">
-                    <input
-                      type="hidden"
-                      name="_pomerium_csrf"
-                      value={csrfToken}
-                    />
                     <input type="hidden" name="action" value="unregister" />
                     <input
                       type="hidden"

--- a/ui/src/components/SessionDeviceCredentials.tsx
+++ b/ui/src/components/SessionDeviceCredentials.tsx
@@ -12,7 +12,6 @@ import WebAuthnAuthenticateButton from "./WebAuthnAuthenticateButton";
 import WebAuthnRegisterButton from "./WebAuthnRegisterButton";
 
 export type SessionDeviceCredentialsProps = {
-  csrfToken: string;
   user: User;
   session: Session;
   webAuthnCreationOptions: WebAuthnCreationOptions;
@@ -20,7 +19,6 @@ export type SessionDeviceCredentialsProps = {
   webAuthnUrl: string;
 };
 export const SessionDeviceCredentials: FC<SessionDeviceCredentialsProps> = ({
-  csrfToken,
   user,
   session,
   webAuthnCreationOptions,
@@ -49,13 +47,11 @@ export const SessionDeviceCredentials: FC<SessionDeviceCredentialsProps> = ({
             <Stack direction="row" justifyContent="center" spacing={1}>
               <WebAuthnRegisterButton
                 creationOptions={webAuthnCreationOptions}
-                csrfToken={csrfToken}
                 url={webAuthnUrl}
                 size="small"
               />
               <WebAuthnAuthenticateButton
                 requestOptions={webAuthnRequestOptions}
-                csrfToken={csrfToken}
                 url={webAuthnUrl}
                 size="small"
               />
@@ -63,7 +59,6 @@ export const SessionDeviceCredentials: FC<SessionDeviceCredentialsProps> = ({
           </Toolbar>
           <Box sx={{ padding: 3, paddingTop: 0 }}>
             <DeviceCredentialsTable
-              csrfToken={csrfToken}
               ids={currentSessionDeviceCredentialIds}
               webAuthnUrl={webAuthnUrl}
             />
@@ -82,7 +77,6 @@ export const SessionDeviceCredentials: FC<SessionDeviceCredentialsProps> = ({
               </Toolbar>
               <Box sx={{ padding: 3, paddingTop: 0 }}>
                 <DeviceCredentialsTable
-                  csrfToken={csrfToken}
                   ids={otherDeviceCredentialIds}
                   webAuthnUrl={webAuthnUrl}
                 />

--- a/ui/src/components/UserInfoPage.tsx
+++ b/ui/src/components/UserInfoPage.tsx
@@ -61,7 +61,6 @@ const UserInfoPage: FC<UserInfoPageProps> = ({ data }) => {
 
         {subpage === "Devices Info" && (
           <SessionDeviceCredentials
-            csrfToken={data?.csrfToken}
             session={data?.session}
             user={data?.user}
             webAuthnCreationOptions={data?.webAuthnCreationOptions}

--- a/ui/src/components/WebAuthnButton.tsx
+++ b/ui/src/components/WebAuthnButton.tsx
@@ -5,7 +5,6 @@ import AlertDialog from "./AlertDialog";
 
 export type WebAuthnButtonProps = Omit<ButtonProps, "action"> & {
   action: string;
-  csrfToken: string;
   enable: boolean;
   onClick: () => Promise<unknown>;
   text: string;
@@ -13,7 +12,6 @@ export type WebAuthnButtonProps = Omit<ButtonProps, "action"> & {
 };
 export const WebAuthnButton: FC<WebAuthnButtonProps> = ({
   action,
-  csrfToken,
   enable,
   onClick,
   text,
@@ -53,7 +51,6 @@ export const WebAuthnButton: FC<WebAuthnButtonProps> = ({
         {text}
       </Button>
       <form ref={formRef} method="post" action={url}>
-        <input type="hidden" name="_pomerium_csrf" value={csrfToken} />
         <input type="hidden" name="action" value={action} />
         <input type="hidden" name={action + "_response"} ref={responseRef} />
       </form>

--- a/ui/src/components/WebAuthnRegisterButton.tsx
+++ b/ui/src/components/WebAuthnRegisterButton.tsx
@@ -57,7 +57,6 @@ export type WebAuthnRegisterButtonProps = Omit<
   "action" | "enable" | "onClick" | "text"
 > & {
   creationOptions: WebAuthnCreationOptions;
-  csrfToken: string;
   url: string;
 };
 export const WebAuthnRegisterButton: FC<WebAuthnRegisterButtonProps> = ({

--- a/ui/src/components/WebAuthnRegistrationPage.tsx
+++ b/ui/src/components/WebAuthnRegistrationPage.tsx
@@ -18,12 +18,10 @@ const WebAuthnRegistrationPage: FC<WebAuthnRegistrationPageProps> = ({
       <Stack direction="row" justifyContent="center" spacing={1}>
         <WebAuthnRegisterButton
           creationOptions={data?.creationOptions}
-          csrfToken={data?.csrfToken}
           url={data?.selfUrl}
         />
         <WebAuthnAuthenticateButton
           requestOptions={data?.requestOptions}
-          csrfToken={data?.csrfToken}
           url={data?.selfUrl}
         />
       </Stack>

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -71,7 +71,6 @@ export type WebAuthnRequestOptions = {
 // page data
 
 type BasePageData = {
-  csrfToken?: string;
   primaryColor?: string;
   secondaryColor?: string;
   logoUrl?: string;
@@ -92,7 +91,6 @@ export type ErrorPageData = BasePageData & {
 };
 
 export type UserInfoData = {
-  csrfToken: string;
   directoryGroups?: Group[];
   directoryUser?: DirectoryUser;
   isEnterprise?: boolean;
@@ -143,7 +141,6 @@ export type WebAuthnRegistrationPageData = BasePageData & {
   page: "WebAuthnRegistration";
 
   creationOptions?: WebAuthnCreationOptions;
-  csrfToken: string;
   requestOptions?: WebAuthnRequestOptions;
   selfUrl: string;
 };


### PR DESCRIPTION
## Summary

Migrate off of github.com/pomerium/csrf and onto filippo.io/csrf. This new package does not rely on tokens/cookies for CSRF protection, but instead on the HTTP headers set by modern browsers. (See https://words.filippo.io/csrf/ for more context.)

However, the header-based approach is incompatible with the OAuth2 login flow, which currently relies on the ability to set a CSRF token in the `state` parameter. To handle this case, fork and adapt some of the logic from github.com/pomerium/csrf around setting and validating a CSRF cookie.

## Related issues

[ENG-2912](https://linear.app/pomerium/issue/ENG-2912/)

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
