### PR TITLE
core/databroker: remove panics/errors on unknown sync message types

### DIFF
--- a/internal/databroker/server_clustered_follower.go
+++ b/internal/databroker/server_clustered_follower.go
@@ -452,8 +452,6 @@ func (srv *clusteredFollowerServer) syncLatestStep(
 			}
 		case *databrokerpb.SyncLatestResponse_Options:
 			payload.options = res.Options
-		default:
-			return op.Failure(fmt.Errorf("unknown message type from sync latest: %T", res))
 		}
 
 		// send the batch payload

--- a/pkg/grpc/databroker/databroker.go
+++ b/pkg/grpc/databroker/databroker.go
@@ -111,8 +111,6 @@ loop:
 			records = append(records, res.Record)
 		case *SyncLatestResponse_Options:
 			options = append(options, res.Options)
-		default:
-			panic(fmt.Sprintf("unexpected response: %T", res))
 		}
 	}
 

--- a/pkg/grpc/databroker/sync.go
+++ b/pkg/grpc/databroker/sync.go
@@ -56,9 +56,6 @@ func SyncRecords[T any, TMessage interface {
 				continue
 			}
 			fn(msg)
-		case *SyncResponse_Options:
-		default:
-			panic(fmt.Sprintf("unexpected response: %T", res))
 		}
 	}
 }
@@ -108,11 +105,6 @@ func SyncLatestRecords[T any, TMessage interface {
 			}
 
 			fn(msg)
-		case *SyncLatestResponse_Options:
-			// TODO:
-
-		default:
-			panic(fmt.Sprintf("unexpected response: %T", res))
 		}
 	}
 }

--- a/pkg/storage/querier_sync.go
+++ b/pkg/storage/querier_sync.go
@@ -152,9 +152,6 @@ func (q *syncQuerier) syncLatest(ctx context.Context) error {
 			q.serverVersion = res.Versions.ServerVersion
 			q.latestRecordVersion = res.Versions.LatestRecordVersion
 			q.mu.Unlock()
-		case *databroker.SyncLatestResponse_Options:
-		default:
-			return fmt.Errorf("unknown message type from sync latest: %T", res)
 		}
 	}
 
@@ -200,14 +197,9 @@ func (q *syncQuerier) sync(ctx context.Context) error {
 
 		q.mu.Lock()
 		switch res := res.Response.(type) {
-
 		case *databroker.SyncResponse_Record:
 			q.latestRecordVersion = max(q.latestRecordVersion, res.Record.Version)
 			q.records.Put(res.Record)
-
-		case *databroker.SyncResponse_Options:
-		default:
-			panic(fmt.Sprintf("unexpected response: %T", res))
 		}
 		q.mu.Unlock()
 	}

--- a/pkg/synccache/sync_cache.go
+++ b/pkg/synccache/sync_cache.go
@@ -166,7 +166,6 @@ func (c *syncCache) sync(ctx context.Context, client databroker.DataBrokerServic
 		}
 
 		switch res := res.Response.(type) {
-
 		case *databroker.SyncResponse_Record:
 			// either delete or update the record
 			if res.Record.DeletedAt != nil {
@@ -184,9 +183,6 @@ func (c *syncCache) sync(ctx context.Context, client databroker.DataBrokerServic
 			if err != nil {
 				return fmt.Errorf("sync-cache: error updating record version in cache (record-type=%s): %w", recordType, err)
 			}
-		case *databroker.SyncResponse_Options:
-		default:
-			panic(fmt.Sprintf("unexpected response: %T", res))
 		}
 	}
 
@@ -243,9 +239,6 @@ func (c *syncCache) syncLatest(ctx context.Context, client databroker.DataBroker
 			if err != nil {
 				return fmt.Errorf("sync-cache: error saving versions to cache (record-type=%s): %w", recordType, err)
 			}
-		case *databroker.SyncLatestResponse_Options:
-		default:
-			return fmt.Errorf("sync-cache: unknown message type from sync latest stream (record-type=%s): %T", recordType, res)
 		}
 	}
 


### PR DESCRIPTION
## Summary
The databroker has two streaming methods: `Sync` and `SyncLatest`. These methods return records, options and versions, but some consumers only need the records and ignore the other types. The way this is done is with a type switch and in some cases either a panic or an error in the default case.

We may want to add additional message types in the future, and it would be safer to simply ignore message types we don't know about (even if we update the code to handle new message types, older consumers would error out and that's probably not the behavior we want)

## Related issues
- [ENG-3284](https://linear.app/pomerium/issue/ENG-3284/enterprise-console-cluster-syncer-crashloop)

## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
