### PR TITLE
chore: allow parallel golangci-lint runners

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 version: "2"
+run:
+  allow-parallel-runners: true
 linters:
   default: none
   enable:


### PR DESCRIPTION
## Summary
disable the file lock that prevents concurrent golangci-lint invocations, which is problematic when running builds in multiple git worktrees. 
