### PR TITLE
update Envoy to 1.35.6-p1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.8.1
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524
-	github.com/pomerium/envoy-custom v1.35.4-p1
+	github.com/pomerium/envoy-custom v1.35.6-p1
 	github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46
 	github.com/pomerium/webauthn v0.0.0-20240603205124-0428df511172
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -678,8 +678,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 h1:3YQY1sb54tEEbr0L73rjHkpLB0IB6qh3zl1+XQbMLis=
 github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524/go.mod h1:7fGbUYJnU8RcxZJvUvhukOIBv1G7LWDAHMfDxAf5+Y0=
-github.com/pomerium/envoy-custom v1.35.4-p1 h1:jgDpNtVxW2Ug+nvaGgCQEEtX1p4K1/Bsrltcgclwwlk=
-github.com/pomerium/envoy-custom v1.35.4-p1/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
+github.com/pomerium/envoy-custom v1.35.6-p1 h1:RpyNhpD/u20nmjUfO/spE6UyJtZPAu8CFQDmQp9crsg=
+github.com/pomerium/envoy-custom v1.35.6-p1/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 h1:NRTg8JOXCxcIA1lAgD74iYud0rbshbWOB3Ou4+Huil8=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46/go.mod h1:QqZmx6ZgPxz18va7kqoT4t/0yJtP7YFIDiT/W2n2fZ4=
 github.com/pomerium/webauthn v0.0.0-20240603205124-0428df511172 h1:TqoPqRgXSHpn+tEJq6H72iCS5pv66j3rPprThUEZg0E=

--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	envoyVersion = "1.35.4-p1"
+	envoyVersion = "1.35.6-p1"
 	targets      = []string{
 		"darwin-amd64",
 		"darwin-arm64",


### PR DESCRIPTION
## Summary

https://github.com/pomerium/pomerium/pull/5895 should have been merged to the `main` branch first and then backported to the v0.31 release branch (instead of merged directly to the release branch). I forgot that we haven't yet updated to Envoy 1.36 on the `main` branch.

## Related issues

https://linear.app/pomerium/issue/ENG-3036/upgrade-envoy-to-13410-1356-1362

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
