### PR TITLE
envoy: return error from get-envoy download

### DIFF
--- a/pkg/grpc/databroker/mock_databroker/matchers.go
+++ b/pkg/grpc/databroker/mock_databroker/matchers.go
@@ -1,4 +1,4 @@
-package mock_databroker //nolint:revive,stylecheck
+package mock_databroker //nolint:revive
 
 import (
 	"fmt"


### PR DESCRIPTION
## Summary
During the github outage last week we ended up downloading an envoy binary as a 404 page and storing it in docker. Our get-envoy script should've errored out, but it wasn't checking the status code from the download. It will now.

## Related issues
- [ENG-3314](https://linear.app/pomerium/issue/ENG-3314/core-get-envoy-command-should-return-an-error-if-the-download-fails)


## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
