### PR TITLE
ssh: show an error if login not enabled

### DIFF
--- a/pkg/ssh/auth.go
+++ b/pkg/ssh/auth.go
@@ -237,7 +237,7 @@ func (a *Auth) handleLogin(
 ) error {
 	cfg := a.currentConfig.Load()
 	if cfg.Options.UseStatelessAuthenticateFlow() {
-		return errors.New("ssh login is not currently enabled")
+		return status.Error(codes.FailedPrecondition, "ssh login is not currently enabled")
 	}
 
 	bindingKey, err := sessionIDFromFingerprint(publicKeyFingerprint)

--- a/pkg/ssh/auth_test.go
+++ b/pkg/ssh/auth_test.go
@@ -363,6 +363,7 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 		_, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), exampleAuthInfo, nil, noopQuerier{})
 
 		assert.ErrorContains(t, err, "ssh login is not currently enabled")
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 	})
 
 	minimalConfig := func(idpURL string) *atomic.Pointer[config.Config] {


### PR DESCRIPTION
## Summary

Do not generate an ssh login link if we know that login is not supported. Instead, show an error message to the user.

## Related issues

https://linear.app/pomerium/issue/ENG-3200/core-do-not-generate-ssh-login-url-for-stateless-authenticate-flow

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
