### PR TITLE
ssh: fix diagnostic logs not being displayed

### DIFF
--- a/pkg/ssh/tui/core/tea_listener.go
+++ b/pkg/ssh/tui/core/tea_listener.go
@@ -4,7 +4,9 @@ import (
 	"slices"
 
 	tea "charm.land/bubbletea/v2"
+	"google.golang.org/protobuf/proto"
 
+	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
 	"github.com/pomerium/pomerium/pkg/ssh/models"
 )
 
@@ -34,4 +36,10 @@ func (tl *TeaListener[T, K]) OnModelReset(items []T) {
 	tl.sender.SendTeaMsg(models.ModelResetMsg[T, K]{
 		Items: slices.Clone(items),
 	})
+}
+
+func (tl *TeaListener[T, K]) OnDiagnosticsReceived(diagnostics []*extensions_ssh.Diagnostic) {
+	for _, d := range diagnostics {
+		tl.sender.SendTeaMsg(proto.CloneOf(d))
+	}
 }

--- a/pkg/ssh/tui/tunnel/config.go
+++ b/pkg/ssh/tui/tunnel/config.go
@@ -146,6 +146,10 @@ func NewStyles(theme *style.Theme) Styles {
 			Help:        help.NewStyles(theme),
 			ContextMenu: menu.NewStyles(theme),
 			Dialog:      dialog.NewStyles(theme),
+			Logs: LogsStyles{
+				Warning: theme.TextWarning,
+				Error:   theme.TextError,
+			},
 		},
 	}
 	// Note: dialog text needs a background, otherwise it is rendered incorrectly.


### PR DESCRIPTION
This fixes SSH diagnostic logs not being displayed in the Logs panel.

For example, `ssh -R route-name:443` should now correctly display this warning:

<img width="1507" height="807" alt="Screenshot From 2026-02-26 20-17-23" src="https://github.com/user-attachments/assets/f2505e79-79e9-4de4-9ba9-bc60aa5378ab" />
