### PR TITLE
config: derive signing key from shared secret

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -4,9 +4,12 @@ import (
 	"bytes"
 	"cmp"
 	"context"
+	"crypto/elliptic"
+	"crypto/sha256"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"iter"
@@ -19,11 +22,13 @@ import (
 	"strings"
 	"time"
 
+	"filippo.io/keygen"
 	"github.com/go-viper/mapstructure/v2"
 	goset "github.com/hashicorp/go-set/v3"
 	"github.com/rs/zerolog"
 	"github.com/spf13/viper"
 	"github.com/volatiletech/null/v9"
+	"golang.org/x/crypto/hkdf"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/pomerium/pomerium/config/otelconfig"
@@ -1448,6 +1453,10 @@ func (o *Options) GetSigningKey() ([]byte, error) {
 		return nil, nil
 	}
 
+	if o.SigningKey == "" && o.SigningKeyFile == "" {
+		return o.deriveSigningKey()
+	}
+
 	rawSigningKey := o.SigningKey
 	if o.SigningKeyFile != "" {
 		bs, err := os.ReadFile(o.SigningKeyFile)
@@ -1464,6 +1473,24 @@ func (o *Options) GetSigningKey() ([]byte, error) {
 	}
 
 	return []byte(rawSigningKey), nil
+}
+
+func (o *Options) deriveSigningKey() ([]byte, error) {
+	sharedSecret, err := o.GetSharedKey()
+	if err != nil {
+		return nil, nil
+	}
+
+	r := hkdf.New(sha256.New, sharedSecret, nil, []byte("derived-jwt-signing-key"))
+	priv, err := keygen.ECDSALegacy(elliptic.P256(), r)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't derive JWT signing key: %w", err)
+	}
+	der, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't marshal derived JWT signing key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: der}), nil
 }
 
 // GetAccessLogFields returns the access log fields. If none are set, the default fields are returned.

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1259,7 +1259,6 @@ func TestOptions_GetSigningKey(t *testing.T) {
 		output []byte
 		err    error
 	}{
-		{"missing", "", []byte{}, nil},
 		{"pem", `
 -----BEGIN EC PRIVATE KEY-----
 MHQCAQEEIGGh6FlBe8yy9dRJgm+35lj3naGFtDODOf6leCW1bRGwoAcGBSuBBAAK
@@ -1351,6 +1350,34 @@ LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IUUNBUUVFSUdHaDZGbEJlOHl5OWRSSmdtKzM1
 			assert.Equal(t, tc.output, output)
 		})
 	}
+
+	// If no signing key is specified, one should be derived from the shared secret.
+	t.Run("derived", func(t *testing.T) {
+		t.Parallel()
+		o := NewDefaultOptions()
+		require.NoError(t, o.Validate())
+		key, err := o.GetSigningKey()
+		assert.NoError(t, err)
+		_, err = cryptutil.DecodePrivateKey(key)
+		assert.NoError(t, err)
+	})
+	// The derived key should be deterministic: for the same shared secret,
+	// the signing key should always be the same.
+	t.Run("deterministic", func(t *testing.T) {
+		t.Parallel()
+		o := NewDefaultOptions()
+		o.SharedKey = base64.StdEncoding.EncodeToString(
+			[]byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890+/AAAA="))
+		require.NoError(t, o.Validate())
+		key, err := o.GetSigningKey()
+		assert.NoError(t, err)
+		assert.Equal(t, `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIKgZBs2Con07f98aF1eGk8Z+6pMIXTy9gsMiddPEMhv9oAoGCCqGSM49
+AwEHoUQDQgAE2EUdBs4O1nfxBWQ2AIZRnFih9sBmSKp0vhRvcWljmqLxmBISoJMj
+9ocNmZaB7dTBIPOBz5rTQQRxwo3egxzK5Q==
+-----END EC PRIVATE KEY-----
+`, string(key))
+	})
 }
 
 func TestOptions_GetCookieSecret(t *testing.T) {


### PR DESCRIPTION
## Summary

If a JWT signing key is not specified explicitly, derive one from the shared secret.

## Related issues

https://linear.app/pomerium/issue/ENG-3436/core-derive-jwt-signing-key-from-shared-secret-if-not-set-explicitly

## User Explanation

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
