### PR TITLE
fix(identity): exclude AccessTokenAllowedAudiences from provider hash

### DIFF
--- a/config/identity_test.go
+++ b/config/identity_test.go
@@ -58,6 +58,46 @@ func TestOptions_GetIdentityProviderForPolicy(t *testing.T) {
 	assert.Equal(t, perPolicyAccessTokenAllowedAudiences, idp.AccessTokenAllowedAudiences.GetValues())
 }
 
+func TestPoliciesWithDifferentAudiencesShareProviderID(t *testing.T) {
+	// ENG-2977: routes with different idp_access_token_allowed_audiences but the
+	// same IdP should produce the same provider ID so users don't get forced to
+	// re-login when navigating between them.
+	opts := &Options{
+		AuthenticateURLString: "https://authenticate.example.com",
+		ClientID:              "client-id",
+		ClientSecret:          "client-secret",
+		Provider:              oidc.Name,
+		ProviderURL:           "https://my-idp.example.com",
+	}
+
+	aud1 := []string{"audience1", "audience2"}
+	aud2 := []string{"audience3"}
+
+	idpNoAudiences, err := opts.GetIdentityProviderForPolicy(nil)
+	require.NoError(t, err)
+
+	idpWithAud1, err := opts.GetIdentityProviderForPolicy(&Policy{
+		IDPAccessTokenAllowedAudiences: &aud1,
+	})
+	require.NoError(t, err)
+
+	idpWithAud2, err := opts.GetIdentityProviderForPolicy(&Policy{
+		IDPAccessTokenAllowedAudiences: &aud2,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, idpNoAudiences.GetId(), idpWithAud1.GetId(),
+		"provider ID should not change when audiences are set")
+	assert.Equal(t, idpNoAudiences.GetId(), idpWithAud2.GetId(),
+		"provider ID should not change with different audiences")
+
+	// Verify that audiences are still correctly populated on the provider
+	// (the field still exists, just doesn't affect the hash).
+	assert.Nil(t, idpNoAudiences.AccessTokenAllowedAudiences)
+	assert.Equal(t, aud1, idpWithAud1.AccessTokenAllowedAudiences.GetValues())
+	assert.Equal(t, aud2, idpWithAud2.AccessTokenAllowedAudiences.GetValues())
+}
+
 func TestHostedAuthenticateDerivedCredentials(t *testing.T) {
 	// The credentials for hosted authenticate should be derived from the shared
 	// secret deterministically.

--- a/internal/authenticateflow/authenticateflow_int_test.go
+++ b/internal/authenticateflow/authenticateflow_int_test.go
@@ -35,6 +35,65 @@ func newHTTPUpstream(
 	return up, route
 }
 
+func TestDifferentAudiencesShareSession(t *testing.T) {
+	// ENG-2977: routes with different idp_access_token_allowed_audiences but the
+	// same IdP should share a session. Before the fix, different audiences caused
+	// different provider hashes, which forced a re-login when navigating between
+	// routes even though the underlying IdP session was the same.
+	env := testenv.New(t)
+
+	env.Add(scenarios.NewIDP([]*scenarios.User{{Email: "test@example.com"}}))
+
+	aud1 := []string{"audience1", "audience2"}
+	aud2 := []string{"audience3"}
+
+	upstreamA, routeA := newHTTPUpstream(env, "aud-a")
+	upstreamB, routeB := newHTTPUpstream(env, "aud-b")
+
+	// Set different audiences on each route.
+	routeA.Policy(func(p *config.Policy) {
+		p.IDPAccessTokenAllowedAudiences = &aud1
+	})
+	routeB.Policy(func(p *config.Policy) {
+		p.IDPAccessTokenAllowedAudiences = &aud2
+	})
+
+	// Link routes so that authenticating to A propagates session to B.
+	routeA.Policy(func(p *config.Policy) {
+		p.DependsOn = []string{
+			strings.TrimPrefix(routeB.URL().Value(), "https://"),
+		}
+	})
+
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	cj, err := cookiejar.New(nil)
+	require.NoError(t, err)
+	sharedClient := http.Client{Jar: cj}
+	withSharedClient := upstreams.ClientHook(
+		func(_ *http.Client) *http.Client { return &sharedClient })
+
+	// Authenticate to route A (which has audience1).
+	resp, err := upstreamA.Get(routeA, withSharedClient, upstreams.AuthenticateAs("test@example.com"))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+
+	// Route B (audience2) should be accessible without re-login because both
+	// routes share the same IdP — audiences should not affect provider identity.
+	sharedClient.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+		return http.ErrUseLastResponse
+	}
+	resp, err = upstreamB.Get(routeB, withSharedClient)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"route with different audiences but same IdP should not require re-login")
+	io.ReadAll(resp.Body)
+	resp.Body.Close()
+}
+
 func TestMultiDomainLogin(t *testing.T) {
 	env := testenv.New(t)
 

--- a/pkg/grpc/identity/identity.go
+++ b/pkg/grpc/identity/identity.go
@@ -13,10 +13,14 @@ func (x *Provider) Clone() *Provider {
 	return proto.Clone(x).(*Provider)
 }
 
-// Hash computes a sha256 hash of the provider's fields. It excludes the Id field.
+// Hash computes a sha256 hash of the provider's identity-determining fields.
+// It excludes fields that do not affect which IdP session is used:
+//   - Id (derived from the hash itself)
+//   - AccessTokenAllowedAudiences (per-route post-auth filtering, not session identity)
 func (x *Provider) Hash() string {
 	tmp := x.Clone()
 	tmp.Id = ""
+	tmp.AccessTokenAllowedAudiences = nil
 	bs, _ := proto.MarshalOptions{
 		AllowPartial:  true,
 		Deterministic: true,

--- a/pkg/grpc/identity/identity_test.go
+++ b/pkg/grpc/identity/identity_test.go
@@ -11,8 +11,77 @@ import (
 func TestHash(t *testing.T) {
 	t.Parallel()
 
-	p1 := &identity.Provider{Id: "id1"}
-	p2 := &identity.Provider{Id: "id2"}
+	t.Run("excludes Id", func(t *testing.T) {
+		t.Parallel()
+		p1 := &identity.Provider{Id: "id1"}
+		p2 := &identity.Provider{Id: "id2"}
+		assert.Equal(t, p1.Hash(), p2.Hash(), "should ignore ids for hash")
+	})
 
-	assert.Equal(t, p1.Hash(), p2.Hash(), "should ignore ids for hash")
+	t.Run("excludes AccessTokenAllowedAudiences", func(t *testing.T) {
+		t.Parallel()
+
+		base := &identity.Provider{
+			ClientId:               "client-id",
+			ClientSecret:           "client-secret",
+			Type:                   "oidc",
+			Url:                    "https://idp.example.com",
+			AuthenticateServiceUrl: "https://auth.example.com",
+		}
+
+		withAudiences := &identity.Provider{
+			ClientId:               "client-id",
+			ClientSecret:           "client-secret",
+			Type:                   "oidc",
+			Url:                    "https://idp.example.com",
+			AuthenticateServiceUrl: "https://auth.example.com",
+			AccessTokenAllowedAudiences: &identity.Provider_StringList{
+				Values: []string{"aud1", "aud2"},
+			},
+		}
+
+		withDifferentAudiences := &identity.Provider{
+			ClientId:               "client-id",
+			ClientSecret:           "client-secret",
+			Type:                   "oidc",
+			Url:                    "https://idp.example.com",
+			AuthenticateServiceUrl: "https://auth.example.com",
+			AccessTokenAllowedAudiences: &identity.Provider_StringList{
+				Values: []string{"aud3"},
+			},
+		}
+
+		assert.Equal(t, base.Hash(), withAudiences.Hash(),
+			"providers differing only in audiences should have the same hash")
+		assert.Equal(t, base.Hash(), withDifferentAudiences.Hash(),
+			"providers with different audiences should have the same hash")
+	})
+
+	t.Run("excludes AccessTokenAllowedAudiences nil vs empty", func(t *testing.T) {
+		t.Parallel()
+
+		withNil := &identity.Provider{
+			ClientId: "client-id",
+		}
+
+		withEmpty := &identity.Provider{
+			ClientId: "client-id",
+			AccessTokenAllowedAudiences: &identity.Provider_StringList{
+				Values: []string{},
+			},
+		}
+
+		assert.Equal(t, withNil.Hash(), withEmpty.Hash(),
+			"nil and empty audiences should produce the same hash")
+	})
+
+	t.Run("different ClientId produces different hash", func(t *testing.T) {
+		t.Parallel()
+
+		p1 := &identity.Provider{ClientId: "client-a"}
+		p2 := &identity.Provider{ClientId: "client-b"}
+
+		assert.NotEqual(t, p1.Hash(), p2.Hash(),
+			"providers with different client IDs should have different hashes")
+	})
 }


### PR DESCRIPTION
## Summary

- Routes with different `idp_access_token_allowed_audiences` but the same IdP produced different provider IDs, forcing unnecessary re-logins when users navigated between them
- `AccessTokenAllowedAudiences` is a per-route post-auth filtering field, not a session identity field — it should not affect provider identity
- One-line fix: exclude the field from `Provider.Hash()` alongside the already-excluded `Id` field

## Test plan

- [x] Unit tests: 4 subtests on `Hash()` covering audience exclusion, nil-vs-empty, and regression guard (`different ClientId → different hash`)
- [x] Config integration test: `TestPoliciesWithDifferentAudiencesShareProviderID` verifies `GetIdentityProviderForPolicy` returns same provider ID with different audiences
- [x] System integration test: `TestDifferentAudiencesShareSession` runs full Pomerium instance with mock IdP, two routes with different audiences linked via DependsOn, authenticates to route A and verifies route B is accessible without re-login
- [x] `make build` / `make test` / `make lint` — all green
- [x] CI

AI-assisted: implementation drafted by Claude, reviewed by Go expert + code reviewer agents, independently verified by Codex.

Fixes ENG-2977