### PR TITLE
config: remove unused GetOauthOptions() method

### DIFF
--- a/config/identity_test.go
+++ b/config/identity_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/identity/oidc"
+)
+
+func TestOptions_GetIdentityProviderForPolicy(t *testing.T) {
+	exampleScopes := []string{"scope1", "scope2", "scope3"}
+	exampleRequestParams := map[string]string{"extra-param": "param-value"}
+	exampleAccessTokenAllowedAudiences := []string{"audience1", "audience2"}
+	opts := &Options{
+		AuthenticateURLString:          "https://authenticate.example.com",
+		ClientID:                       "client-id",
+		ClientSecret:                   "client-secret",
+		Provider:                       oidc.Name,
+		ProviderURL:                    "https://my-idp.example.com",
+		Scopes:                         exampleScopes,
+		RequestParams:                  exampleRequestParams,
+		IDPAccessTokenAllowedAudiences: &exampleAccessTokenAllowedAudiences,
+	}
+	idp, err := opts.GetIdentityProviderForPolicy(nil)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://authenticate.example.com", idp.AuthenticateServiceUrl)
+	assert.Equal(t, "client-id", idp.ClientId)
+	assert.Equal(t, "client-secret", idp.ClientSecret)
+	assert.Equal(t, oidc.Name, idp.Type)
+	assert.Equal(t, "https://my-idp.example.com", idp.Url)
+	assert.Equal(t, exampleScopes, idp.Scopes)
+	assert.Equal(t, exampleRequestParams, idp.RequestParams)
+	assert.Equal(t, exampleAccessTokenAllowedAudiences, idp.AccessTokenAllowedAudiences.GetValues())
+
+	// If a Policy is provided, it may override the client credentials and
+	// access token allowed audiences.
+	perPolicyAccessTokenAllowedAudiences := []string{"per-policy-allowed-audience"}
+	idp, err = opts.GetIdentityProviderForPolicy(&Policy{
+		IDPClientID:                    "per-policy-client-id",
+		IDPClientSecret:                "per-policy-client-secret",
+		IDPAccessTokenAllowedAudiences: &perPolicyAccessTokenAllowedAudiences,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://authenticate.example.com", idp.AuthenticateServiceUrl)
+	assert.Equal(t, "per-policy-client-id", idp.ClientId)
+	assert.Equal(t, "per-policy-client-secret", idp.ClientSecret)
+	assert.Equal(t, oidc.Name, idp.Type)
+	assert.Equal(t, "https://my-idp.example.com", idp.Url)
+	assert.Equal(t, exampleScopes, idp.Scopes)
+	assert.Equal(t, exampleRequestParams, idp.RequestParams)
+	assert.Equal(t, perPolicyAccessTokenAllowedAudiences, idp.AccessTokenAllowedAudiences.GetValues())
+}

--- a/config/options.go
+++ b/config/options.go
@@ -39,7 +39,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/endpoints"
 	"github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/pkg/hpke"
-	"github.com/pomerium/pomerium/pkg/identity/oauth"
 	"github.com/pomerium/pomerium/pkg/identity/oauth/apple"
 	"github.com/pomerium/pomerium/pkg/policy/parser"
 )
@@ -974,29 +973,6 @@ func (o *Options) GetMetricsCertificate() (*tls.Certificate, error) {
 		return cryptutil.CertificateFromFile(o.MetricsCertificateFile, o.MetricsCertificateKeyFile)
 	}
 	return nil, nil
-}
-
-// GetOauthOptions gets the oauth.Options for the given config options.
-func (o *Options) GetOauthOptions() (oauth.Options, error) {
-	redirectURL, err := o.GetAuthenticateURL()
-	if err != nil {
-		return oauth.Options{}, err
-	}
-	redirectURL = redirectURL.ResolveReference(&url.URL{
-		Path: endpoints.PathAuthenticateCallback,
-	})
-	clientSecret, err := o.GetClientSecret()
-	if err != nil {
-		return oauth.Options{}, err
-	}
-	return oauth.Options{
-		RedirectURL:  redirectURL,
-		ProviderName: o.Provider,
-		ProviderURL:  o.ProviderURL,
-		ClientID:     o.ClientID,
-		ClientSecret: clientSecret,
-		Scopes:       o.Scopes,
-	}, nil
 }
 
 // GetAllPolicies gets all the policies in the options.

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -875,17 +875,6 @@ func TestOptions_UseStatelessAuthenticateFlow(t *testing.T) {
 	})
 }
 
-func TestOptions_GetOauthOptions(t *testing.T) {
-	opts := &Options{AuthenticateURLString: "https://authenticate.example.com"}
-	oauthOptions, err := opts.GetOauthOptions()
-	require.NoError(t, err)
-
-	// Test that oauth redirect url hostname must point to authenticate url hostname.
-	u, err := opts.GetAuthenticateURL()
-	require.NoError(t, err)
-	assert.Equal(t, u.Hostname(), oauthOptions.RedirectURL.Hostname())
-}
-
 func TestOptions_GetAllRouteableGRPCHosts(t *testing.T) {
 	opts := &Options{
 		AuthenticateURLString: "https://authenticate.example.com",


### PR DESCRIPTION
## Summary

Remove the `Options.GetOauthOptions()` method as it appears to be unused outside of a unit test. The `oauth.Options` are currently populated from the `identity.Provider` protobuf message, which is in turn obtained from `Options.GetIdentityProviderForPolicy()`. Add a unit test for this method as it doesn't appear to have one currently.


## Related issues

n/a

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
