### PR TITLE
fix: add remaining keepalives for databroker follower clients & admin endpoint

### DIFF
--- a/config/envoyconfig/bootstrap.go
+++ b/config/envoyconfig/bootstrap.go
@@ -259,7 +259,7 @@ func (b *Builder) BuildBootstrapStaticResources(
 				},
 			},
 		},
-		TypedExtensionProtocolOptions: buildTypedExtensionProtocolOptions(nil, upstreamProtocolHTTP2, Keepalive(false)),
+		TypedExtensionProtocolOptions: buildTypedExtensionProtocolOptions(nil, upstreamProtocolHTTP2, Keepalive(true)),
 		CircuitBreakers:               buildInternalCircuitBreakers(cfg),
 	}
 

--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -103,6 +103,12 @@ func TestBuilder_BuildBootstrapStaticResources(t *testing.T) {
 								"explicitHttpConfig": {
 									"http2ProtocolOptions": {
 										"allowConnect": true,
+										"connectionKeepalive": {
+											"connectionIdleInterval": "300s",
+											"interval": "360s",
+											"intervalJitter": {"value": 15},
+											"timeout": "60s"
+										},
 										"initialConnectionWindowSize": 1048576,
 										"initialStreamWindowSize": 65536,
 										"maxConcurrentStreams": 100

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -88,7 +88,6 @@ func (b *Builder) BuildListeners(
 		return nil, err
 	}
 	listeners = append(listeners, li)
-
 	return listeners, nil
 }
 

--- a/config/envoyconfig/listeners_grpc.go
+++ b/config/envoyconfig/listeners_grpc.go
@@ -92,6 +92,8 @@ func (b *Builder) buildGRPCHTTPConnectionManagerFilter() *envoy_config_listener_
 						Cluster: "pomerium-control-plane-grpc",
 					},
 					// disable the timeout to support grpc streaming
+					// setting the timeout to 0 might not disable it envoy
+					// see github.com/envoyproxy/envoy/issues/35812
 					Timeout: &durationpb.Duration{
 						Seconds: 0,
 					},


### PR DESCRIPTION
## Summary

Adds client keepalives to databroker clients used by cluster followers.

Ensures the admin cluster pomerium-control-plane-grpc also has keepalives.


## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
