### PR TITLE
ci: upgrade to Go 1.26.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,4 @@
 golangci-lint 2.9.0
-golang 1.25.7
+golang 1.26.0
 nodejs 22.22.0
 protoc 33.5

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN make npm-install
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 AS build
+FROM golang:1.26.0-bookworm@sha256:eae3cdfa040d0786510a5959d36a836978724d03b34a166ba2e0e198baac9196 AS build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -13,7 +13,7 @@ RUN make npm-install
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 AS build
+FROM golang:1.26.0-bookworm@sha256:eae3cdfa040d0786510a5959d36a836978724d03b34a166ba2e0e198baac9196 AS build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -99,7 +99,7 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 								"checkSettings": {
 									"contextExtensions": {
 										"internal": "false",
-										"route_checksum": "10993227095879864081",
+										"route_checksum": "14103096999915755832",
 										"route_id": "5fbd81d8f19363f4"
 									}
 								}
@@ -157,7 +157,7 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 								"checkSettings": {
 									"contextExtensions": {
 										"internal": "false",
-										"route_checksum": "10993227095879864081",
+										"route_checksum": "14103096999915755832",
 										"route_id": "5fbd81d8f19363f4"
 									}
 								}

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -410,14 +410,14 @@ func Test_buildPolicyRoutes(t *testing.T) {
 		8: "301084c3bd94c1ed",
 	}
 	routeChecksums := []string{
-		1: "105829291223266551",
-		2: "168811719375129368",
-		3: "392922693826853236",
-		4: "1103983569889896895",
-		5: "14172407652990248361",
-		6: "9079642729437579652",
-		7: "14151910878299839395",
-		8: "13580047737899170772",
+		1: "4185135981598691222",
+		2: "17243923343394049378",
+		3: "1307763399711531906",
+		4: "15143469008566139819",
+		5: "4947687983720841345",
+		6: "11930851347526394010",
+		7: "1355165688899044140",
+		8: "13048266954008269578",
 	}
 
 	b := &Builder{filemgr: filemgr.NewManager(), reproxy: reproxy.New()}
@@ -1222,7 +1222,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_checksum": "1414804973622257578",
+								"route_checksum": "1464516012399008995",
 								"route_id": "98f90d58022ca963"
 							}
 						}
@@ -1299,7 +1299,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_checksum": "385466414550258748",
+								"route_checksum": "4237645575197842515",
 								"route_id": "81175a3a9df11dd8"
 							}
 						}
@@ -1397,7 +1397,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_checksum": "14479919645404695926",
+								"route_checksum": "11670645605092253613",
 								"route_id": "ad0a23467bbdb773"
 							}
 						}
@@ -1500,7 +1500,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 							"checkSettings": {
 								"contextExtensions": {
 									"internal": "false",
-									"route_checksum": "7112686737530806788",
+									"route_checksum": "1290862050961979127",
 									"route_id": "1013c6be524d7fbd"
 								}
 							}
@@ -1616,7 +1616,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 							"checkSettings": {
 								"contextExtensions": {
 									"internal": "false",
-									"route_checksum": "5474432157160068338",
+									"route_checksum": "9620786651719703487",
 									"route_id": "a81e6b1e66c1e2cd"
 								}
 							}
@@ -1751,7 +1751,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_checksum": "2735131765392818671",
+								"route_checksum": "5457048859855758037",
 								"route_id": "4d5ee69fcc359f45"
 							}
 						}
@@ -1827,7 +1827,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_checksum": "2053034748487599595",
+								"route_checksum": "15625287366784495270",
 								"route_id": "4d5ee69fcc359f45"
 							}
 						}
@@ -1908,7 +1908,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_checksum": "11117878444533100516",
+								"route_checksum": "1779771381363437172",
 								"route_id": "4d5ee69fcc359f45"
 							}
 						}
@@ -1984,7 +1984,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_checksum": "10132352166098665000",
+								"route_checksum": "12940139384537454225",
 								"route_id": "4d5ee69fcc359f45"
 							}
 						}
@@ -2060,7 +2060,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_checksum": "8086028274907240845",
+								"route_checksum": "16239753187996878797",
 								"route_id": "4d5ee69fcc359f45"
 							}
 						}
@@ -2141,7 +2141,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 						"checkSettings": {
 							"contextExtensions": {
 								"internal": "false",
-								"route_checksum": "10371447269466962626",
+								"route_checksum": "8475895422017842413",
 								"route_id": "4d5ee69fcc359f45"
 							}
 						}

--- a/examples/mutual-tls/Dockerfile
+++ b/examples/mutual-tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.7-bookworm@sha256:38342f3e7a504bf1efad858c18e771f84b66dc0b363add7a57c9a0bbb6cf7b12 AS build-env
+FROM golang:1.26.0-bookworm@sha256:eae3cdfa040d0786510a5959d36a836978724d03b34a166ba2e0e198baac9196 AS build-env
 
 WORKDIR /go/src/app
 ADD . /go/src/app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pomerium/pomerium
 
-go 1.25.4
+go 1.26.0
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20251209175733-2a1774d88802.1


### PR DESCRIPTION
## Summary

Upgrade Go from 1.25.x to 1.26.0 in go.mod, .tool-versions, and Dockerfiles.

Go 1.26 [reordered](https://github.com/golang/go/commit/2a71af11fc7e45903be9ab84e59c668bb051f528) the fields in `net/url.URL`, which changes the output of `hashstructure`-based checksums used in route configuration. The checksums are non-cryptographic hashes used for change detection, so the value change is benign. Updated expected `route_checksum` values in envoyconfig tests accordingly.

## Related issues

## User Explanation

No user-facing changes.

## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review