### PR TITLE
feat(ssh): add single setup databroker indexing

### DIFF
--- a/internal/databroker/server_clustered_follower_test.go
+++ b/internal/databroker/server_clustered_follower_test.go
@@ -107,14 +107,15 @@ func TestClusteredFollowerServer(t *testing.T) {
 		})
 
 		ctx := databrokerpb.WithOutgoingClusterRequestMode(t.Context(), databrokerpb.ClusterRequestModeLocal)
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			res1, err := local.ServerInfo(ctx, new(emptypb.Empty))
+			assert.NoError(c, err)
 
-		res1, err := local.ServerInfo(ctx, new(emptypb.Empty))
-		assert.NoError(t, err)
+			res2, err := databrokerpb.NewDataBrokerServiceClient(cc).ServerInfo(ctx, new(emptypb.Empty))
+			assert.NoError(c, err)
 
-		res2, err := databrokerpb.NewDataBrokerServiceClient(cc).ServerInfo(ctx, new(emptypb.Empty))
-		assert.NoError(t, err)
-
-		assert.Empty(t, cmp.Diff(res1, res2, protocmp.Transform()))
+			assert.Empty(c, cmp.Diff(res1, res2, protocmp.Transform()))
+		}, time.Second*3, time.Millisecond*30)
 	})
 	t.Run("local write", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
## Summary

The indexing on databroker records will happen server-side, so no client api calls will have to be synchronized across pomerium services.

## Related issues

[ENG-3139](https://linear.app/pomerium/issue/ENG-3139/ssh-authorization-code-flow-wait-for-init-single-setup-for-databroker)


## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
