### PR TITLE
databroker: add CompositeRecordID utility for building record IDs

### DIFF
--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -1,6 +1,6 @@
 {
   "config": "v0.15.0",
   "hosted-authenticate-oidc": "v0.1.0",
-  "mcp": "v0.13.0",
+  "mcp": "v0.14.0",
   "ssh": "v0.10.0"
 }

--- a/pkg/grpc/databroker/databroker.go
+++ b/pkg/grpc/databroker/databroker.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/url"
 
 	"google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
@@ -167,6 +168,17 @@ func (x *QueryRequest) SetFilterByIDOrIndex(idOrIndex string) {
 
 // default is 4MB, but we'll do 1MB
 const maxMessageSize = 1024 * 1024 * 1
+
+// CompositeRecordID builds a deterministic record ID from key-value pairs
+// using URL query string encoding. Keys are sorted alphabetically to ensure
+// consistent output regardless of map iteration order.
+func CompositeRecordID(m map[string]any) string {
+	v := make(url.Values, len(m))
+	for key, val := range m {
+		v.Set(key, fmt.Sprint(val))
+	}
+	return v.Encode()
+}
 
 // OptimumPutRequestsFromRecords creates one or more PutRequests from a slice of records.
 // If the size of the request exceeds the max message size it will be split in half


### PR DESCRIPTION
## Summary

Add `CompositeRecordID(map[string]any) string` utility to `pkg/grpc/databroker` that builds deterministic, URL-safe composite record IDs using `url.Values.Encode()`. Migrate all pipe-separated (`|`) composite key constructions in MCP storage to use dedicated helper functions backed by the new utility.

## Related issues

## User Explanation

No user-facing changes.

## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review