### PR TITLE
filter generated code, test utils, mocks from coverage report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,14 @@ cover: get-envoy ## Runs go test with coverage
 	@echo "==> $@"
 	$(GO) test $(GO_TESTFLAGS) -tags "$(BUILDTAGS)" -coverprofile=coverage.txt ./...
 	@sed -i.bak '/\.pb\.go\:/d' coverage.txt
-	@sed -i.bak '/\/mock\.go\:/d' coverage.txt
+	@sed -i.bak '/\/mock_.*\.go\:/d' coverage.txt
+	@sed -i.bak '/\.gen\.go\:/d' coverage.txt
+	@sed -i.bak '/\/internal\/testenv\/:/d' coverage.txt
+	@sed -i.bak '/\/internal\/testutil\/:/d' coverage.txt
+	@sed -i.bak '/\/internal\/tests\/:/d' coverage.txt
+	@sed -i.bak '/\/storagetest\/:/d' coverage.txt
+	@sed -i.bak '/\/integration\/:/d' coverage.txt
+	@sed -i.bak '/\/examples\/:/d' coverage.txt
 	@sort -o coverage.txt coverage.txt
 
 .PHONY: clean


### PR DESCRIPTION
Adds the following filters to the coverage report generated by 'make cover':
- `mock_*.go` (previously only matched `mock.go`)
- `*.gen.go`
- `internal/testenv/`
- `internal/testutil/`
- `internal/tests/`
- `pkg/storage/storagetest/`
- `integration/`
- `examples/`