### PR TITLE
fix: validate GCS metadata identity response before using as token

### DIFF
--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -393,10 +393,9 @@ func TestEvaluator(t *testing.T) {
 			assert.Equal(t, "a@example.com", res.Headers.Get("Impersonate-User"))
 		})
 		t.Run("google_cloud_serverless", func(t *testing.T) {
-			cleanup := withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+			withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
 				_, _ = w.Write([]byte("eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJleGFtcGxlIn0.signature"))
 			})
-			defer cleanup()
 
 			res, err := eval(t, options, []proto.Message{
 				&session.Session{

--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -393,29 +393,32 @@ func TestEvaluator(t *testing.T) {
 			assert.Equal(t, "a@example.com", res.Headers.Get("Impersonate-User"))
 		})
 		t.Run("google_cloud_serverless", func(t *testing.T) {
-			withMockGCP(t, func() {
-				res, err := eval(t, options, []proto.Message{
-					&session.Session{
-						Id:     "session1",
-						UserId: "user1",
-					},
-					&user.User{
-						Id:    "user1",
-						Email: "a@example.com",
-					},
-				}, &Request{
-					Policy: policies[2],
-					Session: RequestSession{
-						ID: "session1",
-					},
-					HTTP: RequestHTTP{
-						Method: http.MethodGet,
-						URL:    "https://from.example.com",
-					},
-				})
-				require.NoError(t, err)
-				assert.NotEmpty(t, res.Headers.Get("Authorization"))
+			cleanup := withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJleGFtcGxlIn0.signature"))
 			})
+			defer cleanup()
+
+			res, err := eval(t, options, []proto.Message{
+				&session.Session{
+					Id:     "session1",
+					UserId: "user1",
+				},
+				&user.User{
+					Id:    "user1",
+					Email: "a@example.com",
+				},
+			}, &Request{
+				Policy: policies[2],
+				Session: RequestSession{
+					ID: "session1",
+				},
+				HTTP: RequestHTTP{
+					Method: http.MethodGet,
+					URL:    "https://from.example.com",
+				},
+			})
+			require.NoError(t, err)
+			assert.NotEmpty(t, res.Headers.Get("Authorization"))
 		})
 	})
 	t.Run("email", func(t *testing.T) {

--- a/authorize/evaluator/google_cloud_serverless.go
+++ b/authorize/evaluator/google_cloud_serverless.go
@@ -3,6 +3,7 @@ package evaluator
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -85,17 +86,38 @@ func (src *gcpIdentityTokenSource) Token() (*oauth2.Token, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if res.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("metadata identity endpoint returned HTTP %d for audience %q: %s",
+				res.StatusCode, src.audience, truncateBody(bs))
+		}
+
 		return string(bs), nil
 	})
 	if err != nil {
 		return nil, err
 	}
 
+	token := strings.TrimSpace(res.(string))
+	if token == "" {
+		return nil, errors.New("metadata identity endpoint returned an empty token")
+	}
+
 	return &oauth2.Token{
-		AccessToken: strings.TrimSpace(res.(string)),
+		AccessToken: token,
 		TokenType:   "bearer",
 		Expiry:      GCPIdentityNow().Add(GCPIdentityTokenExpiration),
 	}, nil
+}
+
+// truncateBody returns a prefix of the response body for error messages.
+func truncateBody(bs []byte) string {
+	const maxLen = 200
+	s := strings.TrimSpace(string(bs))
+	if len(s) > maxLen {
+		return s[:maxLen] + "..."
+	}
+	return s
 }
 
 type gcpTokenSourceKey struct {

--- a/authorize/evaluator/google_cloud_serverless.go
+++ b/authorize/evaluator/google_cloud_serverless.go
@@ -102,6 +102,9 @@ func (src *gcpIdentityTokenSource) Token() (*oauth2.Token, error) {
 	if token == "" {
 		return nil, errors.New("metadata identity endpoint returned an empty token")
 	}
+	if strings.ContainsAny(token, "\r\n") {
+		return nil, fmt.Errorf("metadata identity endpoint returned a token containing newlines for audience %q", src.audience)
+	}
 
 	return &oauth2.Token{
 		AccessToken: token,

--- a/authorize/evaluator/google_cloud_serverless_test.go
+++ b/authorize/evaluator/google_cloud_serverless_test.go
@@ -7,41 +7,102 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 )
 
-func withMockGCP(t *testing.T, f func()) {
+func withMockGCP(t *testing.T, handler http.HandlerFunc) (cleanup func()) {
+	t.Helper()
 	originalGCPIdentityDocURL := GCPIdentityDocURL
-	defer func() {
-		GCPIdentityDocURL = originalGCPIdentityDocURL
-		GCPIdentityNow = time.Now
-	}()
+	originalNow := GCPIdentityNow
 
 	now := time.Date(2020, 1, 1, 1, 0, 0, 0, time.UTC)
 	GCPIdentityNow = func() time.Time {
 		return now
 	}
 
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "Google", r.Header.Get("Metadata-Flavor"))
-		assert.Equal(t, "full", r.URL.Query().Get("format"))
-		_, _ = w.Write([]byte(now.Format(time.RFC3339)))
-	}))
-	defer srv.Close()
-
+	srv := httptest.NewServer(handler)
 	GCPIdentityDocURL = srv.URL
-	f()
+
+	// clear the global token source cache so tests don't interfere
+	gcpTokenSources.Lock()
+	saved := gcpTokenSources.m
+	gcpTokenSources.m = make(map[gcpTokenSourceKey]oauth2.TokenSource)
+	gcpTokenSources.Unlock()
+
+	return func() {
+		srv.Close()
+		GCPIdentityDocURL = originalGCPIdentityDocURL
+		GCPIdentityNow = originalNow
+		gcpTokenSources.Lock()
+		gcpTokenSources.m = saved
+		gcpTokenSources.Unlock()
+	}
 }
 
 func TestGCPIdentityTokenSource(t *testing.T) {
 	t.Parallel()
 
-	withMockGCP(t, func() {
+	t.Run("success", func(t *testing.T) {
+		cleanup := withMockGCP(t, func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, "Google", r.Header.Get("Metadata-Flavor"))
+			assert.Equal(t, "full", r.URL.Query().Get("format"))
+			_, _ = w.Write([]byte("eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJleGFtcGxlIn0.signature"))
+		})
+		defer cleanup()
+
 		src, err := getGoogleCloudServerlessTokenSource("", "example")
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		token, err := src.Token()
-		assert.NoError(t, err)
-		assert.Equal(t, "2020-01-01T01:00:00Z", token.AccessToken)
+		require.NoError(t, err)
+		assert.Equal(t, "eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJleGFtcGxlIn0.signature", token.AccessToken)
+	})
+
+	t.Run("non-200 status returns error", func(t *testing.T) {
+		cleanup := withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("<!DOCTYPE html><html><body>not found</body></html>"))
+		})
+		defer cleanup()
+
+		src, err := getGoogleCloudServerlessTokenSource("", "bad-audience")
+		require.NoError(t, err)
+
+		token, err := src.Token()
+		assert.Nil(t, token)
+		assert.ErrorContains(t, err, "metadata identity endpoint returned HTTP 404")
+		assert.ErrorContains(t, err, "bad-audience")
+	})
+
+	t.Run("empty body returns error", func(t *testing.T) {
+		cleanup := withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			// write nothing
+		})
+		defer cleanup()
+
+		src, err := getGoogleCloudServerlessTokenSource("", "empty-response")
+		require.NoError(t, err)
+
+		token, err := src.Token()
+		assert.Nil(t, token)
+		assert.ErrorContains(t, err, "empty token")
+	})
+
+	t.Run("non-200 prevents invalid Authorization header", func(t *testing.T) {
+		// This is the exact scenario that caused the staging 503:
+		// metadata server returns 404, body gets used as Bearer token,
+		// Envoy rejects the invalid header value.
+		cleanup := withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			_, _ = w.Write([]byte("not found\n"))
+		})
+		defer cleanup()
+
+		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app")
+		assert.Error(t, err)
+		assert.Nil(t, headers, "must not produce headers with an invalid token")
 	})
 }
 

--- a/authorize/evaluator/google_cloud_serverless_test.go
+++ b/authorize/evaluator/google_cloud_serverless_test.go
@@ -3,11 +3,13 @@ package evaluator
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/net/http/httpguts"
 	"golang.org/x/oauth2"
 )
 
@@ -74,6 +76,18 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 		assert.ErrorContains(t, err, "bad-audience")
 	})
 
+	t.Run("staging-like 403 returns error and no headers", func(t *testing.T) {
+		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = w.Write([]byte("Unauthenticated\n"))
+		})
+
+		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app")
+		assert.ErrorContains(t, err, "metadata identity endpoint returned HTTP 403")
+		assert.ErrorContains(t, err, "Unauthenticated")
+		assert.Nil(t, headers)
+	})
+
 	t.Run("empty body returns error", func(t *testing.T) {
 		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
@@ -88,17 +102,33 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 		assert.ErrorContains(t, err, "empty token")
 	})
 
-	t.Run("non-200 prevents invalid Authorization header", func(t *testing.T) {
-		// This is the exact scenario that caused the staging 503:
-		// metadata server returns 404, body gets used as Bearer token,
-		// Envoy rejects the invalid header value.
+	t.Run("whitespace-only body returns error", func(t *testing.T) {
 		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
-			w.WriteHeader(http.StatusNotFound)
-			_, _ = w.Write([]byte("not found\n"))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("  \n  \t  "))
 		})
 
+		src, err := getGoogleCloudServerlessTokenSource("", "whitespace-only")
+		require.NoError(t, err)
+
+		token, err := src.Token()
+		assert.Nil(t, token)
+		assert.ErrorContains(t, err, "empty token")
+	})
+
+	t.Run("multiline 200 body returns error and no headers", func(t *testing.T) {
+		// Asserts that the token validator blocks embedded newlines from becoming
+		// invalid Bearer tokens. The httpguts check is test-only evidence.
+		body := "error\nnot-found"
+		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(body))
+		})
+
+		assert.False(t, httpguts.ValidHeaderFieldValue("Bearer "+strings.TrimSpace(body)))
+
 		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app")
-		assert.Error(t, err)
+		assert.ErrorContains(t, err, "token containing newlines")
 		assert.Nil(t, headers, "must not produce headers with an invalid token")
 	})
 }

--- a/authorize/evaluator/google_cloud_serverless_test.go
+++ b/authorize/evaluator/google_cloud_serverless_test.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/oauth2"
 )
 
-func withMockGCP(t *testing.T, handler http.HandlerFunc) (cleanup func()) {
+func withMockGCP(t *testing.T, handler http.HandlerFunc) {
 	t.Helper()
 	originalGCPIdentityDocURL := GCPIdentityDocURL
 	originalNow := GCPIdentityNow
@@ -30,26 +30,26 @@ func withMockGCP(t *testing.T, handler http.HandlerFunc) (cleanup func()) {
 	gcpTokenSources.m = make(map[gcpTokenSourceKey]oauth2.TokenSource)
 	gcpTokenSources.Unlock()
 
-	return func() {
+	t.Cleanup(func() {
 		srv.Close()
 		GCPIdentityDocURL = originalGCPIdentityDocURL
 		GCPIdentityNow = originalNow
 		gcpTokenSources.Lock()
 		gcpTokenSources.m = saved
 		gcpTokenSources.Unlock()
-	}
+	})
 }
 
 func TestGCPIdentityTokenSource(t *testing.T) {
-	t.Parallel()
+	// Not parallel: withMockGCP mutates package-level globals
+	// (GCPIdentityDocURL, GCPIdentityNow) without synchronization.
 
 	t.Run("success", func(t *testing.T) {
-		cleanup := withMockGCP(t, func(w http.ResponseWriter, r *http.Request) {
+		withMockGCP(t, func(w http.ResponseWriter, r *http.Request) {
 			assert.Equal(t, "Google", r.Header.Get("Metadata-Flavor"))
 			assert.Equal(t, "full", r.URL.Query().Get("format"))
 			_, _ = w.Write([]byte("eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJleGFtcGxlIn0.signature"))
 		})
-		defer cleanup()
 
 		src, err := getGoogleCloudServerlessTokenSource("", "example")
 		require.NoError(t, err)
@@ -60,11 +60,10 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 	})
 
 	t.Run("non-200 status returns error", func(t *testing.T) {
-		cleanup := withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte("<!DOCTYPE html><html><body>not found</body></html>"))
 		})
-		defer cleanup()
 
 		src, err := getGoogleCloudServerlessTokenSource("", "bad-audience")
 		require.NoError(t, err)
@@ -76,11 +75,10 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 	})
 
 	t.Run("empty body returns error", func(t *testing.T) {
-		cleanup := withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)
 			// write nothing
 		})
-		defer cleanup()
 
 		src, err := getGoogleCloudServerlessTokenSource("", "empty-response")
 		require.NoError(t, err)
@@ -94,11 +92,10 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 		// This is the exact scenario that caused the staging 503:
 		// metadata server returns 404, body gets used as Bearer token,
 		// Envoy rejects the invalid header value.
-		cleanup := withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNotFound)
 			_, _ = w.Write([]byte("not found\n"))
 		})
-		defer cleanup()
 
 		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app")
 		assert.Error(t, err)

--- a/authorize/evaluator/google_cloud_serverless_test.go
+++ b/authorize/evaluator/google_cloud_serverless_test.go
@@ -83,8 +83,10 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 		})
 
 		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app")
-		assert.ErrorContains(t, err, "metadata identity endpoint returned HTTP 403")
-		assert.ErrorContains(t, err, "Unauthenticated")
+		assert.EqualError(t, err,
+			"error retrieving google cloud serverless token: "+
+				`metadata identity endpoint returned HTTP 403 for audience "https://example.run.app": `+
+				"Unauthenticated")
 		assert.Nil(t, headers)
 	})
 
@@ -117,8 +119,8 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 	})
 
 	t.Run("multiline 200 body returns error and no headers", func(t *testing.T) {
-		// Asserts that the token validator blocks embedded newlines from becoming
-		// invalid Bearer tokens. The httpguts check is test-only evidence.
+		// If a metadata response body contains embedded newlines, reject it
+		// instead of forwarding it as the token value.
 		body := "error\nnot-found"
 		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusOK)

--- a/authorize/evaluator/google_cloud_serverless_test.go
+++ b/authorize/evaluator/google_cloud_serverless_test.go
@@ -127,11 +127,26 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 			_, _ = w.Write([]byte(body))
 		})
 
+		// Confirm the test fixture would be invalid as an HTTP header value.
 		assert.False(t, httpguts.ValidHeaderFieldValue("Bearer "+strings.TrimSpace(body)))
 
 		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app")
 		assert.ErrorContains(t, err, "token containing newlines")
 		assert.Nil(t, headers, "must not produce headers with an invalid token")
+	})
+
+	t.Run("carriage-return-only body returns error", func(t *testing.T) {
+		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("token\rinjection"))
+		})
+
+		src, err := getGoogleCloudServerlessTokenSource("", "carriage-return-only")
+		require.NoError(t, err)
+
+		token, err := src.Token()
+		assert.Nil(t, token)
+		assert.ErrorContains(t, err, "token containing newlines")
 	})
 }
 


### PR DESCRIPTION
## Summary

- reject non-200 responses from the GCP metadata identity endpoint instead of using the response body as a bearer token
- reject empty metadata tokens after trimming whitespace
- include the audience and a truncated response body in errors to improve diagnostics
- add regression coverage around unexpected metadata responses and header generation

## Context

While investigating an environment-specific failure mode, we found that unexpected responses from the metadata identity endpoint could flow into the authorization-header path. This PR hardens that code path so bad metadata responses are treated as errors instead of token material.

This is a correctness and defense-in-depth fix. It should not be read as a claim that this PR alone explains every aspect of the incident being investigated.

## Test plan

- [x] success path still returns a token
- [x] non-200 metadata responses return an error
- [x] empty metadata responses return an error
- [x] header-generation path does not emit headers when token retrieval fails
- [x] existing evaluator coverage still passes
- [x] `make build`
- [x] `make test`
- [x] `make lint`

## AI Assistance

AI helped draft the initial diagnosis and test coverage. I manually reviewed the change, validated the behavior against a live environment, and reran the repository validation commands.
