### PR TITLE
chore: add pre-commit hooks and fix UI formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,3 +30,17 @@ repos:
         args: ["check-component-versions"]
         pass_filenames: false
         always_run: true
+  - repo: local
+    hooks:
+      - id: ui-format
+        name: ui-format
+        language: system
+        entry: bash -c 'cd ui && npm ci --silent && npm run format'
+        files: "^ui/.*\\.(ts|tsx|js|mjs|json)$"
+        pass_filenames: false
+      - id: ui-lint
+        name: ui-lint
+        language: system
+        entry: bash -c 'cd ui && npm ci --silent && npm run lint'
+        files: "^ui/.*\\.(ts|tsx|js|mjs)$"
+        pass_filenames: false

--- a/ui/eslint.config.mjs
+++ b/ui/eslint.config.mjs
@@ -15,8 +15,8 @@ export default [
     languageOptions: {
       globals: {
         ...globals.browser,
-        ...globals.node,  // for scripts/esbuild.ts
-      }
+        ...globals.node, // for scripts/esbuild.ts
+      },
     },
   },
 

--- a/ui/scripts/esbuild.ts
+++ b/ui/scripts/esbuild.ts
@@ -1,5 +1,5 @@
 /// <reference types="node" />
-import type { BuildOptions} from "esbuild";
+import type { BuildOptions } from "esbuild";
 import { build, context } from "esbuild";
 
 async function run() {

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,11 +1,12 @@
 import { Box, CssBaseline, ThemeProvider } from "@mui/material";
-import type { FC} from "react";
+import type { FC } from "react";
 import React, { useLayoutEffect } from "react";
 
 import ErrorPage from "./components/ErrorPage";
 import Footer from "./components/Footer";
 import Header from "./components/Header";
 import RoutesPage from "./components/RoutesPage";
+import SessionBindingInfoPage from "./components/SessionBindingInfo";
 import SignInSuccessPage from "./components/SignInSuccessPage";
 import SignInVerifyPage from "./components/SignInVerifyPage";
 import SignOutConfirmPage from "./components/SignOutConfirmPage";
@@ -17,7 +18,6 @@ import WebAuthnRegistrationPage from "./components/WebAuthnRegistrationPage";
 import { SubpageContextProvider } from "./context/Subpage";
 import { createTheme } from "./theme";
 import type { PageData } from "./types";
-import SessionBindingInfoPage from "./components/SessionBindingInfo";
 
 const App: FC = () => {
   const data = (window["POMERIUM_DATA"] || {}) as PageData;
@@ -62,7 +62,7 @@ const App: FC = () => {
       body = <SignInSuccessPage data={data} />;
       break;
     case "SessionBindingInfo":
-      body = <SessionBindingInfoPage data={data}/>;
+      body = <SessionBindingInfoPage data={data} />;
       break;
   }
 

--- a/ui/src/components/AlertDialog.tsx
+++ b/ui/src/components/AlertDialog.tsx
@@ -1,6 +1,4 @@
-import type {
-  AlertColor,
-  DialogProps} from "@mui/material";
+import type { AlertColor, DialogProps } from "@mui/material";
 import {
   Alert,
   Dialog,

--- a/ui/src/components/ErrorPage.tsx
+++ b/ui/src/components/ErrorPage.tsx
@@ -1,5 +1,4 @@
-import type {
-  ListItemProps} from "@mui/material";
+import type { ListItemProps } from "@mui/material";
 import {
   Alert,
   AlertTitle,

--- a/ui/src/components/SessionBindingInfo.tsx
+++ b/ui/src/components/SessionBindingInfo.tsx
@@ -1,11 +1,8 @@
-import type { FC } from "react";
-import type { SessionBindingInfoPageData } from "src/types";
-import {SmallTooltip} from "src/components/Tooltips";
-import SidebarPage from "./SidebarPage";
-import Section from "./Section";
-import ContentCopyIcon from '@mui/icons-material/ContentCopy';
-
+import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import {
+  Box,
+  Button,
+  IconButton,
   Paper,
   Table,
   TableBody,
@@ -13,106 +10,135 @@ import {
   TableContainer,
   TableHead,
   TableRow,
-  Button,
-  Box,
-  IconButton,
 } from "@mui/material";
+import type { FC } from "react";
+import { SmallTooltip } from "src/components/Tooltips";
+import type { SessionBindingInfoPageData } from "src/types";
+
+import Section from "./Section";
+import SidebarPage from "./SidebarPage";
 
 type SessionBindingInfoProps = {
-    data: SessionBindingInfoPageData;
-}
+  data: SessionBindingInfoPageData;
+};
 
-const SessionBindingInfoPage: FC<SessionBindingInfoProps> = ({data}) => {
+const SessionBindingInfoPage: FC<SessionBindingInfoProps> = ({ data }) => {
   return (
-     <SidebarPage data={data}>
-        <Section title="Client bindings">
-          <SessionBindingInfoContent data={data}></SessionBindingInfoContent>
-        </Section>
-     </SidebarPage>
-  )
-}
+    <SidebarPage data={data}>
+      <Section title="Client bindings">
+        <SessionBindingInfoContent data={data}></SessionBindingInfoContent>
+      </Section>
+    </SidebarPage>
+  );
+};
 
-const SessionBindingInfoContent : FC<SessionBindingInfoProps> = ({data}) => {
-    return (
-        <>
-            <TableContainer component={Paper} sx={{ maxWidth: 1200,  mb: 2 }}>
-                    <Table size="small" aria-label="metadata table">
-                      <TableHead>
-                        <TableRow>
-                          <TableCell variant="head">Protocol</TableCell>
-                          <TableCell variant="head" sx={{ whiteSpace: 'nowrap'}}>
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                              Fingerprint
-                              <SmallTooltip description="Run `ssh-keygen -l -f <client-pub-key>` to check against your fingerprint"/>
-                            </Box>
-                          </TableCell>
-                          <TableCell variant="head">Initiated From</TableCell>
-                          <TableCell variant="head">IssuedAt</TableCell>
-                          <TableCell variant="head">ExpiresAt</TableCell>
-                          <TableCell variant="head">Actions</TableCell>
-                           <TableCell variant="head">
-                            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                              Remember me?
-                              <SmallTooltip description="When enabled, your client is persistently bound to your user. Revoking removes this persistent binding."/>
-                            </Box>
-                          </TableCell>
-                        </TableRow>
-                      </TableHead>
-                      <TableBody>
-                        {data.sessionBindings?.filter((s) => s.Protocol === "ssh").map((s) => (
-                            <TableRow key={s.DetailsSSH.FingerprintID}>
-                            <TableCell>{s.Protocol}</TableCell>
-                            <TableCell component="th" scope="row">
-                              <Box sx={{ display: 'flex', alignItems: 'center', whiteSpace: 'nowrap' }}>
-                                {s.DetailsSSH.FingerprintID}
-                                <IconButton
-                                  aria-label="Copy fingerprint"
-                                  size="small"
-                                  onClick={() => {
-                                    navigator.clipboard.writeText(s.DetailsSSH.FingerprintID);
-                                  }}
-                                >
-                                    <ContentCopyIcon fontSize="small"></ContentCopyIcon>
-                                </IconButton>
-                              </Box>
-                            </TableCell>
-                            <TableCell>{s.DetailsSSH.SourceAddress}</TableCell>
-                            <TableCell>{s.IssuedAt}</TableCell>
-                            <TableCell>{s.ExpiresAt}</TableCell>
-                            <TableCell>
-                              <Box
-                                component="form"
-                                action={s.RevokeSessionBindingURL}
-                                method="POST"
-                                sx={{ display: "inline-flex", gap: 1 }}
-                              >
-                                <input type="hidden" name="sessionBindingID" value={s.SessionBindingID} />
-                                <Button size="small" type="submit" variant="contained">
-                                  Revoke
-                                </Button>
-                              </Box>
-                            </TableCell>
-                            <TableCell>
-                              <Box
-                                component="form"
-                                action={s.RevokeIdentityBindingURL}
-                                method="POST"
-                                sx={{ display: "inline-flex", gap: 1, alignItems:"center" }}
-                              >
-                                <input type="hidden" name="sessionBindingID" value={s.SessionBindingID} />
-                                <Button size="small" type="submit" variant="contained" disabled={!s.HasIdentityBinding}>
-                                  Revoke
-                                </Button>
-                              </Box>
-                            </TableCell>
-                          </TableRow>
-                        )) }
-                      </TableBody>
-                    </Table>
-                  </TableContainer>
-        </>
-    )
-
+const SessionBindingInfoContent: FC<SessionBindingInfoProps> = ({ data }) => {
+  return (
+    <>
+      <TableContainer component={Paper} sx={{ maxWidth: 1200, mb: 2 }}>
+        <Table size="small" aria-label="metadata table">
+          <TableHead>
+            <TableRow>
+              <TableCell variant="head">Protocol</TableCell>
+              <TableCell variant="head" sx={{ whiteSpace: "nowrap" }}>
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  Fingerprint
+                  <SmallTooltip description="Run `ssh-keygen -l -f <client-pub-key>` to check against your fingerprint" />
+                </Box>
+              </TableCell>
+              <TableCell variant="head">Initiated From</TableCell>
+              <TableCell variant="head">IssuedAt</TableCell>
+              <TableCell variant="head">ExpiresAt</TableCell>
+              <TableCell variant="head">Actions</TableCell>
+              <TableCell variant="head">
+                <Box sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                  Remember me?
+                  <SmallTooltip description="When enabled, your client is persistently bound to your user. Revoking removes this persistent binding." />
+                </Box>
+              </TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.sessionBindings
+              ?.filter((s) => s.Protocol === "ssh")
+              .map((s) => (
+                <TableRow key={s.DetailsSSH.FingerprintID}>
+                  <TableCell>{s.Protocol}</TableCell>
+                  <TableCell component="th" scope="row">
+                    <Box
+                      sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        whiteSpace: "nowrap",
+                      }}
+                    >
+                      {s.DetailsSSH.FingerprintID}
+                      <IconButton
+                        aria-label="Copy fingerprint"
+                        size="small"
+                        onClick={() => {
+                          navigator.clipboard.writeText(
+                            s.DetailsSSH.FingerprintID
+                          );
+                        }}
+                      >
+                        <ContentCopyIcon fontSize="small"></ContentCopyIcon>
+                      </IconButton>
+                    </Box>
+                  </TableCell>
+                  <TableCell>{s.DetailsSSH.SourceAddress}</TableCell>
+                  <TableCell>{s.IssuedAt}</TableCell>
+                  <TableCell>{s.ExpiresAt}</TableCell>
+                  <TableCell>
+                    <Box
+                      component="form"
+                      action={s.RevokeSessionBindingURL}
+                      method="POST"
+                      sx={{ display: "inline-flex", gap: 1 }}
+                    >
+                      <input
+                        type="hidden"
+                        name="sessionBindingID"
+                        value={s.SessionBindingID}
+                      />
+                      <Button size="small" type="submit" variant="contained">
+                        Revoke
+                      </Button>
+                    </Box>
+                  </TableCell>
+                  <TableCell>
+                    <Box
+                      component="form"
+                      action={s.RevokeIdentityBindingURL}
+                      method="POST"
+                      sx={{
+                        display: "inline-flex",
+                        gap: 1,
+                        alignItems: "center",
+                      }}
+                    >
+                      <input
+                        type="hidden"
+                        name="sessionBindingID"
+                        value={s.SessionBindingID}
+                      />
+                      <Button
+                        size="small"
+                        type="submit"
+                        variant="contained"
+                        disabled={!s.HasIdentityBinding}
+                      >
+                        Revoke
+                      </Button>
+                    </Box>
+                  </TableCell>
+                </TableRow>
+              ))}
+          </TableBody>
+        </Table>
+      </TableContainer>
+    </>
+  );
 };
 
 export default SessionBindingInfoPage;

--- a/ui/src/components/SignInSuccessPage.tsx
+++ b/ui/src/components/SignInSuccessPage.tsx
@@ -1,23 +1,21 @@
-import type { FC } from "react";
-import type { SignInSuccessPageData } from "src/types";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import {
+  Accordion,
+  AccordionDetails,
+  AccordionSummary,
+  Box,
+  Link,
   Paper,
-  TableContainer,
   Table,
-  TableHead,
   TableBody,
   TableCell,
+  TableContainer,
+  TableHead,
   TableRow,
-  Button,
-  Box,
   Typography,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
-  Link,
-} from '@mui/material'
-
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+} from "@mui/material";
+import type { FC } from "react";
+import type { SignInSuccessPageData } from "src/types";
 
 type SignInSuccessPageProps = {
   data: SignInSuccessPageData;
@@ -55,15 +53,21 @@ const SignInSuccessPage: FC<SignInSuccessPageProps> = ({ data }) => {
               </TableHead>
               <TableBody>
                 <TableRow>
-                  <TableCell component="th" scope="row">Name</TableCell>
+                  <TableCell component="th" scope="row">
+                    Name
+                  </TableCell>
                   <TableCell>{data.user.name}</TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell component="th" scope="row">Protocol</TableCell>
+                  <TableCell component="th" scope="row">
+                    Protocol
+                  </TableCell>
                   <TableCell>{data.protocol}</TableCell>
                 </TableRow>
                 <TableRow>
-                  <TableCell component="th" scope="row">Expiry date</TableCell>
+                  <TableCell component="th" scope="row">
+                    Expiry date
+                  </TableCell>
                   <TableCell>{data.expiresAt}</TableCell>
                 </TableRow>
               </TableBody>
@@ -72,11 +76,12 @@ const SignInSuccessPage: FC<SignInSuccessPageProps> = ({ data }) => {
         </AccordionDetails>
       </Accordion>
 
-      <Box sx={{ mt: 4}}>Need to change users?
+      <Box sx={{ mt: 4 }}>
+        Need to change users?
         <Link
           href="/.pomerium/session_binding_info"
           sx={{
-            ml : 1,
+            ml: 1,
             display: "inline-block",
             px: 2,
             py: 0.75,

--- a/ui/src/components/SignInVerifyPage.tsx
+++ b/ui/src/components/SignInVerifyPage.tsx
@@ -12,10 +12,11 @@ import {
   TableRow,
   Typography,
 } from "@mui/material";
-import type { FC} from "react";
+import type { FC } from "react";
 import React, { useEffect, useState } from "react";
 import type { SignInVerifyPageData } from "src/types";
-import {SmallTooltip } from "./Tooltips";
+
+import { SmallTooltip } from "./Tooltips";
 
 type SignInVerifyPageProps = {
   data: SignInVerifyPageData;
@@ -136,7 +137,14 @@ const SignInVerifyPage: FC<SignInVerifyPageProps> = ({ data }) => {
         </Box>
       </Box>
       <Box sx={{ maxWidth: 540, mx: "auto", px: 2 }}>
-        <Box sx={{ display: "flex", flexDirection: "row", justifyContent: "center", mb: 1 }}>
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "row",
+            justifyContent: "center",
+            mb: 1,
+          }}
+        >
           <FormControlLabel
             control={
               <Checkbox
@@ -149,7 +157,7 @@ const SignInVerifyPage: FC<SignInVerifyPageProps> = ({ data }) => {
             }
             label="Remember me"
           />
-          <SmallTooltip description="When enabled, your client is persistently bound to your user. This can be undone later"/>
+          <SmallTooltip description="When enabled, your client is persistently bound to your user. This can be undone later" />
         </Box>
 
         <Stack

--- a/ui/src/components/Tooltips.tsx
+++ b/ui/src/components/Tooltips.tsx
@@ -1,23 +1,17 @@
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { IconButton, Tooltip } from "@mui/material";
 import type { FC } from "react";
-import {
-    Tooltip,
-    IconButton,
-} from "@mui/material";
 
 type SmallTooltipProps = {
-    description : string;
-}
+  description: string;
+};
 
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 export const SmallTooltip: FC<SmallTooltipProps> = ({ description }) => {
-    return (
-        <Tooltip
-            title={description}
-            arrow
-        >
-            <IconButton size="small" sx={{ p: 0 }}>
-                <InfoOutlinedIcon fontSize="small" />
-            </IconButton>
-        </Tooltip>
-    );
+  return (
+    <Tooltip title={description} arrow>
+      <IconButton size="small" sx={{ p: 0 }}>
+        <InfoOutlinedIcon fontSize="small" />
+      </IconButton>
+    </Tooltip>
+  );
 };

--- a/ui/src/components/UpstreamErrorPage.tsx
+++ b/ui/src/components/UpstreamErrorPage.tsx
@@ -1,6 +1,5 @@
 import { CheckCircleRounded, Circle } from "@mui/icons-material";
-import type {
-  TypographyProps} from "@mui/material";
+import type { TypographyProps } from "@mui/material";
 import {
   Alert,
   AlertTitle,
@@ -10,7 +9,7 @@ import {
   Divider,
   Link,
   Stack,
-  Typography
+  Typography,
 } from "@mui/material";
 import type { FC } from "react";
 import React from "react";

--- a/ui/src/components/UserSidebarContent.tsx
+++ b/ui/src/components/UserSidebarContent.tsx
@@ -7,7 +7,7 @@ import {
 } from "@mui/material";
 import type { FC, ReactNode } from "react";
 import React, { useContext } from "react";
-import { Link, User, Users, Lock } from "react-feather";
+import { Link, Lock, User, Users } from "react-feather";
 
 import { SubpageContext } from "../context/Subpage";
 import type { SidebarData } from "../types";
@@ -40,9 +40,9 @@ const baseSectionList: Subpage[] = [
     pathname: "/.pomerium/routes",
   },
   {
-    title : "Client Bindings",
-    icon: <Lock/>,
-    pathname : "/.pomerium/session_binding_info"
+    title: "Client Bindings",
+    icon: <Lock />,
+    pathname: "/.pomerium/session_binding_info",
   },
 ];
 

--- a/ui/src/components/WebAuthnButton.tsx
+++ b/ui/src/components/WebAuthnButton.tsx
@@ -1,6 +1,6 @@
 import type { ButtonProps } from "@mui/material";
 import { Button } from "@mui/material";
-import type { FC} from "react";
+import type { FC } from "react";
 import React, { useRef, useState } from "react";
 
 import AlertDialog from "./AlertDialog";

--- a/ui/src/context/Subpage.tsx
+++ b/ui/src/context/Subpage.tsx
@@ -1,4 +1,4 @@
-import type { FC} from "react";
+import type { FC } from "react";
 import React, { createContext, useState } from "react";
 
 export interface SubpageContextValue {

--- a/ui/src/theme/index.ts
+++ b/ui/src/theme/index.ts
@@ -1,10 +1,7 @@
 import "@fontsource/dm-mono";
 import "@fontsource/dm-sans";
-import type {
-  Theme as MuiTheme} from "@mui/material";
-import {
-  createTheme as muiCreateTheme,
-} from "@mui/material";
+import type { Theme as MuiTheme } from "@mui/material";
+import { createTheme as muiCreateTheme } from "@mui/material";
 import common from "@mui/material/colors/common";
 
 import { softShadows } from "./shadows";

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -185,15 +185,15 @@ export type SessionBindingData = {
   IssuedAt: string;
   ExpiresAt: string;
   RevokeSessionBindingURL: string;
-  HasIdentityBinding : boolean;
+  HasIdentityBinding: boolean;
   RevokeIdentityBindingURL: string;
-  DetailsSSH : DetailsSSH;
+  DetailsSSH: DetailsSSH;
 };
 
 export type DetailsSSH = {
-  FingerprintID : string;
+  FingerprintID: string;
   SourceAddress: string;
-}
+};
 
 export type PageData =
   | ErrorPageData


### PR DESCRIPTION
## Summary
- Add ui-format and ui-lint pre-commit hooks to enforce formatting on UI files
- Fix prettier formatting issues left by #5931

## Test plan
- [x] `npm run format` produces no changes
- [x] `npm run lint` passes
- [x] `npm run build` succeeds

Refs #5931, #5930