### PR TITLE
core/mcp: add mcp_prefer_client_dcr runtime flag

### DIFF
--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -30,6 +30,11 @@ var (
 	// RuntimeFlagMCP enables the MCP services for the authorize service
 	RuntimeFlagMCP = runtimeFlag("mcp", false)
 
+	// RuntimeFlagMCPPreferClientDCR causes upstream MCP OAuth setup to prefer
+	// Dynamic Client Registration (RFC 7591) over Client ID Metadata Documents
+	// when the upstream authorization server advertises support for both.
+	RuntimeFlagMCPPreferClientDCR = runtimeFlag("mcp_prefer_client_dcr", false)
+
 	// RuntimeFlagPomeriumJWTEndpoint enables the /.pomerium/jwt endpoint, for retrieving
 	// signed user info claims from an upstream single-page web application. This endpoint
 	// is deprecated pending removal in a future release, but this flag allows a temporary

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -57,6 +57,7 @@ type Handler struct {
 	sessionExpiry           time.Duration
 	httpClient              *http.Client // for upstream discovery fetches
 	asMetadataDomainMatcher *DomainMatcher
+	preferClientDCR         bool
 }
 
 // HandlerOption is a functional option for configuring a Handler.
@@ -142,6 +143,7 @@ func New(
 		sessionExpiry:           cfg.Options.CookieExpire,
 		httpClient:              http.DefaultClient,
 		asMetadataDomainMatcher: asDomainMatcher,
+		preferClientDCR:         cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCPPreferClientDCR),
 	}
 
 	for _, opt := range opts {

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -51,7 +51,7 @@ type Handler struct {
 	storage                 HandlerStorage
 	cipher                  cipher.AEAD
 	hosts                   *HostInfo
-	hostsSingleFlight       singleflight.Group
+	dcrSingleFlight         singleflight.Group
 	clientMetadataFetcher   *ClientMetadataFetcher
 	getAuthenticator        AuthenticatorGetter
 	sessionExpiry           time.Duration

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -542,7 +542,7 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 	downstreamHost string,
 	redirectURI string,
 ) (*oauth21proto.UpstreamOAuthClient, error) {
-	return getOrRegisterUpstreamOAuthClient(ctx, srv.storage, &srv.hostsSingleFlight, srv.httpClient, discovery, downstreamHost, redirectURI)
+	return getOrRegisterUpstreamOAuthClient(ctx, srv.storage, &srv.dcrSingleFlight, srv.httpClient, discovery, downstreamHost, redirectURI)
 }
 
 // getOrRegisterUpstreamOAuthClient returns a cached DCR client for (issuer,

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -453,6 +453,7 @@ func (srv *Handler) resolveAutoDiscoveryAuth(ctx context.Context, params *autoDi
 		WithFallbackAuthorizationURL(params.Info.AuthorizationServerURL),
 		WithASMetadataDomainMatcher(srv.asMetadataDomainMatcher),
 		WithAllowDCRFallback(true),
+		WithPreferDCR(srv.preferClientDCR),
 	}
 	setupOpts = append(setupOpts, upstreamOAuthSetupOptsFromConfig(params.Info.UpstreamOAuth2)...)
 	setup, setupErr := runUpstreamOAuthSetup(ctx, srv.httpClient, params.Info.UpstreamURL, params.Host, setupOpts...)

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"time"
 
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
@@ -541,6 +542,22 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 	downstreamHost string,
 	redirectURI string,
 ) (*oauth21proto.UpstreamOAuthClient, error) {
+	return getOrRegisterUpstreamOAuthClient(ctx, srv.storage, &srv.hostsSingleFlight, srv.httpClient, discovery, downstreamHost, redirectURI)
+}
+
+// getOrRegisterUpstreamOAuthClient returns a cached DCR client for (issuer,
+// downstreamHost) or performs RFC 7591 registration and stores the result.
+// Concurrent callers for the same key deduplicate through the provided
+// singleflight group.
+func getOrRegisterUpstreamOAuthClient(
+	ctx context.Context,
+	storage HandlerStorage,
+	sf *singleflight.Group,
+	httpClient *http.Client,
+	discovery *discoveryResult,
+	downstreamHost string,
+	redirectURI string,
+) (*oauth21proto.UpstreamOAuthClient, error) {
 	if discovery == nil {
 		return nil, fmt.Errorf("discovery result is nil")
 	}
@@ -548,7 +565,7 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 		return nil, fmt.Errorf("upstream authorization server %s does not advertise a registration_endpoint for dynamic client registration", discovery.Issuer)
 	}
 
-	if client, err := srv.storage.GetUpstreamOAuthClient(ctx, discovery.Issuer, downstreamHost); err == nil {
+	if client, err := storage.GetUpstreamOAuthClient(ctx, discovery.Issuer, downstreamHost); err == nil {
 		if client.ClientId != "" {
 			return client, nil
 		}
@@ -557,8 +574,8 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 	}
 
 	sfKey := fmt.Sprintf("dcr:%s:%s", discovery.Issuer, downstreamHost)
-	result, err, _ := srv.hostsSingleFlight.Do(sfKey, func() (any, error) {
-		if client, cacheErr := srv.storage.GetUpstreamOAuthClient(ctx, discovery.Issuer, downstreamHost); cacheErr == nil {
+	result, err, _ := sf.Do(sfKey, func() (any, error) {
+		if client, cacheErr := storage.GetUpstreamOAuthClient(ctx, discovery.Issuer, downstreamHost); cacheErr == nil {
 			if client.ClientId != "" {
 				return client, nil
 			}
@@ -566,7 +583,7 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 			log.Ctx(ctx).Warn().Err(cacheErr).Str("issuer", discovery.Issuer).Str("downstream_host", downstreamHost).Msg("mcp/auto-discovery: DCR cache re-check failed inside singleflight, proceeding to registration")
 		}
 
-		registeredClient, registerErr := srv.registerWithUpstreamAS(ctx, discovery, downstreamHost, redirectURI)
+		registeredClient, registerErr := registerWithUpstreamAS(ctx, httpClient, discovery, downstreamHost, redirectURI)
 		if registerErr != nil {
 			return nil, registerErr
 		}
@@ -575,7 +592,7 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 			return nil, fmt.Errorf("upstream AS %s returned empty client_id from dynamic client registration", discovery.Issuer)
 		}
 
-		if putErr := srv.storage.PutUpstreamOAuthClient(ctx, registeredClient); putErr != nil {
+		if putErr := storage.PutUpstreamOAuthClient(ctx, registeredClient); putErr != nil {
 			return nil, fmt.Errorf("storing dynamic client registration: %w", putErr)
 		}
 
@@ -591,8 +608,9 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 	return client, nil
 }
 
-func (srv *Handler) registerWithUpstreamAS(
+func registerWithUpstreamAS(
 	ctx context.Context,
+	httpClient *http.Client,
 	discovery *discoveryResult,
 	downstreamHost string,
 	redirectURI string,
@@ -616,7 +634,7 @@ func (srv *Handler) registerWithUpstreamAS(
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	resp, err := srv.httpClient.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("sending registration request: %w", err)
 	}

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -317,6 +317,20 @@ func (h *UpstreamAuthHandler) handle401(
 		return nil, nil
 	}
 
+	// An empty ClientID means the setup layer deferred client identity to DCR —
+	// either the upstream AS doesn't support CIMD, or the operator opted into
+	// mcp_prefer_client_dcr. Register now so the persisted PendingUpstreamAuth
+	// carries the real client_id that the /authorize and token-exchange paths
+	// will later read from it.
+	if setup.ClientID == "" {
+		registeredClient, regErr := getOrRegisterUpstreamOAuthClient(ctx, h.storage, &h.singleFlight, h.httpClient, setup.Discovery, host, setup.RedirectURI)
+		if regErr != nil {
+			return nil, fmt.Errorf("registering upstream oauth client: %w", regErr)
+		}
+		setup.ClientID = registeredClient.GetClientId()
+		setup.ClientSecret = registeredClient.GetClientSecret()
+	}
+
 	// Generate PKCE
 	verifier, challenge, err := generatePKCE()
 	if err != nil {

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -81,6 +81,7 @@ type UpstreamAuthHandler struct {
 	hosts                   *HostInfo
 	httpClient              *http.Client
 	asMetadataDomainMatcher *DomainMatcher
+	preferClientDCR         bool
 	singleFlight            singleflight.Group
 }
 
@@ -90,12 +91,14 @@ func NewUpstreamAuthHandler(
 	hosts *HostInfo,
 	httpClient *http.Client,
 	asMetadataDomainMatcher *DomainMatcher,
+	preferClientDCR bool,
 ) *UpstreamAuthHandler {
 	return &UpstreamAuthHandler{
 		storage:                 storage,
 		hosts:                   hosts,
 		httpClient:              httpClient,
 		asMetadataDomainMatcher: asMetadataDomainMatcher,
+		preferClientDCR:         preferClientDCR,
 	}
 }
 
@@ -143,7 +146,9 @@ func NewUpstreamAuthHandlerFromConfig(
 	hosts := NewHostInfo(cfg, httpClient)
 	asDomainMatcher := NewDomainMatcher(cfg.Options.GetMCPAllowedAsMetadataDomains())
 
-	return NewUpstreamAuthHandler(storage, hosts, httpClient, asDomainMatcher), nil
+	return NewUpstreamAuthHandler(storage, hosts, httpClient, asDomainMatcher,
+		cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCPPreferClientDCR),
+	), nil
 }
 
 // GetUpstreamToken looks up a cached upstream token for the given route context and host.
@@ -301,6 +306,7 @@ func (h *UpstreamAuthHandler) handle401(
 		WithFallbackAuthorizationURL(serverInfo.AuthorizationServerURL),
 		WithASMetadataDomainMatcher(h.asMetadataDomainMatcher),
 		WithAllowDCRFallback(true),
+		WithPreferDCR(h.preferClientDCR),
 	}
 	setupOpts = append(setupOpts, upstreamOAuthSetupOptsFromConfig(serverInfo.UpstreamOAuth2)...)
 	setup, err := runUpstreamOAuthSetup(ctx, h.httpClient, resourceURL, host, setupOpts...)

--- a/internal/mcp/upstream_auth_test.go
+++ b/internal/mcp/upstream_auth_test.go
@@ -1266,7 +1266,6 @@ func TestHandle401_PreferDCR_RegistersClient(t *testing.T) {
 
 	var (
 		upstreamURL      string
-		registerCalled   bool
 		registerCallHits int
 	)
 	upstreamSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1291,7 +1290,6 @@ func TestHandle401_PreferDCR_RegistersClient(t *testing.T) {
 				ClientIDMetadataDocumentSupported: true,
 			})
 		case "/oauth/register":
-			registerCalled = true
 			registerCallHits++
 			w.WriteHeader(http.StatusCreated)
 			json.NewEncoder(w).Encode(map[string]any{
@@ -1357,10 +1355,8 @@ func TestHandle401_PreferDCR_RegistersClient(t *testing.T) {
 	require.NotNil(t, action, "handle401 should return an action")
 	require.NotNil(t, capturedPending, "pending auth should be persisted")
 
-	assert.True(t, registerCalled,
-		"handle401 must invoke upstream /oauth/register when preferDCR elects DCR")
 	assert.Equal(t, 1, registerCallHits,
-		"DCR should be performed exactly once")
+		"handle401 must invoke upstream /oauth/register exactly once when preferDCR elects DCR")
 	assert.Equal(t, "dcr-registered-client-id", capturedPending.ClientId,
 		"pending auth ClientId should be the DCR-registered client id")
 	assert.Equal(t, "dcr-registered-client-secret", capturedPending.ClientSecret,

--- a/internal/mcp/upstream_auth_test.go
+++ b/internal/mcp/upstream_auth_test.go
@@ -1252,3 +1252,117 @@ func (s *autoDiscoveryTestStorage) PutUpstreamMCPToken(ctx context.Context, toke
 	}
 	return nil
 }
+
+// TestHandle401_PreferDCR_RegistersClient covers the reactive 401 path when
+// the mcp_prefer_client_dcr flag is on and the upstream AS advertises both
+// CIMD and DCR: runUpstreamOAuthSetup returns an empty ClientID so the caller
+// runs DCR, and handle401 must perform that registration before persisting
+// PendingUpstreamAuth — otherwise pending.ClientId would be empty and both the
+// /authorize rebuild (handler_connect.go reusing pending) and the token
+// exchange in handler_client_oauth_callback.go would send client_id="" to the
+// upstream AS, breaking the flow.
+func TestHandle401_PreferDCR_RegistersClient(t *testing.T) {
+	t.Parallel()
+
+	var (
+		upstreamURL      string
+		registerCalled   bool
+		registerCallHits int
+	)
+	upstreamSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/.well-known/oauth-protected-resource/mcp",
+			"/.well-known/oauth-protected-resource":
+			json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+				Resource:             upstreamURL + "/mcp",
+				AuthorizationServers: []string{upstreamURL + "/oauth"},
+			})
+		case "/.well-known/oauth-authorization-server/oauth":
+			// Upstream supports BOTH CIMD and DCR.
+			json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+				Issuer:                            upstreamURL + "/oauth",
+				AuthorizationEndpoint:             upstreamURL + "/oauth/authorize",
+				TokenEndpoint:                     upstreamURL + "/oauth/token",
+				RegistrationEndpoint:              upstreamURL + "/oauth/register",
+				ResponseTypesSupported:            []string{"code"},
+				GrantTypesSupported:               []string{"authorization_code"},
+				CodeChallengeMethodsSupported:     []string{"S256"},
+				ClientIDMetadataDocumentSupported: true,
+			})
+		case "/oauth/register":
+			registerCalled = true
+			registerCallHits++
+			w.WriteHeader(http.StatusCreated)
+			json.NewEncoder(w).Encode(map[string]any{
+				"client_id":                "dcr-registered-client-id",
+				"client_secret":            "dcr-registered-client-secret",
+				"client_secret_expires_at": 0, // 0 means never expires per RFC 7591
+			})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer upstreamSrv.Close()
+	upstreamURL = upstreamSrv.URL
+
+	parsedUpstream, err := url.Parse(upstreamURL)
+	require.NoError(t, err)
+
+	cfg := &config.Config{
+		Options: &config.Options{
+			Policies: []config.Policy{
+				{
+					Name: "test-mcp-server",
+					From: "https://proxy.example.com",
+					To:   config.WeightedURLs{{URL: *parsedUpstream}},
+					MCP:  &config.MCP{Server: &config.MCPServer{}},
+				},
+			},
+		},
+	}
+	hosts := NewHostInfo(cfg, nil)
+
+	var capturedPending *oauth21proto.PendingUpstreamAuth
+	store := &testUpstreamAuthStorage{
+		putPendingUpstreamAuthFunc: func(_ context.Context, pending *oauth21proto.PendingUpstreamAuth) error {
+			capturedPending = pending
+			return nil
+		},
+	}
+
+	handler := &UpstreamAuthHandler{
+		storage:                 store,
+		hosts:                   hosts,
+		httpClient:              upstreamSrv.Client(),
+		asMetadataDomainMatcher: allowLocalhost(),
+		preferClientDCR:         true, // runtime flag is ON
+	}
+
+	routeCtx := &extproc.RouteContext{
+		RouteID: "route-123",
+		UserID:  "user-123",
+		IsMCP:   true,
+	}
+
+	action, err := handler.HandleUpstreamResponse(
+		context.Background(),
+		routeCtx,
+		"proxy.example.com",
+		upstreamURL+"/mcp",
+		401,
+		"",
+	)
+	require.NoError(t, err)
+	require.NotNil(t, action, "handle401 should return an action")
+	require.NotNil(t, capturedPending, "pending auth should be persisted")
+
+	assert.True(t, registerCalled,
+		"handle401 must invoke upstream /oauth/register when preferDCR elects DCR")
+	assert.Equal(t, 1, registerCallHits,
+		"DCR should be performed exactly once")
+	assert.Equal(t, "dcr-registered-client-id", capturedPending.ClientId,
+		"pending auth ClientId should be the DCR-registered client id")
+	assert.Equal(t, "dcr-registered-client-secret", capturedPending.ClientSecret,
+		"pending auth ClientSecret should be the DCR-registered client secret")
+}

--- a/internal/mcp/upstream_oauth_setup.go
+++ b/internal/mcp/upstream_oauth_setup.go
@@ -22,6 +22,7 @@ type upstreamOAuthSetupConfig struct {
 	fallbackAuthorizationURL string                 // AS issuer URL fallback when PRM fails (from config)
 	asMetadataDomainMatcher  *DomainMatcher         // allowlist for upstream AS/PRM metadata URL domains
 	allowDCRFallback         bool
+	preferDCR                bool
 
 	// Static endpoint overrides — skip discovery entirely when both are set.
 	staticAuthorizationEndpoint string
@@ -67,6 +68,15 @@ func WithASMetadataDomainMatcher(m *DomainMatcher) UpstreamOAuthSetupOption {
 func WithAllowDCRFallback(v bool) UpstreamOAuthSetupOption {
 	return func(c *upstreamOAuthSetupConfig) {
 		c.allowDCRFallback = v
+	}
+}
+
+// WithPreferDCR makes DCR the preferred registration path when the upstream AS
+// advertises both client_id_metadata_document and a registration_endpoint. Only
+// takes effect when DCR fallback is also allowed.
+func WithPreferDCR(v bool) UpstreamOAuthSetupOption {
+	return func(c *upstreamOAuthSetupConfig) {
+		c.preferDCR = v
 	}
 }
 
@@ -197,7 +207,18 @@ func runUpstreamOAuthSetup(
 					"client_id_metadata_document", discovery.Issuer)
 			}
 		}
-		if discovery.ClientIDMetadataDocumentSupported {
+		// When both CIMD and DCR are available and the operator has opted into
+		// preferring DCR, leave clientID empty so the caller runs DCR. When DCR
+		// is not reachable (fallback disabled or no registration endpoint), fall
+		// through to CIMD.
+		preferDCR := cfg.preferDCR && cfg.allowDCRFallback && discovery.RegistrationEndpoint != ""
+		if preferDCR {
+			log.Ctx(ctx).Info().
+				Str("issuer", discovery.Issuer).
+				Str("registration_endpoint", discovery.RegistrationEndpoint).
+				Bool("cimd_supported", discovery.ClientIDMetadataDocumentSupported).
+				Msg("ext_proc: mcp_prefer_client_dcr set, using DCR over client_id_metadata_document")
+		} else if discovery.ClientIDMetadataDocumentSupported {
 			clientID = buildClientIDURL(downstreamHost)
 		}
 	}

--- a/internal/mcp/upstream_oauth_setup_test.go
+++ b/internal/mcp/upstream_oauth_setup_test.go
@@ -819,6 +819,174 @@ func TestRunUpstreamOAuthSetup(t *testing.T) {
 		require.NotNil(t, result)
 		assert.Equal(t, []string{"custom-scope"}, result.Scopes)
 	})
+
+	t.Run("prefer DCR selects DCR when both CIMD and DCR supported", func(t *testing.T) {
+		t.Parallel()
+
+		var srvURL string
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+					Resource:             srvURL,
+					AuthorizationServers: []string{srvURL + "/oauth"},
+				})
+			case "/.well-known/oauth-authorization-server/oauth":
+				json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+					Issuer:                            srvURL + "/oauth",
+					AuthorizationEndpoint:             srvURL + "/oauth/authorize",
+					TokenEndpoint:                     srvURL + "/oauth/token",
+					RegistrationEndpoint:              srvURL + "/oauth/register",
+					ResponseTypesSupported:            []string{"code"},
+					GrantTypesSupported:               []string{"authorization_code"},
+					CodeChallengeMethodsSupported:     []string{"S256"},
+					ClientIDMetadataDocumentSupported: true,
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+		srvURL = srv.URL
+
+		result, err := runUpstreamOAuthSetup(context.Background(), srv.Client(), srvURL, "proxy.example.com",
+			WithASMetadataDomainMatcher(allowLocalhost()),
+			WithAllowDCRFallback(true),
+			WithPreferDCR(true),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		// When preferring DCR, ClientID must be empty so the caller triggers DCR
+		// registration via getOrRegisterUpstreamOAuthClient.
+		assert.Empty(t, result.ClientID, "DCR preference should leave ClientID empty for caller-side DCR")
+		assert.Equal(t, srvURL+"/oauth/register", result.Discovery.RegistrationEndpoint)
+		assert.True(t, result.Discovery.ClientIDMetadataDocumentSupported)
+	})
+
+	t.Run("prefer DCR falls back to CIMD when registration endpoint missing", func(t *testing.T) {
+		t.Parallel()
+
+		var srvURL string
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+					Resource:             srvURL,
+					AuthorizationServers: []string{srvURL + "/oauth"},
+				})
+			case "/.well-known/oauth-authorization-server/oauth":
+				// CIMD supported, but no registration_endpoint — DCR not actually available.
+				json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+					Issuer:                            srvURL + "/oauth",
+					AuthorizationEndpoint:             srvURL + "/oauth/authorize",
+					TokenEndpoint:                     srvURL + "/oauth/token",
+					ResponseTypesSupported:            []string{"code"},
+					GrantTypesSupported:               []string{"authorization_code"},
+					CodeChallengeMethodsSupported:     []string{"S256"},
+					ClientIDMetadataDocumentSupported: true,
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+		srvURL = srv.URL
+
+		result, err := runUpstreamOAuthSetup(context.Background(), srv.Client(), srvURL, "proxy.example.com",
+			WithASMetadataDomainMatcher(allowLocalhost()),
+			WithAllowDCRFallback(true),
+			WithPreferDCR(true),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		// No DCR endpoint → fall back to CIMD.
+		assert.Contains(t, result.ClientID, "metadata.json")
+	})
+
+	t.Run("prefer DCR with pre-registered credentials keeps pre-registered", func(t *testing.T) {
+		t.Parallel()
+
+		var srvURL string
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+					Resource:             srvURL,
+					AuthorizationServers: []string{srvURL + "/oauth"},
+				})
+			case "/.well-known/oauth-authorization-server/oauth":
+				json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+					Issuer:                            srvURL + "/oauth",
+					AuthorizationEndpoint:             srvURL + "/oauth/authorize",
+					TokenEndpoint:                     srvURL + "/oauth/token",
+					RegistrationEndpoint:              srvURL + "/oauth/register",
+					ResponseTypesSupported:            []string{"code"},
+					GrantTypesSupported:               []string{"authorization_code"},
+					CodeChallengeMethodsSupported:     []string{"S256"},
+					ClientIDMetadataDocumentSupported: true,
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+		srvURL = srv.URL
+
+		result, err := runUpstreamOAuthSetup(context.Background(), srv.Client(), srvURL, "proxy.example.com",
+			WithASMetadataDomainMatcher(allowLocalhost()),
+			WithAllowDCRFallback(true),
+			WithPreferDCR(true),
+			WithPreRegisteredCredentials("preset-client-id", "preset-secret"),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		// Pre-registered credentials always win over CIMD and DCR.
+		assert.Equal(t, "preset-client-id", result.ClientID)
+		assert.Equal(t, "preset-secret", result.ClientSecret)
+	})
+
+	t.Run("prefer DCR without allowDCRFallback still uses CIMD", func(t *testing.T) {
+		t.Parallel()
+
+		var srvURL string
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			switch r.URL.Path {
+			case "/.well-known/oauth-protected-resource":
+				json.NewEncoder(w).Encode(ProtectedResourceMetadata{
+					Resource:             srvURL,
+					AuthorizationServers: []string{srvURL + "/oauth"},
+				})
+			case "/.well-known/oauth-authorization-server/oauth":
+				json.NewEncoder(w).Encode(AuthorizationServerMetadata{
+					Issuer:                            srvURL + "/oauth",
+					AuthorizationEndpoint:             srvURL + "/oauth/authorize",
+					TokenEndpoint:                     srvURL + "/oauth/token",
+					RegistrationEndpoint:              srvURL + "/oauth/register",
+					ResponseTypesSupported:            []string{"code"},
+					GrantTypesSupported:               []string{"authorization_code"},
+					CodeChallengeMethodsSupported:     []string{"S256"},
+					ClientIDMetadataDocumentSupported: true,
+				})
+			default:
+				w.WriteHeader(http.StatusNotFound)
+			}
+		}))
+		defer srv.Close()
+		srvURL = srv.URL
+
+		// Without WithAllowDCRFallback(true), prefer-DCR has no DCR to prefer.
+		result, err := runUpstreamOAuthSetup(context.Background(), srv.Client(), srvURL, "proxy.example.com",
+			WithASMetadataDomainMatcher(allowLocalhost()),
+			WithPreferDCR(true),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.Contains(t, result.ClientID, "metadata.json")
+	})
 }
 
 func TestBuildAuthorizationURL_ExtraParams(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds an opt-in runtime flag `mcp_prefer_client_dcr` (default `false`). When an upstream MCP server advertises support for both Client ID Metadata Documents (CIMD) and Dynamic Client Registration (DCR), Pomerium will use DCR. When unset, the existing CIMD-preferred behavior is unchanged.

Intended for local development environments where CIMD is not practical (e.g. the upstream AS cannot fetch the proxy's client metadata URL). Pre-registered credentials continue to override both paths.

## Related issues

## User Explanation

Add to `runtime_flags` in the Pomerium config to force DCR with MCP upstreams that support both methods:

```yaml
runtime_flags:
  mcp_prefer_client_dcr: true
```

## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review