### PR TITLE
ssh tui: fix log viewer text styles

### DIFF
--- a/pkg/ssh/tui/style/style.go
+++ b/pkg/ssh/tui/style/style.go
@@ -56,6 +56,7 @@ type Colors struct {
 	TextError     color.Color
 	TextTimestamp color.Color
 	TextLink      color.Color
+	TextNotice    color.Color
 
 	BrandPrimary   AccentColor
 	BrandSecondary AccentColor
@@ -178,6 +179,7 @@ type Theme struct {
 	TextWarning   lipgloss.Style
 	TextError     lipgloss.Style
 	TextLink      lipgloss.Style
+	TextNotice    lipgloss.Style
 
 	TextStatusHealthy   lipgloss.Style
 	TextStatusDegraded  lipgloss.Style
@@ -282,6 +284,9 @@ func NewTheme(colors Colors, opts ...ThemeOption) *Theme {
 	textLink := newStyle()
 	set(&textLink, lipgloss.Style.Foreground, colors.TextLink)
 
+	textNotice := newStyle()
+	set(&textNotice, lipgloss.Style.Foreground, colors.TextNotice)
+
 	textStatusHealthy := newStyle()
 	set(&textStatusHealthy, lipgloss.Style.Foreground, colors.TextSuccess)
 
@@ -381,6 +386,7 @@ func NewTheme(colors Colors, opts ...ThemeOption) *Theme {
 		TextWarning:              textWarning,
 		TextError:                textError,
 		TextLink:                 textLink,
+		TextNotice:               textNotice,
 		TextStatusHealthy:        textStatusHealthy,
 		TextStatusDegraded:       textStatusDegraded,
 		TextStatusUnhealthy:      textStatusUnhealthy,
@@ -407,6 +413,7 @@ var Ansi16Colors = Colors{
 	TextWarning:          ansi.Yellow,
 	TextError:            ansi.Red,
 	TextTimestamp:        ansi.White,
+	TextNotice:           ansi.Blue,
 	BrandPrimary: AccentColor{
 		Normal:          ansi.White,
 		Bright:          ansi.BrightWhite,
@@ -461,6 +468,7 @@ var Deemphasized = Colors{
 	TextError:                          ansi.Black,
 	TextTimestamp:                      ansi.Black,
 	TextLink:                           ansi.Black,
+	TextNotice:                         ansi.Black,
 	BrandPrimary:                       AccentColor{Normal: ansi.Black, Bright: ansi.Black, ContrastingText: ansi.BrightBlack},
 	BrandSecondary:                     AccentColor{Normal: ansi.Black, Bright: ansi.Black, ContrastingText: ansi.BrightBlack},
 	Accent1:                            AccentColor{Normal: ansi.Black, Bright: ansi.Black, ContrastingText: ansi.BrightBlack},

--- a/pkg/ssh/tui/widgets/logviewer/config.go
+++ b/pkg/ssh/tui/widgets/logviewer/config.go
@@ -13,9 +13,11 @@ type Config struct {
 }
 
 type Styles struct {
-	Border        lipgloss.Style
-	BorderFocused lipgloss.Style
-	Timestamp     lipgloss.Style
+	Border          lipgloss.Style
+	BorderFocused   lipgloss.Style
+	Timestamp       lipgloss.Style
+	RepeatIndicator lipgloss.Style
+	Text            lipgloss.Style
 }
 
 type Options struct {
@@ -57,8 +59,10 @@ var DefaultKeyMap = KeyMap{
 
 func NewStyles(theme *style.Theme, accentColor style.AccentColor) Styles {
 	return Styles{
-		Border:        lipgloss.NewStyle().Inherit(theme.Card),
-		BorderFocused: lipgloss.NewStyle().Inherit(theme.Card).BorderForeground(accentColor.Normal),
-		Timestamp:     lipgloss.NewStyle().Inherit(theme.TextTimestamp).Faint(true),
+		Border:          lipgloss.NewStyle().Inherit(theme.Card),
+		BorderFocused:   lipgloss.NewStyle().Inherit(theme.Card).BorderForeground(accentColor.Normal),
+		Timestamp:       lipgloss.NewStyle().Inherit(theme.TextTimestamp).Faint(true),
+		RepeatIndicator: theme.TextNotice,
+		Text:            theme.TextNormal,
 	}
 }

--- a/pkg/ssh/tui/widgets/logviewer/logs.go
+++ b/pkg/ssh/tui/widgets/logviewer/logs.go
@@ -93,7 +93,7 @@ func (m *Model) KeyMap() help.KeyMap {
 func (m *Model) Push(msg string) {
 	var timestamp string
 	if m.config.ShowTimestamp {
-		timestamp = m.config.Styles.Style().Timestamp.Render(fmt.Sprintf("[%sZ]", time.Now().UTC().Format(time.TimeOnly)))
+		timestamp = fmt.Sprintf("[%sZ]", time.Now().UTC().Format(time.TimeOnly))
 	}
 	if last := m.tail.Value.(*LogEntry); last != nil && last.Timestamp == timestamp && last.Message == msg {
 		last.Count++
@@ -287,18 +287,19 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 	return nil
 }
 
-var textBlue = lipgloss.NewStyle().Foreground(ansi.Blue)
-
 func (m *Model) View() uv.Drawable {
 	node := m.visibleHead
 	lines := make([][]rune, 0, m.height)
+	styles := m.config.Styles.Style()
 	for range m.height {
 		entry := node.Value.(*LogEntry)
+		timestamp := styles.Timestamp.Render(entry.Timestamp)
 		var value string
+		msg := styles.Text.Render(entry.Message)
 		if entry.Count == 1 {
-			value = strings.Join([]string{entry.Timestamp, entry.Message}, " ")
+			value = strings.Join([]string{timestamp, msg}, " ")
 		} else if entry.Count > 1 {
-			value = strings.Join([]string{entry.Timestamp, textBlue.Render(fmt.Sprintf("(x%d)", entry.Count)), entry.Message}, " ")
+			value = strings.Join([]string{timestamp, styles.RepeatIndicator.Render(fmt.Sprintf("(x%d)", entry.Count)), msg}, " ")
 		}
 		line := []rune(ansi.Truncate(value, m.width-1, "…"))
 		// pad the line to match the actual rendered width

--- a/pkg/ssh/tui/widgets/table/table.go
+++ b/pkg/ssh/tui/widgets/table/table.go
@@ -14,6 +14,7 @@ package table
 
 import (
 	"slices"
+	"strings"
 
 	"charm.land/bubbles/v2/help"
 	"charm.land/bubbles/v2/key"
@@ -279,9 +280,14 @@ func (m *Model[T, K]) View() uv.Drawable {
 		border = m.config.Styles.Style().BorderFocused
 	}
 
+	var sb strings.Builder
+	sb.WriteString(m.headersView())
+	sb.WriteString("\n")
+	sb.WriteString(m.viewport.View())
+
 	return uv.NewStyledString(
 		style.RenderBorderTitles(
-			border.Render(m.headersView()+"\n"+m.viewport.View()),
+			border.Render(sb.String()),
 			border.GetBorderStyle(),
 			m.config.BorderTitleLeft,
 			m.config.BorderTitleRight))


### PR DESCRIPTION
This adds some missing text style config to the log viewer widget. There is also a new `TextNotice` color which is used to style the repeat counter next to log messages.