### PR TITLE
ssh: configure interrupt options for tunnel status command

### DIFF
--- a/pkg/ssh/cli/commands/tunnel_status.go
+++ b/pkg/ssh/cli/commands/tunnel_status.go
@@ -12,6 +12,7 @@ import (
 	"github.com/muesli/termenv"
 	"github.com/spf13/cobra"
 
+	"github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/identity"
 	"github.com/pomerium/pomerium/pkg/ssh/api"
@@ -366,6 +367,12 @@ func NewTunnelCommand(ic cli.InternalCLI, ctrl api.ChannelControlInterface, defa
 			defer ctrl.PermissionDataModel().RemoveListener(permissionListener)
 			ctrl.RouteDataModel().AddListener(routeListener)
 			defer ctrl.RouteDataModel().RemoveListener(routeListener)
+
+			_ = ctrl.SendControlAction(&ssh.SSHChannelControlAction{
+				Action: &ssh.SSHChannelControlAction_SetInterruptOptions{
+					SetInterruptOptions: model.InterruptOptions(),
+				},
+			})
 
 			retModel, err := ic.RunProgram(prog.Program)
 			if err != nil {

--- a/pkg/ssh/tui/tunnel/tunnel_status.go
+++ b/pkg/ssh/tui/tunnel/tunnel_status.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"container/ring"
 	"fmt"
+	"strings"
 
 	"charm.land/bubbles/v2/key"
 	tea "charm.land/bubbletea/v2"
@@ -589,4 +590,22 @@ func (m *Model) View() tea.View {
 // should be called after the program exits.
 func (m *Model) Error() error {
 	return m.exitError
+}
+
+func (m *Model) InterruptOptions() *extensions_ssh.SSHChannelControlAction_InterruptOptions {
+	var buf strings.Builder
+	buf.WriteString(ansi.ResetModeAltScreenSaveCursor) // 1049 l
+	buf.WriteString(ansi.SetModeTextCursorEnable)      // 25 h
+	buf.WriteString(ansi.ResetModeBracketedPaste)      // 2004 l
+	buf.WriteString(ansi.ResetModeMouseButtonEvent)    // 1002 l
+	buf.WriteString(ansi.ResetModeMouseAnyEvent)       // 1003 l
+	buf.WriteString(ansi.ResetModeMouseExtSgr)         // 1006 l
+
+	if m.config.Styles.Style().BackgroundColor != nil {
+		buf.WriteString(ansi.ResetBackgroundColor)
+	}
+
+	return &extensions_ssh.SSHChannelControlAction_InterruptOptions{
+		SendChannelData: []byte(buf.String()),
+	}
 }


### PR DESCRIPTION
This configures interrupt options for the tunnel status command in the internal CLI, which should reset all modified terminal modes.