### PR TITLE
config/envoyconfig: disable route timeouts on MCP server routes

### DIFF
--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -622,7 +622,8 @@ func shouldDisableStreamIdleTimeout(options *config.Options, policy *config.Poli
 	return policy.GetAllowWebsockets(options) ||
 		policy.IsTCP() ||
 		policy.IsUDP() ||
-		policy.IsForKubernetes() // disable for kubernetes so that tailing logs works (#2182)
+		policy.IsForKubernetes() || // disable for kubernetes so that tailing logs works (#2182)
+		policy.IsMCPServer() // MCP Streamable-HTTP uses long-lived SSE streams that must not be cut
 }
 
 func getRewriteOptions(policy *config.Policy) (prefixRewrite string, regexRewrite *envoy_type_matcher_v3.RegexMatchAndSubstitute) {

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -254,21 +254,21 @@ func TestTimeouts(t *testing.T) {
 		mcpServer       bool
 		expect          string
 	}{
-		{"", "", false, false, `"timeout": "3s"`},
-		{"", "", true, false, `"timeout": "0s", "idleTimeout": "0s"`},
-		{"5s", "", true, false, `"timeout": "5s", "idleTimeout": "0s"`},
-		{"", "0s", false, false, `"timeout": "3s","idleTimeout": "0s"`},
-		{"", "5s", false, false, `"timeout": "3s","idleTimeout": "5s"`},
-		{"5s", "", false, false, `"timeout": "5s"`},
-		{"5s", "4s", false, false, `"timeout": "5s","idleTimeout": "4s"`},
-		{"0s", "4s", false, false, `"timeout": "0s","idleTimeout": "4s"`},
-		// MCP server routes: disable Envoy's route timeout and idle timeout by
-		// default so long-lived Streamable-HTTP SSE streams aren't cut.
-		{"", "", false, true, `"timeout": "0s", "idleTimeout": "0s"`},
+		{expect: `"timeout": "3s"`},
+		{allowWebsockets: true, expect: `"timeout": "0s", "idleTimeout": "0s"`},
+		{upstream: "5s", allowWebsockets: true, expect: `"timeout": "5s", "idleTimeout": "0s"`},
+		{idle: "0s", expect: `"timeout": "3s","idleTimeout": "0s"`},
+		{idle: "5s", expect: `"timeout": "3s","idleTimeout": "5s"`},
+		{upstream: "5s", expect: `"timeout": "5s"`},
+		{upstream: "5s", idle: "4s", expect: `"timeout": "5s","idleTimeout": "4s"`},
+		{upstream: "0s", idle: "4s", expect: `"timeout": "0s","idleTimeout": "4s"`},
+		// MCP server routes disable Envoy's route and idle timeouts by default
+		// so long-lived Streamable-HTTP SSE streams aren't cut.
+		{mcpServer: true, expect: `"timeout": "0s", "idleTimeout": "0s"`},
 		// operator-set timeout / idleTimeout still override the MCP defaults.
-		{"5s", "", false, true, `"timeout": "5s", "idleTimeout": "0s"`},
-		{"", "5s", false, true, `"timeout": "0s", "idleTimeout": "5s"`},
-		{"10s", "20s", false, true, `"timeout": "10s", "idleTimeout": "20s"`},
+		{upstream: "5s", mcpServer: true, expect: `"timeout": "5s", "idleTimeout": "0s"`},
+		{idle: "5s", mcpServer: true, expect: `"timeout": "0s", "idleTimeout": "5s"`},
+		{upstream: "10s", idle: "20s", mcpServer: true, expect: `"timeout": "10s", "idleTimeout": "20s"`},
 	}
 
 	for _, tc := range testCases {

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -251,34 +251,44 @@ func TestTimeouts(t *testing.T) {
 	testCases := []struct {
 		upstream, idle  string
 		allowWebsockets bool
+		mcpServer       bool
 		expect          string
 	}{
-		{"", "", false, `"timeout": "3s"`},
-		{"", "", true, `"timeout": "0s", "idleTimeout": "0s"`},
-		{"5s", "", true, `"timeout": "5s", "idleTimeout": "0s"`},
-		{"", "0s", false, `"timeout": "3s","idleTimeout": "0s"`},
-		{"", "5s", false, `"timeout": "3s","idleTimeout": "5s"`},
-		{"5s", "", false, `"timeout": "5s"`},
-		{"5s", "4s", false, `"timeout": "5s","idleTimeout": "4s"`},
-		{"0s", "4s", false, `"timeout": "0s","idleTimeout": "4s"`},
+		{"", "", false, false, `"timeout": "3s"`},
+		{"", "", true, false, `"timeout": "0s", "idleTimeout": "0s"`},
+		{"5s", "", true, false, `"timeout": "5s", "idleTimeout": "0s"`},
+		{"", "0s", false, false, `"timeout": "3s","idleTimeout": "0s"`},
+		{"", "5s", false, false, `"timeout": "3s","idleTimeout": "5s"`},
+		{"5s", "", false, false, `"timeout": "5s"`},
+		{"5s", "4s", false, false, `"timeout": "5s","idleTimeout": "4s"`},
+		{"0s", "4s", false, false, `"timeout": "0s","idleTimeout": "4s"`},
+		// MCP server routes: disable Envoy's route timeout and idle timeout by
+		// default so long-lived Streamable-HTTP SSE streams aren't cut.
+		{"", "", false, true, `"timeout": "0s", "idleTimeout": "0s"`},
+		// operator-set timeout / idleTimeout still override the MCP defaults.
+		{"5s", "", false, true, `"timeout": "5s", "idleTimeout": "0s"`},
+		{"", "5s", false, true, `"timeout": "0s", "idleTimeout": "5s"`},
+		{"10s", "20s", false, true, `"timeout": "10s", "idleTimeout": "20s"`},
 	}
 
 	for _, tc := range testCases {
 		b := &Builder{filemgr: filemgr.NewManager()}
+		policy := config.Policy{
+			From:            "https://example.com",
+			To:              mustParseWeightedURLs(t, "https://to.example.com"),
+			Path:            "/test",
+			UpstreamTimeout: getDuration(tc.upstream),
+			IdleTimeout:     getDuration(tc.idle),
+			AllowWebsockets: tc.allowWebsockets,
+		}
+		if tc.mcpServer {
+			policy.MCP = &config.MCP{Server: &config.MCPServer{}}
+		}
 		routes, err := b.buildRoutesForPoliciesWithHost(&config.Config{Options: &config.Options{
 			CookieName:             "pomerium",
 			DefaultUpstreamTimeout: time.Second * 3,
 			SharedKey:              cryptutil.NewBase64Key(),
-			Policies: []config.Policy{
-				{
-					From:            "https://example.com",
-					To:              mustParseWeightedURLs(t, "https://to.example.com"),
-					Path:            "/test",
-					UpstreamTimeout: getDuration(tc.upstream),
-					IdleTimeout:     getDuration(tc.idle),
-					AllowWebsockets: tc.allowWebsockets,
-				},
-			},
+			Policies:               []config.Policy{policy},
 		}}, "example.com")
 		if !assert.NoError(t, err, "%v", tc) || !assert.Len(t, routes, 1, tc) || !assert.NotNil(t, routes[0].GetRoute(), "%v", tc) {
 			continue
@@ -308,7 +318,7 @@ func TestTimeouts(t *testing.T) {
 				{ "enabled": false, "upgradeType": "spdy/3.1"}
 			]
 		}`, tc.expect, tc.allowWebsockets)
-		testutil.AssertProtoJSONEqual(t, expect, routes[0].GetRoute())
+		testutil.AssertProtoJSONEqual(t, expect, routes[0].GetRoute(), "%v", tc)
 	}
 }
 


### PR DESCRIPTION
## Summary

Two Envoy timers currently cut long-lived MCP Streamable-HTTP SSE streams mid-session. The route timeout puts a 30-second wall-clock ceiling on the entire response, so any tool call that runs longer is killed. The HCM stream_idle_timeout defaults to 5 minutes, so any stream that goes quiet for five minutes is reset, even if the call is legitimately still in flight.

Disable both timers for MCP server routes by default, matching the existing handling for websocket, TCP, UDP, and Kubernetes routes. An operator-set timeout or idleTimeout on the route still overrides the defaults, so anyone who does want a shorter ceiling on an MCP route can set one.

## Related issues

[ENG-3936](https://linear.app/pomerium/issue/ENG-3936/mcp-server-routes-let-envoy-cut-sse-streams-route-timeout-hcm-stream)

## User Explanation

MCP server routes can now carry long-lived SSE streams without the proxy cutting them. Tool calls that run longer than 30 seconds, and streams that go quiet for more than 5 minutes, no longer cause Envoy to reset the connection. Operators who want a shorter ceiling on a specific MCP route can still set ``timeout`` or ``idleTimeout`` on it.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (``bug``)
- [ ] ready for review