### PR TITLE
databroker: support default path for file backend

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"reflect"
 	"slices"
 	"strings"
@@ -327,7 +328,7 @@ var defaultOptions = Options{
 	AuthenticateCallbackPath: "/oauth2/callback",
 
 	AutocertOptions: AutocertOptions{
-		Folder: fileutil.DataDir(),
+		Folder: filepath.Join(fileutil.DataDir(), "autocert"),
 	},
 	DataBroker: DataBrokerOptions{
 		StorageType: "memory",

--- a/internal/fileutil/directories.go
+++ b/internal/fileutil/directories.go
@@ -3,6 +3,7 @@ package fileutil
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 )
 
 // CacheDir returns $XDG_CACHE_HOME/pomerium, or $HOME/.cache/pomerium, or /tmp/pomerium/cache
@@ -16,17 +17,21 @@ func CacheDir() string {
 	return dir
 }
 
-// DataDir returns $XDG_DATA_HOME/pomerium, or $HOME/.local/share/pomerium, or /tmp/pomerium/data
+// DataDir returns $XDG_DATA_HOME/pomerium, or $HOME/.local/share/pomerium, or /var/tmp/pomerium/data
 func DataDir() string {
-	dir := os.Getenv("XDG_DATA_HOME")
-	if dir != "" {
-		dir = filepath.Join(dir, "pomerium")
-	} else {
-		if home, err := os.UserHomeDir(); err == nil {
-			dir = filepath.Join(home, ".local", "share", "pomerium")
-		} else {
-			dir = filepath.Join(os.TempDir(), "pomerium", "data")
+	if runtime.GOOS == "darwin" {
+		if dir, err := os.UserHomeDir(); err == nil {
+			return filepath.Join(dir, "Library", "Application Support", "pomerium")
 		}
 	}
-	return dir
+
+	if dir := os.Getenv("XDG_DATA_HOME"); dir != "" {
+		return filepath.Join(dir, "pomerium")
+	}
+
+	if home, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(home, ".local", "share", "pomerium")
+	}
+
+	return "/var/tmp/pomerium/data"
 }

--- a/pkg/storage/file/pebble_test.go
+++ b/pkg/storage/file/pebble_test.go
@@ -1,0 +1,51 @@
+package file_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/storage/file"
+)
+
+func TestOpenPebbleDB(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "test")
+		t.Setenv("XDG_DATA_HOME", dir)
+		db, err := file.OpenPebbleDB("")
+		require.NoError(t, err)
+		assert.NoError(t, db.Close())
+		_, err = os.Stat(filepath.Join(dir, "pomerium", "databroker", "MANIFEST-000001"))
+		require.NoError(t, err)
+	})
+	t.Run("bare", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "test")
+		t.Setenv("XDG_DATA_HOME", dir)
+		db, err := file.OpenPebbleDB("file:")
+		require.NoError(t, err)
+		assert.NoError(t, db.Close())
+		_, err = os.Stat(filepath.Join(dir, "pomerium", "databroker", "MANIFEST-000001"))
+		require.NoError(t, err)
+	})
+	t.Run("empty path", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "test")
+		t.Setenv("XDG_DATA_HOME", dir)
+		db, err := file.OpenPebbleDB("file://")
+		require.NoError(t, err)
+		assert.NoError(t, db.Close())
+		_, err = os.Stat(filepath.Join(dir, "pomerium", "databroker", "MANIFEST-000001"))
+		require.NoError(t, err)
+	})
+	t.Run("absolute path", func(t *testing.T) {
+		dir := filepath.Join(t.TempDir(), "test")
+		t.Setenv("XDG_DATA_HOME", dir)
+		db, err := file.OpenPebbleDB(dir)
+		require.NoError(t, err)
+		assert.NoError(t, db.Close())
+		_, err = os.Stat(filepath.Join(dir, "MANIFEST-000001"))
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## Summary
Add support for a default path if the DSN for the file storage backend is the empty string, `file:` or `file://`. Also add support for when the DSN is just a path (`/tmp/example` becomes `file:///tmp/example`).

Also update the way we determine the data directory so that on a mac it returns a directory in `~/Library/Application Support`, and change the fall back from `/tmp/pomerium/data` to `/var/tmp/pomerium/data`, which is a little more persistent.

I also moved the autocert data to its own folder, which makes this a breaking change.

## Related issues
- [ENG-2959](https://linear.app/pomerium/issue/ENG-2959/core-add-support-for-a-default-file-path-for-the-on-disk-databroker)

## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
