### PR TITLE
ssh tui: fix data races related to model updates

### DIFF
--- a/pkg/ssh/models/channels.go
+++ b/pkg/ssh/models/channels.go
@@ -20,25 +20,7 @@ func (c Channel) Key() uint32 {
 	return c.ID
 }
 
-type ChannelUpdateListener interface {
-	OnDiagnosticsReceived(diagnostics []*extensions_ssh.Diagnostic)
-}
-
-type ChannelUpdateMsg = IndexUpdateMsg[Channel, uint32]
-
-// ChannelModel keeps track of cluster health/status by listening for
-// channel events. Used for the TUI. Not thread-safe.
-type ChannelModel struct {
-	ItemModel[Channel, uint32]
-}
-
-func NewChannelModel() *ChannelModel {
-	return &ChannelModel{
-		ItemModel: NewItemModel[Channel](),
-	}
-}
-
-func (m *ChannelModel) BuildRow(c Channel) []string {
+func (c Channel) ToRow() []string {
 	cols := []string{
 		strconv.FormatUint(uint64(c.ID), 10), // Channel
 		c.Status,                             // Status
@@ -59,6 +41,22 @@ func (m *ChannelModel) BuildRow(c Channel) []string {
 		}
 	}
 	return cols
+}
+
+type ChannelUpdateListener interface {
+	OnDiagnosticsReceived(diagnostics []*extensions_ssh.Diagnostic)
+}
+
+// ChannelModel keeps track of cluster health/status by listening for
+// channel events. Used for the TUI. Not thread-safe.
+type ChannelModel struct {
+	ItemModel[Channel, uint32]
+}
+
+func NewChannelModel() *ChannelModel {
+	return &ChannelModel{
+		ItemModel: NewItemModel[Channel](),
+	}
 }
 
 func (m *ChannelModel) HandleEvent(event *extensions_ssh.ChannelEvent) {

--- a/pkg/ssh/models/item_model.go
+++ b/pkg/ssh/models/item_model.go
@@ -14,13 +14,9 @@ func (i Index) IsValid(model interface{ End() Index }) bool {
 	return i >= 0 && i < model.End()
 }
 
-type IndexUpdateMsg[T Item[K], K comparable] struct {
-	Item  T
-	Index Index
-}
-
 type Item[K comparable] interface {
 	Key() K
+	ToRow() []string
 }
 
 type ItemModel[T Item[K], K comparable] interface {
@@ -41,6 +37,15 @@ type itemModel[T Item[K], K comparable] struct {
 	items       []T
 	indexLookup map[K]Index
 	listeners   []ItemModelListener[T, K]
+}
+
+type IndexUpdateMsg[T Item[K], K comparable] struct {
+	Begin, End Index
+	Items      []T
+}
+
+type ModelResetMsg[T Item[K], K comparable] struct {
+	Items []T
 }
 
 type ItemModelListener[T Item[K], K comparable] interface {

--- a/pkg/ssh/models/item_model_test.go
+++ b/pkg/ssh/models/item_model_test.go
@@ -20,6 +20,10 @@ func (td TestData) Key() int {
 	return td.ID
 }
 
+func (td TestData) ToRow() []string {
+	return []string{td.Str}
+}
+
 func TestItemModel_Empty(t *testing.T) {
 	m := models.NewItemModel[TestData]()
 	{

--- a/pkg/ssh/models/routes.go
+++ b/pkg/ssh/models/routes.go
@@ -3,6 +3,7 @@ package models
 import (
 	"fmt"
 	"strings"
+	"sync"
 
 	datav3 "github.com/envoyproxy/go-control-plane/envoy/data/core/v3"
 
@@ -23,13 +24,22 @@ const (
 	EndpointStatusUnknown  = "UNKNOWN"
 )
 
-type Route portforward.RouteInfo
+type Route struct {
+	portforward.RouteInfo
+	Status string
+	Health string
+}
 
 func (r Route) Key() string {
 	return r.ClusterID
 }
 
-type RouteUpdateMsg = IndexUpdateMsg[Route, string]
+func (r Route) ToRow() []string {
+	to, _, _ := r.To.Flatten()
+	remote := fmt.Sprintf("%s:%d", r.From, r.Port)
+	local := strings.Join(to, ",")
+	return []string{r.Status, r.Health, remote, local}
+}
 
 type RouteModel struct {
 	ItemModel[Route, string]
@@ -37,6 +47,7 @@ type RouteModel struct {
 	clusterHealth         map[string]string
 	clusterEndpointStatus map[string]string
 	eventHandlers         RouteModelEventHandlers
+	mu                    sync.Mutex
 }
 
 type RouteModelEventHandlers struct {
@@ -57,30 +68,14 @@ func NewRouteModel(eventHandlers RouteModelEventHandlers) *RouteModel {
 	}
 }
 
-func (m *RouteModel) BuildRow(route Route) []string {
-	status := "--"
-	health := "--"
-	if _, ok := m.activePortForwards[route.ClusterID]; ok {
-		status = EndpointStatusActive
-		if stat, ok := m.clusterEndpointStatus[route.ClusterID]; ok {
-			status = stat
-		}
-		health = m.clusterHealth[route.ClusterID]
-		if health == "" {
-			health = HealthUnknown
-		}
-	}
-
-	to, _, _ := route.To.Flatten()
-	remote := fmt.Sprintf("%s:%d", route.From, route.Port)
-	local := strings.Join(to, ",")
-	return []string{status, health, remote, local}
-}
-
 func (m *RouteModel) HandleClusterEndpointsUpdate(added map[string]portforward.RoutePortForwardInfo, removed map[string]struct{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	for k, v := range added {
 		m.activePortForwards[k] = v
-		m.Put(Route(v.RouteInfo))
+		route := Route{RouteInfo: v.RouteInfo}
+		m.hydrateHealthStatus(&route)
+		m.Put(route)
 	}
 	for k := range removed {
 		delete(m.activePortForwards, k)
@@ -91,20 +86,26 @@ func (m *RouteModel) HandleClusterEndpointsUpdate(added map[string]portforward.R
 }
 
 func (m *RouteModel) HandleRoutesUpdate(routes []portforward.RouteInfo) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	items := make([]Route, len(routes))
 	for i, r := range routes {
-		items[i] = Route(r)
+		route := Route{RouteInfo: r}
+		m.hydrateHealthStatus(&route)
+		items[i] = route
 	}
 	m.Reset(items)
 }
 
 func (m *RouteModel) HandleClusterHealthUpdate(msg *datav3.HealthCheckEvent) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	var md extensions_ssh.EndpointMetadata
 	err := msg.Metadata.TypedFilterMetadata["com.pomerium.ssh.endpoint"].UnmarshalTo(&md)
 	if err != nil {
 		panic(err)
 	}
-	affected := Route(m.activePortForwards[msg.ClusterName].RouteInfo)
+	affected := Route{RouteInfo: m.activePortForwards[msg.ClusterName].RouteInfo}
 	switch event := msg.Event.(type) {
 	case *datav3.HealthCheckEvent_AddHealthyEvent:
 		m.clusterHealth[msg.ClusterName] = HealthHealthy
@@ -123,7 +124,25 @@ func (m *RouteModel) HandleClusterHealthUpdate(msg *datav3.HealthCheckEvent) {
 	default:
 		panic(fmt.Sprintf("unexpected corev3.isHealthCheckEvent_Event: %#v", event))
 	}
+	m.hydrateHealthStatus(&affected)
 	m.Put(affected)
+}
+
+func (m *RouteModel) hydrateHealthStatus(route *Route) {
+	status := "--"
+	health := "--"
+	if _, ok := m.activePortForwards[route.ClusterID]; ok {
+		status = EndpointStatusActive
+		if stat, ok := m.clusterEndpointStatus[route.ClusterID]; ok {
+			status = stat
+		}
+		health = m.clusterHealth[route.ClusterID]
+		if health == "" {
+			health = HealthUnknown
+		}
+	}
+	route.Status = status
+	route.Health = health
 }
 
 func (m *RouteModel) EditRoute(route Route) {

--- a/pkg/ssh/tui/core/double_buffer.go
+++ b/pkg/ssh/tui/core/double_buffer.go
@@ -1,0 +1,62 @@
+package core
+
+import (
+	"sync"
+	"sync/atomic"
+
+	uv "github.com/charmbracelet/ultraviolet"
+)
+
+type buffer struct {
+	uv.ScreenBuffer
+	width, height int
+	mu            sync.Mutex
+	_             [24]byte // pad to cache line
+}
+
+type DoubleBuffer struct {
+	buffers [2]buffer
+	back    *buffer
+	front   atomic.Pointer[buffer]
+}
+
+func NewDoubleBuffer() *DoubleBuffer {
+	db := &DoubleBuffer{
+		buffers: [2]buffer{
+			{
+				ScreenBuffer: uv.NewScreenBuffer(0, 0),
+			},
+			{
+				ScreenBuffer: uv.NewScreenBuffer(0, 0),
+			},
+		},
+	}
+	db.back = &db.buffers[0]
+	db.back.mu.Lock()
+	db.front.Store(&db.buffers[1])
+	return db
+}
+
+func (db *DoubleBuffer) UpdateView(width, height int, drawable uv.Drawable) {
+	back := db.back
+	if back.width != width || back.height != height {
+		back.width = width
+		back.height = height
+		back.ScreenBuffer = uv.NewScreenBuffer(width, height)
+	}
+	drawable.Draw(back, uv.Rect(0, 0, back.width, back.height))
+	db.swap()
+}
+
+func (db *DoubleBuffer) Draw(scr uv.Screen, area uv.Rectangle) {
+	front := db.front.Load()
+	front.mu.Lock()
+	defer front.mu.Unlock()
+	front.Draw(scr, area)
+}
+
+func (db *DoubleBuffer) swap() {
+	db.back.mu.Unlock()              // unlock the current back buffer
+	db.back = db.front.Swap(db.back) // swap the front and back buffers
+	db.back.mu.Lock()                // wait for the previous frame to finish rendering
+}

--- a/pkg/ssh/tui/core/tea_listener.go
+++ b/pkg/ssh/tui/core/tea_listener.go
@@ -1,0 +1,37 @@
+package core
+
+import (
+	"slices"
+
+	tea "charm.land/bubbletea/v2"
+
+	"github.com/pomerium/pomerium/pkg/ssh/models"
+)
+
+type TeaMsgSender interface {
+	SendTeaMsg(msg tea.Msg)
+}
+
+type TeaListener[T models.Item[K], K comparable] struct {
+	sender TeaMsgSender
+}
+
+func NewTeaListener[T models.Item[K], K comparable](sender TeaMsgSender) *TeaListener[T, K] {
+	return &TeaListener[T, K]{
+		sender: sender,
+	}
+}
+
+func (tl *TeaListener[T, K]) OnIndexUpdate(begin models.Index, end models.Index, items []T) {
+	tl.sender.SendTeaMsg(models.IndexUpdateMsg[T, K]{
+		Begin: begin,
+		End:   end,
+		Items: slices.Clone(items),
+	})
+}
+
+func (tl *TeaListener[T, K]) OnModelReset(items []T) {
+	tl.sender.SendTeaMsg(models.ModelResetMsg[T, K]{
+		Items: slices.Clone(items),
+	})
+}

--- a/pkg/ssh/tui/tunnel/components/channels/component.go
+++ b/pkg/ssh/tui/tunnel/components/channels/component.go
@@ -31,8 +31,7 @@ const (
 )
 
 type ComponentFactory struct {
-	config    Config
-	itemModel *models.ChannelModel
+	config Config
 }
 
 type (
@@ -75,15 +74,13 @@ func (c *ComponentFactory) NewWidget(component components.Component) core.Widget
 					},
 				},
 			},
-			c.itemModel,
 		))
 	return w
 }
 
-func NewComponentFactory(config Config, itemModel *models.ChannelModel) components.ComponentFactory {
+func NewComponentFactory(config Config) components.ComponentFactory {
 	return &ComponentFactory{
-		config:    config,
-		itemModel: itemModel,
+		config: config,
 	}
 }
 

--- a/pkg/ssh/tui/tunnel/components/permissions/component.go
+++ b/pkg/ssh/tui/tunnel/components/permissions/component.go
@@ -32,8 +32,7 @@ type (
 )
 
 type ComponentFactory struct {
-	config    Config
-	itemModel *models.PermissionModel
+	config Config
 }
 
 // NewWidget implements components.ComponentFactory.
@@ -61,14 +60,13 @@ func (c *ComponentFactory) NewWidget(component components.Component) core.Widget
 					})
 				},
 			},
-		}, c.itemModel),
+		}),
 	)
 }
 
-func NewComponentFactory(config Config, itemModel *models.PermissionModel) components.ComponentFactory {
+func NewComponentFactory(config Config) components.ComponentFactory {
 	return &ComponentFactory{
-		config:    config,
-		itemModel: itemModel,
+		config: config,
 	}
 }
 

--- a/pkg/ssh/tui/tunnel/components/routes/component.go
+++ b/pkg/ssh/tui/tunnel/components/routes/component.go
@@ -27,8 +27,7 @@ const (
 )
 
 type ComponentFactory struct {
-	config    Config
-	itemModel *models.RouteModel
+	config Config
 }
 
 type (
@@ -67,15 +66,13 @@ func (c *ComponentFactory) NewWidget(component components.Component) core.Widget
 						})
 					},
 				},
-			},
-			c.itemModel),
+			}),
 	)
 }
 
-func NewComponentFactory(config Config, itemModel *models.RouteModel) components.ComponentFactory {
+func NewComponentFactory(config Config) components.ComponentFactory {
 	return &ComponentFactory{
-		config:    config,
-		itemModel: itemModel,
+		config: config,
 	}
 }
 

--- a/pkg/ssh/tui/widgets/dialog/dialog.go
+++ b/pkg/ssh/tui/widgets/dialog/dialog.go
@@ -70,6 +70,7 @@ func (m *Model) Reset(options Options) {
 	m.options.KeyMap.Prev.SetEnabled(len(m.options.Buttons) > 1)
 
 	var buttonCells []layout.RowCell
+	styles := m.config.Styles.Style()
 	for i, bc := range m.options.Buttons {
 		btn := core.NewWidget(strconv.Itoa(i), label.NewModel(label.Config{
 			Styles: style.Bind(m.config.Styles, func(base *Styles) label.Styles {
@@ -87,7 +88,7 @@ func (m *Model) Reset(options Options) {
 		buttonCells = append(buttonCells, layout.RowCell{
 			Title: bc.Label,
 			SizeFunc: func() int {
-				return lipgloss.Width(bc.Label) + m.config.Styles.Style().Button.GetHorizontalFrameSize()
+				return lipgloss.Width(bc.Label) + styles.Button.GetHorizontalFrameSize()
 			},
 			Widget: btn,
 		})
@@ -160,9 +161,10 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 		}
 	case tea.MouseMsg:
 		pos := msg.Mouse()
+		styles := m.config.Styles.Style()
 		// offset by (1, 1) since the border is not part of the canvas
-		offsetX := m.config.Styles.Style().Dialog.GetBorderLeftSize()
-		offsetY := m.config.Styles.Style().Dialog.GetBorderTopSize()
+		offsetX := styles.Dialog.GetBorderLeftSize()
+		offsetY := styles.Dialog.GetBorderTopSize()
 		local, inBounds := m.Parent().TranslateGlobalToLocalPos(uv.Pos(pos.X-offsetX, pos.Y-offsetY))
 		if !inBounds {
 			switch msg.(type) {
@@ -249,12 +251,13 @@ func (m *Model) flashBorder() tea.Cmd {
 func (m *Model) SizeHint() (int, int) {
 	w, h := m.options.Contents.Model().SizeHint()
 	parityAdjust := 0
+	styles := m.config.Styles.Style()
 	if len(m.buttons) > 0 {
 		h++
 		buttonsWidth := 0
 		for _, btn := range m.options.Buttons {
 			buttonsWidth += lipgloss.Width(btn.Label)
-			buttonsWidth += m.config.Styles.Style().Button.GetHorizontalFrameSize()
+			buttonsWidth += styles.Button.GetHorizontalFrameSize()
 		}
 		if m.options.ButtonsAlignment == lipgloss.Center {
 			// If the buttons don't center evenly, increase the total width by 1
@@ -264,8 +267,8 @@ func (m *Model) SizeHint() (int, int) {
 		}
 		w = max(w, buttonsWidth)
 	}
-	w += m.config.Styles.Style().Dialog.GetHorizontalFrameSize() + parityAdjust
-	h += m.config.Styles.Style().Dialog.GetVerticalFrameSize()
+	w += styles.Dialog.GetHorizontalFrameSize() + parityAdjust
+	h += styles.Dialog.GetVerticalFrameSize()
 	return w, h
 }
 
@@ -329,14 +332,16 @@ func (m *Model) KeyMap() help.KeyMap {
 }
 
 func (m *Model) OnResized(w, h int) {
-	m.grid.Resize(max(0, w-m.config.Styles.Style().Dialog.GetHorizontalFrameSize()),
-		max(0, h-m.config.Styles.Style().Dialog.GetVerticalFrameSize()))
+	styles := m.config.Styles.Style()
+	m.grid.Resize(max(0, w-styles.Dialog.GetHorizontalFrameSize()),
+		max(0, h-styles.Dialog.GetVerticalFrameSize()))
 }
 
 func (m *Model) View() uv.Drawable {
-	style := m.config.Styles.Style().Dialog
+	styles := m.config.Styles.Style()
+	style := styles.Dialog
 	if m.borderFlashing {
-		style = m.config.Styles.Style().DialogFlash
+		style = styles.DialogFlash
 	}
 	return uv.NewStyledString(style.Render(m.canvas.Render()))
 }

--- a/pkg/ssh/tui/widgets/logviewer/logs.go
+++ b/pkg/ssh/tui/widgets/logviewer/logs.go
@@ -178,8 +178,9 @@ func (m *Model) scrollToBottom() {
 }
 
 func (m *Model) OnResized(maxWidth, maxHeight int) {
-	maxWidth = max(0, maxWidth-m.config.Styles.Style().Border.GetHorizontalFrameSize())
-	maxHeight = max(0, maxHeight-m.config.Styles.Style().Border.GetVerticalFrameSize())
+	styles := m.config.Styles.Style()
+	maxWidth = max(0, maxWidth-styles.Border.GetHorizontalFrameSize())
+	maxHeight = max(0, maxHeight-styles.Border.GetVerticalFrameSize())
 	shrinkBy := m.height - maxHeight
 	for range int(math.Abs(float64(shrinkBy))) {
 		if shrinkBy < 0 {
@@ -323,9 +324,9 @@ func (m *Model) View() uv.Drawable {
 		}
 	}
 
-	border := m.config.Styles.Style().Border
+	border := styles.Border
 	if m.focused {
-		border = m.config.Styles.Style().BorderFocused
+		border = styles.BorderFocused
 	}
 
 	var sb strings.Builder

--- a/pkg/ssh/tui/widgets/menu/menu.go
+++ b/pkg/ssh/tui/widgets/menu/menu.go
@@ -49,10 +49,11 @@ type Model struct {
 }
 
 func (m *Model) SizeHint() (int, int) {
+	styles := m.config.Styles.Style()
 	x := m.maxLabelWidth +
-		m.config.Styles.Style().Border.GetHorizontalFrameSize() +
-		m.config.Styles.Style().MenuEntry.GetHorizontalFrameSize()
-	y := len(m.options.Entries) + m.config.Styles.Style().Border.GetVerticalFrameSize()
+		styles.Border.GetHorizontalFrameSize() +
+		styles.MenuEntry.GetHorizontalFrameSize()
+	y := len(m.options.Entries) + styles.Border.GetVerticalFrameSize()
 	return x, y
 }
 
@@ -150,10 +151,11 @@ func (m *Model) Update(msg tea.Msg) tea.Cmd {
 }
 
 func (m *Model) hitTest(localPos uv.Position) (int, bool) {
+	styles := m.config.Styles.Style()
 	rect := uv.Rect(
-		m.config.Styles.Style().Border.GetBorderLeftSize()+m.config.Styles.Style().SelectedMenuEntry.GetMarginLeft(),
-		m.config.Styles.Style().Border.GetBorderTopSize(), // assumes no vertical padding
-		m.maxLabelWidth+m.config.Styles.Style().SelectedMenuEntry.GetHorizontalPadding(),
+		styles.Border.GetBorderLeftSize()+styles.SelectedMenuEntry.GetMarginLeft(),
+		styles.Border.GetBorderTopSize(), // assumes no vertical padding
+		m.maxLabelWidth+styles.SelectedMenuEntry.GetHorizontalPadding(),
 		len(m.options.Entries))
 	if localPos.In(rect) {
 		return localPos.Y - rect.Min.Y, true
@@ -197,19 +199,20 @@ func (m *Model) KeyMap() help.KeyMap {
 func (m *Model) OnResized(_, _ int) {}
 
 func (m *Model) View() uv.Drawable {
+	styles := m.config.Styles.Style()
 	labels := make([]string, 0, len(m.options.Entries))
 	for i, e := range m.options.Entries {
 		width := lipgloss.Width(e.Label)
 		var style lipgloss.Style
 		if m.hovered == i {
-			style = m.config.Styles.Style().SelectedMenuEntry
+			style = styles.SelectedMenuEntry
 		} else {
-			style = m.config.Styles.Style().MenuEntry
+			style = styles.MenuEntry
 		}
 		if width < m.maxLabelWidth {
 			style = style.PaddingRight(style.GetPaddingRight() + (m.maxLabelWidth - width))
 		}
 		labels = append(labels, style.Render(e.Label))
 	}
-	return uv.NewStyledString(m.config.Styles.Style().Border.Render(lipgloss.JoinVertical(lipgloss.Left, labels...)))
+	return uv.NewStyledString(styles.Border.Render(lipgloss.JoinVertical(lipgloss.Left, labels...)))
 }


### PR DESCRIPTION
This fixes several data races related to concurrent rendering and model updating. Some model callbacks were changed to be propagated using tea.Msg instead, and the top level model uses a new double-buffer drawable to ensure View() is always called from the same thread as Update.