### PR TITLE
envoy: update envoy-custom to v1.36.4-rc3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.8.1
 	github.com/pomerium/datasource v0.18.2-0.20251215235505-61480e03ee98
-	github.com/pomerium/envoy-custom v1.36.4-rc2
+	github.com/pomerium/envoy-custom v1.36.4-rc3
 	github.com/pomerium/protoutil v0.0.0-20251201162221-d34540764f26
 	github.com/pomerium/webauthn v0.0.0-20251201185147-460aab40892d
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -687,8 +687,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pomerium/datasource v0.18.2-0.20251215235505-61480e03ee98 h1:z8gyv8wsLicU8eGhixqRLvi+Emt3FqBIAU2BJLF8sE0=
 github.com/pomerium/datasource v0.18.2-0.20251215235505-61480e03ee98/go.mod h1:so/PRl85oMKCUySaHMhR6NiKns6EyVQ9r0d9Pv3HUzA=
-github.com/pomerium/envoy-custom v1.36.4-rc2 h1:Rksg4Eq5fJ0I59rTVlU50xHs/VA48OdxR2Kqb39ZNBI=
-github.com/pomerium/envoy-custom v1.36.4-rc2/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
+github.com/pomerium/envoy-custom v1.36.4-rc3 h1:VCJN03YO1KGz3oVR3Y8+FNIF82CbxdVaeBOgwJcESoQ=
+github.com/pomerium/envoy-custom v1.36.4-rc3/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
 github.com/pomerium/protoutil v0.0.0-20251201162221-d34540764f26 h1:Fd5IvAaWkSfOotf8MjxYf5eGYVu83wAr9PgFiF6sqo4=
 github.com/pomerium/protoutil v0.0.0-20251201162221-d34540764f26/go.mod h1:P04B/0fQffoCKSxnnfiMEJlyuyUC/R7ZRUuJW6g0ETo=
 github.com/pomerium/webauthn v0.0.0-20251201185147-460aab40892d h1:QsjApae6Ai3MZ3IirIIPSAcVe4Rp4auln+BX0RQLxw4=


### PR DESCRIPTION
Related issue: https://linear.app/pomerium/issue/ENG-3325/bug-mcp-route-returning-ssh-as-authority