### PR TITLE
feat(blob): chunk readers should only read from finalized recordings

### DIFF
--- a/pkg/storage/blob/chunk.go
+++ b/pkg/storage/blob/chunk.go
@@ -25,6 +25,7 @@ var (
 	ErrMetadataMismatch   = errors.New("given metadata is different from previous metadata")
 	ErrChunkWriteConflict = errors.New("chunk already exists")
 	ErrChunkGap           = errors.New("chunk gap detected")
+	ErrNotYetFinalized    = errors.New("recording not yet finalized for reading")
 )
 
 type chunkID int
@@ -273,11 +274,24 @@ func (c *chunkWriter) Finalize(ctx context.Context, sig *recording.RecordingSign
 
 // Read methods
 
-func NewChunkReader(schema SchemaV1WithKey, bucket *blob.Bucket) ChunkReader {
+// NewChunkReader returns a ChunkReader for the recording.
+// It returns an error if the recording is not yet finalized
+func NewChunkReader(ctx context.Context, schema SchemaV1WithKey, bucket *blob.Bucket) (ChunkReader, error) {
+	path, _ := schema.SignaturePath()
+
+	ok, err := bucket.Exists(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if !ok {
+		return nil, ErrNotYetFinalized
+	}
+
 	return &chunkReader{
 		schema: schema,
 		bucket: bucket,
-	}
+	}, nil
 }
 
 func (c *chunkReader) getManifest(ctx context.Context) (*recording.ChunkManifest, error) {

--- a/pkg/storage/blob/chunk_test.go
+++ b/pkg/storage/blob/chunk_test.go
@@ -37,8 +37,8 @@ func TestChunkReaderWriter(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { b.Close() })
 		testChunkReaderWriterConformance(t,
-			func(schema blob.SchemaV1WithKey) blob.ChunkReader {
-				return blob.NewChunkReader(schema, b)
+			func(schema blob.SchemaV1WithKey) (blob.ChunkReader, error) {
+				return blob.NewChunkReader(t.Context(), schema, b)
 			},
 			func(ctx context.Context, schema blob.SchemaV1WithKey) (blob.ChunkWriter, error) {
 				return blob.NewChunkWriter(ctx, schema, b)
@@ -58,8 +58,8 @@ func TestChunkReaderWriter(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, b)
 		testChunkReaderWriterConformance(t,
-			func(schema blob.SchemaV1WithKey) blob.ChunkReader {
-				return blob.NewChunkReader(schema, b)
+			func(schema blob.SchemaV1WithKey) (blob.ChunkReader, error) {
+				return blob.NewChunkReader(t.Context(), schema, b)
 			},
 			func(ctx context.Context, schema blob.SchemaV1WithKey) (blob.ChunkWriter, error) {
 				return blob.NewChunkWriter(ctx, schema, b)
@@ -92,7 +92,7 @@ func TestConformanceChecks(t *testing.T) {
 }
 
 func testChunkReaderWriterConformance(t *testing.T,
-	rF func(blob.SchemaV1WithKey) blob.ChunkReader,
+	rF func(blob.SchemaV1WithKey) (blob.ChunkReader, error),
 	wrF func(context.Context, blob.SchemaV1WithKey) (blob.ChunkWriter, error),
 	bk *gblob.Bucket,
 	skipLockCheck bool,
@@ -137,7 +137,8 @@ func testChunkReaderWriterConformance(t *testing.T,
 			assert.Equal(t, md.GetId(), jsonExistingMd.GetId())
 			assert.Equal(t, md.GetRecordingType(), jsonExistingMd.GetRecordingType())
 
-			cr := rF(schema)
+			cr, err := rF(schema)
+			require.NoError(t, err)
 			all, err := cr.GetAll(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, []byte("foobarbaz"), all)
@@ -223,7 +224,8 @@ func testChunkReaderWriterConformance(t *testing.T,
 			require.NoError(t, cw2.WriteChunk(ctx, []byte("bar"), emptyCheckSum()))
 			require.NoError(t, cw2.Finalize(ctx, &recording.RecordingSignature{}))
 
-			cr := rF(schema)
+			cr, err := rF(schema)
+			require.NoError(t, err)
 			all, err := cr.GetAll(ctx)
 			require.NoError(t, err)
 			assert.Equal(t, []byte("foobar"), all)
@@ -293,6 +295,21 @@ func testChunkReaderWriterConformance(t *testing.T,
 
 			_, err := wrF(ctx, schema)
 			require.ErrorIs(t, err, blob.ErrChunkGap)
+		})
+
+		t.Run("cannot read non-finalized chunks", func(t *testing.T) {
+			t.Parallel()
+			schema := blob.NewSchemaV1WithKey(blob.SchemaV1{}, "in-progress")
+			ctx := t.Context()
+
+			chunk0Path, ct0 := schema.ChunkPath(0)
+			require.NoError(t, bk.WriteAll(ctx, chunk0Path, []byte("chunk0"), &gblob.WriterOptions{ContentType: ct0}))
+			chunk2Path, ct2 := schema.ChunkPath(1)
+			require.NoError(t, bk.WriteAll(ctx, chunk2Path, []byte("chunk2"), &gblob.WriterOptions{ContentType: ct2}))
+
+			_, err := rF(schema)
+			assert.Error(t, err)
+			assert.ErrorIs(t, err, blob.ErrNotYetFinalized)
 		})
 	})
 


### PR DESCRIPTION
## Summary

To support player controls in asciinema player, end time & relative timestamps of the entire recording must be known ahead of playing the recording.

In practice, this means that we should only read from recordings that are done.

## Related issues

Indirectly part of https://linear.app/pomerium/issue/ENG-3803/console-replay-larger-recordings

## User Explanation

N/A

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] ready for review
