### PR TITLE
fix (ui): fixed content layout shift for sign-in verify countdown

### DIFF
--- a/ui/src/components/SignInVerifyPage.tsx
+++ b/ui/src/components/SignInVerifyPage.tsx
@@ -99,7 +99,7 @@ const SignInVerifyPage: FC<SignInVerifyPageProps> = ({ data }) => {
           <Typography variant="subtitle2" sx={{ mr: 1 }}>
             Expires in
           </Typography>
-          <Typography variant="h6" component="span" sx={{ fontVariantNumeric: "tabular-nums", fontWeight: 600 }}>
+          <Typography variant="h6" component="span" sx={{ fontFamily: "monospace", fontVariantNumeric: "tabular-nums", fontWeight: 600 }}>
             {formatMMSS(remainingSeconds)}
           </Typography>
         </Box>


### PR DESCRIPTION
## Summary

Fixes a small ui issue where the content shifts for the countdown on the sign-in verify page.

## Related issues

Relates to [ENG-3056](https://linear.app/pomerium/issue/ENG-3056/ssh-authorization-code-flow-initial-implementation)

## User Explanation

Now there is no more content layout shift (CLS) when the countdown counts down.

## Screenshots and Recordings

**Before**

![CleanShot 2025-11-10 at 10 12 38](https://github.com/user-attachments/assets/20684e9d-8120-468e-882b-28d6a53670db)

**After**

![CleanShot 2025-11-10 at 10 11 19](https://github.com/user-attachments/assets/45010d97-ad6f-45a2-9720-7457ef39a8dd)

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
