### PR TITLE
update -config option in dockerfiles

### DIFF
--- a/.github/Dockerfile-cloudrun
+++ b/.github/Dockerfile-cloudrun
@@ -13,4 +13,4 @@ ENV GRPC_INSECURE=true
 ENV INSECURE_SERVER=true
 
 ENTRYPOINT [ "/bin/pomerium" ]
-CMD ["-config","/pomerium/config.yaml"]
+CMD ["--config","/pomerium/config.yaml"]

--- a/.github/Dockerfile-release
+++ b/.github/Dockerfile-release
@@ -7,4 +7,4 @@ WORKDIR /pomerium
 COPY pomerium /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 ENTRYPOINT [ "/bin/pomerium" ]
-CMD ["-config","/pomerium/config.yaml"]
+CMD ["--config","/pomerium/config.yaml"]

--- a/.github/Dockerfile-release-debug
+++ b/.github/Dockerfile-release-debug
@@ -7,4 +7,4 @@ WORKDIR /pomerium
 COPY pomerium /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 ENTRYPOINT [ "/bin/pomerium" ]
-CMD ["-config","/pomerium/config.yaml"]
+CMD ["--config","/pomerium/config.yaml"]

--- a/.github/Dockerfile-release-debug-nonroot
+++ b/.github/Dockerfile-release-debug-nonroot
@@ -7,4 +7,4 @@ WORKDIR /pomerium
 COPY pomerium /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 ENTRYPOINT [ "/bin/pomerium" ]
-CMD ["-config","/pomerium/config.yaml"]
+CMD ["--config","/pomerium/config.yaml"]

--- a/.github/Dockerfile-release-nonroot
+++ b/.github/Dockerfile-release-nonroot
@@ -7,4 +7,4 @@ WORKDIR /pomerium
 COPY pomerium /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 ENTRYPOINT [ "/bin/pomerium" ]
-CMD ["-config","/pomerium/config.yaml"]
+CMD ["--config","/pomerium/config.yaml"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ WORKDIR /pomerium
 COPY --from=build /go/src/github.com/pomerium/pomerium/bin/* /bin/
 COPY --from=build /config.yaml /pomerium/config.yaml
 ENTRYPOINT [ "/bin/pomerium" ]
-CMD ["-config","/pomerium/config.yaml"]
+CMD ["--config","/pomerium/config.yaml"]

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -38,4 +38,4 @@ COPY --from=build /config.yaml /pomerium/config.yaml
 COPY --from=build /go/bin/dlv /bin
 COPY scripts/debug-entrypoint.sh /
 ENTRYPOINT [ "/bin/pomerium" ]
-CMD ["-config","/pomerium/config.yaml"]
+CMD ["--config","/pomerium/config.yaml"]


### PR DESCRIPTION
## Summary

The single-dash "-config" option was deprecated when the Core -> Zero import feature was implemented. Update the Dockerfiles to "--config" so the deprecation warning does not show at startup.

## Related issues

https://linear.app/pomerium/issue/ENG-3031/core-syntax-config-is-deprecated-warning-from-docker-images

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
