### PR TITLE
dependabot: split go deps into subgroups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -36,3 +36,20 @@ updates:
       go:
         patterns:
           - "*"
+        exclude-patterns:
+          - "go.opentelemetry.io/*"
+          - "github.com/exaring/otelpgx"
+          - "charm.land/*"
+          - "github.com/charmbracelet/*"
+          - "github.com/muesli/termenv"
+          - "github.com/mattn/go-runewidth"
+      otel:
+        patterns:
+          - "go.opentelemetry.io/*"
+          - "github.com/exaring/otelpgx"
+      tui:
+        patterns:
+          - "charm.land/*"
+          - "github.com/charmbracelet/*"
+          - "github.com/muesli/termenv"
+          - "github.com/mattn/go-runewidth"


### PR DESCRIPTION
## Summary

Go dependencies updates sometimes require resolving issues in multiple groups of packages, it would likely be more convenient to have them update with more granularity. 
i.e. https://github.com/pomerium/pomerium/pull/6005

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
