### PR TITLE
authorize: fix race in TestEvaluateUpstreamTunnel

### DIFF
--- a/authorize/ssh_grpc_test.go
+++ b/authorize/ssh_grpc_test.go
@@ -65,9 +65,9 @@ func TestEvaluateUpstreamTunnel(t *testing.T) {
 			Id:    "USER-1",
 			Email: "user@example.com",
 		})
-	state := a.state.Load()
+	state := *a.state.Load()
 	state.dataBrokerClient = db
-	a.state.Store(state)
+	a.state.Store(&state)
 
 	res, err := a.EvaluateUpstreamTunnel(t.Context(), ssh.AuthRequest{
 		SessionID:        "SESSION-1",


### PR DESCRIPTION
## Summary

I haven't been able to reproduce this data race locally, but I think making a copy of the current state (by dereferencing the `*authorizeState`) before updating the `dataBrokerClient` field should prevent the data race.

## Related issues

https://linear.app/pomerium/issue/ENG-3384/core-data-race-during-testevaluateupstreamtunnel

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
