### PR TITLE
envoy: fix ready check

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -488,6 +488,9 @@ func (srv *Server) readiness(ctx context.Context, exited chan struct{}) {
 	ticker := time.NewTicker(time.Second * 30)
 	defer ticker.Stop()
 
+	firstTime := time.NewTicker(time.Second)
+	defer firstTime.Stop()
+
 	for {
 		select {
 		case <-exited:
@@ -495,7 +498,7 @@ func (srv *Server) readiness(ctx context.Context, exited chan struct{}) {
 		case <-ctx.Done():
 			// small optimization to bring up envoy as ready
 			return
-		case <-time.After(time.Second):
+		case <-firstTime.C:
 			if err := srv.envoyReady(ctx); err != nil {
 				health.ReportError(health.EnvoyServer, err)
 			} else {


### PR DESCRIPTION
## Summary
I believe the expectation for the envoy ready check is that it would be performed every 30 seconds, except the first time, which would happen 1 second after starting. However the way the code was written, it simply always checked every second.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
