### PR TITLE
bump Go version to 1.25.10 [v0.32]

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golangci-lint 2.8.0
-golang 1.25.9
+golang 1.25.10
 goreleaser 2.13.3
 nodejs 22.22.0
 protoc 33.4


### PR DESCRIPTION
Update to the latest Go 1.25 release (on the v0.32 release branch).