### PR TITLE
update Envoy to 1.35.8-p1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.8.1
 	github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524
-	github.com/pomerium/envoy-custom v1.35.7-p1
+	github.com/pomerium/envoy-custom v1.35.8-p1
 	github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46
 	github.com/pomerium/webauthn v0.0.0-20240603205124-0428df511172
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -680,8 +680,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524 h1:3YQY1sb54tEEbr0L73rjHkpLB0IB6qh3zl1+XQbMLis=
 github.com/pomerium/datasource v0.18.2-0.20221108160055-c6134b5ed524/go.mod h1:7fGbUYJnU8RcxZJvUvhukOIBv1G7LWDAHMfDxAf5+Y0=
-github.com/pomerium/envoy-custom v1.35.7-p1 h1:sUeCyNA//3LKRveNYymU0Nq5unav+YF8dugNvwPkYkU=
-github.com/pomerium/envoy-custom v1.35.7-p1/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
+github.com/pomerium/envoy-custom v1.35.8-p1 h1:T+WlzoGVOu8PdCOJLmagKAu3jicr12s4HYU/VOV+GoU=
+github.com/pomerium/envoy-custom v1.35.8-p1/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46 h1:NRTg8JOXCxcIA1lAgD74iYud0rbshbWOB3Ou4+Huil8=
 github.com/pomerium/protoutil v0.0.0-20240813175624-47b7ac43ff46/go.mod h1:QqZmx6ZgPxz18va7kqoT4t/0yJtP7YFIDiT/W2n2fZ4=
 github.com/pomerium/webauthn v0.0.0-20240603205124-0428df511172 h1:TqoPqRgXSHpn+tEJq6H72iCS5pv66j3rPprThUEZg0E=

--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	envoyVersion = "1.35.7-p1"
+	envoyVersion = "1.35.8-p1"
 	targets      = []string{
 		"darwin-amd64",
 		"darwin-arm64",


### PR DESCRIPTION
## Summary

Update Envoy to 1.35.8-p1 on the v0.31 release branch.

## Related issues

https://linear.app/pomerium/issue/ENG-3300/upgrade-envoy-to-13412-1358-1364

## User Explanation

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
