### PR TITLE
ssh: improve internal cli output management

### DIFF
--- a/pkg/ssh/messages.go
+++ b/pkg/ssh/messages.go
@@ -35,11 +35,17 @@ type DisconnectMsg struct {
 	Language string
 }
 
-// Used for debug print outs of packets.
 type ChannelDataMsg struct {
 	PeersID uint32 `sshtype:"94"`
 	Length  uint32
 	Rest    []byte `ssh:"rest"`
+}
+
+type ChannelExtendedDataMsg struct {
+	PeersID      uint32 `sshtype:"95"`
+	DataTypeCode uint32
+	Length       uint32
+	Rest         []byte `ssh:"rest"`
 }
 
 // See RFC 4254, section 5.1.

--- a/pkg/ssh/ssh_int_test.go
+++ b/pkg/ssh/ssh_int_test.go
@@ -244,7 +244,7 @@ func (s *SSHTestSuite) TestReevaluatePolicyOnConfigChange() {
 	}))
 
 	sess.Wait()
-	s.ErrorContains(client.Wait(), "ssh: disconnect, reason 2: Permission Denied: access denied")
+	s.ErrorContains(client.Wait(), "ssh: disconnect, reason 2: Permission Denied: access denied{via_upstream}")
 }
 
 func (s *SSHTestSuite) TestRevokeSession() {
@@ -286,7 +286,7 @@ func (s *SSHTestSuite) TestRevokeSession() {
 	})
 	s.Require().NoError(err)
 	sess.Wait()
-	s.ErrorContains(client.Wait(), "ssh: disconnect, reason 2: Permission Denied: no longer authorized")
+	s.ErrorContains(client.Wait(), "ssh: disconnect, reason 2: Permission Denied: no longer authorized{via_upstream}")
 }
 
 func (s *SSHTestSuite) TestDirectTcpipSession() {
@@ -349,7 +349,7 @@ func (s *SSHTestSuite) TestLoginLogout() {
 
 	output, err := sess.CombinedOutput("logout")
 	s.Require().NoError(err)
-	s.Equal("Logged out successfully\r\n", string(output))
+	s.Equal("Logged out successfully\n", string(output))
 }
 
 func (s *SSHTestSuite) TestWhoami() {

--- a/pkg/ssh/stream.go
+++ b/pkg/ssh/stream.go
@@ -231,8 +231,6 @@ func (sh *StreamHandler) Run(ctx context.Context) error {
 				if err := sh.handleAuthRequest(ctx, req.AuthRequest); err != nil {
 					return err
 				}
-			case nil:
-				return status.Errorf(codes.Internal, "bug: received empty ClientMessage")
 			default:
 				return status.Errorf(codes.Internal, "received invalid client message type %#T", req)
 			}


### PR DESCRIPTION
This contains a few improvements to how stdout and stderr from the internal cli are handled:
- Separate stdout and stderr internally; stderr messages are now sent via `ChannelExtendedData` with `SSH2_EXTENDED_DATA_STDERR` data type.
- When the client requests a pty for the session, stderr output now emulates newline translation processing which is disabled when the client enters raw mode.
- Commands not marked as interactive will now work as normal when a pty is requested. This would previously show an error to avoid displaying text that would not be rendered correctly by the client.