### PR TITLE
mcp: strip default ports when comparing PRM resource to upstream URL

### DIFF
--- a/internal/mcp/upstream_oauth_setup.go
+++ b/internal/mcp/upstream_oauth_setup.go
@@ -321,7 +321,8 @@ func runDiscovery(
 	return nil, fmt.Errorf("no protected resource metadata found")
 }
 
-// originOf extracts the scheme+host from a URL (e.g. "https://example.com/path" → "https://example.com").
+// originOf extracts the scheme+host from a URL (e.g. "https://example.com/path" → "https://example.com"),
+// stripping the scheme's default port per RFC 3986 §6.2.3.
 // Returns an error if the URL cannot be parsed or is missing scheme/host.
 func originOf(rawURL string) (string, error) {
 	if rawURL == "" {
@@ -334,7 +335,39 @@ func originOf(rawURL string) (string, error) {
 	if u.Scheme == "" || u.Host == "" {
 		return "", fmt.Errorf("URL %q missing scheme or host", rawURL)
 	}
-	return (&url.URL{Scheme: u.Scheme, Host: u.Host}).String(), nil
+	return (&url.URL{Scheme: u.Scheme, Host: canonicalHost(u.Scheme, u.Host)}).String(), nil
+}
+
+// canonicalHost returns the URL host with the scheme's default port stripped
+// (RFC 3986 §6.2.3): https://example.com:443 → example.com, http://example.com:80 → example.com.
+// Non-default ports are preserved. Case is preserved; callers needing
+// case-insensitive comparison should fold separately.
+func canonicalHost(scheme, host string) string {
+	defaultPort := defaultPortForScheme(scheme)
+	if defaultPort == "" {
+		return host
+	}
+	hostname, port, err := net.SplitHostPort(host)
+	if err != nil || port != defaultPort {
+		return host
+	}
+	if strings.Contains(hostname, ":") {
+		return "[" + hostname + "]"
+	}
+	return hostname
+}
+
+// defaultPortForScheme returns the well-known default port for a URL scheme,
+// or "" if the scheme has no default to strip.
+func defaultPortForScheme(scheme string) string {
+	switch strings.ToLower(scheme) {
+	case "https":
+		return "443"
+	case "http":
+		return "80"
+	default:
+		return ""
+	}
 }
 
 // runDiscoveryFromPRM completes discovery using a successfully fetched PRM document.
@@ -605,9 +638,11 @@ func checkResourceAllowed(upstreamServerURL, prmResource string) (bool, error) {
 		return false, fmt.Errorf("PRM resource %q missing scheme or host", prmResource)
 	}
 
-	// Same origin check (scheme + host, where host includes port).
-	// Use case-insensitive comparison per RFC 3986 §3.1 (scheme) and §3.2.2 (host).
-	if !strings.EqualFold(upstream.Scheme, resource.Scheme) || !strings.EqualFold(upstream.Host, resource.Host) {
+	// Same origin per RFC 3986 §3.1 (scheme), §3.2.2 (host), §6.2.3 (default port).
+	if !strings.EqualFold(upstream.Scheme, resource.Scheme) {
+		return false, nil
+	}
+	if !strings.EqualFold(canonicalHost(upstream.Scheme, upstream.Host), canonicalHost(resource.Scheme, resource.Host)) {
 		return false, nil
 	}
 

--- a/internal/mcp/upstream_oauth_setup_test.go
+++ b/internal/mcp/upstream_oauth_setup_test.go
@@ -1132,6 +1132,44 @@ func TestCheckResourceAllowed(t *testing.T) {
 			prmResource:       "https://example.com/path",
 			expectAllowed:     true,
 		},
+		{
+			// Regression for ENG-3963: ingress controller emits upstream URLs with
+			// an explicit :443 for ExternalName services; canonical PRM resources omit it.
+			name:              "https default port stripped from upstream",
+			upstreamServerURL: "https://mcp.example.com:443",
+			prmResource:       "https://mcp.example.com",
+			expectAllowed:     true,
+		},
+		{
+			name:              "https default port stripped from PRM resource",
+			upstreamServerURL: "https://mcp.example.com",
+			prmResource:       "https://mcp.example.com:443",
+			expectAllowed:     true,
+		},
+		{
+			name:              "https default port stripped on both sides with subpath",
+			upstreamServerURL: "https://mcp.example.com:443/mcp",
+			prmResource:       "https://mcp.example.com",
+			expectAllowed:     true,
+		},
+		{
+			name:              "http default port stripped",
+			upstreamServerURL: "http://mcp.example.com:80",
+			prmResource:       "http://mcp.example.com",
+			expectAllowed:     true,
+		},
+		{
+			name:              "non-default port still rejected against bare host",
+			upstreamServerURL: "https://mcp.example.com:8443",
+			prmResource:       "https://mcp.example.com",
+			expectAllowed:     false,
+		},
+		{
+			name:              "default port mismatched scheme rejected",
+			upstreamServerURL: "https://mcp.example.com:80",
+			prmResource:       "https://mcp.example.com",
+			expectAllowed:     false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -1144,6 +1182,36 @@ func TestCheckResourceAllowed(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, tt.expectAllowed, allowed)
 			}
+		})
+	}
+}
+
+func TestCanonicalHost(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		scheme   string
+		host     string
+		expected string
+	}{
+		{name: "https strips 443", scheme: "https", host: "example.com:443", expected: "example.com"},
+		{name: "http strips 80", scheme: "http", host: "example.com:80", expected: "example.com"},
+		{name: "https keeps non-default port", scheme: "https", host: "example.com:8443", expected: "example.com:8443"},
+		{name: "http keeps non-default port", scheme: "http", host: "example.com:8080", expected: "example.com:8080"},
+		{name: "https mismatched default port preserved", scheme: "https", host: "example.com:80", expected: "example.com:80"},
+		{name: "no port unchanged", scheme: "https", host: "example.com", expected: "example.com"},
+		{name: "uppercase scheme normalized", scheme: "HTTPS", host: "example.com:443", expected: "example.com"},
+		{name: "ipv6 default port stripped", scheme: "https", host: "[::1]:443", expected: "[::1]"},
+		{name: "ipv6 non-default port preserved", scheme: "https", host: "[::1]:8443", expected: "[::1]:8443"},
+		{name: "ipv6 with no port unchanged", scheme: "https", host: "[::1]", expected: "[::1]"},
+		{name: "unknown scheme leaves host alone", scheme: "ftp", host: "example.com:21", expected: "example.com:21"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			assert.Equal(t, tt.expected, canonicalHost(tt.scheme, tt.host))
 		})
 	}
 }


### PR DESCRIPTION
## Summary

When the ingress controller emits an upstream URL with an explicit `:443` (its standard form for ExternalName services), the PRM resource check fails origin equality against a canonical PRM resource that omits the port. As a result, every Kubernetes-routed MCP server backed by an HTTPS `ExternalName` service falls through to "no upstream OAuth" and returns 401.

Strip the scheme's default port (RFC 3986 §6.2.3) before comparing scheme+host in `checkResourceAllowed`, and apply the same canonicalization in `originOf` so the resource identifier used as the OAuth audience is canonical. Path-prefix matching handles the residual `mcp_server_path` case once the port mismatch is resolved.

## Related issues

- [ENG-3963](https://linear.app/pomerium/issue/ENG-3963/pomerium-mcp-prm-resource-check-fails-on-default-ports-every-https)

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (\`bug\`)
- [ ] ready for review