### PR TITLE
envoy: store version to avoid importing files package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -109,6 +109,7 @@ require (
 	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.45.0
 	golang.org/x/exp v0.0.0-20250620022241-b7579e27df2b
+	golang.org/x/mod v0.29.0
 	golang.org/x/net v0.47.0
 	golang.org/x/oauth2 v0.32.0
 	golang.org/x/sync v0.18.0
@@ -315,7 +316,6 @@ require (
 	go.uber.org/zap/exp v0.3.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
-	golang.org/x/mod v0.29.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
 	golang.org/x/tools v0.38.0 // indirect
 	google.golang.org/genproto v0.0.0-20250603155806-513f23925822 // indirect

--- a/internal/version/components.go
+++ b/internal/version/components.go
@@ -13,7 +13,7 @@ var componentsJSON []byte
 // Components returns the versions of components in pomerium.
 func Components() map[string]string {
 	m := map[string]string{
-		"envoy": envoyversion.Version,
+		"envoy": envoyversion.Version(),
 	}
 	err := json.Unmarshal(componentsJSON, &m)
 	if err != nil {

--- a/pkg/envoy/envoyversion/envoyversion.go
+++ b/pkg/envoy/envoyversion/envoyversion.go
@@ -1,4 +1,38 @@
 package envoyversion
 
-// Version is the envoy version
-const Version = "1.36.2-rc1"
+import (
+	"runtime/debug"
+	"strings"
+
+	"golang.org/x/mod/module"
+
+	_ "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh" // to get version info
+)
+
+// Version returns the envoy version.
+func Version() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+
+	var modVersion string
+	for _, dep := range info.Deps {
+		if dep.Path == "github.com/pomerium/envoy-custom" {
+			if dep.Replace != nil {
+				modVersion = dep.Replace.Version
+			} else {
+				modVersion = dep.Version
+			}
+			break
+		}
+	}
+
+	if module.IsPseudoVersion(modVersion) {
+		if base, err := module.PseudoVersionBase(modVersion); err == nil {
+			modVersion = base
+		}
+	}
+
+	return strings.TrimPrefix(modVersion, "v")
+}

--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -23,7 +23,7 @@ var (
 		"linux-amd64",
 		"linux-arm64",
 	}
-	baseURL = "https://github.com/pomerium/envoy-custom/releases/download/v" + envoyversion.Version
+	baseURL = "https://github.com/pomerium/envoy-custom/releases/download/v" + envoyversion.Version()
 )
 
 func main() {
@@ -65,7 +65,7 @@ func runAll(ctx context.Context) error {
 			return download(ctx, "./envoy-"+target+".sha256", baseURL+"/envoy-"+target+".sha256")
 		})
 		eg.Go(func() error {
-			return os.WriteFile("./envoy-"+target+".version", []byte(envoyversion.Version+"\n"), 0o600)
+			return os.WriteFile("./envoy-"+target+".version", []byte(envoyversion.Version()+"\n"), 0o600)
 		})
 	}
 	return eg.Wait()


### PR DESCRIPTION
## Summary
When we import the `files` package under `envoy` it requires the envoy files to have been downloaded since they aren't stored in git. This ended up making any package which imports pomerium also have to download the files and be built with the `embed_pomerium` tag.

Instead we can store the version of envoy we download separately and only import that, which should make it possible to import pomerium without requiring the build tag.

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
