### PR TITLE
mcp: add upstream OAuth discovery core functions (RFC 9728/8414)

### DIFF
--- a/internal/mcp/testdata/github_authorization_server_metadata.json
+++ b/internal/mcp/testdata/github_authorization_server_metadata.json
@@ -1,0 +1,9 @@
+{
+  "issuer": "https://github.com/login/oauth",
+  "authorization_endpoint": "https://github.com/login/oauth/authorize",
+  "token_endpoint": "https://github.com/login/oauth/access_token",
+  "response_types_supported": ["code"],
+  "grant_types_supported": ["authorization_code", "refresh_token"],
+  "service_documentation": "https://docs.github.com/apps/creating-github-apps/registering-a-github-app/registering-a-github-app",
+  "code_challenge_methods_supported": ["S256"]
+}

--- a/internal/mcp/testdata/github_protected_resource_metadata.json
+++ b/internal/mcp/testdata/github_protected_resource_metadata.json
@@ -1,0 +1,20 @@
+{
+  "resource_name": "GitHub MCP Server",
+  "resource": "https://api.githubcopilot.com/mcp",
+  "authorization_servers": ["https://github.com/login/oauth"],
+  "bearer_methods_supported": ["header"],
+  "scopes_supported": [
+    "gist",
+    "notifications",
+    "public_repo",
+    "repo",
+    "repo:status",
+    "repo_deployment",
+    "user",
+    "user:email",
+    "user:follow",
+    "read:gpg_key",
+    "read:org",
+    "project"
+  ]
+}

--- a/internal/mcp/upstream_discovery.go
+++ b/internal/mcp/upstream_discovery.go
@@ -1,0 +1,191 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"slices"
+	"strings"
+)
+
+// maxMetadataResponseBytes is the maximum size of a metadata response body.
+// OAuth metadata documents are small JSON; 1 MB is generous.
+const maxMetadataResponseBytes = 1 << 20
+
+// FetchProtectedResourceMetadata fetches and parses OAuth 2.0 Protected Resource Metadata
+// (RFC 9728) from the given URL. The URL is typically obtained from the resource_metadata
+// parameter in a WWW-Authenticate header, or constructed as a well-known fallback.
+//
+// Validates that the required fields (resource, authorization_servers) are present per RFC 9728 §4.
+func FetchProtectedResourceMetadata(
+	ctx context.Context,
+	client *http.Client,
+	metadataURL string,
+) (*ProtectedResourceMetadata, error) {
+	var meta ProtectedResourceMetadata
+	if err := fetchJSON(ctx, client, metadataURL, &meta); err != nil {
+		return nil, err
+	}
+	if err := ValidateProtectedResourceMetadata(&meta); err != nil {
+		return nil, err
+	}
+	return &meta, nil
+}
+
+// FetchAuthorizationServerMetadata fetches and parses OAuth 2.0 Authorization Server Metadata
+// (RFC 8414) from the given issuer URL. It tries endpoints in the MCP-specified priority order:
+//
+// For issuer URLs with path components:
+//  1. {origin}/.well-known/oauth-authorization-server/{path}
+//  2. {origin}/.well-known/openid-configuration/{path}
+//  3. {origin}/{path}/.well-known/openid-configuration
+//
+// For issuer URLs without path:
+//  1. {origin}/.well-known/oauth-authorization-server
+//  2. {origin}/.well-known/openid-configuration
+//
+// Validates MCP requirements: code_challenge_methods_supported MUST include "S256",
+// grant_types_supported MUST include "authorization_code".
+func FetchAuthorizationServerMetadata(
+	ctx context.Context,
+	client *http.Client,
+	issuerURL string,
+) (*AuthorizationServerMetadata, error) {
+	urls, err := BuildAuthorizationServerMetadataURLs(issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("building AS metadata URLs: %w", err)
+	}
+
+	var lastErr error
+	for _, u := range urls {
+		var meta AuthorizationServerMetadata
+		if err := fetchJSON(ctx, client, u, &meta); err != nil {
+			lastErr = err
+			continue
+		}
+		if err := ValidateAuthorizationServerMetadata(&meta); err != nil {
+			lastErr = err
+			continue
+		}
+		return &meta, nil
+	}
+
+	if lastErr != nil {
+		return nil, fmt.Errorf("authorization server metadata not found at any well-known endpoint: %w", lastErr)
+	}
+	return nil, fmt.Errorf("authorization server metadata not found at any well-known endpoint")
+}
+
+// BuildProtectedResourceMetadataURLs returns the well-known URLs to probe for
+// Protected Resource Metadata when the WWW-Authenticate header lacks a resource_metadata parameter.
+//
+// Per RFC 9728, the well-known path is /.well-known/oauth-protected-resource.
+// For URLs with path components, it returns both the path-suffixed and root variants.
+func BuildProtectedResourceMetadataURLs(upstreamURL string) ([]string, error) {
+	u, err := url.Parse(upstreamURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing upstream URL: %w", err)
+	}
+
+	origin := url.URL{Scheme: u.Scheme, Host: u.Host}
+	p := strings.TrimSuffix(u.Path, "/")
+
+	if p == "" {
+		return []string{
+			origin.String() + WellKnownProtectedResourceEndpoint,
+		}, nil
+	}
+
+	return []string{
+		origin.String() + path.Join(WellKnownProtectedResourceEndpoint, p),
+		origin.String() + WellKnownProtectedResourceEndpoint,
+	}, nil
+}
+
+// BuildAuthorizationServerMetadataURLs returns the well-known URLs to try for
+// Authorization Server Metadata discovery in the MCP-specified priority order.
+func BuildAuthorizationServerMetadataURLs(issuerURL string) ([]string, error) {
+	u, err := url.Parse(issuerURL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing issuer URL: %w", err)
+	}
+
+	origin := url.URL{Scheme: u.Scheme, Host: u.Host}
+	p := strings.TrimSuffix(u.Path, "/")
+
+	if p == "" {
+		return []string{
+			origin.String() + "/.well-known/oauth-authorization-server",
+			origin.String() + "/.well-known/openid-configuration",
+		}, nil
+	}
+
+	return []string{
+		origin.String() + "/.well-known/oauth-authorization-server" + p,
+		origin.String() + "/.well-known/openid-configuration" + p,
+		origin.String() + p + "/.well-known/openid-configuration",
+	}, nil
+}
+
+// ValidateProtectedResourceMetadata validates that a ProtectedResourceMetadata
+// document contains the required fields per RFC 9728 §4.
+func ValidateProtectedResourceMetadata(meta *ProtectedResourceMetadata) error {
+	if meta == nil {
+		return fmt.Errorf("nil protected resource metadata")
+	}
+	if meta.Resource == "" {
+		return fmt.Errorf("protected resource metadata: resource is required")
+	}
+	if len(meta.AuthorizationServers) == 0 {
+		return fmt.Errorf("protected resource metadata: authorization_servers must contain at least one entry")
+	}
+	return nil
+}
+
+// ValidateAuthorizationServerMetadata validates that an AuthorizationServerMetadata
+// document meets MCP requirements:
+// - code_challenge_methods_supported MUST include "S256" (MCP requires PKCE)
+// - grant_types_supported MUST include "authorization_code"
+func ValidateAuthorizationServerMetadata(meta *AuthorizationServerMetadata) error {
+	if meta == nil {
+		return fmt.Errorf("nil authorization server metadata")
+	}
+	if !slices.Contains(meta.CodeChallengeMethodsSupported, "S256") {
+		return fmt.Errorf("authorization server metadata: code_challenge_methods_supported must include S256 (MCP requires PKCE)")
+	}
+	// Per RFC 8414 §2, if grant_types_supported is omitted, the default is
+	// ["authorization_code", "implicit"], which includes authorization_code.
+	if meta.GrantTypesSupported != nil && !slices.Contains(meta.GrantTypesSupported, "authorization_code") {
+		return fmt.Errorf("authorization server metadata: grant_types_supported must include authorization_code")
+	}
+	return nil
+}
+
+// fetchJSON fetches a URL and decodes the JSON response into dst.
+// Returns an error if the response status is not 200 OK.
+func fetchJSON(ctx context.Context, client *http.Client, url string, dst any) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return fmt.Errorf("creating request for %s: %w", url, err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("fetching %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("fetching %s: unexpected status %d", url, resp.StatusCode)
+	}
+
+	if err := json.NewDecoder(io.LimitReader(resp.Body, maxMetadataResponseBytes)).Decode(dst); err != nil {
+		return fmt.Errorf("decoding JSON from %s: %w", url, err)
+	}
+	return nil
+}

--- a/internal/mcp/upstream_discovery_test.go
+++ b/internal/mcp/upstream_discovery_test.go
@@ -1,0 +1,690 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func loadTestdata(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	require.NoError(t, err)
+	return data
+}
+
+func TestFetchProtectedResourceMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		handler     http.HandlerFunc
+		expected    *ProtectedResourceMetadata
+		expectError string
+	}{
+		{
+			name: "github MCP server metadata",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(loadTestdata(t, "github_protected_resource_metadata.json"))
+			},
+			expected: &ProtectedResourceMetadata{
+				ResourceName:           "GitHub MCP Server",
+				Resource:               "https://api.githubcopilot.com/mcp",
+				AuthorizationServers:   []string{"https://github.com/login/oauth"},
+				BearerMethodsSupported: []string{"header"},
+				ScopesSupported: []string{
+					"gist", "notifications", "public_repo", "repo",
+					"repo:status", "repo_deployment", "user", "user:email",
+					"user:follow", "read:gpg_key", "read:org", "project",
+				},
+			},
+		},
+		{
+			name: "minimal valid metadata",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+					Resource:             "https://example.com/mcp",
+					AuthorizationServers: []string{"https://auth.example.com"},
+				})
+			},
+			expected: &ProtectedResourceMetadata{
+				Resource:             "https://example.com/mcp",
+				AuthorizationServers: []string{"https://auth.example.com"},
+			},
+		},
+		{
+			name: "missing resource field fails validation",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+					AuthorizationServers: []string{"https://auth.example.com"},
+				})
+			},
+			expectError: "resource",
+		},
+		{
+			name: "missing authorization_servers fails validation",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+					Resource: "https://example.com/mcp",
+				})
+			},
+			expectError: "authorization_servers",
+		},
+		{
+			name: "empty authorization_servers fails validation",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+					Resource:             "https://example.com/mcp",
+					AuthorizationServers: []string{},
+				})
+			},
+			expectError: "authorization_servers",
+		},
+		{
+			name: "server returns 404",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			expectError: "404",
+		},
+		{
+			name: "server returns invalid JSON",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`{invalid json`))
+			},
+			expectError: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			result, err := FetchProtectedResourceMetadata(context.Background(), srv.Client(), srv.URL)
+			if tc.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+				return
+			}
+			if tc.expected == nil {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestFetchAuthorizationServerMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		handler     http.HandlerFunc
+		expected    *AuthorizationServerMetadata
+		expectError string
+	}{
+		{
+			name: "github authorization server metadata",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(loadTestdata(t, "github_authorization_server_metadata.json"))
+			},
+			expected: &AuthorizationServerMetadata{
+				Issuer:                        "https://github.com/login/oauth",
+				AuthorizationEndpoint:         "https://github.com/login/oauth/authorize",
+				TokenEndpoint:                 "https://github.com/login/oauth/access_token",
+				ResponseTypesSupported:        []string{"code"},
+				GrantTypesSupported:           []string{"authorization_code", "refresh_token"},
+				ServiceDocumentation:          "https://docs.github.com/apps/creating-github-apps/registering-a-github-app/registering-a-github-app",
+				CodeChallengeMethodsSupported: []string{"S256"},
+			},
+		},
+		{
+			name: "minimal valid AS metadata",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+					Issuer:                        "https://auth.example.com",
+					AuthorizationEndpoint:         "https://auth.example.com/authorize",
+					TokenEndpoint:                 "https://auth.example.com/token",
+					ResponseTypesSupported:        []string{"code"},
+					GrantTypesSupported:           []string{"authorization_code"},
+					CodeChallengeMethodsSupported: []string{"S256"},
+				})
+			},
+			expected: &AuthorizationServerMetadata{
+				Issuer:                        "https://auth.example.com",
+				AuthorizationEndpoint:         "https://auth.example.com/authorize",
+				TokenEndpoint:                 "https://auth.example.com/token",
+				ResponseTypesSupported:        []string{"code"},
+				GrantTypesSupported:           []string{"authorization_code"},
+				CodeChallengeMethodsSupported: []string{"S256"},
+			},
+		},
+		{
+			name: "server returns 404 on all well-known endpoints",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			expectError: "not found",
+		},
+		{
+			name: "server returns invalid JSON",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(`not json`))
+			},
+			expectError: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			srv := httptest.NewServer(tc.handler)
+			defer srv.Close()
+
+			// Use the server URL as the issuer URL (no path, so it should try
+			// /.well-known/oauth-authorization-server then /.well-known/openid-configuration)
+			result, err := FetchAuthorizationServerMetadata(context.Background(), srv.Client(), srv.URL)
+			if tc.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+				return
+			}
+			if tc.expected == nil {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestFetchAuthorizationServerMetadata_PathBasedIssuer(t *testing.T) {
+	t.Parallel()
+
+	// Simulate GitHub's path-based issuer: https://github.com/login/oauth
+	// The spec says to try:
+	// 1. /.well-known/oauth-authorization-server/login/oauth
+	// 2. /.well-known/openid-configuration/login/oauth
+	// 3. /login/oauth/.well-known/openid-configuration
+
+	t.Run("finds metadata at first well-known path", func(t *testing.T) {
+		t.Parallel()
+		var requestedPaths []string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestedPaths = append(requestedPaths, r.URL.Path)
+			if r.URL.Path == "/.well-known/oauth-authorization-server/login/oauth" {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(loadTestdata(t, "github_authorization_server_metadata.json"))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		result, err := FetchAuthorizationServerMetadata(context.Background(), srv.Client(), srv.URL+"/login/oauth")
+		require.NoError(t, err)
+		assert.Equal(t, "https://github.com/login/oauth", result.Issuer)
+		// Should only have made one request since the first one succeeded
+		assert.Equal(t, []string{"/.well-known/oauth-authorization-server/login/oauth"}, requestedPaths)
+	})
+
+	t.Run("falls back to second well-known path", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/.well-known/openid-configuration/login/oauth" {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(loadTestdata(t, "github_authorization_server_metadata.json"))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		result, err := FetchAuthorizationServerMetadata(context.Background(), srv.Client(), srv.URL+"/login/oauth")
+		require.NoError(t, err)
+		assert.Equal(t, "https://github.com/login/oauth", result.Issuer)
+	})
+
+	t.Run("falls back to third well-known path", func(t *testing.T) {
+		t.Parallel()
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path == "/login/oauth/.well-known/openid-configuration" {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write(loadTestdata(t, "github_authorization_server_metadata.json"))
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		result, err := FetchAuthorizationServerMetadata(context.Background(), srv.Client(), srv.URL+"/login/oauth")
+		require.NoError(t, err)
+		assert.Equal(t, "https://github.com/login/oauth", result.Issuer)
+	})
+}
+
+func TestFetchAuthorizationServerMetadata_RequestOrder(t *testing.T) {
+	t.Parallel()
+
+	t.Run("no-path issuer tries correct endpoints in order", func(t *testing.T) {
+		t.Parallel()
+		var requestedPaths []string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestedPaths = append(requestedPaths, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		_, err := FetchAuthorizationServerMetadata(context.Background(), srv.Client(), srv.URL)
+		require.Error(t, err)
+		assert.Equal(t, []string{
+			"/.well-known/oauth-authorization-server",
+			"/.well-known/openid-configuration",
+		}, requestedPaths)
+	})
+
+	t.Run("path-based issuer tries correct endpoints in order", func(t *testing.T) {
+		t.Parallel()
+		var requestedPaths []string
+
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestedPaths = append(requestedPaths, r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		_, err := FetchAuthorizationServerMetadata(context.Background(), srv.Client(), srv.URL+"/login/oauth")
+		require.Error(t, err)
+		assert.Equal(t, []string{
+			"/.well-known/oauth-authorization-server/login/oauth",
+			"/.well-known/openid-configuration/login/oauth",
+			"/login/oauth/.well-known/openid-configuration",
+		}, requestedPaths)
+	})
+}
+
+func TestFetchAuthorizationServerMetadata_ValidationFailureFallthrough(t *testing.T) {
+	t.Parallel()
+
+	t.Run("first endpoint returns metadata failing validation, second succeeds", func(t *testing.T) {
+		t.Parallel()
+
+		// First endpoint returns metadata without S256 (fails validation),
+		// second endpoint returns valid metadata.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/.well-known/oauth-authorization-server":
+				// Missing S256 — fails ValidateAuthorizationServerMetadata
+				json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+					Issuer:                        "https://auth.example.com",
+					AuthorizationEndpoint:         "https://auth.example.com/authorize",
+					TokenEndpoint:                 "https://auth.example.com/token",
+					ResponseTypesSupported:        []string{"code"},
+					GrantTypesSupported:           []string{"authorization_code"},
+					CodeChallengeMethodsSupported: []string{"plain"},
+				})
+			case "/.well-known/openid-configuration":
+				// Valid — includes S256
+				json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+					Issuer:                        "https://auth.example.com",
+					AuthorizationEndpoint:         "https://auth.example.com/authorize",
+					TokenEndpoint:                 "https://auth.example.com/token",
+					ResponseTypesSupported:        []string{"code"},
+					GrantTypesSupported:           []string{"authorization_code"},
+					CodeChallengeMethodsSupported: []string{"S256"},
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+
+		result, err := FetchAuthorizationServerMetadata(context.Background(), srv.Client(), srv.URL)
+		require.NoError(t, err)
+		assert.Equal(t, "https://auth.example.com", result.Issuer)
+		assert.Equal(t, []string{"S256"}, result.CodeChallengeMethodsSupported)
+	})
+}
+
+func TestFetchProtectedResourceMetadata_ContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+			Resource:             "https://example.com",
+			AuthorizationServers: []string{"https://auth.example.com"},
+		})
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	_, err := FetchProtectedResourceMetadata(ctx, srv.Client(), srv.URL)
+	require.Error(t, err)
+}
+
+func TestBuildProtectedResourceMetadataURLs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		upstreamURL string
+		expected    []string
+		expectError bool
+	}{
+		{
+			name:        "root URL",
+			upstreamURL: "https://api.example.com",
+			expected: []string{
+				"https://api.example.com/.well-known/oauth-protected-resource",
+			},
+		},
+		{
+			name:        "URL with path",
+			upstreamURL: "https://api.example.com/mcp",
+			expected: []string{
+				"https://api.example.com/.well-known/oauth-protected-resource/mcp",
+				"https://api.example.com/.well-known/oauth-protected-resource",
+			},
+		},
+		{
+			name:        "URL with deeper path",
+			upstreamURL: "https://api.example.com/v1/mcp/server",
+			expected: []string{
+				"https://api.example.com/.well-known/oauth-protected-resource/v1/mcp/server",
+				"https://api.example.com/.well-known/oauth-protected-resource",
+			},
+		},
+		{
+			name:        "URL with trailing slash treated as root",
+			upstreamURL: "https://api.example.com/",
+			expected: []string{
+				"https://api.example.com/.well-known/oauth-protected-resource",
+			},
+		},
+		{
+			name:        "invalid URL returns error",
+			upstreamURL: "://invalid",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := BuildProtectedResourceMetadataURLs(tc.upstreamURL)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestBuildAuthorizationServerMetadataURLs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		issuerURL   string
+		expected    []string
+		expectError bool
+	}{
+		{
+			name:      "root issuer (no path)",
+			issuerURL: "https://auth.example.com",
+			expected: []string{
+				"https://auth.example.com/.well-known/oauth-authorization-server",
+				"https://auth.example.com/.well-known/openid-configuration",
+			},
+		},
+		{
+			name:      "issuer with path (GitHub-style)",
+			issuerURL: "https://github.com/login/oauth",
+			expected: []string{
+				"https://github.com/.well-known/oauth-authorization-server/login/oauth",
+				"https://github.com/.well-known/openid-configuration/login/oauth",
+				"https://github.com/login/oauth/.well-known/openid-configuration",
+			},
+		},
+		{
+			name:      "issuer with single path segment",
+			issuerURL: "https://auth.example.com/oauth",
+			expected: []string{
+				"https://auth.example.com/.well-known/oauth-authorization-server/oauth",
+				"https://auth.example.com/.well-known/openid-configuration/oauth",
+				"https://auth.example.com/oauth/.well-known/openid-configuration",
+			},
+		},
+		{
+			name:      "issuer with trailing slash treated as root",
+			issuerURL: "https://auth.example.com/",
+			expected: []string{
+				"https://auth.example.com/.well-known/oauth-authorization-server",
+				"https://auth.example.com/.well-known/openid-configuration",
+			},
+		},
+		{
+			name:        "invalid URL returns error",
+			issuerURL:   "://invalid",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := BuildAuthorizationServerMetadataURLs(tc.issuerURL)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func TestValidateProtectedResourceMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		meta        *ProtectedResourceMetadata
+		expectError string
+	}{
+		{
+			name: "valid github metadata",
+			meta: &ProtectedResourceMetadata{
+				Resource:             "https://api.githubcopilot.com/mcp",
+				AuthorizationServers: []string{"https://github.com/login/oauth"},
+				ScopesSupported:      []string{"repo"},
+			},
+		},
+		{
+			name: "valid minimal metadata",
+			meta: &ProtectedResourceMetadata{
+				Resource:             "https://example.com",
+				AuthorizationServers: []string{"https://auth.example.com"},
+			},
+		},
+		{
+			name: "missing resource",
+			meta: &ProtectedResourceMetadata{
+				AuthorizationServers: []string{"https://auth.example.com"},
+			},
+			expectError: "resource",
+		},
+		{
+			name: "missing authorization_servers",
+			meta: &ProtectedResourceMetadata{
+				Resource: "https://example.com",
+			},
+			expectError: "authorization_servers",
+		},
+		{
+			name: "empty authorization_servers",
+			meta: &ProtectedResourceMetadata{
+				Resource:             "https://example.com",
+				AuthorizationServers: []string{},
+			},
+			expectError: "authorization_servers",
+		},
+		{
+			name:        "nil metadata",
+			meta:        nil,
+			expectError: "nil",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateProtectedResourceMetadata(tc.meta)
+			if tc.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestValidateAuthorizationServerMetadata(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		meta        *AuthorizationServerMetadata
+		expectError string
+	}{
+		{
+			name: "valid github AS metadata",
+			meta: &AuthorizationServerMetadata{
+				Issuer:                        "https://github.com/login/oauth",
+				AuthorizationEndpoint:         "https://github.com/login/oauth/authorize",
+				TokenEndpoint:                 "https://github.com/login/oauth/access_token",
+				ResponseTypesSupported:        []string{"code"},
+				GrantTypesSupported:           []string{"authorization_code", "refresh_token"},
+				CodeChallengeMethodsSupported: []string{"S256"},
+			},
+		},
+		{
+			name: "valid minimal metadata",
+			meta: &AuthorizationServerMetadata{
+				Issuer:                        "https://auth.example.com",
+				AuthorizationEndpoint:         "https://auth.example.com/authorize",
+				TokenEndpoint:                 "https://auth.example.com/token",
+				ResponseTypesSupported:        []string{"code"},
+				GrantTypesSupported:           []string{"authorization_code"},
+				CodeChallengeMethodsSupported: []string{"S256"},
+			},
+		},
+		{
+			name: "missing S256 in code_challenge_methods_supported",
+			meta: &AuthorizationServerMetadata{
+				Issuer:                        "https://auth.example.com",
+				AuthorizationEndpoint:         "https://auth.example.com/authorize",
+				TokenEndpoint:                 "https://auth.example.com/token",
+				ResponseTypesSupported:        []string{"code"},
+				GrantTypesSupported:           []string{"authorization_code"},
+				CodeChallengeMethodsSupported: []string{"plain"},
+			},
+			expectError: "S256",
+		},
+		{
+			name: "empty code_challenge_methods_supported",
+			meta: &AuthorizationServerMetadata{
+				Issuer:                 "https://auth.example.com",
+				AuthorizationEndpoint:  "https://auth.example.com/authorize",
+				TokenEndpoint:          "https://auth.example.com/token",
+				ResponseTypesSupported: []string{"code"},
+				GrantTypesSupported:    []string{"authorization_code"},
+			},
+			expectError: "S256",
+		},
+		{
+			name: "missing authorization_code grant type",
+			meta: &AuthorizationServerMetadata{
+				Issuer:                        "https://auth.example.com",
+				AuthorizationEndpoint:         "https://auth.example.com/authorize",
+				TokenEndpoint:                 "https://auth.example.com/token",
+				ResponseTypesSupported:        []string{"code"},
+				GrantTypesSupported:           []string{"client_credentials"},
+				CodeChallengeMethodsSupported: []string{"S256"},
+			},
+			expectError: "authorization_code",
+		},
+		{
+			name: "empty grant_types_supported array fails validation",
+			meta: &AuthorizationServerMetadata{
+				Issuer:                        "https://auth.example.com",
+				AuthorizationEndpoint:         "https://auth.example.com/authorize",
+				TokenEndpoint:                 "https://auth.example.com/token",
+				ResponseTypesSupported:        []string{"code"},
+				GrantTypesSupported:           []string{},
+				CodeChallengeMethodsSupported: []string{"S256"},
+			},
+			expectError: "authorization_code",
+		},
+		{
+			name: "nil grant_types_supported defaults to authorization_code per RFC 8414",
+			meta: &AuthorizationServerMetadata{
+				Issuer:                        "https://auth.example.com",
+				AuthorizationEndpoint:         "https://auth.example.com/authorize",
+				TokenEndpoint:                 "https://auth.example.com/token",
+				ResponseTypesSupported:        []string{"code"},
+				CodeChallengeMethodsSupported: []string{"S256"},
+			},
+		},
+		{
+			name:        "nil metadata",
+			meta:        nil,
+			expectError: "nil",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := ValidateAuthorizationServerMetadata(tc.meta)
+			if tc.expectError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.expectError)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}

--- a/internal/mcp/www_authenticate.go
+++ b/internal/mcp/www_authenticate.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"strings"
+
+	"github.com/shogo82148/go-sfv"
+)
+
+// WWWAuthenticateParams represents parsed parameters from a Bearer WWW-Authenticate header.
+// Used when Pomerium acts as a client to remote MCP servers, parsing the upstream's 401 response.
+type WWWAuthenticateParams struct {
+	// Realm is the optional protection realm.
+	Realm string
+
+	// Error is the error code, e.g., "insufficient_scope" (RFC 6750 §3.1).
+	Error string
+
+	// ErrorDescription is a human-readable error description.
+	ErrorDescription string
+
+	// Scope contains the required scopes (space-delimited in the header per RFC 6750 §3).
+	// Per MCP spec, scope from WWW-Authenticate takes priority over scopes_supported from PRM.
+	Scope []string
+
+	// ResourceMetadata is the URL to fetch Protected Resource Metadata (RFC 9728 §5.1).
+	ResourceMetadata string
+}
+
+// ParseWWWAuthenticate parses a Bearer WWW-Authenticate header value using go-sfv.
+// It strips the "Bearer " prefix and decodes the remainder as an SFV dictionary,
+// matching the encoding pattern used in SetWWWAuthenticateHeader.
+//
+// Returns nil if the header is empty, not a Bearer challenge, or has malformed SFV.
+func ParseWWWAuthenticate(value string) *WWWAuthenticateParams {
+	if !strings.HasPrefix(value, "Bearer ") {
+		return nil
+	}
+
+	dict, err := sfv.DecodeDictionary([]string{strings.TrimPrefix(value, "Bearer ")})
+	if err != nil {
+		return nil
+	}
+
+	params := &WWWAuthenticateParams{}
+	for _, member := range dict {
+		s, ok := member.Item.Value.(string)
+		if !ok {
+			continue
+		}
+		switch member.Key {
+		case "resource_metadata":
+			params.ResourceMetadata = s
+		case "scope":
+			params.Scope = strings.Fields(s)
+		case "error":
+			params.Error = s
+		case "error_description":
+			params.ErrorDescription = s
+		case "realm":
+			params.Realm = s
+		}
+	}
+	return params
+}

--- a/internal/mcp/www_authenticate_test.go
+++ b/internal/mcp/www_authenticate_test.go
@@ -1,0 +1,97 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseWWWAuthenticate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected *WWWAuthenticateParams
+	}{
+		{
+			name:     "empty string returns nil",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "non-Bearer scheme returns nil",
+			input:    `Basic realm="example"`,
+			expected: nil,
+		},
+		{
+			name:     "Bearer only without params returns empty params",
+			input:    "Bearer ",
+			expected: &WWWAuthenticateParams{},
+		},
+		{
+			name:  "resource_metadata only",
+			input: `Bearer resource_metadata="https://upstream/.well-known/oauth-protected-resource"`,
+			expected: &WWWAuthenticateParams{
+				ResourceMetadata: "https://upstream/.well-known/oauth-protected-resource",
+			},
+		},
+		{
+			name:  "all parameters",
+			input: `Bearer realm="mcp-server", resource_metadata="https://upstream/.well-known/oauth-protected-resource", scope="mcp:read mcp:write", error="insufficient_scope", error_description="Token does not have required scope"`,
+			expected: &WWWAuthenticateParams{
+				Realm:            "mcp-server",
+				ResourceMetadata: "https://upstream/.well-known/oauth-protected-resource",
+				Scope:            []string{"mcp:read", "mcp:write"},
+				Error:            "insufficient_scope",
+				ErrorDescription: "Token does not have required scope",
+			},
+		},
+		{
+			name:  "scope with single value",
+			input: `Bearer scope="mcp:admin"`,
+			expected: &WWWAuthenticateParams{
+				Scope: []string{"mcp:admin"},
+			},
+		},
+		{
+			name:  "insufficient_scope error without scope param",
+			input: `Bearer error="insufficient_scope"`,
+			expected: &WWWAuthenticateParams{
+				Error: "insufficient_scope",
+			},
+		},
+		{
+			name:  "round-trip with SetWWWAuthenticateHeader output",
+			input: `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"`,
+			expected: &WWWAuthenticateParams{
+				ResourceMetadata: "https://example.com/.well-known/oauth-protected-resource",
+			},
+		},
+		{
+			name:  "non-string SFV values are silently skipped",
+			input: `Bearer resource_metadata="https://example.com", max_age=3600`,
+			expected: &WWWAuthenticateParams{
+				ResourceMetadata: "https://example.com",
+			},
+		},
+		{
+			name:     "malformed SFV returns nil",
+			input:    `Bearer !!!invalid`,
+			expected: nil,
+		},
+		{
+			name:     "case sensitive Bearer prefix",
+			input:    `bearer resource_metadata="https://example.com"`,
+			expected: nil, // "bearer" != "Bearer"
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := ParseWWWAuthenticate(tc.input)
+			assert.Equal(t, tc.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Add core upstream discovery functions for MCP proxy OAuth flow, implementing RFC 9728 (Protected Resource Metadata) and RFC 8414 (Authorization Server Metadata):

- `ParseWWWAuthenticate` — parse Bearer WWW-Authenticate headers using go-sfv (round-trip compatible with existing `SetWWWAuthenticateHeader`)
- `FetchProtectedResourceMetadata` / `FetchAuthorizationServerMetadata` — fetch and validate metadata from well-known endpoints
- `BuildProtectedResourceMetadataURLs` / `BuildAuthorizationServerMetadataURLs` — construct well-known URLs with MCP-specified priority order for path-based issuers
- `ValidateProtectedResourceMetadata` / `ValidateAuthorizationServerMetadata` — validate required fields and MCP constraints (PKCE S256, authorization_code grant)

These are stateless core functions that will be consumed by ext_proc for 401/403 response handling. Response body capped at 1MB via `io.LimitReader`.

## Related issues

- ENG-3555

## User Explanation

No user-facing changes. Internal implementation for upcoming upstream MCP server authorization discovery.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review