### PR TITLE
core/envoy: update listeners to use additional addresses instead of the ipv4_compat flag

### DIFF
--- a/config/envoyconfig/acmetlsalpn.go
+++ b/config/envoyconfig/acmetlsalpn.go
@@ -24,6 +24,8 @@ func (b *Builder) buildACMETLSALPNCluster(
 	cfg *config.Config,
 ) *envoy_config_cluster_v3.Cluster {
 	port, _ := strconv.ParseUint(cfg.ACMETLSALPNPort, 10, 32)
+	endpoint := &envoy_config_endpoint_v3.Endpoint{}
+	endpoint.Address, _ = buildTCPListenAddresses("127.0.0.1", uint32(port))
 	return &envoy_config_cluster_v3.Cluster{
 		Name: acmeTLSALPNClusterName,
 		LoadAssignment: &envoy_config_endpoint_v3.ClusterLoadAssignment{
@@ -31,9 +33,7 @@ func (b *Builder) buildACMETLSALPNCluster(
 			Endpoints: []*envoy_config_endpoint_v3.LocalityLbEndpoints{{
 				LbEndpoints: []*envoy_config_endpoint_v3.LbEndpoint{{
 					HostIdentifier: &envoy_config_endpoint_v3.LbEndpoint_Endpoint{
-						Endpoint: &envoy_config_endpoint_v3.Endpoint{
-							Address: buildTCPAddress("127.0.0.1", uint32(port)),
-						},
+						Endpoint: endpoint,
 					},
 				}},
 			}},

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -523,12 +523,14 @@ func (b *Builder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoi
 			u.Host = strings.ReplaceAll(e.url.Host, "localhost", "127.0.0.1")
 		}
 
+		endpoint := &envoy_config_endpoint_v3.Endpoint{
+			Hostname: e.url.Host,
+		}
+		endpoint.Address, _ = buildTCPListenAddresses(u.Host, defaultPort)
+
 		lbe := &envoy_config_endpoint_v3.LbEndpoint{
 			HostIdentifier: &envoy_config_endpoint_v3.LbEndpoint_Endpoint{
-				Endpoint: &envoy_config_endpoint_v3.Endpoint{
-					Address:  buildTCPAddress(u.Host, defaultPort),
-					Hostname: e.url.Host,
-				},
+				Endpoint: endpoint,
 			},
 			LoadBalancingWeight: e.loadBalancerWeight,
 		}

--- a/config/envoyconfig/envoyconfig.go
+++ b/config/envoyconfig/envoyconfig.go
@@ -17,6 +17,7 @@ import (
 	envoy_config_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_extensions_access_loggers_grpc_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
 	metadatav3 "github.com/envoyproxy/go-control-plane/envoy/type/metadata/v3"
 	envoy_tracing_v3 "github.com/envoyproxy/go-control-plane/envoy/type/tracing/v3"
@@ -140,12 +141,18 @@ func buildAccessLogs(options *config.Options) []*envoy_config_accesslog_v3.Acces
 	}}
 }
 
-func buildTCPAddress(hostport string, defaultPort uint32) *envoy_config_core_v3.Address {
-	return buildAddress(envoy_config_core_v3.SocketAddress_TCP, hostport, defaultPort)
+func buildTCPListenAddresses(
+	hostport string,
+	defaultPort uint32,
+) (mainAddress *envoy_config_core_v3.Address, additionalAddresses []*envoy_config_listener_v3.AdditionalAddress) {
+	return buildListenAddresses(envoy_config_core_v3.SocketAddress_TCP, hostport, defaultPort)
 }
 
-func buildUDPAddress(hostport string, defaultPort uint32) *envoy_config_core_v3.Address {
-	return buildAddress(envoy_config_core_v3.SocketAddress_UDP, hostport, defaultPort)
+func buildUDPListenAddresses(
+	hostport string,
+	defaultPort uint32,
+) (mainAddress *envoy_config_core_v3.Address, additionalAddresses []*envoy_config_listener_v3.AdditionalAddress) {
+	return buildListenAddresses(envoy_config_core_v3.SocketAddress_UDP, hostport, defaultPort)
 }
 
 func buildIPAddressFromURL(src string) (*envoy_config_core_v3.Address, error) {
@@ -189,7 +196,11 @@ func buildIPAddressFromURL(src string) (*envoy_config_core_v3.Address, error) {
 	}, nil
 }
 
-func buildAddress(protocol envoy_config_core_v3.SocketAddress_Protocol, hostport string, defaultPort uint32) *envoy_config_core_v3.Address {
+func buildListenAddresses(
+	protocol envoy_config_core_v3.SocketAddress_Protocol,
+	hostport string,
+	defaultPort uint32,
+) (mainAddress *envoy_config_core_v3.Address, additionalAddresses []*envoy_config_listener_v3.AdditionalAddress) {
 	host, strport, err := net.SplitHostPort(hostport)
 	if err != nil {
 		host = hostport
@@ -207,19 +218,45 @@ func buildAddress(protocol envoy_config_core_v3.SocketAddress_Protocol, hostport
 		}
 	}
 
-	is4in6 := false
-	if addr, err := netip.ParseAddr(host); err == nil {
-		is4in6 = addr.Is4In6()
+	mainAddress = &envoy_config_core_v3.Address{
+		Address: &envoy_config_core_v3.Address_SocketAddress{
+			SocketAddress: &envoy_config_core_v3.SocketAddress{
+				Protocol:      protocol,
+				Address:       host,
+				PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{PortValue: port},
+			},
+		},
 	}
 
-	return &envoy_config_core_v3.Address{
-		Address: &envoy_config_core_v3.Address_SocketAddress{SocketAddress: &envoy_config_core_v3.SocketAddress{
-			Protocol:      protocol,
-			Address:       host,
-			PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{PortValue: port},
-			Ipv4Compat:    host == "::" || is4in6,
-		}},
+	// if we are binding all addresses in ipv6 also bind all addresses in ipv4
+	if host == "::" {
+		additionalAddresses = append(additionalAddresses, &envoy_config_listener_v3.AdditionalAddress{
+			Address: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol:      protocol,
+						Address:       "0.0.0.0",
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{PortValue: port},
+					},
+				},
+			},
+		})
+	} else if addr, err := netip.ParseAddr(host); err == nil && addr.Is4In6() {
+		// if this is an ipv4 in ipv6 addresses, also bind the ipv4 address
+		additionalAddresses = append(additionalAddresses, &envoy_config_listener_v3.AdditionalAddress{
+			Address: &envoy_config_core_v3.Address{
+				Address: &envoy_config_core_v3.Address_SocketAddress{
+					SocketAddress: &envoy_config_core_v3.SocketAddress{
+						Protocol:      protocol,
+						Address:       addr.Unmap().String(),
+						PortSpecifier: &envoy_config_core_v3.SocketAddress_PortValue{PortValue: port},
+					},
+				},
+			},
+		})
 	}
+
+	return mainAddress, additionalAddresses
 }
 
 var rootCABundle struct {

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -92,7 +92,10 @@ func (b *Builder) BuildListeners(
 }
 
 // newListener creates envoy listener with certain default values
-func newListener(name, statPrefix string, socketOpts ...*envoy_config_core_v3.SocketOption) *envoy_config_listener_v3.Listener {
+func newListener(
+	name, statPrefix string,
+	socketOpts ...*envoy_config_core_v3.SocketOption,
+) *envoy_config_listener_v3.Listener {
 	return &envoy_config_listener_v3.Listener{
 		Name:                          name,
 		StatPrefix:                    statPrefix,
@@ -107,21 +110,34 @@ func newListener(name, statPrefix string, socketOpts ...*envoy_config_core_v3.So
 }
 
 // newQUICListener creates a new envoy listener that handles QUIC connections.
-func newQUICListener(name string, address *envoy_config_core_v3.Address) *envoy_config_listener_v3.Listener {
+func newQUICListener(
+	name string,
+	mainAddress *envoy_config_core_v3.Address,
+	additionalAddresses []*envoy_config_listener_v3.AdditionalAddress,
+) *envoy_config_listener_v3.Listener {
 	li := newListener(name, name)
-	li.Address = address
+	li.Address = mainAddress
+	li.AdditionalAddresses = additionalAddresses
+	// udp listeners with concurrency > 1 require reuse port to be enabled
+	li.EnableReusePort = wrapperspb.Bool(true)
 	li.UdpListenerConfig = &envoy_config_listener_v3.UdpListenerConfig{
 		QuicOptions: &envoy_config_listener_v3.QuicProtocolOptions{},
 		DownstreamSocketConfig: &envoy_config_core_v3.UdpSocketConfig{
-			PreferGro: &wrapperspb.BoolValue{Value: true},
+			PreferGro: wrapperspb.Bool(true),
 		},
 	}
 	return li
 }
 
 // newTCPListener creates a new envoy listener that handles TCP connections.
-func newTCPListener(name, statPrefix string, address *envoy_config_core_v3.Address, opts ...*envoy_config_core_v3.SocketOption) *envoy_config_listener_v3.Listener {
+func newTCPListener(
+	name, statPrefix string,
+	mainAddress *envoy_config_core_v3.Address,
+	additionalAddresses []*envoy_config_listener_v3.AdditionalAddress,
+	opts ...*envoy_config_core_v3.SocketOption,
+) *envoy_config_listener_v3.Listener {
 	li := newListener(name, statPrefix, opts...)
-	li.Address = address
+	li.Address = mainAddress
+	li.AdditionalAddresses = additionalAddresses
 	return li
 }

--- a/config/envoyconfig/listeners_debug.go
+++ b/config/envoyconfig/listeners_debug.go
@@ -24,7 +24,7 @@ func (b *Builder) buildDebugListener(cfg *config.Config) (*envoy_config_listener
 		return nil, fmt.Errorf("error parsing debug address %s: %w", cfg.Options.DebugAddress.String, err)
 	}
 
-	li := newTCPListener("debug", "debug", addr)
+	li := newTCPListener("debug", "debug", addr, nil)
 	li.FilterChains = []*envoy_config_listener_v3.FilterChain{filterChain}
 	return li, nil
 }

--- a/config/envoyconfig/listeners_envoy_admin.go
+++ b/config/envoyconfig/listeners_envoy_admin.go
@@ -25,7 +25,7 @@ func (b *Builder) buildEnvoyAdminListener(_ context.Context, cfg *config.Config)
 		return nil, fmt.Errorf("envoy_admin_addr %s: %w", cfg.Options.EnvoyAdminAddress, err)
 	}
 
-	li := newTCPListener("envoy-admin", "envoy-admin", addr)
+	li := newTCPListener("envoy-admin", "envoy-admin", addr, nil)
 	li.FilterChains = []*envoy_config_listener_v3.FilterChain{filterChain}
 	return li, nil
 }

--- a/config/envoyconfig/listeners_grpc.go
+++ b/config/envoyconfig/listeners_grpc.go
@@ -21,15 +21,16 @@ func (b *Builder) buildGRPCListener(ctx context.Context, cfg *config.Config) (*e
 		Filters: []*envoy_config_listener_v3.Filter{filter},
 	}
 
-	var address *envoy_config_core_v3.Address
+	var mainAddress *envoy_config_core_v3.Address
+	var additionalAddresses []*envoy_config_listener_v3.AdditionalAddress
 	if cfg.Options.GetGRPCInsecure() {
-		address = buildTCPAddress(cfg.Options.GetGRPCAddr(), 80)
+		mainAddress, additionalAddresses = buildTCPListenAddresses(cfg.Options.GetGRPCAddr(), 80)
 	} else {
-		address = buildTCPAddress(cfg.Options.GetGRPCAddr(), 443)
+		mainAddress, additionalAddresses = buildTCPListenAddresses(cfg.Options.GetGRPCAddr(), 443)
 	}
 
 	opts := getTCPListenerSocketOpts()
-	li := newTCPListener("grpc-ingress", "grpc-ingress", address, opts...)
+	li := newTCPListener("grpc-ingress", "grpc-ingress", mainAddress, additionalAddresses, opts...)
 	li.FilterChains = []*envoy_config_listener_v3.FilterChain{&filterChain}
 
 	if cfg.Options.GetGRPCInsecure() {

--- a/config/envoyconfig/listeners_main.go
+++ b/config/envoyconfig/listeners_main.go
@@ -35,7 +35,8 @@ func (b *Builder) buildMainInsecureListener(
 	cfg *config.Config,
 	fullyStatic bool,
 ) (*envoy_config_listener_v3.Listener, error) {
-	li := newTCPListener("http-ingress", "http-ingress", buildTCPAddress(cfg.Options.Addr, 80))
+	mainAddress, additionalAddresses := buildTCPListenAddresses(cfg.Options.Addr, 80)
+	li := newTCPListener("http-ingress", "http-ingress", mainAddress, additionalAddresses)
 
 	// listener filters
 	if cfg.Options.UseProxyProtocol {
@@ -56,7 +57,8 @@ func (b *Builder) buildMainQUICListener(
 	cfg *config.Config,
 	fullyStatic bool,
 ) (*envoy_config_listener_v3.Listener, error) {
-	li := newQUICListener("quic-ingress", buildUDPAddress(cfg.Options.Addr, 443))
+	mainAddress, additionalAddresses := buildUDPListenAddresses(cfg.Options.Addr, 443)
+	li := newQUICListener("quic-ingress", mainAddress, additionalAddresses)
 
 	// access log
 	if cfg.Options.DownstreamMTLS.Enforcement == config.MTLSEnforcementRejectConnection {
@@ -87,7 +89,8 @@ func (b *Builder) buildMainTLSListener(
 	cfg *config.Config,
 	fullyStatic bool,
 ) (*envoy_config_listener_v3.Listener, error) {
-	li := newTCPListener("https-ingress", "https-ingress", buildTCPAddress(cfg.Options.Addr, 443))
+	mainAddress, additionalAddresses := buildTCPListenAddresses(cfg.Options.Addr, 443)
+	li := newTCPListener("https-ingress", "https-ingress", mainAddress, additionalAddresses)
 
 	// listener filters
 	if cfg.Options.UseProxyProtocol {

--- a/config/envoyconfig/listeners_metrics.go
+++ b/config/envoyconfig/listeners_metrics.go
@@ -80,8 +80,8 @@ func (b *Builder) buildMetricsListener(cfg *config.Config) (*envoy_config_listen
 		host = ""
 	}
 
-	addr := buildTCPAddress(net.JoinHostPort(host, port), 9902)
-	li := newTCPListener(fmt.Sprintf("metrics-ingress-%d", hashutil.MustHash(addr)), "metrics-ingress", addr)
+	mainAddress, additionalAddresses := buildTCPListenAddresses(net.JoinHostPort(host, port), 9902)
+	li := newTCPListener(fmt.Sprintf("metrics-ingress-%d", hashutil.MustHash(mainAddress)), "metrics-ingress", mainAddress, additionalAddresses)
 	li.FilterChains = []*envoy_config_listener_v3.FilterChain{filterChain}
 	return li, nil
 }

--- a/config/envoyconfig/listeners_ssh.go
+++ b/config/envoyconfig/listeners_ssh.go
@@ -170,14 +170,14 @@ func buildSSHListener(cfg *config.Config) (*envoy_config_listener_v3.Listener, e
 	)
 
 	li := &envoy_config_listener_v3.Listener{
-		Name:    "ssh",
-		Address: buildTCPAddress(cfg.Options.SSHAddr, 22),
+		Name: "ssh",
 		FilterChains: []*envoy_config_listener_v3.FilterChain{
 			{
 				Filters: filters,
 			},
 		},
 	}
+	li.Address, li.AdditionalAddresses = buildTCPListenAddresses(cfg.Options.SSHAddr, 22)
 	return li, nil
 }
 

--- a/config/envoyconfig/listeners_test.go
+++ b/config/envoyconfig/listeners_test.go
@@ -113,6 +113,17 @@ func TestBuildListeners(t *testing.T) {
 				assert.JSONEq(t, `{
 					"allowExtendedConnect": true
 				}`, httpConfig.Get("http3ProtocolOptions").String())
+				assert.JSONEq(t, `{
+					"address": "::",
+					"portValue": 443,
+					"protocol": "UDP"
+				}`, gjson.Get(protojson.Format(li), "address.socketAddress").String())
+				assert.JSONEq(t, `{
+					"address": "0.0.0.0",
+					"portValue": 443,
+					"protocol": "UDP"
+				}`, gjson.Get(protojson.Format(li), "additionalAddresses.0.address.socketAddress").String())
+				assert.True(t, li.GetEnableReusePort().GetValue())
 			}
 		}
 

--- a/config/envoyconfig/outbound.go
+++ b/config/envoyconfig/outbound.go
@@ -32,7 +32,7 @@ func (b *Builder) buildOutboundListener(cfg *config.Config) (*envoy_config_liste
 				},
 			},
 		},
-	}, opts...)
+	}, nil, opts...)
 	li.FilterChains = []*envoy_config_listener_v3.FilterChain{{
 		Name:    "outbound-ingress",
 		Filters: []*envoy_config_listener_v3.Filter{filter},

--- a/config/envoyconfig/quic.go
+++ b/config/envoyconfig/quic.go
@@ -40,8 +40,8 @@ func newQUICAltSvcHeaderFilter(cfg *config.Config) *envoy_extensions_filters_net
 	if cfg.Options.HTTP3AdvertisePort.Valid {
 		advertisePort = cfg.Options.HTTP3AdvertisePort.Uint32
 	} else {
-		listenAddr := buildUDPAddress(cfg.Options.Addr, 443)
-		advertisePort = listenAddr.GetSocketAddress().GetPortValue()
+		mainAddress, _ := buildUDPListenAddresses(cfg.Options.Addr, 443)
+		advertisePort = mainAddress.GetSocketAddress().GetPortValue()
 	}
 	return HTTPHeaderMutationsFilter(&envoy_extensions_filters_http_header_mutation_v3.HeaderMutation{
 		Mutations: &envoy_extensions_filters_http_header_mutation_v3.Mutations{

--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -2,5 +2,5 @@
   "config": "v0.28.0",
   "hosted-authenticate-oidc": "v0.1.0",
   "mcp": "v0.27.0",
-  "ssh": "v0.14.0"
+  "ssh": "v0.15.0"
 }


### PR DESCRIPTION
## Summary

Instead of using `ipv4_compat` with `::`, we can listen on two addresses using `additional_addresses`. This fixes an issue with the QUIC listener on MacOS.

## Related issues
- [ENG-3850](https://linear.app/pomerium/issue/ENG-3850/http3-quic-macos-so-reuseport-concurrency-issue)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
