### PR TITLE
config: retain alt-stat-name if set in the protobuf

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -191,7 +191,9 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 		}
 	}
 
-	cluster.AltStatName = getClusterStatsName(policy)
+	if cluster.AltStatName == "" {
+		cluster.AltStatName = getClusterStatsName(policy)
+	}
 	upstreamProtocol := getUpstreamProtocolForPolicy(ctx, policy)
 
 	name := getClusterID(policy)

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -1256,3 +1256,21 @@ func mustParseWeightedURLs(t *testing.T, urls ...string) []config.WeightedURL {
 	require.NoError(t, err)
 	return wu
 }
+
+func Test_buildPolicyCluster(t *testing.T) {
+	t.Parallel()
+	b := New("local-grpc", "local-http", "local-metrics", filemgr.NewManager(), nil, true)
+
+	t.Run("retain cluster stat name", func(t *testing.T) {
+		t.Parallel()
+		cluster, err := b.buildPolicyCluster(t.Context(), &config.Config{Options: config.NewDefaultOptions()}, &config.Policy{
+			From: "https://from.example.com",
+			To:   mustParseWeightedURLs(t, "https://example.com"),
+			EnvoyOpts: &envoy_config_cluster_v3.Cluster{
+				AltStatName: "alt-stat-name",
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "alt-stat-name", cluster.AltStatName)
+	})
+}


### PR DESCRIPTION
## Summary

Retains `alt_stat_name` field for a route if explicitly set in the config protobuf. 

## Related issues

Ref: https://linear.app/pomerium/issue/ENG-3007

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
