### PR TITLE
fix(mcp): include request path in upstream_auth PRM URL and normalize trailing slash

### DIFF
--- a/internal/mcp/handler_metadata.go
+++ b/internal/mcp/handler_metadata.go
@@ -210,7 +210,7 @@ func ProtectedResourceMetadataURL(host, requestPath string) string {
 	return (&url.URL{
 		Scheme: "https",
 		Host:   host,
-		Path:   WellKnownProtectedResourceEndpoint + requestPath,
+		Path:   path.Join(WellKnownProtectedResourceEndpoint, requestPath),
 	}).String()
 }
 

--- a/internal/mcp/handler_metadata_test.go
+++ b/internal/mcp/handler_metadata_test.go
@@ -23,7 +23,7 @@ func TestWWWAuthenticate(t *testing.T) {
 			name:        "root path",
 			host:        "example.com",
 			requestPath: "/",
-			expected:    `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource/"`,
+			expected:    `Bearer resource_metadata="https://example.com/.well-known/oauth-protected-resource"`,
 		},
 		{
 			name:        "empty path",

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -372,14 +372,15 @@ func (h *UpstreamAuthHandler) handle401(
 	}
 
 	// Return 401 with Pomerium's own PRM so the MCP client re-runs its auth flow.
-	prmURL := (&url.URL{
-		Scheme: "https",
-		Host:   host,
-		Path:   WellKnownProtectedResourceEndpoint,
-	}).String()
+	// Extract the request path from originalURL so the resource_metadata URI
+	// matches the path-based well-known endpoint (RFC 9728 §4).
+	var requestPath string
+	if parsed, err := url.Parse(originalURL); err == nil {
+		requestPath = parsed.Path
+	}
 
 	return &extproc.UpstreamAuthAction{
-		WWWAuthenticate: fmt.Sprintf(`Bearer resource_metadata="%s"`, prmURL),
+		WWWAuthenticate: fmt.Sprintf(`Bearer resource_metadata="%s"`, ProtectedResourceMetadataURL(host, requestPath)),
 	}, nil
 }
 

--- a/internal/mcp/upstream_auth_test.go
+++ b/internal/mcp/upstream_auth_test.go
@@ -124,6 +124,9 @@ func TestHandleUpstreamResponse_DownstreamHostRouting(t *testing.T) {
 			"action should contain a WWW-Authenticate header pointing to Pomerium's PRM")
 		assert.Contains(t, action.WWWAuthenticate, "proxy.example.com",
 			"WWW-Authenticate should reference the downstream host")
+		assert.Contains(t, action.WWWAuthenticate,
+			`resource_metadata="https://proxy.example.com/.well-known/oauth-protected-resource/mcp"`,
+			"resource_metadata URI should include the request path per RFC 9728 §4")
 
 		// Verify the pending auth state
 		require.NotNil(t, capturedPending)

--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -1,6 +1,6 @@
 {
   "config": "v0.24.0",
   "hosted-authenticate-oidc": "v0.1.0",
-  "mcp": "v0.25.0",
+  "mcp": "v0.26.0",
   "ssh": "v0.12.0"
 }


### PR DESCRIPTION
## Summary

Follow-up to #6200. The `upstream_auth.go` `handle401` path had the same bug: when Pomerium returns a 401 to tell the MCP client to re-authenticate, the `resource_metadata` URI in `WWW-Authenticate` was missing the request path, causing a resource mismatch for path-based MCP routes.

Additionally, `ProtectedResourceMetadataURL` now normalizes trailing slashes (stripping `/` from root paths) to match the behavior of `BuildProtectedResourceMetadataURLs` in `upstream_discovery.go`, which already does this normalization.

## Related issues

- #6199
- #6200

## User Explanation

MCP clients connecting to path-based MCP servers through Pomerium's upstream auth flow will no longer fail OAuth discovery due to a resource mismatch in the `WWW-Authenticate` header.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review