### PR TITLE
core/consolidated-api: validate routes, policies, settings

### DIFF
--- a/internal/databroker/server_backend_config.go
+++ b/internal/databroker/server_backend_config.go
@@ -15,12 +15,14 @@ import (
 	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/version"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
+	"github.com/pomerium/pomerium/pkg/policy"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
@@ -69,6 +71,10 @@ func (srv *backendConfigServer) CreatePolicy(
 	}
 	entity.CreatedAt = timestamppb.Now()
 
+	if err := srv.validatePolicy(entity); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid policy: %w", err))
+	}
+
 	record, err := srv.createEntity(ctx, entity, &entity.Id)
 	if err != nil {
 		return nil, err
@@ -92,6 +98,10 @@ func (srv *backendConfigServer) CreateRoute(
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("route is required"))
 	}
 	entity.CreatedAt = timestamppb.Now()
+
+	if err := srv.validateRoute(entity); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid route: %w", err))
+	}
 
 	record, err := srv.createEntity(ctx, entity, &entity.Id)
 	if err != nil {
@@ -585,8 +595,12 @@ func (srv *backendConfigServer) UpdatePolicy(
 	if err != nil {
 		return nil, err
 	}
-
 	entity.CreatedAt = original.CreatedAt
+
+	if err := srv.validatePolicy(entity); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid policy: %w", err))
+	}
+
 	record, err := srv.putEntity(ctx, entity)
 	if err != nil {
 		return nil, err
@@ -619,6 +633,11 @@ func (srv *backendConfigServer) UpdateRoute(
 	}
 
 	entity.CreatedAt = original.CreatedAt
+
+	if err := srv.validateRoute(entity); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid route: %w", err))
+	}
+
 	record, err := srv.putEntity(ctx, entity)
 	if err != nil {
 		return nil, err
@@ -686,8 +705,12 @@ func (srv *backendConfigServer) UpdateSettings(
 	} else if err != nil {
 		return nil, err
 	}
-
 	entity.CreatedAt = original.CreatedAt
+
+	if err := srv.validateSettings(entity); err != nil {
+		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("invalid settings: %w", err))
+	}
+
 	record, err := srv.putEntity(ctx, entity)
 	if err != nil {
 		return nil, err
@@ -835,6 +858,30 @@ func (srv *backendConfigServer) putEntity(
 	}
 
 	return records[0], nil
+}
+
+func (srv *backendConfigServer) validatePolicy(entity *configpb.Policy) error {
+	if len(entity.Rego) == 0 && len(entity.GetSourcePpl()) > 0 {
+		_, err := policy.GenerateRegoFromReader(strings.NewReader(entity.GetSourcePpl()))
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (srv *backendConfigServer) validateRoute(entity *configpb.Route) error {
+	p, err := config.NewPolicyFromProto(entity)
+	if err != nil {
+		return err
+	}
+	return p.Validate()
+}
+
+func (srv *backendConfigServer) validateSettings(entity *configpb.Settings) error {
+	options := config.NewDefaultOptions()
+	options.ApplySettings(context.Background(), nil, entity)
+	return options.Validate()
 }
 
 func listRecords[T any, TMsg interface {

--- a/internal/databroker/server_backend_config_test.go
+++ b/internal/databroker/server_backend_config_test.go
@@ -10,6 +10,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -156,7 +157,9 @@ func TestConfigSettings(t *testing.T) {
 				Id: databroker.GlobalSettingsID,
 			},
 		}))
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		res.Msg.Settings.CreatedAt = nil
+		res.Msg.Settings.ModifiedAt = nil
 		assert.Empty(t, cmp.Diff(&configpb.Settings{
 			Id: proto.String(databroker.GlobalSettingsID),
 		}, res.Msg.GetSettings(), protocmp.Transform()))
@@ -165,9 +168,13 @@ func TestConfigSettings(t *testing.T) {
 		t.Parallel()
 
 		res, err := client.GetSettings(t.Context(), connect.NewRequest(&configpb.GetSettingsRequest{}))
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		res.Msg.Settings.CreatedAt = nil
+		res.Msg.Settings.ModifiedAt = nil
 		assert.Empty(t, cmp.Diff(&configpb.Settings{
 			Id: proto.String(databroker.GlobalSettingsID),
 		}, res.Msg.GetSettings(), protocmp.Transform()))
 	})
+
+	storagetest.TestConfigServiceSettings(t, client)
 }

--- a/pkg/storage/storagetest/configservice.go
+++ b/pkg/storage/storagetest/configservice.go
@@ -7,6 +7,7 @@ import (
 	"connectrpc.com/connect"
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -112,6 +113,14 @@ func TestConfigServiceKeyPairs(t *testing.T, client configconnect.ConfigServiceC
 func TestConfigServicePolicies(t *testing.T, client configconnect.ConfigServiceClient) {
 	t.Helper()
 
+	_, err := client.CreatePolicy(t.Context(), connect.NewRequest(&configpb.CreatePolicyRequest{
+		Policy: &configpb.Policy{
+			Id:        new("invalid-policy"),
+			SourcePpl: new("<INVALID>"),
+		},
+	}))
+	require.Equal(t, connect.CodeInvalidArgument.String(), connect.CodeOf(err).String(), "should validate policies")
+
 	listRes, err := client.ListPolicies(t.Context(), connect.NewRequest(&configpb.ListPoliciesRequest{}))
 	assert.NoError(t, err)
 	assert.Empty(t, listRes.Msg.Policies, "should return no policies when none of have been added yet")
@@ -206,27 +215,40 @@ func TestConfigServicePolicies(t *testing.T, client configconnect.ConfigServiceC
 func TestConfigServiceRoutes(t *testing.T, client configconnect.ConfigServiceClient) {
 	t.Helper()
 
+	_, err := client.CreateRoute(t.Context(), connect.NewRequest(&configpb.CreateRouteRequest{
+		Route: &configpb.Route{
+			Id:   new("invalid-route"),
+			From: "<INVALID>",
+		},
+	}))
+	assert.Equal(t, connect.CodeInvalidArgument.String(), connect.CodeOf(err).String(), "should validate routes")
+
 	listRes, err := client.ListRoutes(t.Context(), connect.NewRequest(&configpb.ListRoutesRequest{}))
 	assert.NoError(t, err)
-	assert.Empty(t, listRes.Msg.Routes, "should return no routes when none of have been added yet")
+	assert.Empty(t, listRes.Msg.Routes, "should return no routes when none have been added yet")
 
 	for i := range 1000 {
 		res, err := client.CreateRoute(t.Context(), connect.NewRequest(&configpb.CreateRouteRequest{
 			Route: &configpb.Route{
 				Id:   new(fmt.Sprintf("r-%04d", i+1)),
 				Name: new(fmt.Sprintf("route-%04d", i+1)),
+				From: fmt.Sprintf("https://from-%04d.example.com", i+1),
+				To:   []string{fmt.Sprintf("https://to-%04d.example.com", i+1)},
 			},
 		}))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, res.Msg.Route)
 	}
 
 	_, err = client.CreateRoute(t.Context(), connect.NewRequest(&configpb.CreateRouteRequest{
 		Route: &configpb.Route{
-			Id: new("r-0300"),
+			Id:   new("r-0300"),
+			Name: new("route-0300"),
+			From: "https://from-0300.example.com",
+			To:   []string{"https://to-0300.example.com"},
 		},
 	}))
-	assert.Equal(t, connect.CodeAlreadyExists, connect.CodeOf(err), "should prevent creation of routes with the same id")
+	assert.Equal(t, connect.CodeAlreadyExists.String(), connect.CodeOf(err).String(), "should prevent creation of routes with the same id")
 
 	listRes, err = client.ListRoutes(t.Context(), connect.NewRequest(&configpb.ListRoutesRequest{
 		Limit:   new(uint64(10)),
@@ -383,4 +405,16 @@ func TestConfigServiceServiceAccounts(t *testing.T, client configconnect.ConfigS
 		assert.NotEmpty(t, cmp.Diff(s.GetModifiedAt(), getRes.Msg.GetServiceAccount().GetModifiedAt(), protocmp.Transform()),
 			"should update the modified at timestamp")
 	}
+}
+
+func TestConfigServiceSettings(t *testing.T, client configconnect.ConfigServiceClient) {
+	t.Helper()
+
+	_, err := client.UpdateSettings(t.Context(), connect.NewRequest(&configpb.UpdateSettingsRequest{
+		Settings: &configpb.Settings{
+			Id:       new("78408adf-56e4-41d0-af6a-ca1b2d8d2cb6"),
+			Services: new("<INVALID>"),
+		},
+	}))
+	assert.Equal(t, connect.CodeInvalidArgument.String(), connect.CodeOf(err).String(), "should validate settings")
 }


### PR DESCRIPTION
## Summary
Update the consolidated API to validate routes, policies, and settings when they are created or updated.

## Related issues
- [ENG-3685](https://linear.app/pomerium/issue/ENG-3685/coreconsolidated-api-should-validate-resources)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
