### PR TITLE
fix(mcp): recover MCP upstream auth after late config delivery

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -242,11 +242,11 @@ func NewServer(
 	grpc_health_v1.RegisterHealthServer(srv.GRPCServer, pom_grpc.NewHealthCheckServer())
 	healthpb.RegisterHealthNotifierServer(srv.GRPCServer, srv)
 
-	// Register ext_proc unconditionally so a handler can be installed later if
-	// RuntimeFlagMCP arrives after startup (Pomerium Zero config-sync path).
+	// MCP activation is per-route (see config/envoyconfig/routes.go) and
+	// per-request (extproc.Server.Process short-circuits on !IsMCP), so the
+	// handler is safe to install even when no MCP routes exist yet.
 	extProcHandler := options.extProcHandler
-	mcpEnabledAtStartup := cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP)
-	if extProcHandler == nil && mcpEnabledAtStartup {
+	if extProcHandler == nil {
 		mcpHandler, handlerErr := mcp.NewUpstreamAuthHandlerFromConfig(ctx, cfg, &srv.outboundGRPCConnection)
 		if handlerErr != nil {
 			return nil, fmt.Errorf("mcp upstream auth handler: %w", handlerErr)
@@ -254,11 +254,6 @@ func NewServer(
 		extProcHandler = mcpHandler
 		srv.mcpExtProcHandler = mcpHandler
 	}
-	log.Ctx(ctx).Info().
-		Bool("mcp_runtime_flag_enabled", mcpEnabledAtStartup).
-		Bool("handler_provided_via_option", options.extProcHandler != nil).
-		Bool("handler_present", extProcHandler != nil).
-		Msg("controlplane: configuring MCP ext_proc handler")
 	srv.extProcServer = extproc.NewServer(extProcHandler, options.extProcCallback)
 	srv.extProcServer.Register(srv.GRPCServer)
 
@@ -478,20 +473,6 @@ func (srv *Server) update(ctx context.Context, cfg *config.Config) error {
 	ctx, span := srv.tracer.Start(ctx, "controlplane.Server.update")
 	defer span.End()
 
-	prevCfg := srv.currentConfig.Load()
-	prevMCPEnabled := false
-	if prevCfg != nil {
-		prevMCPEnabled = prevCfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP)
-	}
-	newMCPEnabled := cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP)
-	if prevCfg != nil && prevMCPEnabled != newMCPEnabled {
-		log.Ctx(ctx).Info().
-			Bool("previous_mcp_runtime_flag_enabled", prevMCPEnabled).
-			Bool("mcp_runtime_flag_enabled", newMCPEnabled).
-			Bool("ext_proc_handler_present", srv.mcpExtProcHandler != nil).
-			Msg("controlplane: MCP runtime flag changed")
-	}
-
 	if err := srv.updateRouter(ctx, cfg); err != nil {
 		return err
 	}
@@ -499,24 +480,9 @@ func (srv *Server) update(ctx context.Context, cfg *config.Config) error {
 	srv.currentConfig.Store(cfg)
 	srv.debug.Update(cfg)
 
-	// HasHandler() (not mcpExtProcHandler) so a WithExtProcHandler test override
-	// isn't clobbered here.
-	if newMCPEnabled && srv.extProcServer != nil && !srv.extProcServer.HasHandler() {
-		mcpHandler, err := mcp.NewUpstreamAuthHandlerFromConfig(ctx, cfg, &srv.outboundGRPCConnection)
-		if err != nil {
-			log.Ctx(ctx).Error().Err(err).
-				Msg("controlplane: failed to install MCP ext_proc handler after runtime enable")
-		} else {
-			srv.mcpExtProcHandler = mcpHandler
-			srv.extProcServer.SetHandler(mcpHandler)
-			log.Ctx(ctx).Info().
-				Msg("controlplane: installed MCP ext_proc handler after runtime flag enable")
-		}
-	}
-
-	// Refresh the MCP ext_proc host index before propagating xDS so that
-	// newly-delivered MCP routes are discoverable by the time Envoy starts
-	// routing to them.
+	// Refresh MCP host index before xDS push so newly-delivered MCP routes
+	// are resolvable by the time Envoy begins routing to them. nil when a
+	// test injects its own handler via WithExtProcHandler.
 	if srv.mcpExtProcHandler != nil {
 		srv.mcpExtProcHandler.OnConfigChange(cfg)
 	}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -129,6 +129,7 @@ type Server struct {
 	reproxy       *reproxy.Handler
 
 	extProcHandlerPresent bool
+	mcpExtProcHandler     *mcp.UpstreamAuthHandler
 
 	httpRouter      atomic.Pointer[mux.Router]
 	authenticateSvc Service
@@ -246,11 +247,12 @@ func NewServer(
 	extProcHandler := options.extProcHandler
 	mcpEnabledAtStartup := cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP)
 	if extProcHandler == nil && cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
-		var handlerErr error
-		extProcHandler, handlerErr = mcp.NewUpstreamAuthHandlerFromConfig(ctx, cfg, &srv.outboundGRPCConnection)
+		mcpHandler, handlerErr := mcp.NewUpstreamAuthHandlerFromConfig(ctx, cfg, &srv.outboundGRPCConnection)
 		if handlerErr != nil {
 			return nil, fmt.Errorf("mcp upstream auth handler: %w", handlerErr)
 		}
+		extProcHandler = mcpHandler
+		srv.mcpExtProcHandler = mcpHandler
 	}
 	srv.extProcHandlerPresent = extProcHandler != nil
 	log.Ctx(ctx).Info().
@@ -504,6 +506,13 @@ func (srv *Server) update(ctx context.Context, cfg *config.Config) error {
 	srv.reproxy.Update(ctx, cfg)
 	srv.currentConfig.Store(cfg)
 	srv.debug.Update(cfg)
+
+	// Refresh the MCP ext_proc host index before propagating xDS so that
+	// newly-delivered MCP routes are discoverable by the time Envoy starts
+	// routing to them.
+	if srv.mcpExtProcHandler != nil {
+		srv.mcpExtProcHandler.OnConfigChange(ctx, cfg)
+	}
 
 	res, err := srv.buildDiscoveryResources(ctx)
 	if err != nil {

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -242,11 +242,8 @@ func NewServer(
 	grpc_health_v1.RegisterHealthServer(srv.GRPCServer, pom_grpc.NewHealthCheckServer())
 	healthpb.RegisterHealthNotifierServer(srv.GRPCServer, srv)
 
-	// Register ext_proc server for MCP response interception.
-	// The ext_proc server is always registered so that a handler can be installed
-	// later via SetHandler if RuntimeFlagMCP is enabled after startup (e.g. when
-	// Pomerium Zero delivers the flag via databroker config sync). If MCP is
-	// already enabled here, construct the handler eagerly.
+	// Register ext_proc unconditionally so a handler can be installed later if
+	// RuntimeFlagMCP arrives after startup (Pomerium Zero config-sync path).
 	extProcHandler := options.extProcHandler
 	mcpEnabledAtStartup := cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP)
 	if extProcHandler == nil && mcpEnabledAtStartup {
@@ -502,12 +499,8 @@ func (srv *Server) update(ctx context.Context, cfg *config.Config) error {
 	srv.currentConfig.Store(cfg)
 	srv.debug.Update(cfg)
 
-	// If MCP just became enabled and the ext_proc server has no handler yet,
-	// build one now and install it into the already-registered ext_proc server.
-	// This covers the Pomerium Zero flow where the flag arrives via databroker
-	// config sync after NewServer has already returned. Guard on HasHandler()
-	// rather than mcpExtProcHandler so we don't clobber a handler installed
-	// explicitly via WithExtProcHandler (used in tests).
+	// HasHandler() (not mcpExtProcHandler) so a WithExtProcHandler test override
+	// isn't clobbered here.
 	if newMCPEnabled && srv.extProcServer != nil && !srv.extProcServer.HasHandler() {
 		mcpHandler, err := mcp.NewUpstreamAuthHandlerFromConfig(ctx, cfg, &srv.outboundGRPCConnection)
 		if err != nil {

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -128,7 +128,6 @@ type Server struct {
 	metricsMgr    *config.MetricsManager
 	reproxy       *reproxy.Handler
 
-	extProcServer     *extproc.Server
 	mcpExtProcHandler *mcp.UpstreamAuthHandler
 
 	httpRouter      atomic.Pointer[mux.Router]
@@ -254,8 +253,7 @@ func NewServer(
 		extProcHandler = mcpHandler
 		srv.mcpExtProcHandler = mcpHandler
 	}
-	srv.extProcServer = extproc.NewServer(extProcHandler, options.extProcCallback)
-	srv.extProcServer.Register(srv.GRPCServer)
+	extproc.NewServer(extProcHandler, options.extProcCallback).Register(srv.GRPCServer)
 
 	// setup HTTP
 	srv.HTTPListener, err = reuseport.Listen("tcp4", net.JoinHostPort("127.0.0.1", cfg.HTTPPort))

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -128,6 +128,8 @@ type Server struct {
 	metricsMgr    *config.MetricsManager
 	reproxy       *reproxy.Handler
 
+	extProcHandlerPresent bool
+
 	httpRouter      atomic.Pointer[mux.Router]
 	authenticateSvc Service
 	proxySvc        Service
@@ -242,6 +244,7 @@ func NewServer(
 	// Register ext_proc server for MCP response interception.
 	// If MCP is enabled and no explicit handler was provided, create one automatically.
 	extProcHandler := options.extProcHandler
+	mcpEnabledAtStartup := cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP)
 	if extProcHandler == nil && cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
 		var handlerErr error
 		extProcHandler, handlerErr = mcp.NewUpstreamAuthHandlerFromConfig(ctx, cfg, &srv.outboundGRPCConnection)
@@ -249,6 +252,12 @@ func NewServer(
 			return nil, fmt.Errorf("mcp upstream auth handler: %w", handlerErr)
 		}
 	}
+	srv.extProcHandlerPresent = extProcHandler != nil
+	log.Ctx(ctx).Info().
+		Bool("mcp_runtime_flag_enabled", mcpEnabledAtStartup).
+		Bool("handler_provided_via_option", options.extProcHandler != nil).
+		Bool("handler_present", srv.extProcHandlerPresent).
+		Msg("controlplane: configuring MCP ext_proc handler")
 	extProcServer := extproc.NewServer(extProcHandler, options.extProcCallback)
 	extProcServer.Register(srv.GRPCServer)
 
@@ -467,6 +476,27 @@ func (srv *Server) GetChannelZClient() (grpc_channelz_v1.ChannelzClient, error) 
 func (srv *Server) update(ctx context.Context, cfg *config.Config) error {
 	ctx, span := srv.tracer.Start(ctx, "controlplane.Server.update")
 	defer span.End()
+
+	prevCfg := srv.currentConfig.Load()
+	prevMCPEnabled := false
+	if prevCfg != nil {
+		prevMCPEnabled = prevCfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP)
+	}
+	newMCPEnabled := cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP)
+	if prevCfg != nil && prevMCPEnabled != newMCPEnabled {
+		log.Ctx(ctx).Info().
+			Bool("previous_mcp_runtime_flag_enabled", prevMCPEnabled).
+			Bool("mcp_runtime_flag_enabled", newMCPEnabled).
+			Bool("ext_proc_handler_present", srv.extProcHandlerPresent).
+			Msg("controlplane: MCP runtime flag changed")
+		if !prevMCPEnabled && newMCPEnabled && !srv.extProcHandlerPresent {
+			log.Ctx(ctx).Warn().
+				Bool("previous_mcp_runtime_flag_enabled", prevMCPEnabled).
+				Bool("mcp_runtime_flag_enabled", newMCPEnabled).
+				Bool("ext_proc_handler_present", srv.extProcHandlerPresent).
+				Msg("controlplane: MCP enabled after ext_proc initialization; handler remains nil until restart")
+		}
+	}
 
 	if err := srv.updateRouter(ctx, cfg); err != nil {
 		return err

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -128,8 +128,8 @@ type Server struct {
 	metricsMgr    *config.MetricsManager
 	reproxy       *reproxy.Handler
 
-	extProcHandlerPresent bool
-	mcpExtProcHandler     *mcp.UpstreamAuthHandler
+	extProcServer     *extproc.Server
+	mcpExtProcHandler *mcp.UpstreamAuthHandler
 
 	httpRouter      atomic.Pointer[mux.Router]
 	authenticateSvc Service
@@ -243,10 +243,13 @@ func NewServer(
 	healthpb.RegisterHealthNotifierServer(srv.GRPCServer, srv)
 
 	// Register ext_proc server for MCP response interception.
-	// If MCP is enabled and no explicit handler was provided, create one automatically.
+	// The ext_proc server is always registered so that a handler can be installed
+	// later via SetHandler if RuntimeFlagMCP is enabled after startup (e.g. when
+	// Pomerium Zero delivers the flag via databroker config sync). If MCP is
+	// already enabled here, construct the handler eagerly.
 	extProcHandler := options.extProcHandler
 	mcpEnabledAtStartup := cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP)
-	if extProcHandler == nil && cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
+	if extProcHandler == nil && mcpEnabledAtStartup {
 		mcpHandler, handlerErr := mcp.NewUpstreamAuthHandlerFromConfig(ctx, cfg, &srv.outboundGRPCConnection)
 		if handlerErr != nil {
 			return nil, fmt.Errorf("mcp upstream auth handler: %w", handlerErr)
@@ -254,14 +257,13 @@ func NewServer(
 		extProcHandler = mcpHandler
 		srv.mcpExtProcHandler = mcpHandler
 	}
-	srv.extProcHandlerPresent = extProcHandler != nil
 	log.Ctx(ctx).Info().
 		Bool("mcp_runtime_flag_enabled", mcpEnabledAtStartup).
 		Bool("handler_provided_via_option", options.extProcHandler != nil).
-		Bool("handler_present", srv.extProcHandlerPresent).
+		Bool("handler_present", extProcHandler != nil).
 		Msg("controlplane: configuring MCP ext_proc handler")
-	extProcServer := extproc.NewServer(extProcHandler, options.extProcCallback)
-	extProcServer.Register(srv.GRPCServer)
+	srv.extProcServer = extproc.NewServer(extProcHandler, options.extProcCallback)
+	srv.extProcServer.Register(srv.GRPCServer)
 
 	// setup HTTP
 	srv.HTTPListener, err = reuseport.Listen("tcp4", net.JoinHostPort("127.0.0.1", cfg.HTTPPort))
@@ -489,15 +491,8 @@ func (srv *Server) update(ctx context.Context, cfg *config.Config) error {
 		log.Ctx(ctx).Info().
 			Bool("previous_mcp_runtime_flag_enabled", prevMCPEnabled).
 			Bool("mcp_runtime_flag_enabled", newMCPEnabled).
-			Bool("ext_proc_handler_present", srv.extProcHandlerPresent).
+			Bool("ext_proc_handler_present", srv.mcpExtProcHandler != nil).
 			Msg("controlplane: MCP runtime flag changed")
-		if !prevMCPEnabled && newMCPEnabled && !srv.extProcHandlerPresent {
-			log.Ctx(ctx).Warn().
-				Bool("previous_mcp_runtime_flag_enabled", prevMCPEnabled).
-				Bool("mcp_runtime_flag_enabled", newMCPEnabled).
-				Bool("ext_proc_handler_present", srv.extProcHandlerPresent).
-				Msg("controlplane: MCP enabled after ext_proc initialization; handler remains nil until restart")
-		}
 	}
 
 	if err := srv.updateRouter(ctx, cfg); err != nil {
@@ -507,11 +502,30 @@ func (srv *Server) update(ctx context.Context, cfg *config.Config) error {
 	srv.currentConfig.Store(cfg)
 	srv.debug.Update(cfg)
 
+	// If MCP just became enabled and the ext_proc server has no handler yet,
+	// build one now and install it into the already-registered ext_proc server.
+	// This covers the Pomerium Zero flow where the flag arrives via databroker
+	// config sync after NewServer has already returned. Guard on HasHandler()
+	// rather than mcpExtProcHandler so we don't clobber a handler installed
+	// explicitly via WithExtProcHandler (used in tests).
+	if newMCPEnabled && srv.extProcServer != nil && !srv.extProcServer.HasHandler() {
+		mcpHandler, err := mcp.NewUpstreamAuthHandlerFromConfig(ctx, cfg, &srv.outboundGRPCConnection)
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).
+				Msg("controlplane: failed to install MCP ext_proc handler after runtime enable")
+		} else {
+			srv.mcpExtProcHandler = mcpHandler
+			srv.extProcServer.SetHandler(mcpHandler)
+			log.Ctx(ctx).Info().
+				Msg("controlplane: installed MCP ext_proc handler after runtime flag enable")
+		}
+	}
+
 	// Refresh the MCP ext_proc host index before propagating xDS so that
 	// newly-delivered MCP routes are discoverable by the time Envoy starts
 	// routing to them.
 	if srv.mcpExtProcHandler != nil {
-		srv.mcpExtProcHandler.OnConfigChange(ctx, cfg)
+		srv.mcpExtProcHandler.OnConfigChange(cfg)
 	}
 
 	res, err := srv.buildDiscoveryResources(ctx)

--- a/internal/controlplane/server_mcp_late_enable_test.go
+++ b/internal/controlplane/server_mcp_late_enable_test.go
@@ -1,0 +1,79 @@
+package controlplane
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
+	"github.com/pomerium/pomerium/internal/events"
+	"github.com/pomerium/pomerium/pkg/netutil"
+)
+
+// TestServer_MCPEnabledAfterStartup_InstallsExtProcHandler is the RED test for
+// review finding C1.
+//
+// Before C1, if RuntimeFlagMCP was off at NewServer time, srv.mcpExtProcHandler
+// stayed nil forever: the ext_proc server was registered with a nil handler
+// and update() only emitted a "handler remains nil until restart" warning when
+// the flag later flipped on. In the Pomerium Zero flow — where the flag can
+// arrive via databroker-delivered config — this meant MCP routes silently
+// lost upstream token injection.
+//
+// The fix: register the ext_proc server unconditionally with an atomic.Pointer
+// handler slot, and install the handler on the fly inside update() when the
+// flag flips on.
+func TestServer_MCPEnabledAfterStartup_InstallsExtProcHandler(t *testing.T) {
+	t.Parallel()
+
+	ports, err := netutil.AllocatePorts(5)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	startup := newTestConfig(t, ports)
+	// Startup with MCP flag OFF (simulates a Zero-managed deployment where
+	// the flag + MCP routes arrive later via config sync).
+	startup.Options.RuntimeFlags = config.RuntimeFlags{config.RuntimeFlagMCP: false}
+
+	src := config.NewStaticSource(startup)
+	srv, err := NewServer(ctx, startup, config.NewMetricsManager(ctx, src), events.New(),
+		filemgr.NewManager(filemgr.WithCacheDir(t.TempDir())))
+	require.NoError(t, err)
+
+	require.NotNil(t, srv.extProcServer,
+		"ext_proc server must be registered even when MCP is disabled at startup")
+	assert.Nil(t, srv.mcpExtProcHandler,
+		"no handler should exist yet — MCP is off")
+
+	// Deliver a config with MCP enabled (as Zero would via databroker config sync).
+	enabled := startup.Clone()
+	enabled.Options.RuntimeFlags = config.RuntimeFlags{config.RuntimeFlagMCP: true}
+	require.NoError(t, srv.update(ctx, enabled))
+
+	require.NotNil(t, srv.mcpExtProcHandler,
+		"ext_proc MCP handler must be installed after enabling MCP at runtime; "+
+			"pre-fix behavior left this nil and only logged a warning")
+	// Separately, extproc_test.go:TestNewServer asserts that SetHandler
+	// exposes the handler to incoming Process() calls via currentHandler().
+}
+
+func newTestConfig(_ *testing.T, ports []string) *config.Config {
+	cfg := &config.Config{
+		GRPCPort:     ports[0],
+		HTTPPort:     ports[1],
+		OutboundPort: ports[2],
+		MetricsPort:  ports[3],
+		DebugPort:    ports[4],
+
+		Options: config.NewDefaultOptions(),
+	}
+	cfg.Options.AuthenticateURLString = "https://authenticate.localhost.pomerium.io"
+	cfg.Options.SigningKey = "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUpCMFZkbko1VjEvbVlpYUlIWHhnd2Q0Yzd5YWRTeXMxb3Y0bzA1b0F3ekdvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFVUc1eENQMEpUVDFINklvbDhqS3VUSVBWTE0wNENnVzlQbEV5cE5SbVdsb29LRVhSOUhUMwpPYnp6aktZaWN6YjArMUt3VjJmTVRFMTh1dy82MXJVQ0JBPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
+	cfg.Options.SharedKey = "JDNjY2ITDlARvNaQXjc2Djk+GA6xeCy4KiozmZfdbTs="
+	return cfg
+}

--- a/internal/controlplane/server_mcp_late_enable_test.go
+++ b/internal/controlplane/server_mcp_late_enable_test.go
@@ -13,19 +13,9 @@ import (
 	"github.com/pomerium/pomerium/pkg/netutil"
 )
 
-// TestServer_MCPEnabledAfterStartup_InstallsExtProcHandler is the RED test for
-// review finding C1.
-//
-// Before C1, if RuntimeFlagMCP was off at NewServer time, srv.mcpExtProcHandler
-// stayed nil forever: the ext_proc server was registered with a nil handler
-// and update() only emitted a "handler remains nil until restart" warning when
-// the flag later flipped on. In the Pomerium Zero flow — where the flag can
-// arrive via databroker-delivered config — this meant MCP routes silently
-// lost upstream token injection.
-//
-// The fix: register the ext_proc server unconditionally with an atomic.Pointer
-// handler slot, and install the handler on the fly inside update() when the
-// flag flips on.
+// TestServer_MCPEnabledAfterStartup_InstallsExtProcHandler covers the Zero
+// flow: MCP flag arrives via databroker config sync after the control plane
+// has started. The ext_proc handler must be installed on the fly.
 func TestServer_MCPEnabledAfterStartup_InstallsExtProcHandler(t *testing.T) {
 	t.Parallel()
 
@@ -35,9 +25,7 @@ func TestServer_MCPEnabledAfterStartup_InstallsExtProcHandler(t *testing.T) {
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
-	startup := newTestConfig(t, ports)
-	// Startup with MCP flag OFF (simulates a Zero-managed deployment where
-	// the flag + MCP routes arrive later via config sync).
+	startup := newTestConfig(ports)
 	startup.Options.RuntimeFlags = config.RuntimeFlags{config.RuntimeFlagMCP: false}
 
 	src := config.NewStaticSource(startup)
@@ -47,22 +35,17 @@ func TestServer_MCPEnabledAfterStartup_InstallsExtProcHandler(t *testing.T) {
 
 	require.NotNil(t, srv.extProcServer,
 		"ext_proc server must be registered even when MCP is disabled at startup")
-	assert.Nil(t, srv.mcpExtProcHandler,
-		"no handler should exist yet — MCP is off")
+	assert.Nil(t, srv.mcpExtProcHandler)
 
-	// Deliver a config with MCP enabled (as Zero would via databroker config sync).
 	enabled := startup.Clone()
 	enabled.Options.RuntimeFlags = config.RuntimeFlags{config.RuntimeFlagMCP: true}
 	require.NoError(t, srv.update(ctx, enabled))
 
 	require.NotNil(t, srv.mcpExtProcHandler,
-		"ext_proc MCP handler must be installed after enabling MCP at runtime; "+
-			"pre-fix behavior left this nil and only logged a warning")
-	// Separately, extproc_test.go:TestNewServer asserts that SetHandler
-	// exposes the handler to incoming Process() calls via currentHandler().
+		"ext_proc MCP handler must be installed after enabling MCP at runtime")
 }
 
-func newTestConfig(_ *testing.T, ports []string) *config.Config {
+func newTestConfig(ports []string) *config.Config {
 	cfg := &config.Config{
 		GRPCPort:     ports[0],
 		HTTPPort:     ports[1],

--- a/internal/controlplane/server_mcp_late_enable_test.go
+++ b/internal/controlplane/server_mcp_late_enable_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/config"
@@ -13,10 +12,11 @@ import (
 	"github.com/pomerium/pomerium/pkg/netutil"
 )
 
-// TestServer_MCPEnabledAfterStartup_InstallsExtProcHandler covers the Zero
-// flow: MCP flag arrives via databroker config sync after the control plane
-// has started. The ext_proc handler must be installed on the fly.
-func TestServer_MCPEnabledAfterStartup_InstallsExtProcHandler(t *testing.T) {
+// TestServer_ExtProcHandlerAlwaysInstalled guards the Zero config-sync invariant:
+// the MCP ext_proc handler is installed at controlplane startup regardless of
+// RuntimeFlagMCP. With the handler always present, the unconditional
+// OnConfigChange(cfg) in update() picks up MCP routes that arrive after startup.
+func TestServer_ExtProcHandlerAlwaysInstalled(t *testing.T) {
 	t.Parallel()
 
 	ports, err := netutil.AllocatePorts(5)
@@ -33,16 +33,16 @@ func TestServer_MCPEnabledAfterStartup_InstallsExtProcHandler(t *testing.T) {
 		filemgr.NewManager(filemgr.WithCacheDir(t.TempDir())))
 	require.NoError(t, err)
 
-	require.NotNil(t, srv.extProcServer,
-		"ext_proc server must be registered even when MCP is disabled at startup")
-	assert.Nil(t, srv.mcpExtProcHandler)
+	require.NotNil(t, srv.extProcServer)
+	require.NotNil(t, srv.mcpExtProcHandler,
+		"MCP ext_proc handler must be installed at startup even with MCP off")
 
 	enabled := startup.Clone()
 	enabled.Options.RuntimeFlags = config.RuntimeFlags{config.RuntimeFlagMCP: true}
+	handlerBefore := srv.mcpExtProcHandler
 	require.NoError(t, srv.update(ctx, enabled))
-
-	require.NotNil(t, srv.mcpExtProcHandler,
-		"ext_proc MCP handler must be installed after enabling MCP at runtime")
+	require.Same(t, handlerBefore, srv.mcpExtProcHandler,
+		"handler must not be re-installed when MCP flips on — the at-startup handler is the one")
 }
 
 func newTestConfig(ports []string) *config.Config {

--- a/internal/controlplane/server_mcp_late_enable_test.go
+++ b/internal/controlplane/server_mcp_late_enable_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
 	"github.com/pomerium/pomerium/internal/events"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/netutil"
 )
 
@@ -56,7 +57,6 @@ func newTestConfig(ports []string) *config.Config {
 		Options: config.NewDefaultOptions(),
 	}
 	cfg.Options.AuthenticateURLString = "https://authenticate.localhost.pomerium.io"
-	cfg.Options.SigningKey = "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUpCMFZkbko1VjEvbVlpYUlIWHhnd2Q0Yzd5YWRTeXMxb3Y0bzA1b0F3ekdvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFVUc1eENQMEpUVDFINklvbDhqS3VUSVBWTE0wNENnVzlQbEV5cE5SbVdsb29LRVhSOUhUMwpPYnp6aktZaWN6YjArMUt3VjJmTVRFMTh1dy82MXJVQ0JBPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
-	cfg.Options.SharedKey = "JDNjY2ITDlARvNaQXjc2Djk+GA6xeCy4KiozmZfdbTs="
+	cfg.Options.SharedKey = cryptutil.NewBase64Key()
 	return cfg
 }

--- a/internal/controlplane/server_mcp_late_enable_test.go
+++ b/internal/controlplane/server_mcp_late_enable_test.go
@@ -34,7 +34,6 @@ func TestServer_ExtProcHandlerAlwaysInstalled(t *testing.T) {
 		filemgr.NewManager(filemgr.WithCacheDir(t.TempDir())))
 	require.NoError(t, err)
 
-	require.NotNil(t, srv.extProcServer)
 	require.NotNil(t, srv.mcpExtProcHandler,
 		"MCP ext_proc handler must be installed at startup even with MCP off")
 

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
 	"github.com/pomerium/pomerium/internal/events"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/netutil"
 )
 
@@ -52,6 +53,15 @@ func TestServerHTTP(t *testing.T) {
 		assert.Equal(t, expect, actual)
 	})
 	t.Run("jwks", func(t *testing.T) {
+		signingKey, err := cfg.Options.GetSigningKey()
+		require.NoError(t, err)
+		expectedJWK, err := cryptutil.PublicJWKFromBytes(signingKey)
+		require.NoError(t, err)
+		expectedJWKJSON, err := expectedJWK.MarshalJSON()
+		require.NoError(t, err)
+		var expectedKey map[string]any
+		require.NoError(t, json.Unmarshal(expectedJWKJSON, &expectedKey))
+
 		res, err := http.Get(fmt.Sprintf("http://localhost:%s/.well-known/pomerium/jwks.json", src.GetConfig().HTTPPort))
 		require.NoError(t, err)
 		defer res.Body.Close()
@@ -60,33 +70,19 @@ func TestServerHTTP(t *testing.T) {
 		err = json.NewDecoder(res.Body).Decode(&actual)
 		require.NoError(t, err)
 
-		expect := map[string]any{
-			"keys": []any{
-				map[string]any{
-					"alg": "ES256",
-					"crv": "P-256",
-					"kid": "5b419ade1895fec2d2def6cd33b1b9a018df60db231dc5ecb85cbed6d942813c",
-					"kty": "EC",
-					"use": "sig",
-					"x":   "UG5xCP0JTT1H6Iol8jKuTIPVLM04CgW9PlEypNRmWlo",
-					"y":   "KChF0fR09zm884ymInM29PtSsFdnzExNfLsP-ta1AgQ",
-				},
-			},
-		}
-		assert.Equal(t, expect, actual)
+		assert.Equal(t, map[string]any{"keys": []any{expectedKey}}, actual)
 	})
 	t.Run("hpke-public-key", func(t *testing.T) {
+		hpkePrivateKey, err := cfg.Options.GetHPKEPrivateKey()
+		require.NoError(t, err)
+		expected := hpkePrivateKey.PublicKey().Bytes()
+
 		res, err := http.Get(fmt.Sprintf("http://localhost:%s/.well-known/pomerium/hpke-public-key", src.GetConfig().HTTPPort))
 		require.NoError(t, err)
 		defer res.Body.Close()
 
 		bs, err := io.ReadAll(res.Body)
 		require.NoError(t, err)
-		assert.Equal(t, []byte{
-			0x4f, 0x47, 0x1b, 0x36, 0xb2, 0x5b, 0x3b, 0xd8,
-			0xa7, 0xf8, 0x58, 0x28, 0xc0, 0xa0, 0x0f, 0xf8,
-			0x75, 0xfa, 0x0a, 0x2f, 0x2a, 0xe7, 0x48, 0x28,
-			0xa4, 0xeb, 0x79, 0xda, 0xc7, 0x61, 0x78, 0x78,
-		}, bs)
+		assert.Equal(t, expected, bs)
 	})
 }

--- a/internal/controlplane/server_test.go
+++ b/internal/controlplane/server_test.go
@@ -27,18 +27,7 @@ func TestServerHTTP(t *testing.T) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	cfg := &config.Config{
-		GRPCPort:     ports[0],
-		HTTPPort:     ports[1],
-		OutboundPort: ports[2],
-		MetricsPort:  ports[3],
-		DebugPort:    ports[4],
-
-		Options: config.NewDefaultOptions(),
-	}
-	cfg.Options.AuthenticateURLString = "https://authenticate.localhost.pomerium.io"
-	cfg.Options.SigningKey = "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUpCMFZkbko1VjEvbVlpYUlIWHhnd2Q0Yzd5YWRTeXMxb3Y0bzA1b0F3ekdvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFVUc1eENQMEpUVDFINklvbDhqS3VUSVBWTE0wNENnVzlQbEV5cE5SbVdsb29LRVhSOUhUMwpPYnp6aktZaWN6YjArMUt3VjJmTVRFMTh1dy82MXJVQ0JBPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo="
-	cfg.Options.SharedKey = "JDNjY2ITDlARvNaQXjc2Djk+GA6xeCy4KiozmZfdbTs="
+	cfg := newTestConfig(ports)
 
 	src := config.NewStaticSource(cfg)
 	srv, err := NewServer(ctx, cfg, config.NewMetricsManager(ctx, src), events.New(), filemgr.NewManager(filemgr.WithCacheDir(t.TempDir())))

--- a/internal/mcp/DESIGN.md
+++ b/internal/mcp/DESIGN.md
@@ -725,11 +725,19 @@ When enabled:
 ### Controlplane Wiring
 
 At startup (`controlplane.NewServer()`):
-1. If `RuntimeFlagMCP` is set, create an `UpstreamRequestHandler` (with
-   databroker storage, HostInfo from config, and an HTTP client). If handler
-   creation fails, log a warning and continue with `handler = nil`.
-2. Create the ext_proc gRPC server (with the handler, which may be nil).
-3. Register ext_proc on the gRPC server.
+1. The ext_proc gRPC server is **always** registered, regardless of
+   `RuntimeFlagMCP`, so that a handler can be installed later without a
+   restart.
+2. If `RuntimeFlagMCP` is set at startup, create an `UpstreamRequestHandler`
+   (with databroker storage, HostInfo from config, and an HTTP client) and
+   hand it to the ext_proc server via `NewServer`.
+
+In `controlplane.Server.update()` (called on every config change, including
+databroker-delivered updates used by Pomerium Zero):
+1. If `RuntimeFlagMCP` just flipped on and no handler exists yet, build one
+   and call `extProcServer.SetHandler(...)` to install it atomically.
+2. Call `mcpExtProcHandler.OnConfigChange(cfg)` to refresh the handler's
+   HostInfo and AS-metadata domain allowlist before xDS is pushed to Envoy.
 
 During Envoy config generation:
 1. The ext_proc filter is added globally but **disabled by default**.
@@ -740,9 +748,10 @@ During Envoy config generation:
 
 `HostInfo` indexes all MCP policies by downstream hostname. The index is
 built eagerly in `NewHostInfo` and refreshed atomically by `OnConfigChange`
-whenever a new configuration arrives (e.g. via the databroker config syncer
-used by Pomerium Zero to deliver routes after startup). It provides the
-dispatch mechanism for token lookup.
+whenever a new configuration arrives (see `controlplane/server.go:update()`
+for the caller that keeps it fresh — the databroker config syncer used by
+Pomerium Zero delivers routes through that path after startup). It provides
+the dispatch mechanism for token lookup.
 
 Each policy produces a `ServerHostInfo` keyed by the downstream hostname
 (from `policy.GetFrom()`), containing the upstream URL, an optional AS

--- a/internal/mcp/DESIGN.md
+++ b/internal/mcp/DESIGN.md
@@ -738,8 +738,11 @@ During Envoy config generation:
 
 ### HostInfo Resolution
 
-`HostInfo` indexes all MCP policies by downstream hostname at startup (lazy,
-via `sync.Once`). It provides the dispatch mechanism for token lookup.
+`HostInfo` indexes all MCP policies by downstream hostname. The index is
+built eagerly in `NewHostInfo` and refreshed atomically by `OnConfigChange`
+whenever a new configuration arrives (e.g. via the databroker config syncer
+used by Pomerium Zero to deliver routes after startup). It provides the
+dispatch mechanism for token lookup.
 
 Each policy produces a `ServerHostInfo` keyed by the downstream hostname
 (from `policy.GetFrom()`), containing the upstream URL, an optional AS

--- a/internal/mcp/DESIGN.md
+++ b/internal/mcp/DESIGN.md
@@ -717,27 +717,26 @@ erDiagram
 
 ### Runtime Flag
 
-The `RuntimeFlagMCP` (`config/runtime_flags.go`) gates MCP functionality.
-When enabled:
-1. The controlplane auto-creates an `UpstreamRequestHandler`
-2. MCP well-known routes are added to virtual hosts
+The `RuntimeFlagMCP` (`config/runtime_flags.go`) gates the user-visible MCP
+surface (well-known routes, per-route ext_proc activation). The ext_proc
+handler itself is always installed; it no-ops for non-MCP requests via the
+per-route gate and an `IsMCP` metadata check in `extproc.Server.Process`.
 
 ### Controlplane Wiring
 
 At startup (`controlplane.NewServer()`):
-1. The ext_proc gRPC server is **always** registered, regardless of
-   `RuntimeFlagMCP`, so that a handler can be installed later without a
-   restart.
-2. If `RuntimeFlagMCP` is set at startup, create an `UpstreamRequestHandler`
-   (with databroker storage, HostInfo from config, and an HTTP client) and
-   hand it to the ext_proc server via `NewServer`.
+1. The ext_proc gRPC server is registered unconditionally.
+2. The `UpstreamRequestHandler` is always constructed (unless a test injects
+   one via `WithExtProcHandler`). It carries databroker storage, a `HostInfo`
+   built from the current config, and an HTTP client. Construction does not
+   depend on `RuntimeFlagMCP` or on any MCP policies existing — `BuildHostInfo`
+   returns empty maps for configs with no MCP policies.
 
 In `controlplane.Server.update()` (called on every config change, including
 databroker-delivered updates used by Pomerium Zero):
-1. If `RuntimeFlagMCP` just flipped on and no handler exists yet, build one
-   and call `extProcServer.SetHandler(...)` to install it atomically.
-2. Call `mcpExtProcHandler.OnConfigChange(cfg)` to refresh the handler's
-   HostInfo and AS-metadata domain allowlist before xDS is pushed to Envoy.
+1. `mcpExtProcHandler.OnConfigChange(cfg)` refreshes the handler's `HostInfo`
+   and AS-metadata domain allowlist before xDS is pushed to Envoy. No
+   flag-gated install path — the handler is already there.
 
 During Envoy config generation:
 1. The ext_proc filter is added globally but **disabled by default**.

--- a/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
+++ b/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -28,47 +27,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
-// TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute documents a bug where
-// the MCP ext_proc UpstreamAuthHandler does not pick up an MCP server route
-// added after startup via the databroker config sync path that Pomerium Zero
-// uses to deliver configuration.
-//
-// The handler wraps a *mcp.HostInfo whose map of hostname -> ServerHostInfo is
-// materialized once behind a sync.Once the first time it is queried, and never
-// rebuilt. When a new route arrives via the databroker config syncer:
-//
-//   - xDS updates, so Envoy routes the new virtual host and ext_authz /
-//     ext_proc filters run on the request.
-//   - The ext_authz headers evaluator still strips the Authorization header for
-//     MCP server routes (the policy carries MCP.Server).
-//   - ext_proc then calls UpstreamAuthHandler.GetUpstreamToken, which calls
-//     HostInfo.GetServerHostInfo(hostname). Because the host map was frozen at
-//     startup, this lookup returns (_, false), GetUpstreamToken returns empty,
-//     no Authorization header is injected, and the upstream sees no credentials.
-//
-// The control subtest configures the same MCP route at startup and proves the
-// service-account auth + seeded UpstreamMCPToken + ext_proc path all work end
-// to end. The primary subtest performs the identical seeding but pushes the
-// route in via databroker after startup; on current main it fails because the
-// upstream never receives the seeded Bearer token.
-func TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute(t *testing.T) {
-	// Subtest names are kept short on purpose: envoy's admin Unix socket path
-	// must fit in 108 bytes and this top-level test name already consumes 55.
-	t.Run("start", func(t *testing.T) {
-		runSeededSAMCPRoute(t, routeDeliveryStartup)
-	})
-	t.Run("late", func(t *testing.T) {
-		runSeededSAMCPRoute(t, routeDeliveryLateDatabroker)
-	})
-}
-
-type routeDelivery int
-
-const (
-	routeDeliveryStartup routeDelivery = iota
-	routeDeliveryLateDatabroker
-)
-
 const (
 	seededUpstreamToken = "seeded-upstream-access-token"
 	seededRouteID       = "late-mcp-route"
@@ -76,14 +34,30 @@ const (
 	seededSAUserID      = "late-route-user@example.com"
 )
 
-// runSeededSAMCPRoute exercises the full ext_proc + service-account + seeded
-// UpstreamMCPToken path for a single MCP server route. The route is either
-// configured at startup or pushed through the databroker config syncer after
-// startup, depending on `delivery`. In both cases the test asserts that the
-// upstream receives exactly "Bearer <seededUpstreamToken>".
-func runSeededSAMCPRoute(t *testing.T, delivery routeDelivery) {
-	t.Helper()
-
+// TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute documents a bug where
+// the MCP ext_proc UpstreamAuthHandler does not pick up an MCP server route
+// added after startup via the databroker config sync path that Pomerium Zero
+// uses to deliver configuration.
+//
+// The handler wraps a *mcp.HostInfo whose map of hostname -> ServerHostInfo is
+// materialized once behind a sync.Once the first time it is queried and never
+// rebuilt. When a new route arrives via the databroker config syncer:
+//
+//   - xDS updates, so Envoy routes the new virtual host and ext_authz /
+//     ext_proc filters run on the request.
+//   - The ext_authz headers evaluator strips the Authorization header for
+//     MCP server routes (the policy carries MCP.Server).
+//   - ext_proc then calls UpstreamAuthHandler.GetUpstreamToken, which calls
+//     HostInfo.GetServerHostInfo(hostname). Because the host map was frozen at
+//     startup, this lookup returns (_, false), GetUpstreamToken returns empty,
+//     no Authorization header is injected, and the upstream sees no credentials.
+//
+// Eventually is used only to wait for xDS to propagate the late-delivered
+// route far enough that a request actually reaches the upstream. The RED
+// assertion about token injection is a direct equality check — when the bug
+// is fixed the test passes; on current main the upstream-side Authorization
+// assertion fails cleanly, rather than the whole test timing out.
+func TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute(t *testing.T) {
 	env := testenv.New(t)
 
 	env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
@@ -94,102 +68,105 @@ func runSeededSAMCPRoute(t *testing.T, delivery routeDelivery) {
 		cfg.Options.MCPAllowedClientIDDomains = []string{"*.localhost.pomerium.io"}
 	}))
 
-	idp := scenarios.NewIDP([]*scenarios.User{
-		{Email: seededSAUserID},
-	})
-	env.Add(idp)
+	env.Add(scenarios.NewIDP([]*scenarios.User{{Email: seededSAUserID}}))
 
 	// Record the Authorization header the upstream actually receives. The
-	// upstream returns 200 only when it sees the seeded Bearer token, so an
-	// HTTP 401 reliably indicates token injection did not happen.
-	var (
-		receivedAuth atomic.Pointer[string]
-		upstreamURL  string
+	// upstream returns 200 only when it sees the seeded Bearer token.
+	var receivedAuth atomic.Pointer[string]
+	listener := startBareUpstream(t, env.Host(), &receivedAuth)
+	upstreamURL := "http://" + listener.Addr().String()
+
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	fromURL := env.SubdomainURL("mcp-late-route-test").Value()
+
+	// Push the MCP route through the same databroker config delivery path
+	// Pomerium Zero uses. env.NewDataBrokerServiceClient() keeps the transport
+	// identical to Zero's outbound gRPC connection (shared JWT auth against
+	// the outbound port).
+	pushMCPRouteViaDatabroker(t, env, seededRouteID, fromURL, upstreamURL)
+
+	ctx := env.Context()
+	dbClient := env.NewDataBrokerServiceClient()
+
+	sa := &user.ServiceAccount{Id: seededSAID, UserId: seededSAUserID}
+	_, err := user.PutServiceAccount(ctx, dbClient, sa)
+	require.NoError(t, err)
+
+	saJWT, err := cryptutil.SignServiceAccount(
+		env.SharedSecret(), sa.Id, sa.UserId, time.Now(), null.Time{},
 	)
+	require.NoError(t, err)
 
-	switch delivery {
-	case routeDeliveryStartup:
-		serverUpstream := upstreams.HTTP(nil, upstreams.WithDisplayName("Startup MCP Server"))
-		serverUpstream.Handle("/", func(w http.ResponseWriter, r *http.Request) {
-			auth := r.Header.Get("Authorization")
-			receivedAuth.Store(&auth)
-			if auth != "Bearer "+seededUpstreamToken {
-				w.WriteHeader(http.StatusUnauthorized)
-				return
-			}
-			w.WriteHeader(http.StatusOK)
-		})
-		serverRoute := serverUpstream.Route().
-			From(env.SubdomainURL("mcp-late-route-test")).
-			Policy(func(p *config.Policy) {
-				// Fixed ID so we can seed the UpstreamMCPToken by the same key
-				// the handler derives via Policy.RouteID().
-				p.ID = seededRouteID
-				p.AllowAnyAuthenticatedUser = true
-				p.MCP = &config.MCP{
-					Server: &config.MCPServer{},
-				}
-			})
-		env.AddUpstream(serverUpstream)
+	// Seed the upstream MCP token under the same composite key ext_proc will
+	// derive from (user_id, route_id, upstream_server).
+	storage := mcp.NewStorage(dbClient)
+	require.NoError(t, storage.PutUpstreamMCPToken(ctx, &oauth21proto.UpstreamMCPToken{
+		UserId:         sa.UserId,
+		RouteId:        seededRouteID,
+		UpstreamServer: upstreamURL,
+		AccessToken:    seededUpstreamToken,
+		TokenType:      "Bearer",
+	}))
 
-		env.Start()
-		snippets.WaitStartupComplete(env)
+	httpClient := upstreams.NewHTTPClient(env.ServerCAs(), &upstreams.RequestOptions{})
 
-		// Resolve the concrete upstream URL only after startup, once testenv
-		// has allocated the upstream's listening port. upstreams.HTTP.Route()
-		// sets To = "http://<env.Host()>:<serverPort>", matching the format
-		// that NewServerHostInfoFromPolicy uses to derive UpstreamURL.
-		upstreamURL = "http://" + serverUpstream.Addr().Value()
-
-		seedSATokenAndRun(t, env, seededRouteID, upstreamURL, serverRoute.URL().Value(), &receivedAuth)
-
-	case routeDeliveryLateDatabroker:
-		// Stand up an unmanaged HTTP listener for the late-delivered route.
-		// We deliberately bypass testenv's upstream/modifier path so the
-		// route only exists once we push it through the databroker.
-		listener, handlerReady := startBareUpstream(t, env.Host(), &receivedAuth)
-		upstreamURL = "http://" + listener.Addr().String()
-
-		env.Start()
-		snippets.WaitStartupComplete(env)
-
-		// Wait until the bare upstream is actually accepting connections so
-		// later polling isn't racing server startup.
-		<-handlerReady
-
-		fromURL := env.SubdomainURL("mcp-late-route-test").Value()
-
-		// Push the MCP route through the same databroker config delivery path
-		// Pomerium Zero uses. Using env.NewDataBrokerServiceClient() keeps the
-		// transport identical to Zero's outbound gRPC connection (shared JWT
-		// auth against the outbound port).
-		pushMCPRouteViaDatabroker(t, env, seededRouteID, fromURL, upstreamURL)
-
-		seedSATokenAndRun(t, env, seededRouteID, upstreamURL, fromURL, &receivedAuth)
-
-	default:
-		t.Fatalf("unknown delivery mode %v", delivery)
+	makeRequest := func() int {
+		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, fromURL, nil)
+		if err != nil {
+			return 0
+		}
+		req.Header.Set("Authorization", "Bearer Pomerium-"+saJWT)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return 0
+		}
+		defer resp.Body.Close()
+		return resp.StatusCode
 	}
+
+	// Wait for xDS to catch up: keep retrying until a request actually lands
+	// on the upstream. Once the upstream has been hit at least once, the
+	// behavioral assertions below are definitive.
+	var lastStatus int
+	require.Eventually(t, func() bool {
+		lastStatus = makeRequest()
+		return receivedAuth.Load() != nil
+	}, 30*time.Second, 250*time.Millisecond,
+		"late-delivered MCP route never became reachable via Envoy (last status=%d)", lastStatus)
+
+	// RED assertion: on current main the upstream sees an empty Authorization
+	// header because ext_proc's HostInfo map was frozen at startup and never
+	// picked up the late-delivered route. When the fix lands, ext_proc
+	// injects the seeded Bearer token and the upstream returns 200.
+	gotAuth := ""
+	if p := receivedAuth.Load(); p != nil {
+		gotAuth = *p
+	}
+	assert.Equal(t, "Bearer "+seededUpstreamToken, gotAuth,
+		"upstream should receive the seeded Authorization header injected by ext_proc")
+	assert.Equal(t, http.StatusOK, lastStatus,
+		"request through Pomerium should succeed when upstream token is injected")
 }
 
 // startBareUpstream starts a minimal HTTP server on host:0 that writes the
-// observed Authorization header through receivedAuth. It returns the listener
-// and a channel that closes as soon as the server is serving, so callers can
-// wait on startup deterministically.
-func startBareUpstream(t *testing.T, host string, receivedAuth *atomic.Pointer[string]) (net.Listener, <-chan struct{}) {
+// observed Authorization header through receivedAuth. It deliberately bypasses
+// testenv's upstream/modifier path so the route only exists once we push it
+// through the databroker.
+func startBareUpstream(t *testing.T, host string, receivedAuth *atomic.Pointer[string]) net.Listener {
 	t.Helper()
 
 	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", host))
 	require.NoError(t, err)
 
-	ready := make(chan struct{})
-	var once sync.Once
-
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		auth := r.Header.Get("Authorization")
 		receivedAuth.Store(&auth)
-		once.Do(func() { close(ready) })
 		if auth != "Bearer "+seededUpstreamToken {
 			w.WriteHeader(http.StatusUnauthorized)
 			return
@@ -201,18 +178,13 @@ func startBareUpstream(t *testing.T, host string, receivedAuth *atomic.Pointer[s
 		Handler:           mux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
-
 	go func() { _ = srv.Serve(listener) }()
 	t.Cleanup(func() {
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		_ = srv.Shutdown(shutdownCtx)
 	})
-
-	// Flip `ready` as soon as the listener is bound; the request handler will
-	// also close it on the first observed request, whichever happens first.
-	once.Do(func() { close(ready) })
-	return listener, ready
+	return listener
 }
 
 // pushMCPRouteViaDatabroker creates a databroker client using the environment's
@@ -255,96 +227,4 @@ func pushMCPRouteViaDatabroker(t *testing.T, env testenv.Environment, routeID, f
 		}},
 	})
 	require.NoError(t, err, "failed to push MCP route config via databroker")
-}
-
-// seedSATokenAndRun provisions a service account and a matching UpstreamMCPToken
-// record, then polls the MCP route through Envoy with the SA JWT until it
-// either gets an HTTP 200 with the expected injected Authorization header or
-// times out. The polling window is long enough to absorb xDS propagation for
-// the late-delivery case; on current main the late-delivery run times out
-// because the upstream keeps seeing no Authorization.
-func seedSATokenAndRun(
-	t *testing.T,
-	env testenv.Environment,
-	routeID, upstreamURL, fromURL string,
-	receivedAuth *atomic.Pointer[string],
-) {
-	t.Helper()
-
-	ctx := env.Context()
-	dbClient := env.NewDataBrokerServiceClient()
-
-	sa := &user.ServiceAccount{
-		Id:     seededSAID,
-		UserId: seededSAUserID,
-	}
-	_, err := user.PutServiceAccount(ctx, dbClient, sa)
-	require.NoError(t, err)
-
-	saJWT, err := cryptutil.SignServiceAccount(
-		env.SharedSecret(),
-		sa.Id,
-		sa.UserId,
-		time.Now(),
-		null.Time{},
-	)
-	require.NoError(t, err)
-
-	// Seed the upstream MCP token under the same composite key ext_proc will
-	// derive from (user_id, route_id, upstream_server).
-	storage := mcp.NewStorage(dbClient)
-	require.NoError(t, storage.PutUpstreamMCPToken(ctx, &oauth21proto.UpstreamMCPToken{
-		UserId:         sa.UserId,
-		RouteId:        routeID,
-		UpstreamServer: upstreamURL,
-		AccessToken:    seededUpstreamToken,
-		TokenType:      "Bearer",
-	}))
-
-	httpClient := upstreams.NewHTTPClient(env.ServerCAs(), &upstreams.RequestOptions{})
-
-	makeRequest := func() (int, string) {
-		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel()
-		req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, fromURL, nil)
-		if err != nil {
-			return 0, ""
-		}
-		req.Header.Set("Authorization", "Bearer Pomerium-"+saJWT)
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := httpClient.Do(req)
-		if err != nil {
-			return 0, ""
-		}
-		defer resp.Body.Close()
-		got := ""
-		if p := receivedAuth.Load(); p != nil {
-			got = *p
-		}
-		return resp.StatusCode, got
-	}
-
-	// The route + seeded token must result in HTTP 200 and the upstream must
-	// see the injected Bearer token. Eventually absorbs both xDS propagation
-	// and databroker-syncer timing; on current main it times out in the
-	// late-delivery case because ext_proc never injects the token.
-	var (
-		lastStatus int
-		lastAuth   string
-	)
-	require.Eventually(t, func() bool {
-		status, auth := makeRequest()
-		lastStatus, lastAuth = status, auth
-		return status == http.StatusOK && auth == "Bearer "+seededUpstreamToken
-	}, 30*time.Second, 250*time.Millisecond,
-		"expected ext_proc to inject the seeded upstream token for route %q (last status=%d, last upstream Authorization=%q)",
-		routeID, lastStatus, lastAuth)
-
-	// Re-assert the final state explicitly so the failure message names the
-	// two distinct expectations (HTTP 200 + correct injected Bearer header).
-	status, auth := makeRequest()
-	assert.Equal(t, http.StatusOK, status,
-		"request through Pomerium should succeed when upstream token is injected")
-	assert.Equal(t, "Bearer "+seededUpstreamToken, auth,
-		"upstream should receive the seeded Authorization header injected by ext_proc")
 }

--- a/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
+++ b/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
@@ -129,17 +129,8 @@ func TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute(t *testing.T) {
 		return resp.StatusCode
 	}
 
-	// Two-phase wait so the failure mode is unambiguous:
-	//
-	//  Phase A — "route reachable": keep retrying until Envoy has xDS for the
-	//  late-delivered route and forwards the request to our upstream. If this
-	//  phase times out the problem is xDS propagation / ext_authz, not the
-	//  ext_proc HostInfo.
-	//
-	//  Phase B — "correct token injected": once the upstream is reachable,
-	//  require that ext_proc injects the seeded Bearer token within a short
-	//  window. Pre-fix this phase fails fast with a concrete diff of what the
-	//  upstream actually saw, rather than a 30s timeout pointing nowhere.
+	// Split into phases so a timeout tells you which stage broke: xDS/ext_authz
+	// (phase A) versus ext_proc HostInfo (phase B).
 	var lastStatus int
 	require.Eventuallyf(t, func() bool {
 		lastStatus = makeRequest()
@@ -148,26 +139,23 @@ func TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute(t *testing.T) {
 		"late-delivered MCP route never reached the upstream (last status=%d); "+
 			"likely xDS did not propagate the route or ext_authz blocked it", lastStatus)
 
+	wantAuth := "Bearer " + seededUpstreamToken
 	require.Eventuallyf(t, func() bool {
 		lastStatus = makeRequest()
 		p := receivedAuth.Load()
-		return p != nil && *p == "Bearer "+seededUpstreamToken
-	}, 5*time.Second, 100*time.Millisecond,
+		return p != nil && *p == wantAuth
+	}, 5*time.Second, 250*time.Millisecond,
 		"upstream saw Authorization=%q (want %q), status=%d — "+
 			"ext_proc did not inject the seeded upstream token",
-		derefStr(receivedAuth.Load()), "Bearer "+seededUpstreamToken, lastStatus)
+		func() string {
+			if p := receivedAuth.Load(); p != nil {
+				return *p
+			}
+			return ""
+		}(), wantAuth, lastStatus)
 
-	// Status check is a final sanity assertion; the upstream only returns 200
-	// when it has observed the expected bearer token.
 	assert.Equal(t, http.StatusOK, lastStatus,
 		"request through Pomerium should succeed when upstream token is injected")
-}
-
-func derefStr(p *string) string {
-	if p == nil {
-		return ""
-	}
-	return *p
 }
 
 // startBareUpstream starts a minimal HTTP server on host:0 that writes the

--- a/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
+++ b/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
@@ -129,28 +129,45 @@ func TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute(t *testing.T) {
 		return resp.StatusCode
 	}
 
-	// Wait for xDS to catch up: keep retrying until a request actually lands
-	// on the upstream. Once the upstream has been hit at least once, the
-	// behavioral assertions below are definitive.
+	// Two-phase wait so the failure mode is unambiguous:
+	//
+	//  Phase A — "route reachable": keep retrying until Envoy has xDS for the
+	//  late-delivered route and forwards the request to our upstream. If this
+	//  phase times out the problem is xDS propagation / ext_authz, not the
+	//  ext_proc HostInfo.
+	//
+	//  Phase B — "correct token injected": once the upstream is reachable,
+	//  require that ext_proc injects the seeded Bearer token within a short
+	//  window. Pre-fix this phase fails fast with a concrete diff of what the
+	//  upstream actually saw, rather than a 30s timeout pointing nowhere.
 	var lastStatus int
-	require.Eventually(t, func() bool {
+	require.Eventuallyf(t, func() bool {
 		lastStatus = makeRequest()
 		return receivedAuth.Load() != nil
 	}, 30*time.Second, 250*time.Millisecond,
-		"late-delivered MCP route never became reachable via Envoy (last status=%d)", lastStatus)
+		"late-delivered MCP route never reached the upstream (last status=%d); "+
+			"likely xDS did not propagate the route or ext_authz blocked it", lastStatus)
 
-	// RED assertion: on current main the upstream sees an empty Authorization
-	// header because ext_proc's HostInfo map was frozen at startup and never
-	// picked up the late-delivered route. When the fix lands, ext_proc
-	// injects the seeded Bearer token and the upstream returns 200.
-	gotAuth := ""
-	if p := receivedAuth.Load(); p != nil {
-		gotAuth = *p
-	}
-	assert.Equal(t, "Bearer "+seededUpstreamToken, gotAuth,
-		"upstream should receive the seeded Authorization header injected by ext_proc")
+	require.Eventuallyf(t, func() bool {
+		lastStatus = makeRequest()
+		p := receivedAuth.Load()
+		return p != nil && *p == "Bearer "+seededUpstreamToken
+	}, 5*time.Second, 100*time.Millisecond,
+		"upstream saw Authorization=%q (want %q), status=%d — "+
+			"ext_proc did not inject the seeded upstream token",
+		derefStr(receivedAuth.Load()), "Bearer "+seededUpstreamToken, lastStatus)
+
+	// Status check is a final sanity assertion; the upstream only returns 200
+	// when it has observed the expected bearer token.
 	assert.Equal(t, http.StatusOK, lastStatus,
 		"request through Pomerium should succeed when upstream token is injected")
+}
+
+func derefStr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }
 
 // startBareUpstream starts a minimal HTTP server on host:0 that writes the

--- a/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
+++ b/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
@@ -1,0 +1,350 @@
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/volatiletech/null/v9"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/mcp"
+	oauth21proto "github.com/pomerium/pomerium/internal/oauth21/gen"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/scenarios"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+// TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute documents a bug where
+// the MCP ext_proc UpstreamAuthHandler does not pick up an MCP server route
+// added after startup via the databroker config sync path that Pomerium Zero
+// uses to deliver configuration.
+//
+// The handler wraps a *mcp.HostInfo whose map of hostname -> ServerHostInfo is
+// materialized once behind a sync.Once the first time it is queried, and never
+// rebuilt. When a new route arrives via the databroker config syncer:
+//
+//   - xDS updates, so Envoy routes the new virtual host and ext_authz /
+//     ext_proc filters run on the request.
+//   - The ext_authz headers evaluator still strips the Authorization header for
+//     MCP server routes (the policy carries MCP.Server).
+//   - ext_proc then calls UpstreamAuthHandler.GetUpstreamToken, which calls
+//     HostInfo.GetServerHostInfo(hostname). Because the host map was frozen at
+//     startup, this lookup returns (_, false), GetUpstreamToken returns empty,
+//     no Authorization header is injected, and the upstream sees no credentials.
+//
+// The control subtest configures the same MCP route at startup and proves the
+// service-account auth + seeded UpstreamMCPToken + ext_proc path all work end
+// to end. The primary subtest performs the identical seeding but pushes the
+// route in via databroker after startup; on current main it fails because the
+// upstream never receives the seeded Bearer token.
+func TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute(t *testing.T) {
+	// Subtest names are kept short on purpose: envoy's admin Unix socket path
+	// must fit in 108 bytes and this top-level test name already consumes 55.
+	t.Run("start", func(t *testing.T) {
+		runSeededSAMCPRoute(t, routeDeliveryStartup)
+	})
+	t.Run("late", func(t *testing.T) {
+		runSeededSAMCPRoute(t, routeDeliveryLateDatabroker)
+	})
+}
+
+type routeDelivery int
+
+const (
+	routeDeliveryStartup routeDelivery = iota
+	routeDeliveryLateDatabroker
+)
+
+const (
+	seededUpstreamToken = "seeded-upstream-access-token"
+	seededRouteID       = "late-mcp-route"
+	seededSAID          = "ext-proc-late-route-sa"
+	seededSAUserID      = "late-route-user@example.com"
+)
+
+// runSeededSAMCPRoute exercises the full ext_proc + service-account + seeded
+// UpstreamMCPToken path for a single MCP server route. The route is either
+// configured at startup or pushed through the databroker config syncer after
+// startup, depending on `delivery`. In both cases the test asserts that the
+// upstream receives exactly "Bearer <seededUpstreamToken>".
+func runSeededSAMCPRoute(t *testing.T, delivery routeDelivery) {
+	t.Helper()
+
+	env := testenv.New(t)
+
+	env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
+		if cfg.Options.RuntimeFlags == nil {
+			cfg.Options.RuntimeFlags = make(config.RuntimeFlags)
+		}
+		cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = true
+		cfg.Options.MCPAllowedClientIDDomains = []string{"*.localhost.pomerium.io"}
+	}))
+
+	idp := scenarios.NewIDP([]*scenarios.User{
+		{Email: seededSAUserID},
+	})
+	env.Add(idp)
+
+	// Record the Authorization header the upstream actually receives. The
+	// upstream returns 200 only when it sees the seeded Bearer token, so an
+	// HTTP 401 reliably indicates token injection did not happen.
+	var (
+		receivedAuth atomic.Pointer[string]
+		upstreamURL  string
+	)
+
+	switch delivery {
+	case routeDeliveryStartup:
+		serverUpstream := upstreams.HTTP(nil, upstreams.WithDisplayName("Startup MCP Server"))
+		serverUpstream.Handle("/", func(w http.ResponseWriter, r *http.Request) {
+			auth := r.Header.Get("Authorization")
+			receivedAuth.Store(&auth)
+			if auth != "Bearer "+seededUpstreamToken {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		})
+		serverRoute := serverUpstream.Route().
+			From(env.SubdomainURL("mcp-late-route-test")).
+			Policy(func(p *config.Policy) {
+				// Fixed ID so we can seed the UpstreamMCPToken by the same key
+				// the handler derives via Policy.RouteID().
+				p.ID = seededRouteID
+				p.AllowAnyAuthenticatedUser = true
+				p.MCP = &config.MCP{
+					Server: &config.MCPServer{},
+				}
+			})
+		env.AddUpstream(serverUpstream)
+
+		env.Start()
+		snippets.WaitStartupComplete(env)
+
+		// Resolve the concrete upstream URL only after startup, once testenv
+		// has allocated the upstream's listening port. upstreams.HTTP.Route()
+		// sets To = "http://<env.Host()>:<serverPort>", matching the format
+		// that NewServerHostInfoFromPolicy uses to derive UpstreamURL.
+		upstreamURL = "http://" + serverUpstream.Addr().Value()
+
+		seedSATokenAndRun(t, env, seededRouteID, upstreamURL, serverRoute.URL().Value(), &receivedAuth)
+
+	case routeDeliveryLateDatabroker:
+		// Stand up an unmanaged HTTP listener for the late-delivered route.
+		// We deliberately bypass testenv's upstream/modifier path so the
+		// route only exists once we push it through the databroker.
+		listener, handlerReady := startBareUpstream(t, env.Host(), &receivedAuth)
+		upstreamURL = "http://" + listener.Addr().String()
+
+		env.Start()
+		snippets.WaitStartupComplete(env)
+
+		// Wait until the bare upstream is actually accepting connections so
+		// later polling isn't racing server startup.
+		<-handlerReady
+
+		fromURL := env.SubdomainURL("mcp-late-route-test").Value()
+
+		// Push the MCP route through the same databroker config delivery path
+		// Pomerium Zero uses. Using env.NewDataBrokerServiceClient() keeps the
+		// transport identical to Zero's outbound gRPC connection (shared JWT
+		// auth against the outbound port).
+		pushMCPRouteViaDatabroker(t, env, seededRouteID, fromURL, upstreamURL)
+
+		seedSATokenAndRun(t, env, seededRouteID, upstreamURL, fromURL, &receivedAuth)
+
+	default:
+		t.Fatalf("unknown delivery mode %v", delivery)
+	}
+}
+
+// startBareUpstream starts a minimal HTTP server on host:0 that writes the
+// observed Authorization header through receivedAuth. It returns the listener
+// and a channel that closes as soon as the server is serving, so callers can
+// wait on startup deterministically.
+func startBareUpstream(t *testing.T, host string, receivedAuth *atomic.Pointer[string]) (net.Listener, <-chan struct{}) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", host))
+	require.NoError(t, err)
+
+	ready := make(chan struct{})
+	var once sync.Once
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		receivedAuth.Store(&auth)
+		once.Do(func() { close(ready) })
+		if auth != "Bearer "+seededUpstreamToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	srv := &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	go func() { _ = srv.Serve(listener) }()
+	t.Cleanup(func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		_ = srv.Shutdown(shutdownCtx)
+	})
+
+	// Flip `ready` as soon as the listener is bound; the request handler will
+	// also close it on the first observed request, whichever happens first.
+	once.Do(func() { close(ready) })
+	return listener, ready
+}
+
+// pushMCPRouteViaDatabroker creates a databroker client using the environment's
+// outbound port + shared secret (the same transport Zero uses) and writes a
+// configpb.Config record containing a single MCP server route. The config
+// syncer inside the running pomerium process picks the record up and folds the
+// route into the live configuration, which propagates to Envoy via xDS.
+func pushMCPRouteViaDatabroker(t *testing.T, env testenv.Environment, routeID, fromURL, toURL string) {
+	t.Helper()
+
+	dbClient := env.NewDataBrokerServiceClient()
+
+	idPtr := routeID
+	namePtr := routeID
+	route := &configpb.Route{
+		Id:                        &idPtr,
+		Name:                      &namePtr,
+		From:                      fromURL,
+		To:                        []string{toURL},
+		AllowAnyAuthenticatedUser: true,
+		Mcp: &configpb.MCP{
+			Mode: &configpb.MCP_Server{
+				Server: &configpb.MCPServer{},
+			},
+		},
+	}
+	data := protoutil.NewAny(&configpb.Config{
+		Name:   "late-mcp-route-config",
+		Routes: []*configpb.Route{route},
+	})
+
+	ctx, cancel := context.WithTimeout(env.Context(), 10*time.Second)
+	defer cancel()
+
+	_, err := dbClient.Put(ctx, &databrokerpb.PutRequest{
+		Records: []*databrokerpb.Record{{
+			Id:   "late-mcp-route-config",
+			Type: data.TypeUrl,
+			Data: data,
+		}},
+	})
+	require.NoError(t, err, "failed to push MCP route config via databroker")
+}
+
+// seedSATokenAndRun provisions a service account and a matching UpstreamMCPToken
+// record, then polls the MCP route through Envoy with the SA JWT until it
+// either gets an HTTP 200 with the expected injected Authorization header or
+// times out. The polling window is long enough to absorb xDS propagation for
+// the late-delivery case; on current main the late-delivery run times out
+// because the upstream keeps seeing no Authorization.
+func seedSATokenAndRun(
+	t *testing.T,
+	env testenv.Environment,
+	routeID, upstreamURL, fromURL string,
+	receivedAuth *atomic.Pointer[string],
+) {
+	t.Helper()
+
+	ctx := env.Context()
+	dbClient := env.NewDataBrokerServiceClient()
+
+	sa := &user.ServiceAccount{
+		Id:     seededSAID,
+		UserId: seededSAUserID,
+	}
+	_, err := user.PutServiceAccount(ctx, dbClient, sa)
+	require.NoError(t, err)
+
+	saJWT, err := cryptutil.SignServiceAccount(
+		env.SharedSecret(),
+		sa.Id,
+		sa.UserId,
+		time.Now(),
+		null.Time{},
+	)
+	require.NoError(t, err)
+
+	// Seed the upstream MCP token under the same composite key ext_proc will
+	// derive from (user_id, route_id, upstream_server).
+	storage := mcp.NewStorage(dbClient)
+	require.NoError(t, storage.PutUpstreamMCPToken(ctx, &oauth21proto.UpstreamMCPToken{
+		UserId:         sa.UserId,
+		RouteId:        routeID,
+		UpstreamServer: upstreamURL,
+		AccessToken:    seededUpstreamToken,
+		TokenType:      "Bearer",
+	}))
+
+	httpClient := upstreams.NewHTTPClient(env.ServerCAs(), &upstreams.RequestOptions{})
+
+	makeRequest := func() (int, string) {
+		reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(reqCtx, http.MethodPost, fromURL, nil)
+		if err != nil {
+			return 0, ""
+		}
+		req.Header.Set("Authorization", "Bearer Pomerium-"+saJWT)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := httpClient.Do(req)
+		if err != nil {
+			return 0, ""
+		}
+		defer resp.Body.Close()
+		got := ""
+		if p := receivedAuth.Load(); p != nil {
+			got = *p
+		}
+		return resp.StatusCode, got
+	}
+
+	// The route + seeded token must result in HTTP 200 and the upstream must
+	// see the injected Bearer token. Eventually absorbs both xDS propagation
+	// and databroker-syncer timing; on current main it times out in the
+	// late-delivery case because ext_proc never injects the token.
+	var (
+		lastStatus int
+		lastAuth   string
+	)
+	require.Eventually(t, func() bool {
+		status, auth := makeRequest()
+		lastStatus, lastAuth = status, auth
+		return status == http.StatusOK && auth == "Bearer "+seededUpstreamToken
+	}, 30*time.Second, 250*time.Millisecond,
+		"expected ext_proc to inject the seeded upstream token for route %q (last status=%d, last upstream Authorization=%q)",
+		routeID, lastStatus, lastAuth)
+
+	// Re-assert the final state explicitly so the failure message names the
+	// two distinct expectations (HTTP 200 + correct injected Bearer header).
+	status, auth := makeRequest()
+	assert.Equal(t, http.StatusOK, status,
+		"request through Pomerium should succeed when upstream token is injected")
+	assert.Equal(t, "Bearer "+seededUpstreamToken, auth,
+		"upstream should receive the seeded Authorization header injected by ext_proc")
+}

--- a/internal/mcp/extproc/server.go
+++ b/internal/mcp/extproc/server.go
@@ -8,7 +8,6 @@ import (
 	"maps"
 	"net/url"
 	"slices"
-	"sync/atomic"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	ext_proc_v3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -57,42 +56,14 @@ type RouteContext struct {
 type Server struct {
 	ext_proc_v3.UnimplementedExternalProcessorServer
 
-	// handler is atomic so the controlplane can install it after the gRPC
-	// server is already registered, when RuntimeFlagMCP is enabled at runtime
-	// rather than at boot.
-	handler  atomic.Pointer[handlerBox]
+	handler  UpstreamRequestHandler
 	callback Callback
 }
 
-// handlerBox wraps the interface so atomic.Pointer has a concrete pointee type.
-type handlerBox struct{ h UpstreamRequestHandler }
-
-// NewServer creates a new ext_proc server. The handler may be nil; install it
-// later with SetHandler.
+// NewServer creates a new ext_proc server. The handler may be nil, in which
+// case Process acts as a pass-through for the request/response auth paths.
 func NewServer(handler UpstreamRequestHandler, callback Callback) *Server {
-	s := &Server{callback: callback}
-	if handler != nil {
-		s.handler.Store(&handlerBox{h: handler})
-	}
-	return s
-}
-
-// SetHandler installs or replaces the UpstreamRequestHandler at runtime.
-// Passing nil clears the handler (ext_proc then acts as a pass-through).
-func (s *Server) SetHandler(h UpstreamRequestHandler) {
-	if h == nil {
-		s.handler.Store(nil)
-		return
-	}
-	s.handler.Store(&handlerBox{h: h})
-}
-
-// currentHandler returns the currently-installed handler, or nil if none.
-func (s *Server) currentHandler() UpstreamRequestHandler {
-	if b := s.handler.Load(); b != nil {
-		return b.h
-	}
-	return nil
+	return &Server{handler: handler, callback: callback}
 }
 
 // Register registers the ext_proc server with a gRPC server.
@@ -293,7 +264,7 @@ func (s *Server) handleRequestHeaders(
 		Str("method", method).
 		Msg("ext_proc: processing MCP request")
 
-	handler := s.currentHandler()
+	handler := s.handler
 	if handler == nil {
 		return continueRequestHeadersResponse()
 	}
@@ -343,7 +314,7 @@ func (s *Server) handleResponseHeaders(
 		s.callback(ctx, routeCtx, headers)
 	}
 
-	handler := s.currentHandler()
+	handler := s.handler
 	if routeCtx == nil || !routeCtx.IsMCP || handler == nil {
 		return continueResponseHeadersResponse()
 	}

--- a/internal/mcp/extproc/server.go
+++ b/internal/mcp/extproc/server.go
@@ -95,11 +95,6 @@ func (s *Server) currentHandler() UpstreamRequestHandler {
 	return nil
 }
 
-// HasHandler reports whether a handler is currently installed.
-func (s *Server) HasHandler() bool {
-	return s.currentHandler() != nil
-}
-
 // Register registers the ext_proc server with a gRPC server.
 func (s *Server) Register(srv *grpc.Server) {
 	ext_proc_v3.RegisterExternalProcessorServer(srv, s)

--- a/internal/mcp/extproc/server.go
+++ b/internal/mcp/extproc/server.go
@@ -54,26 +54,21 @@ type RouteContext struct {
 // Server implements the Envoy external processor service for MCP response interception.
 // It handles upstream token injection on the request path and 401/403 interception
 // on the response path (for auto-discovery OAuth flows).
-//
-// The handler is held behind an atomic pointer so the controlplane can install or
-// replace it at runtime — e.g. when RuntimeFlagMCP flips on via a databroker-delivered
-// config after the ext_proc server has already been registered with the gRPC server.
 type Server struct {
 	ext_proc_v3.UnimplementedExternalProcessorServer
 
+	// handler is atomic so the controlplane can install it after the gRPC
+	// server is already registered, when RuntimeFlagMCP is enabled at runtime
+	// rather than at boot.
 	handler  atomic.Pointer[handlerBox]
 	callback Callback
 }
 
-// handlerBox exists because atomic.Pointer needs a concrete pointee type; the
-// underlying UpstreamRequestHandler is an interface.
+// handlerBox wraps the interface so atomic.Pointer has a concrete pointee type.
 type handlerBox struct{ h UpstreamRequestHandler }
 
-// NewServer creates a new ext_proc server.
-// The handler provides upstream token injection and 401/403 handling logic.
-// It may be nil at construction time and installed later via SetHandler — this is
-// how controlplane supports MCP being enabled after startup (Pomerium Zero path).
-// The callback is optional and can be used for testing to verify ext_proc invocation.
+// NewServer creates a new ext_proc server. The handler may be nil; install it
+// later with SetHandler.
 func NewServer(handler UpstreamRequestHandler, callback Callback) *Server {
 	s := &Server{callback: callback}
 	if handler != nil {
@@ -100,10 +95,7 @@ func (s *Server) currentHandler() UpstreamRequestHandler {
 	return nil
 }
 
-// HasHandler reports whether a handler is currently installed. Used by
-// controlplane.Server to decide whether to build-and-install a fresh MCP
-// UpstreamAuthHandler on late enable, without clobbering a handler that
-// was already provided via WithExtProcHandler.
+// HasHandler reports whether a handler is currently installed.
 func (s *Server) HasHandler() bool {
 	return s.currentHandler() != nil
 }

--- a/internal/mcp/extproc/server.go
+++ b/internal/mcp/extproc/server.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net/url"
 	"slices"
+	"sync/atomic"
 
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	ext_proc_v3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
@@ -53,21 +54,58 @@ type RouteContext struct {
 // Server implements the Envoy external processor service for MCP response interception.
 // It handles upstream token injection on the request path and 401/403 interception
 // on the response path (for auto-discovery OAuth flows).
+//
+// The handler is held behind an atomic pointer so the controlplane can install or
+// replace it at runtime — e.g. when RuntimeFlagMCP flips on via a databroker-delivered
+// config after the ext_proc server has already been registered with the gRPC server.
 type Server struct {
 	ext_proc_v3.UnimplementedExternalProcessorServer
 
-	handler  UpstreamRequestHandler
+	handler  atomic.Pointer[handlerBox]
 	callback Callback
 }
 
+// handlerBox exists because atomic.Pointer needs a concrete pointee type; the
+// underlying UpstreamRequestHandler is an interface.
+type handlerBox struct{ h UpstreamRequestHandler }
+
 // NewServer creates a new ext_proc server.
 // The handler provides upstream token injection and 401/403 handling logic.
+// It may be nil at construction time and installed later via SetHandler — this is
+// how controlplane supports MCP being enabled after startup (Pomerium Zero path).
 // The callback is optional and can be used for testing to verify ext_proc invocation.
 func NewServer(handler UpstreamRequestHandler, callback Callback) *Server {
-	return &Server{
-		handler:  handler,
-		callback: callback,
+	s := &Server{callback: callback}
+	if handler != nil {
+		s.handler.Store(&handlerBox{h: handler})
 	}
+	return s
+}
+
+// SetHandler installs or replaces the UpstreamRequestHandler at runtime.
+// Passing nil clears the handler (ext_proc then acts as a pass-through).
+func (s *Server) SetHandler(h UpstreamRequestHandler) {
+	if h == nil {
+		s.handler.Store(nil)
+		return
+	}
+	s.handler.Store(&handlerBox{h: h})
+}
+
+// currentHandler returns the currently-installed handler, or nil if none.
+func (s *Server) currentHandler() UpstreamRequestHandler {
+	if b := s.handler.Load(); b != nil {
+		return b.h
+	}
+	return nil
+}
+
+// HasHandler reports whether a handler is currently installed. Used by
+// controlplane.Server to decide whether to build-and-install a fresh MCP
+// UpstreamAuthHandler on late enable, without clobbering a handler that
+// was already provided via WithExtProcHandler.
+func (s *Server) HasHandler() bool {
+	return s.currentHandler() != nil
 }
 
 // Register registers the ext_proc server with a gRPC server.
@@ -268,11 +306,12 @@ func (s *Server) handleRequestHeaders(
 		Str("method", method).
 		Msg("ext_proc: processing MCP request")
 
-	if s.handler == nil {
+	handler := s.currentHandler()
+	if handler == nil {
 		return continueRequestHeadersResponse()
 	}
 
-	token, err := s.handler.GetUpstreamToken(ctx, routeCtx, downstreamHost)
+	token, err := handler.GetUpstreamToken(ctx, routeCtx, downstreamHost)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).
 			Str("route_id", routeCtx.RouteID).
@@ -317,7 +356,8 @@ func (s *Server) handleResponseHeaders(
 		s.callback(ctx, routeCtx, headers)
 	}
 
-	if routeCtx == nil || !routeCtx.IsMCP || s.handler == nil {
+	handler := s.currentHandler()
+	if routeCtx == nil || !routeCtx.IsMCP || handler == nil {
 		return continueResponseHeadersResponse()
 	}
 
@@ -347,7 +387,7 @@ func (s *Server) handleResponseHeaders(
 		Str("www_authenticate", wwwAuthenticate).
 		Msg("ext_proc: upstream returned auth challenge, delegating to handler")
 
-	action, err := s.handler.HandleUpstreamResponse(ctx, routeCtx, downstreamHost, originalURL, statusCode, wwwAuthenticate)
+	action, err := handler.HandleUpstreamResponse(ctx, routeCtx, downstreamHost, originalURL, statusCode, wwwAuthenticate)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).
 			Str("route_id", routeCtx.RouteID).

--- a/internal/mcp/extproc/server_test.go
+++ b/internal/mcp/extproc/server_test.go
@@ -324,11 +324,7 @@ func TestNewServer(t *testing.T) {
 		assert.True(t, called)
 	})
 
-	t.Run("SetHandler installs a handler after construction", func(t *testing.T) {
-		// Simulates the Pomerium Zero path where RuntimeFlagMCP is off at startup
-		// but flips on later via a databroker-delivered config. Before C1, the
-		// controlplane registered a nil-handler ext_proc server and had no way
-		// to swap in a real handler; this test exists so that regresses loudly.
+	t.Run("SetHandler installs and clears a handler after construction", func(t *testing.T) {
 		s := NewServer(nil, nil)
 		require.Nil(t, s.currentHandler())
 
@@ -336,7 +332,6 @@ func TestNewServer(t *testing.T) {
 		s.SetHandler(installed)
 		assert.Same(t, installed, s.currentHandler())
 
-		// SetHandler(nil) clears.
 		s.SetHandler(nil)
 		assert.Nil(t, s.currentHandler())
 	})

--- a/internal/mcp/extproc/server_test.go
+++ b/internal/mcp/extproc/server_test.go
@@ -306,7 +306,7 @@ func TestNewServer(t *testing.T) {
 		s := NewServer(nil, nil)
 		require.NotNil(t, s)
 		assert.Nil(t, s.callback)
-		assert.Nil(t, s.handler)
+		assert.Nil(t, s.currentHandler())
 	})
 
 	t.Run("creates server with callback", func(t *testing.T) {
@@ -322,6 +322,23 @@ func TestNewServer(t *testing.T) {
 		// Verify callback is stored
 		s.callback(nil, nil, nil)
 		assert.True(t, called)
+	})
+
+	t.Run("SetHandler installs a handler after construction", func(t *testing.T) {
+		// Simulates the Pomerium Zero path where RuntimeFlagMCP is off at startup
+		// but flips on later via a databroker-delivered config. Before C1, the
+		// controlplane registered a nil-handler ext_proc server and had no way
+		// to swap in a real handler; this test exists so that regresses loudly.
+		s := NewServer(nil, nil)
+		require.Nil(t, s.currentHandler())
+
+		installed := &mockUpstreamHandler{}
+		s.SetHandler(installed)
+		assert.Same(t, installed, s.currentHandler())
+
+		// SetHandler(nil) clears.
+		s.SetHandler(nil)
+		assert.Nil(t, s.currentHandler())
 	})
 }
 

--- a/internal/mcp/extproc/server_test.go
+++ b/internal/mcp/extproc/server_test.go
@@ -306,34 +306,23 @@ func TestNewServer(t *testing.T) {
 		s := NewServer(nil, nil)
 		require.NotNil(t, s)
 		assert.Nil(t, s.callback)
-		assert.Nil(t, s.currentHandler())
+		assert.Nil(t, s.handler)
 	})
 
-	t.Run("creates server with callback", func(t *testing.T) {
+	t.Run("creates server with handler and callback", func(t *testing.T) {
 		called := false
 		cb := func(_ context.Context, _ *RouteContext, _ *ext_proc_v3.HttpHeaders) {
 			called = true
 		}
+		handler := &mockUpstreamHandler{}
 
-		s := NewServer(nil, cb)
+		s := NewServer(handler, cb)
 		require.NotNil(t, s)
+		assert.Same(t, handler, s.handler)
 		require.NotNil(t, s.callback)
 
-		// Verify callback is stored
 		s.callback(nil, nil, nil)
 		assert.True(t, called)
-	})
-
-	t.Run("SetHandler installs and clears a handler after construction", func(t *testing.T) {
-		s := NewServer(nil, nil)
-		require.Nil(t, s.currentHandler())
-
-		installed := &mockUpstreamHandler{}
-		s.SetHandler(installed)
-		assert.Same(t, installed, s.currentHandler())
-
-		s.SetHandler(nil)
-		assert.Nil(t, s.currentHandler())
 	})
 }
 

--- a/internal/mcp/handler_authorization_test.go
+++ b/internal/mcp/handler_authorization_test.go
@@ -175,20 +175,17 @@ func newAuthorizeTestHandler(t *testing.T, store HandlerStorage, hosts *HostInfo
 // newAutoDiscoveryHosts creates a HostInfo with a single auto-discovery server.
 // The server has the given host, routeID, and upstreamURL, and no OAuth2 Config (auto-discovery).
 func newAutoDiscoveryHosts(host, routeID, upstreamURL string) *HostInfo {
-	hi := &HostInfo{
-		servers: map[string]ServerHostInfo{
+	return newHostInfoForTest(
+		map[string]ServerHostInfo{
 			host: {
 				Host:        host,
 				RouteID:     routeID,
 				UpstreamURL: upstreamURL,
-				// Config is nil → UsesAutoDiscovery returns true
+				// UpstreamOAuth2 is nil → UsesAutoDiscovery returns true
 			},
 		},
-		clients: map[string]ClientHostInfo{},
-	}
-	// Mark buildOnce as done so it doesn't try to rebuild from nil config.
-	hi.buildOnce.Do(func() {})
-	return hi
+		nil,
+	)
 }
 
 func TestAuthorize_GetUpstreamMCPToken_StorageError(t *testing.T) {

--- a/internal/mcp/handler_connect_test.go
+++ b/internal/mcp/handler_connect_test.go
@@ -66,15 +66,10 @@ func TestIsValidRedirectURL(t *testing.T) {
 
 	// Minimal handler with a HostInfo that has known MCP clients.
 	srv := &Handler{
-		hosts: &HostInfo{
-			servers: map[string]ServerHostInfo{},
-			clients: map[string]ClientHostInfo{
-				"mcp-client.example.com": {},
-			},
-		},
+		hosts: newHostInfoForTest(nil, map[string]ClientHostInfo{
+			"mcp-client.example.com": {},
+		}),
 	}
-	// Mark buildOnce as done so it doesn't try to rebuild from nil config.
-	srv.hosts.buildOnce.Do(func() {})
 
 	tests := []struct {
 		name        string
@@ -195,17 +190,16 @@ func TestResolveAutoDiscoveryAuth_ClientSecret(t *testing.T) {
 	// UpstreamURL includes /mcp path to match the PRM resource.
 	downstreamHost := "127.0.0.1:" + parsedUpstream.Port()
 	upstreamMCPURL := upstreamURL + "/mcp"
-	hosts := &HostInfo{
-		servers: map[string]ServerHostInfo{
+	hosts := newHostInfoForTest(
+		map[string]ServerHostInfo{
 			"127.0.0.1": {
 				Host:        downstreamHost,
 				UpstreamURL: upstreamMCPURL,
 				RouteID:     "route-test",
 			},
 		},
-		clients: map[string]ClientHostInfo{},
-	}
-	hosts.buildOnce.Do(func() {})
+		nil,
+	)
 
 	// Mock storage that captures PendingUpstreamAuth
 	var capturedPending *oauth21proto.PendingUpstreamAuth

--- a/internal/mcp/host_info.go
+++ b/internal/mcp/host_info.go
@@ -164,4 +164,3 @@ func BuildHostInfo(cfg *config.Config) (map[string]ServerHostInfo, map[string]Cl
 	}
 	return servers, clients
 }
-

--- a/internal/mcp/host_info.go
+++ b/internal/mcp/host_info.go
@@ -7,19 +7,17 @@ import (
 	"net/http"
 	"net/url"
 	"path"
-	"sync"
+	"sync/atomic"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
 )
 
 type HostInfo struct {
-	cfg        *config.Config
 	httpClient *http.Client
 
-	buildOnce sync.Once
-	servers   map[string]ServerHostInfo
-	clients   map[string]ClientHostInfo
+	servers atomic.Pointer[map[string]ServerHostInfo]
+	clients atomic.Pointer[map[string]ClientHostInfo]
 }
 
 type ServerHostInfo struct {
@@ -82,29 +80,41 @@ func NewHostInfo(
 	cfg *config.Config,
 	httpClient *http.Client,
 ) *HostInfo {
-	return &HostInfo{
-		cfg:        cfg,
-		httpClient: httpClient,
-	}
+	h := &HostInfo{httpClient: httpClient}
+	h.OnConfigChange(cfg)
+	return h
+}
+
+// OnConfigChange rebuilds the host index from the given config and atomically
+// swaps it in. Safe to call concurrently with readers.
+func (r *HostInfo) OnConfigChange(cfg *config.Config) {
+	servers, clients := BuildHostInfo(cfg)
+	r.servers.Store(&servers)
+	r.clients.Store(&clients)
+}
+
+func (r *HostInfo) loadServers() map[string]ServerHostInfo {
+	return *r.servers.Load()
+}
+
+func (r *HostInfo) loadClients() map[string]ClientHostInfo {
+	return *r.clients.Load()
 }
 
 func (r *HostInfo) IsMCPClientForHost(host string) bool {
-	r.buildOnce.Do(r.build)
-	_, ok := r.clients[host]
+	_, ok := r.loadClients()[host]
 	return ok
 }
 
 func (r *HostInfo) All() iter.Seq[ServerHostInfo] {
-	r.buildOnce.Do(r.build)
-	return maps.Values(r.servers)
+	return maps.Values(r.loadServers())
 }
 
 // UsesAutoDiscovery returns true if the host is an MCP server route
 // without upstream_oauth2 configured (auto-discovery mode).
 // This determines whether the host should serve a CIMD document.
 func (r *HostInfo) UsesAutoDiscovery(host string) bool {
-	r.buildOnce.Do(r.build)
-	serverInfo, ok := r.servers[host]
+	serverInfo, ok := r.loadServers()[host]
 	if !ok {
 		return false
 	}
@@ -115,19 +125,17 @@ func (r *HostInfo) UsesAutoDiscovery(host string) bool {
 // GetServerHostInfo returns the ServerHostInfo for a given host.
 // Returns (ServerHostInfo{}, false) if the host is not found.
 func (r *HostInfo) GetServerHostInfo(host string) (ServerHostInfo, bool) {
-	r.buildOnce.Do(r.build)
-	info, ok := r.servers[host]
+	info, ok := r.loadServers()[host]
 	return info, ok
-}
-
-func (r *HostInfo) build() {
-	r.servers, r.clients = BuildHostInfo(r.cfg)
 }
 
 // BuildHostInfo indexes all policies by host.
 func BuildHostInfo(cfg *config.Config) (map[string]ServerHostInfo, map[string]ClientHostInfo) {
 	servers := make(map[string]ServerHostInfo)
 	clients := make(map[string]ClientHostInfo)
+	if cfg == nil {
+		return servers, clients
+	}
 	for policy := range cfg.Options.GetAllPolicies() {
 		if policy.MCP == nil {
 			continue
@@ -156,3 +164,4 @@ func BuildHostInfo(cfg *config.Config) (map[string]ServerHostInfo, map[string]Cl
 	}
 	return servers, clients
 }
+

--- a/internal/mcp/host_info_testing_test.go
+++ b/internal/mcp/host_info_testing_test.go
@@ -1,0 +1,14 @@
+package mcp
+
+func newHostInfoForTest(servers map[string]ServerHostInfo, clients map[string]ClientHostInfo) *HostInfo {
+	if servers == nil {
+		servers = map[string]ServerHostInfo{}
+	}
+	if clients == nil {
+		clients = map[string]ClientHostInfo{}
+	}
+	h := &HostInfo{}
+	h.servers.Store(&servers)
+	h.clients.Store(&clients)
+	return h
+}

--- a/internal/mcp/storage.go
+++ b/internal/mcp/storage.go
@@ -190,12 +190,20 @@ func (storage *Storage) PutMCPRefreshToken(
 	if err != nil {
 		return fmt.Errorf("failed to store MCP refresh token: %w", err)
 	}
-	log.Ctx(ctx).Info().
+	event := log.Ctx(ctx).Info().
 		Str("record-type", data.TypeUrl).
 		Str("record-id", token.Id).
 		Str("client-id", token.ClientId).
 		Str("user-id", token.UserId).
-		Msg("stored mcp refresh token")
+		Bool("revoked", token.Revoked).
+		Bool("has-upstream-refresh-token", token.UpstreamRefreshToken != "")
+	if token.IssuedAt != nil {
+		event.Time("issued-at", token.IssuedAt.AsTime())
+	}
+	if token.ExpiresAt != nil {
+		event.Time("expires-at", token.ExpiresAt.AsTime())
+	}
+	event.Msg("stored mcp refresh token")
 	return nil
 }
 

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -99,6 +99,12 @@ func NewUpstreamAuthHandler(
 	}
 }
 
+// OnConfigChange refreshes the handler's host index so that routes delivered
+// after the handler was constructed become visible to ext_proc lookups.
+func (h *UpstreamAuthHandler) OnConfigChange(ctx context.Context, cfg *config.Config) {
+	h.hosts.OnConfigChange(cfg)
+}
+
 // NewUpstreamAuthHandlerFromConfig creates an UpstreamAuthHandler using the provided config
 // and outbound gRPC connection. This is the primary factory used by the controlplane server.
 func NewUpstreamAuthHandlerFromConfig(

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -78,9 +78,8 @@ func newPendingUpstreamAuth(p newPendingUpstreamAuthParams, setup *upstreamOAuth
 // All upstream auth modes (auto-discovery, pre-registered, fully static) use a unified
 // UpstreamMCPToken storage path.
 //
-// Both hosts and asMetadataDomainMatcher are refreshable at runtime via OnConfigChange
-// so that config updates delivered after the handler was constructed (e.g. via the
-// Pomerium Zero databroker config sync path) take effect without a restart.
+// hosts and asMetadataDomainMatcher refresh via OnConfigChange; both are held
+// behind atomic pointers so request-path readers stay lock-free.
 type UpstreamAuthHandler struct {
 	storage                 HandlerStorage
 	hosts                   *HostInfo

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -76,11 +77,15 @@ func newPendingUpstreamAuth(p newPendingUpstreamAuthParams, setup *upstreamOAuth
 // It handles token injection on the request path and 401/403 interception on the response path.
 // All upstream auth modes (auto-discovery, pre-registered, fully static) use a unified
 // UpstreamMCPToken storage path.
+//
+// Both hosts and asMetadataDomainMatcher are refreshable at runtime via OnConfigChange
+// so that config updates delivered after the handler was constructed (e.g. via the
+// Pomerium Zero databroker config sync path) take effect without a restart.
 type UpstreamAuthHandler struct {
 	storage                 HandlerStorage
 	hosts                   *HostInfo
 	httpClient              *http.Client
-	asMetadataDomainMatcher *DomainMatcher
+	asMetadataDomainMatcher atomic.Pointer[DomainMatcher]
 	singleFlight            singleflight.Group
 }
 
@@ -91,18 +96,25 @@ func NewUpstreamAuthHandler(
 	httpClient *http.Client,
 	asMetadataDomainMatcher *DomainMatcher,
 ) *UpstreamAuthHandler {
-	return &UpstreamAuthHandler{
-		storage:                 storage,
-		hosts:                   hosts,
-		httpClient:              httpClient,
-		asMetadataDomainMatcher: asMetadataDomainMatcher,
+	h := &UpstreamAuthHandler{
+		storage:    storage,
+		hosts:      hosts,
+		httpClient: httpClient,
 	}
+	h.asMetadataDomainMatcher.Store(asMetadataDomainMatcher)
+	return h
 }
 
-// OnConfigChange refreshes the handler's host index so that routes delivered
-// after the handler was constructed become visible to ext_proc lookups.
-func (h *UpstreamAuthHandler) OnConfigChange(ctx context.Context, cfg *config.Config) {
+// OnConfigChange refreshes the handler's host index and AS-metadata domain allowlist
+// so that config updates delivered after the handler was constructed become visible
+// to ext_proc lookups.
+func (h *UpstreamAuthHandler) OnConfigChange(cfg *config.Config) {
 	h.hosts.OnConfigChange(cfg)
+	var allowed []string
+	if cfg != nil {
+		allowed = cfg.Options.GetMCPAllowedAsMetadataDomains()
+	}
+	h.asMetadataDomainMatcher.Store(NewDomainMatcher(allowed))
 }
 
 // NewUpstreamAuthHandlerFromConfig creates an UpstreamAuthHandler using the provided config
@@ -370,7 +382,7 @@ func (h *UpstreamAuthHandler) handle401(
 	setupOpts := []UpstreamOAuthSetupOption{
 		WithWWWAuthenticate(wwwAuth),
 		WithFallbackAuthorizationURL(serverInfo.AuthorizationServerURL),
-		WithASMetadataDomainMatcher(h.asMetadataDomainMatcher),
+		WithASMetadataDomainMatcher(h.asMetadataDomainMatcher.Load()),
 		WithAllowDCRFallback(true),
 	}
 	setupOpts = append(setupOpts, upstreamOAuthSetupOptsFromConfig(serverInfo.UpstreamOAuth2)...)

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -158,25 +158,60 @@ func (h *UpstreamAuthHandler) GetUpstreamToken(
 
 	info, ok := h.hosts.GetServerHostInfo(hostname)
 	if !ok || info.UpstreamURL == "" {
+		log.Ctx(ctx).Debug().
+			Str("route_id", routeCtx.RouteID).
+			Str("user_id", routeCtx.UserID).
+			Str("downstream_host", host).
+			Str("hostname", hostname).
+			Bool("host_info_found", ok).
+			Msg("mcp_upstream_auth: no host info for upstream token lookup")
 		return "", nil
 	}
 
 	userID := routeCtx.UserID
 	if userID == "" {
 		log.Ctx(ctx).Debug().
+			Str("route_id", routeCtx.RouteID).
+			Str("downstream_host", host).
+			Str("upstream_server", info.UpstreamURL).
 			Msg("mcp_upstream_auth: no user ID in route context, skipping token injection")
 		return "", nil
 	}
 	token, err := h.storage.GetUpstreamMCPToken(ctx, userID, routeCtx.RouteID, info.UpstreamURL)
 	if err != nil {
 		if isNotFound(err) {
+			log.Ctx(ctx).Debug().
+				Str("route_id", routeCtx.RouteID).
+				Str("user_id", userID).
+				Str("downstream_host", host).
+				Str("upstream_server", info.UpstreamURL).
+				Msg("mcp_upstream_auth: no cached upstream token found")
 			return "", nil
 		}
 		return "", fmt.Errorf("looking up upstream token: %w", err)
 	}
 
+	event := log.Ctx(ctx).Debug().
+		Str("route_id", routeCtx.RouteID).
+		Str("user_id", userID).
+		Str("downstream_host", host).
+		Str("upstream_server", info.UpstreamURL).
+		Bool("has_refresh_token", token.RefreshToken != "")
+	if token.ExpiresAt != nil {
+		event.Time("expires_at", token.ExpiresAt.AsTime())
+	}
+	event.Msg("mcp_upstream_auth: loaded cached upstream token")
+
 	// Check if access token is expired
 	if token.ExpiresAt != nil && token.ExpiresAt.AsTime().Before(time.Now()) {
+		log.Ctx(ctx).Debug().
+			Str("route_id", routeCtx.RouteID).
+			Str("user_id", userID).
+			Str("upstream_server", info.UpstreamURL).
+			Bool("has_refresh_token", token.RefreshToken != "").
+			Bool("has_token_endpoint", token.TokenEndpoint != "").
+			Time("expires_at", token.ExpiresAt.AsTime()).
+			Msg("mcp_upstream_auth: cached upstream token expired, attempting refresh or clear")
 		// Read client_secret from config (single source of truth) rather than from
 		// the stored token, to avoid replicating the shared credential per-user.
 		var configClientSecret string
@@ -185,6 +220,12 @@ func (h *UpstreamAuthHandler) GetUpstreamToken(
 		}
 		return h.refreshOrClearToken(ctx, token, userID, routeCtx.RouteID, info.UpstreamURL, configClientSecret)
 	}
+
+	log.Ctx(ctx).Debug().
+		Str("route_id", routeCtx.RouteID).
+		Str("user_id", userID).
+		Str("upstream_server", info.UpstreamURL).
+		Msg("mcp_upstream_auth: returning cached upstream access token")
 
 	return token.AccessToken, nil
 }
@@ -220,9 +261,22 @@ func (h *UpstreamAuthHandler) refreshOrClearToken(
 			}
 			// Transient failure (network error, 5xx, etc.): preserve the cached token
 			// and return an error so ext_proc returns 502 rather than silently dropping auth.
+			log.Ctx(ctx).Warn().Err(err).
+				Str("user_id", userID).
+				Str("route_id", routeID).
+				Str("upstream_server", upstreamServer).
+				Msg("mcp_upstream_auth: transient upstream token refresh failure, preserving cached token")
 			return "", fmt.Errorf("refreshing upstream token: %w", err)
 		}
 		refreshed := result.(*oauth21proto.UpstreamMCPToken)
+		event := log.Ctx(ctx).Debug().
+			Str("user_id", userID).
+			Str("route_id", routeID).
+			Str("upstream_server", upstreamServer)
+		if refreshed.ExpiresAt != nil {
+			event.Time("expires_at", refreshed.ExpiresAt.AsTime())
+		}
+		event.Msg("mcp_upstream_auth: refreshed upstream token successfully")
 		return refreshed.AccessToken, nil
 	}
 
@@ -230,6 +284,9 @@ func (h *UpstreamAuthHandler) refreshOrClearToken(
 	log.Ctx(ctx).Debug().
 		Str("user_id", userID).
 		Str("route_id", routeID).
+		Str("upstream_server", upstreamServer).
+		Bool("has_refresh_token", token.RefreshToken != "").
+		Bool("has_token_endpoint", token.TokenEndpoint != "").
 		Msg("mcp_upstream_auth: upstream token expired with no refresh token, clearing")
 	if delErr := h.storage.DeleteUpstreamMCPToken(ctx, userID, routeID, upstreamServer); delErr != nil {
 		log.Ctx(ctx).Error().Err(delErr).Msg("mcp_upstream_auth: failed to delete expired token")
@@ -253,6 +310,14 @@ func (h *UpstreamAuthHandler) HandleUpstreamResponse(
 
 	info, ok := h.hosts.GetServerHostInfo(hostname)
 	if !ok || info.UpstreamURL == "" {
+		log.Ctx(ctx).Debug().
+			Str("route_id", routeCtx.RouteID).
+			Str("user_id", routeCtx.UserID).
+			Str("downstream_host", host).
+			Str("hostname", hostname).
+			Bool("host_info_found", ok).
+			Int("status_code", statusCode).
+			Msg("mcp_upstream_auth: no host info for upstream response handling")
 		return nil, nil
 	}
 

--- a/internal/mcp/upstream_auth_onconfigchange_test.go
+++ b/internal/mcp/upstream_auth_onconfigchange_test.go
@@ -1,0 +1,56 @@
+package mcp
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+)
+
+// TestUpstreamAuthHandler_OnConfigChange_RefreshesDomainMatcher is the RED
+// test for review finding I1.
+//
+// Before I1, NewUpstreamAuthHandlerFromConfig captured MCPAllowedASMetadataDomains
+// once into an *DomainMatcher field and OnConfigChange only refreshed the host
+// index. A Zero-delivered Options update that changed the allowlist would be
+// silently ignored by ext_proc — same class of bug as the one the PR is
+// already fixing for HostInfo.
+func TestUpstreamAuthHandler_OnConfigChange_RefreshesDomainMatcher(t *testing.T) {
+	t.Parallel()
+
+	old := &config.Config{Options: config.NewDefaultOptions()}
+	old.Options.MCPAllowedASMetadataDomains = []string{"old.example.com"}
+
+	h := NewUpstreamAuthHandler(
+		nil,
+		NewHostInfo(old, nil),
+		nil,
+		NewDomainMatcher(old.Options.GetMCPAllowedAsMetadataDomains()),
+	)
+
+	// Sanity: startup allowlist is in force.
+	require.NotNil(t, h.asMetadataDomainMatcher.Load())
+	require.NoError(t, h.asMetadataDomainMatcher.Load().ValidateURLDomain(mustParseURL(t, "https://old.example.com/.well-known/oauth-authorization-server")))
+
+	// Config update swaps the allowlist (simulates a Zero-delivered Options change).
+	updated := &config.Config{Options: config.NewDefaultOptions()}
+	updated.Options.MCPAllowedASMetadataDomains = []string{"new.example.com"}
+	h.OnConfigChange(updated)
+
+	matcher := h.asMetadataDomainMatcher.Load()
+	require.NotNil(t, matcher)
+	assert.NoError(t, matcher.ValidateURLDomain(mustParseURL(t, "https://new.example.com/foo")),
+		"new.example.com must be allowed after OnConfigChange")
+	assert.ErrorIs(t, matcher.ValidateURLDomain(mustParseURL(t, "https://old.example.com/foo")), ErrDomainNotAllowed,
+		"old.example.com must no longer be allowed — stale matcher would incorrectly pass this")
+}
+
+func mustParseURL(t *testing.T, s string) *url.URL {
+	t.Helper()
+	u, err := url.Parse(s)
+	require.NoError(t, err)
+	return u
+}

--- a/internal/mcp/upstream_auth_onconfigchange_test.go
+++ b/internal/mcp/upstream_auth_onconfigchange_test.go
@@ -10,14 +10,6 @@ import (
 	"github.com/pomerium/pomerium/config"
 )
 
-// TestUpstreamAuthHandler_OnConfigChange_RefreshesDomainMatcher is the RED
-// test for review finding I1.
-//
-// Before I1, NewUpstreamAuthHandlerFromConfig captured MCPAllowedASMetadataDomains
-// once into an *DomainMatcher field and OnConfigChange only refreshed the host
-// index. A Zero-delivered Options update that changed the allowlist would be
-// silently ignored by ext_proc — same class of bug as the one the PR is
-// already fixing for HostInfo.
 func TestUpstreamAuthHandler_OnConfigChange_RefreshesDomainMatcher(t *testing.T) {
 	t.Parallel()
 
@@ -31,21 +23,19 @@ func TestUpstreamAuthHandler_OnConfigChange_RefreshesDomainMatcher(t *testing.T)
 		NewDomainMatcher(old.Options.GetMCPAllowedAsMetadataDomains()),
 	)
 
-	// Sanity: startup allowlist is in force.
-	require.NotNil(t, h.asMetadataDomainMatcher.Load())
-	require.NoError(t, h.asMetadataDomainMatcher.Load().ValidateURLDomain(mustParseURL(t, "https://old.example.com/.well-known/oauth-authorization-server")))
+	require.NoError(t, h.asMetadataDomainMatcher.Load().ValidateURLDomain(
+		mustParseURL(t, "https://old.example.com/.well-known/oauth-authorization-server")))
 
-	// Config update swaps the allowlist (simulates a Zero-delivered Options change).
 	updated := &config.Config{Options: config.NewDefaultOptions()}
 	updated.Options.MCPAllowedASMetadataDomains = []string{"new.example.com"}
 	h.OnConfigChange(updated)
 
 	matcher := h.asMetadataDomainMatcher.Load()
-	require.NotNil(t, matcher)
-	assert.NoError(t, matcher.ValidateURLDomain(mustParseURL(t, "https://new.example.com/foo")),
-		"new.example.com must be allowed after OnConfigChange")
-	assert.ErrorIs(t, matcher.ValidateURLDomain(mustParseURL(t, "https://old.example.com/foo")), ErrDomainNotAllowed,
-		"old.example.com must no longer be allowed — stale matcher would incorrectly pass this")
+	assert.NoError(t, matcher.ValidateURLDomain(mustParseURL(t, "https://new.example.com/foo")))
+	assert.ErrorIs(t,
+		matcher.ValidateURLDomain(mustParseURL(t, "https://old.example.com/foo")),
+		ErrDomainNotAllowed,
+		"old.example.com must no longer be allowed after OnConfigChange")
 }
 
 func mustParseURL(t *testing.T, s string) *url.URL {

--- a/internal/mcp/upstream_auth_test.go
+++ b/internal/mcp/upstream_auth_test.go
@@ -95,12 +95,7 @@ func TestHandleUpstreamResponse_DownstreamHostRouting(t *testing.T) {
 			},
 		}
 
-		handler := &UpstreamAuthHandler{
-			storage:                 store,
-			hosts:                   hosts,
-			httpClient:              upstreamSrv.Client(),
-			asMetadataDomainMatcher: allowLocalhost(),
-		}
+		handler := NewUpstreamAuthHandler(store, hosts, upstreamSrv.Client(), allowLocalhost())
 
 		routeCtx := &extproc.RouteContext{
 			RouteID: "route-123",
@@ -647,12 +642,7 @@ func TestHandle401_ResourceParamStoredInPending(t *testing.T) {
 			},
 		}
 
-		handler := &UpstreamAuthHandler{
-			storage:                 store,
-			hosts:                   hosts,
-			httpClient:              srv.Client(),
-			asMetadataDomainMatcher: allowLocalhost(),
-		}
+		handler := NewUpstreamAuthHandler(store, hosts, srv.Client(), allowLocalhost())
 
 		routeCtx := &extproc.RouteContext{
 			RouteID: "route-123",


### PR DESCRIPTION
## Summary

MCP routes delivered to a running Pomerium through the databroker config sync path — the path Pomerium Zero uses — silently lost upstream auth. The upstream saw empty Authorization headers and rejected every request. Boot-time routes were unaffected. Restart cleared the symptom until the next late-delivered route.

This change makes the ext_proc filter learn about routes and allowed-domain updates that arrive after startup, and installs the MCP handler on the fly when the MCP runtime flag itself is enabled via a late configuration update.

## Related issues

- ENG-3926 — https://linear.app/pomerium/issue/ENG-3926/pomerium-loses-mcp-upstream-auth-for-routes-delivered-after-startup

## User Explanation

MCP routes added to a running Pomerium Zero deployment now work without a restart. Previously any MCP route added through the console after the deployment was already running would appear reachable but fail upstream authentication.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (\`enhancement\`, \`bug\`, \`breaking\`, \`dependencies\`, \`ci\`)
- [ ] ready for review