### PR TITLE
authorize: ssh upstream policy support

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -136,6 +136,8 @@ func getClientCertificateInfo(
 type RequestSSH struct {
 	Username  string `json:"username"`
 	PublicKey []byte `json:"publickey"`
+
+	ReverseTunnel bool `json:"-"`
 }
 
 // RequestSession is the session field in the request.

--- a/authorize/evaluator/policy_evaluator.go
+++ b/authorize/evaluator/policy_evaluator.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 
 	"github.com/pomerium/pomerium/authorize/internal/store"
@@ -103,10 +104,49 @@ func (q policyQuery) checksum() string {
 	return fmt.Sprintf("%x", cryptutil.Hash("script", []byte(q.script)))
 }
 
+func (q *policyQuery) prepareQuery(ctx context.Context, store *store.Store) error {
+	log.Ctx(ctx).
+		Trace().
+		Str("script", q.script).
+		Msg("authorize: rego script for policy evaluation")
+
+	r := rego.New(
+		rego.Store(store),
+		rego.Module("pomerium.policy", q.script),
+		rego.Query("result = data.pomerium.policy"),
+		rego.EnablePrintStatements(true),
+		getGoogleCloudServerlessHeadersRegoOption,
+		criteria.SSHVerifyUserCert,
+		store.GetDataBrokerRecordOption(),
+	)
+
+	pq, err := r.PrepareForEval(ctx)
+	// if no package is in the src, add it
+	if err != nil && strings.Contains(err.Error(), "package expected") {
+		r := rego.New(
+			rego.Store(store),
+			rego.Module("pomerium.policy", "package pomerium.policy\n\n"+q.script),
+			rego.Query("result = data.pomerium.policy"),
+			rego.EnablePrintStatements(true),
+			getGoogleCloudServerlessHeadersRegoOption,
+			criteria.SSHVerifyUserCert,
+			store.GetDataBrokerRecordOption(),
+		)
+		pq, err = r.PrepareForEval(ctx)
+	}
+	if err != nil {
+		return err
+	}
+
+	q.PreparedEvalQuery = pq
+	return nil
+}
+
 // A PolicyEvaluator evaluates policies.
 type PolicyEvaluator struct {
-	queries        []policyQuery
-	policyChecksum uint64
+	queries             []policyQuery
+	upstreamTunnelQuery policyQuery
+	policyChecksum      uint64
 }
 
 // NewPolicyEvaluator creates a new PolicyEvaluator.
@@ -114,6 +154,12 @@ func NewPolicyEvaluator(
 	ctx context.Context, store *store.Store, configPolicy *config.Policy,
 	addDefaultClientCertificateRule bool,
 ) (*PolicyEvaluator, error) {
+	ctx = log.WithContext(ctx, func(c zerolog.Context) zerolog.Context {
+		return c.
+			Str("from", configPolicy.From).
+			Interface("to", configPolicy.To)
+	})
+
 	e := new(PolicyEvaluator)
 	e.policyChecksum = configPolicy.Checksum()
 
@@ -149,42 +195,23 @@ func NewPolicyEvaluator(
 
 	// for each script, create a rego and prepare a query.
 	for i := range e.queries {
-		log.Ctx(ctx).
-			Trace().
-			Str("script", e.queries[i].script).
-			Str("from", configPolicy.From).
-			Interface("to", configPolicy.To).
-			Msg("authorize: rego script for policy evaluation")
-
-		r := rego.New(
-			rego.Store(store),
-			rego.Module("pomerium.policy", e.queries[i].script),
-			rego.Query("result = data.pomerium.policy"),
-			rego.EnablePrintStatements(true),
-			getGoogleCloudServerlessHeadersRegoOption,
-			criteria.SSHVerifyUserCert,
-			store.GetDataBrokerRecordOption(),
-		)
-
-		q, err := r.PrepareForEval(ctx)
-		// if no package is in the src, add it
-		if err != nil && strings.Contains(err.Error(), "package expected") {
-			r := rego.New(
-				rego.Store(store),
-				rego.Module("pomerium.policy", "package pomerium.policy\n\n"+e.queries[i].script),
-				rego.Query("result = data.pomerium.policy"),
-				rego.EnablePrintStatements(true),
-				getGoogleCloudServerlessHeadersRegoOption,
-				criteria.SSHVerifyUserCert,
-				store.GetDataBrokerRecordOption(),
-			)
-			q, err = r.PrepareForEval(ctx)
+		if err := e.queries[i].prepareQuery(ctx, store); err != nil {
+			return nil, err
 		}
+	}
+
+	// prepare any upstream policy for evaluation as well
+	if ppl := configPolicy.UpstreamTunnelPPL(); ppl != nil {
+		r, err := policy.GenerateRegoFromPolicy(ppl)
 		if err != nil {
 			return nil, err
 		}
-
-		e.queries[i].PreparedEvalQuery = q
+		e.upstreamTunnelQuery = policyQuery{
+			script: r,
+		}
+		if err := e.upstreamTunnelQuery.prepareQuery(ctx, store); err != nil {
+			return nil, err
+		}
 	}
 
 	return e, nil
@@ -192,10 +219,17 @@ func NewPolicyEvaluator(
 
 // Evaluate evaluates the policy rego scripts.
 func (e *PolicyEvaluator) Evaluate(ctx context.Context, req *PolicyRequest) (*PolicyResponse, error) {
+	if req.SSH.ReverseTunnel {
+		return evaluateQueries(ctx, req, e.upstreamTunnelQuery)
+	}
+	return evaluateQueries(ctx, req, e.queries...)
+}
+
+func evaluateQueries(ctx context.Context, req *PolicyRequest, queries ...policyQuery) (*PolicyResponse, error) {
 	res := NewPolicyResponse()
 	// run each query and merge the results
-	for _, query := range e.queries {
-		o, err := e.evaluateQuery(ctx, req, query)
+	for _, query := range queries {
+		o, err := evaluateQuery(ctx, req, query)
 		if err != nil {
 			return nil, err
 		}
@@ -212,7 +246,7 @@ func (e *PolicyEvaluator) Evaluate(ctx context.Context, req *PolicyRequest) (*Po
 	return res, nil
 }
 
-func (e *PolicyEvaluator) evaluateQuery(ctx context.Context, req *PolicyRequest, query policyQuery) (*PolicyResponse, error) {
+func evaluateQuery(ctx context.Context, req *PolicyRequest, query policyQuery) (*PolicyResponse, error) {
 	ctx, span := trace.Continue(ctx, "authorize.PolicyEvaluator.evaluateQuery")
 	defer span.End()
 	span.SetAttributes(attribute.String("script_checksum", query.checksum()))
@@ -231,14 +265,14 @@ func (e *PolicyEvaluator) evaluateQuery(ctx context.Context, req *PolicyRequest,
 	}
 
 	res := &PolicyResponse{
-		Allow: e.getRuleResult("allow", rs[0].Bindings),
-		Deny:  e.getRuleResult("deny", rs[0].Bindings),
+		Allow: getRuleResult("allow", rs[0].Bindings),
+		Deny:  getRuleResult("deny", rs[0].Bindings),
 	}
 	return res, nil
 }
 
 // getRuleResult gets the rule result var. It expects a boolean, [boolean, []string] or [boolean, []string, object].
-func (e *PolicyEvaluator) getRuleResult(name string, vars rego.Vars) (result RuleResult) {
+func getRuleResult(name string, vars rego.Vars) (result RuleResult) {
 	result = NewRuleResult(false)
 
 	m, ok := vars["result"].(map[string]any)

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	"github.com/rs/zerolog"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc/codes"
@@ -77,7 +78,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 			if s != nil {
 				return a.requireLoginResponse(ctx, in, req)
 			}
-			a.logAuthorizeCheck(ctx, req, &evaluator.Result{
+			a.logAuthorizeCheck(ctx, zerolog.InfoLevel, req, &evaluator.Result{
 				Allow: evaluator.NewRuleResult(true, criteria.ReasonMCPHandshake),
 			}, s)
 			return a.okResponse(make(http.Header), nil), nil
@@ -99,7 +100,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Str("request-id", requestID).Msg("grpc check ext_authz_error")
 	}
-	a.logAuthorizeCheck(ctx, req, res, s)
+	a.logAuthorizeCheck(ctx, zerolog.InfoLevel, req, res, s)
 	return resp, err
 }
 

--- a/authorize/log.go
+++ b/authorize/log.go
@@ -21,10 +21,16 @@ import (
 
 func (a *Authorize) logAuthorizeCheck(
 	ctx context.Context,
+	level zerolog.Level,
 	req *evaluator.Request,
 	res *evaluator.Result,
 	s sessionOrServiceAccount,
 ) {
+	evt := log.Ctx(ctx).WithLevel(level).Str("service", "authorize")
+	if !evt.Enabled() {
+		return
+	}
+
 	ctx, span := a.tracer.Start(ctx, "authorize.grpc.LogAuthorizeCheck")
 	defer span.End()
 
@@ -39,7 +45,6 @@ func (a *Authorize) logAuthorizeCheck(
 	hdrs := req.HTTP.Headers
 	impersonateDetails := a.getImpersonateDetails(ctx, s)
 
-	evt := log.Ctx(ctx).Info().Str("service", "authorize")
 	fields := a.currentConfig.Load().Options.GetAuthorizeLogFields()
 	for _, field := range fields {
 		evt = populateLogEvent(ctx, field, evt, req, s, u, impersonateDetails, res)

--- a/authorize/log_test.go
+++ b/authorize/log_test.go
@@ -66,7 +66,7 @@ func Test_logAuthorizeCheck(t *testing.T) {
 	}
 	ctx = requestid.WithValue(ctx, "REQUEST-ID")
 
-	a.logAuthorizeCheck(ctx, req, res, &session.Session{
+	a.logAuthorizeCheck(ctx, zerolog.InfoLevel, req, res, &session.Session{
 		Id:     "SESS-1",
 		UserId: "USER-1",
 	})

--- a/config/policy.go
+++ b/config/policy.go
@@ -212,7 +212,9 @@ type Policy struct {
 	UpstreamTunnel *UpstreamTunnel `mapstructure:"upstream_tunnel" yaml:"upstream_tunnel,omitempty" json:"upstream_tunnel,omitempty"`
 }
 
-type UpstreamTunnel struct{}
+type UpstreamTunnel struct {
+	SSHPolicy *PPLPolicy `mapstructure:"ssh_policy" yaml:"ssh_policy,omitempty" json:"ssh_policy,omitempty"`
+}
 
 // MCP is an experimental support for Model Context Protocol upstreams configuration
 type MCP struct {

--- a/config/policy_ppl.go
+++ b/config/policy_ppl.go
@@ -90,3 +90,12 @@ func (p *Policy) ToPPL() *parser.Policy {
 
 	return ppl
 }
+
+func (p *Policy) UpstreamTunnelPPL() *parser.Policy {
+	if p.UpstreamTunnel == nil {
+		return nil
+	} else if p.UpstreamTunnel.SSHPolicy == nil {
+		return nil
+	}
+	return p.UpstreamTunnel.SSHPolicy.Policy
+}

--- a/config/policy_ppl_test.go
+++ b/config/policy_ppl_test.go
@@ -621,3 +621,23 @@ func TestPolicy_ToPPL_Embedded(t *testing.T) {
 		},
 	}, policy2.ToPPL())
 }
+
+func TestUpstreamTunnelPPL(t *testing.T) {
+	var p Policy
+	assert.Nil(t, p.UpstreamTunnelPPL())
+	p.UpstreamTunnel = &UpstreamTunnel{}
+	assert.Nil(t, p.UpstreamTunnelPPL())
+	p.UpstreamTunnel.SSHPolicy = &PPLPolicy{}
+	assert.Nil(t, p.UpstreamTunnelPPL())
+	ppl := parser.Policy{
+		Rules: []parser.Rule{{
+			Action: parser.ActionAllow,
+			And: []parser.Criterion{{
+				Name: "foo",
+				Data: parser.String("bar"),
+			}},
+		}},
+	}
+	p.UpstreamTunnel.SSHPolicy.Policy = &ppl
+	assert.Same(t, &ppl, p.UpstreamTunnelPPL())
+}

--- a/pkg/ssh/portforward/manager.go
+++ b/pkg/ssh/portforward/manager.go
@@ -38,7 +38,7 @@ type StaticPort struct {
 }
 
 type RouteEvaluator interface {
-	EvaluateRoute(ctx context.Context, info RouteInfo) error
+	EvaluateRoute(ctx context.Context, route *config.Policy) error
 }
 
 type UpdateListener interface {

--- a/pkg/ssh/portforward/mock/mock_port_forward.go
+++ b/pkg/ssh/portforward/mock/mock_port_forward.go
@@ -13,6 +13,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	config "github.com/pomerium/pomerium/config"
 	portforward "github.com/pomerium/pomerium/pkg/ssh/portforward"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -42,17 +43,17 @@ func (m *MockRouteEvaluator) EXPECT() *MockRouteEvaluatorMockRecorder {
 }
 
 // EvaluateRoute mocks base method.
-func (m *MockRouteEvaluator) EvaluateRoute(ctx context.Context, info portforward.RouteInfo) error {
+func (m *MockRouteEvaluator) EvaluateRoute(ctx context.Context, route *config.Policy) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EvaluateRoute", ctx, info)
+	ret := m.ctrl.Call(m, "EvaluateRoute", ctx, route)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EvaluateRoute indicates an expected call of EvaluateRoute.
-func (mr *MockRouteEvaluatorMockRecorder) EvaluateRoute(ctx, info any) *MockRouteEvaluatorEvaluateRouteCall {
+func (mr *MockRouteEvaluatorMockRecorder) EvaluateRoute(ctx, route any) *MockRouteEvaluatorEvaluateRouteCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateRoute", reflect.TypeOf((*MockRouteEvaluator)(nil).EvaluateRoute), ctx, info)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateRoute", reflect.TypeOf((*MockRouteEvaluator)(nil).EvaluateRoute), ctx, route)
 	return &MockRouteEvaluatorEvaluateRouteCall{Call: call}
 }
 
@@ -68,13 +69,13 @@ func (c *MockRouteEvaluatorEvaluateRouteCall) Return(arg0 error) *MockRouteEvalu
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockRouteEvaluatorEvaluateRouteCall) Do(f func(context.Context, portforward.RouteInfo) error) *MockRouteEvaluatorEvaluateRouteCall {
+func (c *MockRouteEvaluatorEvaluateRouteCall) Do(f func(context.Context, *config.Policy) error) *MockRouteEvaluatorEvaluateRouteCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockRouteEvaluatorEvaluateRouteCall) DoAndReturn(f func(context.Context, portforward.RouteInfo) error) *MockRouteEvaluatorEvaluateRouteCall {
+func (c *MockRouteEvaluatorEvaluateRouteCall) DoAndReturn(f func(context.Context, *config.Policy) error) *MockRouteEvaluatorEvaluateRouteCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }


### PR DESCRIPTION
## Summary

Add a field to the UpstreamTunnel config struct accepting a PPL policy to control which ssh connections can serve as upstreams for a route.

Update the policy evaluator to store a separate upstream policy query. When building a policy evaluator, prepare both the existing queries and this new upstream policy query.

Add a field to the RequestSSH struct to signal whether to evaluate the regular policy or the upstream policy.

Refactor the existing EvaluatePortForward and EvaluateRoute methods to accept a `*config.Policy`, for compatibility with the policy evaluator setup.

## Related issues

https://linear.app/pomerium/issue/ENG-2955/enforce-upstreamtunnel-policy-on-reverse-tunnel-attachments

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
