### PR TITLE
core/pebble: fix batch not always being closed

### DIFF
--- a/pkg/storage/file/pebble.go
+++ b/pkg/storage/file/pebble.go
@@ -128,6 +128,8 @@ func (backend *Backend) init() error {
 
 func (backend *Backend) initIndices() error {
 	batch := backend.db.NewIndexedBatch()
+	defer func() { _ = batch.Close() }()
+
 	now := time.Now()
 
 	backend.options = make(map[string]*databrokerpb.Options)


### PR DESCRIPTION
## Summary
Not sure if this actually causing any issues, but the batch should either be committed or closed, and if there was an error during initialization we weren't closing it.

## Related issues
- [ENG-3807](https://linear.app/pomerium/issue/ENG-3807/corepebble-batch-not-always-closed)


## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
