### PR TITLE
config: remove unused 'debug' option

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -60,9 +60,6 @@ type Options struct {
 	// InstallationID is used to indicate a unique installation of pomerium. Useful for telemetry.
 	InstallationID string `mapstructure:"installation_id" yaml:"installation_id,omitempty"`
 
-	// Debug is deprecated.
-	Debug bool `mapstructure:"pomerium_debug" yaml:"pomerium_debug,omitempty"`
-
 	// LogLevel sets the global override for log level. All Loggers will use at least this value.
 	// Possible options are "info","warn","debug" and "error". Defaults to "info".
 	LogLevel LogLevel `mapstructure:"log_level" yaml:"log_level,omitempty"`

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -136,10 +136,6 @@ func Test_bindEnvs(t *testing.T) {
 	o.viper = viper.New()
 	v := viper.New()
 	os.Clearenv()
-	defer os.Unsetenv("POMERIUM_DEBUG")
-	defer os.Unsetenv("POLICY")
-	defer os.Unsetenv("HEADERS")
-	t.Setenv("POMERIUM_DEBUG", "true")
 	t.Setenv("POLICY", "LSBmcm9tOiBodHRwczovL2h0dHBiaW4ubG9jYWxob3N0LnBvbWVyaXVtLmlvCiAgdG86IAogICAgLSBodHRwOi8vbG9jYWxob3N0OjgwODEsMQo=")
 	t.Setenv("HEADERS", `{"X-Custom-1":"foo", "X-Custom-2":"bar"}`)
 	err := bindEnvs(v)
@@ -151,9 +147,6 @@ func Test_bindEnvs(t *testing.T) {
 		t.Errorf("Could not unmarshal %#v: %s", o, err)
 	}
 	o.viper = v
-	if !o.Debug {
-		t.Errorf("Failed to load POMERIUM_DEBUG from environment")
-	}
 	if len(o.Policies) != 1 {
 		t.Error("failed to bind POLICY env")
 	}

--- a/examples/config/config.example.env
+++ b/examples/config/config.example.env
@@ -3,7 +3,6 @@
 
 # Main configuration flags
 # export ADDRESS=":8443"                      # optional, default is 443
-# export POMERIUM_DEBUG=true                  # optional, default is false
 # export SERVICE="all"                        # optional, default is all
 # export LOG_LEVEL="info"                     # optional, default is debug
 


### PR DESCRIPTION
The `pomerium_debug` option was deprecated and is no longer referenced outside of one unit test. Let's remove it.

Also remove unnecessary calls to `os.Unsetenv()` in the related unit test. (`t.Setenv()` will automatically restore the original value at the end of the test).