### PR TITLE
fix: apply TLSUpstreamServerName to health checks via transport_socket_match_criteria

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -251,7 +251,24 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 	cluster.OutlierDetection = policy.OutlierDetection.ToEnvoy()
 	cluster.HealthChecks = nil
 	for _, hc := range policy.HealthChecks {
-		cluster.HealthChecks = append(cluster.HealthChecks, hc.ToEnvoy())
+		envoyHC := hc.ToEnvoy()
+
+		// If TLSUpstreamServerName is set and we have TLS transport socket matches,
+		// set transport_socket_match_criteria so health checks use the correct TLS SNI
+		if policy.TLSUpstreamServerName != "" && len(cluster.TransportSocketMatches) > 0 {
+			for _, tsm := range cluster.TransportSocketMatches {
+				if tsm.TransportSocket != nil && tsm.TransportSocket.Name == "tls" {
+					envoyHC.TransportSocketMatchCriteria = &structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							tsm.Name: structpb.NewBoolValue(true),
+						},
+					}
+					break
+				}
+			}
+		}
+
+		cluster.HealthChecks = append(cluster.HealthChecks, envoyHC)
 	}
 	if policy.HealthyPanicThreshold.IsValid() {
 		cluster.CommonLbConfig = &envoy_config_cluster_v3.Cluster_CommonLbConfig{

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/protoutil"
@@ -1365,4 +1366,48 @@ func Test_buildPolicyCluster(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "stat-name", cluster.AltStatName)
 	})
+}
+
+func Test_buildPolicyCluster_HealthCheckTLS(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	filemgr := filemgr.NewManager()
+	b := New("local-connect", "local-grpc", "local-http", "local-debug", "local-metrics", filemgr, nil, true)
+
+	policy := &config.Policy{
+		From:                  "https://grafana.example.com",
+		To:                    config.WeightedURLs{{URL: mustParseWeightedURLs(t, "https://localhost:3000")[0].URL}},
+		TLSUpstreamServerName: "grafana.example.com",
+		HealthChecks: []*configpb.HealthCheck{{
+			Timeout:            durationpb.New(time.Second * 10),
+			Interval:           durationpb.New(time.Second * 60),
+			HealthyThreshold:   wrapperspb.UInt32(1),
+			UnhealthyThreshold: wrapperspb.UInt32(3),
+			HealthChecker: &configpb.HealthCheck_HttpHealthCheck_{
+				HttpHealthCheck: &configpb.HealthCheck_HttpHealthCheck{
+					Path: "/api/health",
+					ExpectedStatuses: []*configpb.HealthCheck_Int64Range{{
+						Start: 200,
+						End:   400,
+					}},
+				},
+			},
+		}},
+	}
+
+	cluster, err := b.buildPolicyCluster(ctx, &config.Config{Options: config.NewDefaultOptions()}, policy)
+	require.NoError(t, err)
+
+	// Assert that the health check has transport_socket_match_criteria set
+	require.Len(t, cluster.HealthChecks, 1)
+	hc := cluster.HealthChecks[0]
+
+	tsMatch := hc.GetTransportSocketMatchCriteria()
+	require.NotNil(t, tsMatch, "health check should have transport_socket_match_criteria set")
+
+	// Verify the match criteria contains the TLS transport socket name
+	require.NotEmpty(t, cluster.TransportSocketMatches, "cluster should have TLS transport socket matches")
+	tsName := cluster.TransportSocketMatches[0].Name
+	require.NotNil(t, tsMatch.Fields[tsName], "transport_socket_match_criteria should reference TLS socket")
 }


### PR DESCRIPTION
## Summary

When `tls_upstream_server_name` is configured on a route with health checks, ensure Envoy's health checker uses the correct TLS SNI by setting transport_socket_match_criteria on the health check configuration.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

This prevents SSL errors like 'no alternative certificate subject name matches target hostname' when the upstream certificate is issued for the route's domain rather than localhost.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
