### PR TITLE
authorize: add missing MCP explanation trace

### DIFF
--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -129,6 +129,7 @@ func TestAuthorize_handleResult(t *testing.T) {
 		res, err := a.handleResult(t.Context(),
 			&envoy_service_auth_v3.CheckRequest{},
 			&evaluator.Request{
+				HTTP:   evaluator.RequestHTTP{Host: "example.com"},
 				Policy: &config.Policy{MCP: &config.MCP{Server: &config.MCPServer{}}},
 			},
 			&evaluator.Result{
@@ -136,6 +137,12 @@ func TestAuthorize_handleResult(t *testing.T) {
 			})
 		assert.NoError(t, err)
 		assert.Equal(t, 401, int(res.GetDeniedResponse().GetStatus().GetCode()))
+		assertContainsHeaderValue(t,
+			"Www-Authenticate",
+			`Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"`,
+			res.GetDeniedResponse().GetHeaders())
+		assert.Contains(t, res.GetDeniedResponse().GetBody(),
+			"This is an MCP route. It is not meant to be accessed directly in the browser.")
 	})
 	t.Run("mcp-route-user-unauthenticated, mcp flag is off", func(t *testing.T) {
 		opt.RuntimeFlags[config.RuntimeFlagMCP] = false


### PR DESCRIPTION
## Summary

I had previously added some custom MCP error page explanation text in the handleResultDenied() method. However there is also special MCP error page handling in the requireLoginResponse() method, which I had missed.

Extract the logic for adding the error page explanation text to its own method, and call this new method from both MCP error code paths.

## Related issues

https://linear.app/pomerium/issue/ENG-3388/zero-401-on-mcp-routes-lacks-clear-explanationrecovery

## User Explanation

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
