### PR TITLE
config: migrate remaining mapstructure imports

### DIFF
--- a/config/bearer_token_format.go
+++ b/config/bearer_token_format.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 )

--- a/config/codec_type.go
+++ b/config/codec_type.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	envoy_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 )
 
 // The CodecType specifies which codec to use for downstream connections.

--- a/config/constants.go
+++ b/config/constants.go
@@ -3,7 +3,7 @@ package config
 import (
 	"errors"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/viper"
 	"google.golang.org/protobuf/encoding/protojson"
 
@@ -30,7 +30,7 @@ var protoPartial = protojson.UnmarshalOptions{AllowPartial: true, DiscardUnknown
 // ViperPolicyHooks are used to decode options and policy coming from YAML and env vars
 var ViperPolicyHooks = viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 	mapstructure.StringToTimeDurationHookFunc(),
-	mapstructure.StringToSliceHookFunc(","),
+	mapstructure.StringToWeakSliceHookFunc(","),
 	// decode policy including all protobuf-native notations - i.e. duration as `1s`
 	// https://developers.google.com/protocol-buffers/docs/proto3#json
 	DecodePolicyHookFunc(),

--- a/config/custom.go
+++ b/config/custom.go
@@ -13,8 +13,8 @@ import (
 	"unicode"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	"github.com/go-viper/mapstructure/v2"
 	goset "github.com/hashicorp/go-set/v3"
-	"github.com/mitchellh/mapstructure"
 	"github.com/volatiletech/null/v9"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"

--- a/config/custom_test.go
+++ b/config/custom_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"

--- a/config/otelconfig/otelconfig.go
+++ b/config/otelconfig/otelconfig.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/mitchellh/mapstructure"
+	"github.com/go-viper/mapstructure/v2"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"google.golang.org/protobuf/types/known/durationpb"
 )

--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,6 @@ require (
 	github.com/mholt/acmez/v3 v3.1.3
 	github.com/minio/minio-go/v7 v7.0.95
 	github.com/mitchellh/hashstructure/v2 v2.0.2
-	github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c
 	github.com/natefinch/atomic v1.0.1
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/open-policy-agent/opa v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -595,8 +595,6 @@ github.com/minio/minlz v1.0.1-0.20250507153514-87eb42fe8882 h1:0lgqHvJWHLGW5TuOb
 github.com/minio/minlz v1.0.1-0.20250507153514-87eb42fe8882/go.mod h1:qT0aEB35q79LLornSzeDH75LBf3aH1MV+jB5w9Wasec=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
-github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c h1:cqn374mizHuIWj+OSJCajGr/phAmuMug9qIX3l9CflE=
-github.com/mitchellh/mapstructure v1.5.1-0.20231216201459-8508981c8b6c/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
 github.com/moby/go-archive v0.1.0 h1:Kk/5rdW/g+H8NHdJW2gsXyZ7UnzvJNOy6VKJqueWdcQ=


### PR DESCRIPTION
## Summary

The `github.com/mitchellh/mapstructure` repo is archived, and `github.com/go-viper/mapstructure` is the blessed replacement according to https://gist.github.com/mitchellh/90029601268e59a29e64e55bab1c5bdc#the-list.

Update the remaining `mapstructure` imports to the new package.

The behavior of `StringToSliceHookFunc()` has changed slightly, in a way that breaks decoding of the `POLICY` environment variable. However we can use [StringToWeakSliceHookFunc()](https://pkg.go.dev/github.com/go-viper/mapstructure/v2#StringToWeakSliceHookFunc) instead, which provides the old behavior. Other than that, it looks like all the unit tests still pass.

## Related issues

- https://github.com/pomerium/pomerium/issues/5566

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
