### PR TITLE
core/autocert: detect use_proxy_protocol changes in http redirect server

### DIFF
--- a/internal/autocert/manager.go
+++ b/internal/autocert/manager.go
@@ -54,6 +54,7 @@ type Manager struct {
 	acmeMgr             atomic.Pointer[certmagic.ACMEIssuer]
 	srv                 *http.Server
 	srvAddr             string
+	srvLi               net.Listener
 	srvUseProxyProtocol bool
 
 	acmeTLSALPNLock     sync.Mutex
@@ -334,6 +335,10 @@ func (mgr *Manager) updateServer(ctx context.Context, cfg *config.Config) {
 		_ = mgr.srv.Close()
 		mgr.srv = nil
 	}
+	if mgr.srvLi != nil {
+		_ = mgr.srvLi.Close()
+		mgr.srvLi = nil
+	}
 
 	if srvAddr == "" {
 		return
@@ -348,31 +353,33 @@ func (mgr *Manager) updateServer(ctx context.Context, cfg *config.Config) {
 			redirect.ServeHTTP(w, r)
 		}),
 	}
+	mgr.srv = hsrv
+
+	li, err := net.Listen("tcp", srvAddr)
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("failed to listen on http redirect addr")
+		return
+	}
+	if srvUseProxyProtocol {
+		li = &proxyproto.Listener{
+			Listener:          li,
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+	}
+	mgr.srvLi = li
+
 	go func() {
-		li, err := net.Listen("tcp", srvAddr)
-		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msg("failed to listen on http redirect addr")
-			return
-		}
-		defer li.Close()
-
-		if srvUseProxyProtocol {
-			li = &proxyproto.Listener{
-				Listener:          li,
-				ReadHeaderTimeout: 10 * time.Second,
-			}
-		}
-
 		log.Ctx(ctx).Info().
 			Str("addr", srvAddr).
 			Bool("use-proxy-protocol", srvUseProxyProtocol).
 			Msg("starting http redirect server")
 		err = hsrv.Serve(li)
-		if err != nil {
+		if errors.Is(err, http.ErrServerClosed) {
+			log.Ctx(ctx).Info().Msg("http redirect server exited")
+		} else if err != nil {
 			log.Ctx(ctx).Error().Err(err).Msg("failed to run http redirect server")
 		}
 	}()
-	mgr.srv = hsrv
 }
 
 func (mgr *Manager) updateACMETLSALPNServer(ctx context.Context, cfg *config.Config) {

--- a/internal/autocert/manager_test.go
+++ b/internal/autocert/manager_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/uuid"
 	"github.com/mholt/acmez/v3/acme"
+	"github.com/pires/go-proxyproto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/ocsp"
@@ -323,25 +324,64 @@ func TestRedirect(t *testing.T) {
 		},
 	})
 	_, err = New(t.Context(), src)
-	if !assert.NoError(t, err) {
-		return
-	}
-	err = waitFor(addr)
-	if !assert.NoError(t, err) {
-		return
-	}
+	require.NoError(t, err)
 
 	client := &http.Client{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+				conn, err := (&net.Dialer{}).DialContext(ctx, network, addr)
+				if err != nil {
+					return nil, err
+				}
+
+				hdr := &proxyproto.Header{
+					Version:           2,
+					Command:           proxyproto.PROXY,
+					TransportProtocol: proxyproto.TCPv4,
+					SourceAddr:        &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 80},
+					DestinationAddr:   &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 80},
+				}
+				_, err = hdr.WriteTo(conn)
+				if err != nil {
+					_ = conn.Close()
+					return nil, err
+				}
+
+				return conn, nil
+			},
+		},
 		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
 		},
 	}
 
+	go func() {
+		src.SetConfig(t.Context(), &config.Config{
+			Options: &config.Options{
+				HTTPRedirectAddr: addr,
+				SetResponseHeaders: map[string]string{
+					"X-Frame-Options":           "SAMEORIGIN",
+					"X-XSS-Protection":          "1; mode=block",
+					"Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+				},
+				UseProxyProtocol: true,
+			},
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		res, err := client.Get(fmt.Sprintf("http://%s", addr))
+		if err != nil {
+			t.Log(err)
+			return false
+		}
+		res.Body.Close()
+		return res.StatusCode != http.StatusBadRequest
+	}, 5*time.Second, 100*time.Millisecond)
+
 	res, err := client.Get(fmt.Sprintf("http://%s", addr))
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer res.Body.Close()
+	require.NoError(t, err)
+	res.Body.Close()
 
 	assert.Equal(t, http.StatusMovedPermanently, res.StatusCode, "should redirect to https")
 	for k, v := range src.GetConfig().Options.SetResponseHeaders {


### PR DESCRIPTION
## Summary
For the http redirect server, in addition to detecting changes to the http redirect address, also detect changes to the `use_proxy_protocol` option.

Previously if only the `use_proxy_protocol` option was changed, we wouldn't create a new proxy protocol listener, resulting in the server expecting standard HTTP traffic, leading to 400 errors.

## Related issues
- #6180 


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
