### PR TITLE
reverse tunnel: populate route info in endpoint metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.9.2
 	github.com/pomerium/datasource v0.18.2-0.20260302183053-e25f80cacf66
-	github.com/pomerium/envoy-custom v1.37.0-rc2
+	github.com/pomerium/envoy-custom v1.37.0-rc2.0.20260227195746-cc8ad9b8b8aa
 	github.com/pomerium/protoutil v0.0.0-20260302182909-6eabaf0f0268
 	github.com/pomerium/webauthn v0.0.0-20260302175238-137bd362944b
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -737,8 +737,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pomerium/datasource v0.18.2-0.20260302183053-e25f80cacf66 h1:ojRbRcg3Azqa2IeAbXNwXNkagyRfBlgoHtYDlnU2vWs=
 github.com/pomerium/datasource v0.18.2-0.20260302183053-e25f80cacf66/go.mod h1:vNQ+UHyJ+539EfXAxYeMPeUYza4ddVOqKA56lnvWhNI=
-github.com/pomerium/envoy-custom v1.37.0-rc2 h1:ua5PDUhbE1sltW6AcaILRxni2j77zU3uBTbMmeItQC4=
-github.com/pomerium/envoy-custom v1.37.0-rc2/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
+github.com/pomerium/envoy-custom v1.37.0-rc2.0.20260227195746-cc8ad9b8b8aa h1:xTlssid8vDhksow+0RiiV9eoVGIjdUP0mcjUeUSRbfw=
+github.com/pomerium/envoy-custom v1.37.0-rc2.0.20260227195746-cc8ad9b8b8aa/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
 github.com/pomerium/protoutil v0.0.0-20260302182909-6eabaf0f0268 h1:b30plSVTZBAao/rWx779texCVuDsQbfb9rP9Flhlqmo=
 github.com/pomerium/protoutil v0.0.0-20260302182909-6eabaf0f0268/go.mod h1:N81RWX6YmxJoRrVutDLO5JS7LgRWMGZquSAI9i2Dhps=
 github.com/pomerium/webauthn v0.0.0-20260302175238-137bd362944b h1:qnmPqKePAWNKrQymmGERbpwdMrqK2lEYnbc61wObTgM=

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -593,6 +593,11 @@ func buildEndpointMetadata(info portforward.RoutePortForwardInfo) *extensions_ss
 			RequestedHost: info.Permission.HostMatcher.InputPattern(),
 			RequestedPort: info.Permission.RequestedPort,
 		},
+		PomeriumRouteInfo: &extensions_ssh.EndpointMetadata_RouteInfo{
+			From:     info.From,
+			Hostname: info.Hostname,
+			Port:     info.Port,
+		},
 	}
 }
 

--- a/pkg/ssh/manager_test.go
+++ b/pkg/ssh/manager_test.go
@@ -201,6 +201,11 @@ func TestReverseTunnelEDS(t *testing.T) {
 			Value:     22,
 			IsDynamic: false,
 		},
+		PomeriumRouteInfo: &extensions_ssh.EndpointMetadata_RouteInfo{
+			From:     "ssh://host1",
+			Hostname: "host1",
+			Port:     22,
+		},
 		MatchedPermission: &extensions_ssh.PortForwardPermission{
 			RequestedHost: "host1",
 			RequestedPort: 22,
@@ -210,6 +215,11 @@ func TestReverseTunnelEDS(t *testing.T) {
 		ServerPort: &extensions_ssh.ServerPort{
 			Value:     22,
 			IsDynamic: false,
+		},
+		PomeriumRouteInfo: &extensions_ssh.EndpointMetadata_RouteInfo{
+			From:     "ssh://host2",
+			Hostname: "host2",
+			Port:     22,
 		},
 		MatchedPermission: &extensions_ssh.PortForwardPermission{
 			RequestedHost: "host2",


### PR DESCRIPTION
This populates the new endpoint metadata fields introduced in https://github.com/pomerium/envoy-custom/pull/161.