### PR TITLE
fix: databroker client updates should propagate to ssh codes

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -67,7 +67,7 @@ func New(ctx context.Context, cfg *config.Config) (*Authorize, error) {
 	}
 	a.state.Store(state)
 
-	codeIssuer := code.NewIssuer(ctx, a.GetDataBrokerServiceClient())
+	codeIssuer := code.NewIssuer(ctx, a)
 	a.accessTracker = NewAccessTracker(a, accessTrackerMaxSize, accessTrackerDebouncePeriod)
 	a.ssh = ssh.NewStreamManager(ctx, ssh.NewAuth(a, &a.currentConfig, a.tracerProvider, codeIssuer), cfg)
 	return a, nil

--- a/internal/authenticateflow/stateful.go
+++ b/internal/authenticateflow/stateful.go
@@ -121,8 +121,8 @@ func NewStateful(
 	}
 
 	s.dataBrokerClient = databroker.NewDataBrokerServiceClient(dataBrokerConn)
-	s.codeReader = code.NewReader(s.dataBrokerClient)
-	s.codeRevoker = code.NewRevoker(s.dataBrokerClient)
+	s.codeReader = code.NewReader(databroker.NewStaticClientGetter(s.dataBrokerClient))
+	s.codeRevoker = code.NewRevoker(databroker.NewStaticClientGetter(s.dataBrokerClient))
 	return s, nil
 }
 

--- a/pkg/grpc/databroker/client.go
+++ b/pkg/grpc/databroker/client.go
@@ -1,0 +1,19 @@
+package databroker
+
+type ClientGetter interface {
+	GetDataBrokerServiceClient() DataBrokerServiceClient
+}
+
+func NewStaticClientGetter(client DataBrokerServiceClient) ClientGetter {
+	return staticClientGetter{
+		client: client,
+	}
+}
+
+type staticClientGetter struct {
+	client DataBrokerServiceClient
+}
+
+func (w staticClientGetter) GetDataBrokerServiceClient() DataBrokerServiceClient {
+	return w.client
+}

--- a/pkg/ssh/auth.go
+++ b/pkg/ssh/auth.go
@@ -31,9 +31,14 @@ import (
 	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 )
 
-type Evaluator interface {
+//nolint:revive
+type SSHEvaluator interface {
 	EvaluateSSH(ctx context.Context, streamID uint64, req *Request) (*evaluator.Result, error)
-	GetDataBrokerServiceClient() databroker.DataBrokerServiceClient
+}
+
+type Evaluator interface {
+	SSHEvaluator
+	databroker.ClientGetter
 	InvalidateCacheForRecords(context.Context, ...*databroker.Record)
 }
 

--- a/pkg/ssh/code/code_manager.go
+++ b/pkg/ssh/code/code_manager.go
@@ -23,7 +23,7 @@ type Status struct {
 }
 
 type codeManager struct {
-	client           databroker.DataBrokerServiceClient
+	clientB          databroker.ClientGetter
 	accessMu         *sync.RWMutex
 	codeByExpiration *btree.BTreeG[Status]
 }
@@ -37,14 +37,14 @@ func (c *codeManager) ClearRecords(_ context.Context) {
 }
 
 func (c *codeManager) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
-	return c.client
+	return c.clientB.GetDataBrokerServiceClient()
 }
 
 func newCodeManager(
-	client databroker.DataBrokerServiceClient,
+	client databroker.ClientGetter,
 ) *codeManager {
 	return &codeManager{
-		client:   client,
+		clientB:  client,
 		accessMu: &sync.RWMutex{},
 		codeByExpiration: btree.NewG(2, func(a, b Status) bool {
 			return cmp.Or(

--- a/pkg/ssh/code/revoker.go
+++ b/pkg/ssh/code/revoker.go
@@ -12,22 +12,23 @@ import (
 )
 
 type revoker struct {
-	client databroker.DataBrokerServiceClient
+	clientB databroker.ClientGetter
 }
 
 var _ Revoker = (*revoker)(nil)
 
-func NewRevoker(client databroker.DataBrokerServiceClient) Revoker {
+func NewRevoker(client databroker.ClientGetter) Revoker {
 	return &revoker{
-		client: client,
+		clientB: client,
 	}
 }
 
 func (r *revoker) RevokeCode(ctx context.Context, codeID CodeID) error {
-	rec, err := r.client.Get(ctx, &databroker.GetRequest{
-		Type: "type.googleapis.com/session.SessionBindingRequest",
-		Id:   string(codeID),
-	})
+	rec, err := r.clientB.GetDataBrokerServiceClient().
+		Get(ctx, &databroker.GetRequest{
+			Type: "type.googleapis.com/session.SessionBindingRequest",
+			Id:   string(codeID),
+		})
 
 	if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
 		return nil
@@ -41,19 +42,21 @@ func (r *revoker) RevokeCode(ctx context.Context, codeID CodeID) error {
 
 	rec.Record.DeletedAt = timestamppb.Now()
 
-	_, err = r.client.Patch(ctx, &databroker.PatchRequest{
-		Records: []*databroker.Record{
-			rec.Record,
-		},
-	})
+	_, err = r.clientB.GetDataBrokerServiceClient().
+		Patch(ctx, &databroker.PatchRequest{
+			Records: []*databroker.Record{
+				rec.Record,
+			},
+		})
 	return err
 }
 
 func (r *revoker) RevokeSessionBinding(ctx context.Context, bindingID BindingID) error {
-	sbResp, err := r.client.Get(ctx, &databroker.GetRequest{
-		Type: "type.googleapis.com/session.SessionBinding",
-		Id:   string(bindingID),
-	})
+	sbResp, err := r.clientB.GetDataBrokerServiceClient().
+		Get(ctx, &databroker.GetRequest{
+			Type: "type.googleapis.com/session.SessionBinding",
+			Id:   string(bindingID),
+		})
 
 	if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
 		return nil
@@ -66,18 +69,19 @@ func (r *revoker) RevokeSessionBinding(ctx context.Context, bindingID BindingID)
 	}
 	rec := sbResp.Record
 	rec.DeletedAt = timestamppb.Now()
-	_, err = r.client.Patch(ctx, &databroker.PatchRequest{
-		Records: []*databroker.Record{
-			rec,
-		},
-	})
+	_, err = r.clientB.GetDataBrokerServiceClient().
+		Patch(ctx, &databroker.PatchRequest{
+			Records: []*databroker.Record{
+				rec,
+			},
+		})
 	return err
 }
 
 func (r *revoker) RevokeSessionBindingBySession(ctx context.Context, sessionID string) ([]*databroker.Record, error) {
 	b := backoff.WithContext(backoff.NewExponentialBackOff(), ctx)
 	recs, err := backoff.RetryWithData(func() ([]*databroker.Record, error) {
-		return getSessionBindingBySession(ctx, r.client, sessionID)
+		return getSessionBindingBySession(ctx, r.clientB.GetDataBrokerServiceClient(), sessionID)
 	}, b)
 	if err != nil {
 		return nil, err
@@ -88,7 +92,7 @@ func (r *revoker) RevokeSessionBindingBySession(ctx context.Context, sessionID s
 	for _, rec := range recs {
 		rec.DeletedAt = timestamppb.Now()
 	}
-	_, err = r.client.Patch(ctx, &databroker.PatchRequest{
+	_, err = r.clientB.GetDataBrokerServiceClient().Patch(ctx, &databroker.PatchRequest{
 		Records: recs,
 	})
 	return recs, err


### PR DESCRIPTION
## Summary

SSH auth code flow is causing Pomerium to not start cleanly / update properly.

Databroker grpc client changes now propagate to the SSH code manager

## Related issues

N/A, slack thread.

## User Explanation

N/A

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] ready for review
