### PR TITLE
update get-envoy tool to fetch binaries from oci images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ docs/.vuepress/dist/
 pkg/envoy/files/envoy-*-?????
 pkg/envoy/files/envoy-*-?????.sha256
 pkg/envoy/files/envoy-*-?????.version
+pkg/envoy/files/envoy-*-?????.lock
 
 gha-creds-*.json
 

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,8 @@ GO_TESTFLAGS := -race
 ifeq ($(shell env -u GOOS $(GO) env GOOS), darwin)
 	GO_TESTFLAGS :=
 endif
-ENVOY_OCI_REPO ?= "docker.io/pomerium/envoy-custom"
+ENVOY_OCI_REPO ?= "ghcr.io/pomerium/envoy-custom"
+GET_ENVOY_DEBUG :=
 
 .PHONY: all
 all: clean build-deps test lint build ## Runs a clean, build, fmt, lint, test, and vet.
@@ -55,7 +56,7 @@ check-component-versions:
 .PHONY: get-envoy
 get-envoy: ## Fetch envoy binaries
 	@echo "==> $@"
-	@cd pkg/envoy/files && env -u GOOS $(GO) run ../get-envoy --repo $(ENVOY_OCI_REPO)
+	@cd pkg/envoy/files && env -u GOOS $(GO) run ../get-envoy --repo $(ENVOY_OCI_REPO) $(if $(GET_ENVOY_DEBUG),--debug,)
 
 .PHONY: deps-build
 deps-build: get-envoy ## Install build dependencies

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ GO_TESTFLAGS := -race
 ifeq ($(shell env -u GOOS $(GO) env GOOS), darwin)
 	GO_TESTFLAGS :=
 endif
+ENVOY_OCI_REPO ?= "docker.io/pomerium/envoy-custom"
 
 .PHONY: all
 all: clean build-deps test lint build ## Runs a clean, build, fmt, lint, test, and vet.
@@ -54,7 +55,7 @@ check-component-versions:
 .PHONY: get-envoy
 get-envoy: ## Fetch envoy binaries
 	@echo "==> $@"
-	@cd pkg/envoy/files && env -u GOOS $(GO) run ../get-envoy
+	@cd pkg/envoy/files && env -u GOOS $(GO) run ../get-envoy --repo $(ENVOY_OCI_REPO)
 
 .PHONY: deps-build
 deps-build: get-envoy ## Install build dependencies

--- a/cmd/pomerium/main.go
+++ b/cmd/pomerium/main.go
@@ -28,7 +28,7 @@ func main() {
 	var configFile string
 	root := &cobra.Command{
 		Use:          "pomerium",
-		Version:      fmt.Sprintf("pomerium: %s\nenvoy: %s", version.FullVersion(), files.FullVersion()),
+		Version:      fmt.Sprintf("pomerium: %s\nenvoy: %s", version.FullVersion(), files.Lockfile().Version),
 		SilenceUsage: true,
 	}
 	root.AddCommand(zero_cmd.BuildRootCmd())
@@ -60,7 +60,7 @@ func main() {
 func run(ctx context.Context, configFile string) error {
 	var src config.Source
 
-	src, err := config.NewFileOrEnvironmentSource(ctx, configFile, files.FullVersion())
+	src, err := config.NewFileOrEnvironmentSource(ctx, configFile, files.Lockfile().Version)
 	if err != nil {
 		return err
 	}

--- a/databroker/databroker.go
+++ b/databroker/databroker.go
@@ -62,7 +62,7 @@ func New(ctx context.Context, cfg *config.Config, eventsMgr *events.Manager, opt
 
 	ui, si := grpcutil.AttachMetadataInterceptors(
 		metadata.Pairs(
-			grpcutil.MetadataKeyEnvoyVersion, files.FullVersion(),
+			grpcutil.MetadataKeyEnvoyVersion, files.Lockfile().Version,
 			grpcutil.MetadataKeyPomeriumVersion, version.FullVersion(),
 		),
 	)

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/bits-and-blooms/bitset v1.24.4
 	github.com/caddyserver/certmagic v0.25.2
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/charmbracelet/colorprofile v0.4.1
 	github.com/charmbracelet/ultraviolet v0.0.0-20251212194010-b927aa605560
 	github.com/charmbracelet/x/ansi v0.11.6
@@ -75,6 +76,7 @@ require (
 	github.com/natefinch/atomic v1.0.1
 	github.com/oapi-codegen/runtime v1.2.0
 	github.com/open-policy-agent/opa v1.14.0
+	github.com/opencontainers/image-spec v1.1.1
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.11.0
 	github.com/pomerium/datasource v0.18.2-0.20260323191748-64aefe7b0777
@@ -91,6 +93,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.24.5
 	github.com/shogo82148/go-sfv v0.3.3
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.10
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
 	github.com/testcontainers/testcontainers-go v0.40.0
@@ -134,6 +137,7 @@ require (
 	google.golang.org/grpc v1.79.3
 	google.golang.org/protobuf v1.36.11
 	gopkg.in/yaml.v3 v3.0.1
+	oras.land/oras-go/v2 v2.6.0
 	sigs.k8s.io/yaml v1.6.0
 )
 
@@ -189,7 +193,6 @@ require (
 	github.com/caddyserver/zerossl v0.1.5 // indirect
 	github.com/ccoveille/go-safecast v1.8.2 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/charmbracelet/x/conpty v0.2.0 // indirect
 	github.com/charmbracelet/x/exp/ordered v0.1.0 // indirect
 	github.com/charmbracelet/x/term v0.2.2 // indirect
@@ -289,7 +292,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/onsi/ginkgo v1.16.5 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
@@ -316,7 +318,6 @@ require (
 	github.com/sourcegraph/conc v0.3.1-0.20240121214520-5f936abd7ae8 // indirect
 	github.com/spf13/afero v1.15.0 // indirect
 	github.com/spf13/cast v1.10.0 // indirect
-	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/spiffe/go-spiffe/v2 v2.6.0 // indirect
 	github.com/sryoya/protorand v0.0.0-20240429201223-e7440656b2a4 // indirect
 	github.com/stretchr/objx v0.5.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.11.0
 	github.com/pomerium/datasource v0.18.2-0.20260323191748-64aefe7b0777
-	github.com/pomerium/envoy-custom v1.37.0-rc3
+	github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260331001551-046de5d7c5da
 	github.com/pomerium/protoutil v0.0.0-20260320182559-344554199ec4
 	github.com/pomerium/webauthn v0.0.0-20260323191702-04e03510044d
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pomerium/datasource v0.18.2-0.20260323191748-64aefe7b0777 h1:cHDFzYxooeXxzU+0zdkMmugoazaFP0NoEIgeQJ74tmQ=
 github.com/pomerium/datasource v0.18.2-0.20260323191748-64aefe7b0777/go.mod h1:44JiWJv2Ox4PvoH5Hco7o2o6xaAOagWv8YeOP5LPaYE=
-github.com/pomerium/envoy-custom v1.37.0-rc3 h1:IymnBJgKYsiTxv4iYYpOceN/7hDuVnlPwUELRQGoEKc=
-github.com/pomerium/envoy-custom v1.37.0-rc3/go.mod h1:R70sMIoym9epTfWd3Zghf9/2nLw44nhT6xZBFTPaGRg=
+github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260331001551-046de5d7c5da h1:aS+bHfLE8IuLblPpXQVzKChYQQTlfEHkK6h3bmigcVM=
+github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260331001551-046de5d7c5da/go.mod h1:7Svo/CaRt9vfJ22sEC+T/q/y2WNi/cZTlugNYUS7xwI=
 github.com/pomerium/protoutil v0.0.0-20260320182559-344554199ec4 h1:RHHibl6nTworBf9VOicD8+nEnfXTdfU6sik/yC8qrNE=
 github.com/pomerium/protoutil v0.0.0-20260320182559-344554199ec4/go.mod h1:m5tdX94ef0vCL5fgAJP6vW2GZWkU1+KfLlERBzlVeDs=
 github.com/pomerium/webauthn v0.0.0-20260323191702-04e03510044d h1:3w3v7enh57Ch1XhwEPfiTMpj84AwEh9syWehMlHpRQ8=

--- a/go.sum
+++ b/go.sum
@@ -1407,6 +1407,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
+oras.land/oras-go/v2 v2.6.0 h1:X4ELRsiGkrbeox69+9tzTu492FMUu7zJQW6eJU+I2oc=
+oras.land/oras-go/v2 v2.6.0/go.mod h1:magiQDfG6H1O9APp+rOsvCPcW1GD2MM7vgnKY0Y+u1o=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -205,7 +205,7 @@ func NewServer(
 	}
 	ui, si := grpcutil.AttachMetadataInterceptors(
 		metadata.Pairs(
-			grpcutil.MetadataKeyEnvoyVersion, files.FullVersion(),
+			grpcutil.MetadataKeyEnvoyVersion, files.Lockfile().Version,
 			grpcutil.MetadataKeyPomeriumVersion, version.FullVersion(),
 		),
 	)

--- a/internal/controlplane/server_debug.go
+++ b/internal/controlplane/server_debug.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -119,8 +120,10 @@ func (srv *debugServer) versionHandler() http.HandlerFunc {
 		BuildTime   string `json:"build_time"`
 	}
 	type envoyVersion struct {
-		Version     string `json:"version"`
-		FullVersion string `json:"full_version"`
+		Version    string `json:"version"`
+		SourceRepo string `json:"source_repo"`
+		GitCommit  string `json:"git_commit"`
+		BuildTime  string `json:"build_time"`
 	}
 	type versionInfo struct {
 		Pomerium   pomeriumVersion   `json:"pomerium"`
@@ -129,6 +132,7 @@ func (srv *debugServer) versionHandler() http.HandlerFunc {
 	}
 
 	return func(w http.ResponseWriter, _ *http.Request) {
+		envoyLockfile := files.Lockfile()
 		info := versionInfo{
 			Pomerium: pomeriumVersion{
 				Version:     version.Version,
@@ -138,8 +142,10 @@ func (srv *debugServer) versionHandler() http.HandlerFunc {
 				BuildTime:   version.BuildTime(),
 			},
 			Envoy: envoyVersion{
-				Version:     files.Version(),
-				FullVersion: files.FullVersion(),
+				Version:    envoyLockfile.Version,
+				SourceRepo: envoyLockfile.SourceRepo(),
+				GitCommit:  envoyLockfile.GitCommit(),
+				BuildTime:  envoyLockfile.BuildTimestamp().UTC().Format(time.RFC3339),
 			},
 			Components: version.Components(),
 		}

--- a/internal/zero/cmd/command_import.go
+++ b/internal/zero/cmd/command_import.go
@@ -38,7 +38,7 @@ func BuildImportCmd() *cobra.Command {
 				return fmt.Errorf("no config file provided")
 			}
 			log.SetLevel(zerolog.ErrorLevel)
-			src, err := config.NewFileOrEnvironmentSource(cmd.Context(), configFile, files.FullVersion())
+			src, err := config.NewFileOrEnvironmentSource(cmd.Context(), configFile, files.Lockfile().Version)
 			if err != nil {
 				return err
 			}

--- a/pkg/cmd/pomerium/pomerium.go
+++ b/pkg/cmd/pomerium/pomerium.go
@@ -130,7 +130,7 @@ func (p *Pomerium) Start(ctx context.Context, tracerProvider oteltrace.TracerPro
 	_, _ = maxprocs.Set(maxprocs.Logger(func(s string, i ...any) { log.Ctx(ctx).Debug().Msgf(s, i...) }))
 
 	evt := log.Ctx(ctx).Info().
-		Str("envoy-version", files.FullVersion()).
+		Str("envoy-version", files.Lockfile().Version).
 		Str("version", version.FullVersion())
 	if buildTime := version.BuildTime(); buildTime != "" {
 		evt = evt.Str("built", buildTime)

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -132,9 +132,11 @@ func NewServer(
 	src.OnConfigChange(ctx, srv.onConfigChange)
 	srv.onConfigChange(ctx, src.GetConfig())
 
+	lockfile := files.Lockfile()
 	log.Ctx(ctx).Debug().
 		Str("path", envoyPath).
-		Str("checksum", files.Checksum()).
+		Str("version", lockfile.Version).
+		Str("checksum", lockfile.Digest).
 		Msg("running envoy")
 
 	return srv, nil

--- a/pkg/envoy/envoyversion/envoyversion.go
+++ b/pkg/envoy/envoyversion/envoyversion.go
@@ -2,37 +2,11 @@ package envoyversion
 
 import (
 	"runtime/debug"
-	"strings"
 
 	"golang.org/x/mod/module"
 
 	_ "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh" // to get version info
 )
-
-func PseudoVersionTimeRev() string {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return ""
-	}
-
-	var modVersion string
-	for _, dep := range info.Deps {
-		if dep.Path == "github.com/pomerium/envoy-custom" {
-			if dep.Replace != nil {
-				modVersion = dep.Replace.Version
-			} else {
-				modVersion = dep.Version
-			}
-			break
-		}
-	}
-	if module.IsPseudoVersion(modVersion) {
-		t, _ := module.PseudoVersionTime(modVersion)
-		rev, _ := module.PseudoVersionRev(modVersion)
-		return t.UTC().Format(module.PseudoVersionTimestampFormat) + "-" + rev
-	}
-	return ""
-}
 
 // Version returns the envoy version.
 func Version() string {
@@ -53,11 +27,14 @@ func Version() string {
 		}
 	}
 
+	// If the version is tagged, the corresponding image will have that exact tag.
+	// If the version is a pseudo-version, the image tag will exactly match the
+	// "yyyymmddhhmmss-abcdef123456" part of the pseudo-version string.
 	if module.IsPseudoVersion(modVersion) {
-		if base, err := module.PseudoVersionBase(modVersion); err == nil {
-			modVersion = base
-		}
+		t, _ := module.PseudoVersionTime(modVersion)
+		rev, _ := module.PseudoVersionRev(modVersion)
+		return t.UTC().Format(module.PseudoVersionTimestampFormat) + "-" + rev
 	}
 
-	return strings.TrimPrefix(modVersion, "v")
+	return modVersion
 }

--- a/pkg/envoy/envoyversion/envoyversion.go
+++ b/pkg/envoy/envoyversion/envoyversion.go
@@ -9,6 +9,31 @@ import (
 	_ "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh" // to get version info
 )
 
+func PseudoVersionTimeRev() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+
+	var modVersion string
+	for _, dep := range info.Deps {
+		if dep.Path == "github.com/pomerium/envoy-custom" {
+			if dep.Replace != nil {
+				modVersion = dep.Replace.Version
+			} else {
+				modVersion = dep.Version
+			}
+			break
+		}
+	}
+	if module.IsPseudoVersion(modVersion) {
+		t, _ := module.PseudoVersionTime(modVersion)
+		rev, _ := module.PseudoVersionRev(modVersion)
+		return t.UTC().Format(module.PseudoVersionTimestampFormat) + "-" + rev
+	}
+	return ""
+}
+
 // Version returns the envoy version.
 func Version() string {
 	info, ok := debug.ReadBuildInfo()

--- a/pkg/envoy/envoyversion/lockfile.go
+++ b/pkg/envoy/envoyversion/lockfile.go
@@ -1,0 +1,40 @@
+package envoyversion
+
+import (
+	"strconv"
+	"strings"
+	"time"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+type Lockfile struct {
+	// Output filename
+	Filename string `json:"filename"`
+	// Decompressed size
+	Size int64 `json:"size"`
+	// Digest of the decompressed file. This is not an OCI CAS digest.
+	Digest string `json:"digest"`
+	// Go mod version string
+	Version string `json:"version"`
+	// Remote manifest descriptor
+	ManifestDescriptor v1.Descriptor `json:"manifest_descriptor"`
+	// Labels from the ImageConfig referenced in the manifest
+	Labels map[string]string `json:"labels"`
+}
+
+func (lf Lockfile) SourceRepo() string {
+	return strings.TrimSuffix(strings.TrimPrefix(lf.Labels["BUILD_SCM_REMOTE"], "https://"), ".git")
+}
+
+func (lf Lockfile) GitCommit() string {
+	return lf.Labels["BUILD_SCM_REVISION"]
+}
+
+func (lf Lockfile) BuildTimestamp() time.Time {
+	unix, err := strconv.ParseInt(lf.Labels["BUILD_TIMESTAMP"], 10, 64)
+	if err != nil {
+		return time.Time{}
+	}
+	return time.Unix(unix, 0)
+}

--- a/pkg/envoy/extract_debug_local.go
+++ b/pkg/envoy/extract_debug_local.go
@@ -12,7 +12,7 @@ import (
 var DebugLocalEnvoyPath string
 
 func init() {
-	files.SetFiles(nil, "<external> _", "")
+	files.SetFiles(nil, `{}`)
 }
 
 func extract(dstName string) (err error) {

--- a/pkg/envoy/extract_embed.go
+++ b/pkg/envoy/extract_embed.go
@@ -12,8 +12,9 @@ import (
 	"strings"
 
 	"github.com/cespare/xxhash/v2"
-	"github.com/pomerium/pomerium/pkg/envoy/files"
 	"github.com/zeebo/xxh3"
+
+	"github.com/pomerium/pomerium/pkg/envoy/files"
 )
 
 func extract(dstName string) error {

--- a/pkg/envoy/extract_embed.go
+++ b/pkg/envoy/extract_embed.go
@@ -5,23 +5,35 @@ package envoy
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 	"strings"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/pomerium/pomerium/pkg/envoy/files"
+	"github.com/zeebo/xxh3"
 )
 
-func extract(dstName string) (err error) {
-	checksum, err := hex.DecodeString(strings.Fields(files.Checksum())[0])
-	if err != nil {
-		return fmt.Errorf("checksum %s: %w", files.Checksum(), err)
+func extract(dstName string) error {
+	lockfile := files.Lockfile()
+	digestStr := lockfile.Digest
+	alg, digest, ok := strings.Cut(digestStr, ":")
+	if !ok {
+		return fmt.Errorf("invalid digest format: expecting 'algorithm:digest'")
 	}
-
+	var hash hash.Hash
+	switch alg {
+	case "sha256":
+		hash = sha256.New()
+	case "xxh3":
+		hash = xxh3.New()
+	case "xxh64":
+		hash = xxhash.New()
+	}
 	hr := &hashReader{
-		Hash: sha256.New(),
+		Hash: hash,
 		r:    bytes.NewReader(files.Binary()),
 	}
 
@@ -35,9 +47,9 @@ func extract(dstName string) (err error) {
 		return err
 	}
 
-	sum := hr.Sum(nil)
-	if !bytes.Equal(sum, checksum) {
-		return fmt.Errorf("expected %x, got %x checksum", checksum, sum)
+	actual := fmt.Sprintf("%x", hr.Sum(nil))
+	if actual != digest {
+		return fmt.Errorf("expected %s, got %s checksum", digest, actual)
 	}
 	return nil
 }

--- a/pkg/envoy/files/files.go
+++ b/pkg/envoy/files/files.go
@@ -3,7 +3,9 @@ package files
 
 import (
 	_ "embed" // for embedded files
-	"strings"
+	"encoding/json"
+
+	"github.com/pomerium/pomerium/pkg/envoy/envoyversion"
 )
 
 // Binary returns the raw envoy binary bytes.
@@ -11,17 +13,11 @@ func Binary() []byte {
 	return rawBinary
 }
 
-// Checksum returns the checksum for the embedded envoy binary.
-func Checksum() string {
-	return strings.Fields(rawChecksum)[0]
-}
-
-// FullVersion returns the full version string for envoy.
-func FullVersion() string {
-	return Version() + "+" + Checksum()
-}
-
-// Version returns the envoy version.
-func Version() string {
-	return strings.TrimSpace(rawVersion)
+// Lockfile returns the embedded lockfile describing the envoy binary.
+func Lockfile() envoyversion.Lockfile {
+	var lockfile envoyversion.Lockfile
+	if err := json.Unmarshal(rawLockfile, &lockfile); err != nil {
+		panic(err)
+	}
+	return lockfile
 }

--- a/pkg/envoy/files/files_darwin_arm64.go
+++ b/pkg/envoy/files/files_darwin_arm64.go
@@ -7,8 +7,5 @@ import _ "embed" // embed
 //go:embed envoy-darwin-arm64
 var rawBinary []byte
 
-//go:embed envoy-darwin-arm64.sha256
-var rawChecksum string
-
-//go:embed envoy-darwin-arm64.version
-var rawVersion string
+//go:embed envoy-darwin-arm64.lock
+var rawLockfile []byte

--- a/pkg/envoy/files/files_external.go
+++ b/pkg/envoy/files/files_external.go
@@ -4,13 +4,10 @@ package files
 
 var rawBinary []byte
 
-var rawChecksum string
-
-var rawVersion string
+var rawLockfile []byte
 
 // SetFiles sets external source for envoy
-func SetFiles(bin []byte, checksum, version string) {
+func SetFiles(bin []byte, lockfile []byte) {
 	rawBinary = bin
-	rawChecksum = checksum
-	rawVersion = version
+	rawLockfile = lockfile
 }

--- a/pkg/envoy/files/files_linux_amd64.go
+++ b/pkg/envoy/files/files_linux_amd64.go
@@ -7,8 +7,5 @@ import _ "embed" // embed
 //go:embed envoy-linux-amd64
 var rawBinary []byte
 
-//go:embed envoy-linux-amd64.sha256
-var rawChecksum string
-
-//go:embed envoy-linux-amd64.version
-var rawVersion string
+//go:embed envoy-linux-amd64.lock
+var rawLockfile []byte

--- a/pkg/envoy/files/files_linux_arm64.go
+++ b/pkg/envoy/files/files_linux_arm64.go
@@ -7,8 +7,5 @@ import _ "embed" // embed
 //go:embed envoy-linux-arm64
 var rawBinary []byte
 
-//go:embed envoy-linux-arm64.sha256
-var rawChecksum string
-
-//go:embed envoy-linux-arm64.version
-var rawVersion string
+//go:embed envoy-linux-arm64.lock
+var rawLockfile []byte

--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -41,7 +41,7 @@ func main() {
 	}
 }
 
-func logDebug(format string, args ...any) {
+func debugf(format string, args ...any) {
 	if debug {
 		format = "[debug] " + format
 		if !strings.HasSuffix(format, "\n") {
@@ -77,16 +77,16 @@ type fetchResult struct {
 func fetch(outputDir string, remoteRepoName string) error {
 	version := envoyversion.Version()
 	ctx := context.Background()
-	logDebug("envoy version: %s", version)
+	debugf("envoy version: %s", version)
 	absOutputDir, _ := filepath.Abs(outputDir)
-	logDebug("remote repo: %s; output dir: %s", remoteRepoName, absOutputDir)
+	debugf("remote repo: %s; output dir: %s", remoteRepoName, absOutputDir)
 
 	repo, err := remote.NewRepository(remoteRepoName)
 	if err != nil {
 		return err
 	}
 
-	logDebug("[remote] fetching index")
+	debugf("[remote] fetching index")
 	indexDesc, reader, err := repo.FetchReference(ctx, version)
 	if err != nil {
 		return err
@@ -106,7 +106,7 @@ func fetch(outputDir string, remoteRepoName string) error {
 		return fmt.Errorf("remote index is empty")
 	}
 
-	logDebug("[remote] found valid index containing %d platforms", len(index.Manifests))
+	debugf("[remote] found valid index containing %d platforms", len(index.Manifests))
 
 	var wg sync.WaitGroup
 	requests := make([]fetchRequest, len(index.Manifests))
@@ -117,7 +117,7 @@ func fetch(outputDir string, remoteRepoName string) error {
 			fmt.Fprintf(os.Stderr, "skipping manifest with missing platform info: %s\n", manifestDesc.Digest)
 			continue
 		}
-		logDebug("[remote] found manifest for platform %s/%s", platform.OS, platform.Architecture)
+		debugf("[remote] found manifest for platform %s/%s", platform.OS, platform.Architecture)
 
 		requests[i] = fetchRequest{
 			manifestDesc: manifestDesc,
@@ -160,7 +160,7 @@ func fetchPlatform(ctx context.Context, req fetchRequest, outputDir string, repo
 		return false, nil
 	}
 
-	logDebug("[%s] fetching platform manifest", req.platform)
+	debugf("[%s] fetching platform manifest", req.platform)
 	reader, err := repo.Fetch(ctx, req.manifestDesc)
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch manifest %s: %w", req.manifestDesc.Digest, err)
@@ -227,7 +227,7 @@ func fetchPlatform(ctx context.Context, req fetchRequest, outputDir string, repo
 	if err != nil {
 		panic(err)
 	}
-	if err := os.WriteFile(lockfileName+".tmp", jsonData, 0o444); err != nil {
+	if err := os.WriteFile(lockfileName+".tmp", jsonData, 0o440); err != nil {
 		return false, fmt.Errorf("failed to write lockfile: %w", err)
 	}
 	if err := os.Rename(lockfileName+".tmp", lockfileName); err != nil {
@@ -243,13 +243,13 @@ func needsUpdate(dst string, manifestDesc v1.Descriptor) (bool, error) {
 	fileInfo, err := os.Stat(dst)
 	if err != nil {
 		if os.IsNotExist(err) {
-			logDebug(dbgPrefix + "no binary present; update required")
+			debugf(dbgPrefix + "no binary present; update required")
 			return true, nil
 		}
 		return false, err
 	}
 
-	logDebug(dbgPrefix+"reading lockfile %s.lock", dst)
+	debugf(dbgPrefix+"reading lockfile %s.lock", dst)
 	if data, err := os.ReadFile(dst + ".lock"); err != nil {
 		if os.IsNotExist(err) {
 			// Clean up artifacts from older versions of this tool
@@ -259,7 +259,7 @@ func needsUpdate(dst string, manifestDesc v1.Descriptor) (bool, error) {
 			if _, err := os.Stat(dst + ".version"); err == nil {
 				_ = os.Remove(dst + ".version")
 			}
-			logDebug(dbgPrefix + "no lockfile found; update required")
+			debugf(dbgPrefix + "no lockfile found; update required")
 			return true, nil
 		}
 		return false, fmt.Errorf("failed to read lockfile for %s: %w", dst, err)
@@ -269,17 +269,17 @@ func needsUpdate(dst string, manifestDesc v1.Descriptor) (bool, error) {
 
 	// Check if the remote manifest matches the local one
 	if !content.Equal(lockfile.ManifestDescriptor, manifestDesc) {
-		logDebug(dbgPrefix + "local manifest is out of date; update required")
+		debugf(dbgPrefix + "local manifest is out of date; update required")
 		return true, nil
 	}
-	logDebug(dbgPrefix + "local manifest is up to date")
+	debugf(dbgPrefix + "local manifest is up to date")
 
 	// Check if the file on disk matches the digest in the lockfile
 	if fileInfo.Size() != lockfile.Size {
-		logDebug(dbgPrefix + "cached binary size does not match the size indicated in the lockfile")
+		debugf(dbgPrefix + "cached binary size does not match the size indicated in the lockfile")
 		return true, nil
 	}
-	logDebug(dbgPrefix + "checking if cached binary checksum matches lockfile")
+	debugf(dbgPrefix + "checking if cached binary checksum matches lockfile")
 
 	hash := newHash()
 	file, err := os.Open(dst)
@@ -292,16 +292,16 @@ func needsUpdate(dst string, manifestDesc v1.Descriptor) (bool, error) {
 		return false, err
 	}
 	if fmt.Sprintf("%s:%x", preferredHashAlg, hash.Sum(nil)) != lockfile.Digest {
-		logDebug(dbgPrefix + "cached binary checksum mismatch, update required")
+		debugf(dbgPrefix + "cached binary checksum mismatch, update required")
 		return true, nil
 	}
 
-	logDebug(dbgPrefix + "cached binary is up to date")
+	debugf(dbgPrefix + "cached binary is up to date")
 	return false, nil
 }
 
 func extract(outputFilename string, layer io.Reader) (_ int64, _ string, retErr error) {
-	logDebug("extracting binary to %s", outputFilename)
+	debugf("extracting binary to %s", outputFilename)
 
 	tmpFilename := outputFilename + ".tmp"
 	file, err := os.Create(tmpFilename)
@@ -349,7 +349,7 @@ func extract(outputFilename string, layer io.Reader) (_ int64, _ string, retErr 
 		return 0, "", err
 	}
 
-	logDebug("extracted binary to %s (size: %d; digest: %s)", outputFilename, size, digest)
+	debugf("extracted binary to %s (size: %d; digest: %s)", outputFilename, size, digest)
 	return size, digest, nil
 }
 

--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/klauspost/compress/zstd"
@@ -23,17 +24,30 @@ import (
 	"github.com/pomerium/pomerium/pkg/envoy/envoyversion"
 )
 
+var debug bool
+
 func main() {
 	var outputDir string
 	var repo string
 	pflag.StringVarP(&outputDir, "output", "o", ".", "output directory")
-	pflag.StringVar(&repo, "repo", "docker.io/pomerium/envoy-custom", "image repo")
+	pflag.BoolVar(&debug, "debug", false, "enable debug logs")
+	pflag.StringVar(&repo, "repo", "ghcr.io/pomerium/envoy-custom", "image repo")
 	pflag.Parse()
 
 	err := fetch(outputDir, repo)
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
+	}
+}
+
+func logDebug(format string, args ...any) {
+	if debug {
+		format = "[debug] " + format
+		if !strings.HasSuffix(format, "\n") {
+			format += "\n"
+		}
+		fmt.Fprintf(os.Stderr, format, args...)
 	}
 }
 
@@ -63,11 +77,16 @@ type fetchResult struct {
 func fetch(outputDir string, remoteRepoName string) error {
 	version := envoyversion.Version()
 	ctx := context.Background()
+	logDebug("envoy version: %s", version)
+	absOutputDir, _ := filepath.Abs(outputDir)
+	logDebug("remote repo: %s; output dir: %s", remoteRepoName, absOutputDir)
 
 	repo, err := remote.NewRepository(remoteRepoName)
 	if err != nil {
 		return err
 	}
+
+	logDebug("[remote] fetching index")
 	indexDesc, reader, err := repo.FetchReference(ctx, version)
 	if err != nil {
 		return err
@@ -80,10 +99,14 @@ func fetch(outputDir string, remoteRepoName string) error {
 	if err := indexReader.Verify(); err != nil {
 		return fmt.Errorf("content verification failed for index %s: %w", indexDesc.Digest, err)
 	}
-
 	if index.MediaType != indexMediaType {
 		return fmt.Errorf("expected reference to be an oci index, got %s instead", index.MediaType)
 	}
+	if len(index.Manifests) == 0 {
+		return fmt.Errorf("remote index is empty")
+	}
+
+	logDebug("[remote] found valid index containing %d platforms", len(index.Manifests))
 
 	var wg sync.WaitGroup
 	requests := make([]fetchRequest, len(index.Manifests))
@@ -94,6 +117,8 @@ func fetch(outputDir string, remoteRepoName string) error {
 			fmt.Fprintf(os.Stderr, "skipping manifest with missing platform info: %s\n", manifestDesc.Digest)
 			continue
 		}
+		logDebug("[remote] found manifest for platform %s/%s", platform.OS, platform.Architecture)
+
 		requests[i] = fetchRequest{
 			manifestDesc: manifestDesc,
 			platform:     *platform,
@@ -135,6 +160,7 @@ func fetchPlatform(ctx context.Context, req fetchRequest, outputDir string, repo
 		return false, nil
 	}
 
+	logDebug("[%s] fetching platform manifest", req.platform)
 	reader, err := repo.Fetch(ctx, req.manifestDesc)
 	if err != nil {
 		return false, fmt.Errorf("failed to fetch manifest %s: %w", req.manifestDesc.Digest, err)
@@ -212,15 +238,18 @@ func fetchPlatform(ctx context.Context, req fetchRequest, outputDir string, repo
 
 func needsUpdate(dst string, manifestDesc v1.Descriptor) (bool, error) {
 	var lockfile envoyversion.Lockfile
+	dbgPrefix := fmt.Sprintf("[%s/%s] ", manifestDesc.Platform.OS, manifestDesc.Platform.Architecture)
 
 	fileInfo, err := os.Stat(dst)
 	if err != nil {
 		if os.IsNotExist(err) {
+			logDebug(dbgPrefix + "no binary present; update required")
 			return true, nil
 		}
 		return false, err
 	}
 
+	logDebug(dbgPrefix+"reading lockfile %s.lock", dst)
 	if data, err := os.ReadFile(dst + ".lock"); err != nil {
 		if os.IsNotExist(err) {
 			// Clean up artifacts from older versions of this tool
@@ -230,6 +259,7 @@ func needsUpdate(dst string, manifestDesc v1.Descriptor) (bool, error) {
 			if _, err := os.Stat(dst + ".version"); err == nil {
 				_ = os.Remove(dst + ".version")
 			}
+			logDebug(dbgPrefix + "no lockfile found; update required")
 			return true, nil
 		}
 		return false, fmt.Errorf("failed to read lockfile for %s: %w", dst, err)
@@ -239,13 +269,18 @@ func needsUpdate(dst string, manifestDesc v1.Descriptor) (bool, error) {
 
 	// Check if the remote manifest matches the local one
 	if !content.Equal(lockfile.ManifestDescriptor, manifestDesc) {
+		logDebug(dbgPrefix + "local manifest is out of date; update required")
 		return true, nil
 	}
+	logDebug(dbgPrefix + "local manifest is up to date")
 
 	// Check if the file on disk matches the digest in the lockfile
 	if fileInfo.Size() != lockfile.Size {
+		logDebug(dbgPrefix + "cached binary size does not match the size indicated in the lockfile")
 		return true, nil
 	}
+	logDebug(dbgPrefix + "checking if cached binary checksum matches lockfile")
+
 	hash := newHash()
 	file, err := os.Open(dst)
 	if err != nil {
@@ -257,13 +292,17 @@ func needsUpdate(dst string, manifestDesc v1.Descriptor) (bool, error) {
 		return false, err
 	}
 	if fmt.Sprintf("%s:%x", preferredHashAlg, hash.Sum(nil)) != lockfile.Digest {
+		logDebug(dbgPrefix + "cached binary checksum mismatch, update required")
 		return true, nil
 	}
 
+	logDebug(dbgPrefix + "cached binary is up to date")
 	return false, nil
 }
 
 func extract(outputFilename string, layer io.Reader) (_ int64, _ string, retErr error) {
+	logDebug("extracting binary to %s", outputFilename)
+
 	tmpFilename := outputFilename + ".tmp"
 	file, err := os.Create(tmpFilename)
 	if err != nil {
@@ -288,7 +327,7 @@ func extract(outputFilename string, layer io.Reader) (_ int64, _ string, retErr 
 	if err != nil {
 		return 0, "", err
 	}
-	if hdr.Name != "envoy" {
+	if hdr.Name != "envoy" && hdr.Name != "envoy.stripped" {
 		return 0, "", fmt.Errorf("encountered unknown file in archive: %s", hdr.Name)
 	}
 
@@ -309,6 +348,8 @@ func extract(outputFilename string, layer io.Reader) (_ int64, _ string, retErr 
 	if err := os.Rename(tmpFilename, outputFilename); err != nil {
 		return 0, "", err
 	}
+
+	logDebug("extracted binary to %s (size: %d; digest: %s)", outputFilename, size, digest)
 	return size, digest, nil
 }
 

--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -227,7 +227,7 @@ func fetchPlatform(ctx context.Context, req fetchRequest, outputDir string, repo
 	if err != nil {
 		panic(err)
 	}
-	if err := os.WriteFile(lockfileName+".tmp", jsonData, 0o440); err != nil {
+	if err := os.WriteFile(lockfileName+".tmp", jsonData, 0o400); err != nil {
 		return false, fmt.Errorf("failed to write lockfile: %w", err)
 	}
 	if err := os.Rename(lockfileName+".tmp", lockfileName); err != nil {

--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -1,193 +1,326 @@
 package main
 
 import (
+	"archive/tar"
 	"context"
+	"encoding/json"
+	"errors"
 	"fmt"
+	"hash"
 	"io"
-	"net/http"
 	"os"
+	"path/filepath"
 	"runtime"
-	"slices"
-	"time"
+	"sync"
 
-	"github.com/rs/zerolog"
-	"golang.org/x/sync/errgroup"
+	"github.com/klauspost/compress/zstd"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/spf13/pflag"
+	"github.com/zeebo/xxh3"
+	"oras.land/oras-go/v2/content"
+	"oras.land/oras-go/v2/registry/remote"
 
-	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/envoy/envoyversion"
 )
 
-var (
-	targets = []string{
-		"darwin-arm64",
-		"linux-amd64",
-		"linux-arm64",
+func main() {
+	var outputDir string
+	var repo string
+	pflag.StringVarP(&outputDir, "output", "o", ".", "output directory")
+	pflag.StringVar(&repo, "repo", "docker.io/pomerium/envoy-custom", "image repo")
+	pflag.Parse()
+
+	err := fetch(outputDir, repo)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
-	baseURL = "https://github.com/pomerium/envoy-custom/releases/download/v" + envoyversion.Version()
+}
+
+const (
+	indexMediaType       = "application/vnd.oci.image.index.v1+json"
+	imageConfigMediaType = "application/vnd.oci.image.config.v1+json"
+	zstdLayerType        = "application/vnd.oci.image.layer.v1.tar+zstd"
 )
 
-func main() {
-	log.SetLevel(zerolog.InfoLevel)
+const preferredHashAlg = "xxh3"
+
+func newHash() hash.Hash {
+	return xxh3.New()
+}
+
+type fetchRequest struct {
+	manifestDesc v1.Descriptor
+	platform     v1.Platform
+	version      string
+}
+
+type fetchResult struct {
+	didUpdate bool
+	err       error
+}
+
+func fetch(outputDir string, remoteRepoName string) error {
+	version := envoyversion.PseudoVersionTimeRev()
 	ctx := context.Background()
-	err := run(ctx, os.Args)
+
+	repo, err := remote.NewRepository(remoteRepoName)
 	if err != nil {
-		log.Fatal().Err(err).Send()
+		return err
 	}
-}
-
-func run(ctx context.Context, args []string) error {
-	mode := "all"
-	if len(args) > 1 {
-		mode = args[1]
+	indexDesc, reader, err := repo.FetchReference(ctx, version)
+	if err != nil {
+		return err
+	}
+	indexReader := content.NewVerifyReader(reader, indexDesc)
+	var index v1.Index
+	if err := json.NewDecoder(indexReader).Decode(&index); err != nil {
+		return err
+	}
+	if err := indexReader.Verify(); err != nil {
+		return fmt.Errorf("content verification failed for index %s: %w", indexDesc.Digest, err)
 	}
 
-	switch mode {
-	case "all":
-		return runAll(ctx)
-	case "current":
-		return runCurrent(ctx)
-	default:
-		if slices.Contains(targets, mode) {
-			return runArch(ctx, mode)
+	if index.MediaType != indexMediaType {
+		return fmt.Errorf("expected reference to be an oci index, got %s instead", index.MediaType)
+	}
+
+	var wg sync.WaitGroup
+	requests := make([]fetchRequest, len(index.Manifests))
+	results := make([]fetchResult, len(index.Manifests))
+	for i, manifestDesc := range index.Manifests {
+		platform := manifestDesc.Platform
+		if platform == nil {
+			fmt.Fprintf(os.Stderr, "skipping manifest with missing platform info: %s\n", manifestDesc.Digest)
+			continue
+		}
+		requests[i] = fetchRequest{
+			manifestDesc: manifestDesc,
+			platform:     *platform,
+			version:      version,
 		}
 	}
 
-	return fmt.Errorf("unknown mode: %s", mode)
-}
-
-func runAll(ctx context.Context) error {
-	eg, ctx := errgroup.WithContext(ctx)
-	for _, target := range targets {
-
-		eg.Go(func() error {
-			return download(ctx, "./envoy-"+target, baseURL+"/envoy-"+target)
-		})
-		eg.Go(func() error {
-			return download(ctx, "./envoy-"+target+".sha256", baseURL+"/envoy-"+target+".sha256")
-		})
-		eg.Go(func() error {
-			return os.WriteFile("./envoy-"+target+".version", []byte(envoyversion.Version()+"\n"), 0o600)
+	for i, req := range requests {
+		wg.Go(func() {
+			didUpdate, err := fetchPlatform(ctx, req, outputDir, repo)
+			results[i] = fetchResult{didUpdate, err}
 		})
 	}
-	return eg.Wait()
-}
-
-func runCurrent(ctx context.Context) error {
-	return runArch(ctx, runtime.GOOS+"-"+runtime.GOARCH)
-}
-
-func runArch(ctx context.Context, arch string) error {
-	err := download(ctx, "./envoy", baseURL+"/envoy-"+arch)
-	if err != nil {
-		return err
+	wg.Wait()
+	for i := range len(index.Manifests) {
+		req := requests[i]
+		res := results[i]
+		if res.err != nil {
+			fmt.Fprintf(os.Stderr, "%s/%s: error: %s\n", req.platform.OS, req.platform.Architecture, res.err)
+			continue
+		}
+		filename := platformFilename(requests[i].platform)
+		if res.didUpdate {
+			fmt.Fprintf(os.Stderr, "%s => %s\n", filename, version)
+		} else {
+			fmt.Fprintf(os.Stderr, "%s (up to date)\n", filename)
+		}
 	}
-
-	err = os.Chmod("./envoy", 0o755)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
-func download(
-	ctx context.Context,
-	dstPath string,
-	srcURL string,
-) error {
-	fi, err := os.Stat(dstPath)
-	if err == nil {
-		lastModified, err := getURLLastModified(ctx, srcURL)
+func fetchPlatform(ctx context.Context, req fetchRequest, outputDir string, repo *remote.Repository) (bool, error) {
+	dst := filepath.Join(outputDir, platformFilename(req.platform))
+
+	// Check if the file is up to date
+	if ok, err := needsUpdate(dst, req.manifestDesc); err != nil {
+		return false, err
+	} else if !ok {
+		return false, nil
+	}
+
+	reader, err := repo.Fetch(ctx, req.manifestDesc)
+	if err != nil {
+		return false, fmt.Errorf("failed to fetch manifest %s: %w", req.manifestDesc.Digest, err)
+	}
+
+	manifestReader := content.NewVerifyReader(reader, req.manifestDesc)
+	var manifest v1.Manifest
+	if err := json.NewDecoder(manifestReader).Decode(&manifest); err != nil {
+		return false, err
+	}
+	if err := manifestReader.Verify(); err != nil {
+		return false, fmt.Errorf("content verification failed for manifest %s: %w", req.manifestDesc.Digest, err)
+	}
+
+	var labels map[string]string
+	if manifest.Config.MediaType == imageConfigMediaType {
+		reader, err := repo.Fetch(ctx, manifest.Config)
 		if err != nil {
-			return fmt.Errorf("error getting download last modified (url=%s): %w", srcURL, err)
+			return false, fmt.Errorf("failed to fetch image config: %w", err)
 		}
-
-		if timesMatch(fi.ModTime(), lastModified) {
-			log.Ctx(ctx).Debug().Str("url", srcURL).Str("dst", dstPath).Msg("skipping download")
-			return nil
+		imageReader := content.NewVerifyReader(reader, manifest.Config)
+		var ic v1.Image
+		if err := json.NewDecoder(imageReader).Decode(&ic); err != nil {
+			return false, err
 		}
-
-	} else if !os.IsNotExist(err) {
-		return fmt.Errorf("error reading destination path file info (dst=%s): %w", dstPath, err)
-	}
-
-	log.Ctx(ctx).Info().Str("url", srcURL).Str("dst", dstPath).Msg("downloading")
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srcURL, nil)
-	if err != nil {
-		return fmt.Errorf("error creating GET request for download (url=%s): %w", srcURL, err)
-	}
-
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return fmt.Errorf("error making GET request for download (url=%s): %w", srcURL, err)
-	}
-	defer res.Body.Close()
-
-	if err := checkHTTPStatus(srcURL, res); err != nil {
-		return err
-	}
-
-	dst, err := os.Create(dstPath)
-	if err != nil {
-		return fmt.Errorf("error creating downloaded file (url=%s dst=%s): %w", srcURL, dstPath, err)
-	}
-
-	_, err = io.Copy(dst, res.Body)
-	if err != nil {
-		_ = dst.Close()
-		_ = os.Remove(dstPath)
-		return fmt.Errorf("error copying downloaded file (url=%s dst=%s): %w", srcURL, dstPath, err)
-	}
-
-	err = dst.Close()
-	if err != nil {
-		_ = os.Remove(dstPath)
-		return fmt.Errorf("error closing destination file: %w", err)
-	}
-
-	if lastModified, err := time.Parse(http.TimeFormat, res.Header.Get("Last-Modified")); err == nil {
-		err = os.Chtimes(dstPath, time.Time{}, lastModified)
-		if err != nil {
-			return fmt.Errorf("error writing last modified timestamp: %w", err)
+		if err := imageReader.Verify(); err != nil {
+			return false, fmt.Errorf("content verification failed for image spec %s: %w", manifest.Config.Digest, err)
 		}
+		labels = ic.Config.Labels
 	}
 
-	return nil
+	if len(manifest.Layers) != 1 {
+		return false, fmt.Errorf("expected 1 layer, got %d", len(manifest.Layers))
+	}
+	layer0 := manifest.Layers[0]
+
+	if layer0.MediaType != zstdLayerType {
+		return false, fmt.Errorf("unexpected layer type (want %s, got %s)", zstdLayerType, layer0.MediaType)
+	}
+
+	layer, err := repo.Blobs().Fetch(ctx, layer0)
+	if err != nil {
+		return false, err
+	}
+	layerReader := content.NewVerifyReader(layer, layer0)
+	size, digest, err := extract(dst, layerReader)
+	if err != nil {
+		return false, fmt.Errorf("failed to extract layer into %s: %w", layer0.Digest, err)
+	}
+	if err := layerReader.Verify(); err != nil {
+		return false, fmt.Errorf("content verification failed for layer %s: %w", layer0.Digest, err)
+	}
+
+	lockfile := envoyversion.Lockfile{
+		Filename:           dst,
+		Digest:             digest,
+		Size:               size,
+		Version:            req.version,
+		ManifestDescriptor: req.manifestDesc,
+		Labels:             labels,
+	}
+	lockfileName := dst + ".lock"
+	jsonData, err := json.MarshalIndent(lockfile, "", "  ")
+	if err != nil {
+		panic(err)
+	}
+	if err := os.WriteFile(lockfileName+".tmp", jsonData, 0o444); err != nil {
+		return false, fmt.Errorf("failed to write lockfile: %w", err)
+	}
+	if err := os.Rename(lockfileName+".tmp", lockfileName); err != nil {
+		return false, fmt.Errorf("failed to write lockfile: %w", err)
+	}
+	return true, nil
 }
 
-func getURLLastModified(
-	ctx context.Context,
-	srcURL string,
-) (time.Time, error) {
-	// check to see if the file needs to be updated
-	headReq, err := http.NewRequestWithContext(ctx, http.MethodHead, srcURL, nil)
+func needsUpdate(dst string, manifestDesc v1.Descriptor) (bool, error) {
+	var lockfile envoyversion.Lockfile
+
+	fileInfo, err := os.Stat(dst)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("error creating head request for download: %w", err)
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
 	}
 
-	res, err := http.DefaultClient.Do(headReq)
+	if data, err := os.ReadFile(dst + ".lock"); err != nil {
+		if os.IsNotExist(err) {
+			// Clean up artifacts from older versions of this tool
+			if _, err := os.Stat(dst + ".sha256"); err == nil {
+				_ = os.Remove(dst + ".sha256")
+			}
+			if _, err := os.Stat(dst + ".version"); err == nil {
+				_ = os.Remove(dst + ".version")
+			}
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to read lockfile for %s: %w", dst, err)
+	} else if err := json.Unmarshal(data, &lockfile); err != nil {
+		return false, fmt.Errorf("failed to read lockfile for %s: %w", dst, err)
+	}
+
+	// Check if the remote manifest matches the local one
+	if !content.Equal(lockfile.ManifestDescriptor, manifestDesc) {
+		return true, nil
+	}
+
+	// Check if the file on disk matches the digest in the lockfile
+	if fileInfo.Size() != lockfile.Size {
+		return true, nil
+	}
+	hash := newHash()
+	file, err := os.Open(dst)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("error making head request for download: %w", err)
+		return false, err
 	}
-	defer res.Body.Close()
-
-	if err := checkHTTPStatus(srcURL, res); err != nil {
-		return time.Time{}, err
+	_, err = io.Copy(hash, file)
+	_ = file.Close()
+	if err != nil {
+		return false, err
+	}
+	if fmt.Sprintf("%s:%x", preferredHashAlg, hash.Sum(nil)) != lockfile.Digest {
+		return true, nil
 	}
 
-	return time.Parse(http.TimeFormat, res.Header.Get("Last-Modified"))
+	return false, nil
 }
 
-func checkHTTPStatus(srcURL string, res *http.Response) error {
-	if res.StatusCode/100 != 2 {
-		msg, _ := io.ReadAll(io.LimitReader(res.Body, 1024))
-		return fmt.Errorf("unexpected status code for download (url=%s): %s %s", srcURL, res.Status, msg)
+func extract(outputFilename string, layer io.Reader) (_ int64, _ string, retErr error) {
+	tmpFilename := outputFilename + ".tmp"
+	file, err := os.Create(tmpFilename)
+	if err != nil {
+		return 0, "", err
 	}
-	return nil
+	defer func() {
+		if retErr != nil {
+			_ = file.Close()
+		}
+		if _, err := os.Stat(tmpFilename); err == nil {
+			_ = os.Remove(tmpFilename)
+		}
+	}()
+	decompressor, err := zstd.NewReader(layer, zstd.WithDecoderConcurrency(runtime.NumCPU()))
+	if err != nil {
+		return 0, "", err
+	}
+	defer decompressor.Close()
+	tarReader := tar.NewReader(decompressor)
+
+	hdr, err := tarReader.Next()
+	if err != nil {
+		return 0, "", err
+	}
+	if hdr.Name != "envoy" {
+		return 0, "", fmt.Errorf("encountered unknown file in archive: %s", hdr.Name)
+	}
+
+	hash := newHash()
+	tr := io.TeeReader(tarReader, hash)
+	size, err := io.Copy(file, tr)
+	if err != nil {
+		return 0, "", err
+	}
+	if _, err := tarReader.Next(); !errors.Is(err, io.EOF) {
+		return 0, "", fmt.Errorf("expected archive to contain only 1 file, but found more")
+	}
+
+	digest := fmt.Sprintf("%s:%x", preferredHashAlg, hash.Sum(nil))
+	if err := file.Close(); err != nil {
+		return 0, "", err
+	}
+	if err := os.Rename(tmpFilename, outputFilename); err != nil {
+		return 0, "", err
+	}
+	return size, digest, nil
 }
 
-func timesMatch(tm1, tm2 time.Time) bool {
-	diff := tm2.Sub(tm1)
-	return diff >= -5*time.Minute && diff <= 5*time.Minute
+var archMappings = map[string]string{
+	"x86_64":  "amd64",
+	"aarch64": "arm64",
+}
+
+func platformFilename(platform v1.Platform) string {
+	arch := platform.Architecture
+	if m, ok := archMappings[platform.Architecture]; ok {
+		arch = m
+	}
+	return fmt.Sprintf("envoy-%s-%s", platform.OS, arch)
 }

--- a/pkg/envoy/get-envoy/main.go
+++ b/pkg/envoy/get-envoy/main.go
@@ -61,7 +61,7 @@ type fetchResult struct {
 }
 
 func fetch(outputDir string, remoteRepoName string) error {
-	version := envoyversion.PseudoVersionTimeRev()
+	version := envoyversion.Version()
 	ctx := context.Background()
 
 	repo, err := remote.NewRepository(remoteRepoName)


### PR DESCRIPTION
This replaces the get-envoy tool with a new implementation that fetches binaries from OCI images published to https://github.com/orgs/pomerium/packages?repo_name=envoy-custom using the bazel rules added here: https://github.com/pomerium/envoy-custom/pull/169

The images are automatically tagged with the go module pseudo-version suffix string of the form `timestamp-commithash` where `timestamp` has the format `20060102150405` and `commithash` is the git commit hash truncated to the first 12 bytes. Tagged releases also tag the respective images with the release version in addition to the pseudo-version tag. When the get-envoy tool is run, it reads this version string from the `github.com/pomerium/envoy-custom` dependency in the current module and fetches the oci image with the matching tag. 

The tag must point to an oci image index (multi platform image) containing manifests for each supported os/arch. For example, it would look something like this:
```json
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 915,
      "digest": "sha256:aeb6d0110d631e4323bff3288cb2316b8fed157d19bc21c1f8296c0df8b8d24e",
      "platform": {
        "architecture": "x86_64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 915,
      "digest": "sha256:1ad4dec5d225bd32961a69c729da05584383d39d492a8591f7dda457384c497c",
      "platform": {
        "architecture": "aarch64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "size": 915,
      "digest": "sha256:cf0fb32c7987283728441a73fd58edd3c52d639ab867b0f6ddb6b58c24308682",
      "platform": {
        "architecture": "aarch64",
        "os": "darwin"
      }
    }
  ]
}
```

The tool will extract all available images for each os/arch listed in the index. 

The tool expects the images to be constructed in a particular way: they are runnable container images (not generic oci artifacts) with a single layer containing only the envoy binary in the filesystem tarball. The layer must have media type `application/vnd.oci.image.layer.v1.tar+zstd`; i.e. standard oci image layer, not imported into docker first.

The existing `.sha256` and `.version` files are replaced by a new json lockfile which looks like this:

```jsonc
{
  "filename": "envoy-linux-arm64",
  "size": 86136600,
  "digest": "xxh3:55f0eb7d86e17b14",
  "version": "20260331001551-046de5d7c5da",
  "manifest_descriptor": {
    "mediaType": "application/vnd.oci.image.manifest.v1+json",
    "digest": "sha256:1ad4dec5d225bd32961a69c729da05584383d39d492a8591f7dda457384c497c",
    "size": 915,
    "platform": {
      "architecture": "aarch64",
      "os": "linux"
    }
  },
  "labels": {
    "BUILD_EMBED_LABEL": "",
    "BUILD_HOST": "envoy-custom-homelab-xbrtt-runner-mtz28",
    "BUILD_SCM_BRANCH": "main",
    "BUILD_SCM_HASH": "e48de918372c3f3d5fa323538eb179da2ca393f3",
    "BUILD_SCM_REMOTE": "https://github.com/pomerium/envoy-custom",
    "BUILD_SCM_REVISION": "046de5d7c5dafee695aeee45e751bd023029fcdb",
    "BUILD_SCM_STATUS": "Clean",
    "BUILD_TIMESTAMP": "1774916941",
    "BUILD_USER": "runner",
    "ENVOY_BUILD_SCM_REVISION": "046de5d7c5dafee695aeee45e751bd023029fcdb",
    "FORMATTED_DATE": "2026 Mar 31 00 29 01 Tue",
    "STABLE_BUILD_SCM_REVISION": "046de5d7c5dafee695aeee45e751bd023029fcdb",
    "STABLE_BUILD_SCM_REVISION_TIMESTAMP": "20260331001551",
    "STABLE_BUILD_SCM_STATUS": "Clean",
    "STABLE_BUILD_SCM_TAG": "vX.Y.Z" // for tagged releases only
  }
}
```

The labels are injected into the image automatically from the bazel workspace status info in envoy-custom.

By default `make get-envoy` will pull the release binaries from `ghcr.io/pomerium/envoy-custom`. The repo can be swapped with the ENVOY_OCI_REPO variable. For example to pull debug binaries (which are the same as the release binaries, but with debug symbols), run `make get-envoy ENVOY_OCI_REPO=ghcr.io/pomerium/envoy-custom-debug`. 

You can also run `make get-envoy GET_ENVOY_DEBUG=1` to turn on debug logs.