### PR TITLE
ssh: serve route config via RDS

### DIFF
--- a/config/envoyconfig/listeners_ssh.go
+++ b/config/envoyconfig/listeners_ssh.go
@@ -25,6 +25,12 @@ import (
 	"github.com/pomerium/pomerium/pkg/ssh/ratelimit"
 )
 
+// SSHRouteConfigName is the name of the dynamic SSH route configuration served via
+// generic_proxy RDS. The SSH listener references this name in its GenericRds config
+// source and the xDS server publishes the matching RouteConfiguration resource at
+// the generic_proxy RouteConfiguration TypeURL.
+const SSHRouteConfigName = "ssh-route-config"
+
 func newRateLimitEntries() []*envoy_common_ratelimit_v3.RateLimitDescriptor_Entry {
 	return []*envoy_common_ratelimit_v3.RateLimitDescriptor_Entry{
 		{
@@ -42,13 +48,13 @@ func newRateLimitEntries() []*envoy_common_ratelimit_v3.RateLimitDescriptor_Entr
 	}
 }
 
+// buildSSHListener builds the SSH listener config. The route table is intentionally
+// not embedded here: it is served separately via generic_proxy RDS so that route
+// changes (e.g. policy/workspace add/remove) do not modify the listener proto and
+// therefore do not trigger a listener swap with its associated drain timer.
 func buildSSHListener(cfg *config.Config) (*envoy_config_listener_v3.Listener, error) {
 	if cfg.Options.SSHAddr == "" {
 		return nil, nil
-	}
-	rc, err := buildRouteConfig(cfg)
-	if err != nil {
-		return nil, err
 	}
 
 	authorizeService := &envoy_config_core_v3.GrpcService{
@@ -161,8 +167,14 @@ func buildSSHListener(cfg *config.Config) (*envoy_config_listener_v3.Listener, e
 							}),
 						},
 					},
-					RouteSpecifier: &envoy_generic_proxy_v3.GenericProxy_RouteConfig{
-						RouteConfig: rc,
+					RouteSpecifier: &envoy_generic_proxy_v3.GenericProxy_GenericRds{
+						GenericRds: &envoy_generic_proxy_v3.GenericRds{
+							RouteConfigName: SSHRouteConfigName,
+							ConfigSource: &envoy_config_core_v3.ConfigSource{
+								ResourceApiVersion:    envoy_config_core_v3.ApiVersion_V3,
+								ConfigSourceSpecifier: &envoy_config_core_v3.ConfigSource_Ads{},
+							},
+						},
 					},
 				}),
 			},

--- a/config/envoyconfig/listeners_ssh_test.go
+++ b/config/envoyconfig/listeners_ssh_test.go
@@ -1,6 +1,7 @@
 package envoyconfig
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -114,6 +115,50 @@ func TestBuildSSHListener(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, l.ValidateAll())
 	})
+}
+
+// Tests for route-table validation: after the SSH listener moved to RDS, route
+// parsing happens in BuildSSHRouteConfigurations rather than buildSSHListener.
+func TestBuildSSHRouteConfigurations(t *testing.T) {
+	t.Parallel()
+
+	b := &Builder{}
+
+	t.Run("no listener configured", func(t *testing.T) {
+		cfg := &config.Config{
+			Options: config.NewDefaultOptions(),
+		}
+		cfg.Options.Policies = []config.Policy{
+			{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://to1:22")},
+		}
+		rcs, err := b.BuildSSHRouteConfigurations(context.Background(), cfg)
+		assert.NoError(t, err)
+		assert.Nil(t, rcs)
+	})
+	t.Run("listener configured, no routes", func(t *testing.T) {
+		cfg := &config.Config{
+			Options: config.NewDefaultOptions(),
+		}
+		cfg.Options.SSHAddr = "0.0.0.0:22"
+		rcs, err := b.BuildSSHRouteConfigurations(context.Background(), cfg)
+		assert.NoError(t, err)
+		assert.Len(t, rcs, 1)
+		assert.Equal(t, SSHRouteConfigName, rcs[0].Name)
+	})
+	t.Run("listener and routes", func(t *testing.T) {
+		cfg := &config.Config{
+			Options: config.NewDefaultOptions(),
+		}
+		cfg.Options.SSHAddr = "0.0.0.0:22"
+		cfg.Options.Policies = []config.Policy{
+			{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://to1:22")},
+			{From: "ssh://host2", To: mustParseWeightedURLs(t, "ssh://to2:22")},
+		}
+		rcs, err := b.BuildSSHRouteConfigurations(context.Background(), cfg)
+		assert.NoError(t, err)
+		assert.Len(t, rcs, 1)
+		assert.Equal(t, SSHRouteConfigName, rcs[0].Name)
+	})
 	t.Run("invalid From url", func(t *testing.T) {
 		cfg := &config.Config{
 			Options: config.NewDefaultOptions(),
@@ -122,7 +167,7 @@ func TestBuildSSHListener(t *testing.T) {
 		cfg.Options.Policies = []config.Policy{
 			{From: "ssh://\x7f", To: mustParseWeightedURLs(t, "ssh://to1:22")},
 		}
-		_, err := buildSSHListener(cfg)
+		_, err := b.BuildSSHRouteConfigurations(context.Background(), cfg)
 		assert.Error(t, err)
 	})
 	t.Run("multiple To urls", func(t *testing.T) {
@@ -133,7 +178,7 @@ func TestBuildSSHListener(t *testing.T) {
 		cfg.Options.Policies = []config.Policy{
 			{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://to1:22", "ssh://to2:22")},
 		}
-		_, err := buildSSHListener(cfg)
+		_, err := b.BuildSSHRouteConfigurations(context.Background(), cfg)
 		assert.Error(t, err)
 	})
 	t.Run("To url missing scheme", func(t *testing.T) {
@@ -144,7 +189,7 @@ func TestBuildSSHListener(t *testing.T) {
 		cfg.Options.Policies = []config.Policy{
 			{From: "ssh://host1", To: mustParseWeightedURLs(t, "http://to1:22")},
 		}
-		_, err := buildSSHListener(cfg)
+		_, err := b.BuildSSHRouteConfigurations(context.Background(), cfg)
 		assert.Error(t, err)
 	})
 }

--- a/config/envoyconfig/route_configurations_ssh.go
+++ b/config/envoyconfig/route_configurations_ssh.go
@@ -1,0 +1,37 @@
+package envoyconfig
+
+import (
+	"context"
+
+	envoy_generic_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/v3"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/telemetry/trace"
+)
+
+// BuildSSHRouteConfigurations builds the route configurations for the generic_proxy
+// SSH RDS service. Returning these as a separate xDS resource (rather than inlining
+// them into the SSH listener) is what allows route changes to propagate without
+// modifying the listener and triggering a drain.
+//
+// The returned slice always contains zero or one entries: a single
+// "ssh-route-config" resource keyed by SSHRouteConfigName when the SSH listener is
+// active, or nil otherwise.
+func (b *Builder) BuildSSHRouteConfigurations(
+	ctx context.Context,
+	cfg *config.Config,
+) ([]*envoy_generic_proxy_v3.RouteConfiguration, error) {
+	_, span := trace.Continue(ctx, "envoyconfig.Builder.BuildSSHRouteConfigurations")
+	defer span.End()
+
+	if !shouldStartSSHListener(cfg.Options) || cfg.Options.SSHAddr == "" {
+		return nil, nil
+	}
+
+	rc, err := buildRouteConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	rc.Name = SSHRouteConfigName
+	return []*envoy_generic_proxy_v3.RouteConfiguration{rc}, nil
+}

--- a/internal/controlplane/xds.go
+++ b/internal/controlplane/xds.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	clusterTypeURL            = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
-	listenerTypeURL           = "type.googleapis.com/envoy.config.listener.v3.Listener"
-	routeConfigurationTypeURL = "type.googleapis.com/envoy.config.route.v3.RouteConfiguration"
+	clusterTypeURL               = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
+	listenerTypeURL              = "type.googleapis.com/envoy.config.listener.v3.Listener"
+	routeConfigurationTypeURL    = "type.googleapis.com/envoy.config.route.v3.RouteConfiguration"
+	sshRouteConfigurationTypeURL = "type.googleapis.com/envoy.extensions.filters.network.generic_proxy.v3.RouteConfiguration"
 )
 
 func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*envoy_service_discovery_v3.Resource, error) {
@@ -77,6 +78,22 @@ func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*e
 		return nil
 	})
 
+	var sshRouteConfigurationResources []*envoy_service_discovery_v3.Resource
+	eg.Go(func() error {
+		sshRouteConfigurations, err := srv.Builder.BuildSSHRouteConfigurations(ctx, cfg)
+		if err != nil {
+			return fmt.Errorf("error building ssh route configurations: %w", err)
+		}
+		for _, routeConfiguration := range sshRouteConfigurations {
+			sshRouteConfigurationResources = append(sshRouteConfigurationResources, &envoy_service_discovery_v3.Resource{
+				Name:     routeConfiguration.Name,
+				Version:  hex.EncodeToString(cryptutil.HashProto(routeConfiguration)),
+				Resource: protoutil.NewAny(routeConfiguration),
+			})
+		}
+		return nil
+	})
+
 	err := eg.Wait()
 	if err != nil {
 		return nil, err
@@ -86,11 +103,13 @@ func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*e
 		Int("cluster-count", len(clusterResources)).
 		Int("listener-count", len(listenerResources)).
 		Int("route-configuration-count", len(routeConfigurationResources)).
+		Int("ssh-route-configuration-count", len(sshRouteConfigurationResources)).
 		Msg("controlplane: built discovery resources")
 
 	return map[string][]*envoy_service_discovery_v3.Resource{
-		clusterTypeURL:            clusterResources,
-		listenerTypeURL:           listenerResources,
-		routeConfigurationTypeURL: routeConfigurationResources,
+		clusterTypeURL:               clusterResources,
+		listenerTypeURL:              listenerResources,
+		routeConfigurationTypeURL:    routeConfigurationResources,
+		sshRouteConfigurationTypeURL: sshRouteConfigurationResources,
 	}, nil
 }

--- a/internal/controlplane/xdsmgr/log.go
+++ b/internal/controlplane/xdsmgr/log.go
@@ -7,6 +7,7 @@ import (
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_generic_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/v3"
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 
 	"github.com/pomerium/pomerium/internal/log"
@@ -15,9 +16,10 @@ import (
 )
 
 var (
-	clusterTypeURL            = protoutil.GetTypeURL((*envoy_config_cluster_v3.Cluster)(nil))
-	listenerTypeURL           = protoutil.GetTypeURL((*envoy_config_listener_v3.Listener)(nil))
-	routeConfigurationTypeURL = protoutil.GetTypeURL((*envoy_config_route_v3.RouteConfiguration)(nil))
+	clusterTypeURL               = protoutil.GetTypeURL((*envoy_config_cluster_v3.Cluster)(nil))
+	listenerTypeURL              = protoutil.GetTypeURL((*envoy_config_listener_v3.Listener)(nil))
+	routeConfigurationTypeURL    = protoutil.GetTypeURL((*envoy_config_route_v3.RouteConfiguration)(nil))
+	sshRouteConfigurationTypeURL = protoutil.GetTypeURL((*envoy_generic_proxy_v3.RouteConfiguration)(nil))
 )
 
 func logNACK(ctx context.Context, req *envoy_service_discovery_v3.DeltaDiscoveryRequest) {
@@ -44,6 +46,8 @@ func getHealthCheck(typeURL string) health.Check {
 	case listenerTypeURL:
 		return health.XDSListener
 	case routeConfigurationTypeURL:
+		return health.XDSRouteConfiguration
+	case sshRouteConfigurationTypeURL:
 		return health.XDSRouteConfiguration
 	default:
 		return health.XDSOther

--- a/internal/controlplane/xdsmgr/xdsmgr.go
+++ b/internal/controlplane/xdsmgr/xdsmgr.go
@@ -278,18 +278,20 @@ func buildDiscoveryResponsesForConsistentUpdates(in []*envoy_service_discovery_v
 	// Stale CDS clusters and related EDS endpoints (ones no longer being referenced) can then be removed.
 
 	updateOrder := map[string]int{
-		clusterTypeURL:            1,
-		listenerTypeURL:           2,
-		routeConfigurationTypeURL: 3,
+		clusterTypeURL:               1,
+		listenerTypeURL:              2,
+		routeConfigurationTypeURL:    3,
+		sshRouteConfigurationTypeURL: 3,
 	}
 	slices.SortFunc(updates, func(a, b *envoy_service_discovery_v3.DeltaDiscoveryResponse) int {
 		return cmp.Compare(updateOrder[a.TypeUrl], updateOrder[b.TypeUrl])
 	})
 
 	removeOrder := map[string]int{
-		routeConfigurationTypeURL: 1,
-		listenerTypeURL:           2,
-		clusterTypeURL:            3,
+		routeConfigurationTypeURL:    1,
+		sshRouteConfigurationTypeURL: 1,
+		listenerTypeURL:              2,
+		clusterTypeURL:               3,
 	}
 	slices.SortFunc(removals, func(a, b *envoy_service_discovery_v3.DeltaDiscoveryResponse) int {
 		return cmp.Compare(removeOrder[a.TypeUrl], removeOrder[b.TypeUrl])


### PR DESCRIPTION
## Summary

Adding or removing an SSH route currently mutates the SSH listener proto, because the routes are inlined inside the generic_proxy filter. Envoy responds by creating a new listener and draining the old one for drain_time_s (default 600s), which terminates active SSH sessions riding the old listener — even when the changed route is unrelated to those sessions.

Switch the SSH listener's RouteSpecifier from an inline RouteConfig to generic_proxy.GenericRds with an ADS config source, and publish the matching RouteConfiguration as a separate xDS resource. The listener proto then becomes a pure function of the static SSH options (ssh_address, host keys, user CA, RLS settings); route changes flow exclusively through

  envoy.extensions.filters.network.generic_proxy.v3.RouteConfiguration

and never touch the listener.

This mirrors the layering the HTTP listener already uses (HTTP RDS), giving SSH parity in operational guarantees: route updates are delivered as xDS deltas with no listener swap, no filter-chain drain, and no client-visible disruption.

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

Fixes #6324

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

If you maintain the SSH route policy dynamically, this change will ensure existing SSH connections aren't disrupted each time the policy changes.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
