### PR TITLE
fix: standardize resolving sessions

### DIFF
--- a/authorize/ssh_grpc.go
+++ b/authorize/ssh_grpc.go
@@ -95,6 +95,13 @@ func (a *Authorize) ServeChannel(stream extensions_ssh.StreamManagement_ServeCha
 func (a *Authorize) EvaluateSSH(ctx context.Context, streamID uint64, req *ssh.Request) (*evaluator.Result, error) {
 	ctx = a.withQuerierForCheckRequest(ctx)
 
+	sessionID := ""
+	// this checks to make sure if the binding ID was never set,
+	// then the criteria will return un-authenticated
+	if req.SessionBindingID != "" && req.SessionID != "" {
+		sessionID = req.SessionID
+	}
+
 	evalreq := evaluator.Request{
 		HTTP: evaluator.RequestHTTP{
 			Hostname: req.Hostname,
@@ -105,7 +112,7 @@ func (a *Authorize) EvaluateSSH(ctx context.Context, streamID uint64, req *ssh.R
 			PublicKey: req.PublicKey,
 		},
 		Session: evaluator.RequestSession{
-			ID: req.SessionID,
+			ID: sessionID,
 		},
 	}
 


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

[ENG-3172](https://linear.app/pomerium/issue/ENG-3172/session-binding-expiry-not-handled-correctly-in-all-cases)

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] ready for review
