### PR TITLE
ssh: enable listener if ssh_address is set but no ssh routes exist

### DIFF
--- a/config/envoyconfig/listeners_ssh.go
+++ b/config/envoyconfig/listeners_ssh.go
@@ -28,9 +28,6 @@ func buildSSHListener(cfg *config.Config) (*envoy_config_listener_v3.Listener, e
 	if err != nil {
 		return nil, err
 	}
-	if rc == nil {
-		return nil, nil
-	}
 
 	authorizeService := &envoy_config_core_v3.GrpcService{
 		Timeout: durationpb.New(0),
@@ -181,7 +178,9 @@ func buildRouteConfig(cfg *config.Config) (*envoy_generic_proxy_v3.RouteConfigur
 		})
 	}
 	if len(routeMatchers) == 0 {
-		return nil, nil
+		return &envoy_generic_proxy_v3.RouteConfiguration{
+			Name: "route_config",
+		}, nil
 	}
 	return &envoy_generic_proxy_v3.RouteConfiguration{
 		Name: "route_config",

--- a/config/envoyconfig/listeners_ssh_test.go
+++ b/config/envoyconfig/listeners_ssh_test.go
@@ -29,7 +29,7 @@ func TestBuildSSHListener(t *testing.T) {
 		cfg.Options.SSHAddr = "0.0.0.0:22"
 		l, err := buildSSHListener(cfg)
 		assert.NoError(t, err)
-		assert.Nil(t, l)
+		assert.NotNil(t, l)
 	})
 	t.Run("no address set, but routes present", func(t *testing.T) {
 		cfg := &config.Config{


### PR DESCRIPTION
Previously, for the ssh listener to be enabled, both of the following were required:
- The `ssh_address` field is set
- At least one route with the `ssh://` scheme is present

This removes the additional requirement of having an ssh route. The listener being enabled is now only controlled by the presence of the `ssh_address` field.