### PR TITLE
core/debug: add raft debug handler

### DIFF
--- a/internal/controlplane/server_debug.go
+++ b/internal/controlplane/server_debug.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/databroker/raft"
 	channelzdebugui "github.com/pomerium/pomerium/internal/debug/channelz/ui"
 	"github.com/pomerium/pomerium/internal/version"
 	"github.com/pomerium/pomerium/pkg/envoy/files"
@@ -75,6 +76,8 @@ func (srv *debugServer) Update(cfg *config.Config) {
 		mux.HandleFunc("GET /options/", srv.databrokerOptionsHandler())
 		// databroker
 		mux.HandleFunc("GET /databroker/", srv.databrokerHandler())
+		// raft
+		mux.HandleFunc("GET /raft", srv.raftHandler())
 		// Channelz
 		// https://github.com/grpc/proposal/blob/master/A14-channelz.md
 		// https://github.com/grpc/grpc/blob/master/doc/connectivity-semantics-and-api.md
@@ -188,6 +191,7 @@ func (srv *debugServer) indexHandler() http.HandlerFunc {
 			<li><a href="/version">Version</a></li>
 			<li><a href="/databroker/">Databroker</a></li>
 			<li><a href="/options"> Databroker (options)</a></li>
+			<li><a href="/raft">Raft</li>
 			<li><a href="/debug/pprof/">Go PProf</a></li>
 			<li><a href="/channelz">ChannelZ</li>
 		</ul>
@@ -626,4 +630,11 @@ func (v *versionedConfigData) RenderCondition(c *configpb.VersionedConfig_Condit
 		)
 	}
 	return template.HTML(b.String()) //nolint:gosec // output is from HTML template execution
+}
+
+func (srv *debugServer) raftHandler() http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(raft.Stats())
+	}
 }

--- a/internal/databroker/raft/node.go
+++ b/internal/databroker/raft/node.go
@@ -57,5 +57,5 @@ func NewNode(streamLayer StreamLayer, options config.DataBrokerOptions) (Node, e
 		return nil, fmt.Errorf("error bootstrapping cluster: %w", err)
 	}
 
-	return r, nil
+	return addGlobalRaftNode(r), nil
 }

--- a/internal/databroker/raft/stats.go
+++ b/internal/databroker/raft/stats.go
@@ -1,0 +1,60 @@
+package raft
+
+import (
+	"maps"
+	"slices"
+	"sync"
+
+	"github.com/hashicorp/raft"
+)
+
+var globalRaftState = struct {
+	mu        sync.RWMutex
+	nodes     map[int]globalRaftNode
+	nextIndex int
+}{
+	nodes: make(map[int]globalRaftNode),
+}
+
+type globalRaftNode struct {
+	*raft.Raft
+	index int
+}
+
+func addGlobalRaftNode(r *raft.Raft) Node {
+	globalRaftState.mu.Lock()
+	defer globalRaftState.mu.Unlock()
+
+	n := globalRaftNode{
+		Raft:  r,
+		index: globalRaftState.nextIndex,
+	}
+	globalRaftState.nextIndex++
+	globalRaftState.nodes[n.index] = n
+	return n
+}
+
+func (n globalRaftNode) Shutdown() raft.Future {
+	globalRaftState.mu.Lock()
+	delete(globalRaftState.nodes, n.index)
+	globalRaftState.mu.Unlock()
+
+	return n.Raft.Shutdown()
+}
+
+// Stats returns raft debugging stats.
+func Stats() []map[string]string {
+	globalRaftState.mu.RLock()
+	defer globalRaftState.mu.RUnlock()
+
+	var ms []map[string]string
+	idxs := slices.Sorted(maps.Keys(globalRaftState.nodes))
+	for _, idx := range idxs {
+		n := globalRaftState.nodes[idx]
+		m := maps.Clone(n.Stats())
+		_, leaderID := n.LeaderWithID()
+		m["leader"] = string(leaderID)
+		ms = append(ms, m)
+	}
+	return ms
+}


### PR DESCRIPTION
## Summary
Add a raft endpoint to the debug server that exposes the raft debug stats.

## Related issues
- [ENG-3154](https://linear.app/pomerium/issue/ENG-3154/core-expose-raft-health)


## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
