### PR TITLE
core/config: include to addresses in mcp allowed as metadata domains

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -1528,6 +1528,24 @@ func (o *Options) GetAuthorizeLogFields() []log.AuthorizeLogField {
 	return o.AuthorizeLogFields
 }
 
+// GetMCPAllowedAsMetadataDomains gets all the MCP allowed as metadata domains,
+// both those explicitly added and those derived from "to" addresses for MCP
+// server routes.
+func (o *Options) GetMCPAllowedAsMetadataDomains() []string {
+	s := goset.NewTreeSet(strings.Compare)
+	for route := range o.GetAllPolicies() {
+		if route.MCP == nil || route.MCP.Server == nil {
+			continue
+		}
+
+		for _, to := range route.To {
+			s.Insert(to.URL.Hostname())
+		}
+	}
+	s.InsertSlice(o.MCPAllowedASMetadataDomains)
+	return s.Slice()
+}
+
 // NewCookie creates a new Cookie.
 func (o *Options) NewCookie() *http.Cookie {
 	return &http.Cookie{

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1452,6 +1452,29 @@ func TestOptions_GetCSRFSameSite(t *testing.T) {
 	}
 }
 
+func TestOptions_GetMCPAllowedAsMetadataDomains(t *testing.T) {
+	t.Parallel()
+	o := NewDefaultOptions()
+	assert.Empty(t, o.GetMCPAllowedAsMetadataDomains())
+
+	o.MCPAllowedASMetadataDomains = []string{"b.example.com", "a.example.com"}
+	assert.Equal(t, []string{"a.example.com", "b.example.com"}, o.GetMCPAllowedAsMetadataDomains())
+
+	o.Policies = append(o.Policies,
+		Policy{
+			To:  mustParseWeightedURLs(t, "https://a.example.com"),
+			MCP: &MCP{Server: &MCPServer{}},
+		},
+		Policy{
+			To: mustParseWeightedURLs(t, "https://c.example.com"),
+		},
+		Policy{
+			To:  mustParseWeightedURLs(t, "https://d.example.com"),
+			MCP: &MCP{Server: &MCPServer{}},
+		})
+	assert.Equal(t, []string{"a.example.com", "b.example.com", "d.example.com"}, o.GetMCPAllowedAsMetadataDomains())
+}
+
 func TestOptions_RequestParams(t *testing.T) {
 	cases := []struct {
 		label    string

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -130,7 +130,7 @@ func New(
 		cimdHTTPClient = NewSSRFSafeClient()
 	}
 
-	asDomainMatcher := NewDomainMatcher(cfg.Options.MCPAllowedASMetadataDomains)
+	asDomainMatcher := NewDomainMatcher(cfg.Options.GetMCPAllowedAsMetadataDomains())
 
 	h := &Handler{
 		prefix:                  prefix,

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -141,7 +141,7 @@ func NewUpstreamAuthHandlerFromConfig(
 	}
 
 	hosts := NewHostInfo(cfg, httpClient)
-	asDomainMatcher := NewDomainMatcher(cfg.Options.MCPAllowedASMetadataDomains)
+	asDomainMatcher := NewDomainMatcher(cfg.Options.GetMCPAllowedAsMetadataDomains())
 
 	return NewUpstreamAuthHandler(storage, hosts, httpClient, asDomainMatcher), nil
 }

--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -1,6 +1,6 @@
 {
-  "config": "v0.27.0",
+  "config": "v0.28.0",
   "hosted-authenticate-oidc": "v0.1.0",
-  "mcp": "v0.26.0",
+  "mcp": "v0.27.0",
   "ssh": "v0.14.0"
 }


### PR DESCRIPTION
## Summary
Update the MCP allowed as metadata domains check to include any MCP server route `to` addresses.

## Related issues
- [ENG-3761](https://linear.app/pomerium/issue/ENG-3761/auto-seed-as-metadata-domain-matcher-with-route-to-domains)

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
