### PR TITLE
testutil: add NewDatabroker

### DIFF
--- a/pkg/grpc/databroker/testutil/databroker_server.go
+++ b/pkg/grpc/databroker/testutil/databroker_server.go
@@ -1,0 +1,26 @@
+package testutil
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+
+	"github.com/pomerium/pomerium/internal/databroker"
+	"github.com/pomerium/pomerium/internal/testutil"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+func NewTestDatabroker(t *testing.T) databrokerpb.DataBrokerServiceClient {
+	t.Helper()
+
+	srv := databroker.NewBackendServer(noop.NewTracerProvider())
+	t.Cleanup(srv.Stop)
+
+	cc := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(s, srv)
+	})
+	t.Cleanup(func() { cc.Close() })
+
+	return databrokerpb.NewDataBrokerServiceClient(cc)
+}


### PR DESCRIPTION
## Summary

Adds an utility function to spin a new databroker server that could be used in tests in external repos. 

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
