### PR TITLE
core/envoy: use abstract namespace for unix sockets on linux

### DIFF
--- a/config/envoyconfig/bootstrap.go
+++ b/config/envoyconfig/bootstrap.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	envoy_config_accesslog_v3 "github.com/envoyproxy/go-control-plane/envoy/config/accesslog/v3"
@@ -26,12 +25,6 @@ import (
 )
 
 const maxActiveDownstreamConnections = 50000
-
-var (
-	envoyAdminAddressSockName = "pomerium-envoy-admin.sock"
-	envoyAdminAddressMode     = 0o600
-	envoyAdminClusterName     = "pomerium-envoy-admin"
-)
 
 // BuildBootstrap builds the bootstrap config.
 func (b *Builder) BuildBootstrap(
@@ -96,10 +89,7 @@ func (b *Builder) BuildBootstrapAdmin(cfg *config.Config) (admin *envoy_config_b
 
 	admin.Address = &envoy_config_core_v3.Address{
 		Address: &envoy_config_core_v3.Address_Pipe{
-			Pipe: &envoy_config_core_v3.Pipe{
-				Path: filepath.Join(os.TempDir(), envoyAdminAddressSockName),
-				Mode: uint32(envoyAdminAddressMode),
-			},
+			Pipe: GetPipe(envoyAdminAddressSockName),
 		},
 	}
 

--- a/config/envoyconfig/bootstrap.go
+++ b/config/envoyconfig/bootstrap.go
@@ -89,7 +89,7 @@ func (b *Builder) BuildBootstrapAdmin(cfg *config.Config) (admin *envoy_config_b
 
 	admin.Address = &envoy_config_core_v3.Address{
 		Address: &envoy_config_core_v3.Address_Pipe{
-			Pipe: GetPipe(envoyAdminAddressSockName),
+			Pipe: GetPipe(EnvoyAdminAddressSockName),
 		},
 	}
 

--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -11,7 +11,8 @@ import (
 )
 
 func TestBuilder_BuildBootstrapAdmin(t *testing.T) {
-	t.Setenv("TMPDIR", "/tmp")
+	t.Parallel()
+
 	b := New("local-connect", "local-grpc", "local-http", "local-debug", "local-metrics", filemgr.NewManager(), nil, true)
 	t.Run("valid", func(t *testing.T) {
 		adminCfg, err := b.BuildBootstrapAdmin(&config.Config{

--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -26,7 +26,7 @@ func TestBuilder_BuildBootstrapAdmin(t *testing.T) {
 				"address": {
 					"pipe": {
 						"mode": 384,
-						"path": "/tmp/`+envoyAdminAddressSockName+`"
+						"path": "/tmp/`+EnvoyAdminAddressSockName+`"
 					}
 				}
 			}

--- a/config/envoyconfig/clusters_envoy_admin.go
+++ b/config/envoyconfig/clusters_envoy_admin.go
@@ -22,7 +22,7 @@ func (b *Builder) buildEnvoyAdminCluster(_ context.Context, _ *config.Config) (*
 						Endpoint: &envoy_config_endpoint_v3.Endpoint{
 							Address: &envoy_config_core_v3.Address{
 								Address: &envoy_config_core_v3.Address_Pipe{
-									Pipe: GetPipe(envoyAdminAddressSockName),
+									Pipe: GetPipe(EnvoyAdminAddressSockName),
 								},
 							},
 						},

--- a/config/envoyconfig/clusters_envoy_admin.go
+++ b/config/envoyconfig/clusters_envoy_admin.go
@@ -2,8 +2,6 @@ package envoyconfig
 
 import (
 	"context"
-	"os"
-	"path/filepath"
 
 	envoy_config_cluster_v3 "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
@@ -24,10 +22,7 @@ func (b *Builder) buildEnvoyAdminCluster(_ context.Context, _ *config.Config) (*
 						Endpoint: &envoy_config_endpoint_v3.Endpoint{
 							Address: &envoy_config_core_v3.Address{
 								Address: &envoy_config_core_v3.Address_Pipe{
-									Pipe: &envoy_config_core_v3.Pipe{
-										Path: filepath.Join(os.TempDir(), envoyAdminAddressSockName),
-										Mode: uint32(envoyAdminAddressMode),
-									},
+									Pipe: GetPipe(envoyAdminAddressSockName),
 								},
 							},
 						},

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -29,9 +29,7 @@ import (
 )
 
 func Test_BuildClusters(t *testing.T) {
-	// The admin address path is based on os.TempDir(), which will vary from
-	// system to system, so replace this with a stable location.
-	t.Setenv("TMPDIR", "/tmp")
+	t.Parallel()
 
 	opts := config.NewDefaultOptions()
 	ctx := t.Context()

--- a/config/envoyconfig/main_test.go
+++ b/config/envoyconfig/main_test.go
@@ -1,0 +1,11 @@
+package envoyconfig_test
+
+import (
+	"os"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	os.Setenv("POMERIUM_SOCKET_DIRECTORY", "/tmp")
+	os.Exit(m.Run())
+}

--- a/config/envoyconfig/pipe.go
+++ b/config/envoyconfig/pipe.go
@@ -1,0 +1,37 @@
+package envoyconfig
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+)
+
+var (
+	envoyAdminClusterName     = "pomerium-envoy-admin"
+	envoyAdminAddressSockName = "pomerium-envoy-admin.sock"
+)
+
+// GetPipe returns a pipe for use with envoy for the current operating system.
+func GetPipe(name string) *envoy_config_core_v3.Pipe {
+	return GetPipeForOS(runtime.GOOS, name)
+}
+
+// GetPipeForOS returns a pipe for use with envoy for the given operating system.
+// If the POMERIUM_SOCKET_DIRECTORY environment variable is set, that will be
+// where the socket is stored. Otherwise, on linux the abstract socket namespace
+// will be used, and everywhere else os.TempDir() will be used.
+func GetPipeForOS(goos string, name string) *envoy_config_core_v3.Pipe {
+	pipe := new(envoy_config_core_v3.Pipe)
+	if v := os.Getenv("POMERIUM_SOCKET_DIRECTORY"); v != "" {
+		pipe.Path = filepath.Join(v, name)
+		pipe.Mode = 0o600
+	} else if goos == "linux" {
+		pipe.Path = "@" + name
+	} else {
+		pipe.Path = filepath.Join(os.TempDir(), name)
+		pipe.Mode = 0o600
+	}
+	return pipe
+}

--- a/config/envoyconfig/pipe.go
+++ b/config/envoyconfig/pipe.go
@@ -9,8 +9,9 @@ import (
 )
 
 var (
+	// EnvoyAdminAddressSockName is the name of the pomerium envoy admin socket.
+	EnvoyAdminAddressSockName = "pomerium-envoy-admin.sock"
 	envoyAdminClusterName     = "pomerium-envoy-admin"
-	envoyAdminAddressSockName = "pomerium-envoy-admin.sock"
 )
 
 // GetPipe returns a pipe for use with envoy for the current operating system.

--- a/config/envoyconfig/pipe_test.go
+++ b/config/envoyconfig/pipe_test.go
@@ -1,0 +1,39 @@
+package envoyconfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/pomerium/pomerium/config/envoyconfig"
+)
+
+func TestGetPipe(t *testing.T) {
+	t.Setenv("POMERIUM_SOCKET_DIRECTORY", "")
+	assert.Empty(t, cmp.Diff(
+		&envoy_config_core_v3.Pipe{Path: "@test"},
+		envoyconfig.GetPipeForOS("linux", "test"),
+		protocmp.Transform(),
+	))
+	assert.Empty(t, cmp.Diff(
+		&envoy_config_core_v3.Pipe{Path: filepath.Join(os.TempDir(), "test"), Mode: 0o0600},
+		envoyconfig.GetPipeForOS("darwin", "test"),
+		protocmp.Transform(),
+	))
+	t.Setenv("POMERIUM_SOCKET_DIRECTORY", "/tmp/example")
+	assert.Empty(t, cmp.Diff(
+		&envoy_config_core_v3.Pipe{Path: "/tmp/example/test", Mode: 0o0600},
+		envoyconfig.GetPipeForOS("linux", "test"),
+		protocmp.Transform(),
+	))
+	assert.Empty(t, cmp.Diff(
+		&envoy_config_core_v3.Pipe{Path: "/tmp/example/test", Mode: 0o0600},
+		envoyconfig.GetPipeForOS("darwin", "test"),
+		protocmp.Transform(),
+	))
+}

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -146,7 +146,7 @@ func (srv *Server) envoyAdminClient() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			DialContext: func(context.Context, string, string) (net.Conn, error) {
-				return net.Dial("unix", filepath.Join(os.TempDir(), "pomerium-envoy-admin.sock"))
+				return net.Dial("unix", envoyconfig.GetPipe(envoyconfig.EnvoyAdminAddressSockName).GetPath())
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
Use the abstract socket namespace on linux for the envoy admin socket.


## Related issues

Follow up from #6339 

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure
none

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
