### PR TITLE
ui: fix hosted authenticate sidebar and rename to SSH Sessions

### DIFF
--- a/internal/authenticateflow/stateless.go
+++ b/internal/authenticateflow/stateless.go
@@ -257,6 +257,9 @@ func (s *Stateless) GetUserInfoData(r *http.Request, _ *sessions.Handle) handler
 	profile, _ := loadIdentityProfile(r, s.cookieCipher)
 	return handlers.UserInfoData{
 		Profile: profile,
+		RuntimeFlags: map[string]bool{
+			"is_hosted_data_plane": s.options.UseStatelessAuthenticateFlow(),
+		},
 	}
 }
 

--- a/internal/handlers/session_binding_info.go
+++ b/internal/handlers/session_binding_info.go
@@ -36,6 +36,6 @@ func (data SessionInfoData) ToJSON() map[string]any {
 
 func ServeSessionBindingInfo(data SessionInfoData) http.Handler {
 	return httputil.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
-		return ui.ServePage(w, r, "SessionBindingInfo", "Session Bindings", data.ToJSON())
+		return ui.ServePage(w, r, "SessionBindingInfo", "SSH Sessions", data.ToJSON())
 	})
 }

--- a/proxy/data.go
+++ b/proxy/data.go
@@ -60,10 +60,14 @@ func (p *Proxy) getUserInfoData(r *http.Request) handlers.UserInfoData {
 		}
 	}
 
-	data.WebAuthnCreationOptions, data.WebAuthnRequestOptions, _ = p.webauthn.GetOptions(r)
-	data.WebAuthnURL = urlutil.WebAuthnURL(r, urlutil.GetAbsoluteURL(r), state.sharedKey, r.URL.Query())
+	if creationOptions, requestOptions, err := p.webauthn.GetOptions(r); err == nil {
+		data.WebAuthnCreationOptions = creationOptions
+		data.WebAuthnRequestOptions = requestOptions
+		data.WebAuthnURL = urlutil.WebAuthnURL(r, urlutil.GetAbsoluteURL(r), state.sharedKey, r.URL.Query())
+	}
 	data.RuntimeFlags = map[string]bool{
-		"routes_portal": cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagRoutesPortal),
+		"routes_portal":        cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagRoutesPortal),
+		"is_hosted_data_plane": cfg.Options.UseStatelessAuthenticateFlow(),
 	}
 	p.fillEnterpriseUserInfoData(r.Context(), &data)
 	return data

--- a/proxy/data_test.go
+++ b/proxy/data_test.go
@@ -54,6 +54,7 @@ func Test_getUserInfoData(t *testing.T) {
 		data := proxy.getUserInfoData(r)
 		assert.NotNil(t, data.Session)
 		assert.NotNil(t, data.User)
+		assert.Equal(t, false, data.RuntimeFlags["is_hosted_data_plane"])
 	})
 
 	t.Run("session", func(t *testing.T) {
@@ -96,6 +97,7 @@ func Test_getUserInfoData(t *testing.T) {
 		assert.Equal(t, "S1", data.Session.Id)
 		assert.Equal(t, "U1", data.User.Id)
 		assert.True(t, data.IsEnterprise)
+		assert.Equal(t, false, data.RuntimeFlags["is_hosted_data_plane"])
 		if assert.NotNil(t, data.DirectoryUser) {
 			assert.Equal(t, []string{"G1", "G2", "G3"}, data.DirectoryUser.GroupIDs)
 		}

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -60,6 +60,7 @@ const Header: FC<HeaderProps> = ({ includeSidebar, data }) => {
     null;
   const showAvatar =
     data?.page !== "SignOutConfirm" && data?.page !== "SignedOut";
+  const isHosted = data?.runtimeFlags?.is_hosted_data_plane;
 
   const handleDrawerOpen = () => {
     setDrawerOpen(true);
@@ -151,7 +152,7 @@ const Header: FC<HeaderProps> = ({ includeSidebar, data }) => {
           anchorEl={anchorEl}
         >
           <MenuItem onClick={handleUserInfo}>User Info</MenuItem>
-          {data?.runtimeFlags?.routes_portal !== false && (
+          {!isHosted && data?.runtimeFlags?.routes_portal !== false && (
             <MenuItem onClick={handleRoutes}>Routes</MenuItem>
           )}
           <MenuItem onClick={handleLogout}>Logout</MenuItem>

--- a/ui/src/components/SessionBindingInfo.tsx
+++ b/ui/src/components/SessionBindingInfo.tsx
@@ -12,6 +12,7 @@ import {
   TableRow,
 } from "@mui/material";
 import type { FC } from "react";
+import { ExternalLink } from "react-feather";
 import { SmallTooltip } from "src/components/Tooltips";
 import type { SessionBindingInfoPageData } from "src/types";
 
@@ -25,7 +26,21 @@ type SessionBindingInfoProps = {
 const SessionBindingInfoPage: FC<SessionBindingInfoProps> = ({ data }) => {
   return (
     <SidebarPage data={data}>
-      <Section title="Client bindings">
+      <Section
+        title="SSH Sessions"
+        icon={
+          <IconButton
+            component="a"
+            href="https://www.pomerium.com/docs/capabilities/native-ssh-access"
+            target="_blank"
+            rel="noopener noreferrer"
+            size="small"
+            aria-label="SSH documentation"
+          >
+            <ExternalLink size={18} />
+          </IconButton>
+        }
+      >
         <SessionBindingInfoContent data={data}></SessionBindingInfoContent>
       </Section>
     </SidebarPage>
@@ -43,17 +58,23 @@ const SessionBindingInfoContent: FC<SessionBindingInfoProps> = ({ data }) => {
               <TableCell variant="head" sx={{ whiteSpace: "nowrap" }}>
                 <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
                   Fingerprint
-                  <SmallTooltip description="Run `ssh-keygen -l -f <client-pub-key>` to check against your fingerprint" />
+                  <SmallTooltip description="Run `ssh-keygen -l -f <client-pub-key>` to compare fingerprints." />
                 </Box>
               </TableCell>
-              <TableCell variant="head">Initiated From</TableCell>
-              <TableCell variant="head">IssuedAt</TableCell>
-              <TableCell variant="head">ExpiresAt</TableCell>
-              <TableCell variant="head">Actions</TableCell>
-              <TableCell variant="head">
+              <TableCell variant="head">Source IP</TableCell>
+              <TableCell variant="head" align="right">
+                Issued
+              </TableCell>
+              <TableCell variant="head" align="right">
+                Expires
+              </TableCell>
+              <TableCell variant="head" align="right">
+                Actions
+              </TableCell>
+              <TableCell variant="head" align="center">
                 <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                  Remember me?
-                  <SmallTooltip description="When enabled, your client is persistently bound to your user. Revoking removes this persistent binding." />
+                  Remembered
+                  <SmallTooltip description="Trust this device for future SSH logins (skip re-authentication until revoked)." />
                 </Box>
               </TableCell>
             </TableRow>
@@ -87,9 +108,9 @@ const SessionBindingInfoContent: FC<SessionBindingInfoProps> = ({ data }) => {
                     </Box>
                   </TableCell>
                   <TableCell>{s.DetailsSSH.SourceAddress}</TableCell>
-                  <TableCell>{s.IssuedAt}</TableCell>
-                  <TableCell>{s.ExpiresAt}</TableCell>
-                  <TableCell>
+                  <TableCell align="right">{s.IssuedAt}</TableCell>
+                  <TableCell align="right">{s.ExpiresAt}</TableCell>
+                  <TableCell align="right">
                     <Box
                       component="form"
                       action={s.RevokeSessionBindingURL}
@@ -106,7 +127,7 @@ const SessionBindingInfoContent: FC<SessionBindingInfoProps> = ({ data }) => {
                       </Button>
                     </Box>
                   </TableCell>
-                  <TableCell>
+                  <TableCell align="center">
                     <Box
                       component="form"
                       action={s.RevokeIdentityBindingURL}

--- a/ui/src/components/UserInfoPage.tsx
+++ b/ui/src/components/UserInfoPage.tsx
@@ -10,7 +10,12 @@ import {
 import type { FC } from "react";
 import React, { useContext, useEffect, useState } from "react";
 
-import { SubpageContext } from "../context/Subpage";
+import {
+  SUBPAGE_DEVICES,
+  SUBPAGE_GROUPS,
+  SUBPAGE_USER,
+  SubpageContext,
+} from "../context/Subpage";
 import type { UserInfoData } from "../types";
 import GroupDetails from "./GroupDetails";
 import SessionDetails from "./SessionDetails";
@@ -22,6 +27,8 @@ type UserInfoPageProps = {
 };
 const UserInfoPage: FC<UserInfoPageProps> = ({ data }) => {
   const { subpage } = useContext(SubpageContext);
+  const isHosted = data?.runtimeFlags?.is_hosted_data_plane;
+  const activeSubpage = isHosted ? SUBPAGE_USER : subpage;
 
   const [showDeviceEnrolled, setShowDeviceEnrolled] = useState(false);
 
@@ -49,18 +56,18 @@ const UserInfoPage: FC<UserInfoPageProps> = ({ data }) => {
         </DialogActions>
       </Dialog>
       <Stack spacing={3}>
-        {subpage === "User" && (
+        {activeSubpage === SUBPAGE_USER && (
           <SessionDetails session={data?.session} profile={data?.profile} />
         )}
 
-        {subpage === "Groups Info" && (
+        {!isHosted && activeSubpage === SUBPAGE_GROUPS && (
           <GroupDetails
             isEnterprise={data?.isEnterprise}
             groups={data?.directoryGroups}
           />
         )}
 
-        {subpage === "Devices Info" && (
+        {!isHosted && activeSubpage === SUBPAGE_DEVICES && (
           <SessionDeviceCredentials
             session={data?.session}
             user={data?.user}

--- a/ui/src/components/UserSidebarContent.tsx
+++ b/ui/src/components/UserSidebarContent.tsx
@@ -9,7 +9,13 @@ import type { FC, ReactNode } from "react";
 import React, { useContext } from "react";
 import { Link, Lock, User, Users } from "react-feather";
 
-import { SubpageContext } from "../context/Subpage";
+import {
+  SUBPAGE_DEVICES,
+  SUBPAGE_GROUPS,
+  SUBPAGE_ROUTES,
+  SUBPAGE_USER,
+  SubpageContext,
+} from "../context/Subpage";
 import type { SidebarData } from "../types";
 
 export interface Subpage {
@@ -18,43 +24,57 @@ export interface Subpage {
   pathname: string;
 }
 
-const baseSectionList: Subpage[] = [
-  {
-    title: "User",
-    icon: <User />,
-    pathname: "/.pomerium/",
-  },
-  {
-    title: "Groups Info",
-    icon: <Users />,
-    pathname: "/.pomerium/",
-  },
-  {
-    title: "Devices Info",
-    icon: <Devices />,
-    pathname: "/.pomerium/",
-  },
-  {
-    title: "Routes",
-    icon: <Link />,
-    pathname: "/.pomerium/routes",
-  },
-  {
-    title: "Client Bindings",
-    icon: <Lock />,
-    pathname: "/.pomerium/session_binding_info",
-  },
-];
+const userSection: Subpage = {
+  title: SUBPAGE_USER,
+  icon: <User />,
+  pathname: "/.pomerium/",
+};
+
+const groupsSection: Subpage = {
+  title: SUBPAGE_GROUPS,
+  icon: <Users />,
+  pathname: "/.pomerium/",
+};
+
+const baseSectionList: Subpage[] = [userSection];
+
+const deviceSection: Subpage = {
+  title: SUBPAGE_DEVICES,
+  icon: <Devices />,
+  pathname: "/.pomerium/",
+};
+
+const routesSection: Subpage = {
+  title: SUBPAGE_ROUTES,
+  icon: <Link />,
+  pathname: "/.pomerium/routes",
+};
+
+const sshSessionsSection: Subpage = {
+  title: "SSH Sessions",
+  icon: <Lock />,
+  pathname: "/.pomerium/session_binding_info",
+};
 
 function getSectionList(data?: SidebarData): Subpage[] {
-  const sections = [...baseSectionList];
-
-  if (data?.runtimeFlags?.routes_portal === false) {
-    return sections.filter((section) => section.title !== "Routes");
+  if (data?.runtimeFlags?.is_hosted_data_plane) {
+    return [userSection, sshSessionsSection];
   }
 
+  const sections = [...baseSectionList];
+
+  if (data?.isEnterprise) {
+    sections.push(groupsSection);
+  }
+  sections.push(deviceSection);
+  if (data?.runtimeFlags?.routes_portal !== false) {
+    sections.push(routesSection);
+  }
+
+  sections.push(sshSessionsSection);
   return sections;
 }
+
 type UserSidebarContent = {
   close: () => void | null;
   data?: SidebarData;

--- a/ui/src/context/Subpage.tsx
+++ b/ui/src/context/Subpage.tsx
@@ -1,15 +1,30 @@
 import type { FC } from "react";
 import React, { createContext, useState } from "react";
 
+export const SUBPAGE_USER = "User Info";
+export const SUBPAGE_GROUPS = "Groups";
+export const SUBPAGE_DEVICES = "Devices";
+export const SUBPAGE_ROUTES = "Routes";
+
 export interface SubpageContextValue {
   subpage: string;
   setSubpage: (subpage: string) => void;
 }
 
 export const SubpageContext = createContext<SubpageContextValue>({
-  subpage: "User",
+  subpage: SUBPAGE_USER,
   setSubpage: () => {},
 });
+
+const legacySubpageNames = new Map<string, string>([
+  ["User", SUBPAGE_USER],
+  ["User Info", SUBPAGE_USER],
+  ["Groups Info", SUBPAGE_GROUPS],
+  ["Groups", SUBPAGE_GROUPS],
+  ["Devices Info", SUBPAGE_DEVICES],
+  ["Devices", SUBPAGE_DEVICES],
+  ["Routes", SUBPAGE_ROUTES],
+]);
 
 export type SubpageContextProviderProps = {
   page: string;
@@ -23,18 +38,16 @@ export const SubpageContextProvider: FC<SubpageContextProviderProps> = ({
     setState({ ...state, subpage });
   };
   const hashParams = new URLSearchParams(location.hash.substring(1));
+  const legacySubpageParam = hashParams.get("subpage") ?? "";
+  const normalizedSubpage = legacySubpageNames.get(legacySubpageParam);
 
   const initState = {
     subpage:
       page === "DeviceEnrolled"
-        ? "Devices Info"
+        ? SUBPAGE_DEVICES
         : page === "Routes"
-        ? "Routes"
-        : hashParams.get("subpage") === "Groups Info"
-        ? "Groups Info"
-        : hashParams.get("subpage") === "Devices Info"
-        ? "Devices Info"
-        : "User",
+        ? SUBPAGE_ROUTES
+        : normalizedSubpage || SUBPAGE_USER,
     setSubpage,
   };
 

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -72,6 +72,7 @@ export type WebAuthnRequestOptions = {
 type RuntimeFlags = {
   runtimeFlags?: {
     routes_portal?: boolean;
+    is_hosted_data_plane?: boolean;
   };
 };
 
@@ -96,7 +97,10 @@ export type ErrorPageData = BasePageData &
     policyEvaluationTraces?: PolicyEvaluationTrace[];
   };
 
-export type SidebarData = RuntimeFlags;
+export type SidebarData = RuntimeFlags & {
+  isEnterprise?: boolean;
+  page?: string;
+};
 
 export type UserInfoData = RuntimeFlags & {
   directoryGroups?: Group[];


### PR DESCRIPTION
## Summary
- Fixed hosted data plane sidebar to show only User and SSH Sessions
- Renamed "Client Bindings" to "SSH Sessions" throughout
- Added external docs link icon to SSH Sessions page header

## 🧾 
- [x] Verify hosted authenticate sidebar shows only User + SSH Sessions
- [x] Verify SSH Sessions page has external link icon
- [x] Verify Routes not accessible in navigation

<img width="1312" height="1399" alt="Screenshot 2025-12-29 at 4 27 22 PM" src="https://github.com/user-attachments/assets/abb75cf6-9d82-49f0-92ef-b2206112c081" />
<img width="1312" height="1399" alt="Screenshot 2025-12-29 at 4 27 27 PM" src="https://github.com/user-attachments/assets/ac7ad00b-b846-4e12-9380-4179be156661" />


Fixes ENG-3373