### PR TITLE
ci: upgrade goreleaser to v2 and add release dry-run workflow

### DIFF
--- a/.github/goreleaser-mac.yaml
+++ b/.github/goreleaser-mac.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: pomerium
 
 release:
@@ -48,7 +50,7 @@ notarize:
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     id: pomerium
-    builds:
+    ids:
       - pomerium
     files:
       - none*
@@ -57,4 +59,4 @@ checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
 snapshot:
-  name_template: "{{ .Version }}+next+{{ .ShortCommit }}"
+  version_template: "{{ .Version }}+next+{{ .ShortCommit }}"

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -1,3 +1,5 @@
+version: 2
+
 project_name: pomerium
 
 release:
@@ -39,19 +41,16 @@ builds:
 archives:
   - name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     id: pomerium
-    builds:
+    ids:
       - pomerium
     files:
       - none*
-    format_overrides:
-      - goos: windows
-        format: zip
 
 checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
 snapshot:
-  name_template: "{{ .Version }}+next+{{ .ShortCommit }}"
+  version_template: "{{ .Version }}+next+{{ .ShortCommit }}"
 
 dockers:
   - image_templates:
@@ -62,6 +61,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
+      - "--provenance=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -78,6 +78,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
+      - "--provenance=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -94,6 +95,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
+      - "--provenance=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -110,6 +112,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
+      - "--provenance=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -125,6 +128,7 @@ dockers:
     use: buildx
     build_flag_templates:
       - "--pull"
+      - "--provenance=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -142,6 +146,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/arm64"
+      - "--provenance=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -159,6 +164,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/arm64"
+      - "--provenance=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -176,6 +182,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/arm64"
+      - "--provenance=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -193,6 +200,7 @@ dockers:
     build_flag_templates:
       - "--pull"
       - "--platform=linux/arm64"
+      - "--provenance=false"
       - "--label=org.opencontainers.image.created={{.Date}}"
       - "--label=org.opencontainers.image.name={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
@@ -245,7 +253,7 @@ docker_manifests:
 nfpms:
   - id: pomerium
 
-    builds:
+    ids:
       - pomerium
 
     package_name: pomerium
@@ -256,7 +264,6 @@ nfpms:
     license: Apache 2.0
     epoch: 1
     release: 1
-    meta: false
 
     formats:
       - deb
@@ -264,14 +271,14 @@ nfpms:
 
     bindir: /usr/sbin
 
-    empty_folders:
-      - /etc/pomerium
-
     scripts:
       preinstall: ospkg/preinstall.sh
       postinstall: ospkg/postinstall.sh
 
     contents:
+      - dst: /etc/pomerium
+        type: dir
+
       - src: ospkg/conf/config.yaml
         dst: /etc/pomerium/config.yaml
         type: config|noreplace
@@ -287,7 +294,5 @@ nfpms:
       rpm:
         dependencies:
           - systemd-libs
-        replacements:
-          arm64: aarch64
-          amd64: x86_64
-        file_name_template: "{{ .ProjectName }}-{{ .Version }}-{{ .Release }}.{{ .Arch }}"
+        file_name_template: >-
+          {{ .ProjectName }}-{{ .Version }}-{{ .Release }}.{{ if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "arm64" }}aarch64{{ else }}{{ .Arch }}{{ end }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,13 @@ on:
   release:
     types:
       - published
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Perform a dry-run (snapshot build, no publishing)'
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   goreleaser:
@@ -56,16 +63,25 @@ jobs:
       - name: Gcloud login
         run: gcloud auth configure-docker
 
+      - name: Get GoReleaser version
+        id: goreleaser-version
+        run: echo "version=v$(grep '^goreleaser ' .tool-versions | awk '{print $2}')" >> $GITHUB_OUTPUT
+
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6.4.0
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:
-          version: v0.184.0
-          args: release --config .github/goreleaser.yaml
+          version: ${{ steps.goreleaser-version.outputs.version }}
+          args: >-
+            release
+            ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true' && '--snapshot' || '' }}
+            --clean
+            --config .github/goreleaser.yaml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPARITOR_GITHUB_TOKEN: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
 
       - name: trigger mac build
+        if: github.event_name == 'release'
         uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697
         with:
           repository: pomerium/mac-builds
@@ -74,6 +90,7 @@ jobs:
           client-payload: '{ "release": "${{ github.event.release.tag_name }}", "push": "true" }'
 
       - name: Get tag name
+        if: github.event_name == 'release'
         id: tagName
         run: |
           TAG=$(git describe --tags --exact-match)
@@ -81,10 +98,12 @@ jobs:
           echo "version=${TAG#v}" >> $GITHUB_OUTPUT
 
       - name: Install Cloudsmith CLI
+        if: github.event_name == 'release'
         run: |
           pip3 install cloudsmith-cli
 
       - name: Publish to Cloudsmith
+        if: github.event_name == 'release'
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
         working-directory: dist/
@@ -101,13 +120,14 @@ jobs:
           done
 
       - name: Find latest tag
+        if: github.event_name == 'release'
         id: latestTag
         run: |
           LATEST_TAG=$(git tag | grep -vi 'rc' | sort --version-sort | tail -1)
           echo "tag=${LATEST_TAG}" >> $GITHUB_OUTPUT
 
       - name: Publish latest tag
-        if: steps.latestTag.outputs.tag == steps.tagName.outputs.tag
+        if: github.event_name == 'release' && steps.latestTag.outputs.tag == steps.tagName.outputs.tag
         run: |
           docker manifest create -a pomerium/pomerium:latest pomerium/pomerium:amd64-${{ steps.tagName.outputs.tag }} pomerium/pomerium:arm64v8-${{ steps.tagName.outputs.tag }}
           docker manifest push pomerium/pomerium:latest
@@ -127,6 +147,7 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     needs: goreleaser
+    if: github.event_name == 'release'
     steps:
       - name: Checkout Gitops Repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,4 +1,5 @@
 golangci-lint 2.9.0
 golang 1.26.0
+goreleaser 2.13.3
 nodejs 22.22.0
 protoc 33.5

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GO ?= "go"
 GO_LDFLAGS = -ldflags "-s -w $(CTIMEVAR)"
 GOOS = $(shell $(GO) env GOOS)
 GOARCH = $(shell $(GO) env GOARCH)
-GORELEASER_VERSION = v0.174.2
+GORELEASER_VERSION = v$(shell grep '^goreleaser ' .tool-versions | awk '{print $$2}')
 GO_TESTFLAGS := -race
 # disable the race detector in macos
 ifeq ($(shell env -u GOOS $(GO) env GOOS), darwin)
@@ -63,7 +63,7 @@ deps-build: get-envoy ## Install build dependencies
 .PHONY: deps-release
 deps-release: get-envoy ## Install release dependencies
 	@echo "==> $@"
-	@cd /tmp; $(GO) install github.com/goreleaser/goreleaser@${GORELEASER_VERSION}
+	@cd /tmp; $(GO) install github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}
 
 .PHONY: build-deps
 build-deps: deps-build deps-release
@@ -139,7 +139,7 @@ clean: ## Cleanup any build binaries or packages.
 .PHONY: snapshot
 snapshot: build-deps ## Builds the cross-compiled binaries, naming them in such a way for release (eg. binary-GOOS-GOARCH)
 	@echo "==> $@"
-	@goreleaser release --rm-dist -f .github/goreleaser.yaml --snapshot
+	@goreleaser release --clean -f .github/goreleaser.yaml --snapshot
 
 .PHONY: npm-install
 npm-install:

--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -84,6 +84,9 @@ update-tools() {
 	asdf plugin add protoc
 	asdf install protoc latest
 	asdf set protoc latest
+	asdf plugin add goreleaser || true
+	asdf install goreleaser latest:2
+	asdf set goreleaser latest:2
 
 	popd
 }


### PR DESCRIPTION
## Summary

Upgrade GoReleaser from v0.184.0 to v2.13.3 to modernize the release toolchain and fix the v0.32.1 release failure caused by Docker 29 shipping OCI image indexes by default.

**Changes:**
- Migrate `.github/goreleaser.yaml` and `.github/goreleaser-mac.yaml` to v2 schema (`version: 2`, field renames, removed deprecated options)
- Add `--provenance=false` to all docker `build_flag_templates` to prevent OCI image indexes that break `docker manifest create`
- Centralize goreleaser version in `.tool-versions` (single source of truth, matching project convention) instead of hardcoding separately in `Makefile` and workflow
- Replace deprecated `--rm-dist` flag with `--clean`
- Replace `nfpms.overrides.rpm.replacements` (removed in v2) with inline template conditional in `file_name_template`
- Add `workflow_dispatch` trigger with `dry_run` boolean input for manual snapshot builds
- Guard all publish/deploy steps with `if: github.event_name == 'release'` so dry-runs skip publishing
- Add goreleaser to `scripts/update-dependencies` `update-tools()`

## Related issues

- [ENG-3632](https://linear.app/pomerium/issue/ENG-3632/v0321-release-failed-docker-29-breaks-goreleaser-manifest-creation)

## User Explanation

No user-facing changes. This is an internal CI/release toolchain upgrade.

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review