### PR TITLE
authorize: add request ID substitution

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -35,6 +35,7 @@ import (
 
 // Request contains the inputs needed for evaluation.
 type Request struct {
+	ID                 string
 	IsInternal         bool
 	Policy             *config.Policy
 	HTTP               RequestHTTP

--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -197,6 +197,8 @@ func (e *headersEvaluatorEvaluation) fillSetRequestHeaders(ctx context.Context) 
 				return s.GetIdToken().GetRaw()
 			case slices.Equal(ref, []string{"pomerium", "jwt"}):
 				return e.getSignedJWT(ctx)
+			case slices.Equal(ref, []string{"pomerium", "request", "id"}):
+				return e.request.ID
 			case len(ref) > 3 && ref[0] == "pomerium" && ref[1] == "request" && ref[2] == "headers":
 				return e.request.HTTP.Headers[httputil.CanonicalHeaderKey(ref[3])]
 			}

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -215,6 +215,7 @@ func TestHeadersEvaluator(t *testing.T) {
 				}},
 			},
 			&Request{
+				ID: "REQUEST_ID",
 				HTTP: RequestHTTP{
 					Hostname:          "from.example.com",
 					ClientCertificate: ClientCertificateInfo{Leaf: testValidCert},
@@ -231,6 +232,7 @@ func TestHeadersEvaluator(t *testing.T) {
 						"Authorization":            "Bearer ${pomerium.jwt}",
 						"Foo":                      "escaped $$dollar sign",
 						"X-Incoming-Custom-Header": `From-Incoming ${pomerium.request.headers["X-Incoming-Header"]}`,
+						"X-Request-Id":             "${pomerium.request.id}",
 					},
 				},
 				Session: RequestSession{ID: "s1"},
@@ -240,6 +242,7 @@ func TestHeadersEvaluator(t *testing.T) {
 		assert.Equal(t, "CUSTOM_VALUE", output.Headers.Get("X-Custom-Header"))
 		assert.Equal(t, "ID_TOKEN", output.Headers.Get("X-ID-Token"))
 		assert.Equal(t, "ACCESS_TOKEN", output.Headers.Get("X-Access-Token"))
+		assert.Equal(t, "REQUEST_ID", output.Headers.Get("X-Request-Id"))
 		assert.Equal(t, "3febe6467787e93f0a01030e0803072feaa710f724a9dc74de05cfba3d4a6d23",
 			output.Headers.Get("Client-Cert-Fingerprint"))
 		assert.Equal(t, "escaped $dollar sign", output.Headers.Get("Foo"))

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -208,6 +208,7 @@ func (a *Authorize) getEvaluatorRequestFromCheckRequest(
 ) (*evaluator.Request, error) {
 	attrs := in.GetAttributes()
 	req := &evaluator.Request{
+		ID:                 requestid.FromContext(ctx),
 		IsInternal:         envoyconfig.ExtAuthzContextExtensionsIsInternal(attrs.GetContextExtensions()),
 		HTTP:               evaluator.RequestHTTPFromCheckRequest(ctx, in),
 		EnvoyRouteChecksum: envoyconfig.ExtAuthzContextExtensionsRouteChecksum(attrs.GetContextExtensions()),

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/storage"
+	"github.com/pomerium/pomerium/pkg/telemetry/requestid"
 )
 
 const certPEM = `
@@ -61,7 +62,9 @@ func Test_getEvaluatorRequest(t *testing.T) {
 	})
 	a.state.Store(new(authorizeState))
 
-	actual, err := a.getEvaluatorRequestFromCheckRequest(t.Context(),
+	ctx := requestid.WithValue(t.Context(), "example-request-id")
+
+	actual, err := a.getEvaluatorRequestFromCheckRequest(ctx,
 		&envoy_service_auth_v3.CheckRequest{
 			Attributes: &envoy_service_auth_v3.AttributeContext{
 				Request: &envoy_service_auth_v3.AttributeContext_Request{
@@ -94,6 +97,7 @@ func Test_getEvaluatorRequest(t *testing.T) {
 	)
 	require.NoError(t, err)
 	expect := &evaluator.Request{
+		ID:     "example-request-id",
 		Policy: &a.currentConfig.Load().Options.Policies[0],
 		HTTP: evaluator.RequestHTTP{
 			Method:   http.MethodGet,


### PR DESCRIPTION
## Summary

Add a new token substitution `${pomerium.request.id}` for the request ID.

## Related issues

https://linear.app/pomerium/issue/ENG-3150/core-support-forwarding-request-id-to-upstream-service

## User Explanation

Allows forwarding the request ID to an upstream service.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
