### PR TITLE
fix: remove `cd /tmp` from deps-release to fix asdf compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ deps-build: get-envoy ## Install build dependencies
 .PHONY: deps-release
 deps-release: get-envoy ## Install release dependencies
 	@echo "==> $@"
-	@cd /tmp; $(GO) install github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}
+	@$(GO) install github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}
 
 .PHONY: build-deps
 build-deps: deps-build deps-release


### PR DESCRIPTION
## Summary

Remove `cd /tmp` from `deps-release` target — it breaks asdf's go shim since `.tool-versions` isn't found in `/tmp`. The `cd` is unnecessary as `go install pkg@version` doesn't touch local module files.

## Related issues

## User Explanation

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review