### PR TITLE
authorize: fix grpc-web detection

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -407,7 +407,7 @@ func (a *Authorize) shouldRedirect(in *envoy_service_auth_v3.CheckRequest, reque
 		return true
 	}
 
-	if isGRPCRequest(in) {
+	if isGRPCRequest(in) || isGRPCWebRequest(in) {
 		return false
 	}
 

--- a/authorize/check_response_grpc.go
+++ b/authorize/check_response_grpc.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
-	"github.com/tniswong/go.rfcx/rfc7231"
 	"google.golang.org/grpc/codes"
 )
 
@@ -23,22 +22,7 @@ func isGRPCWebRequest(in *envoy_service_auth_v3.CheckRequest) bool {
 	if hdrs == nil {
 		return false
 	}
-
-	v := getHeader(hdrs, "Accept")
-	if v == "" {
-		return false
-	}
-
-	accept, err := rfc7231.ParseAccept(v)
-	if err != nil {
-		return false
-	}
-
-	mediaType, _ := accept.MostAcceptable([]string{
-		"text/html",
-		"application/grpc-web-text",
-	})
-	return mediaType == "application/grpc-web-text"
+	return hdrs["content-type"] == "application/grpc-web-text" || strings.HasPrefix(hdrs["content-type"], "application/grpc-web+")
 }
 
 func deniedResponseForGRPC(

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -454,7 +454,7 @@ func TestAuthorize_deniedResponse(t *testing.T) {
 				Request: &envoy_service_auth_v3.AttributeContext_Request{
 					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 						Headers: map[string]string{
-							"Accept": "application/grpc-web-text",
+							"content-type": "application/grpc-web-text",
 						},
 					},
 				},


### PR DESCRIPTION
## Summary
Fix grpc-web detection. It should be based on the content type, not the accept header, since the accept header isn't part of the spec for grpc-web.

## Related issues
- [ENG-3261](https://linear.app/pomerium/issue/ENG-3261/core-grpc-web-detection-not-working)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
