### PR TITLE
ssh: upstream tunnel auth stubs

### DIFF
--- a/authorize/ssh_grpc.go
+++ b/authorize/ssh_grpc.go
@@ -115,6 +115,11 @@ func (a *Authorize) EvaluateSSH(ctx context.Context, streamID uint64, req *ssh.R
 		evalreq.Policy = a.currentConfig.Load().Options.GetRouteForSSHHostname(req.Hostname)
 	}
 
+	if req.UseUpstreamTunnelPolicy {
+		// XXX: temporary stub
+		log.Ctx(ctx).Debug().Msg("evaluating upstream tunnel policy")
+	}
+
 	res, err := a.state.Load().evaluator.Evaluate(ctx, &evalreq)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("error during OPA evaluation")

--- a/pkg/ssh/mock/mock_auth_interface.go
+++ b/pkg/ssh/mock/mock_auth_interface.go
@@ -16,6 +16,7 @@ import (
 	ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
 	databroker "github.com/pomerium/pomerium/pkg/grpc/databroker"
 	ssh0 "github.com/pomerium/pomerium/pkg/ssh"
+	portforward "github.com/pomerium/pomerium/pkg/ssh/portforward"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -115,6 +116,44 @@ func (c *MockAuthInterfaceEvaluateDelayedCall) Do(f func(context.Context, ssh0.S
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
 func (c *MockAuthInterfaceEvaluateDelayedCall) DoAndReturn(f func(context.Context, ssh0.StreamAuthInfo) error) *MockAuthInterfaceEvaluateDelayedCall {
+	c.Call = c.Call.DoAndReturn(f)
+	return c
+}
+
+// EvaluatePortForward mocks base method.
+func (m *MockAuthInterface) EvaluatePortForward(ctx context.Context, info ssh0.StreamAuthInfo, portForwardInfo portforward.RouteInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EvaluatePortForward", ctx, info, portForwardInfo)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EvaluatePortForward indicates an expected call of EvaluatePortForward.
+func (mr *MockAuthInterfaceMockRecorder) EvaluatePortForward(ctx, info, portForwardInfo any) *MockAuthInterfaceEvaluatePortForwardCall {
+	mr.mock.ctrl.T.Helper()
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluatePortForward", reflect.TypeOf((*MockAuthInterface)(nil).EvaluatePortForward), ctx, info, portForwardInfo)
+	return &MockAuthInterfaceEvaluatePortForwardCall{Call: call}
+}
+
+// MockAuthInterfaceEvaluatePortForwardCall wrap *gomock.Call
+type MockAuthInterfaceEvaluatePortForwardCall struct {
+	*gomock.Call
+}
+
+// Return rewrite *gomock.Call.Return
+func (c *MockAuthInterfaceEvaluatePortForwardCall) Return(arg0 error) *MockAuthInterfaceEvaluatePortForwardCall {
+	c.Call = c.Call.Return(arg0)
+	return c
+}
+
+// Do rewrite *gomock.Call.Do
+func (c *MockAuthInterfaceEvaluatePortForwardCall) Do(f func(context.Context, ssh0.StreamAuthInfo, portforward.RouteInfo) error) *MockAuthInterfaceEvaluatePortForwardCall {
+	c.Call = c.Call.Do(f)
+	return c
+}
+
+// DoAndReturn rewrite *gomock.Call.DoAndReturn
+func (c *MockAuthInterfaceEvaluatePortForwardCall) DoAndReturn(f func(context.Context, ssh0.StreamAuthInfo, portforward.RouteInfo) error) *MockAuthInterfaceEvaluatePortForwardCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/pkg/ssh/portforward/manager_test.go
+++ b/pkg/ssh/portforward/manager_test.go
@@ -89,13 +89,14 @@ func TestPortForwardManager(t *testing.T) {
 		}
 
 		listener := mock_portforward.NewMockUpdateListener(ctrl)
-		eval := mock_portforward.NewMockRouteEvaluator(ctrl)
-		eval.EXPECT().EvaluateRoute(gomock.Eq(expectedInfo1)).Return(nil)
-		eval.EXPECT().EvaluateRoute(gomock.Eq(expectedInfo2)).Return(nil)
-		eval.EXPECT().EvaluateRoute(gomock.Eq(expectedInfo3)).Return(nil)
-
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(3))
-		mgr := portforward.NewManager(cfg, eval)
+		eval := mock_portforward.NewMockRouteEvaluator(ctrl)
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Eq(expectedInfo1)).Return(nil)
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Eq(expectedInfo2)).Return(nil)
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Eq(expectedInfo3)).Return(nil)
+
+		mgr := portforward.NewManager(t.Context(), eval)
+		mgr.OnConfigUpdate(cfg)
 
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))
 		listener.EXPECT().OnClusterEndpointsUpdated(gomock.Len(0), gomock.Len(0))
@@ -179,11 +180,13 @@ func TestPortForwardManager(t *testing.T) {
 
 		listener := mock_portforward.NewMockUpdateListener(ctrl)
 		eval := mock_portforward.NewMockRouteEvaluator(ctrl)
-		eval.EXPECT().EvaluateRoute(gomock.Eq(expectedInfo1)).Return(nil)
-		eval.EXPECT().EvaluateRoute(gomock.Eq(expectedInfo2)).Return(nil)
-		eval.EXPECT().EvaluateRoute(gomock.Eq(expectedInfo3)).Return(nil)
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Eq(expectedInfo1)).Return(nil)
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Eq(expectedInfo2)).Return(nil)
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Eq(expectedInfo3)).Return(nil)
 
-		mgr := portforward.NewManager(cfg, eval)
+		mgr := portforward.NewManager(t.Context(), eval)
+		mgr.OnConfigUpdate(cfg)
+
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(3))
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))
 		listener.EXPECT().OnClusterEndpointsUpdated(gomock.Len(0), gomock.Len(0))
@@ -273,11 +276,13 @@ func TestPortForwardManager(t *testing.T) {
 
 		listener := mock_portforward.NewMockUpdateListener(ctrl)
 		eval := mock_portforward.NewMockRouteEvaluator(ctrl)
-		eval.EXPECT().EvaluateRoute(gomock.Eq(expectedInfo1)).Return(nil)
-		eval.EXPECT().EvaluateRoute(gomock.Eq(expectedInfo2)).Return(nil)
-		eval.EXPECT().EvaluateRoute(gomock.Eq(expectedInfo3)).Return(errors.New("not authorized"))
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Eq(expectedInfo1)).Return(nil)
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Eq(expectedInfo2)).Return(nil)
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Eq(expectedInfo3)).Return(errors.New("not authorized"))
 
-		mgr := portforward.NewManager(cfg, eval)
+		mgr := portforward.NewManager(t.Context(), eval)
+		mgr.OnConfigUpdate(cfg)
+
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(2))
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))
 		listener.EXPECT().OnClusterEndpointsUpdated(gomock.Len(0), gomock.Len(0))
@@ -324,9 +329,11 @@ func TestPortForwardManager(t *testing.T) {
 		cfg.Options.SSHAddr = "localhost:22"
 
 		eval := mock_portforward.NewMockRouteEvaluator(ctrl)
-		eval.EXPECT().EvaluateRoute(gomock.Any()).Return(nil).AnyTimes()
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-		mgr := portforward.NewManager(cfg, eval)
+		mgr := portforward.NewManager(t.Context(), eval)
+		mgr.OnConfigUpdate(cfg)
+
 		_, err := mgr.AddPermission("route-one", 443)
 		assert.NoError(t, err)
 		_, err = mgr.AddPermission("route-one", 443)
@@ -341,9 +348,11 @@ func TestPortForwardManager(t *testing.T) {
 		// cfg.Options.SSHAddr = "localhost:22"
 
 		eval := mock_portforward.NewMockRouteEvaluator(ctrl)
-		eval.EXPECT().EvaluateRoute(gomock.Any()).Return(nil).AnyTimes()
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-		mgr := portforward.NewManager(cfg, eval)
+		mgr := portforward.NewManager(t.Context(), eval)
+		mgr.OnConfigUpdate(cfg)
+
 		_, err := mgr.AddPermission("route-one", 442)
 		assert.ErrorContains(t, err, "invalid port: 442")
 		_, err = mgr.AddPermission("route-one", 22)
@@ -361,9 +370,11 @@ func TestPortForwardManager(t *testing.T) {
 		})
 
 		eval := mock_portforward.NewMockRouteEvaluator(ctrl)
-		eval.EXPECT().EvaluateRoute(gomock.Any()).Return(nil).AnyTimes()
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-		mgr := portforward.NewManager(cfg, eval)
+		mgr := portforward.NewManager(t.Context(), eval)
+		mgr.OnConfigUpdate(cfg)
+
 		for i := range portforward.MaxPermissionEntries {
 			h := slices.Clone(hostname)
 			h[i] = '?'
@@ -383,8 +394,9 @@ func TestPortForwardManager(t *testing.T) {
 
 		listener := mock_portforward.NewMockUpdateListener(ctrl)
 		eval := mock_portforward.NewMockRouteEvaluator(ctrl)
-		eval.EXPECT().EvaluateRoute(gomock.Any()).Return(nil).AnyTimes()
-		mgr := portforward.NewManager(cfg, eval)
+		eval.EXPECT().EvaluateRoute(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mgr := portforward.NewManager(t.Context(), eval)
+		mgr.OnConfigUpdate(cfg)
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(3))
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))

--- a/pkg/ssh/portforward/mock/mock_port_forward.go
+++ b/pkg/ssh/portforward/mock/mock_port_forward.go
@@ -10,6 +10,7 @@
 package mock_portforward
 
 import (
+	context "context"
 	reflect "reflect"
 
 	portforward "github.com/pomerium/pomerium/pkg/ssh/portforward"
@@ -41,17 +42,17 @@ func (m *MockRouteEvaluator) EXPECT() *MockRouteEvaluatorMockRecorder {
 }
 
 // EvaluateRoute mocks base method.
-func (m *MockRouteEvaluator) EvaluateRoute(info portforward.RouteInfo) error {
+func (m *MockRouteEvaluator) EvaluateRoute(ctx context.Context, info portforward.RouteInfo) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EvaluateRoute", info)
+	ret := m.ctrl.Call(m, "EvaluateRoute", ctx, info)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EvaluateRoute indicates an expected call of EvaluateRoute.
-func (mr *MockRouteEvaluatorMockRecorder) EvaluateRoute(info any) *MockRouteEvaluatorEvaluateRouteCall {
+func (mr *MockRouteEvaluatorMockRecorder) EvaluateRoute(ctx, info any) *MockRouteEvaluatorEvaluateRouteCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateRoute", reflect.TypeOf((*MockRouteEvaluator)(nil).EvaluateRoute), info)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateRoute", reflect.TypeOf((*MockRouteEvaluator)(nil).EvaluateRoute), ctx, info)
 	return &MockRouteEvaluatorEvaluateRouteCall{Call: call}
 }
 
@@ -67,13 +68,13 @@ func (c *MockRouteEvaluatorEvaluateRouteCall) Return(arg0 error) *MockRouteEvalu
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRouteEvaluatorEvaluateRouteCall) Do(f func(portforward.RouteInfo) error) *MockRouteEvaluatorEvaluateRouteCall {
+func (c *MockRouteEvaluatorEvaluateRouteCall) Do(f func(context.Context, portforward.RouteInfo) error) *MockRouteEvaluatorEvaluateRouteCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRouteEvaluatorEvaluateRouteCall) DoAndReturn(f func(portforward.RouteInfo) error) *MockRouteEvaluatorEvaluateRouteCall {
+func (c *MockRouteEvaluatorEvaluateRouteCall) DoAndReturn(f func(context.Context, portforward.RouteInfo) error) *MockRouteEvaluatorEvaluateRouteCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
Temporary patch to set up upstream tunnel auth. The actual policy evaluation is not yet implemented.