### PR TITLE
core/synccache: limit batch size

### DIFF
--- a/pkg/synccache/sync_cache.go
+++ b/pkg/synccache/sync_cache.go
@@ -23,6 +23,9 @@ const (
 	fieldServerVersion byte = 1
 	fieldRecordVersion byte = 2
 	fieldRecord        byte = 3
+
+	// if a batch exceeds 4GB pebble panics, so just commit every 128MB
+	maxBatchSize = 1024 * 1024 * 128
 )
 
 var (
@@ -114,6 +117,19 @@ func (c *syncCache) Sync(ctx context.Context, client databroker.DataBrokerServic
 	return c.sync(ctx, client, recordType, serverVersion.Value, recordVersion.Value)
 }
 
+func (c *syncCache) commitAndRecreateBatch(batch **pebble.Batch) error {
+	err := (*batch).Commit(c.writeOptions)
+	if err != nil {
+		return fmt.Errorf("sync-cache: error committing changes to cache: %w", err)
+	}
+	err = (*batch).Close()
+	if err != nil {
+		return fmt.Errorf("sync-cache: error closing batch: %w", err)
+	}
+	*batch = c.db.NewBatch()
+	return nil
+}
+
 func (c *syncCache) recordKey(recordType, recordID string) []byte {
 	return slices.Concat(c.recordPrefix(recordType), []byte(recordID))
 }
@@ -151,7 +167,7 @@ func (c *syncCache) sync(ctx context.Context, client databroker.DataBrokerServic
 
 	// batch the updates together
 	batch := c.db.NewBatch()
-	defer batch.Close()
+	defer func() { _ = batch.Close() }()
 
 	for {
 		res, err := stream.Recv()
@@ -184,11 +200,18 @@ func (c *syncCache) sync(ctx context.Context, client databroker.DataBrokerServic
 				return fmt.Errorf("sync-cache: error updating record version in cache (record-type=%s): %w", recordType, err)
 			}
 		}
+
+		if batch.Len() > maxBatchSize {
+			err = c.commitAndRecreateBatch(&batch)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
-	err = batch.Commit(c.writeOptions)
+	err = c.commitAndRecreateBatch(&batch)
 	if err != nil {
-		return fmt.Errorf("sync-cache: error committing changes to cache (record-type=%s): %w", recordType, err)
+		return err
 	}
 
 	return nil
@@ -207,7 +230,7 @@ func (c *syncCache) syncLatest(ctx context.Context, client databroker.DataBroker
 
 	// batch the updates together
 	batch := c.db.NewBatch()
-	defer batch.Close()
+	defer func() { _ = batch.Close() }()
 
 	// delete all the existing data
 	err = c.pebbleDeletePrefix(batch, c.recordTypePrefix(recordType))
@@ -240,11 +263,18 @@ func (c *syncCache) syncLatest(ctx context.Context, client databroker.DataBroker
 				return fmt.Errorf("sync-cache: error saving versions to cache (record-type=%s): %w", recordType, err)
 			}
 		}
+
+		if batch.Len() > maxBatchSize {
+			err = c.commitAndRecreateBatch(&batch)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
-	err = batch.Commit(c.writeOptions)
+	err = c.commitAndRecreateBatch(&batch)
 	if err != nil {
-		return fmt.Errorf("sync-cache: error committing changes to cache (record-type=%s): %w", recordType, err)
+		return err
 	}
 
 	return nil

--- a/pkg/synccache/sync_cache_test.go
+++ b/pkg/synccache/sync_cache_test.go
@@ -1,11 +1,13 @@
 package synccache_test
 
 import (
+	"bytes"
 	"context"
 	"iter"
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/pebble/v2"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -111,4 +113,41 @@ func collect[T any](tb testing.TB, seq iter.Seq2[T, error]) []T {
 		records = append(records, record)
 	}
 	return records
+}
+
+type giantRecordServer struct {
+	databrokerpb.UnimplementedDataBrokerServiceServer
+}
+
+func (srv *giantRecordServer) SyncLatest(
+	_ *databrokerpb.SyncLatestRequest,
+	stream grpc.ServerStreamingServer[databrokerpb.SyncLatestResponse],
+) error {
+	for range 1024 * 5 {
+		err := stream.Send(&databrokerpb.SyncLatestResponse{
+			Response: &databrokerpb.SyncLatestResponse_Record{
+				Record: &databrokerpb.Record{
+					Data: protoutil.NewAnyBytes(bytes.Repeat([]byte{0x01}, 1024*1024)),
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func TestLargeBatch(t *testing.T) {
+	t.Skip("this test uses a very large amount of memory so needs to be run manually")
+
+	srv := &giantRecordServer{}
+	cc := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(s, srv)
+	})
+
+	db := pebbleutil.MustOpenMemory(&pebble.Options{})
+	cache := synccache.New(db, []byte{0x00})
+	err := cache.Sync(t.Context(), databrokerpb.NewDataBrokerServiceClient(cc), "TEST")
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
## Summary
Limit the batch size for the sync cache. Pebble has a fundamental 4GB limitation on the size of a batch of changes. With these changes if we exceed 128MB, we will go ahead and commit the batch and create a new one.

## Related issues
#6072 


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
