### PR TITLE
chore: rm dead mcp check in authz

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/contextutil"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
-	"github.com/pomerium/pomerium/pkg/policy/criteria"
 	"github.com/pomerium/pomerium/pkg/storage"
 	"github.com/pomerium/pomerium/pkg/telemetry/requestid"
 )
@@ -81,21 +80,6 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 	if s != nil {
 		req.Session.ID = s.GetId()
 		req.Session.UserID = s.GetUserId()
-	}
-
-	// For MCP routes that only require authentication (not full authorization),
-	// if we have a valid session, allow the request without running policy evaluation
-	// as policy for MCP may contain check for i.e. tool calls that are not relevant at this stage.
-	if mcpEnabled {
-		if req.Policy.IsMCPServer() && strings.HasPrefix(hreq.URL.Path, mcp.DefaultPrefix) {
-			if s != nil {
-				return a.requireLoginResponse(ctx, in, req)
-			}
-			a.logAuthorizeCheck(ctx, zerolog.InfoLevel, req, &evaluator.Result{
-				Allow: evaluator.NewRuleResult(true, criteria.ReasonMCPHandshake),
-			}, s)
-			return a.okResponse(req, make(http.Header), nil), nil
-		}
 	}
 
 	res, err := state.evaluator.Evaluate(ctx, req)

--- a/pkg/policy/criteria/reasons.go
+++ b/pkg/policy/criteria/reasons.go
@@ -28,7 +28,6 @@ const (
 	ReasonHTTPPathOK                    = "http-path-ok"
 	ReasonHTTPPathUnauthorized          = "http-path-unauthorized"
 	ReasonInvalidClientCertificate      = "invalid-client-certificate"
-	ReasonMCPHandshake                  = "mcp-handshake" // part of MCP protocol handshake
 	ReasonMCPToolMatch                  = "mcp-tool-match"
 	ReasonMCPNotAToolCall               = "mcp-not-a-tool-call" // MCP method is not a tool call
 	ReasonMCPToolNoMatch                = "mcp-tool-no-match"


### PR DESCRIPTION
## Summary

Remove dead branch for MCP authz:
- the non-tool call bypass was handled in https://github.com/pomerium/pomerium/pull/5857
- the `/.pomerium/mcp` access is handled in https://github.com/pomerium/pomerium/blob/34c023701ff0ca0405461916b505b5c600c27914/authorize/evaluator/evaluator.go#L345-L348

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] ready for review
