### PR TITLE
mcp: refresh expired upstream token before forcing reauth

### DIFF
--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -46,12 +46,14 @@ const (
 type AuthenticatorGetter func(ctx context.Context, idpID string) (identity.Authenticator, error)
 
 type Handler struct {
-	prefix                  string
-	trace                   oteltrace.TracerProvider
-	storage                 HandlerStorage
-	cipher                  cipher.AEAD
-	hosts                   *HostInfo
-	hostsSingleFlight       singleflight.Group
+	prefix  string
+	trace   oteltrace.TracerProvider
+	storage HandlerStorage
+	cipher  cipher.AEAD
+	hosts   *HostInfo
+	// singleFlight deduplicates concurrent auxiliary operations keyed by a namespace
+	// prefix: "dcr:" for dynamic client registrations, "mcp:" for upstream token refreshes.
+	singleFlight            singleflight.Group
 	clientMetadataFetcher   *ClientMetadataFetcher
 	getAuthenticator        AuthenticatorGetter
 	sessionExpiry           time.Duration

--- a/internal/mcp/handler_authorization.go
+++ b/internal/mcp/handler_authorization.go
@@ -184,6 +184,29 @@ func (srv *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if tokenErr == nil && token != nil {
+			refreshed, refreshErr := srv.tryRefreshExpiredUpstreamToken(ctx, token, info)
+			if refreshErr != nil {
+				log.Ctx(ctx).Error().Err(refreshErr).
+					Str("user_id", userID).
+					Str("route_id", info.RouteID).
+					Msg("mcp/authorize: transient upstream token refresh failure")
+				if delErr := srv.storage.DeleteAuthorizationRequest(ctx, authReqID); delErr != nil {
+					log.Ctx(ctx).Warn().Err(delErr).Str("id", authReqID).Msg("mcp/authorize: failed to clean up authorization request")
+				}
+				http.Error(w, "internal error", http.StatusInternalServerError)
+				return
+			}
+			if refreshed != nil {
+				log.Ctx(ctx).Info().
+					Str("user_id", userID).
+					Str("route_id", info.RouteID).
+					Msg("mcp/authorize: refreshed expired upstream token, issuing auth code directly")
+				srv.AuthorizationResponse(ctx, w, r, authReqID, v)
+				return
+			}
+		}
+
 		// Resolve upstream auth via pending state or proactive discovery.
 		authURL, resolveErr := srv.resolveAutoDiscoveryAuth(ctx, &autoDiscoveryAuthParams{
 			Hostname:  hostname,

--- a/internal/mcp/handler_authorization_test.go
+++ b/internal/mcp/handler_authorization_test.go
@@ -8,7 +8,10 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/go-jose/go-jose/v3"
 	josejwt "github.com/go-jose/go-jose/v3/jwt"
@@ -16,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/internal/httputil"
 	oauth21proto "github.com/pomerium/pomerium/internal/oauth21/gen"
@@ -31,6 +35,8 @@ type authorizeTestStorage struct {
 	deleteAuthorizationRequestFunc func(ctx context.Context, id string) error
 	getClientFunc                  func(ctx context.Context, id string) (*rfc7591v1.ClientRegistration, error)
 	getUpstreamMCPTokenFunc        func(ctx context.Context, userID, routeID, upstreamServer string) (*oauth21proto.UpstreamMCPToken, error)
+	putUpstreamMCPTokenFunc        func(ctx context.Context, token *oauth21proto.UpstreamMCPToken) error
+	deleteUpstreamMCPTokenFunc     func(ctx context.Context, userID, routeID, upstreamServer string) error
 	getPendingUpstreamAuthFunc     func(ctx context.Context, userID, host string) (*oauth21proto.PendingUpstreamAuth, error)
 }
 
@@ -91,11 +97,17 @@ func (s *authorizeTestStorage) DeleteMCPRefreshToken(context.Context, string) er
 	panic("unexpected call to DeleteMCPRefreshToken")
 }
 
-func (s *authorizeTestStorage) PutUpstreamMCPToken(context.Context, *oauth21proto.UpstreamMCPToken) error {
+func (s *authorizeTestStorage) PutUpstreamMCPToken(ctx context.Context, token *oauth21proto.UpstreamMCPToken) error {
+	if s.putUpstreamMCPTokenFunc != nil {
+		return s.putUpstreamMCPTokenFunc(ctx, token)
+	}
 	panic("unexpected call to PutUpstreamMCPToken")
 }
 
-func (s *authorizeTestStorage) DeleteUpstreamMCPToken(context.Context, string, string, string) error {
+func (s *authorizeTestStorage) DeleteUpstreamMCPToken(ctx context.Context, userID, routeID, upstreamServer string) error {
+	if s.deleteUpstreamMCPTokenFunc != nil {
+		return s.deleteUpstreamMCPTokenFunc(ctx, userID, routeID, upstreamServer)
+	}
 	panic("unexpected call to DeleteUpstreamMCPToken")
 }
 
@@ -355,4 +367,104 @@ func TestAuthorize_GetUpstreamMCPToken_NotFoundFallsThrough(t *testing.T) {
 		"NotFound error should not cause a 500")
 	assert.False(t, deleteAuthReqCalled,
 		"should not clean up auth request on NotFound (flow continues)")
+}
+
+// TestAuthorize_ExpiredTokenWithRefreshToken_RefreshesSilently reproduces ENG-3927:
+// when the cached UpstreamMCPToken is expired but has a valid refresh_token, the
+// Authorize handler must refresh it silently instead of triggering a brand-new
+// interactive OAuth flow via resolveAutoDiscoveryAuth.
+func TestAuthorize_ExpiredTokenWithRefreshToken_RefreshesSilently(t *testing.T) {
+	t.Parallel()
+
+	const (
+		testHost        = "test.example.com"
+		testRouteID     = "test-route-id"
+		testUpstreamURL = "https://upstream.example.com"
+		testClientID    = "test-client-id"
+		testRedirectURI = "https://client.example.com/callback"
+		testSessionID   = "test-session"
+		testUserID      = "test-user"
+	)
+
+	var tokenEndpointHits int32
+	tokenSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenEndpointHits, 1)
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "refresh_token", r.FormValue("grant_type"))
+		assert.Equal(t, "valid-refresh-token", r.FormValue("refresh_token"))
+		assert.Equal(t, "upstream-client-id", r.FormValue("client_id"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	// 404 PRM discovery so that if the handler wrongly falls into resolveAutoDiscoveryAuth
+	// the test fails via the tokenEndpointHits assertion instead of panicking on the stub.
+	discoverySrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(discoverySrv.Close)
+
+	var storedToken *oauth21proto.UpstreamMCPToken
+
+	store := &authorizeTestStorage{
+		createAuthorizationRequestFunc: func(_ context.Context, _ *oauth21proto.AuthorizationRequest) (string, error) {
+			return "test-auth-req-id", nil
+		},
+		getUpstreamMCPTokenFunc: func(_ context.Context, _, _, _ string) (*oauth21proto.UpstreamMCPToken, error) {
+			return &oauth21proto.UpstreamMCPToken{
+				UserId:         testUserID,
+				RouteId:        testRouteID,
+				UpstreamServer: discoverySrv.URL,
+				AccessToken:    "expired-access",
+				RefreshToken:   "valid-refresh-token",
+				TokenEndpoint:  tokenSrv.URL,
+				ClientId:       "upstream-client-id",
+				ExpiresAt:      timestamppb.New(time.Now().Add(-time.Hour)),
+			}, nil
+		},
+		putUpstreamMCPTokenFunc: func(_ context.Context, tok *oauth21proto.UpstreamMCPToken) error {
+			storedToken = tok
+			return nil
+		},
+		getClientFunc: func(_ context.Context, _ string) (*rfc7591v1.ClientRegistration, error) {
+			return &rfc7591v1.ClientRegistration{
+				ResponseMetadata: &rfc7591v1.Metadata{
+					TokenEndpointAuthMethod: new("none"),
+					RedirectUris:            []string{testRedirectURI},
+				},
+			}, nil
+		},
+		getPendingUpstreamAuthFunc: func(_ context.Context, _, _ string) (*oauth21proto.PendingUpstreamAuth, error) {
+			return nil, fmt.Errorf("no pending auth")
+		},
+	}
+
+	hosts := newAutoDiscoveryHosts(testHost, testRouteID, discoverySrv.URL)
+	srv := newAuthorizeTestHandler(t, store, hosts)
+	srv.httpClient = tokenSrv.Client()
+	srv.asMetadataDomainMatcher = NewDomainMatcher(nil) // allow all
+
+	reqURL := makeAuthorizeURL(t, testClientID, testRedirectURI)
+	r := httptest.NewRequest(http.MethodGet, reqURL, nil)
+	r.Host = testHost
+	r.Header.Set(httputil.HeaderPomeriumJWTAssertion, makeTestJWT(t, testSessionID, testUserID))
+
+	w := httptest.NewRecorder()
+	srv.Authorize(w, r)
+
+	// Primary assertion: refresh MUST happen rather than falling into resolveAutoDiscoveryAuth.
+	assert.Equal(t, int32(1), atomic.LoadInt32(&tokenEndpointHits),
+		"expired token with refresh_token should trigger silent refresh against token_endpoint")
+	require.NotNil(t, storedToken, "refreshed token should be written back to storage")
+	assert.Equal(t, "new-access", storedToken.AccessToken)
+	assert.Equal(t, "new-refresh", storedToken.RefreshToken)
+
+	// The client must receive an authorization code (same outcome as when the cached
+	// access token is still fresh) — not a redirect to the upstream AS.
+	assert.Equal(t, http.StatusFound, w.Code)
+	loc := w.Header().Get("Location")
+	assert.True(t, strings.HasPrefix(loc, testRedirectURI),
+		"should redirect to client redirect_uri after silent refresh, got %q", loc)
+	assert.Contains(t, loc, "code=", "redirect should carry the authorization code")
 }

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -128,6 +128,27 @@ func (srv *Handler) ConnectGet(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		if tokenErr == nil && token != nil {
+			refreshed, refreshErr := srv.tryRefreshExpiredUpstreamToken(ctx, token, info)
+			if refreshErr != nil {
+				log.Ctx(ctx).Error().Err(refreshErr).
+					Str("user_id", userID).
+					Str("route_id", info.RouteID).
+					Msg("mcp/connect: transient upstream token refresh failure")
+				http.Error(w, "internal server error", http.StatusInternalServerError)
+				return
+			}
+			if refreshed != nil {
+				log.Ctx(ctx).Info().
+					Str("user_id", userID).
+					Str("route_id", info.RouteID).
+					Str("redirect-url", redirectURL).
+					Msg("mcp/connect: refreshed expired upstream token, redirecting to client")
+				http.Redirect(w, r, redirectURL, http.StatusFound)
+				return
+			}
+		}
+
 		// Create AuthorizationRequest with InternalConnectClientID so the callback
 		// chain redirects back to the client's redirect_url after token acquisition.
 		req := &oauth21proto.AuthorizationRequest{
@@ -390,6 +411,27 @@ type autoDiscoveryAuthParams struct {
 	Info      ServerHostInfo // route info with RouteID and UpstreamURL
 }
 
+// tryRefreshExpiredUpstreamToken attempts a silent OAuth2 refresh_token grant against the
+// upstream AS for an expired cached token. Return values mirror refreshExpiredUpstreamMCPToken:
+//   - (refreshed, nil): refresh succeeded — the caller may short-circuit interactive re-auth.
+//   - (nil, nil):       permanent failure (or no refresh capability); the stale token has
+//     been cleared. The caller should fall through to interactive re-auth.
+//   - (nil, error):     transient failure; the caller should surface it (typically as 500).
+func (srv *Handler) tryRefreshExpiredUpstreamToken(
+	ctx context.Context,
+	token *oauth21proto.UpstreamMCPToken,
+	info ServerHostInfo,
+) (*oauth21proto.UpstreamMCPToken, error) {
+	var configClientSecret string
+	if info.UpstreamOAuth2 != nil {
+		configClientSecret = info.UpstreamOAuth2.ClientSecret
+	}
+	return refreshExpiredUpstreamMCPToken(
+		ctx, srv.storage, srv.httpClient, &srv.singleFlight,
+		token, configClientSecret,
+	)
+}
+
 // resolveAutoDiscoveryAuth checks for pending upstream auth or runs proactive PRM discovery
 // to create PendingUpstreamAuth state for auto-discovery routes.
 // Returns the upstream authorization URL to redirect the user to, or empty string if
@@ -556,7 +598,7 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 	}
 
 	sfKey := fmt.Sprintf("dcr:%s:%s", discovery.Issuer, downstreamHost)
-	result, err, _ := srv.hostsSingleFlight.Do(sfKey, func() (any, error) {
+	result, err, _ := srv.singleFlight.Do(sfKey, func() (any, error) {
 		if client, cacheErr := srv.storage.GetUpstreamOAuthClient(ctx, discovery.Issuer, downstreamHost); cacheErr == nil {
 			if client.ClientId != "" {
 				return client, nil

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -597,7 +597,10 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 		log.Ctx(ctx).Warn().Err(err).Str("issuer", discovery.Issuer).Str("downstream_host", downstreamHost).Msg("mcp/auto-discovery: DCR cache lookup failed, proceeding to registration")
 	}
 
-	sfKey := fmt.Sprintf("dcr:%s:%s", discovery.Issuer, downstreamHost)
+	sfKey := "dcr:" + url.Values{
+		"issuer": {discovery.Issuer},
+		"host":   {downstreamHost},
+	}.Encode()
 	result, err, _ := srv.singleFlight.Do(sfKey, func() (any, error) {
 		if client, cacheErr := srv.storage.GetUpstreamOAuthClient(ctx, discovery.Issuer, downstreamHost); cacheErr == nil {
 			if client.ClientId != "" {

--- a/internal/mcp/handler_connect_test.go
+++ b/internal/mcp/handler_connect_test.go
@@ -7,13 +7,17 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/pomerium/pomerium/internal/httputil"
 	oauth21proto "github.com/pomerium/pomerium/internal/oauth21/gen"
 	rfc7591v1 "github.com/pomerium/pomerium/internal/rfc7591"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
@@ -318,6 +322,83 @@ func TestRegisterWithUpstreamAS_EmptyClientID(t *testing.T) {
 	assert.Contains(t, err.Error(), "client_id")
 }
 
+// TestConnect_ExpiredTokenWithRefreshToken_RefreshesSilently reproduces ENG-3927 on the
+// /.pomerium/mcp/connect path: when the cached UpstreamMCPToken is expired but has a valid
+// refresh_token, ConnectGet must refresh it silently instead of forcing interactive reauth.
+func TestConnect_ExpiredTokenWithRefreshToken_RefreshesSilently(t *testing.T) {
+	t.Parallel()
+
+	const (
+		testHost        = "test.example.com"
+		testRouteID     = "test-route-id"
+		testRedirectURL = "https://test.example.com/.pomerium/routes"
+		testSessionID   = "test-session"
+		testUserID      = "test-user"
+	)
+
+	var tokenEndpointHits int32
+	tokenSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&tokenEndpointHits, 1)
+		require.NoError(t, r.ParseForm())
+		assert.Equal(t, "refresh_token", r.FormValue("grant_type"))
+		assert.Equal(t, "valid-refresh-token", r.FormValue("refresh_token"))
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"new-access","refresh_token":"new-refresh","token_type":"Bearer","expires_in":3600}`))
+	}))
+	t.Cleanup(tokenSrv.Close)
+
+	discoverySrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(discoverySrv.Close)
+
+	var storedToken *oauth21proto.UpstreamMCPToken
+	store := &testConnectStorage{
+		getUpstreamMCPTokenFunc: func(_ context.Context, _, _, _ string) (*oauth21proto.UpstreamMCPToken, error) {
+			return &oauth21proto.UpstreamMCPToken{
+				UserId:         testUserID,
+				RouteId:        testRouteID,
+				UpstreamServer: discoverySrv.URL,
+				AccessToken:    "expired-access",
+				RefreshToken:   "valid-refresh-token",
+				TokenEndpoint:  tokenSrv.URL,
+				ClientId:       "upstream-client-id",
+				ExpiresAt:      timestamppb.New(time.Now().Add(-time.Hour)),
+			}, nil
+		},
+		putUpstreamMCPTokenFunc: func(_ context.Context, tok *oauth21proto.UpstreamMCPToken) error {
+			storedToken = tok
+			return nil
+		},
+	}
+
+	hosts := newAutoDiscoveryHosts(testHost, testRouteID, discoverySrv.URL)
+	srv := &Handler{
+		storage:                 store,
+		hosts:                   hosts,
+		httpClient:              tokenSrv.Client(),
+		asMetadataDomainMatcher: NewDomainMatcher(nil),
+	}
+
+	reqURL := fmt.Sprintf("https://%s/.pomerium/mcp/connect?redirect_url=%s",
+		testHost, url.QueryEscape(testRedirectURL))
+	r := httptest.NewRequest(http.MethodGet, reqURL, nil)
+	r.Host = testHost
+	r.Header.Set(httputil.HeaderPomeriumJWTAssertion, makeTestJWT(t, testSessionID, testUserID))
+
+	w := httptest.NewRecorder()
+	srv.ConnectGet(w, r)
+
+	assert.Equal(t, int32(1), atomic.LoadInt32(&tokenEndpointHits),
+		"expired token with refresh_token should trigger silent refresh")
+	require.NotNil(t, storedToken, "refreshed token should be written back to storage")
+	assert.Equal(t, "new-access", storedToken.AccessToken)
+
+	assert.Equal(t, http.StatusFound, w.Code)
+	assert.Equal(t, testRedirectURL, w.Header().Get("Location"),
+		"connect should redirect back to redirect_url after silent refresh, not to upstream AS")
+}
+
 // testConnectStorage is a mock implementing HandlerStorage for handler_connect tests.
 // Only methods used by the tested code paths are implemented; the rest panic.
 type testConnectStorage struct {
@@ -327,6 +408,9 @@ type testConnectStorage struct {
 	deleteAuthorizationRequestFunc func(ctx context.Context, id string) error
 	getUpstreamOAuthClientFunc     func(ctx context.Context, issuer, downstreamHost string) (*oauth21proto.UpstreamOAuthClient, error)
 	putUpstreamOAuthClientFunc     func(ctx context.Context, client *oauth21proto.UpstreamOAuthClient) error
+	getUpstreamMCPTokenFunc        func(ctx context.Context, userID, routeID, upstreamServer string) (*oauth21proto.UpstreamMCPToken, error)
+	putUpstreamMCPTokenFunc        func(ctx context.Context, token *oauth21proto.UpstreamMCPToken) error
+	deleteUpstreamMCPTokenFunc     func(ctx context.Context, userID, routeID, upstreamServer string) error
 }
 
 func (s *testConnectStorage) GetPendingUpstreamAuth(ctx context.Context, userID, host string) (*oauth21proto.PendingUpstreamAuth, error) {
@@ -405,15 +489,24 @@ func (s *testConnectStorage) DeleteMCPRefreshToken(context.Context, string) erro
 	panic("unexpected call to DeleteMCPRefreshToken")
 }
 
-func (s *testConnectStorage) PutUpstreamMCPToken(context.Context, *oauth21proto.UpstreamMCPToken) error {
+func (s *testConnectStorage) PutUpstreamMCPToken(ctx context.Context, token *oauth21proto.UpstreamMCPToken) error {
+	if s.putUpstreamMCPTokenFunc != nil {
+		return s.putUpstreamMCPTokenFunc(ctx, token)
+	}
 	panic("unexpected call to PutUpstreamMCPToken")
 }
 
-func (s *testConnectStorage) GetUpstreamMCPToken(context.Context, string, string, string) (*oauth21proto.UpstreamMCPToken, error) {
+func (s *testConnectStorage) GetUpstreamMCPToken(ctx context.Context, userID, routeID, upstreamServer string) (*oauth21proto.UpstreamMCPToken, error) {
+	if s.getUpstreamMCPTokenFunc != nil {
+		return s.getUpstreamMCPTokenFunc(ctx, userID, routeID, upstreamServer)
+	}
 	panic("unexpected call to GetUpstreamMCPToken")
 }
 
-func (s *testConnectStorage) DeleteUpstreamMCPToken(context.Context, string, string, string) error {
+func (s *testConnectStorage) DeleteUpstreamMCPToken(ctx context.Context, userID, routeID, upstreamServer string) error {
+	if s.deleteUpstreamMCPTokenFunc != nil {
+		return s.deleteUpstreamMCPTokenFunc(ctx, userID, routeID, upstreamServer)
+	}
 	panic("unexpected call to DeleteUpstreamMCPToken")
 }
 

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -243,7 +243,11 @@ func refreshExpiredUpstreamMCPToken(
 		return nil, nil
 	}
 
-	sfKey := fmt.Sprintf("mcp:%s:%s:%s", userID, routeID, upstreamServer)
+	sfKey := "mcp:" + url.Values{
+		"user":     {userID},
+		"route":    {routeID},
+		"upstream": {upstreamServer},
+	}.Encode()
 	result, err, _ := sf.Do(sfKey, func() (any, error) {
 		return doRefreshUpstreamMCPToken(ctx, storage, httpClient, token, configClientSecret)
 	})

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -211,12 +211,19 @@ func (h *UpstreamAuthHandler) refreshOrClearToken(
 }
 
 // refreshExpiredUpstreamMCPToken refreshes an expired UpstreamMCPToken using its refresh_token.
+// The permanent-vs-transient split is driven by isTokenRefreshPermanent (4xx from the token
+// endpoint vs 5xx / network).
+//
 // Return values encode three outcomes the caller must distinguish:
 //   - (refreshed, nil): refresh succeeded; the new token was persisted.
-//   - (nil, nil):       permanent failure or no refresh capability; the stale token has been
-//     deleted, and the caller should trigger interactive re-auth.
-//   - (nil, error):     transient failure (network / 5xx); the stale token is preserved so a
-//     later retry can still refresh it, and the caller should surface the error.
+//   - (nil, nil):       permanent failure (4xx from the AS — invalid_grant, revoked, etc.)
+//     or no refresh capability. The stale token has been deleted and the caller should
+//     trigger interactive re-auth.
+//   - (nil, error):     transient failure (network / 5xx). The stale token is preserved so
+//     a later retry can still refresh it; the caller should surface the error.
+//
+// Each terminal branch logs inline so failures are always traceable at the refresh site,
+// regardless of whether the caller logs again.
 //
 // Concurrent refreshes for the same (user, route, upstream) are deduplicated via the supplied
 // singleflight.Group.
@@ -262,6 +269,11 @@ func refreshExpiredUpstreamMCPToken(
 			}
 			return nil, nil
 		}
+		// Log transient failures at the source rather than relying on distant callers to log.
+		log.Ctx(ctx).Warn().Err(err).
+			Str("user_id", userID).
+			Str("route_id", routeID).
+			Msg("mcp_upstream_auth: upstream token refresh failed (transient); preserving cached token")
 		return nil, fmt.Errorf("refreshing upstream token: %w", err)
 	}
 	return result.(*oauth21proto.UpstreamMCPToken), nil

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -183,7 +183,7 @@ func (h *UpstreamAuthHandler) GetUpstreamToken(
 		if info.UpstreamOAuth2 != nil {
 			configClientSecret = info.UpstreamOAuth2.ClientSecret
 		}
-		return h.refreshOrClearToken(ctx, token, userID, routeCtx.RouteID, info.UpstreamURL, configClientSecret)
+		return h.refreshOrClearToken(ctx, token, configClientSecret)
 	}
 
 	return token.AccessToken, nil
@@ -195,47 +195,72 @@ func (h *UpstreamAuthHandler) GetUpstreamToken(
 func (h *UpstreamAuthHandler) refreshOrClearToken(
 	ctx context.Context,
 	token *oauth21proto.UpstreamMCPToken,
-	userID, routeID, upstreamServer string,
 	configClientSecret string,
 ) (string, error) {
-	// Try refresh if we have a refresh token and token endpoint.
-	// Uses singleflight to deduplicate concurrent refresh requests.
-	if token.RefreshToken != "" && token.TokenEndpoint != "" {
-		sfKey := fmt.Sprintf("mcp:%s:%s:%s", userID, routeID, upstreamServer)
-		result, err, _ := h.singleFlight.Do(sfKey, func() (any, error) {
-			return h.refreshToken(ctx, token, configClientSecret)
-		})
-		if err != nil {
-			if isTokenRefreshPermanent(err) {
-				// 4xx from token endpoint: the refresh token is invalid/revoked.
-				// Delete the cached token so the next 401 from upstream triggers re-auth.
-				log.Ctx(ctx).Warn().Err(err).
-					Str("user_id", userID).
-					Str("route_id", routeID).
-					Msg("mcp_upstream_auth: refresh token rejected by AS, clearing cached token")
-				if delErr := h.storage.DeleteUpstreamMCPToken(ctx, userID, routeID, upstreamServer); delErr != nil {
-					log.Ctx(ctx).Error().Err(delErr).Msg("mcp_upstream_auth: failed to delete stale token after refresh failure")
-				}
-				return "", nil
-			}
-			// Transient failure (network error, 5xx, etc.): preserve the cached token
-			// and return an error so ext_proc returns 502 rather than silently dropping auth.
-			return "", fmt.Errorf("refreshing upstream token: %w", err)
+	refreshed, err := refreshExpiredUpstreamMCPToken(
+		ctx, h.storage, h.httpClient, &h.singleFlight,
+		token, configClientSecret,
+	)
+	if err != nil {
+		return "", err
+	}
+	if refreshed == nil {
+		return "", nil
+	}
+	return refreshed.AccessToken, nil
+}
+
+// refreshExpiredUpstreamMCPToken refreshes an expired UpstreamMCPToken using its refresh_token.
+// Return values encode three outcomes the caller must distinguish:
+//   - (refreshed, nil): refresh succeeded; the new token was persisted.
+//   - (nil, nil):       permanent failure or no refresh capability; the stale token has been
+//     deleted, and the caller should trigger interactive re-auth.
+//   - (nil, error):     transient failure (network / 5xx); the stale token is preserved so a
+//     later retry can still refresh it, and the caller should surface the error.
+//
+// Concurrent refreshes for the same (user, route, upstream) are deduplicated via the supplied
+// singleflight.Group.
+func refreshExpiredUpstreamMCPToken(
+	ctx context.Context,
+	storage HandlerStorage,
+	httpClient *http.Client,
+	sf *singleflight.Group,
+	token *oauth21proto.UpstreamMCPToken,
+	configClientSecret string,
+) (*oauth21proto.UpstreamMCPToken, error) {
+	userID := token.UserId
+	routeID := token.RouteId
+	upstreamServer := token.UpstreamServer
+
+	if token.RefreshToken == "" || token.TokenEndpoint == "" {
+		log.Ctx(ctx).Debug().
+			Str("user_id", userID).
+			Str("route_id", routeID).
+			Msg("mcp_upstream_auth: upstream token expired with no refresh token, clearing")
+		if delErr := storage.DeleteUpstreamMCPToken(ctx, userID, routeID, upstreamServer); delErr != nil {
+			log.Ctx(ctx).Error().Err(delErr).Msg("mcp_upstream_auth: failed to delete expired token")
 		}
-		refreshed := result.(*oauth21proto.UpstreamMCPToken)
-		return refreshed.AccessToken, nil
+		return nil, nil
 	}
 
-	// Expired with no refresh token - clear it.
-	log.Ctx(ctx).Debug().
-		Str("user_id", userID).
-		Str("route_id", routeID).
-		Msg("mcp_upstream_auth: upstream token expired with no refresh token, clearing")
-	if delErr := h.storage.DeleteUpstreamMCPToken(ctx, userID, routeID, upstreamServer); delErr != nil {
-		log.Ctx(ctx).Error().Err(delErr).Msg("mcp_upstream_auth: failed to delete expired token")
+	sfKey := fmt.Sprintf("mcp:%s:%s:%s", userID, routeID, upstreamServer)
+	result, err, _ := sf.Do(sfKey, func() (any, error) {
+		return doRefreshUpstreamMCPToken(ctx, storage, httpClient, token, configClientSecret)
+	})
+	if err != nil {
+		if isTokenRefreshPermanent(err) {
+			log.Ctx(ctx).Warn().Err(err).
+				Str("user_id", userID).
+				Str("route_id", routeID).
+				Msg("mcp_upstream_auth: refresh token rejected by AS, clearing cached token")
+			if delErr := storage.DeleteUpstreamMCPToken(ctx, userID, routeID, upstreamServer); delErr != nil {
+				log.Ctx(ctx).Error().Err(delErr).Msg("mcp_upstream_auth: failed to delete stale token after refresh failure")
+			}
+			return nil, nil
+		}
+		return nil, fmt.Errorf("refreshing upstream token: %w", err)
 	}
-
-	return "", nil
+	return result.(*oauth21proto.UpstreamMCPToken), nil
 }
 
 // HandleUpstreamResponse processes a 401/403 response from upstream.
@@ -353,12 +378,24 @@ func (h *UpstreamAuthHandler) handle401(
 	}, nil
 }
 
-// refreshToken attempts to refresh an expired upstream token.
-// configClientSecret is the client_secret from route config (single source of truth
-// for pre-registered clients). It is passed in rather than read from the stored token
-// to avoid replicating the shared admin credential in every per-user token record.
+// refreshToken is a thin wrapper around doRefreshUpstreamMCPToken kept for the existing
+// UpstreamAuthHandler tests. New callers should use refreshExpiredUpstreamMCPToken.
 func (h *UpstreamAuthHandler) refreshToken(
 	ctx context.Context,
+	token *oauth21proto.UpstreamMCPToken,
+	configClientSecret string,
+) (*oauth21proto.UpstreamMCPToken, error) {
+	return doRefreshUpstreamMCPToken(ctx, h.storage, h.httpClient, token, configClientSecret)
+}
+
+// doRefreshUpstreamMCPToken performs the actual HTTP refresh call and persists the result.
+// configClientSecret is the client_secret from route config (single source of truth for
+// pre-registered clients). It is passed in rather than read from the stored token to avoid
+// replicating the shared admin credential in every per-user token record.
+func doRefreshUpstreamMCPToken(
+	ctx context.Context,
+	storage HandlerStorage,
+	httpClient *http.Client,
 	token *oauth21proto.UpstreamMCPToken,
 	configClientSecret string,
 ) (*oauth21proto.UpstreamMCPToken, error) {
@@ -386,12 +423,11 @@ func (h *UpstreamAuthHandler) refreshToken(
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	tokenResp, err := exchangeToken(h.httpClient, req)
+	tokenResp, err := exchangeToken(httpClient, req)
 	if err != nil {
 		return nil, fmt.Errorf("token refresh: %w", err)
 	}
 
-	// Update token in storage
 	now := time.Now()
 	refreshedToken := &oauth21proto.UpstreamMCPToken{
 		UserId:                    token.UserId,
@@ -412,12 +448,12 @@ func (h *UpstreamAuthHandler) refreshToken(
 		refreshedToken.ExpiresAt = timestamppb.New(now.Add(time.Duration(tokenResp.ExpiresIn) * time.Second))
 	}
 
-	// Preserve old refresh token if the AS didn't rotate it
+	// Preserve old refresh token if the AS didn't rotate it.
 	if refreshedToken.RefreshToken == "" {
 		refreshedToken.RefreshToken = token.RefreshToken
 	}
 
-	if err := h.storage.PutUpstreamMCPToken(ctx, refreshedToken); err != nil {
+	if err := storage.PutUpstreamMCPToken(ctx, refreshedToken); err != nil {
 		return nil, fmt.Errorf("storing refreshed token: %w", err)
 	}
 

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -394,16 +394,6 @@ func (h *UpstreamAuthHandler) handle401(
 	}, nil
 }
 
-// refreshToken is a thin wrapper around doRefreshUpstreamMCPToken kept for the existing
-// UpstreamAuthHandler tests. New callers should use refreshExpiredUpstreamMCPToken.
-func (h *UpstreamAuthHandler) refreshToken(
-	ctx context.Context,
-	token *oauth21proto.UpstreamMCPToken,
-	configClientSecret string,
-) (*oauth21proto.UpstreamMCPToken, error) {
-	return doRefreshUpstreamMCPToken(ctx, h.storage, h.httpClient, token, configClientSecret)
-}
-
 // doRefreshUpstreamMCPToken performs the actual HTTP refresh call and persists the result.
 // configClientSecret is the client_secret from route config (single source of truth for
 // pre-registered clients). It is passed in rather than read from the stored token to avoid

--- a/internal/mcp/upstream_auth_test.go
+++ b/internal/mcp/upstream_auth_test.go
@@ -323,7 +323,7 @@ func TestRefreshToken_ResourceParam(t *testing.T) {
 			TokenEndpoint:  tokenSrv.URL,
 		}
 
-		refreshed, err := handler.refreshToken(context.Background(), token, "")
+		refreshed, err := doRefreshUpstreamMCPToken(context.Background(), handler.storage, handler.httpClient, token, "")
 		require.NoError(t, err)
 		assert.Equal(t, "new-access-token", refreshed.AccessToken)
 
@@ -374,7 +374,7 @@ func TestRefreshToken_ResourceParam(t *testing.T) {
 			TokenEndpoint:  tokenSrv.URL,
 		}
 
-		refreshed, err := handler.refreshToken(context.Background(), token, "")
+		refreshed, err := doRefreshUpstreamMCPToken(context.Background(), handler.storage, handler.httpClient, token, "")
 		require.NoError(t, err)
 		assert.Equal(t, "new-access-token", refreshed.AccessToken)
 
@@ -424,7 +424,7 @@ func TestRefreshToken_ResourceParam(t *testing.T) {
 			TokenEndpoint:  tokenSrv.URL,
 		}
 
-		_, err := handler.refreshToken(context.Background(), token, "")
+		_, err := doRefreshUpstreamMCPToken(context.Background(), handler.storage, handler.httpClient, token, "")
 		require.NoError(t, err)
 
 		// The resource parameter must NOT be present in the request when empty.
@@ -472,7 +472,7 @@ func TestRefreshToken_ResourceParam(t *testing.T) {
 			TokenEndpoint:  tokenSrv.URL,
 		}
 
-		_, err := handler.refreshToken(context.Background(), token, "")
+		_, err := doRefreshUpstreamMCPToken(context.Background(), handler.storage, handler.httpClient, token, "")
 		require.NoError(t, err)
 
 		require.NotNil(t, storedToken)
@@ -526,7 +526,7 @@ func TestRefreshToken_ClientSecret(t *testing.T) {
 			TokenEndpoint:  tokenSrv.URL,
 		}
 
-		refreshed, err := handler.refreshToken(context.Background(), token, "google-client-secret")
+		refreshed, err := doRefreshUpstreamMCPToken(context.Background(), handler.storage, handler.httpClient, token, "google-client-secret")
 		require.NoError(t, err)
 		assert.Equal(t, "new-access-token", refreshed.AccessToken)
 
@@ -577,7 +577,7 @@ func TestRefreshToken_ClientSecret(t *testing.T) {
 			TokenEndpoint:  tokenSrv.URL,
 		}
 
-		_, err := handler.refreshToken(context.Background(), token, "")
+		_, err := doRefreshUpstreamMCPToken(context.Background(), handler.storage, handler.httpClient, token, "")
 		require.NoError(t, err)
 
 		assert.False(t, capturedFormValues.Has("client_secret"),


### PR DESCRIPTION
## Summary

`/.pomerium/mcp/authorize` and `/.pomerium/mcp/connect` forced a full interactive OAuth flow whenever the cached `UpstreamMCPToken` was past its expiry, even when a valid `refresh_token` was on hand. Now attempt a silent refresh first; on permanent failure drop the stale token and fall through as before.

## Related issues

[ENG-3927](https://linear.app/pomerium/issue/ENG-3927/mcp-authorize-handler-doesnt-refresh-expired-upstreammcptoken-triggers)

## User Explanation

MCP clients no longer get bounced through a full upstream OAuth consent page once a day when their cached access token expires; a fresh token is fetched silently from the upstream's `token_endpoint`.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`bug`)
- [ ] ready for review