### PR TITLE
ci: harden JS dependency supply chain

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -99,3 +99,30 @@ updates:
       npm:
         patterns:
           - "*"
+  - package-ecosystem: "npm"
+    directory: "/ui"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 50
+    groups:
+      npm:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/internal/acceptance/browser"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 50
+    groups:
+      npm:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/internal/acceptance/ws-server"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 50
+    groups:
+      npm:
+        patterns:
+          - "*"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,18 @@
+name: Dependency Review
+on:
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+        with:
+          fail-on-severity: high

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,7 +12,7 @@ jobs:
   dependency-review:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
         with:
           fail-on-severity: high

--- a/.github/workflows/npm-audit-signatures.yml
+++ b/.github/workflows/npm-audit-signatures.yml
@@ -20,8 +20,8 @@ jobs:
       matrix:
         dir: [ui, internal/acceptance/browser, internal/acceptance/ws-server]
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .tool-versions
       - run: cd ${{ matrix.dir }} && npm ci --ignore-scripts

--- a/.github/workflows/npm-audit-signatures.yml
+++ b/.github/workflows/npm-audit-signatures.yml
@@ -1,0 +1,28 @@
+name: NPM Audit Signatures
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+  pull_request:
+    paths:
+      - "**/package.json"
+      - "**/package-lock.json"
+
+permissions:
+  contents: read
+
+jobs:
+  audit-signatures:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        dir: [ui, internal/acceptance/browser, internal/acceptance/ws-server]
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238
+        with:
+          node-version-file: .tool-versions
+      - run: cd ${{ matrix.dir }} && npm ci --ignore-scripts
+      - run: cd ${{ matrix.dir }} && npm audit signatures

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ snapshot: build-deps ## Builds the cross-compiled binaries, naming them in such 
 .PHONY: npm-install
 npm-install:
 	@echo "==> $@"
-	cd ui ; npm install
+	cd ui ; npm ci
 
 .PHONY: help
 help:

--- a/internal/acceptance/browser/package.json
+++ b/internal/acceptance/browser/package.json
@@ -22,5 +22,6 @@
   },
   "engines": {
     "node": ">=22.0.0"
-  }
+  },
+  "packageManager": "npm@10.9.4"
 }

--- a/internal/acceptance/docker-compose.yml
+++ b/internal/acceptance/docker-compose.yml
@@ -89,7 +89,7 @@ services:
     volumes:
       - ./ws-server:/app
       - ws-node-modules:/app/node_modules
-    command: ["sh", "-c", "npm install --silent && node server.js"]
+    command: ["sh", "-c", "npm ci --silent && node server.js"]
     ports:
       - "8081:8080"
     healthcheck:

--- a/internal/acceptance/ws-server/package.json
+++ b/internal/acceptance/ws-server/package.json
@@ -8,5 +8,6 @@
   },
   "dependencies": {
     "ws": "^8.21.0"
-  }
+  },
+  "packageManager": "npm@10.9.4"
 }

--- a/ui/package.json
+++ b/ui/package.json
@@ -8,7 +8,7 @@
     "format": "prettier --write .",
     "lint": "eslint .",
     "watch": "ts-node ./scripts/esbuild.ts --watch",
-    "start": "npm install && npm run watch"
+    "start": "npm run watch"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary

Part of ENG-3808. Standardizes JS dependency supply-chain controls in the core pomerium repo.

- Deterministic installs: `npm install` -> `npm ci` in the Makefile and acceptance docker-compose; remove implicit `npm install` from `ui/package.json` start script
- Package manager pinning: add `packageManager: npm@10.9.4` to the acceptance test package roots
- Dependabot expansion: add npm ecosystem blocks for `/ui`, `/internal/acceptance/browser`, and `/internal/acceptance/ws-server`
- PR gating: add `dependency-review-action`
- Registry verification: add `npm audit signatures` for all npm package roots
- Workflow pin hygiene: annotate SHA-pinned GitHub Actions with human-readable tags and refresh `actions/setup-node` to `v6.3.0`

All GitHub Actions remain SHA-pinned to match repo conventions.

AI-assisted: drafted by Claude, verified locally, reviewed by Codex.

Closes ENG-3811 (pomerium portion), ENG-3812 (pomerium portion), ENG-3814 (pomerium), ENG-3815 (pomerium)

## Test plan

- [x] `npm ci` succeeds in `ui/`, `internal/acceptance/browser/`, and `internal/acceptance/ws-server/`
- [x] `npm audit signatures` passes in all three npm package roots
- [x] `make npm-install` works with `npm ci`
- [x] Modified workflow YAML parses cleanly
- [x] GitHub Actions pass on this PR
- [ ] Dependabot opens npm update PRs for the new package roots
