### PR TITLE
feat(ui/ssh): improve the sign in success page for ssh

### DIFF
--- a/ui/src/components/SignInSuccessPage.tsx
+++ b/ui/src/components/SignInSuccessPage.tsx
@@ -10,48 +10,91 @@ import {
   TableRow,
   Button,
   Box,
+  Typography,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
+  Link,
 } from '@mui/material'
+
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 
 type SignInSuccessPageProps = {
   data: SignInSuccessPageData;
 };
+
 const SignInSuccessPage: FC<SignInSuccessPageProps> = ({ data }) => {
   return (
-    <>
-      <TableContainer component={Paper} sx={{ maxWidth: 540, mx: "auto", mb: 2 }}>
-      <Table size="small" aria-label="metadata table">
-          <TableHead>
-            <TableRow>
-              <TableCell variant="head">Field</TableCell>
-              <TableCell variant="head">Value</TableCell>
-            </TableRow>
-          </TableHead>
-          <TableBody>
-            <TableRow>
-              <TableCell component="th" scope="row">Name</TableCell>
-              <TableCell>{data.user.name}</TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell component="th" scope="row">Protocol</TableCell>
-              <TableCell>{data.protocol}</TableCell>
-            </TableRow>
-            <TableRow>
-              <TableCell component="th" scope="row">Expiry date</TableCell>
-              <TableCell>{data.expiresAt}</TableCell>
-            </TableRow>
-          </TableBody>
-        </Table>
-      </TableContainer>
-      <Box sx={{ maxWidth: 540, mx: "auto", textAlign: "center" }}>
-        <Button
-          variant="contained"
+    <Box sx={{ maxWidth: 540, mx: "auto", textAlign: "center" }}>
+      <Typography variant="h5" fontWeight="bold" gutterBottom>
+        Sign in successful
+      </Typography>
+      <Typography variant="body2" sx={{ mb: 3 }}>
+        You may now close this page
+      </Typography>
+
+      <Accordion>
+        <AccordionSummary
+          expandIcon={<ExpandMoreIcon />}
+          sx={{
+            "& .MuiAccordionSummary-content": {
+              justifyContent: "center",
+            },
+          }}
+        >
+          <Typography align="center">Session details</Typography>
+        </AccordionSummary>
+        <AccordionDetails>
+          <TableContainer component={Paper}>
+            <Table size="small" aria-label="metadata table">
+              <TableHead>
+                <TableRow>
+                  <TableCell variant="head">Field</TableCell>
+                  <TableCell variant="head">Value</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                <TableRow>
+                  <TableCell component="th" scope="row">Name</TableCell>
+                  <TableCell>{data.user.name}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell component="th" scope="row">Protocol</TableCell>
+                  <TableCell>{data.protocol}</TableCell>
+                </TableRow>
+                <TableRow>
+                  <TableCell component="th" scope="row">Expiry date</TableCell>
+                  <TableCell>{data.expiresAt}</TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </TableContainer>
+        </AccordionDetails>
+      </Accordion>
+
+      <Box sx={{ mt: 4}}>Need to change users?
+        <Link
           href="/.pomerium/session_binding_info"
-          sx={{ textTransform: 'none' }}
+          sx={{
+            ml : 1,
+            display: "inline-block",
+            px: 2,
+            py: 0.75,
+            borderRadius: 1,
+            bgcolor: "primary.main",
+            color: "primary.contrastText",
+            fontSize: "0.8125rem",
+            fontWeight: 500,
+            "&:hover": {
+              bgcolor: "primary.dark",
+            },
+          }}
         >
           Manage client bindings
-        </Button>
+        </Link>
       </Box>
-    </>
+    </Box>
   );
 };
+
 export default SignInSuccessPage;


### PR DESCRIPTION
## Summary

https://github.com/user-attachments/assets/01772945-911f-416d-9f07-359b14ef9569


<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
