### PR TITLE
authorize: small logAuthorizeCheck() refactor

### DIFF
--- a/authorize/log.go
+++ b/authorize/log.go
@@ -22,12 +22,19 @@ import (
 func (a *Authorize) logAuthorizeCheck(
 	ctx context.Context,
 	req *evaluator.Request,
-	res *evaluator.Result, s sessionOrServiceAccount, u *user.User,
+	res *evaluator.Result,
+	s sessionOrServiceAccount,
 ) {
 	ctx, span := a.tracer.Start(ctx, "authorize.grpc.LogAuthorizeCheck")
 	defer span.End()
 
 	start := time.Now()
+
+	// if there's a session or service account, load the user
+	var u *user.User
+	if s != nil {
+		u, _ = a.getDataBrokerUser(ctx, s.GetUserId()) // ignore any missing user error
+	}
 
 	hdrs := req.HTTP.Headers
 	impersonateDetails := a.getImpersonateDetails(ctx, s)

--- a/authorize/ssh_grpc.go
+++ b/authorize/ssh_grpc.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pomerium/pomerium/authorize/evaluator"
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
-	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/ssh"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
@@ -146,12 +145,7 @@ func (a *Authorize) EvaluateSSH(ctx context.Context, streamID uint64, req *ssh.R
 	skipLogging := req.LogOnlyIfDenied && allowed
 	if !skipLogging {
 		s, _ := a.getDataBrokerSessionOrServiceAccount(ctx, req.SessionID, 0)
-
-		var u *user.User
-		if s != nil {
-			u, _ = a.getDataBrokerUser(ctx, s.GetUserId())
-		}
-		a.logAuthorizeCheck(ctx, &evalreq, res, s, u)
+		a.logAuthorizeCheck(ctx, &evalreq, res, s)
 	}
 
 	return res, nil


### PR DESCRIPTION
## Summary

Currently the `logAuthorizeCheck()` method accepts a `*user.User` parameter. The two existing callers of this method do not otherwise need this message, so move the record lookup into `logAuthorizeCheck()` itself.

Add a unit test for this method.

## Related issues

n/a

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
