### PR TITLE
ppl: add not_in string matcher

### DIFF
--- a/pkg/policy/criteria/criteria_test.go
+++ b/pkg/policy/criteria/criteria_test.go
@@ -121,6 +121,7 @@ func evaluate(t *testing.T,
 	if err != nil {
 		return nil, fmt.Errorf("error parsing policy: %w", err)
 	}
+	t.Log(regoPolicy)
 
 	r := rego.New(
 		rego.Module("policy.rego", regoPolicy),
@@ -162,7 +163,6 @@ func evaluate(t *testing.T,
 	)
 	preparedQuery, err := r.PrepareForEval(t.Context())
 	if err != nil {
-		t.Log("source:", regoPolicy)
 		return nil, err
 	}
 	resultSet, err := preparedQuery.Eval(t.Context(),

--- a/pkg/policy/criteria/matchers.go
+++ b/pkg/policy/criteria/matchers.go
@@ -25,6 +25,7 @@ func matchString(dst *ast.Body, left *ast.Term, right parser.Value) error {
 		"is":          matchStringIs,
 		"starts_with": matchStringStartsWith,
 		"in":          matchStringIn,
+		"not_in":      matchStringNotIn,
 	}
 	for k, v := range obj {
 		f, ok := lookup[k]
@@ -70,6 +71,17 @@ func matchStringIn(dst *ast.Body, left *ast.Term, right parser.Value) error {
 		return fmt.Errorf("in matcher requires an array of strings")
 	}
 	*dst = append(*dst, ast.Member.Expr(left, ast.NewTerm(arr.RegoValue())))
+	return nil
+}
+
+func matchStringNotIn(dst *ast.Body, left *ast.Term, right parser.Value) error {
+	arr, ok := right.(parser.Array)
+	if !ok {
+		return fmt.Errorf("not_in matcher requires an array of strings")
+	}
+	expr := ast.Member.Expr(left, ast.NewTerm(arr.RegoValue()))
+	expr.Negated = true
+	*dst = append(*dst, expr)
 	return nil
 }
 

--- a/pkg/policy/criteria/matchers_test.go
+++ b/pkg/policy/criteria/matchers_test.go
@@ -116,6 +116,21 @@ func TestStringMatcher(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, `example in ["value1", "value2", "value3"]`, str(body))
 	})
+
+	t.Run("not_in", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchString(&body, ast.VarTerm("example"), parser.Object{
+			"not_in": parser.Array{
+				parser.String("value1"),
+				parser.String("value2"),
+				parser.String("value3"),
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, `not example in ["value1", "value2", "value3"]`, str(body))
+	})
 	t.Run("in with object", func(t *testing.T) {
 		t.Parallel()
 
@@ -138,6 +153,17 @@ func TestStringMatcher(t *testing.T) {
 		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "in matcher requires an array of strings")
+	})
+
+	t.Run("not_in with non-array value", func(t *testing.T) {
+		t.Parallel()
+
+		var body ast.Body
+		err := matchString(&body, ast.VarTerm("example"), parser.Object{
+			"not_in": parser.String("not-an-array"),
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not_in matcher requires an array of strings")
 	})
 }
 

--- a/pkg/policy/criteria/mcp_tool.go
+++ b/pkg/policy/criteria/mcp_tool.go
@@ -41,7 +41,13 @@ func (c mcpToolCriterion) GenerateRule(_ string, data parser.Value) (*ast.Rule, 
 			ast.MustParseExpr(`input.mcp.method == "tools/call"`),
 		},
 	}
-	toolRef := ast.RefTerm(ast.VarTerm("input"), ast.VarTerm("mcp"), ast.VarTerm("tool_call"), ast.VarTerm("name"))
+
+	toolRef := ast.RefTerm(
+		ast.VarTerm("input"),
+		ast.StringTerm("mcp"),
+		ast.StringTerm("tool_call"),
+		ast.StringTerm("name"),
+	)
 	err := matchString(&r3.Body, toolRef, data)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## Summary

adds `not_in` string matcher that allows to build policies like 

```yaml
deny:
  and:
    - mcp_tool:
        not_in: ["query", "list_tables"]
```

## Related issues

Ref: https://linear.app/pomerium/issue/ENG-2960/pplmcp-tool-only-return-true-for-the-underlying-matcher

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
