### PR TITLE
databroker: fix syncer with options message

### DIFF
--- a/pkg/grpc/databroker/syncer.go
+++ b/pkg/grpc/databroker/syncer.go
@@ -212,18 +212,18 @@ func (syncer *Syncer) sync(ctx context.Context) error {
 			return fmt.Errorf("error receiving sync record: %w", err)
 		}
 
-		switch r := res.Response.(type) {
+		switch res := res.Response.(type) {
 		case *SyncResponse_Record:
-			log.Ctx(logCtxRec(ctx, r.Record)).Debug().
+			log.Ctx(logCtxRec(ctx, res.Record)).Debug().
 				Str("syncer-id", syncer.id).
 				Str("syncer-type", syncer.cfg.typeURL).
 				Msg("syncer got record")
 
-			syncer.recordVersion = res.GetRecord().GetVersion()
-			if syncer.cfg.typeURL == "" || syncer.cfg.typeURL == res.GetRecord().GetType() {
+			syncer.recordVersion = res.Record.GetVersion()
+			if syncer.cfg.typeURL == "" || syncer.cfg.typeURL == res.Record.GetType() {
 				syncer.handler.UpdateRecords(
-					context.WithValue(ctx, contextkeys.UpdateRecordsVersion, r.Record.GetVersion()),
-					syncer.serverVersion, []*Record{r.Record})
+					context.WithValue(ctx, contextkeys.UpdateRecordsVersion, res.Record.GetVersion()),
+					syncer.serverVersion, []*Record{res.Record})
 			}
 		}
 	}


### PR DESCRIPTION
## Summary
We missed a place where the call to `Sync` needs to be updated to account for non-record responses.


## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
