### PR TITLE
fix: use X-Serverless-Authorization for Cloud Run serverless auth

### DIFF
--- a/authorize/evaluator/evaluator_test.go
+++ b/authorize/evaluator/evaluator_test.go
@@ -417,7 +417,7 @@ func TestEvaluator(t *testing.T) {
 				},
 			})
 			require.NoError(t, err)
-			assert.NotEmpty(t, res.Headers.Get("Authorization"))
+			assert.NotEmpty(t, res.Headers.Get("X-Serverless-Authorization"))
 		})
 	})
 	t.Run("email", func(t *testing.T) {

--- a/authorize/evaluator/google_cloud_serverless.go
+++ b/authorize/evaluator/google_cloud_serverless.go
@@ -195,7 +195,10 @@ func getGoogleCloudServerlessHeaders(serviceAccount, audience string) (map[strin
 		return nil, fmt.Errorf("error retrieving google cloud serverless token: %w", err)
 	}
 
+	// Use X-Serverless-Authorization so Cloud Run checks this header for IAM
+	// and passes the Authorization header through to the container untouched.
+	// See https://cloud.google.com/run/docs/authenticating/service-to-service
 	return map[string]string{
-		"Authorization": "Bearer " + tok.AccessToken,
+		"X-Serverless-Authorization": "Bearer " + tok.AccessToken,
 	}, nil
 }

--- a/authorize/evaluator/google_cloud_serverless_test.go
+++ b/authorize/evaluator/google_cloud_serverless_test.go
@@ -61,6 +61,20 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 		assert.Equal(t, "eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJleGFtcGxlIn0.signature", token.AccessToken)
 	})
 
+	t.Run("success returns X-Serverless-Authorization header", func(t *testing.T) {
+		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJleGFtcGxlIn0.signature"))
+		})
+
+		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app")
+		require.NoError(t, err)
+		// Cloud Run checks X-Serverless-Authorization for IAM and passes
+		// Authorization through to the container untouched.
+		assert.Equal(t, map[string]string{
+			"X-Serverless-Authorization": "Bearer eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJleGFtcGxlIn0.signature",
+		}, headers)
+	})
+
 	t.Run("non-200 status returns error", func(t *testing.T) {
 		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusNotFound)

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -522,6 +522,34 @@ func TestHeadersEvaluator(t *testing.T) {
 			assert.Contains(t, output.HeadersToRemove, "Authorization")
 		})
 
+		t.Run("mcp server with google cloud serverless auth does not conflict", func(t *testing.T) {
+			withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte("mock-identity-token"))
+			})
+
+			output, err := evalWithMCP(t,
+				[]proto.Message{
+					&session.Session{Id: "s1", UserId: "u1"},
+				},
+				&Request{
+					Policy: &config.Policy{
+						To: config.WeightedURLs{{URL: *mustParseURL("https://myservice.run.app")}},
+						MCP: &config.MCP{
+							Server: &config.MCPServer{},
+						},
+						EnableGoogleCloudServerlessAuthentication: true,
+					},
+					Session: RequestSession{ID: "s1"},
+				})
+			require.NoError(t, err)
+			assert.Contains(t, output.HeadersToRemove, "Authorization")
+			// MCP strips Authorization; Cloud Run token uses a separate header
+			// so the two features don't conflict.
+			assert.Empty(t, output.Headers.Get("Authorization"))
+			assert.Equal(t, "Bearer mock-identity-token",
+				output.Headers.Get("X-Serverless-Authorization"))
+		})
+
 		t.Run("no mcp config", func(t *testing.T) {
 			output, err := evalWithMCP(t,
 				[]proto.Message{


### PR DESCRIPTION
## Summary

Cloud Run supports `X-Serverless-Authorization` as a native alternative to `Authorization` for IAM authentication. When present, Cloud Run uses it for IAM and passes `Authorization` through to the container untouched.

Switch to `X-Serverless-Authorization` unconditionally. This frees the `Authorization` header for application-level use (`set_request_headers`, MCP upstream OAuth, etc.) and fixes an incompatibility where MCP server routes strip `Authorization` via `headers_to_remove`, which also deletes the GCP identity token.

See: https://cloud.google.com/run/docs/authenticating/service-to-service

## Related issues

- ENG-3912

## User Explanation

Google Cloud Run serverless authentication now uses the `X-Serverless-Authorization` header instead of `Authorization`. Cloud Run checks this header first for IAM authentication. This frees the `Authorization` header for application-level use and fixes MCP server routes with Cloud Run auth.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review