### PR TITLE
feat: add SSRF-safe HTTP client for MCP metadata fetching

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -295,6 +295,11 @@ type Options struct {
 	// This is REQUIRED when MCP is enabled - client metadata fetching will fail if empty.
 	MCPAllowedClientIDDomains []string `mapstructure:"mcp_allowed_client_id_domains" yaml:"mcp_allowed_client_id_domains,omitempty" json:"mcp_allowed_client_id_domains,omitempty"`
 
+	// InsecureSkipMCPMetadataSSRFCheck disables SSRF protection for MCP-related
+	// metadata fetching (CIMD, PRM, AS metadata). This is intended for testing
+	// environments where the SSRF-safe client cannot reach test servers on localhost.
+	InsecureSkipMCPMetadataSSRFCheck bool `mapstructure:"-" yaml:"-" json:"-"`
+
 	// CodecType is the codec to use for downstream connections.
 	CodecType CodecType `mapstructure:"codec_type" yaml:"codec_type"`
 

--- a/internal/mcp/client_id_metadata.go
+++ b/internal/mcp/client_id_metadata.go
@@ -67,11 +67,6 @@ type ClientIDMetadataDocument struct {
 // MaxClientMetadataDocumentSize is the maximum size of a client metadata document (5KB per draft recommendation).
 const MaxClientMetadataDocumentSize = 5 * 1024
 
-// DefaultHTTPClient is the default HTTP client used for fetching client metadata documents.
-// This can be overridden to provide custom TLS configuration or security measures.
-// If nil, http.DefaultClient is used.
-var DefaultHTTPClient *http.Client
-
 // ClientMetadataFetcher fetches and validates client metadata documents.
 type ClientMetadataFetcher struct {
 	httpClient    *http.Client
@@ -79,15 +74,11 @@ type ClientMetadataFetcher struct {
 }
 
 // NewClientMetadataFetcher creates a new ClientMetadataFetcher.
-// If httpClient is nil, DefaultHTTPClient is used (or http.DefaultClient if DefaultHTTPClient is also nil).
+// httpClient must be non-nil and should be an SSRF-safe client (e.g. from NewSSRFSafeClient()).
 // If domainMatcher is nil, all domains are rejected (empty allowlist behavior).
-// Callers may provide a custom http.Client to implement SSRF protection or other security measures.
 func NewClientMetadataFetcher(httpClient *http.Client, domainMatcher *DomainMatcher) *ClientMetadataFetcher {
 	if httpClient == nil {
-		httpClient = DefaultHTTPClient
-	}
-	if httpClient == nil {
-		httpClient = http.DefaultClient
+		panic("NewClientMetadataFetcher: httpClient must not be nil")
 	}
 	return &ClientMetadataFetcher{
 		httpClient:    httpClient,

--- a/internal/mcp/client_id_metadata_test.go
+++ b/internal/mcp/client_id_metadata_test.go
@@ -263,7 +263,7 @@ func TestClientMetadataFetcher_Fetch(t *testing.T) {
 	t.Run("rejects when domain not in allowed list", func(t *testing.T) {
 		// Domain matcher that only allows vscode.dev
 		matcher := NewDomainMatcher([]string{"vscode.dev"})
-		fetcher := NewClientMetadataFetcher(nil, matcher)
+		fetcher := NewClientMetadataFetcher(http.DefaultClient, matcher)
 
 		_, err := fetcher.Fetch(context.Background(), "https://evil.com/oauth/client.json")
 		require.Error(t, err)
@@ -273,7 +273,7 @@ func TestClientMetadataFetcher_Fetch(t *testing.T) {
 	})
 
 	t.Run("rejects when no domains configured", func(t *testing.T) {
-		fetcher := NewClientMetadataFetcher(nil, nil)
+		fetcher := NewClientMetadataFetcher(http.DefaultClient, nil)
 
 		_, err := fetcher.Fetch(context.Background(), "https://any.com/oauth/client.json")
 		require.Error(t, err)

--- a/internal/mcp/ssrf.go
+++ b/internal/mcp/ssrf.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"time"
+)
+
+// ErrSSRFBlocked is returned when a request is blocked by SSRF protection.
+var ErrSSRFBlocked = errors.New("ssrf protection")
+
+// isInternalOrSpecial returns true if the IP address is private, loopback, link-local,
+// multicast, or otherwise not a public unicast address.
+func isInternalOrSpecial(ip netip.Addr) bool {
+	ip = ip.Unmap()
+	return !ip.IsValid() ||
+		ip.IsPrivate() ||
+		ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified()
+}
+
+// resolveAndValidate resolves a hostname to IP addresses and returns the first
+// non-internal address. Returns an error if all resolved IPs are internal/special
+// or if the hostname is an IP literal pointing to an internal address.
+func resolveAndValidate(ctx context.Context, host string) (netip.Addr, error) {
+	// If host is an IP literal, check it directly.
+	if ip, err := netip.ParseAddr(host); err == nil {
+		if isInternalOrSpecial(ip) {
+			return netip.Addr{}, fmt.Errorf("%w: blocked IP literal %s", ErrSSRFBlocked, ip)
+		}
+		return ip, nil
+	}
+
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+
+	for _, a := range addrs {
+		ip, ok := netip.AddrFromSlice(a.IP)
+		if !ok {
+			continue
+		}
+		if !isInternalOrSpecial(ip) {
+			return ip, nil
+		}
+	}
+	return netip.Addr{}, fmt.Errorf("%w: all resolved IPs for %q are internal", ErrSSRFBlocked, host)
+}
+
+// httpsOnlyTransport wraps an http.RoundTripper to enforce HTTPS-only requests.
+type httpsOnlyTransport struct {
+	base http.RoundTripper
+}
+
+func (t *httpsOnlyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL == nil || req.URL.Scheme != "https" {
+		return nil, fmt.Errorf("%w: only https is allowed", ErrSSRFBlocked)
+	}
+	return t.base.RoundTrip(req)
+}
+
+// NewSSRFSafeClient creates an *http.Client that enforces HTTPS-only requests,
+// blocks connections to private/loopback/internal IP addresses, and refuses
+// to follow HTTP redirects.
+//
+// Redirects are blocked because the OAuth metadata specs (RFC 8414 §3.2,
+// RFC 9728 §3.2) require a successful response to use 200 OK. Following
+// redirects would also undermine SSRF protection by allowing an attacker-
+// controlled endpoint to bounce requests to internal services.
+func NewSSRFSafeClient() *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+
+	transport := &http.Transport{
+		Proxy:                 nil, // disable proxy to prevent bypass
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+
+			ip, err := resolveAndValidate(ctx, host)
+			if err != nil {
+				return nil, err
+			}
+
+			rawConn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if err != nil {
+				return nil, err
+			}
+
+			cfg := &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				ServerName: host,
+			}
+
+			tlsConn := tls.Client(rawConn, cfg)
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				rawConn.Close()
+				return nil, err
+			}
+			return tlsConn, nil
+		},
+	}
+
+	return &http.Client{
+		Transport: &httpsOnlyTransport{base: transport},
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			// OAuth metadata specs (RFC 8414 §3.2, RFC 9728 §3.2) require 200 OK
+			// for successful responses. Redirects should not be followed for
+			// metadata fetches; they also represent an SSRF amplification vector.
+			return fmt.Errorf("%w: redirects are not allowed", ErrSSRFBlocked)
+		},
+		Timeout: 30 * time.Second,
+	}
+}

--- a/internal/mcp/ssrf_test.go
+++ b/internal/mcp/ssrf_test.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInternalOrSpecial(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		// Private ranges (RFC 1918)
+		{"10.0.0.1", "10.0.0.1", true},
+		{"172.16.0.1", "172.16.0.1", true},
+		{"192.168.1.1", "192.168.1.1", true},
+
+		// Loopback
+		{"loopback v4", "127.0.0.1", true},
+		{"loopback v6", "::1", true},
+
+		// Link-local
+		{"link-local v4", "169.254.1.1", true},
+		{"link-local v6", "fe80::1", true},
+
+		// Multicast
+		{"multicast v4", "224.0.0.1", true},
+		{"multicast v6", "ff02::1", true},
+
+		// Unspecified
+		{"unspecified v4", "0.0.0.0", true},
+		{"unspecified v6", "::", true},
+
+		// IPv6 ULA
+		{"ULA", "fd00::1", true},
+
+		// v4-mapped v6 private
+		{"v4-mapped private", "::ffff:10.0.0.1", true},
+		{"v4-mapped loopback", "::ffff:127.0.0.1", true},
+
+		// Public addresses
+		{"public v4", "8.8.8.8", false},
+		{"public v4 2", "1.1.1.1", false},
+		{"public v6", "2607:f8b0:4004:800::200e", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ip := netip.MustParseAddr(tc.ip)
+			assert.Equal(t, tc.expected, isInternalOrSpecial(ip))
+		})
+	}
+}

--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -1,5 +1,5 @@
 {
-  "config": "v0.19.0",
+  "config": "v0.20.0",
   "hosted-authenticate-oidc": "v0.1.0",
   "mcp": "v0.18.0",
   "ssh": "v0.10.0"


### PR DESCRIPTION
## Summary

Introduces `NewSSRFSafeClient()` — a general-purpose SSRF-safe HTTP client for MCP metadata fetches (CIMD, PRM, AS metadata) that enforces HTTPS-only, blocks private/loopback/internal IPs (including DNS rebinding), and refuses redirects per RFC 8414 §3.2 / RFC 9728 §3.2.

Wires the SSRF-safe client into the CIMD fetcher as the first consumer. Eliminates the package-level `DefaultHTTPClient` global variable, replacing it with a `config.Config.MCPClientMetadataHTTPClient` field for test injection — removes shared mutable state and potential test races. Updates e2e tests to use testenv modifier pattern for HTTP client injection.

## Related issues

- https://linear.app/pomerium/issue/ENG-3650

## User Explanation

No user-facing changes. This hardens internal metadata fetching against SSRF attacks when MCP is enabled.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review