### PR TITLE
core/config: remove the empty string from allow_upgrades

### DIFF
--- a/config/policy.go
+++ b/config/policy.go
@@ -1077,10 +1077,10 @@ func (p *Policy) GetAllowSPDY(options *Options) bool {
 
 func (p *Policy) GetAllowUpgrades(options *Options) []string {
 	if p.AllowUpgrades != nil {
-		return *p.AllowUpgrades
+		return slices.DeleteFunc(*p.AllowUpgrades, func(x string) bool { return x == "" })
 	}
 	if options != nil && options.AllowUpgrades != nil {
-		return *options.AllowUpgrades
+		return slices.DeleteFunc(*options.AllowUpgrades, func(x string) bool { return x == "" })
 	}
 	return nil
 }

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -172,6 +172,10 @@ func TestPolicy_GetAllowUpgrades(t *testing.T) {
 		(&Policy{}).GetAllowUpgrades(&Options{
 			GlobalOptions: GlobalOptions{AllowUpgrades: new([]string{"x", "y", "z"})},
 		}))
+	assert.Equal(t, []string{"x", "y", "z"},
+		(&Policy{}).GetAllowUpgrades(&Options{
+			GlobalOptions: GlobalOptions{AllowUpgrades: new([]string{"x", "", "y", "", "z"})},
+		}))
 }
 
 func TestPolicy_GetAllowWebsockets(t *testing.T) {

--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -1,5 +1,5 @@
 {
-  "config": "v0.28.0",
+  "config": "v0.29.0",
   "hosted-authenticate-oidc": "v0.1.0",
   "mcp": "v0.27.0",
   "ssh": "v0.15.0"


### PR DESCRIPTION
## Summary
Envoy doesn't allow an empty string as an upgrade type. This PR removes all empty strings from the list.

## Related issues
- [ENG-3902](https://linear.app/pomerium/issue/ENG-3902/enabling-allow-upgrades-in-console-or-zero-settings-causes-internal)

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
