### PR TITLE
mcp: remove placeholder scopes from metadata

### DIFF
--- a/internal/mcp/handler_metadata.go
+++ b/internal/mcp/handler_metadata.go
@@ -163,7 +163,6 @@ func getAuthorizationServerMetadata(r *http.Request, prefix string) Authorizatio
 		RevocationEndpoint:                     P(path.Join(prefix, revocationEndpoint)),
 		RevocationEndpointAuthMethodsSupported: []string{"client_secret_post"},
 		RegistrationEndpoint:                   P(path.Join(prefix, registerEndpoint)),
-		ScopesSupported:                        []string{"openid", "offline"},
 		ClientIDMetadataDocumentSupported:      true,
 	}
 }
@@ -180,7 +179,6 @@ func getProtectedResourceMetadata(r *http.Request, _ string) ProtectedResourceMe
 			Scheme: "https",
 			Host:   r.Host,
 		}).String()},
-		ScopesSupported:        []string{"openid", "offline"},
 		BearerMethodsSupported: []string{"header"},
 	}
 }


### PR DESCRIPTION
## Summary

Remove the hardcoded `["openid", "offline"]` scopes from Authorization Server and Protected Resource metadata since they are not enforced and have no functional meaning.

Per RFC 8414, `scopes_supported` is RECOMMENDED but not REQUIRED. These placeholder scopes were not validated during authorization requests, not included in issued tokens, and had no effect on access control.

## Related issues

## User Explanation

No user-facing changes. The `scopes_supported` field is removed from MCP metadata endpoints, but this has no impact on functionality since these scopes were never enforced.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review