### PR TITLE
ci: update update-dependencies script to Go 1.26

### DIFF
--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -75,8 +75,8 @@ update-tools() {
 
 	require-command asdf
 
-	asdf install golang latest:1.25
-	asdf set golang latest:1.25
+	asdf install golang latest:1.26
+	asdf set golang latest:1.26
 	asdf install golangci-lint latest:2
 	asdf set golangci-lint latest:2
 	asdf install nodejs latest:22


### PR DESCRIPTION
## Summary

Update `scripts/update-dependencies` to install Go 1.26 instead of 1.25.

Follow-up to #6123.

## Related issues

## User Explanation

No user-facing changes.

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review