### PR TITLE
Add timeouts to the contexts in TestLoadSessionHandle

### DIFF
--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -2,11 +2,13 @@ package proxy
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/gorilla/mux"
@@ -274,7 +276,8 @@ func TestLoadSessionHandle(t *testing.T) {
 		t.Parallel()
 
 		opts := testOptions(t)
-		proxy, err := New(t.Context(), &config.Config{Options: opts})
+		cxt, clearTimeout := context.WithTimeout(t.Context(), 1*time.Second)
+		proxy, err := New(cxt, &config.Config{Options: opts})
 		require.NoError(t, err)
 
 		r := httptest.NewRequest(http.MethodGet, "/.pomerium/", nil)
@@ -284,12 +287,14 @@ func TestLoadSessionHandle(t *testing.T) {
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), "window.POMERIUM_DATA")
 		assert.NotContains(t, w.Body.String(), "___SESSION_ID___")
+		clearTimeout()
 	})
 	t.Run("cookie session", func(t *testing.T) {
 		t.Parallel()
 
 		opts := testOptions(t)
-		proxy, err := New(t.Context(), &config.Config{Options: opts})
+		cxt, clearTimeout := context.WithTimeout(t.Context(), 1*time.Second)
+		proxy, err := New(cxt, &config.Config{Options: opts})
 		require.NoError(t, err)
 
 		session := encodeSessionHandle(t, opts, &sessions.Handle{
@@ -307,12 +312,14 @@ func TestLoadSessionHandle(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), "___SESSION_ID___")
+		clearTimeout()
 	})
 	t.Run("header session", func(t *testing.T) {
 		t.Parallel()
 
 		opts := testOptions(t)
-		proxy, err := New(t.Context(), &config.Config{Options: opts})
+		cxt, clearTimeout := context.WithTimeout(t.Context(), 1*time.Second)
+		proxy, err := New(cxt, &config.Config{Options: opts})
 		require.NoError(t, err)
 
 		session := encodeSessionHandle(t, opts, &sessions.Handle{
@@ -326,6 +333,7 @@ func TestLoadSessionHandle(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, w.Code)
 		assert.Contains(t, w.Body.String(), "___SESSION_ID___")
+		clearTimeout()
 	})
 }
 


### PR DESCRIPTION
## Summary

https://github.com/pomerium/pomerium/pull/6011 wants to bump `google.golang.org/grpc` from v1.77.0 to v1.78.0. [1] That is causing TestLoadSessionHandle in github.com/pomerium/pomerium/proxy to time out after 10 minutes. The tests create new proxies and call ServeHTTP on test requests. That execution gets all the way to [GetDataBrokerRecord in querier.go](https://github.com/pomerium/pomerium/blob/ba0fcffe81f27f33dd5aa858dba3a1276208ddcd/pkg/storage/querier.go#L70-L95), where it stalls out on `res, err := q.Query(ctx, req, grpc.WaitForReady(true))`. 

What I think is happening is 
`grpc.WaitForReady(true)` makes `q.Query` wait for the GRPC client to connect to the server. [grpc-go v1.78.0](https://github.com/grpc/grpc-go/releases/tag/v1.78.0) fixes a [bug](https://github.com/grpc/grpc-go/pull/8710) where the client would stay in the IDLE state while trying to connect to the GRPC server. What happens now is the client moves to the TRANSIENT_FAILURE state. The WaitForReady option sees TRANSIENT_FAILURE and waits until that failure fixes itself. 

By setting a timeout in the context, we pass that context to `q.Query` eventually, the timeout fires, and GetDataBrokerRecord returns, which is what the test expected all along.

[1]: I bisected the go.mod file in that branch to figure out which dependency was causing the test to time out.

## Related issues

https://github.com/pomerium/pomerium/pull/6011
https://github.com/grpc/grpc-go/pull/8710

## User Explanation

This fixes a bug that was causing a test to fail. The test was relying on a bug in the grpc-go client, which was fixed.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
