### PR TITLE
fix: unexpected data in stream.Stream

### DIFF
--- a/pkg/storage/file/backend.go
+++ b/pkg/storage/file/backend.go
@@ -423,6 +423,7 @@ func (backend *Backend) clearLocked(
 		recordIndexByTypeVersionKeySpace.deleteAll(rw),
 		recordChangeKeySpace.deleteAll(rw),
 		recordChangeIndexByTypeKeySpace.deleteAll(rw),
+		indexableFieldsKeySpace.deleteAll(rw),
 		metadataKeySpace.setServerVersion(rw, newServerVersion),
 		metadataKeySpace.setCheckpointServerVersion(rw, 0),
 		metadataKeySpace.setCheckpointRecordVersion(rw, 0),

--- a/pkg/storage/file/keyspaces.go
+++ b/pkg/storage/file/keyspaces.go
@@ -66,12 +66,17 @@ func (ks indexableFieldsKeySpaceType) encodeKey(
 	)
 }
 
+func (ks indexableFieldsKeySpaceType) deleteAll(w writer) error {
+	return pebbleDeletePrefix(w, []byte{prefixIndexableFieldsKeySpace})
+}
+
 func (ks indexableFieldsKeySpaceType) encodeIndex(idx getByIndex) []byte {
 	return encodeJoinedKey(
 		prefixIndexableFieldsKeySpace,
 		[]byte(idx.recordType),
 		[]byte(idx.field),
 		[]byte(idx.fieldValue),
+		[]byte{},
 	)
 }
 
@@ -314,7 +319,7 @@ func (ks recordKeySpaceType) bounds() (lowerBound, upperBound []byte) {
 }
 
 func (ks recordKeySpaceType) boundsForRecordType(recordType string) (lowerBound, upperBound []byte) {
-	prefix := encodeJoinedKey(prefixRecordKeySpace, []byte(recordType), nil)
+	prefix := encodeJoinedKey(prefixRecordKeySpace, []byte(recordType), []byte{})
 	return prefix, pebbleutil.PrefixToUpperBound(prefix)
 }
 
@@ -609,7 +614,7 @@ var recordChangeIndexByTypeKeySpace recordChangeIndexByTypeKeySpaceType
 
 func (ks recordChangeIndexByTypeKeySpaceType) bounds(recordType string, afterRecordVersion uint64) ([]byte, []byte) {
 	return encodeJoinedKey(prefixRecordChangeIndexByTypeKeySpace, []byte(recordType), encodeUint64(afterRecordVersion+1)),
-		pebbleutil.PrefixToUpperBound(encodeJoinedKey(prefixRecordChangeIndexByTypeKeySpace, []byte(recordType)))
+		pebbleutil.PrefixToUpperBound(encodeJoinedKey(prefixRecordChangeIndexByTypeKeySpace, []byte(recordType), []byte{}))
 }
 
 func (ks recordChangeIndexByTypeKeySpaceType) decodeKey(data []byte) (recordType string, version uint64, err error) {

--- a/pkg/storage/file/keyspaces_test.go
+++ b/pkg/storage/file/keyspaces_test.go
@@ -593,7 +593,7 @@ func TestKeyspaces(t *testing.T) {
 		// check bounds
 		lowerBound, upperBound := recordChangeIndexByTypeKeySpace.bounds("t", 8)
 		assert.Equal(t, []byte{0x05, 't', 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x09}, lowerBound)
-		assert.Equal(t, []byte{0x05, 'u'}, upperBound)
+		assert.Equal(t, []byte{0x05, 't', 0x01}, upperBound)
 
 		for i := range 10 {
 			recordType, version := fmt.Sprintf("t%d", i%2), uint64(i+1)


### PR DESCRIPTION
## Summary

There was a race condition caused by prefix mismatches.


1. The bounds on several keyspaces where set to +1 on the recordType encoded as bytes, leading to
upper bounds of the form on the KV stotre : `session.Session` -> `session.Sessioo` which would include any record type with the prefix `session.Session` like `session.SessionBinding` and `session.SessionBindingRequest` to be included

2. If a record that was not of the type `session.SessionBinding` or `session.SessionBindingRequest` had a record version higher than the `session.Session` (a race condition - that presumably happens more frequently with some amount of latency between services, since most of the time locally I couldn't reproduce this), causing the bound signal to trigger on every iteration which in turn sends the record to the sync Handler. Since the record version of the mismatched type is always higher than the observed record version for the give type (`session.Session`), this process repeats infinitely.




## Related issues

https://github.com/pomerium/pomerium/issues/5922

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] ready for review
