### PR TITLE
acceptance: remove unneeded clearAuthState() calls

### DIFF
--- a/internal/acceptance/browser/tests/authn/csrf-protection.spec.ts
+++ b/internal/acceptance/browser/tests/authn/csrf-protection.spec.ts
@@ -9,17 +9,12 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { clearAuthState } from "../../helpers/authn-flow.js";
 import { tamperCSRFCookie, removeCSRFCookie } from "../../helpers/csrf.js";
 import { getSessionCookie } from "../../helpers/cookies.js";
 import { testUsers } from "../../fixtures/users.js";
 import { urls, paths } from "../../fixtures/test-data.js";
 
 test.describe("CSRF/State Protection", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("should reject callback with missing state parameter", async ({ page }) => {
     // Construct a callback URL without state
     const callbackUrl = new URL(
@@ -145,5 +140,4 @@ test.describe("CSRF/State Protection", () => {
       "Missing CSRF cookie should cause validation failure"
     ).toBe(true);
   });
-
 });

--- a/internal/acceptance/browser/tests/authn/login.spec.ts
+++ b/internal/acceptance/browser/tests/authn/login.spec.ts
@@ -9,17 +9,12 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { login, clearAuthState, isLoggedIn } from "../../helpers/authn-flow.js";
+import { login, isLoggedIn } from "../../helpers/authn-flow.js";
 import { getSessionCookie } from "../../helpers/cookies.js";
 import { testUsers } from "../../fixtures/users.js";
 import { urls } from "../../fixtures/test-data.js";
 
 test.describe("Auth Code Flow Login", () => {
-  test.beforeEach(async ({ page }) => {
-    // Clear any existing auth state
-    await clearAuthState(page);
-  });
-
   test("should redirect unauthenticated user to Keycloak login", async ({ page }) => {
     // Navigate to protected resource
     await page.goto(urls.app, {
@@ -63,7 +58,6 @@ test.describe("Auth Code Flow Login", () => {
     expect(await isLoggedIn(page)).toBe(true);
   });
 
-
   test("should preserve target URL after login redirect", async ({ page }) => {
     const user = testUsers.alice;
     const targetPath = "/by-group";
@@ -92,7 +86,6 @@ test.describe("Auth Code Flow Login", () => {
       );
     }, { timeout: 15000 });
   });
-
 
   test("should request correct OIDC scopes", async ({ page }) => {
     // Navigate to trigger OAuth redirect

--- a/internal/acceptance/browser/tests/authn/logout.spec.ts
+++ b/internal/acceptance/browser/tests/authn/logout.spec.ts
@@ -14,16 +14,12 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { login, clearAuthState } from "../../helpers/authn-flow.js";
-import { getSessionCookie, verifySessionCookieAbsent } from "../../helpers/cookies.js";
+import { login } from "../../helpers/authn-flow.js";
+import { getSessionCookie } from "../../helpers/cookies.js";
 import { testUsers } from "../../fixtures/users.js";
 import { urls, paths } from "../../fixtures/test-data.js";
 
 test.describe("Logout", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("should clear session cookie on logout", async ({ page }) => {
     const user = testUsers.alice;
 
@@ -50,8 +46,8 @@ test.describe("Logout", () => {
     sessionCookie = await getSessionCookie(page);
     expect(
       sessionCookie?.value === "" ||
-        sessionCookie?.value === undefined ||
-        sessionCookie === undefined,
+      sessionCookie?.value === undefined ||
+      sessionCookie === undefined,
       "Session cookie should be cleared after logout"
     ).toBe(true);
   });

--- a/internal/acceptance/browser/tests/authn/token-refresh.spec.ts
+++ b/internal/acceptance/browser/tests/authn/token-refresh.spec.ts
@@ -9,17 +9,13 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { login, clearAuthState, isLoggedIn } from "../../helpers/authn-flow.js";
+import { login, isLoggedIn } from "../../helpers/authn-flow.js";
 import { getSessionCookie } from "../../helpers/cookies.js";
 import { waitForTokenExpiry } from "../../helpers/wait.js";
 import { testUsers } from "../../fixtures/users.js";
 import { urls } from "../../fixtures/test-data.js";
 
 test.describe("Token Refresh", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("should maintain access after token expiry through refresh", async ({ page }) => {
     const user = testUsers.alice;
 
@@ -78,5 +74,4 @@ test.describe("Token Refresh", () => {
       "Session cookie should exist after refresh"
     ).toBeDefined();
   });
-
 });

--- a/internal/acceptance/browser/tests/authz/domain-policy.spec.ts
+++ b/internal/acceptance/browser/tests/authz/domain-policy.spec.ts
@@ -9,15 +9,11 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { login, clearAuthState } from "../../helpers/authn-flow.js";
+import { login } from "../../helpers/authn-flow.js";
 import { testUsers } from "../../fixtures/users.js";
 import { urls, testRoutes } from "../../fixtures/test-data.js";
 
 test.describe("Email Domain Policy", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("should allow access for user with matching email domain", async ({ page }) => {
     // Alice has email alice@company.com - should be allowed
     const user = testUsers.alice;

--- a/internal/acceptance/browser/tests/authz/explicit-deny.spec.ts
+++ b/internal/acceptance/browser/tests/authz/explicit-deny.spec.ts
@@ -9,15 +9,11 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { login, clearAuthState } from "../../helpers/authn-flow.js";
+import { login } from "../../helpers/authn-flow.js";
 import { testUsers } from "../../fixtures/users.js";
 import { urls, testRoutes } from "../../fixtures/test-data.js";
 
 test.describe("Explicit Deny Policy", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("should deny explicitly denied user", async ({ page }) => {
     // Bob is explicitly denied from /deny-bob route
     const user = testUsers.bob;

--- a/internal/acceptance/browser/tests/authz/group-policy.spec.ts
+++ b/internal/acceptance/browser/tests/authz/group-policy.spec.ts
@@ -10,15 +10,11 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { login, clearAuthState } from "../../helpers/authn-flow.js";
+import { login } from "../../helpers/authn-flow.js";
 import { testUsers } from "../../fixtures/users.js";
 import { urls, testRoutes } from "../../fixtures/test-data.js";
 
 test.describe("Group Policy", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("should allow user with matching group", async ({ page }) => {
     // Alice is in admins group
     const user = testUsers.alice;

--- a/internal/acceptance/browser/tests/authz/pomerium-endpoints.spec.ts
+++ b/internal/acceptance/browser/tests/authz/pomerium-endpoints.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { test, expect, APIResponse, Page } from "@playwright/test";
-import { login, clearAuthState } from "../../helpers/authn-flow.js";
+import { login } from "../../helpers/authn-flow.js";
 import { testUsers } from "../../fixtures/users.js";
 import { urls, paths, testRoutes } from "../../fixtures/test-data.js";
 
@@ -70,10 +70,6 @@ function expectUnauthenticatedDenied(
 }
 
 test.describe("Pomerium internal endpoints", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("public endpoints should be accessible without authentication", async ({ page }) => {
     for (const path of publicEndpoints) {
       const response = await requestPath(page, path);

--- a/internal/acceptance/browser/tests/headers/cookie-flags.spec.ts
+++ b/internal/acceptance/browser/tests/headers/cookie-flags.spec.ts
@@ -19,10 +19,6 @@ import {
 import { testUsers } from "../../fixtures/users.js";
 
 test.describe("Cookie Security Flags", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("session cookie should have all required security properties", async ({ page }) => {
     const user = testUsers.alice;
 

--- a/internal/acceptance/browser/tests/headers/cors-preflight.spec.ts
+++ b/internal/acceptance/browser/tests/headers/cors-preflight.spec.ts
@@ -17,7 +17,6 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { clearAuthState } from "../../helpers/authn-flow.js";
 import { sendPreflight, makeCrossOriginRequest, testOrigins } from "../../helpers/cors.js";
 import { urls } from "../../fixtures/test-data.js";
 
@@ -34,10 +33,6 @@ const corsRoutes = {
 };
 
 test.describe("CORS Preflight", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("should pass OPTIONS preflight with cors_allow_preflight enabled", async ({ page }) => {
     // Send preflight to CORS-enabled route
     const url = `${urls.app}${corsRoutes.enabled}`;

--- a/internal/acceptance/browser/tests/headers/jwt-assertion.spec.ts
+++ b/internal/acceptance/browser/tests/headers/jwt-assertion.spec.ts
@@ -9,15 +9,11 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { login, clearAuthState } from "../../helpers/authn-flow.js";
+import { login } from "../../helpers/authn-flow.js";
 import { testUsers } from "../../fixtures/users.js";
 import { urls, testRoutes } from "../../fixtures/test-data.js";
 
 test.describe("JWT Assertion Header", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("claim headers should be passed to upstream", async ({ page }) => {
     const user = testUsers.alice;
 

--- a/internal/acceptance/browser/tests/headers/websocket-upgrade.spec.ts
+++ b/internal/acceptance/browser/tests/headers/websocket-upgrade.spec.ts
@@ -16,7 +16,7 @@
  */
 
 import { test, expect } from "@playwright/test";
-import { login, clearAuthState } from "../../helpers/authn-flow.js";
+import { login } from "../../helpers/authn-flow.js";
 import {
   connectWebSocket,
   sendWebSocketEcho,
@@ -37,10 +37,6 @@ const wsRoutes = {
 };
 
 test.describe("WebSocket Upgrade", () => {
-  test.beforeEach(async ({ page }) => {
-    await clearAuthState(page);
-  });
-
   test("should upgrade authenticated connection to WebSocket", async ({ page }) => {
     const user = testUsers.alice;
 


### PR DESCRIPTION
## Summary

Each test starts its own browser context, so there is no need to explicitly clear the browser state at the beginning of each test case.

## Related issues

n/a

## User Explanation

n/a

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
