### PR TITLE
feat(upstream): add HTTP/3 (QUIC) support for upstream HTTPS connections

### DIFF
--- a/config/envoyconfig/bootstrap.go
+++ b/config/envoyconfig/bootstrap.go
@@ -184,6 +184,11 @@ func (b *Builder) BuildBootstrapLayeredRuntime(ctx context.Context, cfg *config.
 				"min_flush_spans": minFlushSpans,
 			},
 		},
+		"envoy": map[string]any{
+			"reloadable_features": map[string]any{
+				"http3_happy_eyeballs": true,
+			},
+		},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("envoyconfig: failed to create layered runtime layer: %w", err)
@@ -259,7 +264,7 @@ func (b *Builder) BuildBootstrapStaticResources(
 				},
 			},
 		},
-		TypedExtensionProtocolOptions: buildTypedExtensionProtocolOptions(nil, upstreamProtocolHTTP2, Keepalive(true)),
+		TypedExtensionProtocolOptions: buildTypedExtensionProtocolOptions(nil, upstreamProtocolHTTP2, Keepalive(true), false),
 		CircuitBreakers:               buildInternalCircuitBreakers(cfg),
 	}
 

--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -49,6 +49,11 @@ func TestBuilder_BuildBootstrapLayeredRuntime(t *testing.T) {
 						"warn_level": 1024
 					}
 				},
+				"envoy": {
+					"reloadable_features": {
+						"http3_happy_eyeballs": true
+					}
+				},
 				"tracing": {
 					"opentelemetry": {
 						"flush_interval_ms": 5000,

--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -177,7 +177,7 @@ func (b *Builder) buildInternalCluster(
 		endpoints = append(endpoints, NewEndpoint(dst, ts, 1))
 	}
 	if err := b.buildCluster(
-		cluster, name, endpoints, upstreamProtocol, cfg.Options.DNS, keepalive,
+		cluster, name, endpoints, upstreamProtocol, cfg.Options.DNS, keepalive, false,
 	); err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 	}
 
 	if err := b.buildCluster(
-		cluster, name, endpoints, upstreamProtocol, dnsOptions, Keepalive(false),
+		cluster, name, endpoints, upstreamProtocol, dnsOptions, Keepalive(false), cfg.Options.EnableHTTP3Upstream,
 	); err != nil {
 		return nil, err
 	}
@@ -428,6 +428,7 @@ func (b *Builder) buildCluster(
 	upstreamProtocol upstreamProtocolConfig,
 	dnsOptions config.DNSOptions,
 	keepalive Keepalive,
+	enableHTTP3Upstream bool,
 ) error {
 	if len(endpoints) == 0 {
 		return errNoEndpoints
@@ -436,7 +437,7 @@ func (b *Builder) buildCluster(
 	if cluster.ConnectTimeout == nil {
 		cluster.ConnectTimeout = defaultConnectionTimeout
 	}
-	lbEndpoints, err := b.buildLbEndpoints(endpoints)
+	lbEndpoints, err := b.buildLbEndpoints(endpoints, enableHTTP3Upstream)
 	if err != nil {
 		return err
 	}
@@ -447,7 +448,7 @@ func (b *Builder) buildCluster(
 			LbEndpoints: lbEndpoints,
 		}},
 	}
-	cluster.TransportSocketMatches, err = b.buildTransportSocketMatches(endpoints)
+	cluster.TransportSocketMatches, err = b.buildTransportSocketMatches(endpoints, enableHTTP3Upstream)
 	if err != nil {
 		return err
 	}
@@ -457,7 +458,7 @@ func (b *Builder) buildCluster(
 		cluster.TransportSocket = cluster.TransportSocketMatches[0].TransportSocket
 	}
 
-	cluster.TypedExtensionProtocolOptions = buildTypedExtensionProtocolOptions(endpoints, upstreamProtocol, keepalive)
+	cluster.TypedExtensionProtocolOptions = buildTypedExtensionProtocolOptions(endpoints, upstreamProtocol, keepalive, enableHTTP3Upstream)
 	clusterDiscoveryType, err := getClusterDiscoveryType(lbEndpoints, dnsOptions)
 	if err != nil {
 		return err
@@ -510,7 +511,7 @@ func grpcHealthChecks(name string) []*envoy_config_core_v3.HealthCheck {
 	}}
 }
 
-func (b *Builder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoint_v3.LbEndpoint, error) {
+func (b *Builder) buildLbEndpoints(endpoints []Endpoint, enableHTTP3Upstream bool) ([]*envoy_config_endpoint_v3.LbEndpoint, error) {
 	var lbes []*envoy_config_endpoint_v3.LbEndpoint
 	for _, e := range endpoints {
 		defaultPort := uint32(80)
@@ -541,12 +542,16 @@ func (b *Builder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoi
 		}
 
 		if e.transportSocket != nil {
+			fields := map[string]*structpb.Value{
+				e.TransportSocketName(): structpb.NewBoolValue(true),
+			}
+			if enableHTTP3Upstream {
+				fields["quic"] = structpb.NewBoolValue(true)
+			}
 			lbe.Metadata = &envoy_config_core_v3.Metadata{
 				FilterMetadata: map[string]*structpb.Struct{
 					"envoy.transport_socket_match": {
-						Fields: map[string]*structpb.Value{
-							e.TransportSocketName(): structpb.NewBoolValue(true),
-						},
+						Fields: fields,
 					},
 				},
 			}
@@ -556,9 +561,12 @@ func (b *Builder) buildLbEndpoints(endpoints []Endpoint) ([]*envoy_config_endpoi
 	return lbes, nil
 }
 
-func (b *Builder) buildTransportSocketMatches(endpoints []Endpoint) ([]*envoy_config_cluster_v3.Cluster_TransportSocketMatch, error) {
+func (b *Builder) buildTransportSocketMatches(endpoints []Endpoint, enableHTTP3Upstream bool) ([]*envoy_config_cluster_v3.Cluster_TransportSocketMatch, error) {
 	var tsms []*envoy_config_cluster_v3.Cluster_TransportSocketMatch
 	seen := map[string]struct{}{}
+	hasTLS := false
+	var tlsTransportSocket *envoy_config_core_v3.TransportSocket
+
 	for _, e := range endpoints {
 		if e.transportSocket == nil {
 			continue
@@ -580,6 +588,29 @@ func (b *Builder) buildTransportSocketMatches(endpoints []Endpoint) ([]*envoy_co
 			},
 			TransportSocket: e.transportSocket,
 		})
+
+		if e.transportSocket.Name == "tls" {
+			hasTLS = true
+			tlsTransportSocket = e.transportSocket
+		}
+	}
+
+	// For HTTP/3 upstream, prepend QUIC as the first transport socket match.
+	// This ensures QUIC is the default transport for HTTP/3 connections.
+	if enableHTTP3Upstream && hasTLS {
+		quic, err := b.buildQuicUpstreamTransport(tlsTransportSocket)
+		if err != nil {
+			return nil, err
+		}
+		tsms = append([]*envoy_config_cluster_v3.Cluster_TransportSocketMatch{{
+			Name: "quic",
+			Match: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"quic": structpb.NewBoolValue(true),
+				},
+			},
+			TransportSocket: quic,
+		}}, tsms...)
 	}
 	return tsms, nil
 }

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -541,7 +541,7 @@ func Test_buildCluster(t *testing.T) {
 		cluster := newDefaultEnvoyClusterConfig()
 		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, config.DNSOptions{
 			LookupFamily: config.DNSLookupFamilyV4Only,
-		}, Keepalive(false))
+		}, Keepalive(false), false)
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -616,7 +616,7 @@ func Test_buildCluster(t *testing.T) {
 		cluster := newDefaultEnvoyClusterConfig()
 		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, config.DNSOptions{
 			LookupFamily: config.DNSLookupFamilyV4Preferred,
-		}, Keepalive(true))
+		}, Keepalive(true), false)
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -808,7 +808,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		require.NoError(t, err)
 		cluster := newDefaultEnvoyClusterConfig()
-		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, config.DNSOptions{}, Keepalive(false))
+		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, config.DNSOptions{}, Keepalive(false), false)
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -866,7 +866,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		require.NoError(t, err)
 		cluster := newDefaultEnvoyClusterConfig()
-		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, config.DNSOptions{}, Keepalive(false))
+		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, config.DNSOptions{}, Keepalive(false), false)
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -926,7 +926,7 @@ func Test_buildCluster(t *testing.T) {
 		})
 		require.NoError(t, err)
 		cluster := newDefaultEnvoyClusterConfig()
-		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, config.DNSOptions{}, Keepalive(false))
+		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, config.DNSOptions{}, Keepalive(false), false)
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{
@@ -980,7 +980,7 @@ func Test_buildCluster(t *testing.T) {
 		}
 		err = b.buildCluster(cluster, "example", endpoints, upstreamProtocolHTTP2, config.DNSOptions{
 			LookupFamily: config.DNSLookupFamilyV4Only,
-		}, Keepalive(false))
+		}, Keepalive(false), false)
 		require.NoErrorf(t, err, "cluster %+v", cluster)
 		testutil.AssertProtoJSONEqual(t, `
 			{

--- a/config/envoyconfig/listeners_main.go
+++ b/config/envoyconfig/listeners_main.go
@@ -9,6 +9,7 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_extensions_access_loggers_grpc_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/access_loggers/grpc/v3"
+	alt_protocols_cachev3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/alternate_protocols_cache/v3"
 	envoy_extensions_filters_network_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
@@ -166,6 +167,17 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 		LuaFilter(luascripts.RewriteHeaders),
 		LuaFilter(luascripts.LocalReplyType),
 		SetConnectionStateFilter(),
+	}
+	// For HTTP/3 upstream auto-negotiation, add the Alternate Protocols Cache Filter.
+	// This filter parses alt-svc headers from upstream responses and stores them in the cache,
+	// allowing Envoy to discover which backends support HTTP/3.
+	if cfg.Options.EnableHTTP3Upstream {
+		filters = append(filters, &envoy_extensions_filters_network_http_connection_manager.HttpFilter{
+			Name: "envoy.filters.http.alternate_protocols_cache",
+			ConfigType: &envoy_extensions_filters_network_http_connection_manager.HttpFilter_TypedConfig{
+				TypedConfig: marshalAny(&alt_protocols_cachev3.FilterConfig{}),
+			},
+		})
 	}
 	// if we support http3 and this is the non-quic listener, add an alt-svc header indicating h3 is available
 	if !useQUIC && cfg.Options.CodecType == config.CodecTypeHTTP3 {

--- a/config/envoyconfig/protocols.go
+++ b/config/envoyconfig/protocols.go
@@ -79,9 +79,10 @@ func buildTypedExtensionProtocolOptions(
 	endpoints []Endpoint,
 	upstreamProtocol upstreamProtocolConfig,
 	keepalive Keepalive,
+	enableHTTP3Upstream bool,
 ) map[string]*anypb.Any {
 	return map[string]*anypb.Any{
-		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": marshalAny(buildUpstreamProtocolOptions(endpoints, upstreamProtocol, keepalive)),
+		"envoy.extensions.upstreams.http.v3.HttpProtocolOptions": marshalAny(buildUpstreamProtocolOptions(endpoints, upstreamProtocol, keepalive, enableHTTP3Upstream)),
 	}
 }
 
@@ -89,6 +90,7 @@ func buildUpstreamProtocolOptions(
 	endpoints []Endpoint,
 	upstreamProtocol upstreamProtocolConfig,
 	keepalive Keepalive,
+	enableHTTP3Upstream bool,
 ) *envoy_extensions_upstreams_http_v3.HttpProtocolOptions {
 	h2opt := http2ProtocolOptions
 	if keepalive {
@@ -117,12 +119,19 @@ func buildUpstreamProtocolOptions(
 			}
 		}
 		if tlsCount > 0 && tlsCount == len(endpoints) {
+			autoConfig := &envoy_extensions_upstreams_http_v3.HttpProtocolOptions_AutoHttpConfig{
+				HttpProtocolOptions:  http1ProtocolOptions,
+				Http2ProtocolOptions: h2opt,
+			}
+			if enableHTTP3Upstream {
+				autoConfig.Http3ProtocolOptions = http3ProtocolOptions
+				autoConfig.AlternateProtocolsCacheOptions = &envoy_config_core_v3.AlternateProtocolsCacheOptions{
+					Name: "upstream-alt-protocols-cache",
+				}
+			}
 			return &envoy_extensions_upstreams_http_v3.HttpProtocolOptions{
 				UpstreamProtocolOptions: &envoy_extensions_upstreams_http_v3.HttpProtocolOptions_AutoConfig{
-					AutoConfig: &envoy_extensions_upstreams_http_v3.HttpProtocolOptions_AutoHttpConfig{
-						HttpProtocolOptions:  http1ProtocolOptions,
-						Http2ProtocolOptions: h2opt,
-					},
+					AutoConfig: autoConfig,
 				},
 			}
 		} else if h2cCount > 0 && h2cCount == len(endpoints) {

--- a/config/envoyconfig/protocols_test.go
+++ b/config/envoyconfig/protocols_test.go
@@ -65,40 +65,73 @@ func TestBuildUpstreamProtocolOptions(t *testing.T) {
 				},
 			},
 		}
+		autoH3 = &envoy_extensions_upstreams_http_v3.HttpProtocolOptions{
+			UpstreamProtocolOptions: &envoy_extensions_upstreams_http_v3.HttpProtocolOptions_AutoConfig{
+				AutoConfig: &envoy_extensions_upstreams_http_v3.HttpProtocolOptions_AutoHttpConfig{
+					HttpProtocolOptions:  http1ProtocolOptions,
+					Http2ProtocolOptions: http2ProtocolOptions,
+					Http3ProtocolOptions: http3ProtocolOptions,
+					AlternateProtocolsCacheOptions: &envoy_config_core_v3.AlternateProtocolsCacheOptions{
+						Name: "upstream-alt-protocols-cache",
+					},
+				},
+			},
+		}
+		autoH3Keepalive = &envoy_extensions_upstreams_http_v3.HttpProtocolOptions{
+			UpstreamProtocolOptions: &envoy_extensions_upstreams_http_v3.HttpProtocolOptions_AutoConfig{
+				AutoConfig: &envoy_extensions_upstreams_http_v3.HttpProtocolOptions_AutoHttpConfig{
+					HttpProtocolOptions:  http1ProtocolOptions,
+					Http2ProtocolOptions: http2ProtocolOptionsWithKeepalive,
+					Http3ProtocolOptions: http3ProtocolOptions,
+					AlternateProtocolsCacheOptions: &envoy_config_core_v3.AlternateProtocolsCacheOptions{
+						Name: "upstream-alt-protocols-cache",
+					},
+				},
+			},
+		}
 	)
 	cases := []struct {
-		endpoints []string
-		protocol  upstreamProtocolConfig
-		keepalive bool
-		expected  *envoy_extensions_upstreams_http_v3.HttpProtocolOptions
+		endpoints           []string
+		protocol            upstreamProtocolConfig
+		keepalive           bool
+		enableHTTP3Upstream bool
+		expected            *envoy_extensions_upstreams_http_v3.HttpProtocolOptions
 	}{
-		{[]string{"https://foo", "https://bar"}, upstreamProtocolHTTP1, false, explicitH1},
-		{[]string{"https://foo", "https://bar"}, upstreamProtocolHTTP1, true, explicitH1Keepalive},
-		{[]string{"http://foo", "https://bar"}, upstreamProtocolHTTP1, false, explicitH1},
-		{[]string{"http://foo", "https://bar"}, upstreamProtocolHTTP1, true, explicitH1Keepalive},
-		{[]string{"http://foo", "http://bar"}, upstreamProtocolHTTP1, false, explicitH1},
-		{[]string{"http://foo", "http://bar"}, upstreamProtocolHTTP1, true, explicitH1Keepalive},
+		{[]string{"https://foo", "https://bar"}, upstreamProtocolHTTP1, false, false, explicitH1},
+		{[]string{"https://foo", "https://bar"}, upstreamProtocolHTTP1, true, false, explicitH1Keepalive},
+		{[]string{"http://foo", "https://bar"}, upstreamProtocolHTTP1, false, false, explicitH1},
+		{[]string{"http://foo", "https://bar"}, upstreamProtocolHTTP1, true, false, explicitH1Keepalive},
+		{[]string{"http://foo", "http://bar"}, upstreamProtocolHTTP1, false, false, explicitH1},
+		{[]string{"http://foo", "http://bar"}, upstreamProtocolHTTP1, true, false, explicitH1Keepalive},
 
-		{[]string{"https://foo", "https://bar"}, upstreamProtocolHTTP2, false, explicitH2},
-		{[]string{"https://foo", "https://bar"}, upstreamProtocolHTTP2, true, explicitH2Keepalive},
-		{[]string{"http://foo", "https://bar"}, upstreamProtocolHTTP2, false, explicitH2},
-		{[]string{"http://foo", "https://bar"}, upstreamProtocolHTTP2, true, explicitH2Keepalive},
-		{[]string{"http://foo", "http://bar"}, upstreamProtocolHTTP2, false, explicitH2},
-		{[]string{"http://foo", "http://bar"}, upstreamProtocolHTTP2, true, explicitH2Keepalive},
+		{[]string{"https://foo", "https://bar"}, upstreamProtocolHTTP2, false, false, explicitH2},
+		{[]string{"https://foo", "https://bar"}, upstreamProtocolHTTP2, true, false, explicitH2Keepalive},
+		{[]string{"http://foo", "https://bar"}, upstreamProtocolHTTP2, false, false, explicitH2},
+		{[]string{"http://foo", "https://bar"}, upstreamProtocolHTTP2, true, false, explicitH2Keepalive},
+		{[]string{"http://foo", "http://bar"}, upstreamProtocolHTTP2, false, false, explicitH2},
+		{[]string{"http://foo", "http://bar"}, upstreamProtocolHTTP2, true, false, explicitH2Keepalive},
 
-		{[]string{"https://foo", "https://bar"}, upstreamProtocolAuto, false, auto},
-		{[]string{"https://foo", "https://bar"}, upstreamProtocolAuto, true, autoKeepalive},
-		{[]string{"http://foo", "https://bar"}, upstreamProtocolAuto, false, explicitH1},
-		{[]string{"http://foo", "https://bar"}, upstreamProtocolAuto, true, explicitH1Keepalive},
-		{[]string{"http://foo", "http://bar"}, upstreamProtocolAuto, false, explicitH1},
-		{[]string{"http://foo", "http://bar"}, upstreamProtocolAuto, true, explicitH1Keepalive},
+		{[]string{"https://foo", "https://bar"}, upstreamProtocolAuto, false, false, auto},
+		{[]string{"https://foo", "https://bar"}, upstreamProtocolAuto, true, false, autoKeepalive},
+		{[]string{"http://foo", "https://bar"}, upstreamProtocolAuto, false, false, explicitH1},
+		{[]string{"http://foo", "https://bar"}, upstreamProtocolAuto, true, false, explicitH1Keepalive},
+		{[]string{"http://foo", "http://bar"}, upstreamProtocolAuto, false, false, explicitH1},
+		{[]string{"http://foo", "http://bar"}, upstreamProtocolAuto, true, false, explicitH1Keepalive},
 
-		{[]string{"h2c://foo", "http://bar"}, upstreamProtocolAuto, false, explicitH1},
-		{[]string{"h2c://foo", "http://bar"}, upstreamProtocolAuto, true, explicitH1Keepalive},
-		{[]string{"h2c://foo", "https://bar"}, upstreamProtocolAuto, false, explicitH1},
-		{[]string{"h2c://foo", "https://bar"}, upstreamProtocolAuto, true, explicitH1Keepalive},
-		{[]string{"h2c://foo", "h2c://bar"}, upstreamProtocolAuto, false, explicitH2},
-		{[]string{"h2c://foo", "h2c://bar"}, upstreamProtocolAuto, true, explicitH2Keepalive},
+		{[]string{"h2c://foo", "http://bar"}, upstreamProtocolAuto, false, false, explicitH1},
+		{[]string{"h2c://foo", "http://bar"}, upstreamProtocolAuto, true, false, explicitH1Keepalive},
+		{[]string{"h2c://foo", "https://bar"}, upstreamProtocolAuto, false, false, explicitH1},
+		{[]string{"h2c://foo", "https://bar"}, upstreamProtocolAuto, true, false, explicitH1Keepalive},
+		{[]string{"h2c://foo", "h2c://bar"}, upstreamProtocolAuto, false, false, explicitH2},
+		{[]string{"h2c://foo", "h2c://bar"}, upstreamProtocolAuto, true, false, explicitH2Keepalive},
+
+		// HTTP/3 upstream: only affects TLS endpoints in auto mode
+		{[]string{"https://foo", "https://bar"}, upstreamProtocolAuto, false, true, autoH3},
+		{[]string{"https://foo", "https://bar"}, upstreamProtocolAuto, true, true, autoH3Keepalive},
+		{[]string{"http://foo", "http://bar"}, upstreamProtocolAuto, false, true, explicitH1},
+		{[]string{"http://foo", "https://bar"}, upstreamProtocolAuto, false, true, explicitH1},
+		{[]string{"h2c://foo", "h2c://bar"}, upstreamProtocolAuto, false, true, explicitH2},
+		{[]string{"https://foo"}, upstreamProtocolHTTP2, false, true, explicitH2},
 	}
 
 	for _, tc := range cases {
@@ -114,7 +147,8 @@ func TestBuildUpstreamProtocolOptions(t *testing.T) {
 				}
 				endpoints = append(endpoints, endpoint)
 			}
-			testutil.AssertProtoEqual(t, tc.expected, buildUpstreamProtocolOptions(endpoints, tc.protocol, Keepalive(tc.keepalive)))
+			testutil.AssertProtoEqual(t, tc.expected, buildUpstreamProtocolOptions(
+				endpoints, tc.protocol, Keepalive(tc.keepalive), tc.enableHTTP3Upstream))
 		})
 	}
 }

--- a/config/envoyconfig/quic.go
+++ b/config/envoyconfig/quic.go
@@ -10,6 +10,9 @@ import (
 	envoy_extensions_filters_http_header_mutation_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/header_mutation/v3"
 	envoy_extensions_filters_network_http_connection_manager "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
 	envoy_extensions_transport_sockets_quic_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/quic/v3"
+	envoy_extensions_transport_sockets_tls_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/pomerium/pomerium/config"
 )
@@ -30,6 +33,23 @@ func (b *Builder) buildDownstreamQUICTransportSocket(
 		ConfigType: &envoy_config_core_v3.TransportSocket_TypedConfig{
 			TypedConfig: marshalAny(&envoy_extensions_transport_sockets_quic_v3.QuicDownstreamTransport{
 				DownstreamTlsContext: tlsContext,
+			}),
+		},
+	}, nil
+}
+
+func (b *Builder) buildQuicUpstreamTransport(tlsSocket *envoy_config_core_v3.TransportSocket) (*envoy_config_core_v3.TransportSocket, error) {
+	tlsCtx := &envoy_extensions_transport_sockets_tls_v3.UpstreamTlsContext{}
+	if err := anypb.UnmarshalTo(tlsSocket.GetTypedConfig(), tlsCtx, proto.UnmarshalOptions{}); err != nil {
+		return nil, err
+	}
+	tlsCtx.CommonTlsContext.AlpnProtocols = nil
+
+	return &envoy_config_core_v3.TransportSocket{
+		Name: "envoy.transport_sockets.quic",
+		ConfigType: &envoy_config_core_v3.TransportSocket_TypedConfig{
+			TypedConfig: marshalAny(&envoy_extensions_transport_sockets_quic_v3.QuicUpstreamTransport{
+				UpstreamTlsContext: tlsCtx,
 			}),
 		},
 	}, nil

--- a/config/options.go
+++ b/config/options.go
@@ -320,6 +320,7 @@ type Options struct {
 	RuntimeFlags RuntimeFlags `mapstructure:"runtime_flags" yaml:"runtime_flags,omitempty"`
 
 	HTTP3AdvertisePort       null.Uint32               `mapstructure:"-" yaml:"-" json:"-"`
+	EnableHTTP3Upstream      bool                      `mapstructure:"enable_http3_upstream" yaml:"enable_http3_upstream,omitempty"`
 	CircuitBreakerThresholds *CircuitBreakerThresholds `mapstructure:"circuit_breaker_thresholds" yaml:"circuit_breaker_thresholds" json:"circuit_breaker_thresholds"`
 	// Address/Port to bind to for health check http probes
 	HealthCheckAddr string `mapstructure:"health_check_addr" yaml:"health_check_addr,omitempty"`
@@ -1690,6 +1691,7 @@ func (o *Options) ApplySettings(ctx context.Context, certsIndex *cryptutil.Certi
 	if settings.Http3AdvertisePort != nil {
 		o.HTTP3AdvertisePort = null.Uint32From(*settings.Http3AdvertisePort)
 	}
+	set(&o.EnableHTTP3Upstream, settings.EnableHttp3Upstream)
 	if settings.CircuitBreakerThresholds != nil {
 		o.CircuitBreakerThresholds = CircuitBreakerThresholdsFromPB(settings.CircuitBreakerThresholds)
 	}
@@ -1830,6 +1832,9 @@ func (o *Options) ToProto() *configpb.Config {
 		return string(k), v
 	})
 	settings.Http3AdvertisePort = o.HTTP3AdvertisePort.Ptr()
+	if o.EnableHTTP3Upstream {
+		settings.EnableHttp3Upstream = &o.EnableHTTP3Upstream
+	}
 	if o.CircuitBreakerThresholds != nil {
 		settings.CircuitBreakerThresholds = CircuitBreakerThresholdsToPB(o.CircuitBreakerThresholds)
 	}

--- a/pkg/grpc/config/config.pb.go
+++ b/pkg/grpc/config/config.pb.go
@@ -2868,14 +2868,17 @@ type Settings struct {
 	PassIdentityHeaders                               *bool                            `protobuf:"varint,117,opt,name=pass_identity_headers,json=passIdentityHeaders,proto3,oneof" json:"pass_identity_headers,omitempty"`
 	RuntimeFlags                                      map[string]bool                  `protobuf:"bytes,118,rep,name=runtime_flags,json=runtimeFlags,proto3" json:"runtime_flags,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"varint,2,opt,name=value"`
 	Http3AdvertisePort                                *uint32                          `protobuf:"varint,136,opt,name=http3_advertise_port,json=http3AdvertisePort,proto3,oneof" json:"http3_advertise_port,omitempty"`
-	CircuitBreakerThresholds                          *CircuitBreakerThresholds        `protobuf:"bytes,140,opt,name=circuit_breaker_thresholds,json=circuitBreakerThresholds,proto3,oneof" json:"circuit_breaker_thresholds,omitempty"`
-	SshAddress                                        *string                          `protobuf:"bytes,141,opt,name=ssh_address,json=sshAddress,proto3,oneof" json:"ssh_address,omitempty"`
-	SshHostKeyFiles                                   *Settings_StringList             `protobuf:"bytes,142,opt,name=ssh_host_key_files,json=sshHostKeyFiles,proto3,oneof" json:"ssh_host_key_files,omitempty"`
-	SshHostKeys                                       *Settings_StringList             `protobuf:"bytes,143,opt,name=ssh_host_keys,json=sshHostKeys,proto3,oneof" json:"ssh_host_keys,omitempty"`
-	SshHostKeyPairIds                                 []string                         `protobuf:"bytes,167,rep,name=ssh_host_key_pair_ids,json=sshHostKeyPairIds,proto3" json:"ssh_host_key_pair_ids,omitempty"`
-	SshUserCaKeyFile                                  *string                          `protobuf:"bytes,144,opt,name=ssh_user_ca_key_file,json=sshUserCaKeyFile,proto3,oneof" json:"ssh_user_ca_key_file,omitempty"`
-	SshUserCaKey                                      *string                          `protobuf:"bytes,145,opt,name=ssh_user_ca_key,json=sshUserCaKey,proto3,oneof" json:"ssh_user_ca_key,omitempty"`
-	SshUserCaKeyPairId                                *string                          `protobuf:"bytes,168,opt,name=ssh_user_ca_key_pair_id,json=sshUserCaKeyPairId,proto3,oneof" json:"ssh_user_ca_key_pair_id,omitempty"`
+	// Enables HTTP/3 (QUIC) for upstream connections to HTTPS backends.
+	// Discovery is automatic via alt-svc response headers.
+	EnableHttp3Upstream      *bool                     `protobuf:"varint,182,opt,name=enable_http3_upstream,json=enableHttp3Upstream,proto3,oneof" json:"enable_http3_upstream,omitempty"`
+	CircuitBreakerThresholds *CircuitBreakerThresholds `protobuf:"bytes,140,opt,name=circuit_breaker_thresholds,json=circuitBreakerThresholds,proto3,oneof" json:"circuit_breaker_thresholds,omitempty"`
+	SshAddress               *string                   `protobuf:"bytes,141,opt,name=ssh_address,json=sshAddress,proto3,oneof" json:"ssh_address,omitempty"`
+	SshHostKeyFiles          *Settings_StringList      `protobuf:"bytes,142,opt,name=ssh_host_key_files,json=sshHostKeyFiles,proto3,oneof" json:"ssh_host_key_files,omitempty"`
+	SshHostKeys              *Settings_StringList      `protobuf:"bytes,143,opt,name=ssh_host_keys,json=sshHostKeys,proto3,oneof" json:"ssh_host_keys,omitempty"`
+	SshHostKeyPairIds        []string                  `protobuf:"bytes,167,rep,name=ssh_host_key_pair_ids,json=sshHostKeyPairIds,proto3" json:"ssh_host_key_pair_ids,omitempty"`
+	SshUserCaKeyFile         *string                   `protobuf:"bytes,144,opt,name=ssh_user_ca_key_file,json=sshUserCaKeyFile,proto3,oneof" json:"ssh_user_ca_key_file,omitempty"`
+	SshUserCaKey             *string                   `protobuf:"bytes,145,opt,name=ssh_user_ca_key,json=sshUserCaKey,proto3,oneof" json:"ssh_user_ca_key,omitempty"`
+	SshUserCaKeyPairId       *string                   `protobuf:"bytes,168,opt,name=ssh_user_ca_key_pair_id,json=sshUserCaKeyPairId,proto3,oneof" json:"ssh_user_ca_key_pair_id,omitempty"`
 	// mcp_allowed_client_id_domains specifies the allowed domains for MCP client ID metadata URLs.
 	// Supports wildcard patterns like "*.example.com".
 	// This is REQUIRED when MCP is enabled - client metadata fetching will fail if empty.
@@ -3786,6 +3789,13 @@ func (x *Settings) GetHttp3AdvertisePort() uint32 {
 		return *x.Http3AdvertisePort
 	}
 	return 0
+}
+
+func (x *Settings) GetEnableHttp3Upstream() bool {
+	if x != nil && x.EnableHttp3Upstream != nil {
+		return *x.EnableHttp3Upstream
+	}
+	return false
 }
 
 func (x *Settings) GetCircuitBreakerThresholds() *CircuitBreakerThresholds {
@@ -8802,7 +8812,7 @@ const file_config_proto_rawDesc = "" +
 	"\v_source_pplB\x0e\n" +
 	"\f_explanationB\x0e\n" +
 	"\f_remediationB\x11\n" +
-	"\x0f_namespace_nameJ\x04\b\x04\x10\x05\"\xf0b\n" +
+	"\x0f_namespace_nameJ\x04\b\x04\x10\x05\"\xc4c\n" +
 	"\bSettings\x12\x14\n" +
 	"\x02id\x18\x9e\x01 \x01(\tH\x00R\x02id\x88\x01\x01\x12'\n" +
 	"\fnamespace_id\x18\x9f\x01 \x01(\tH\x01R\vnamespaceId\x88\x01\x01\x12#\n" +
@@ -8934,26 +8944,27 @@ const file_config_proto_rawDesc = "" +
 	"\x1derror_message_first_paragraph\x18[ \x01(\tHiR\x1aerrorMessageFirstParagraph\x88\x01\x01\x127\n" +
 	"\x15pass_identity_headers\x18u \x01(\bHjR\x13passIdentityHeaders\x88\x01\x01\x12P\n" +
 	"\rruntime_flags\x18v \x03(\v2+.pomerium.config.Settings.RuntimeFlagsEntryR\fruntimeFlags\x126\n" +
-	"\x14http3_advertise_port\x18\x88\x01 \x01(\rHkR\x12http3AdvertisePort\x88\x01\x01\x12m\n" +
-	"\x1acircuit_breaker_thresholds\x18\x8c\x01 \x01(\v2).pomerium.config.CircuitBreakerThresholdsHlR\x18circuitBreakerThresholds\x88\x01\x01\x12%\n" +
-	"\vssh_address\x18\x8d\x01 \x01(\tHmR\n" +
+	"\x14http3_advertise_port\x18\x88\x01 \x01(\rHkR\x12http3AdvertisePort\x88\x01\x01\x128\n" +
+	"\x15enable_http3_upstream\x18\xb6\x01 \x01(\bHlR\x13enableHttp3Upstream\x88\x01\x01\x12m\n" +
+	"\x1acircuit_breaker_thresholds\x18\x8c\x01 \x01(\v2).pomerium.config.CircuitBreakerThresholdsHmR\x18circuitBreakerThresholds\x88\x01\x01\x12%\n" +
+	"\vssh_address\x18\x8d\x01 \x01(\tHnR\n" +
 	"sshAddress\x88\x01\x01\x12W\n" +
-	"\x12ssh_host_key_files\x18\x8e\x01 \x01(\v2$.pomerium.config.Settings.StringListHnR\x0fsshHostKeyFiles\x88\x01\x01\x12N\n" +
-	"\rssh_host_keys\x18\x8f\x01 \x01(\v2$.pomerium.config.Settings.StringListHoR\vsshHostKeys\x88\x01\x01\x121\n" +
+	"\x12ssh_host_key_files\x18\x8e\x01 \x01(\v2$.pomerium.config.Settings.StringListHoR\x0fsshHostKeyFiles\x88\x01\x01\x12N\n" +
+	"\rssh_host_keys\x18\x8f\x01 \x01(\v2$.pomerium.config.Settings.StringListHpR\vsshHostKeys\x88\x01\x01\x121\n" +
 	"\x15ssh_host_key_pair_ids\x18\xa7\x01 \x03(\tR\x11sshHostKeyPairIds\x124\n" +
-	"\x14ssh_user_ca_key_file\x18\x90\x01 \x01(\tHpR\x10sshUserCaKeyFile\x88\x01\x01\x12+\n" +
-	"\x0fssh_user_ca_key\x18\x91\x01 \x01(\tHqR\fsshUserCaKey\x88\x01\x01\x129\n" +
-	"\x17ssh_user_ca_key_pair_id\x18\xa8\x01 \x01(\tHrR\x12sshUserCaKeyPairId\x88\x01\x01\x12A\n" +
+	"\x14ssh_user_ca_key_file\x18\x90\x01 \x01(\tHqR\x10sshUserCaKeyFile\x88\x01\x01\x12+\n" +
+	"\x0fssh_user_ca_key\x18\x91\x01 \x01(\tHrR\fsshUserCaKey\x88\x01\x01\x129\n" +
+	"\x17ssh_user_ca_key_pair_id\x18\xa8\x01 \x01(\tHsR\x12sshUserCaKeyPairId\x88\x01\x01\x12A\n" +
 	"\x1dmcp_allowed_client_id_domains\x18\x9d\x01 \x03(\tR\x19mcpAllowedClientIdDomains\x12E\n" +
 	"\x1fmcp_allowed_as_metadata_domains\x18\xb1\x01 \x03(\tR\x1bmcpAllowedAsMetadataDomains\x123\n" +
-	"\x12directory_provider\x18\xab\x01 \x01(\tHsR\x11directoryProvider\x88\x01\x01\x12[\n" +
-	"\x1adirectory_provider_options\x18\xac\x01 \x01(\v2\x17.google.protobuf.StructHtR\x18directoryProviderOptions\x88\x01\x01\x12n\n" +
-	"#directory_provider_refresh_interval\x18\xad\x01 \x01(\v2\x19.google.protobuf.DurationHuR directoryProviderRefreshInterval\x88\x01\x01\x12l\n" +
-	"\"directory_provider_refresh_timeout\x18\xae\x01 \x01(\v2\x19.google.protobuf.DurationHvR\x1fdirectoryProviderRefreshTimeout\x88\x01\x01\x12@\n" +
-	"\x19session_recording_enabled\x18\xb2\x01 \x01(\bHwR\x17sessionRecordingEnabled\x88\x01\x01\x12M\n" +
-	"\fblob_storage\x18\xb3\x01 \x01(\v2$.pomerium.config.BlobStorageSettingsHxR\vblobStorage\x88\x01\x01\x128\n" +
-	"\x15auto_apply_changesets\x18\xb4\x01 \x01(\bHyR\x13autoApplyChangesets\x88\x01\x01\x12Q\n" +
-	"\x0eallow_upgrades\x18\xb5\x01 \x01(\v2$.pomerium.config.Settings.StringListHzR\rallowUpgrades\x88\x01\x01\x12:\n" +
+	"\x12directory_provider\x18\xab\x01 \x01(\tHtR\x11directoryProvider\x88\x01\x01\x12[\n" +
+	"\x1adirectory_provider_options\x18\xac\x01 \x01(\v2\x17.google.protobuf.StructHuR\x18directoryProviderOptions\x88\x01\x01\x12n\n" +
+	"#directory_provider_refresh_interval\x18\xad\x01 \x01(\v2\x19.google.protobuf.DurationHvR directoryProviderRefreshInterval\x88\x01\x01\x12l\n" +
+	"\"directory_provider_refresh_timeout\x18\xae\x01 \x01(\v2\x19.google.protobuf.DurationHwR\x1fdirectoryProviderRefreshTimeout\x88\x01\x01\x12@\n" +
+	"\x19session_recording_enabled\x18\xb2\x01 \x01(\bHxR\x17sessionRecordingEnabled\x88\x01\x01\x12M\n" +
+	"\fblob_storage\x18\xb3\x01 \x01(\v2$.pomerium.config.BlobStorageSettingsHyR\vblobStorage\x88\x01\x01\x128\n" +
+	"\x15auto_apply_changesets\x18\xb4\x01 \x01(\bHzR\x13autoApplyChangesets\x88\x01\x01\x12Q\n" +
+	"\x0eallow_upgrades\x18\xb5\x01 \x01(\v2$.pomerium.config.Settings.StringListH{R\rallowUpgrades\x88\x01\x01\x12:\n" +
 	"\n" +
 	"created_at\x18\xa9\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12<\n" +
 	"\vmodified_at\x18\xaa\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
@@ -9094,7 +9105,8 @@ const file_config_proto_rawDesc = "" +
 	"\f_favicon_urlB \n" +
 	"\x1e_error_message_first_paragraphB\x18\n" +
 	"\x16_pass_identity_headersB\x17\n" +
-	"\x15_http3_advertise_portB\x1d\n" +
+	"\x15_http3_advertise_portB\x18\n" +
+	"\x16_enable_http3_upstreamB\x1d\n" +
 	"\x1b_circuit_breaker_thresholdsB\x0e\n" +
 	"\f_ssh_addressB\x15\n" +
 	"\x13_ssh_host_key_filesB\x10\n" +

--- a/pkg/grpc/config/config.pb.json
+++ b/pkg/grpc/config/config.pb.json
@@ -6786,6 +6786,18 @@
               "defaultValue": ""
             },
             {
+              "name": "enable_http3_upstream",
+              "description": "Enables HTTP/3 (QUIC) for upstream connections to HTTPS backends.\nDiscovery is automatic via alt-svc response headers.",
+              "label": "optional",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "_enable_http3_upstream",
+              "defaultValue": ""
+            },
+            {
               "name": "circuit_breaker_thresholds",
               "description": "",
               "label": "optional",

--- a/pkg/grpc/config/config.pb.validate.go
+++ b/pkg/grpc/config/config.pb.validate.go
@@ -4163,6 +4163,10 @@ func (m *Settings) validate(all bool) error {
 		// no validation rules for Http3AdvertisePort
 	}
 
+	if m.EnableHttp3Upstream != nil {
+		// no validation rules for EnableHttp3Upstream
+	}
+
 	if m.CircuitBreakerThresholds != nil {
 
 		if all {

--- a/pkg/grpc/config/config.proto
+++ b/pkg/grpc/config/config.proto
@@ -672,6 +672,9 @@ message Settings {
   optional bool                     pass_identity_headers         = 117;
   map<string, bool>                 runtime_flags                 = 118;
   optional uint32                   http3_advertise_port          = 136;
+  // Enables HTTP/3 (QUIC) for upstream connections to HTTPS backends.
+  // Discovery is automatic via alt-svc response headers.
+  optional bool                     enable_http3_upstream         = 182;
   optional CircuitBreakerThresholds circuit_breaker_thresholds    = 140;
   optional string                   ssh_address                   = 141;
   optional StringList               ssh_host_key_files            = 142;


### PR DESCRIPTION
## Summary

This change enables Pomerium to use HTTP/3 (QUIC) protocol for outbound connections to HTTPS backends when explicitly configured. HTTP/3 discovery occurs automatically via `alt-svc` response headers.

HTTP/3 is opt-in via the `enable_http3_upstream configuration` flag. All other protocol behaviors (HTTP/1.1, HTTP/2, h2c) remain unchanged.

## Related issues

- #6327

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
