### PR TITLE
fix: use X-Serverless-Authorization for MCP routes with Cloud Run auth

### DIFF
--- a/authorize/evaluator/google_cloud_serverless.go
+++ b/authorize/evaluator/google_cloud_serverless.go
@@ -46,7 +46,7 @@ var (
 			return nil, fmt.Errorf("invalid audience type: %T", op2)
 		}
 
-		headers, err := getGoogleCloudServerlessHeaders(string(serviceAccount), string(audience))
+		headers, err := getGoogleCloudServerlessHeaders(string(serviceAccount), string(audience), "Authorization")
 		if err != nil {
 			log.Error().Err(err).Msg("error retrieving google cloud serverless headers")
 			return nil, fmt.Errorf("failed to get google cloud serverless headers: %w", err)
@@ -184,7 +184,13 @@ func getGoogleCloudServerlessTokenSource(serviceAccount, audience string) (oauth
 	return src, nil
 }
 
-func getGoogleCloudServerlessHeaders(serviceAccount, audience string) (map[string]string, error) {
+// getGoogleCloudServerlessHeaders returns a map of headers to add to the
+// request for Google Cloud serverless authentication. The headerName parameter
+// controls which header carries the identity token. Use "Authorization" for
+// standard Cloud Run auth, or "X-Serverless-Authorization" when another
+// mechanism needs the Authorization header (Cloud Run checks
+// X-Serverless-Authorization first when present).
+func getGoogleCloudServerlessHeaders(serviceAccount, audience, headerName string) (map[string]string, error) {
 	src, err := getGoogleCloudServerlessTokenSource(serviceAccount, audience)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving google cloud serverless token source: %w", err)
@@ -196,6 +202,6 @@ func getGoogleCloudServerlessHeaders(serviceAccount, audience string) (map[strin
 	}
 
 	return map[string]string{
-		"Authorization": "Bearer " + tok.AccessToken,
+		headerName: "Bearer " + tok.AccessToken,
 	}, nil
 }

--- a/authorize/evaluator/google_cloud_serverless_test.go
+++ b/authorize/evaluator/google_cloud_serverless_test.go
@@ -82,7 +82,7 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 			_, _ = w.Write([]byte("Unauthenticated\n"))
 		})
 
-		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app")
+		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app", "Authorization")
 		assert.EqualError(t, err,
 			"error retrieving google cloud serverless token: "+
 				`metadata identity endpoint returned HTTP 403 for audience "https://example.run.app": `+
@@ -130,7 +130,7 @@ func TestGCPIdentityTokenSource(t *testing.T) {
 		// Confirm the test fixture would be invalid as an HTTP header value.
 		assert.False(t, httpguts.ValidHeaderFieldValue("Bearer "+strings.TrimSpace(body)))
 
-		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app")
+		headers, err := getGoogleCloudServerlessHeaders("", "https://example.run.app", "Authorization")
 		assert.ErrorContains(t, err, "token containing newlines")
 		assert.Nil(t, headers, "must not produce headers with an invalid token")
 	})

--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -148,7 +148,7 @@ func (e *headersEvaluatorEvaluation) fillGoogleCloudServerlessHeaders(ctx contex
 		toAudience = "https://" + wu.URL.Hostname()
 	}
 
-	h, err := getGoogleCloudServerlessHeaders(e.evaluator.store.GetGoogleCloudServerlessAuthenticationServiceAccount(), toAudience)
+	h, err := getGoogleCloudServerlessHeaders(e.evaluator.store.GetGoogleCloudServerlessAuthenticationServiceAccount(), toAudience, "Authorization")
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("authorize/header-evaluator: error retrieving google cloud serverless headers")
 		return

--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -148,7 +148,14 @@ func (e *headersEvaluatorEvaluation) fillGoogleCloudServerlessHeaders(ctx contex
 		toAudience = "https://" + wu.URL.Hostname()
 	}
 
-	h, err := getGoogleCloudServerlessHeaders(e.evaluator.store.GetGoogleCloudServerlessAuthenticationServiceAccount(), toAudience, "Authorization")
+	// MCP server routes use X-Serverless-Authorization to avoid conflicting
+	// with the Authorization removal in fillMCPHeaders and ext_proc token injection.
+	headerName := "Authorization"
+	if e.request.Policy.IsMCPServer() {
+		headerName = "X-Serverless-Authorization"
+	}
+
+	h, err := getGoogleCloudServerlessHeaders(e.evaluator.store.GetGoogleCloudServerlessAuthenticationServiceAccount(), toAudience, headerName)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("authorize/header-evaluator: error retrieving google cloud serverless headers")
 		return

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -522,6 +522,26 @@ func TestHeadersEvaluator(t *testing.T) {
 			assert.Contains(t, output.HeadersToRemove, "Authorization")
 		})
 
+		t.Run("mcp server with google cloud serverless auth uses x-serverless-authorization", func(t *testing.T) {
+			output, err := evalWithMCP(t,
+				[]proto.Message{
+					&session.Session{Id: "s1", UserId: "u1"},
+				},
+				&Request{
+					Policy: &config.Policy{
+						MCP: &config.MCP{
+							Server: &config.MCPServer{},
+						},
+						EnableGoogleCloudServerlessAuthentication: true,
+					},
+					Session: RequestSession{ID: "s1"},
+				})
+			require.NoError(t, err)
+			assert.Contains(t, output.HeadersToRemove, "Authorization")
+			// GCP token remapped to X-Serverless-Authorization, not Authorization.
+			assert.Empty(t, output.Headers.Get("Authorization"))
+		})
+
 		t.Run("no mcp config", func(t *testing.T) {
 			output, err := evalWithMCP(t,
 				[]proto.Message{


### PR DESCRIPTION
## Summary

MCP server routes are incompatible with `enable_google_cloud_serverless_authentication`.
The GCP identity token set on `Authorization` by ext_authz is immediately deleted by
`headers_to_remove` (added by `fillMCPHeaders`), because Envoy applies `headers_to_set`
before `headers_to_remove`.

Fix: for MCP server routes, send the GCP identity token via `X-Serverless-Authorization`
instead. Cloud Run checks this header first for IAM and passes `Authorization` through
to the container, so ext_proc can still use it for MCP upstream OAuth tokens.

See: https://cloud.google.com/run/docs/authenticating/service-to-service

## Related issues

- ENG-3912

## User Explanation

Routes with both `mcp.server` and `enable_google_cloud_serverless_authentication` now
work correctly. The GCP identity token is sent via `X-Serverless-Authorization`, which
Cloud Run checks for IAM authentication.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review