### PR TITLE
okta: fix device authorization

### DIFF
--- a/pkg/identity/oidc/okta/okta.go
+++ b/pkg/identity/oidc/okta/okta.go
@@ -6,6 +6,7 @@ package okta
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	"github.com/pomerium/pomerium/pkg/identity/oauth"
 	pom_oidc "github.com/pomerium/pomerium/pkg/identity/oidc"
@@ -23,9 +24,17 @@ type Provider struct {
 
 // New instantiates an OpenID Connect (OIDC) provider for Okta.
 func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
+	options := *o
+
+	options.AuthCodeOptions = map[string]string{}
+	maps.Copy(options.AuthCodeOptions, map[string]string{
+		"client_secret": o.ClientSecret,
+	})
+	maps.Copy(options.AuthCodeOptions, o.AuthCodeOptions)
+
 	var p Provider
 	var err error
-	genericOidc, err := pom_oidc.New(ctx, o)
+	genericOidc, err := pom_oidc.New(ctx, &options)
 	if err != nil {
 		return nil, fmt.Errorf("%s: failed creating oidc provider: %w", Name, err)
 	}

--- a/pkg/identity/oidc/okta/okta_test.go
+++ b/pkg/identity/oidc/okta/okta_test.go
@@ -1,0 +1,65 @@
+package okta_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/coreos/go-oidc/v3/oidc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+
+	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/okta"
+)
+
+func TestOktaDeviceAuth(t *testing.T) {
+	t.Parallel()
+
+	var srv *httptest.Server
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(&oidc.ProviderConfig{
+			IssuerURL:     srv.URL,
+			DeviceAuthURL: srv.URL + "/authorize/device",
+		})
+	})
+	mux.HandleFunc("POST /authorize/device", func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "CLIENT_ID", r.FormValue("client_id"), "should pass client_id")
+		assert.Equal(t, "CLIENT_SECRET", r.FormValue("client_secret"), "should pass client_secret")
+		assert.Equal(t, "openid profile email offline_access", r.FormValue("scope"), "should pass scope")
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(&oauth2.DeviceAuthResponse{
+			DeviceCode: "DEVICE_CODE",
+		})
+	})
+
+	srv = httptest.NewServer(mux)
+
+	p, err := okta.New(t.Context(), &oauth.Options{
+		ProviderName: "okta",
+		ProviderURL:  srv.URL,
+		RedirectURL:  mustParseURL(srv.URL),
+		ClientID:     "CLIENT_ID",
+		ClientSecret: "CLIENT_SECRET",
+	})
+	require.NoError(t, err)
+
+	res, err := p.DeviceAuth(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "DEVICE_CODE", res.DeviceCode)
+}
+
+func mustParseURL(rawURL string) *url.URL {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}


### PR DESCRIPTION
## Summary
Okta expects `client_secret` for device authorization to work.

## Related issues
- [ENG-2956](https://linear.app/pomerium/issue/ENG-2956/core-device-code-authentication-not-working-for-okta)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
