### PR TITLE
fix(mcp): include request path in WWW-Authenticate resource_metadata URI

### DIFF
--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -112,7 +112,7 @@ func (a *Authorize) handleResultDenied(
 		denyStatusText = httputil.DetailsText(http.StatusUnauthorized)
 		ctx = attachMCPExplanation(ctx)
 		headers = make(http.Header)
-		err := mcp.SetWWWAuthenticateHeader(headers, request.HTTP.Host)
+		err := mcp.SetWWWAuthenticateHeader(headers, request.HTTP.Host, request.HTTP.Path)
 		if err != nil {
 			return nil, err
 		}
@@ -282,7 +282,7 @@ func (a *Authorize) requireLoginResponse(
 			reason = "Unauthorized"
 			ctx = attachMCPExplanation(ctx)
 			headers = make(http.Header)
-			err := mcp.SetWWWAuthenticateHeader(headers, request.HTTP.Host)
+			err := mcp.SetWWWAuthenticateHeader(headers, request.HTTP.Host, request.HTTP.Path)
 			if err != nil {
 				return nil, err
 			}

--- a/authorize/check_response_test.go
+++ b/authorize/check_response_test.go
@@ -144,6 +144,24 @@ func TestAuthorize_handleResult(t *testing.T) {
 		assert.Contains(t, res.GetDeniedResponse().GetBody(),
 			"This is an MCP route. It is not meant to be accessed directly in the browser.")
 	})
+	t.Run("mcp-route-user-unauthenticated with path, mcp flag is on", func(t *testing.T) {
+		opt.RuntimeFlags[config.RuntimeFlagMCP] = true
+		res, err := a.handleResult(t.Context(),
+			&envoy_service_auth_v3.CheckRequest{},
+			&evaluator.Request{
+				HTTP:   evaluator.RequestHTTP{Host: "example.com", Path: "/mcp"},
+				Policy: &config.Policy{MCP: &config.MCP{Server: &config.MCPServer{}}},
+			},
+			&evaluator.Result{
+				Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+			})
+		assert.NoError(t, err)
+		assert.Equal(t, 401, int(res.GetDeniedResponse().GetStatus().GetCode()))
+		assertContainsHeaderValue(t,
+			"Www-Authenticate",
+			`Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource/mcp"`,
+			res.GetDeniedResponse().GetHeaders())
+	})
 	t.Run("mcp-route-user-unauthenticated, mcp flag is off", func(t *testing.T) {
 		opt.RuntimeFlags[config.RuntimeFlagMCP] = false
 		res, err := a.handleResult(t.Context(),
@@ -176,6 +194,24 @@ func TestAuthorize_handleResult(t *testing.T) {
 			res.GetDeniedResponse().GetHeaders())
 		assert.Contains(t, res.GetDeniedResponse().GetBody(),
 			"This is an MCP route. It is not meant to be accessed directly in the browser.")
+	})
+	t.Run("mcp-route-unauthenticated with path, mcp flag is on", func(t *testing.T) {
+		opt.RuntimeFlags[config.RuntimeFlagMCP] = true
+		res, err := a.handleResult(t.Context(),
+			&envoy_service_auth_v3.CheckRequest{},
+			&evaluator.Request{
+				HTTP:   evaluator.RequestHTTP{Host: "example.com", Path: "/api/mcp/v1"},
+				Policy: &config.Policy{MCP: &config.MCP{Server: &config.MCPServer{}}},
+			},
+			&evaluator.Result{
+				Allow: evaluator.NewRuleResult(false),
+			})
+		assert.NoError(t, err)
+		assert.Equal(t, 401, int(res.GetDeniedResponse().GetStatus().GetCode()))
+		assertContainsHeaderValue(t,
+			"Www-Authenticate",
+			`Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource/api/mcp/v1"`,
+			res.GetDeniedResponse().GetHeaders())
 	})
 	t.Run("mcp-route-denied", func(t *testing.T) {
 		ctx := t.Context()

--- a/internal/mcp/handler_metadata.go
+++ b/internal/mcp/handler_metadata.go
@@ -206,19 +206,19 @@ func getMetadataHandler[T any](fn func(r *http.Request, prefix string) T, prefix
 	return http.HandlerFunc(r.ServeHTTP)
 }
 
-func ProtectedResourceMetadataURL(host string) string {
+func ProtectedResourceMetadataURL(host, requestPath string) string {
 	return (&url.URL{
 		Scheme: "https",
 		Host:   host,
-		Path:   WellKnownProtectedResourceEndpoint,
+		Path:   WellKnownProtectedResourceEndpoint + requestPath,
 	}).String()
 }
 
-func SetWWWAuthenticateHeader(dst http.Header, host string) error {
+func SetWWWAuthenticateHeader(dst http.Header, host, requestPath string) error {
 	dict := sfv.Dictionary{
 		{
 			Key:  "resource_metadata",
-			Item: sfv.Item{Value: ProtectedResourceMetadataURL(host)},
+			Item: sfv.Item{Value: ProtectedResourceMetadataURL(host, requestPath)},
 		},
 	}
 	txt, err := sfv.EncodeDictionary(dict)

--- a/internal/mcp/handler_metadata_test.go
+++ b/internal/mcp/handler_metadata_test.go
@@ -12,11 +12,48 @@ import (
 
 func TestWWWAuthenticate(t *testing.T) {
 	t.Parallel()
-	hdr := make(http.Header)
-	err := mcp.SetWWWAuthenticateHeader(hdr, "example.com")
-	require.NoError(t, err)
-	t.Log(hdr)
-	require.Empty(t, cmp.Diff(hdr, http.Header{
-		"Www-Authenticate": []string{`Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"`},
-	}))
+
+	tests := []struct {
+		name        string
+		host        string
+		requestPath string
+		expected    string
+	}{
+		{
+			name:        "root path",
+			host:        "example.com",
+			requestPath: "/",
+			expected:    `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource/"`,
+		},
+		{
+			name:        "empty path",
+			host:        "example.com",
+			requestPath: "",
+			expected:    `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"`,
+		},
+		{
+			name:        "path-based MCP server",
+			host:        "example.com",
+			requestPath: "/mcp",
+			expected:    `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource/mcp"`,
+		},
+		{
+			name:        "nested path",
+			host:        "example.com",
+			requestPath: "/api/mcp/v1",
+			expected:    `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource/api/mcp/v1"`,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			hdr := make(http.Header)
+			err := mcp.SetWWWAuthenticateHeader(hdr, tc.host, tc.requestPath)
+			require.NoError(t, err)
+			require.Empty(t, cmp.Diff(hdr, http.Header{
+				"Www-Authenticate": []string{tc.expected},
+			}))
+		})
+	}
 }


### PR DESCRIPTION
## Summary

The resource_metadata URL in the WWW-Authenticate header was missing the request path for path-based MCP servers, causing clients to fail OAuth discovery due to a resource mismatch.

Per [RFC 9728 §5.1](https://datatracker.ietf.org/doc/html/rfc9728#section-5.1), well-known URIs for path-based resources should include the path suffix.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

## Related issues

Fixes #6199

## User Explanation

When Pomerium returns a 401 for a path-based MCP server (e.g. `https://example.com/mcp`), the `WWW-Authenticate` header now correctly points to `/.well-known/oauth-protected-resource/mcp` instead of `/.well-known/oauth-protected-resource`. This allows MCP clients (Gemini CLI, Claude Code, etc.) to successfully complete OAuth discovery for path-based MCP servers behind Pomerium.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review