### PR TITLE
routes: append X-Forwarded-Host when host rewrite is active

### DIFF
--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -81,6 +81,7 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-XSS-Protection", "value": "1; mode=block" } }
 						],
 						"route": {
+							"appendXForwardedHost": true,
 							"autoHostRewrite": true,
 							"cluster": "route-5fbd81d8f19363f4",
 							"hashPolicy": [
@@ -139,6 +140,7 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 							{ "appendAction": "OVERWRITE_IF_EXISTS_OR_ADD", "header": { "key": "X-XSS-Protection", "value": "1; mode=block" } }
 						],
 						"route": {
+							"appendXForwardedHost": true,
 							"autoHostRewrite": true,
 							"cluster": "route-5fbd81d8f19363f4",
 							"hashPolicy": [

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -479,13 +479,10 @@ func (b *Builder) buildPolicyRouteRouteAction(options *config.Options, policy *c
 			Cluster: clusterName,
 		},
 		UpgradeConfigs: upgradeConfigs,
-		HostRewriteSpecifier: &envoy_config_route_v3.RouteAction_AutoHostRewrite{
-			AutoHostRewrite: &wrapperspb.BoolValue{Value: !policy.PreserveHostHeader},
-		},
-		Timeout:       routeTimeout,
-		IdleTimeout:   idleTimeout,
-		PrefixRewrite: prefixRewrite,
-		RegexRewrite:  regexRewrite,
+		Timeout:        routeTimeout,
+		IdleTimeout:    idleTimeout,
+		PrefixRewrite:  prefixRewrite,
+		RegexRewrite:   regexRewrite,
 		HashPolicy: []*envoy_config_route_v3.RouteAction_HashPolicy{
 			// hash by the routing key, which is added by authorize.
 			{
@@ -646,15 +643,19 @@ func getRewriteOptions(policy *config.Policy) (prefixRewrite string, regexRewrit
 }
 
 func setHostRewriteOptions(policy *config.Policy, action *envoy_config_route_v3.RouteAction) {
+	// When Envoy rewrites host/:authority, let it carry the original downstream
+	// value forward via X-Forwarded-Host.
 	switch {
 	case policy.HostRewrite != "":
 		action.HostRewriteSpecifier = &envoy_config_route_v3.RouteAction_HostRewriteLiteral{
 			HostRewriteLiteral: policy.HostRewrite,
 		}
+		action.AppendXForwardedHost = shouldAppendXForwardedHost(policy)
 	case policy.HostRewriteHeader != "":
 		action.HostRewriteSpecifier = &envoy_config_route_v3.RouteAction_HostRewriteHeader{
 			HostRewriteHeader: policy.HostRewriteHeader,
 		}
+		action.AppendXForwardedHost = shouldAppendXForwardedHost(policy)
 	case policy.HostPathRegexRewritePattern != "":
 		action.HostRewriteSpecifier = &envoy_config_route_v3.RouteAction_HostRewritePathRegex{
 			HostRewritePathRegex: &envoy_type_matcher_v3.RegexMatchAndSubstitute{
@@ -664,15 +665,29 @@ func setHostRewriteOptions(policy *config.Policy, action *envoy_config_route_v3.
 				Substitution: policy.HostPathRegexRewriteSubstitution,
 			},
 		}
+		action.AppendXForwardedHost = shouldAppendXForwardedHost(policy)
 	case policy.PreserveHostHeader:
 		action.HostRewriteSpecifier = &envoy_config_route_v3.RouteAction_AutoHostRewrite{
 			AutoHostRewrite: wrapperspb.Bool(false),
 		}
+		action.AppendXForwardedHost = false
 	default:
 		action.HostRewriteSpecifier = &envoy_config_route_v3.RouteAction_AutoHostRewrite{
 			AutoHostRewrite: wrapperspb.Bool(true),
 		}
+		action.AppendXForwardedHost = shouldAppendXForwardedHost(policy)
 	}
+}
+
+func shouldAppendXForwardedHost(policy *config.Policy) bool {
+	// Disabling append here prevents Envoy from generating X-Forwarded-Host.
+	// RequestHeadersToRemove still strips any client-supplied value separately.
+	for _, header := range policy.RemoveRequestHeaders {
+		if strings.EqualFold(header, "x-forwarded-host") {
+			return false
+		}
+	}
+	return true
 }
 
 func isProxyFrontingAuthenticate(options *config.Options, host string) (bool, error) {

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -2461,14 +2461,14 @@ func Test_setHostRewriteOptions(t *testing.T) {
 			name:                   "default auto rewrite",
 			policy:                 config.Policy{},
 			expectAppendXForwarded: true,
-			expectAutoHostRewrite:  boolPtr(true),
+			expectAutoHostRewrite:  new(true),
 			expectSpecifierType:    &envoy_config_route_v3.RouteAction_AutoHostRewrite{},
 		},
 		{
 			name:                   "preserve host header",
 			policy:                 config.Policy{PreserveHostHeader: true},
 			expectAppendXForwarded: false,
-			expectAutoHostRewrite:  boolPtr(false),
+			expectAutoHostRewrite:  new(false),
 			expectSpecifierType:    &envoy_config_route_v3.RouteAction_AutoHostRewrite{},
 		},
 		{
@@ -2549,8 +2549,4 @@ func Test_setHostRewriteOptions(t *testing.T) {
 			}
 		})
 	}
-}
-
-func boolPtr(v bool) *bool {
-	return &v
 }

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -286,6 +286,7 @@ func TestTimeouts(t *testing.T) {
 
 		expect := fmt.Sprintf(`{
 			%s,
+			"appendXForwardedHost": true,
 			"autoHostRewrite": true,
 			"cluster": "policy",
 			"hashPolicy": [
@@ -451,6 +452,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"autoHostRewrite": true,
 					"cluster": "policy-1",
 					"hashPolicy": [
@@ -602,6 +604,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"autoHostRewrite": true,
 					"cluster": "policy-3",
 					"hashPolicy": [
@@ -679,6 +682,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"autoHostRewrite": true,
 					"cluster": "policy-4",
 					"hashPolicy": [
@@ -754,6 +758,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"autoHostRewrite": true,
 					"cluster": "policy-5",
 					"hashPolicy": [
@@ -1076,6 +1081,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						}
 					},
 					"route": {
+						"appendXForwardedHost": true,
 						"autoHostRewrite": true,
 						"cluster": "policy-9",
 						"hashPolicy": [
@@ -1098,9 +1104,9 @@ func Test_buildPolicyRoutes(t *testing.T) {
 							{ "enabled": false, "upgradeType": "spdy/3.1"}
 						]
 					},
-        	        "requestHeadersToRemove": [
-        	           	"x-pomerium-reproxy-policy",
-        	           	"x-pomerium-reproxy-policy-hmac"
+					"requestHeadersToRemove": [
+						"x-pomerium-reproxy-policy",
+						"x-pomerium-reproxy-policy-hmac"
 					],
 					"responseHeadersToAdd": [
 						{
@@ -1172,6 +1178,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"autoHostRewrite": true,
 					"cluster": "policy-10",
 					"hashPolicy": [
@@ -1249,6 +1256,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"autoHostRewrite": true,
 					"cluster": "policy-11",
 					"hashPolicy": [
@@ -1348,6 +1356,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 				},
 				"route": {
 					"autoHostRewrite": true,
+					"appendXForwardedHost": true,
 					"cluster": "policy-12",
 					"hashPolicy": [
 						{
@@ -1449,6 +1458,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						}
 					},
 					"route": {
+						"appendXForwardedHost": true,
 						"autoHostRewrite": true,
 						"cluster": "policy-13",
 						"hashPolicy": [
@@ -1549,6 +1559,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 						}
 					},
 					"route": {
+						"appendXForwardedHost": true,
 						"autoHostRewrite": true,
 						"cluster": "pomerium-control-plane-http",
 						"hashPolicy": [
@@ -1702,6 +1713,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"autoHostRewrite": true,
 					"prefixRewrite": "/bar",
 					"cluster": "policy-1",
@@ -1778,6 +1790,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"autoHostRewrite": true,
 					"prefixRewrite": "/foo",
 					"cluster": "policy-2",
@@ -1854,6 +1867,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"autoHostRewrite": true,
 					"regexRewrite": {
 						"pattern": {
@@ -1935,6 +1949,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"hostRewriteLiteral": "literal.example.com",
 					"prefixRewrite": "/bar",
 					"cluster": "policy-4",
@@ -2011,6 +2026,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"hostRewriteHeader": "HOST_HEADER",
 					"prefixRewrite": "/bar",
 					"cluster": "policy-5",
@@ -2087,6 +2103,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 					}
 				},
 				"route": {
+					"appendXForwardedHost": true,
 					"hostRewritePathRegex": {
 						"pattern": {
 							"regex": "^/(.+)/.+$"
@@ -2424,4 +2441,116 @@ func Test_buildPomeriumHTTPRoutesWithMCP(t *testing.T) {
 			`+routeString("prefix", "/.well-known/pomerium/")+`
 		]`, routes)
 	})
+}
+
+func Test_setHostRewriteOptions(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name                   string
+		policy                 config.Policy
+		expectAppendXForwarded bool
+		expectAutoHostRewrite  *bool
+		expectHostRewrite      string
+		expectHostHeader       string
+		expectRegexPattern     string
+		expectRegexSubst       string
+		expectSpecifierType    any
+	}{
+		{
+			name:                   "default auto rewrite",
+			policy:                 config.Policy{},
+			expectAppendXForwarded: true,
+			expectAutoHostRewrite:  boolPtr(true),
+			expectSpecifierType:    &envoy_config_route_v3.RouteAction_AutoHostRewrite{},
+		},
+		{
+			name:                   "preserve host header",
+			policy:                 config.Policy{PreserveHostHeader: true},
+			expectAppendXForwarded: false,
+			expectAutoHostRewrite:  boolPtr(false),
+			expectSpecifierType:    &envoy_config_route_v3.RouteAction_AutoHostRewrite{},
+		},
+		{
+			name:                   "explicit host rewrite",
+			policy:                 config.Policy{HostRewrite: "example.com"},
+			expectAppendXForwarded: true,
+			expectHostRewrite:      "example.com",
+			expectSpecifierType:    &envoy_config_route_v3.RouteAction_HostRewriteLiteral{},
+		},
+		{
+			name:                   "explicit host rewrite header",
+			policy:                 config.Policy{HostRewriteHeader: "X-Custom-Host"},
+			expectAppendXForwarded: true,
+			expectHostHeader:       "X-Custom-Host",
+			expectSpecifierType:    &envoy_config_route_v3.RouteAction_HostRewriteHeader{},
+		},
+		{
+			name:                   "explicit host path regex rewrite",
+			policy:                 config.Policy{HostPathRegexRewritePattern: `^/(.+)$`, HostPathRegexRewriteSubstitution: `\1`},
+			expectAppendXForwarded: true,
+			expectRegexPattern:     `^/(.+)$`,
+			expectRegexSubst:       `\1`,
+			expectSpecifierType:    &envoy_config_route_v3.RouteAction_HostRewritePathRegex{},
+		},
+		{
+			name: "explicit rewrite overrides preserve",
+			policy: config.Policy{
+				HostRewrite:        "example.com",
+				PreserveHostHeader: true,
+			},
+			expectAppendXForwarded: true,
+			expectHostRewrite:      "example.com",
+			expectSpecifierType:    &envoy_config_route_v3.RouteAction_HostRewriteLiteral{},
+		},
+		{
+			name: "remove request headers disables x-forwarded-host append",
+			policy: config.Policy{
+				HostRewrite:          "example.com",
+				RemoveRequestHeaders: []string{"X-Forwarded-Host"},
+			},
+			expectAppendXForwarded: false,
+			expectHostRewrite:      "example.com",
+			expectSpecifierType:    &envoy_config_route_v3.RouteAction_HostRewriteLiteral{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			action := new(envoy_config_route_v3.RouteAction)
+			setHostRewriteOptions(&tc.policy, action)
+
+			assert.Equal(t, tc.expectAppendXForwarded, action.AppendXForwardedHost)
+			assert.IsType(t, tc.expectSpecifierType, action.HostRewriteSpecifier)
+
+			if tc.expectAutoHostRewrite != nil {
+				specifier, ok := action.HostRewriteSpecifier.(*envoy_config_route_v3.RouteAction_AutoHostRewrite)
+				require.True(t, ok)
+				require.NotNil(t, specifier.AutoHostRewrite)
+				assert.Equal(t, *tc.expectAutoHostRewrite, specifier.AutoHostRewrite.Value)
+			}
+			if tc.expectHostRewrite != "" {
+				specifier, ok := action.HostRewriteSpecifier.(*envoy_config_route_v3.RouteAction_HostRewriteLiteral)
+				require.True(t, ok)
+				assert.Equal(t, tc.expectHostRewrite, specifier.HostRewriteLiteral)
+			}
+			if tc.expectHostHeader != "" {
+				specifier, ok := action.HostRewriteSpecifier.(*envoy_config_route_v3.RouteAction_HostRewriteHeader)
+				require.True(t, ok)
+				assert.Equal(t, tc.expectHostHeader, specifier.HostRewriteHeader)
+			}
+			if tc.expectRegexPattern != "" || tc.expectRegexSubst != "" {
+				specifier, ok := action.HostRewriteSpecifier.(*envoy_config_route_v3.RouteAction_HostRewritePathRegex)
+				require.True(t, ok)
+				require.NotNil(t, specifier.HostRewritePathRegex)
+				require.NotNil(t, specifier.HostRewritePathRegex.Pattern)
+				assert.Equal(t, tc.expectRegexPattern, specifier.HostRewritePathRegex.Pattern.Regex)
+				assert.Equal(t, tc.expectRegexSubst, specifier.HostRewritePathRegex.Substitution)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
 }

--- a/internal/acceptance/browser/fixtures/feature-map.json
+++ b/internal/acceptance/browser/fixtures/feature-map.json
@@ -26,6 +26,7 @@
       "files": {
         "headers/cookie-flags.spec.ts": ["Cookie Security Flags", "HttpOnly", "SameSite"],
         "headers/cors-preflight.spec.ts": ["CORS Preflight", "Cross-Origin Requests"],
+        "headers/forwarded-host.spec.ts": ["X-Forwarded-Host", "Host Rewrite", "Preserve Host"],
         "headers/jwt-assertion.spec.ts": ["JWT Claims", "Header Passing", "User Endpoint"],
         "headers/websocket-upgrade.spec.ts": ["WebSocket Upgrade", "Binary Messages", "Preserve Host"]
       }

--- a/internal/acceptance/browser/fixtures/test-data.ts
+++ b/internal/acceptance/browser/fixtures/test-data.ts
@@ -130,6 +130,18 @@ export const testRoutes = {
 
   /** Route requiring both admins and engineering groups */
   engineeringAdmins: "/engineering-admins",
+
+  /** Route with explicit host rewrite for X-Forwarded-Host verification */
+  hostRewrite: "/host-rewrite",
+
+  /** Route with preserve_host_header for comparison */
+  hostRewritePreserve: "/host-rewrite-preserve",
+
+  /** Route using default auto host rewrite */
+  autoHostRewrite: "/auto-host-rewrite",
+
+  /** Route that strips X-Forwarded-Host after rewrite */
+  hostRewriteNoXFH: "/host-rewrite-no-xfh",
 };
 
 /**

--- a/internal/acceptance/browser/helpers/headers.ts
+++ b/internal/acceptance/browser/helpers/headers.ts
@@ -118,6 +118,11 @@ export async function getVerifyResponse(
  */
 function normalizeVerifyResponse(data: Record<string, unknown>): VerifyResponse {
   const headers: Record<string, string> = {};
+  const rawRequest = data.request;
+  const request =
+    typeof rawRequest === "object" && rawRequest !== null
+      ? (rawRequest as Record<string, unknown>)
+      : undefined;
 
   // Handle different header formats
   const rawHeaders = data.headers || data.Headers || {};
@@ -134,10 +139,10 @@ function normalizeVerifyResponse(data: Record<string, unknown>): VerifyResponse 
 
   return {
     headers,
-    path: data.path as string | undefined,
-    host: data.host as string | undefined,
-    method: data.method as string | undefined,
-    protocol: data.protocol as string | undefined,
+    path: (data.path || request?.url) as string | undefined,
+    host: (data.host || request?.host) as string | undefined,
+    method: (data.method || request?.method) as string | undefined,
+    protocol: (data.protocol || request?.protocol) as string | undefined,
   };
 }
 

--- a/internal/acceptance/browser/tests/headers/forwarded-host.spec.ts
+++ b/internal/acceptance/browser/tests/headers/forwarded-host.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * X-Forwarded-Host Tests
+ *
+ * Priority: P1
+ * Validates: upstream receives the original host when Pomerium rewrites Host
+ *
+ * Test Matrix Reference:
+ * | Headers | x-forwarded-host | host_rewrite | Upstream host rewritten and original host forwarded |
+ * | Headers | preserve host header | preserve_host_header: true | Upstream host remains original |
+ */
+
+import { test, expect } from "@playwright/test";
+import { login, clearAuthState } from "../../helpers/authn-flow.js";
+import { testUsers } from "../../fixtures/users.js";
+import { urls, testRoutes } from "../../fixtures/test-data.js";
+
+const expectedOriginalHost = new URL(urls.app).host;
+// Mirrors the /auto-host-rewrite acceptance route's upstream in config.yaml.
+const autoRewrittenHost = "websocket-server:8080";
+const rewrittenHost = "rewritten.example.internal";
+
+async function getRequestInfo(page, route: string) {
+  const response = await page.request.get(`${urls.app}${route}`, {
+    ignoreHTTPSErrors: true,
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  expect(response.ok(), `Expected ${route} to return JSON`).toBe(true);
+  return response.json();
+}
+
+test.describe("X-Forwarded-Host", () => {
+  test.beforeEach(async ({ page }) => {
+    await clearAuthState(page);
+  });
+
+  test("should append x-forwarded-host when host rewrite is active", async ({ page }) => {
+    await login(page, { user: testUsers.alice });
+
+    const response = await getRequestInfo(page, testRoutes.hostRewrite);
+
+    expect(response.host, "Upstream host should be rewritten").toBe(rewrittenHost);
+    expect(
+      response.headers["x-forwarded-host"],
+      "X-Forwarded-Host should contain the original downstream host"
+    ).toContain(expectedOriginalHost);
+    expect(
+      response.headers["x-forwarded-host"],
+      "X-Forwarded-Host should not contain the rewritten upstream host"
+    ).not.toContain(rewrittenHost);
+  });
+
+  test("should append x-forwarded-host when default auto host rewrite is active", async ({
+    page,
+  }) => {
+    await login(page, { user: testUsers.alice });
+
+    const response = await getRequestInfo(page, testRoutes.autoHostRewrite);
+
+    expect(response.host, "Upstream host should be auto-rewritten to the upstream host").toBe(
+      autoRewrittenHost
+    );
+    expect(
+      response.headers["x-forwarded-host"],
+      "X-Forwarded-Host should contain the original downstream host"
+    ).toContain(expectedOriginalHost);
+  });
+
+  test("should preserve the original host when preserve_host_header is enabled", async ({
+    page,
+  }) => {
+    await login(page, { user: testUsers.alice });
+
+    const response = await getRequestInfo(page, testRoutes.hostRewritePreserve);
+
+    expect(response.host, "Upstream should see the original host").toBe(
+      expectedOriginalHost
+    );
+    expect(
+      response.headers["x-forwarded-host"],
+      "X-Forwarded-Host should not be added when preserve_host_header is enabled"
+    ).toBeUndefined();
+  });
+
+  test("should allow removing x-forwarded-host after host rewrite", async ({ page }) => {
+    await login(page, { user: testUsers.alice });
+
+    const response = await getRequestInfo(page, testRoutes.hostRewriteNoXFH);
+
+    expect(response.host, "Upstream host should still be rewritten").toBe(rewrittenHost);
+    expect(
+      response.headers["x-forwarded-host"],
+      "X-Forwarded-Host should be removed before the upstream request"
+    ).toBeUndefined();
+  });
+});

--- a/internal/acceptance/pomerium/config.yaml
+++ b/internal/acceptance/pomerium/config.yaml
@@ -212,6 +212,51 @@ routes:
             - claim/groups: admins
             - claim/groups: engineering
 
+  # Route that preserves the original host header for comparison
+  - from: https://app.localhost.pomerium.io:8443
+    to: http://websocket-server:8080
+    prefix: /host-rewrite-preserve
+    preserve_host_header: true
+    pass_identity_headers: true
+    policy:
+      - allow:
+          or:
+            - authenticated_user: true
+
+  # Route that uses the default auto host rewrite path
+  - from: https://app.localhost.pomerium.io:8443
+    to: http://websocket-server:8080
+    prefix: /auto-host-rewrite
+    pass_identity_headers: true
+    policy:
+      - allow:
+          or:
+            - authenticated_user: true
+
+  # Route that rewrites host but strips X-Forwarded-Host before the upstream
+  - from: https://app.localhost.pomerium.io:8443
+    to: http://websocket-server:8080
+    prefix: /host-rewrite-no-xfh
+    host_rewrite: rewritten.example.internal
+    remove_request_headers:
+      - x-forwarded-host
+    pass_identity_headers: true
+    policy:
+      - allow:
+          or:
+            - authenticated_user: true
+
+  # Route with explicit host rewrite to verify X-Forwarded-Host behavior
+  - from: https://app.localhost.pomerium.io:8443
+    to: http://websocket-server:8080
+    prefix: /host-rewrite
+    host_rewrite: rewritten.example.internal
+    pass_identity_headers: true
+    policy:
+      - allow:
+          or:
+            - authenticated_user: true
+
   # Default route - allows any authenticated user (MUST BE LAST)
   - from: https://app.localhost.pomerium.io:8443
     to: http://upstream:8000

--- a/internal/acceptance/ws-server/server.js
+++ b/internal/acceptance/ws-server/server.js
@@ -71,6 +71,28 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  // Host rewrite test endpoints - echo back the raw upstream request
+  if (
+    req.url &&
+    [
+      "/auto-host-rewrite",
+      "/host-rewrite",
+      "/host-rewrite-preserve",
+      "/host-rewrite-no-xfh",
+    ].some((path) => req.url.startsWith(path))
+  ) {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        path: req.url,
+        method: req.method,
+        host: req.headers.host,
+        headers: req.headers,
+      })
+    );
+    return;
+  }
+
   res.writeHead(404);
   res.end();
 });

--- a/internal/controlplane/grpc_accesslog_test.go
+++ b/internal/controlplane/grpc_accesslog_test.go
@@ -51,23 +51,24 @@ func Test_populateLogEvent(t *testing.T) {
 
 	for _, tc := range []struct {
 		field  log.AccessLogField
+		entry  *envoy_data_accesslog_v3.HTTPAccessLogEntry
 		expect string
 	}{
-		{log.AccessLogFieldAuthority, `{"authority":"AUTHORITY"}`},
-		{log.AccessLogFieldDuration, `{"duration":3000}`},
-		{log.AccessLogFieldForwardedFor, `{"forwarded-for":"FORWARDED-FOR"}`},
-		{log.AccessLogFieldIP, `{"ip":"127.0.0.1"}`},
-		{log.AccessLogFieldMethod, `{"method":"GET"}`},
-		{log.AccessLogFieldPath, `{"path":"https://www.example.com/some/path"}`},
-		{log.AccessLogFieldQuery, `{"query":"a=b"}`},
-		{log.AccessLogFieldReferer, `{"referer":"https://www.example.com/referer"}`},
-		{log.AccessLogFieldRequestID, `{"request-id":"REQUEST-ID"}`},
-		{log.AccessLogFieldResponseCode, `{"response-code":200}`},
-		{log.AccessLogFieldResponseCodeDetails, `{"response-code-details":"RESPONSE-CODE-DETAILS"}`},
-		{log.AccessLogFieldSize, `{"size":1234}`},
-		{log.AccessLogFieldUpstreamCluster, `{"upstream-cluster":"UPSTREAM-CLUSTER"}`},
-		{log.AccessLogFieldUserAgent, `{"user-agent":"USER-AGENT"}`},
-		{unknownAccessLogField, "{}"}, // Unknown log fields should not cause errors
+		{log.AccessLogFieldAuthority, entry, `{"authority":"AUTHORITY"}`},
+		{log.AccessLogFieldDuration, entry, `{"duration":3000}`},
+		{log.AccessLogFieldForwardedFor, entry, `{"forwarded-for":"FORWARDED-FOR"}`},
+		{log.AccessLogFieldIP, entry, `{"ip":"127.0.0.1"}`},
+		{log.AccessLogFieldMethod, entry, `{"method":"GET"}`},
+		{log.AccessLogFieldPath, entry, `{"path":"https://www.example.com/some/path"}`},
+		{log.AccessLogFieldQuery, entry, `{"query":"a=b"}`},
+		{log.AccessLogFieldReferer, entry, `{"referer":"https://www.example.com/referer"}`},
+		{log.AccessLogFieldRequestID, entry, `{"request-id":"REQUEST-ID"}`},
+		{log.AccessLogFieldResponseCode, entry, `{"response-code":200}`},
+		{log.AccessLogFieldResponseCodeDetails, entry, `{"response-code-details":"RESPONSE-CODE-DETAILS"}`},
+		{log.AccessLogFieldSize, entry, `{"size":1234}`},
+		{log.AccessLogFieldUpstreamCluster, entry, `{"upstream-cluster":"UPSTREAM-CLUSTER"}`},
+		{log.AccessLogFieldUserAgent, entry, `{"user-agent":"USER-AGENT"}`},
+		{unknownAccessLogField, entry, "{}"}, // Unknown log fields should not cause errors
 	} {
 		t.Run(string(tc.field), func(t *testing.T) {
 			t.Parallel()
@@ -75,7 +76,7 @@ func Test_populateLogEvent(t *testing.T) {
 			var buf bytes.Buffer
 			log := zerolog.New(&buf)
 			evt := log.Log()
-			evt = populateLogEvent(tc.field, evt, entry)
+			evt = populateLogEvent(tc.field, evt, tc.entry)
 			evt.Send()
 
 			assert.Equal(t, tc.expect, strings.TrimSpace(buf.String()))


### PR DESCRIPTION
## Summary

- switch the implementation from a Pomerium-specific original-host header to Envoy's native `X-Forwarded-Host` handling
- append `X-Forwarded-Host` whenever host rewrite is active, including the default auto-rewrite path and explicit literal/header/regex rewrites
- skip generation when `preserve_host_header: true` or when `remove_request_headers` already removes `x-forwarded-host`
- add runtime acceptance coverage for explicit rewrite, default auto rewrite, preserve-host, and opt-out behavior
- update the docs in `pomerium/documentation` on `bdd/docs-original-host-header`

## Why

The earlier iteration introduced a custom `x-pomerium-original-host` header. This revision aligns the feature with the standard header applications already understand, reuses Envoy's built-in request processing, and keeps the existing escape hatch through `remove_request_headers`.

## Behavior

- `X-Forwarded-Host` is only appended when host rewrite is active.
- `preserve_host_header: true` leaves the original host untouched and does not append `X-Forwarded-Host`.
- `remove_request_headers: [x-forwarded-host]` disables generation and strips any inbound client-supplied value before the upstream request.

## Testing

- `make build`
- `make test`
- `make lint`
- `go test ./config/envoyconfig -run 'TestTimeouts|TestBuilder_buildMainRouteConfiguration|Test_buildPolicyRoutesRewrite|Test_setHostRewriteOptions'`
- `cd internal/acceptance/browser && npx playwright test tests/headers/forwarded-host.spec.ts`

## AI Assistance

- Codex helped rework the implementation from the earlier custom-header approach to Envoy-native `X-Forwarded-Host`, added acceptance coverage, tightened the unit tests, and drafted this PR description.
- I manually reviewed the design, verified the runtime behavior in the acceptance harness, reran build/test/lint, and incorporated Claude review feedback before pushing.
