### PR TITLE
core/config: allow re-issuing JWT for service accounts

### DIFF
--- a/internal/databroker/server_backend_config.go
+++ b/internal/databroker/server_backend_config.go
@@ -126,13 +126,13 @@ func (srv *backendConfigServer) CreateServiceAccount(
 	}
 
 	entity := &user.ServiceAccount{
-		Id:          req.Msg.ServiceAccount.GetId(),
-		NamespaceId: req.Msg.ServiceAccount.NamespaceId,
-		Description: req.Msg.ServiceAccount.Description,
-		UserId:      req.Msg.ServiceAccount.GetUserId(),
-		ExpiresAt:   req.Msg.ServiceAccount.ExpiresAt,
-		IssuedAt:    timestamppb.Now(),
 		AccessedAt:  timestamppb.Now(),
+		Description: req.Msg.ServiceAccount.Description,
+		ExpiresAt:   req.Msg.ServiceAccount.ExpiresAt,
+		Id:          req.Msg.ServiceAccount.GetId(),
+		IssuedAt:    timestamppb.Now(),
+		NamespaceId: req.Msg.ServiceAccount.NamespaceId,
+		UserId:      req.Msg.ServiceAccount.GetUserId(),
 	}
 	if entity.Id == "" {
 		entity.Id = uuid.NewString()
@@ -143,16 +143,9 @@ func (srv *backendConfigServer) CreateServiceAccount(
 		return nil, err
 	}
 
-	srv.mu.RLock()
-	sharedKey := srv.sharedKey
-	srv.mu.RUnlock()
-	var expiresAt null.Time
-	if entity.ExpiresAt.IsValid() {
-		expiresAt = null.TimeFrom(entity.ExpiresAt.AsTime())
-	}
-	jwt, err := cryptutil.SignServiceAccount(sharedKey, entity.Id, entity.UserId, entity.IssuedAt.AsTime(), expiresAt)
+	jwt, err := srv.generateServiceAccountJWT(entity)
 	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("error signing service account: %w", err))
+		return nil, err
 	}
 
 	return connect.NewResponse(&configpb.CreateServiceAccountResponse{
@@ -668,18 +661,26 @@ func (srv *backendConfigServer) UpdateServiceAccount(
 		return nil, err
 	}
 
-	// most fields are immutable, so we only update the ones that are allowed to be modified
 	entity := proto.CloneOf(original)
+	entity.AccessedAt = timestamppb.Now()
 	entity.Description = req.Msg.ServiceAccount.Description
+	entity.ExpiresAt = req.Msg.ServiceAccount.ExpiresAt
 	entity.NamespaceId = req.Msg.ServiceAccount.NamespaceId
+	entity.UserId = req.Msg.ServiceAccount.GetUserId()
 
 	record, err := srv.putEntity(ctx, entity)
 	if err != nil {
 		return nil, err
 	}
 
+	jwt, err := srv.generateServiceAccountJWT(entity)
+	if err != nil {
+		return nil, err
+	}
+
 	return connect.NewResponse(&configpb.UpdateServiceAccountResponse{
 		ServiceAccount: userServiceAccountToConfigServiceAccount(record, entity),
+		Jwt:            jwt,
 	}), nil
 }
 
@@ -795,6 +796,23 @@ func (srv *backendConfigServer) deleteEntity(
 	}
 
 	return nil
+}
+
+func (srv *backendConfigServer) generateServiceAccountJWT(
+	serviceAccount *user.ServiceAccount,
+) (string, error) {
+	srv.mu.RLock()
+	sharedKey := srv.sharedKey
+	srv.mu.RUnlock()
+	var expiresAt null.Time
+	if serviceAccount.ExpiresAt.IsValid() {
+		expiresAt = null.TimeFrom(serviceAccount.ExpiresAt.AsTime())
+	}
+	jwt, err := cryptutil.SignServiceAccount(sharedKey, serviceAccount.Id, serviceAccount.UserId, serviceAccount.IssuedAt.AsTime(), expiresAt)
+	if err != nil {
+		return "", connect.NewError(connect.CodeInternal, fmt.Errorf("error signing service account: %w", err))
+	}
+	return jwt, nil
 }
 
 func (srv *backendConfigServer) getEntity(

--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -1,5 +1,5 @@
 {
-  "config": "v0.28.0",
+  "config": "v0.29.0",
   "hosted-authenticate-oidc": "v0.1.0",
   "mcp": "v0.27.0",
   "ssh": "v0.15.0"

--- a/pkg/grpc/config/config.pb.go
+++ b/pkg/grpc/config/config.pb.go
@@ -6957,10 +6957,13 @@ func (x *UpdateServiceAccountRequest) GetServiceAccount() *ServiceAccount {
 }
 
 type UpdateServiceAccountResponse struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	ServiceAccount *ServiceAccount        `protobuf:"bytes,1,opt,name=service_account,json=serviceAccount,proto3" json:"service_account,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The updated service account.
+	ServiceAccount *ServiceAccount `protobuf:"bytes,1,opt,name=service_account,json=serviceAccount,proto3" json:"service_account,omitempty"`
+	// A newly issued JWT for the service account.
+	Jwt           string `protobuf:"bytes,2,opt,name=jwt,proto3" json:"jwt,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *UpdateServiceAccountResponse) Reset() {
@@ -6998,6 +7001,13 @@ func (x *UpdateServiceAccountResponse) GetServiceAccount() *ServiceAccount {
 		return x.ServiceAccount
 	}
 	return nil
+}
+
+func (x *UpdateServiceAccountResponse) GetJwt() string {
+	if x != nil {
+		return x.Jwt
+	}
+	return ""
 }
 
 type UpdateSettingsRequest struct {
@@ -9357,9 +9367,10 @@ const file_config_proto_rawDesc = "" +
 	"\x13UpdateRouteResponse\x12,\n" +
 	"\x05route\x18\x01 \x01(\v2\x16.pomerium.config.RouteR\x05route\"g\n" +
 	"\x1bUpdateServiceAccountRequest\x12H\n" +
-	"\x0fservice_account\x18\x01 \x01(\v2\x1f.pomerium.config.ServiceAccountR\x0eserviceAccount\"h\n" +
+	"\x0fservice_account\x18\x01 \x01(\v2\x1f.pomerium.config.ServiceAccountR\x0eserviceAccount\"z\n" +
 	"\x1cUpdateServiceAccountResponse\x12H\n" +
-	"\x0fservice_account\x18\x01 \x01(\v2\x1f.pomerium.config.ServiceAccountR\x0eserviceAccount\"N\n" +
+	"\x0fservice_account\x18\x01 \x01(\v2\x1f.pomerium.config.ServiceAccountR\x0eserviceAccount\x12\x10\n" +
+	"\x03jwt\x18\x02 \x01(\tR\x03jwt\"N\n" +
 	"\x15UpdateSettingsRequest\x125\n" +
 	"\bsettings\x18\x01 \x01(\v2\x19.pomerium.config.SettingsR\bsettings\"O\n" +
 	"\x16UpdateSettingsResponse\x125\n" +

--- a/pkg/grpc/config/config.pb.json
+++ b/pkg/grpc/config/config.pb.json
@@ -7495,11 +7495,23 @@
           "fields": [
             {
               "name": "service_account",
-              "description": "",
+              "description": "The updated service account.",
               "label": "",
               "type": "ServiceAccount",
               "longType": "ServiceAccount",
               "fullType": "pomerium.config.ServiceAccount",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "jwt",
+              "description": "A newly issued JWT for the service account.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
               "ismap": false,
               "isoneof": false,
               "oneofdecl": "",

--- a/pkg/grpc/config/config.pb.validate.go
+++ b/pkg/grpc/config/config.pb.validate.go
@@ -11631,6 +11631,8 @@ func (m *UpdateServiceAccountResponse) validate(all bool) error {
 		}
 	}
 
+	// no validation rules for Jwt
+
 	if len(errors) > 0 {
 		return UpdateServiceAccountResponseMultiError(errors)
 	}

--- a/pkg/grpc/config/config.proto
+++ b/pkg/grpc/config/config.proto
@@ -1093,7 +1093,10 @@ message UpdateServiceAccountRequest {
 }
 
 message UpdateServiceAccountResponse {
+  // The updated service account.
   ServiceAccount service_account = 1;
+  // A newly issued JWT for the service account.
+  string jwt = 2;
 }
 
 message UpdateSettingsRequest {

--- a/pkg/storage/storagetest/configservice.go
+++ b/pkg/storage/storagetest/configservice.go
@@ -392,10 +392,13 @@ func TestConfigServiceServiceAccounts(t *testing.T, client configconnect.ConfigS
 
 	s := proto.CloneOf(listRes.Msg.ServiceAccounts[0])
 	s.Description = new("service-account-0999-description-updated")
-	_, err = client.UpdateServiceAccount(t.Context(), connect.NewRequest(&configpb.UpdateServiceAccountRequest{
+	updateRes, err := client.UpdateServiceAccount(t.Context(), connect.NewRequest(&configpb.UpdateServiceAccountRequest{
 		ServiceAccount: s,
 	}))
 	assert.NoError(t, err)
+
+	assert.NotEmpty(t, updateRes.Msg.Jwt,
+		"should return a new jwt on update")
 
 	getRes, err = client.GetServiceAccount(t.Context(), connect.NewRequest(&configpb.GetServiceAccountRequest{
 		Id: "s-0999",


### PR DESCRIPTION
## Summary
Update the config connect service `UpdateServiceAccount` method so that it can re-issue signed JWTs.

## Related issues
- [ENG-2783](https://linear.app/pomerium/issue/ENG-2783/console-support-re-creating-jwt-for-an-existing-service-account)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
