### PR TITLE
tell dependabot to ignore major semver changes to node

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,6 +9,9 @@ updates:
       docker:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: node
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "docker"
     directory: "/.github/"
     schedule:
@@ -18,6 +21,9 @@ updates:
       docker:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: node
+        update-types: ["version-update:semver-major"]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Summary

This should tell dependabot to keep the node major version in the docker dependencies. 

https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#ignore--

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
