### PR TITLE
feat : minor recording storage schema improvements

### DIFF
--- a/internal/recording/server_test.go
+++ b/internal/recording/server_test.go
@@ -137,14 +137,14 @@ func testRecordingServerConformance(t *testing.T, bucketURI string, bk *gblob.Bu
 		}
 
 		// Verify chunk data in blob store.
-		chunkData, err := bk.ReadAll(ctx, "test/ssh/upload/0000000000")
+		chunkData, err := bk.ReadAll(ctx, "test/ssh/v1/upload/recording_0000000000.json")
 		require.NoError(t, err)
 		blobChecksum := md5.Sum(chunkData)
 		assert.Equal(t, checksum, blobChecksum)
 		assert.Equal(t, allData, chunkData)
 
 		// Verify metadata proto.
-		mdProtoData, err := bk.ReadAll(ctx, "test/ssh/upload.proto")
+		mdProtoData, err := bk.ReadAll(ctx, "test/ssh/v1/upload/metadata.proto")
 		assert.NoError(t, err)
 		var mdProto recording.RecordingMetadata
 		require.NoError(t, proto.Unmarshal(mdProtoData, &mdProto))
@@ -152,7 +152,7 @@ func testRecordingServerConformance(t *testing.T, bucketURI string, bk *gblob.Bu
 		assert.Equal(t, recording.RecordingFormat_RecordingFormatSSH, mdProto.GetRecordingType())
 
 		// Verify metadata JSON.
-		mdJSONData, err := bk.ReadAll(ctx, "test/ssh/upload.json")
+		mdJSONData, err := bk.ReadAll(ctx, "test/ssh/v1/upload/metadata.json")
 		require.NoError(t, err)
 		var mdJSON recording.RecordingMetadata
 		require.NoError(t, protojson.Unmarshal(mdJSONData, &mdJSON))
@@ -160,7 +160,7 @@ func testRecordingServerConformance(t *testing.T, bucketURI string, bk *gblob.Bu
 		assert.Equal(t, recording.RecordingFormat_RecordingFormatSSH, mdJSON.GetRecordingType())
 
 		// Verify manifest.
-		manifestData, err := bk.ReadAll(ctx, "test/ssh/upload/manifest")
+		manifestData, err := bk.ReadAll(ctx, "test/ssh/v1/upload/manifest")
 		require.NoError(t, err)
 		var manifest recording.ChunkManifest
 		require.NoError(t, proto.Unmarshal(manifestData, &manifest))
@@ -168,7 +168,7 @@ func testRecordingServerConformance(t *testing.T, bucketURI string, bk *gblob.Bu
 		assert.Equal(t, uint32(len(allData)), manifest.GetItems()[0].GetSize())
 
 		// Verify signature exists.
-		sigExists, err := bk.Exists(ctx, "test/ssh/upload.sig")
+		sigExists, err := bk.Exists(ctx, "test/ssh/v1/upload.sig")
 		require.NoError(t, err)
 		assert.True(t, sigExists)
 	})
@@ -235,20 +235,20 @@ func testRecordingServerConformance(t *testing.T, bucketURI string, bk *gblob.Bu
 		require.NoError(t, err)
 
 		// Verify both chunks in blob store.
-		chunk1Data, err := bk.ReadAll(ctx, "test/ssh/resume/0000000000")
+		chunk1Data, err := bk.ReadAll(ctx, "test/ssh/v1/resume/recording_0000000000.json")
 		require.NoError(t, err)
 		assert.Equal(t, chunk1, chunk1Data)
 
-		chunk2Data, err := bk.ReadAll(ctx, "test/ssh/resume/0000000001")
+		chunk2Data, err := bk.ReadAll(ctx, "test/ssh/v1/resume/recording_0000000001.json")
 		require.NoError(t, err)
 		assert.Equal(t, chunk2, chunk2Data)
 
 		// Recording was not finalized, so sig and manifest should not exist.
-		sigExists, err := bk.Exists(ctx, "test/ssh/resume.sig")
+		sigExists, err := bk.Exists(ctx, "test/ssh/v1/resume.sig")
 		require.NoError(t, err)
 		assert.False(t, sigExists, "signature should not exist before finalization")
 
-		manifestExists, err := bk.Exists(ctx, "test/ssh/resume/manifest")
+		manifestExists, err := bk.Exists(ctx, "test/ssh/v1/resume/manifest")
 		require.NoError(t, err)
 		assert.False(t, manifestExists, "manifest should not exist before finalization")
 	})
@@ -306,7 +306,7 @@ func testRecordingServerConformance(t *testing.T, bucketURI string, bk *gblob.Bu
 
 		// Verify each chunk in blob store.
 		for i, data := range batches {
-			key := fmt.Sprintf("test/ssh/multi/%010d", i)
+			key := fmt.Sprintf("test/ssh/v1/multi/recording_%010d.json", i)
 			chunkData, err := bk.ReadAll(ctx, key)
 			require.NoError(t, err, "chunk %d", i)
 			assert.Equal(t, data, chunkData, "chunk %d data mismatch", i)
@@ -317,7 +317,7 @@ func testRecordingServerConformance(t *testing.T, bucketURI string, bk *gblob.Bu
 		}
 
 		// Verify manifest has all chunks.
-		manifestData, err := bk.ReadAll(ctx, "test/ssh/multi/manifest")
+		manifestData, err := bk.ReadAll(ctx, "test/ssh/v1/multi/manifest")
 		require.NoError(t, err)
 		var manifest recording.ChunkManifest
 		require.NoError(t, proto.Unmarshal(manifestData, &manifest))
@@ -425,7 +425,7 @@ func TestServerOnConfigChange(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = bkB.Close() })
 
-		chunkData, err := bkB.ReadAll(ctx, "test/ssh/switched/0000000000")
+		chunkData, err := bkB.ReadAll(ctx, "test/ssh/v1/switched/recording_0000000000.json")
 		require.NoError(t, err)
 		assert.Equal(t, chunk, chunkData)
 
@@ -434,7 +434,7 @@ func TestServerOnConfigChange(t *testing.T) {
 		require.NoError(t, err)
 		t.Cleanup(func() { _ = bkA.Close() })
 
-		exists, err := bkA.Exists(ctx, "test/ssh/switched/0000000000")
+		exists, err := bkA.Exists(ctx, "test/ssh/v1/switched/recording_0000000000.json")
 		require.NoError(t, err)
 		assert.False(t, exists, "data should not exist in old bucket")
 	})

--- a/pkg/protoutil/delim.go
+++ b/pkg/protoutil/delim.go
@@ -1,0 +1,98 @@
+package protoutil
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"reflect"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+)
+
+func MarshalLenghDelimitedProtojson[T proto.Message](msgs []T) ([]byte, error) {
+	var buf []byte
+	opts := protojson.MarshalOptions{
+		Multiline:         false,
+		Indent:            "",
+		AllowPartial:      false,
+		UseProtoNames:     true,
+		UseEnumNumbers:    false,
+		EmitUnpopulated:   true,
+		EmitDefaultValues: true,
+	}
+	for _, msg := range msgs {
+		data, err := opts.Marshal(msg)
+		if err != nil {
+			return nil, err
+		}
+		buf = append(buf, data...)
+		buf = append(buf, []byte("\n")...)
+	}
+	return buf, nil
+}
+
+func UnmarshalLengthDelimitedProtojson[T proto.Message](data []byte) ([]T, error) {
+	s := bufio.NewScanner(bytes.NewReader(data))
+	var msgs []T
+	for s.Scan() {
+		line := s.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		msg := newProtoMessage[T]()
+		if err := protojson.Unmarshal(line, msg); err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, msg)
+	}
+	return msgs, nil
+}
+
+// MarshalLengthDelimited encodes a slice of proto messages into a single byte
+// buffer using varint-length-delimited framing.
+func MarshalLengthDelimited[T proto.Message](msgs []T) ([]byte, error) {
+	var buf []byte
+	for _, msg := range msgs {
+		data, err := proto.Marshal(msg)
+		if err != nil {
+			return nil, err
+		}
+		buf = protowire.AppendVarint(buf, uint64(len(data)))
+		buf = append(buf, data...)
+	}
+	return buf, nil
+}
+
+// UnmarshalLengthDelimited decodes a varint-length-delimited byte buffer into
+// a slice of proto messages.
+func UnmarshalLengthDelimited[T proto.Message](buf []byte) ([]T, error) {
+	var msgs []T
+	for len(buf) > 0 {
+		size, n := protowire.ConsumeVarint(buf)
+		if n < 0 {
+			return nil, fmt.Errorf("invalid varint in length-delimited stream")
+		}
+		buf = buf[n:]
+		if uint64(len(buf)) < size {
+			return nil, fmt.Errorf("truncated message: need %d bytes, have %d", size, len(buf))
+		}
+		msg := newProtoMessage[T]()
+		if err := proto.Unmarshal(buf[:size], msg); err != nil {
+			return nil, err
+		}
+		msgs = append(msgs, msg)
+		buf = buf[size:]
+	}
+	return msgs, nil
+}
+
+func newProtoMessage[T proto.Message]() T {
+	var zero T
+	t := reflect.TypeOf(zero)
+	if t.Kind() == reflect.Pointer {
+		return reflect.New(t.Elem()).Interface().(T)
+	}
+	return zero
+}

--- a/pkg/protoutil/delim.go
+++ b/pkg/protoutil/delim.go
@@ -1,17 +1,15 @@
 package protoutil
 
 import (
-	"bufio"
 	"bytes"
-	"fmt"
 	"reflect"
 
+	"google.golang.org/protobuf/encoding/protodelim"
 	"google.golang.org/protobuf/encoding/protojson"
-	"google.golang.org/protobuf/encoding/protowire"
 	"google.golang.org/protobuf/proto"
 )
 
-func MarshalLenghDelimitedProtojson[T proto.Message](msgs []T) ([]byte, error) {
+func MarshalNewLineDelimitedProtoJSON[T proto.Message](msgs []T) ([]byte, error) {
 	var buf []byte
 	opts := protojson.MarshalOptions{
 		Multiline:         false,
@@ -23,21 +21,25 @@ func MarshalLenghDelimitedProtojson[T proto.Message](msgs []T) ([]byte, error) {
 		EmitDefaultValues: true,
 	}
 	for _, msg := range msgs {
-		data, err := opts.Marshal(msg)
+		var err error
+		buf, err = opts.MarshalAppend(buf, msg)
 		if err != nil {
 			return nil, err
 		}
-		buf = append(buf, data...)
-		buf = append(buf, []byte("\n")...)
+		buf = append(buf, '\n')
 	}
 	return buf, nil
 }
 
-func UnmarshalLengthDelimitedProtojson[T proto.Message](data []byte) ([]T, error) {
-	s := bufio.NewScanner(bytes.NewReader(data))
+func UnmarshalNewLineDelimitedProtoJSON[T proto.Message](data []byte) ([]T, error) {
 	var msgs []T
-	for s.Scan() {
-		line := s.Bytes()
+	for len(data) > 0 {
+		var line []byte
+		if before, after, ok := bytes.Cut(data, []byte{'\n'}); ok {
+			line, data = before, after
+		} else {
+			line, data = data, nil
+		}
 		if len(bytes.TrimSpace(line)) == 0 {
 			continue
 		}
@@ -53,37 +55,26 @@ func UnmarshalLengthDelimitedProtojson[T proto.Message](data []byte) ([]T, error
 // MarshalLengthDelimited encodes a slice of proto messages into a single byte
 // buffer using varint-length-delimited framing.
 func MarshalLengthDelimited[T proto.Message](msgs []T) ([]byte, error) {
-	var buf []byte
+	var w bytes.Buffer
 	for _, msg := range msgs {
-		data, err := proto.Marshal(msg)
-		if err != nil {
+		if _, err := protodelim.MarshalTo(&w, msg); err != nil {
 			return nil, err
 		}
-		buf = protowire.AppendVarint(buf, uint64(len(data)))
-		buf = append(buf, data...)
 	}
-	return buf, nil
+	return w.Bytes(), nil
 }
 
 // UnmarshalLengthDelimited decodes a varint-length-delimited byte buffer into
 // a slice of proto messages.
 func UnmarshalLengthDelimited[T proto.Message](buf []byte) ([]T, error) {
 	var msgs []T
-	for len(buf) > 0 {
-		size, n := protowire.ConsumeVarint(buf)
-		if n < 0 {
-			return nil, fmt.Errorf("invalid varint in length-delimited stream")
-		}
-		buf = buf[n:]
-		if uint64(len(buf)) < size {
-			return nil, fmt.Errorf("truncated message: need %d bytes, have %d", size, len(buf))
-		}
+	r := bytes.NewReader(buf)
+	for r.Len() > 0 {
 		msg := newProtoMessage[T]()
-		if err := proto.Unmarshal(buf[:size], msg); err != nil {
+		if err := protodelim.UnmarshalFrom(r, msg); err != nil {
 			return nil, err
 		}
 		msgs = append(msgs, msg)
-		buf = buf[size:]
 	}
 	return msgs, nil
 }

--- a/pkg/protoutil/delim_test.go
+++ b/pkg/protoutil/delim_test.go
@@ -2,6 +2,7 @@ package protoutil_test
 
 import (
 	"testing"
+	_ "unsafe"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,16 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/testproto"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
+
+//go:linkname protobufRandSeed google.golang.org/protobuf/internal/detrand.randSeed
+var protobufRandSeed int
+
+// Forces the protojson format to be encoded in stable manner for testing:
+//
+//	https://github.com/golang/protobuf/issues/1121
+func init() {
+	protobufRandSeed = 0
+}
 
 func TestProtoDelim(t *testing.T) {
 	msgs := []*testproto.Test{
@@ -27,7 +38,6 @@ func TestProtoDelim(t *testing.T) {
 			},
 		},
 	}
-
 	data, err := protoutil.MarshalLengthDelimited(msgs)
 	require.NoError(t, err)
 
@@ -52,15 +62,16 @@ func TestProtoJSON(t *testing.T) {
 		},
 	}
 
-	data, err := protoutil.MarshalLenghDelimitedProtojson(msgs)
+	data, err := protoutil.MarshalNewLineDelimitedProtoJSON(msgs)
 	require.NoError(t, err)
+
+	retmsgs, err := protoutil.UnmarshalNewLineDelimitedProtoJSON[*testproto.Test](data)
+	require.NoError(t, err)
+	assert.Empty(t, cmp.Diff(msgs, retmsgs, protocmp.Transform()))
+
 	// should look like ndjson
 	assert.Equal(t, string(data),
 		`{"string_field":"foo","proto_field":{"another_string_field":"bar"}}
 {"string_field":"bar","proto_field":{"another_string_field":"foo"}}
 `)
-
-	retmsgs, err := protoutil.UnmarshalLengthDelimitedProtojson[*testproto.Test](data)
-	require.NoError(t, err)
-	assert.Empty(t, cmp.Diff(msgs, retmsgs, protocmp.Transform()))
 }

--- a/pkg/protoutil/delim_test.go
+++ b/pkg/protoutil/delim_test.go
@@ -1,0 +1,66 @@
+package protoutil_test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/pomerium/pomerium/pkg/grpc/testproto"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+func TestProtoDelim(t *testing.T) {
+	msgs := []*testproto.Test{
+		{
+			StringField: "foo",
+			ProtoField: &testproto.EmbeddedMessage{
+				AnotherStringField: "bar",
+			},
+		},
+		{
+			StringField: "bar",
+			ProtoField: &testproto.EmbeddedMessage{
+				AnotherStringField: "foo",
+			},
+		},
+	}
+
+	data, err := protoutil.MarshalLengthDelimited(msgs)
+	require.NoError(t, err)
+
+	retmsgs, err := protoutil.UnmarshalLengthDelimited[*testproto.Test](data)
+	require.NoError(t, err)
+	assert.Empty(t, cmp.Diff(msgs, retmsgs, protocmp.Transform()))
+}
+
+func TestProtoJSON(t *testing.T) {
+	msgs := []*testproto.Test{
+		{
+			StringField: "foo",
+			ProtoField: &testproto.EmbeddedMessage{
+				AnotherStringField: "bar",
+			},
+		},
+		{
+			StringField: "bar",
+			ProtoField: &testproto.EmbeddedMessage{
+				AnotherStringField: "foo",
+			},
+		},
+	}
+
+	data, err := protoutil.MarshalLenghDelimitedProtojson(msgs)
+	require.NoError(t, err)
+	// should look like ndjson
+	assert.Equal(t, string(data),
+		`{"string_field":"foo","proto_field":{"another_string_field":"bar"}}
+{"string_field":"bar","proto_field":{"another_string_field":"foo"}}
+`)
+
+	retmsgs, err := protoutil.UnmarshalLengthDelimitedProtojson[*testproto.Test](data)
+	require.NoError(t, err)
+	assert.Empty(t, cmp.Diff(msgs, retmsgs, protocmp.Transform()))
+}

--- a/pkg/storage/blob/chunk.go
+++ b/pkg/storage/blob/chunk.go
@@ -9,6 +9,7 @@ import (
 	"iter"
 	"path"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -102,7 +103,7 @@ type manifestInfo struct {
 // in WORM buckets a crash between writing chunks and persisting the manifest
 // would leave chunks that the manifest doesn't know about.
 func (c *chunkWriter) loadManifest(ctx context.Context) error {
-	prefix := c.schema.ObjectPath() + "/"
+	prefix := c.schema.ObjectDir() + "/recording_"
 	iter := c.bucket.List(&blob.ListOptions{
 		Prefix: prefix,
 	})
@@ -122,10 +123,9 @@ func (c *chunkWriter) loadManifest(ctx context.Context) error {
 			continue
 		}
 
-		// Only consider objects whose basename parses as a chunk ID integer.
-		// This skips manifest, signature, and any other non-chunk objects.
 		base := path.Base(obj.Key)
-		id, err := strconv.Atoi(base)
+		idStr := strings.TrimSuffix(strings.TrimPrefix(base, "recording_"), ".json")
+		id, err := strconv.Atoi(idStr)
 		if err != nil {
 			continue
 		}

--- a/pkg/storage/blob/chunk_test.go
+++ b/pkg/storage/blob/chunk_test.go
@@ -199,10 +199,10 @@ func testChunkReaderWriterConformance(t *testing.T,
 			assert.Equal(t, blob.ContentTypeJSON, jsonMdAttrs.ContentType, "metadata json content type")
 
 			for i := range 3 {
-				chunkPath := schema.ObjectPath() + "/" + fmt.Sprintf("%010d", i)
+				chunkPath := schema.ObjectDir() + "/recording_" + fmt.Sprintf("%010d", i) + ".json"
 				chunkAttrs, err := bk.Attributes(ctx, chunkPath)
 				require.NoError(t, err)
-				assert.Equal(t, blob.ContentTypeProtobuf, chunkAttrs.ContentType, "chunk %d content type", i)
+				assert.Equal(t, blob.ContentTypeProtojson, chunkAttrs.ContentType, "chunk %d content type", i)
 			}
 
 			manifestPath, expectedManifestCT := schema.ManifestPath()

--- a/pkg/storage/blob/schema.go
+++ b/pkg/storage/blob/schema.go
@@ -8,10 +8,19 @@ import (
 )
 
 const (
-	ContentTypeJSON     = "application/json"
-	ContentTypeProtobuf = "application/protobuf"
+	ContentTypeJSON      = "application/json"
+	ContentTypeProtobuf  = "application/protobuf"
+	ContentTypeProtojson = "application/json+protobuf"
 )
 
+// SchemaV1 constructs a filepath structure like:
+//
+//	<cluster-id>/<recording-type>/<version>/<key>
+//	|-- metadata.json
+//	|-- metadata.proto
+//	|-- manifest
+//	|-- recording_0000000000.json
+//	|-- recording_XXXXXXXXXX.json
 type SchemaV1 struct {
 	RecordingType string
 	ClusterID     string
@@ -19,7 +28,7 @@ type SchemaV1 struct {
 
 func (c SchemaV1) ListMiddleware() middleware.ListMiddleware {
 	return func(op *middleware.ListOp) error {
-		op.Opts.Prefix = c.BasePath() + Separator
+		op.Opts.Prefix = c.basePath() + Separator
 		op.Opts.Delimiter = Separator
 		return nil
 	}
@@ -35,32 +44,32 @@ func AsIDStr(cID chunkID) string {
 	return fmt.Sprintf("%010d", cID)
 }
 
-func (c SchemaV1) BasePath() string {
-	return path.Join(c.ClusterID, c.RecordingType)
+func (c SchemaV1) basePath() string {
+	return path.Join(c.ClusterID, c.RecordingType, "v1")
 }
 
-func (c SchemaV1) ObjectPath(key string) string {
-	return path.Join(c.BasePath(), key)
+func (c SchemaV1) ObjectDir(key string) string {
+	return path.Join(c.basePath(), key)
 }
 
 func (c SchemaV1) MetadataJSON(key string) (fullPath string, contentType string) {
-	return path.Join(c.BasePath(), key+".json"), ContentTypeJSON
+	return path.Join(c.ObjectDir(key), "metadata.json"), ContentTypeJSON
 }
 
 func (c SchemaV1) MetadataPath(key string) (fullPath string, contentType string) {
-	return path.Join(c.BasePath(), key+".proto"), ContentTypeProtobuf
+	return path.Join(c.ObjectDir(key), "metadata.proto"), ContentTypeProtobuf
 }
 
 func (c SchemaV1) ManifestPath(key string) (fullPath string, contentType string) {
-	return path.Join(c.BasePath(), key, "manifest"), ContentTypeProtobuf
+	return path.Join(c.ObjectDir(key), "manifest"), ContentTypeProtobuf
 }
 
 func (c SchemaV1) SignaturePath(key string) (fullPath string, contentType string) {
-	return path.Join(c.BasePath(), key+".sig"), ContentTypeProtobuf
+	return path.Join(c.basePath(), key+".sig"), ContentTypeProtobuf
 }
 
 func (c SchemaV1) ChunkPath(key string, id chunkID) (fullPath string, contentType string) {
-	return path.Join(c.BasePath(), key, AsIDStr(id)), ContentTypeProtobuf
+	return path.Join(c.ObjectDir(key), "recording_"+AsIDStr(id)+".json"), ContentTypeProtojson
 }
 
 func (c SchemaV1) Validate() error {
@@ -100,8 +109,8 @@ func (c SchemaV1WithKey) MetadataJSON() (fullPath string, contentType string) {
 	return c.SchemaV1.MetadataJSON(c.Key)
 }
 
-func (c SchemaV1WithKey) ObjectPath() string {
-	return c.SchemaV1.ObjectPath(c.Key)
+func (c SchemaV1WithKey) ObjectDir() string {
+	return path.Join(c.SchemaV1.ObjectDir(c.Key))
 }
 
 func (c SchemaV1WithKey) ManifestPath() (fullPath string, contentType string) {

--- a/pkg/storage/blob/schema_test.go
+++ b/pkg/storage/blob/schema_test.go
@@ -9,16 +9,10 @@ import (
 	"github.com/pomerium/pomerium/pkg/storage/blob"
 )
 
-func TestSchemaV1_BasePath(t *testing.T) {
-	t.Parallel()
-	s := blob.SchemaV1{ClusterID: "cluster-1", RecordingType: "ssh"}
-	assert.Equal(t, "cluster-1/ssh", s.BasePath())
-}
-
 func TestSchemaV1_ObjectPath(t *testing.T) {
 	t.Parallel()
 	s := blob.SchemaV1{ClusterID: "c1", RecordingType: "ssh"}
-	assert.Equal(t, "c1/ssh/rec-42", s.ObjectPath("rec-42"))
+	assert.Equal(t, "c1/ssh/v1/rec-42", s.ObjectDir("rec-42"))
 }
 
 func TestSchemaV1_MetadataPath(t *testing.T) {
@@ -26,7 +20,7 @@ func TestSchemaV1_MetadataPath(t *testing.T) {
 	s := blob.SchemaV1{ClusterID: "c1", RecordingType: "ssh"}
 
 	p, ct := s.MetadataPath("rec-1")
-	assert.Equal(t, "c1/ssh/rec-1.proto", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1/metadata.proto", p)
 	assert.Equal(t, blob.ContentTypeProtobuf, ct)
 }
 
@@ -35,7 +29,7 @@ func TestSchemaV1_MetadataJSON(t *testing.T) {
 	s := blob.SchemaV1{ClusterID: "c1", RecordingType: "ssh"}
 
 	p, ct := s.MetadataJSON("rec-1")
-	assert.Equal(t, "c1/ssh/rec-1.json", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1/metadata.json", p)
 	assert.Equal(t, blob.ContentTypeJSON, ct)
 }
 
@@ -44,7 +38,7 @@ func TestSchemaV1_ManifestPath(t *testing.T) {
 	s := blob.SchemaV1{ClusterID: "c1", RecordingType: "ssh"}
 
 	p, ct := s.ManifestPath("rec-1")
-	assert.Equal(t, "c1/ssh/rec-1/manifest", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1/manifest", p)
 	assert.Equal(t, blob.ContentTypeProtobuf, ct)
 }
 
@@ -53,7 +47,7 @@ func TestSchemaV1_SignaturePath(t *testing.T) {
 	s := blob.SchemaV1{ClusterID: "c1", RecordingType: "ssh"}
 
 	p, ct := s.SignaturePath("rec-1")
-	assert.Equal(t, "c1/ssh/rec-1.sig", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1.sig", p)
 	assert.Equal(t, blob.ContentTypeProtobuf, ct)
 }
 
@@ -62,11 +56,11 @@ func TestSchemaV1_ChunkPath(t *testing.T) {
 	s := blob.SchemaV1{ClusterID: "c1", RecordingType: "ssh"}
 
 	p, ct := s.ChunkPath("rec-1", 0)
-	assert.Equal(t, "c1/ssh/rec-1/0000000000", p)
-	assert.Equal(t, blob.ContentTypeProtobuf, ct)
+	assert.Equal(t, "c1/ssh/v1/rec-1/recording_0000000000.json", p)
+	assert.Equal(t, blob.ContentTypeProtojson, ct)
 
 	p, _ = s.ChunkPath("rec-1", 42)
-	assert.Equal(t, "c1/ssh/rec-1/0000000042", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1/recording_0000000042.json", p)
 }
 
 func TestAsIDStr(t *testing.T) {
@@ -82,36 +76,25 @@ func TestSchemaV1WithKey(t *testing.T) {
 	base := blob.SchemaV1{ClusterID: "c1", RecordingType: "ssh"}
 	s := blob.NewSchemaV1WithKey(base, "rec-1")
 
-	assert.Equal(t, "c1/ssh/rec-1", s.ObjectPath())
+	assert.Equal(t, "c1/ssh/v1/rec-1", s.ObjectDir())
 
 	p, ct := s.MetadataPath()
-	assert.Equal(t, "c1/ssh/rec-1.proto", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1/metadata.proto", p)
 	assert.Equal(t, blob.ContentTypeProtobuf, ct)
 
 	p, ct = s.MetadataJSON()
-	assert.Equal(t, "c1/ssh/rec-1.json", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1/metadata.json", p)
 	assert.Equal(t, blob.ContentTypeJSON, ct)
 
 	p, ct = s.ManifestPath()
-	assert.Equal(t, "c1/ssh/rec-1/manifest", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1/manifest", p)
 	assert.Equal(t, blob.ContentTypeProtobuf, ct)
 
 	p, ct = s.SignaturePath()
-	assert.Equal(t, "c1/ssh/rec-1.sig", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1.sig", p)
 	assert.Equal(t, blob.ContentTypeProtobuf, ct)
 
 	p, ct = s.ChunkPath(5)
-	assert.Equal(t, "c1/ssh/rec-1/0000000005", p)
-	assert.Equal(t, blob.ContentTypeProtobuf, ct)
-}
-
-func TestSchemaV1_EmptyFields(t *testing.T) {
-	t.Parallel()
-	s := blob.SchemaV1{}
-
-	assert.Equal(t, "", s.BasePath())
-	assert.Equal(t, "key", s.ObjectPath("key"))
-
-	p, _ := s.ChunkPath("key", 0)
-	assert.Equal(t, "key/0000000000", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1/recording_0000000005.json", p)
+	assert.Equal(t, blob.ContentTypeProtojson, ct)
 }

--- a/pkg/storage/blob/util.go
+++ b/pkg/storage/blob/util.go
@@ -86,11 +86,10 @@ func IterateRecordingIDs(
 			}
 			log.Ctx(op.Ctx).Trace().Str("key", obj.Key).Msg("listing objects")
 
-			before, ok := strings.CutSuffix(obj.Key, ".proto")
-			if !ok {
+			if !obj.IsDir {
 				continue
 			}
-			recordingID := path.Base(before)
+			recordingID := path.Base(strings.TrimSuffix(obj.Key, Separator))
 			if recordingID == "" {
 				continue
 			}


### PR DESCRIPTION
## Summary

- Adds a missing version prefix for the schema. 

- Collapses root level metadata/sig/manifest into the object_dir to reduce the number of objects that needed to be listed & makes the objects stored more human readable.

new schema looks like:
```
	<cluster-id>/<recording-type>/<version>/<key>
	|-- metadata.json
	|-- metadata.proto
	|-- manifest
	|-- recording_0000000000.json
	|-- recording_XXXXXXXXXX.json
```

- Adds helpers to protoutil package for marshalling and unmarshalling arrays of protobuf / protojson arrays. These used to be defined in pomerium-console, but make more sense in core for some upcoming work.

## Related issues

Pre-cursor to [ENG-3848](https://linear.app/pomerium/issue/ENG-3848/session-recordings-contents-need-to-be-searchable-indexable-by-storage).

We'll probably want to rewrite in https://github.com/pomerium/pomerium/pull/6283 proto-delimited arrays to protojson delimited arrays

## User Explanation

N/A

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] ready for review
