### PR TITLE
core/session: remove exp and nbf

### DIFF
--- a/pkg/grpc/session/handle.go
+++ b/pkg/grpc/session/handle.go
@@ -33,12 +33,6 @@ func (x *Handle) MarshalJSON() ([]byte, error) {
 	if len(x.Aud) > 0 {
 		m["aud"] = x.Aud
 	}
-	if x.Exp != nil {
-		m["exp"] = jwt.NewNumericDate(x.Exp.AsTime())
-	}
-	if x.Nbf != nil {
-		m["nbf"] = jwt.NewNumericDate(x.Nbf.AsTime())
-	}
 	if x.Iat != nil {
 		m["iat"] = jwt.NewNumericDate(x.Iat.AsTime())
 	}
@@ -66,13 +60,11 @@ func (x *Handle) UnmarshalJSON(data []byte) error {
 	var claims struct {
 		// standard claims
 
-		Issuer    null.String      `json:"iss,omitzero"`
-		Subject   null.String      `json:"sub,omitzero"`
-		Audience  jwt.Audience     `json:"aud,omitzero"`
-		Expiry    *jwt.NumericDate `json:"exp,omitzero"`
-		NotBefore *jwt.NumericDate `json:"nbf,omitzero"`
-		IssuedAt  *jwt.NumericDate `json:"iat,omitzero"`
-		JTI       null.String      `json:"jti,omitzero"`
+		Issuer   null.String      `json:"iss,omitzero"`
+		Subject  null.String      `json:"sub,omitzero"`
+		Audience jwt.Audience     `json:"aud,omitzero"`
+		IssuedAt *jwt.NumericDate `json:"iat,omitzero"`
+		JTI      null.String      `json:"jti,omitzero"`
 
 		// special claims
 
@@ -98,12 +90,6 @@ func (x *Handle) UnmarshalJSON(data []byte) error {
 	}
 	if len(claims.Audience) > 0 {
 		x.Aud = claims.Audience
-	}
-	if claims.Expiry != nil {
-		x.Exp = timestamppb.New(claims.Expiry.Time())
-	}
-	if claims.NotBefore != nil {
-		x.Nbf = timestamppb.New(claims.NotBefore.Time())
 	}
 	if claims.IssuedAt != nil {
 		x.Iat = timestamppb.New(claims.IssuedAt.Time())

--- a/pkg/grpc/session/handle_test.go
+++ b/pkg/grpc/session/handle_test.go
@@ -26,8 +26,6 @@ func TestHandle(t *testing.T) {
 		"databroker_record_version": 10001,
 		"iss": "ISSUER",
 		"aud": ["AUDIENCE1","AUDIENCE2"],
-		"exp": 1500000000,
-		"nbf": 1600000000,
 		"iat": 1700000000
 	}`), &h))
 	assert.Empty(t, cmp.Diff(&session.Handle{
@@ -38,8 +36,6 @@ func TestHandle(t *testing.T) {
 		DatabrokerRecordVersion: proto.Uint64(10001),
 		Iss:                     new("ISSUER"),
 		Aud:                     []string{"AUDIENCE1", "AUDIENCE2"},
-		Exp:                     timestamppb.New(time.Unix(1500000000, 0)),
-		Nbf:                     timestamppb.New(time.Unix(1600000000, 0)),
 		Iat:                     timestamppb.New(time.Unix(1700000000, 0)),
 	}, &h, protocmp.Transform()))
 
@@ -59,8 +55,6 @@ func TestHandle(t *testing.T) {
 		"databroker_record_version": 10001,
 		"iss": "ISSUER",
 		"aud": ["AUDIENCE1","AUDIENCE2"],
-		"exp": 1500000000,
-		"nbf": 1600000000,
 		"iat": 1700000000
 	}`, string(bs))
 }


### PR DESCRIPTION
## Summary
Remove the session handle `exp` and `nbf` fields. These were not previously defined for the session state stored in cookies, and including them seems to cause issues: https://github.com/pomerium/pomerium/blob/0-31-0/internal/sessions/state.go#L19.

## Related issues
- #6304 


## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
