### PR TITLE
chore: set code ttl for ssh to 15 mins

### DIFF
--- a/pkg/ssh/code/api.go
+++ b/pkg/ssh/code/api.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DefaultCodeTTL = time.Minute
+	DefaultCodeTTL = time.Minute * 15
 
 	queryLimit = 100000
 )


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
