### PR TITLE
Add envoy_concurrency config option

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -290,6 +290,11 @@ type Options struct {
 	EnvoyAdminAddress            string    `mapstructure:"envoy_admin_address" yaml:"envoy_admin_address"`
 	EnvoyBindConfigSourceAddress string    `mapstructure:"envoy_bind_config_source_address" yaml:"envoy_bind_config_source_address,omitempty"`
 	EnvoyBindConfigFreebind      null.Bool `mapstructure:"envoy_bind_config_freebind" yaml:"envoy_bind_config_freebind,omitempty"`
+	// EnvoyConcurrency sets the number of worker threads for the Envoy process.
+	// This can be used to work around issues on platforms where SO_REUSEPORT
+	// is not supported for certain listener types (e.g., QUIC on macOS).
+	// If unset, Envoy will use its default (number of CPU cores).
+	EnvoyConcurrency *uint32 `mapstructure:"envoy_concurrency" yaml:"envoy_concurrency,omitempty"`
 
 	// ProgrammaticRedirectDomainWhitelist restricts the allowed redirect URLs when using programmatic login.
 	ProgrammaticRedirectDomainWhitelist []string `mapstructure:"programmatic_redirect_domain_whitelist" yaml:"programmatic_redirect_domain_whitelist,omitempty" json:"programmatic_redirect_domain_whitelist,omitempty"`

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -286,7 +286,13 @@ func (srv *Server) run(ctx context.Context, cfg *config.Config) error {
 	//
 	// Since we rely on automaxprocs to set the GOMAXPROCS based on the CPU quota, we can rely on that
 	// same behavior for envoy.
-	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs) {
+	//
+	// Alternatively, a user can explicitly set envoy_concurrency in the configuration file
+	// (useful for platforms like macOS where QUIC requires concurrency=1 but GOMAXPROCS
+	// cannot be controlled, e.g. with Homebrew/launchd).
+	if concurrency := cfg.Options.EnvoyConcurrency; concurrency != nil {
+		args = append(args, "--concurrency", strconv.FormatUint(uint64(*concurrency), 10))
+	} else if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs) {
 		args = append(args, "--concurrency", strconv.Itoa(runtime.GOMAXPROCS(0)))
 	}
 


### PR DESCRIPTION
## Summary

Adds a new `envoy_concurrency` configuration option that allows setting Envoy's `--concurrency` flag independently of GOMAXPROCS. This is useful for platforms like macOS with Homebrew where the launchd environment cannot be modified and GOMAXPROCS cannot be controlled.

Fixes the QUIC/http3 issue on macOS where Envoy requires concurrency=1 due to SO_REUSEPORT not being supported for UDP listeners.

## Related issues

- #6246

## User Explanation

On macOS with Homebrew, you can now set `envoy_concurrency: 1` in your config to enable QUIC/http3 support without needing to modify the launchd environment.

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review