### PR TITLE
databroker: fix unnecessary required connection string

### DIFF
--- a/config/options_databroker.go
+++ b/config/options_databroker.go
@@ -77,8 +77,8 @@ func (o *DataBrokerOptions) ToProto(dst *configpb.Settings) {
 // Validate validates the databroker options.
 func (o *DataBrokerOptions) Validate() error {
 	switch o.StorageType {
-	case StorageInMemoryName:
-	case StoragePostgresName, StorageFileName:
+	case StorageInMemoryName, StorageFileName:
+	case StoragePostgresName:
 		if o.StorageConnectionString == "" && o.StorageConnectionStringFile == "" {
 			return ErrMissingDataBrokerStorageConnectionString
 		}

--- a/config/options_databroker_test.go
+++ b/config/options_databroker_test.go
@@ -25,12 +25,21 @@ func TestDataBrokerOptions_GetStorageConnectionString(t *testing.T) {
 
 		o := config.NewDefaultOptions()
 		o.Services = "databroker"
-		o.DataBroker.StorageType = "postgres"
 		o.SharedKey = cryptutil.NewBase64Key()
 
+		o.DataBroker.StorageType = "memory"
+		o.DataBroker.StorageConnectionString = ""
+		assert.NoError(t, o.Validate(),
+			"should not require a storage connection string for memory")
+
+		o.DataBroker.StorageType = "file"
+		o.DataBroker.StorageConnectionString = ""
+		assert.NoError(t, o.Validate(),
+			"should not require a storage connection string for file")
+
+		o.DataBroker.StorageType = "postgres"
 		assert.ErrorContains(t, o.Validate(), "missing databroker storage backend dsn",
 			"should validate DSN")
-
 		o.DataBroker.StorageConnectionString = "DSN"
 		assert.NoError(t, o.Validate(),
 			"should have no error when the dsn is set")


### PR DESCRIPTION
## Summary
The databroker connection string should not be required for the `file` backend because it has a default now.

## Related issues
- [ENG-2959](https://linear.app/pomerium/issue/ENG-2959/core-add-support-for-a-default-file-path-for-the-on-disk-databroker)

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
