### PR TITLE
fix(test) : websocket_int shorten test names

### DIFF
--- a/config/envoyconfig/websocket_int_test.go
+++ b/config/envoyconfig/websocket_int_test.go
@@ -50,7 +50,7 @@ func TestWebsocketViaMiddleEnvoy(t *testing.T) {
 		expectBackendSawMiddleHop bool
 	}{
 		{
-			name:                      "middle envoy with upgrade_configs",
+			name:                      "middle envoy with upgrade",
 			middleAllowsUpgrade:       true,
 			expectClientSuccess:       true,
 			expectBackendUpgrade:      true,
@@ -62,7 +62,7 @@ func TestWebsocketViaMiddleEnvoy(t *testing.T) {
 			// without upgrade_configs). Asserting the status pins the fact
 			// that middle Envoy was the one rejecting; a startup failure
 			// would surface as 503 from Pomerium instead.
-			name:                      "middle envoy without upgrade_configs",
+			name:                      "middle envoy without upgrade",
 			middleAllowsUpgrade:       false,
 			expectClientSuccess:       false,
 			expectClientStatus:        http.StatusForbidden,
@@ -78,7 +78,7 @@ func TestWebsocketViaMiddleEnvoy(t *testing.T) {
 			// down without relaying an HTTP response. The client sees an
 			// aborted handshake (no status). Status 0 distinguishes this
 			// from a missing-upstream failure (which would return 503).
-			name:                      "pomerium remove_request_headers strips upgrade",
+			name:                      "pomerium remove_request_headers",
 			middleAllowsUpgrade:       true,
 			pomeriumRemoveHdrs:        []string{"Connection", "Upgrade"},
 			expectClientSuccess:       false,


### PR DESCRIPTION
## Summary

On linux we hit a unix sock path character limit in `websocket_int_test.go` (108 characters) because in the testenv the 
pomerium-envoy-admin.sock path is constructed from t.TempDir() which constructs paths looking like:

`/tmp/<TestFunc><SubtestNameSanitized><10digits>/001/<pomerium-envoy-admin.sock >` which in this case exceeds 108. I'm not sure why this originally passed in CI, and now does not, but it's 100% reproducible on my dev machines running Ubuntu 24.04 and Ubuntu 26.04

```
{"service":"envoy","name":"envoy","time":"2026-05-12T14:52:49-04:00","message":"Path \"/tmp/TestWebsocketViaMiddleEnvoymiddle_envoy_without_upgrade_configs4098989110/001/pomerium-envoy-admin.sock\" exceeds maximum UNIX domain socket path size of 108."}
```

## Related issues

https://github.com/pomerium/pomerium/pull/6332

## User Explanation

N/A

## AI disclosure

N/A

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
