### PR TITLE
envoy: update envoy-custom to v1.36.5-p1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -69,7 +69,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.8.1
 	github.com/pomerium/datasource v0.18.2-0.20260116153236-1f58110d0e17
-	github.com/pomerium/envoy-custom v1.36.4-rc3
+	github.com/pomerium/envoy-custom v1.36.5-p1
 	github.com/pomerium/protoutil v0.0.0-20260116153545-19d2ae5b7518
 	github.com/pomerium/webauthn v0.0.0-20260116153041-d32e028c3f7e
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -692,8 +692,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pomerium/datasource v0.18.2-0.20260116153236-1f58110d0e17 h1:0xmmqjD1vvGKuUdV7XmVfVndgBYqjKcXB4o7Szv5fso=
 github.com/pomerium/datasource v0.18.2-0.20260116153236-1f58110d0e17/go.mod h1:E+aEx9rVJm+lNWcKUzMHY6MobZC0HchBCn9zdP2EfHE=
-github.com/pomerium/envoy-custom v1.36.4-rc3 h1:VCJN03YO1KGz3oVR3Y8+FNIF82CbxdVaeBOgwJcESoQ=
-github.com/pomerium/envoy-custom v1.36.4-rc3/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
+github.com/pomerium/envoy-custom v1.36.5-p1 h1:Cs/KLpVAlI1gFflRh0EGaeh5VlAHW+IltAflV+HB1No=
+github.com/pomerium/envoy-custom v1.36.5-p1/go.mod h1:+wpbZvum83bq/OD4cp9/8IZiMV6boBkwDhlFPLOoWoI=
 github.com/pomerium/protoutil v0.0.0-20260116153545-19d2ae5b7518 h1:xIW5acZOr+EBXMapcOYsBCY/o7uh5GpKVVkk8iaTRFU=
 github.com/pomerium/protoutil v0.0.0-20260116153545-19d2ae5b7518/go.mod h1:vPV2+oC0DppJcM14IwN5nCJXW0Bh6J6r5Kg/vjEb0kQ=
 github.com/pomerium/webauthn v0.0.0-20260116153041-d32e028c3f7e h1:ACaHHitpK9WxN8Rd+hXPktyE3dWvfsfq9Hq86Kb8yU4=


### PR DESCRIPTION
## Summary

Update to envoy-custom v1.36.5-p1 (on the v0.32 release branch).

## Related issues

https://linear.app/pomerium/issue/ENG-3711/upgrade-envoy-to-1365

## User Explanation

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
