### PR TITLE
telemetry/databroker: set node_id when in clustered mode

### DIFF
--- a/pkg/storage/file/metrics.go
+++ b/pkg/storage/file/metrics.go
@@ -176,6 +176,7 @@ func (backend *Backend) registerMetrics() (metric.Registration, error) {
 		backend.mu.RLock()
 		pm := backend.db.Metrics()
 		serverVersion, recordVersion, err := backend.getCheckpointLocked(backend.db)
+		attrs := backend.metricAttributes
 		backend.mu.RUnlock()
 
 		if err != nil {
@@ -186,8 +187,13 @@ func (backend *Backend) registerMetrics() (metric.Registration, error) {
 			}
 		}
 
-		o.ObserveFloat64(checkpointServerVersion, float64(serverVersion))
-		o.ObserveFloat64(checkpointRecordVersion, float64(recordVersion))
+		if len(attrs) > 0 {
+			o.ObserveFloat64(checkpointServerVersion, float64(serverVersion), metric.WithAttributes(attrs...))
+			o.ObserveFloat64(checkpointRecordVersion, float64(recordVersion), metric.WithAttributes(attrs...))
+		} else {
+			o.ObserveFloat64(checkpointServerVersion, float64(serverVersion))
+			o.ObserveFloat64(checkpointRecordVersion, float64(recordVersion))
+		}
 		o.ObserveInt64(blockCacheSize, pm.BlockCache.Size)
 		o.ObserveInt64(blockCacheCount, pm.BlockCache.Count)
 		o.ObserveInt64(blockCacheHits, pm.BlockCache.Hits)


### PR DESCRIPTION
## Summary

Adds `node_id` label to the databroker backend metrics when databroker is in clustered mode. 

## Related issues

Ref: https://linear.app/pomerium/issue/ENG-2971/telemetrydatabroker-how-in-sync-nodes-are-in-a-cluster

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
