### PR TITLE
feat: add unix socket support for target resources

### DIFF
--- a/config/custom.go
+++ b/config/custom.go
@@ -280,7 +280,7 @@ type WeightedURL struct {
 
 // Validate validates that the WeightedURL is valid.
 func (u *WeightedURL) Validate() error {
-	if u.URL.Hostname() == "" {
+	if u.URL.Hostname() == "" && !urlutil.IsUnixScheme(u.URL.Scheme) {
 		return errHostnameMustBeSpecified
 	}
 	if u.URL.Scheme == "" {
@@ -301,7 +301,7 @@ func ParseWeightedURL(dst string) (*WeightedURL, error) {
 		return nil, fmt.Errorf("%s: %w", to, err)
 	}
 
-	if u.Hostname() == "" {
+	if u.Hostname() == "" && !urlutil.IsUnixScheme(u.Scheme) {
 		return nil, errHostnameMustBeSpecified
 	}
 

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -336,7 +336,7 @@ func (b *Builder) buildPolicyTransportSocket(
 	policy *config.Policy,
 	dst url.URL,
 ) (*envoy_config_core_v3.TransportSocket, error) {
-	if dst.Scheme != "https" {
+	if dst.Scheme != "https" && dst.Scheme != "unix+https" {
 		return nil, nil
 	}
 
@@ -523,14 +523,19 @@ func (b *Builder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoi
 			u.Host = strings.ReplaceAll(e.url.Host, "localhost", "127.0.0.1")
 		}
 
-		endpoint := &envoy_config_endpoint_v3.Endpoint{
-			Hostname: e.url.Host,
+		var addr *envoy_config_core_v3.Address
+		if urlutil.IsUnixScheme(e.url.Scheme) {
+			addr = buildPipeAddress(e.url.Path, 0o600)
+		} else {
+			addr, _ = buildTCPListenAddresses(u.Host, defaultPort)
 		}
-		endpoint.Address, _ = buildTCPListenAddresses(u.Host, defaultPort)
 
 		lbe := &envoy_config_endpoint_v3.LbEndpoint{
 			HostIdentifier: &envoy_config_endpoint_v3.LbEndpoint_Endpoint{
-				Endpoint: endpoint,
+				Endpoint: &envoy_config_endpoint_v3.Endpoint{
+					Address:  addr,
+					Hostname: e.url.Host,
+				},
 			},
 			LoadBalancingWeight: e.loadBalancerWeight,
 		}
@@ -600,7 +605,14 @@ func validateClusterNamesUnique(clusters []*envoy_config_cluster_v3.Cluster) err
 
 func allIPAddresses(lbEndpoints []*envoy_config_endpoint_v3.LbEndpoint) bool {
 	for _, lbe := range lbEndpoints {
-		if net.ParseIP(urlutil.StripPort(lbe.GetEndpoint().GetAddress().GetSocketAddress().GetAddress())) == nil {
+		addr := lbe.GetEndpoint().GetAddress()
+		if addr.GetSocketAddress() != nil {
+			if net.ParseIP(urlutil.StripPort(addr.GetSocketAddress().GetAddress())) == nil {
+				return false
+			}
+		} else if addr.GetPipe() != nil {
+			continue
+		} else {
 			return false
 		}
 	}

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -336,7 +336,7 @@ func (b *Builder) buildPolicyTransportSocket(
 	policy *config.Policy,
 	dst url.URL,
 ) (*envoy_config_core_v3.TransportSocket, error) {
-	if dst.Scheme != "https" && dst.Scheme != "unix+https" {
+	if dst.Scheme != "https" && dst.Scheme != "https+unix" {
 		return nil, nil
 	}
 

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -525,7 +525,7 @@ func (b *Builder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoi
 
 		var addr *envoy_config_core_v3.Address
 		if urlutil.IsUnixScheme(e.url.Scheme) {
-			addr = buildPipeAddress(e.url.Path, 0o600)
+			addr = buildPipeAddress(e.url.Path)
 		} else {
 			addr, _ = buildTCPListenAddresses(u.Host, defaultPort)
 		}

--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -148,6 +148,22 @@ func buildTCPListenAddresses(
 	return buildListenAddresses(envoy_config_core_v3.SocketAddress_TCP, hostport, defaultPort)
 }
 
+func buildPipeAddress(path string, mode uint32) *envoy_config_core_v3.Address {
+	return &envoy_config_core_v3.Address{
+		Address: &envoy_config_core_v3.Address_Pipe{
+			Pipe: &envoy_config_core_v3.Pipe{
+				Path: path,
+				Mode: mode,
+			},
+		},
+	}
+}
+
+func buildTCPAddress(hostport string, defaultPort uint32) *envoy_config_core_v3.Address {
+	mainAddress, _ := buildListenAddresses(envoy_config_core_v3.SocketAddress_TCP, hostport, defaultPort)
+	return mainAddress
+}
+
 func buildUDPListenAddresses(
 	hostport string,
 	defaultPort uint32,

--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -148,20 +148,14 @@ func buildTCPListenAddresses(
 	return buildListenAddresses(envoy_config_core_v3.SocketAddress_TCP, hostport, defaultPort)
 }
 
-func buildPipeAddress(path string, mode uint32) *envoy_config_core_v3.Address {
+func buildPipeAddress(path string) *envoy_config_core_v3.Address {
 	return &envoy_config_core_v3.Address{
 		Address: &envoy_config_core_v3.Address_Pipe{
 			Pipe: &envoy_config_core_v3.Pipe{
 				Path: path,
-				Mode: mode,
 			},
 		},
 	}
-}
-
-func buildTCPAddress(hostport string, defaultPort uint32) *envoy_config_core_v3.Address {
-	mainAddress, _ := buildListenAddresses(envoy_config_core_v3.SocketAddress_TCP, hostport, defaultPort)
-	return mainAddress
 }
 
 func buildUDPListenAddresses(

--- a/config/envoyconfig/protocols.go
+++ b/config/envoyconfig/protocols.go
@@ -110,7 +110,7 @@ func buildUpstreamProtocolOptions(
 		// when using TLS use ALPN auto config
 		var tlsCount, h2cCount int
 		for _, e := range endpoints {
-			if e.transportSocket != nil {
+			if e.transportSocket != nil || e.url.Scheme == "unix+https" {
 				tlsCount++
 			} else if e.url.Scheme == "h2c" {
 				h2cCount++

--- a/config/envoyconfig/protocols.go
+++ b/config/envoyconfig/protocols.go
@@ -110,7 +110,7 @@ func buildUpstreamProtocolOptions(
 		// when using TLS use ALPN auto config
 		var tlsCount, h2cCount int
 		for _, e := range endpoints {
-			if e.transportSocket != nil || e.url.Scheme == "unix+https" {
+			if e.transportSocket != nil || e.url.Scheme == "https+unix" {
 				tlsCount++
 			} else if e.url.Scheme == "h2c" {
 				h2cCount++

--- a/config/policy.go
+++ b/config/policy.go
@@ -737,6 +737,14 @@ func (p *Policy) Validate() error {
 		return fmt.Errorf("config: cannot mix udp and non-udp To URLs")
 	}
 
+	// It is an error to mix unix and non-unix To URLs.
+	if _, hasUnix := toSchemes["unix"]; hasUnix && len(toSchemes) > 1 {
+		return fmt.Errorf("config: cannot mix unix and non-unix To URLs")
+	}
+	if _, hasUnixPlusHTTPS := toSchemes["unix+https"]; hasUnixPlusHTTPS && len(toSchemes) > 1 {
+		return fmt.Errorf("config: cannot mix unix and non-unix To URLs")
+	}
+
 	if err := p.Redirect.validate(); err != nil {
 		return fmt.Errorf("config: %w", err)
 	}

--- a/config/policy.go
+++ b/config/policy.go
@@ -741,7 +741,7 @@ func (p *Policy) Validate() error {
 	if _, hasUnix := toSchemes["unix"]; hasUnix && len(toSchemes) > 1 {
 		return fmt.Errorf("config: cannot mix unix and non-unix To URLs")
 	}
-	if _, hasUnixPlusHTTPS := toSchemes["unix+https"]; hasUnixPlusHTTPS && len(toSchemes) > 1 {
+	if _, hasUnixPlusHTTPS := toSchemes["https+unix"]; hasUnixPlusHTTPS && len(toSchemes) > 1 {
 		return fmt.Errorf("config: cannot mix unix and non-unix To URLs")
 	}
 

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -59,7 +59,7 @@ func Test_PolicyValidate(t *testing.T) {
 		{"mix of TCP and non-TCP To URLs", Policy{From: "tcp+https://httpbin.corp.example:4000", To: mustParseWeightedURLs(t, "https://example.com", "tcp://example.com:5000")}, true},
 		{"UDP To URLs", Policy{From: "udp+https://httpbin.corp.example:4000", To: mustParseWeightedURLs(t, "udp://one.example.com:5000", "udp://two.example.com:5000")}, false},
 		{"unix To URLs", Policy{From: "https://example.com", To: mustParseWeightedURLs(t, "unix:///var/run/docker.sock")}, false},
-		{"unix+https To URLs", Policy{From: "https://example.com", To: mustParseWeightedURLs(t, "unix+https:///var/run/docker.sock")}, false},
+		{"https+unix To URLs", Policy{From: "https://example.com", To: mustParseWeightedURLs(t, "https+unix:///var/run/docker.sock")}, false},
 		{"mix of unix and non-unix To URLs", Policy{From: "https://example.com", To: mustParseWeightedURLs(t, "unix:///var/run/docker.sock", "https://example.com")}, true},
 		{"too many depends_on hosts", Policy{From: "https://httpbin.corp.example", To: mustParseWeightedURLs(t, "https://httpbin.corp.notatld"), DependsOn: []string{"a", "b", "c", "d", "e", "f"}}, true},
 	}

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -58,6 +58,9 @@ func Test_PolicyValidate(t *testing.T) {
 		{"TCP To URLs", Policy{From: "tcp+https://httpbin.corp.example:4000", To: mustParseWeightedURLs(t, "tcp://one.example.com:5000", "tcp://two.example.com:5000")}, false},
 		{"mix of TCP and non-TCP To URLs", Policy{From: "tcp+https://httpbin.corp.example:4000", To: mustParseWeightedURLs(t, "https://example.com", "tcp://example.com:5000")}, true},
 		{"UDP To URLs", Policy{From: "udp+https://httpbin.corp.example:4000", To: mustParseWeightedURLs(t, "udp://one.example.com:5000", "udp://two.example.com:5000")}, false},
+		{"unix To URLs", Policy{From: "https://example.com", To: mustParseWeightedURLs(t, "unix:///var/run/docker.sock")}, false},
+		{"unix+https To URLs", Policy{From: "https://example.com", To: mustParseWeightedURLs(t, "unix+https:///var/run/docker.sock")}, false},
+		{"mix of unix and non-unix To URLs", Policy{From: "https://example.com", To: mustParseWeightedURLs(t, "unix:///var/run/docker.sock", "https://example.com")}, true},
 		{"too many depends_on hosts", Policy{From: "https://httpbin.corp.example", To: mustParseWeightedURLs(t, "https://httpbin.corp.notatld"), DependsOn: []string{"a", "b", "c", "d", "e", "f"}}, true},
 	}
 

--- a/internal/urlutil/url.go
+++ b/internal/urlutil/url.go
@@ -71,10 +71,15 @@ func ValidateURL(u *url.URL) error {
 	if u.Scheme == "" {
 		return fmt.Errorf("%s url does not contain a valid scheme", u.String())
 	}
-	if u.Host == "" {
+	if u.Host == "" && !IsUnixScheme(u.Scheme) {
 		return fmt.Errorf("%s url does not contain a valid hostname", u.String())
 	}
 	return nil
+}
+
+// IsUnixScheme returns true if the scheme is a unix socket scheme.
+func IsUnixScheme(scheme string) bool {
+	return scheme == "unix" || scheme == "unix+https"
 }
 
 // DeepCopy creates a deep copy of a *url.URL

--- a/internal/urlutil/url.go
+++ b/internal/urlutil/url.go
@@ -79,7 +79,7 @@ func ValidateURL(u *url.URL) error {
 
 // IsUnixScheme returns true if the scheme is a unix socket scheme.
 func IsUnixScheme(scheme string) bool {
-	return scheme == "unix" || scheme == "unix+https"
+	return scheme == "unix" || scheme == "https+unix"
 }
 
 // DeepCopy creates a deep copy of a *url.URL

--- a/internal/urlutil/url_test.go
+++ b/internal/urlutil/url_test.go
@@ -100,11 +100,39 @@ func TestValidateURL(t *testing.T) {
 	}{
 		{"good", &url.URL{Scheme: "https", Host: "some.example"}, false},
 		{"nil", nil, true},
+		{"unix scheme without host", &url.URL{Scheme: "unix", Path: "/var/run/docker.sock"}, false},
+		{"unix+https scheme without host", &url.URL{Scheme: "unix+https", Path: "/var/run/docker.sock"}, false},
+		{"https scheme without host", &url.URL{Scheme: "https", Path: "/path"}, true},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if err := ValidateURL(tt.u); (err != nil) != tt.wantErr {
 				t.Errorf("ValidateURL() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestIsUnixScheme(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		scheme string
+		want   bool
+	}{
+		{"unix", true},
+		{"unix+https", true},
+		{"https", false},
+		{"http", false},
+		{"h2c", false},
+		{"tcp", false},
+		{"udp", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.scheme, func(t *testing.T) {
+			if got := IsUnixScheme(tt.scheme); got != tt.want {
+				t.Errorf("IsUnixScheme(%q) = %v, want %v", tt.scheme, got, tt.want)
 			}
 		})
 	}

--- a/internal/urlutil/url_test.go
+++ b/internal/urlutil/url_test.go
@@ -101,7 +101,7 @@ func TestValidateURL(t *testing.T) {
 		{"good", &url.URL{Scheme: "https", Host: "some.example"}, false},
 		{"nil", nil, true},
 		{"unix scheme without host", &url.URL{Scheme: "unix", Path: "/var/run/docker.sock"}, false},
-		{"unix+https scheme without host", &url.URL{Scheme: "unix+https", Path: "/var/run/docker.sock"}, false},
+		{"https+unix scheme without host", &url.URL{Scheme: "https+unix", Path: "/var/run/docker.sock"}, false},
 		{"https scheme without host", &url.URL{Scheme: "https", Path: "/path"}, true},
 	}
 
@@ -121,7 +121,7 @@ func TestIsUnixScheme(t *testing.T) {
 		want   bool
 	}{
 		{"unix", true},
-		{"unix+https", true},
+		{"https+unix", true},
 		{"https", false},
 		{"http", false},
 		{"h2c", false},


### PR DESCRIPTION
## Summary

Add support for unix:// and unix+https:// URL schemes to route to Unix domain sockets as upstream destinations.

## Related issues

- #6246

## User Explanation

Pomerium currently only supports TCP/UDP host-based upstreams. Many services (Docker, PostgreSQL, Redis, Nginx, etc.) expose Unix domain sockets as an alternative to network ports.

Benefits:

1. Direct socket access - Route to Unix sockets like unix:///var/run/docker.sock without needing a network port, reducing attack surface and latency.
2. TLS support - The unix+https:// scheme enables TLS-encrypted connections to Unix socket services that support HTTPS over Unix sockets (e.g., nginx with proxy_protocol).
3. Protocol auto-detection - unix:// uses HTTP/1.1, while unix+https:// leverages existing ALPN-based protocol detection (HTTP/1.1 or HTTP/2).
4. Security - Unix sockets can use filesystem permissions for access control instead of network-level restrictions.
5. Consistent with existing patterns - Follows the same scheme mixing rules as TCP/UDP upstreams.

Example use case:
```
routes:
  - from: https://secure.internal.example.com
    to: https+unix:///run/nginx-tls.sock
```

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
