### PR TITLE
authenticate: fix callback path

### DIFF
--- a/authenticate/handlers.go
+++ b/authenticate/handlers.go
@@ -19,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 
+	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/authenticateflow"
 	"github.com/pomerium/pomerium/internal/handlers"
 	"github.com/pomerium/pomerium/internal/httputil"
@@ -32,15 +33,17 @@ import (
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
-// Handler returns the authenticate service's handler chain.
-func (a *Authenticate) Handler() http.Handler {
-	r := httputil.NewRouter()
-	a.Mount(r)
-	return r
-}
-
 // Mount mounts the authenticate routes to the given router.
 func (a *Authenticate) Mount(r *mux.Router) {
+	r.PathPrefix("/").Handler(a)
+}
+
+func (a *Authenticate) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	a.currentRouter.Load().ServeHTTP(w, r)
+}
+
+func (a *Authenticate) newRouter(cfg *config.Config) *mux.Router {
+	r := httputil.NewRouter()
 	r.StrictSlash(true)
 	r.Use(middleware.SetHeaders(httputil.HeadersContentSecurityPolicy))
 	// disable csrf checking for these endpoints
@@ -48,7 +51,7 @@ func (a *Authenticate) Mount(r *mux.Router) {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == "/.pomerium/verify-access-token" ||
 				r.URL.Path == "/.pomerium/verify-identity-token" ||
-				r.URL.Path == "/oauth2/callback" { // protected by separate CSRF token
+				r.URL.Path == cfg.Options.AuthenticateCallbackPath { // protected by separate CSRF token
 				r = csrf.UnsafeSkipCheck(r)
 			}
 			h.ServeHTTP(w, r)
@@ -68,9 +71,10 @@ func (a *Authenticate) Mount(r *mux.Router) {
 	r.Path("/robots.txt").HandlerFunc(a.RobotsTxt).Methods(http.MethodGet)
 
 	// Identity Provider (IdP) endpoints
-	r.Path("/oauth2/callback").Handler(httputil.HandlerFunc(a.OAuthCallback)).Methods(http.MethodGet, http.MethodPost)
+	r.Path(cfg.Options.AuthenticateCallbackPath).Handler(httputil.HandlerFunc(a.OAuthCallback)).Methods(http.MethodGet, http.MethodPost)
 
 	a.mountDashboard(r)
+	return r
 }
 
 func (a *Authenticate) mountDashboard(r *mux.Router) {

--- a/authenticate/handlers_callback_test.go
+++ b/authenticate/handlers_callback_test.go
@@ -1,0 +1,78 @@
+package authenticate_test
+
+import (
+	"net/http"
+	"net/http/cookiejar"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/authenticate"
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/httputil"
+	"github.com/pomerium/pomerium/internal/testutil/mockidp"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+)
+
+func TestCallback(t *testing.T) {
+	t.Setenv("DEBUG_FORCE_AUTHENTICATE_FLOW", "stateless")
+
+	idp := mockidp.New(mockidp.Config{})
+	idpURL := idp.Start(t)
+
+	options := config.NewDefaultOptions()
+	options.CookieSecret = cryptutil.NewBase64Key()
+	options.SharedKey = cryptutil.NewBase64Key()
+	options.Provider = "oidc"
+	options.ProviderURL = idpURL
+	options.ClientID = "CLIENT_ID"
+	options.ClientSecret = "CLIENT_SECRET"
+	a, err := authenticate.New(t.Context(), &config.Config{Options: options})
+	require.NoError(t, err)
+
+	srv := httptest.NewTLSServer(a)
+	t.Cleanup(srv.Close)
+	options.AuthenticateURLString = srv.URL
+	options.AuthenticateCallbackPath = "/test/callback"
+	a.OnConfigChange(t.Context(), &config.Config{Options: options})
+
+	cj, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	c := &http.Client{
+		Transport: httputil.GetInsecureTransport(),
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Jar: cj,
+	}
+
+	r, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL+"/.pomerium/sign_in", nil)
+	require.NoError(t, err)
+	res, err := c.Do(r)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, res.StatusCode)
+	_ = res.Body.Close()
+
+	u, err := url.Parse(res.Header.Get("Location"))
+	require.NoError(t, err)
+	q := u.Query()
+	q.Add("email", "u1@example.com")
+	u.RawQuery = q.Encode()
+
+	r, err = http.NewRequestWithContext(t.Context(), http.MethodGet, u.String(), nil)
+	require.NoError(t, err)
+	r.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	res, err = c.Do(r)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, res.StatusCode)
+	_ = res.Body.Close()
+
+	r, err = http.NewRequestWithContext(t.Context(), http.MethodGet, res.Header.Get("Location"), nil)
+	require.NoError(t, err)
+	res, err = c.Do(r)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusFound, res.StatusCode)
+	_ = res.Body.Close()
+}

--- a/authenticate/handlers_verify_test.go
+++ b/authenticate/handlers_verify_test.go
@@ -38,7 +38,7 @@ func TestVerifyAccessToken(t *testing.T) {
 		strings.NewReader(`{"accessToken":"ACCESS TOKEN"}`))
 	require.NoError(t, err)
 
-	a.Handler().ServeHTTP(w, r)
+	a.ServeHTTP(w, r)
 
 	assert.Equal(t, 200, w.Code)
 	assert.JSONEq(t, `{"valid":false}`, w.Body.String())

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -76,8 +76,8 @@ func (srv *Server) mountCommonEndpoints(root *mux.Router, cfg *config.Config) er
 	root.HandleFunc("/ping", handlers.HealthCheck)
 
 	traceHandler := trace.NewHTTPMiddleware(otelhttp.WithTracerProvider(srv.tracerProvider))
-	root.Handle("/.well-known/pomerium", traceHandler(handlers.WellKnownPomerium(authenticateURL)))
-	root.Handle("/.well-known/pomerium/", traceHandler(handlers.WellKnownPomerium(authenticateURL)))
+	root.Handle("/.well-known/pomerium", traceHandler(handlers.WellKnownPomerium(authenticateURL, cfg.Options.AuthenticateCallbackPath)))
+	root.Handle("/.well-known/pomerium/", traceHandler(handlers.WellKnownPomerium(authenticateURL, cfg.Options.AuthenticateCallbackPath)))
 	root.Path("/.well-known/pomerium/jwks.json").Methods(http.MethodGet).Handler(traceHandler(handlers.JWKSHandler(signingKey)))
 	root.Path(urlutil.HPKEPublicKeyPath).Methods(http.MethodGet).Handler(traceHandler(hpke_handlers.HPKEPublicKeyHandler(hpkePublicKey)))
 

--- a/internal/handlers/well_known_pomerium.go
+++ b/internal/handlers/well_known_pomerium.go
@@ -11,7 +11,7 @@ import (
 )
 
 // WellKnownPomerium returns the /.well-known/pomerium handler.
-func WellKnownPomerium(authenticateURL *url.URL) http.Handler {
+func WellKnownPomerium(authenticateURL *url.URL, authenticateCallbackPath string) http.Handler {
 	return cors.AllowAll().Handler(httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
 		wellKnownURLs := struct {
 			Issuer                string `json:"issuer"`
@@ -20,7 +20,7 @@ func WellKnownPomerium(authenticateURL *url.URL) http.Handler {
 			FrontchannelLogoutURI string `json:"frontchannel_logout_uri"`          // https://openid.net/specs/openid-connect-frontchannel-1_0.html
 		}{
 			urlutil.GetAbsoluteURL(r).ResolveReference(&url.URL{Path: "/"}).String(),
-			authenticateURL.ResolveReference(&url.URL{Path: "/oauth2/callback"}).String(),
+			authenticateURL.ResolveReference(&url.URL{Path: authenticateCallbackPath}).String(),
 			urlutil.GetAbsoluteURL(r).ResolveReference(&url.URL{Path: "/.well-known/pomerium/jwks.json"}).String(),
 			urlutil.GetAbsoluteURL(r).ResolveReference(&url.URL{Path: "/.pomerium/sign_out"}).String(),
 		}

--- a/internal/handlers/well_known_pomerium_test.go
+++ b/internal/handlers/well_known_pomerium_test.go
@@ -18,17 +18,17 @@ func TestWellKnownPomeriumHandler(t *testing.T) {
 		r := httptest.NewRequest(http.MethodOptions, "/", nil)
 		r.Header.Set("Origin", authenticateURL.String())
 		r.Header.Set("Access-Control-Request-Method", http.MethodGet)
-		WellKnownPomerium(authenticateURL).ServeHTTP(w, r)
+		WellKnownPomerium(authenticateURL, "/oauth2/callback").ServeHTTP(w, r)
 		assert.Equal(t, http.StatusNoContent, w.Result().StatusCode)
 	})
 	t.Run("links", func(t *testing.T) {
 		authenticateURL, _ := url.Parse("https://authenticate.example.com")
 		w := httptest.NewRecorder()
 		r := httptest.NewRequest(http.MethodGet, "https://route.example.com", nil)
-		WellKnownPomerium(authenticateURL).ServeHTTP(w, r)
+		WellKnownPomerium(authenticateURL, "/test/callback").ServeHTTP(w, r)
 		assert.JSONEq(t, `{
 			"issuer": "https://route.example.com/",
-			"authentication_callback_endpoint": "https://authenticate.example.com/oauth2/callback",
+			"authentication_callback_endpoint": "https://authenticate.example.com/test/callback",
 			"frontchannel_logout_uri": "https://route.example.com/.pomerium/sign_out",
 			"jwks_uri": "https://route.example.com/.well-known/pomerium/jwks.json"
 		}`, w.Body.String())


### PR DESCRIPTION
## Summary
The authenticate callback path option wasn't being used in the authenticate service. To get this to work we needed to dynamically construct the `mux.Router` any time the config was updated. This is similar to what we do in the proxy service.

## Related issues
- [ENG-2951](https://linear.app/pomerium/issue/ENG-2951/core-fix-or-remove-the-authenticate-callback-path-setting)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
