### PR TITLE
oidc/hosted: fix hashing of derived IdP proto

### DIFF
--- a/config/identity_test.go
+++ b/config/identity_test.go
@@ -70,15 +70,12 @@ func TestHostedAuthenticateDerivedCredentials(t *testing.T) {
 	}
 	idp, err := opts.GetIdentityProviderForPolicy(nil)
 
-	expectedClientSecret, _ := base64.StdEncoding.DecodeString(
-		"dR0xnpwDSEWtwK/Gve7jL/u0p/ja3j4oW0i83AtdrJe28XFBWG8BQT5cqn11fzBUJqwkY9SBei/DTpo1FxvOAw==")
-
 	require.NoError(t, err)
 	testutil.AssertProtoEqual(t, &identity.Provider{
-		Id:                     "YessfRlH8f2seIb7el8qxaj6RaWbz7CtEILzMtvOZT5D",
+		Id:                     "MYyOB5SZpAVTcgxvNqn06lhNq0VdantTikkv6QN0Z9B",
 		AuthenticateServiceUrl: "https://authenticate.example.com",
 		ClientId:               "https://authenticate.example.com",
-		ClientSecret:           string(expectedClientSecret),
+		ClientSecret:           "dR0xnpwDSEWtwK/Gve7jL/u0p/ja3j4oW0i83AtdrJe28XFBWG8BQT5cqn11fzBUJqwkY9SBei/DTpo1FxvOAw",
 		Type:                   "hosted",
 		Url:                    "https://authenticate.pomerium.app",
 	}, idp)

--- a/pkg/identity/oidc/hosted/derived.go
+++ b/pkg/identity/oidc/hosted/derived.go
@@ -3,6 +3,7 @@ package hosted
 import (
 	"crypto/ed25519"
 	"crypto/sha256"
+	"encoding/base64"
 	"net/url"
 
 	"golang.org/x/crypto/hkdf"
@@ -36,7 +37,7 @@ func DeriveProviderInfo(idp *identity.Provider, o Options) error {
 		return err
 	}
 	idp.ClientId = authenticateURL.String()
-	idp.ClientSecret = string(priv)
+	idp.ClientSecret = base64.RawStdEncoding.EncodeToString(priv)
 
 	if idp.Url == "" {
 		idp.Url = DefaultProviderURL

--- a/pkg/identity/oidc/hosted/derived_test.go
+++ b/pkg/identity/oidc/hosted/derived_test.go
@@ -29,11 +29,9 @@ func TestDeriveProviderInfo(t *testing.T) {
 			AuthenticateURLString: "https://client.example.com",
 			SharedKey:             base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0}, 32)),
 		})
-		expectedKey, _ := base64.RawStdEncoding.DecodeString(
-			"XDQoBGE41Nct7vr1PGAR4PXI125iGjRY31YzNDmDF5VSZkmQAX/2AXwhchudEEL7UHVHuFlTvuFuOv7UFktKCg")
 		assert.NoError(t, err)
 		assert.Equal(t, "https://client.example.com", idp.ClientId)
-		assert.Equal(t, string(expectedKey), idp.ClientSecret)
+		assert.Equal(t, "XDQoBGE41Nct7vr1PGAR4PXI125iGjRY31YzNDmDF5VSZkmQAX/2AXwhchudEEL7UHVHuFlTvuFuOv7UFktKCg", idp.ClientSecret)
 		assert.Equal(t, "https://authenticate.pomerium.app", idp.Url)
 	})
 	t.Run("provider URL already set", func(t *testing.T) {

--- a/pkg/identity/oidc/hosted/hosted.go
+++ b/pkg/identity/oidc/hosted/hosted.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/ed25519"
+	"encoding/base64"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -50,7 +51,11 @@ func New(ctx context.Context, o *oauth.Options) (*Provider, error) {
 	// in the oauth.Options. Copy it out of this field and clear the field as it
 	// should not be sent to the identity provider.
 	// TODO: refactor this to give the signing key its own dedicated field.
-	key := ed25519.PrivateKey(o.ClientSecret)
+	keyBytes, err := base64.RawStdEncoding.DecodeString(o.ClientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("invalid client secret: %w", err)
+	}
+	key := ed25519.PrivateKey(keyBytes)
 	o2 := *o
 	o2.ClientSecret = ""
 


### PR DESCRIPTION
## Summary

Base64 encode the derived client key used with the hosted authenticate OIDC flow. Storing the client key directly in the `client_secret` field is not compatible with the `Hash()` method, because the proto `Marshal()` method will return an error if the `client_secret` is not a valid UTF-8 string.

## Related issues

https://linear.app/pomerium/issue/ENG-3259/core-cannot-change-hosted-provider-from-prod-to-staging

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
