### PR TITLE
core/envoyconfig: change the error code for ext_authz errors from 500 to 503

### DIFF
--- a/config/envoyconfig/filters.go
+++ b/config/envoyconfig/filters.go
@@ -25,7 +25,7 @@ func ExtAuthzFilter(grpcClientTimeout *durationpb.Duration) *envoy_extensions_fi
 		ConfigType: &envoy_extensions_filters_network_http_connection_manager.HttpFilter_TypedConfig{
 			TypedConfig: protoutil.NewAny(&envoy_extensions_filters_http_ext_authz_v3.ExtAuthz{
 				StatusOnError: &envoy_type_v3.HttpStatus{
-					Code: envoy_type_v3.StatusCode_InternalServerError,
+					Code: envoy_type_v3.StatusCode_ServiceUnavailable,
 				},
 				Services: &envoy_extensions_filters_http_ext_authz_v3.ExtAuthz_GrpcService{
 					GrpcService: &envoy_config_core_v3.GrpcService{

--- a/config/envoyconfig/testdata/main_http_connection_manager_filter.json
+++ b/config/envoyconfig/testdata/main_http_connection_manager_filter.json
@@ -80,7 +80,7 @@
           },
           "transportApiVersion": "V3",
           "statusOnError": {
-            "code": "InternalServerError"
+            "code": "ServiceUnavailable"
           },
           "metadataContextNamespaces": ["com.pomerium.client-certificate-info"]
         }
@@ -99,9 +99,7 @@
           "messageTimeout": "10s",
           "metadataOptions": {
             "forwardingNamespaces": {
-              "untyped": [
-                "envoy.filters.http.ext_authz"
-              ]
+              "untyped": ["envoy.filters.http.ext_authz"]
             }
           }
         }


### PR DESCRIPTION
## Summary
Currently if ext_authz fails we return a `500` error. This PR updates the returned status code to be a `503` error instead.

## Related issues
- [ENG-3833](https://linear.app/pomerium/issue/ENG-3833/core-back-pressure-mechanism-for-high-throughput-grpc-return-retriable)


## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
