### PR TITLE
add incremental config diffing for route changes

### DIFF
--- a/config/diff/config_differ.go
+++ b/config/diff/config_differ.go
@@ -1,0 +1,145 @@
+// Package diff provides incremental diffing of pomerium configuration.
+package diff
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/pomerium/pomerium/config"
+)
+
+type RouteEventKind uint8
+
+const (
+	RouteDeleted RouteEventKind = iota
+	RouteUpserted
+)
+
+type RouteEvent struct {
+	Kind    RouteEventKind
+	RouteID string
+	Policy  *config.Policy // Only set for RouteUpserted
+}
+
+type OnRouteEvents func([]RouteEvent)
+
+type ConfigDiffer struct {
+	hashFn   func(*config.Policy) uint64
+	filterFn func(*config.Policy) bool
+	onEvents OnRouteEvents
+
+	currentConfig atomic.Pointer[config.Config]
+	wakeC         chan struct{}
+
+	prev map[string]uint64 // routeID → hash
+}
+
+type Option func(*ConfigDiffer)
+
+// WithHashFunc sets a custom hash function for determining route changes.
+func WithHashFunc(fn func(*config.Policy) uint64) Option {
+	return func(d *ConfigDiffer) {
+		d.hashFn = fn
+	}
+}
+
+// WithFilterFunc sets a custom filter function for selecting which policies
+// to include in diff computations.
+func WithFilterFunc(fn func(*config.Policy) bool) Option {
+	return func(d *ConfigDiffer) {
+		d.filterFn = fn
+	}
+}
+
+func WithOnRouteEvents(fn OnRouteEvents) Option {
+	return func(d *ConfigDiffer) {
+		d.onEvents = fn
+	}
+}
+
+func DefaultTunnelRouteHash(p *config.Policy) uint64 {
+	return p.Checksum()
+}
+
+func DefaultTunnelRouteFilter(*config.Policy) bool {
+	return true
+}
+
+func NewConfigDiffer(opts ...Option) *ConfigDiffer {
+	d := &ConfigDiffer{
+		hashFn:   DefaultTunnelRouteHash,
+		filterFn: DefaultTunnelRouteFilter,
+		wakeC:    make(chan struct{}, 1),
+		prev:     make(map[string]uint64),
+	}
+	for _, opt := range opts {
+		opt(d)
+	}
+	return d
+}
+
+func (d *ConfigDiffer) OnConfigUpdated(cfg *config.Config) {
+	d.currentConfig.Store(cfg)
+	select {
+	case d.wakeC <- struct{}{}:
+	default:
+	}
+}
+
+func (d *ConfigDiffer) Run(ctx context.Context) error {
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-d.wakeC:
+			cfg := d.currentConfig.Load()
+			if events := d.computeDiff(cfg); len(events) > 0 && d.onEvents != nil {
+				d.onEvents(events)
+			}
+		}
+	}
+}
+
+func (d *ConfigDiffer) computeDiff(cfg *config.Config) []RouteEvent {
+	curr := make(map[string]uint64)
+	currPolicies := make(map[string]*config.Policy)
+
+	if cfg != nil && cfg.Options != nil {
+		for p := range cfg.Options.GetAllPolicies() {
+			if !d.filterFn(p) {
+				continue
+			}
+			id := p.ID
+			if id == "" {
+				continue
+			}
+			curr[id] = d.hashFn(p)
+			currPolicies[id] = p
+		}
+	}
+
+	var events []RouteEvent
+
+	for id := range d.prev {
+		if _, ok := curr[id]; !ok {
+			events = append(events, RouteEvent{
+				Kind:    RouteDeleted,
+				RouteID: id,
+			})
+		}
+	}
+
+	for id, h := range curr {
+		oldH, existed := d.prev[id]
+		if !existed || oldH != h {
+			events = append(events, RouteEvent{
+				Kind:    RouteUpserted,
+				RouteID: id,
+				Policy:  currPolicies[id],
+			})
+		}
+	}
+
+	d.prev = curr
+	return events
+}

--- a/config/diff/config_differ_test.go
+++ b/config/diff/config_differ_test.go
@@ -1,0 +1,609 @@
+package diff_test
+
+import (
+	"context"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/config/diff"
+)
+
+func mustParseURL(t *testing.T, s string) url.URL {
+	t.Helper()
+	u, err := url.Parse(s)
+	require.NoError(t, err)
+	return *u
+}
+
+type eventCollector struct {
+	mu       sync.Mutex
+	batches  [][]diff.RouteEvent
+	received chan struct{}
+}
+
+func newEventCollector() *eventCollector {
+	return &eventCollector{
+		received: make(chan struct{}, 100),
+	}
+}
+
+func (c *eventCollector) callback(events []diff.RouteEvent) {
+	c.mu.Lock()
+	c.batches = append(c.batches, events)
+	c.mu.Unlock()
+	c.received <- struct{}{}
+}
+
+func (c *eventCollector) waitForBatch(t *testing.T, timeout time.Duration) []diff.RouteEvent {
+	t.Helper()
+	select {
+	case <-c.received:
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		if len(c.batches) == 0 {
+			t.Fatal("received signal but no batches")
+		}
+		batch := c.batches[0]
+		c.batches = c.batches[1:]
+		return batch
+	case <-time.After(timeout):
+		t.Fatal("timeout waiting for events")
+		return nil
+	}
+}
+
+func (c *eventCollector) expectNoBatch(t *testing.T, wait time.Duration) {
+	t.Helper()
+	select {
+	case <-c.received:
+		t.Fatal("unexpected event batch received")
+	case <-time.After(wait):
+	}
+}
+
+func TestConfigDiffer_EmptyToNonEmpty(t *testing.T) {
+	t.Parallel()
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(diff.WithOnRouteEvents(collector.callback))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	cfg := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+				{
+					ID:             "route-2",
+					From:           "https://api.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:9090")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg)
+
+	events := collector.waitForBatch(t, time.Second)
+	require.Len(t, events, 2)
+	for _, e := range events {
+		assert.Equal(t, diff.RouteUpserted, e.Kind)
+	}
+	ids := map[string]bool{events[0].RouteID: true, events[1].RouteID: true}
+	assert.True(t, ids["route-1"])
+	assert.True(t, ids["route-2"])
+}
+
+func TestConfigDiffer_RouteDeleted(t *testing.T) {
+	t.Parallel()
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(diff.WithOnRouteEvents(collector.callback))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	cfg1 := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+				{
+					ID:             "route-2",
+					From:           "https://api.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:9090")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg1)
+	collector.waitForBatch(t, time.Second)
+
+	cfg2 := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg2)
+
+	events := collector.waitForBatch(t, time.Second)
+	require.Len(t, events, 1)
+	assert.Equal(t, diff.RouteDeleted, events[0].Kind)
+	assert.Equal(t, "route-2", events[0].RouteID)
+}
+
+func TestConfigDiffer_RouteUpdated(t *testing.T) {
+	t.Parallel()
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(diff.WithOnRouteEvents(collector.callback))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	cfg1 := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg1)
+	collector.waitForBatch(t, time.Second)
+
+	cfg2 := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:9999")}}, // changed
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg2)
+
+	events := collector.waitForBatch(t, time.Second)
+	require.Len(t, events, 1)
+	assert.Equal(t, diff.RouteUpserted, events[0].Kind)
+	assert.Equal(t, "route-1", events[0].RouteID)
+}
+
+func TestConfigDiffer_NoChangeNoEvent(t *testing.T) {
+	t.Parallel()
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(diff.WithOnRouteEvents(collector.callback))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	cfg := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg)
+	collector.waitForBatch(t, time.Second)
+
+	differ.OnConfigUpdated(cfg)
+	collector.expectNoBatch(t, 100*time.Millisecond)
+}
+
+func TestConfigDiffer_FiltersNonTunnelRoutes(t *testing.T) {
+	t.Parallel()
+
+	tunnelFilter := func(p *config.Policy) bool {
+		return p.UpstreamTunnel != nil
+	}
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(
+		diff.WithFilterFunc(tunnelFilter),
+		diff.WithOnRouteEvents(collector.callback),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	cfg := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "tunnel-route",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+				{
+					ID:   "non-tunnel-route",
+					From: "https://web.example.com",
+					To:   config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:3000")}},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg)
+
+	events := collector.waitForBatch(t, time.Second)
+	require.Len(t, events, 1)
+	assert.Equal(t, "tunnel-route", events[0].RouteID)
+}
+
+func TestConfigDiffer_CustomHashFunc(t *testing.T) {
+	t.Parallel()
+
+	fromOnlyHash := func(p *config.Policy) uint64 {
+		h := uint64(0)
+		for _, c := range p.From {
+			h = h*31 + uint64(c)
+		}
+		return h
+	}
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(
+		diff.WithHashFunc(fromOnlyHash),
+		diff.WithOnRouteEvents(collector.callback),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	cfg1 := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg1)
+	collector.waitForBatch(t, time.Second)
+
+	cfg2 := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:9999")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg2)
+	collector.expectNoBatch(t, 100*time.Millisecond)
+}
+
+func TestConfigDiffer_CustomFilter(t *testing.T) {
+	t.Parallel()
+
+	apiOnlyFilter := func(p *config.Policy) bool {
+		return len(p.ID) >= 3 && p.ID[:3] == "api"
+	}
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(
+		diff.WithFilterFunc(apiOnlyFilter),
+		diff.WithOnRouteEvents(collector.callback),
+	)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	cfg := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "api-route",
+					From:           "https://api.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+				{
+					ID:             "web-route",
+					From:           "https://web.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:3000")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg)
+
+	events := collector.waitForBatch(t, time.Second)
+	require.Len(t, events, 1)
+	assert.Equal(t, "api-route", events[0].RouteID)
+}
+
+func TestConfigDiffer_NonBlocking(t *testing.T) {
+	t.Parallel()
+
+	differ := diff.NewConfigDiffer()
+
+	cfg := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	done := make(chan struct{})
+	go func() {
+		differ.OnConfigUpdated(cfg)
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("OnConfigUpdated blocked")
+	}
+}
+
+func TestConfigDiffer_CoalescesRapidUpdates(t *testing.T) {
+	t.Parallel()
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(diff.WithOnRouteEvents(collector.callback))
+
+	for i := range 10 {
+		cfg := &config.Config{
+			Options: &config.Options{
+				Policies: []config.Policy{
+					{
+						ID:             "route-1",
+						From:           "https://app.example.com",
+						To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:"+string(rune('0'+i))+"000")}},
+						UpstreamTunnel: &config.UpstreamTunnel{},
+					},
+				},
+			},
+		}
+		differ.OnConfigUpdated(cfg)
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	events := collector.waitForBatch(t, time.Second)
+	require.Len(t, events, 1)
+	assert.Equal(t, diff.RouteUpserted, events[0].Kind)
+
+	collector.expectNoBatch(t, 100*time.Millisecond)
+}
+
+func TestConfigDiffer_MixedOperations(t *testing.T) {
+	t.Parallel()
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(diff.WithOnRouteEvents(collector.callback))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	cfg1 := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app1.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8081")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+				{
+					ID:             "route-2",
+					From:           "https://app2.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8082")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+				{
+					ID:             "route-3",
+					From:           "https://app3.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8083")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg1)
+	collector.waitForBatch(t, time.Second)
+
+	cfg2 := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app1.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8081")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+				{
+					ID:             "route-3",
+					From:           "https://app3.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:9999")}}, // updated
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+				{
+					ID:             "route-4",
+					From:           "https://app4.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8084")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg2)
+
+	events := collector.waitForBatch(t, time.Second)
+	require.Len(t, events, 3)
+
+	byID := make(map[string]diff.RouteEvent)
+	for _, e := range events {
+		byID[e.RouteID] = e
+	}
+
+	assert.Equal(t, diff.RouteDeleted, byID["route-2"].Kind)
+	assert.Equal(t, diff.RouteUpserted, byID["route-3"].Kind)
+	assert.Equal(t, diff.RouteUpserted, byID["route-4"].Kind)
+}
+
+func TestConfigDiffer_NilConfig(t *testing.T) {
+	t.Parallel()
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(diff.WithOnRouteEvents(collector.callback))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	cfg1 := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg1)
+	collector.waitForBatch(t, time.Second)
+
+	differ.OnConfigUpdated(nil)
+
+	events := collector.waitForBatch(t, time.Second)
+	require.Len(t, events, 1)
+	assert.Equal(t, diff.RouteDeleted, events[0].Kind)
+	assert.Equal(t, "route-1", events[0].RouteID)
+}
+
+func TestConfigDiffer_NilOptions(t *testing.T) {
+	t.Parallel()
+
+	collector := newEventCollector()
+	differ := diff.NewConfigDiffer(diff.WithOnRouteEvents(collector.callback))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	go differ.Run(ctx)
+
+	cfg1 := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					ID:             "route-1",
+					From:           "https://app.example.com",
+					To:             config.WeightedURLs{{URL: mustParseURL(t, "http://localhost:8080")}},
+					UpstreamTunnel: &config.UpstreamTunnel{},
+				},
+			},
+		},
+	}
+
+	differ.OnConfigUpdated(cfg1)
+	collector.waitForBatch(t, time.Second)
+
+	differ.OnConfigUpdated(&config.Config{Options: nil})
+
+	events := collector.waitForBatch(t, time.Second)
+	require.Len(t, events, 1)
+	assert.Equal(t, diff.RouteDeleted, events[0].Kind)
+	assert.Equal(t, "route-1", events[0].RouteID)
+}
+
+func TestConfigDiffer_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	differ := diff.NewConfigDiffer()
+	ctx, cancel := context.WithCancel(t.Context())
+
+	errC := make(chan error, 1)
+	go func() {
+		errC <- differ.Run(ctx)
+	}()
+
+	cancel()
+
+	select {
+	case err := <-errC:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(time.Second):
+		t.Fatal("Run did not exit on context cancellation")
+	}
+}


### PR DESCRIPTION
## Summary

Add `ConfigDiffer` utility that computes incremental diffs between config updates, emitting batched route events (upserted/deleted) via callback.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
