### PR TITLE
add internal/cmd/mock-idp standalone command

### DIFF
--- a/internal/cmd/mock-idp/main.go
+++ b/internal/cmd/mock-idp/main.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"os/signal"
+
+	"github.com/gorilla/mux"
+
+	"github.com/pomerium/pomerium/internal/testutil/mockidp"
+)
+
+func main() {
+	var config mockidp.Config
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		fmt.Fprintf(os.Stderr, "usage: %s [flags] '<mockidp.Config json string>'\n", os.Args[0])
+		os.Exit(1)
+	}
+	if err := json.Unmarshal([]byte(flag.Arg(0)), &config); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+	idp := mockidp.New(config)
+	r := mux.NewRouter()
+	idp.Register(r)
+	server := httptest.NewServer(r)
+
+	fmt.Printf("Server listening on %s\n", server.Listener.Addr())
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	<-c
+	server.Close()
+}

--- a/internal/testutil/mockidp/mockidp.go
+++ b/internal/testutil/mockidp/mockidp.go
@@ -50,8 +50,8 @@ type refreshTokenData struct {
 }
 
 type Config struct {
-	Users            []*User
-	EnableDeviceAuth bool
+	Users            []*User `json:"users"`
+	EnableDeviceAuth bool    `json:"enable_device_auth"`
 }
 
 func New(cfg Config) *IDP {
@@ -477,8 +477,8 @@ func (token *idToken) Encode(signingKey jose.SigningKey) string {
 }
 
 type User struct {
-	ID        string
-	Email     string
-	FirstName string
-	LastName  string
+	ID        string `json:"-"`
+	Email     string `json:"email"`
+	FirstName string `json:"first_name,omitempty"`
+	LastName  string `json:"last_name,omitempty"`
 }


### PR DESCRIPTION
Adds a simple mock-idp command. This is used as part of a self-contained pomerium environment for generating some screenshots for documentation.