### PR TITLE
chore: rotate goreleaser mac signing identity

### DIFF
--- a/.github/goreleaser-mac.yaml
+++ b/.github/goreleaser-mac.yaml
@@ -41,7 +41,7 @@ notarize:
   macos_native:
     - enabled: '{{ isEnvSet "SIGN_BINARIES" }}'
       sign:
-        identity: CC3DF18605EE508E04ABA66690466E1721314BF5
+        identity: 4CCCBFF19C6ABD0AED5047C3A833B8E05F098F89
       notarize:
         profile_name: pomerium_proxy
         wait: true


### PR DESCRIPTION
## Summary

- Replace expiring Mac Installer Distribution cert fingerprint (`CC3DF186...`) with new Developer ID Installer cert (`4CCCBFF19C6ABD0AED5047C3A833B8E05F098F89`) in goreleaser-mac.yaml

## Context

OPE-244 / ENG-3479. Part of the Apple cert rotation -- old Ross Smith certs expire 2026-04-25.

## Test plan

- [x] Merge after mac-builds PR is verified
- [x] Verify next proxy release signs and notarizes correctly -- [v0.32.5-rc.1 cert pipeline PASSED](https://github.com/pomerium/mac-builds/actions/runs/23814630346) (Import CSC, signing key, notarization profile all green; goreleaser build failed on pre-existing envoy embedding issue, not cert-related)

## AI Disclosure

PR created with AI assistance. Changes reviewed by Bobby.