### PR TITLE
ppl: mcp-tool change to only return true on match

### DIFF
--- a/pkg/policy/criteria/mcp_tool.go
+++ b/pkg/policy/criteria/mcp_tool.go
@@ -21,13 +21,13 @@ func (mcpToolCriterion) Name() string {
 
 func (c mcpToolCriterion) GenerateRule(_ string, data parser.Value) (*ast.Rule, []*ast.Rule, error) {
 	r1 := c.g.NewRule(c.Name())
-	r1.Head.Value = NewCriterionTerm(true, ReasonMCPNotAToolCall)
+	r1.Head.Value = NewCriterionTerm(false, ReasonMCPNotAToolCall)
 	r1.Body = ast.Body{
 		ast.MustParseExpr(`not input.mcp.method`),
 	}
 
 	r2 := &ast.Rule{
-		Head: generator.NewHead("", NewCriterionTerm(true, ReasonMCPNotAToolCall)),
+		Head: generator.NewHead("", NewCriterionTerm(false, ReasonMCPNotAToolCall)),
 		Body: ast.Body{
 			ast.MustParseExpr(`input.mcp.method`),
 			ast.MustParseExpr(`input.mcp.method != "tools/call"`),


### PR DESCRIPTION
## Summary

Update `mcp_tool` PPL criterion to only return `true` when a specific mcp tool is called, and its name condition matches. 

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
