### PR TITLE
authorize: add client cert SAN substitutions

### DIFF
--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -3,6 +3,7 @@ package evaluator
 import (
 	"context"
 	"crypto/sha256"
+	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -56,6 +57,9 @@ type headersEvaluatorEvaluation struct {
 
 	gotSignedJWT    bool
 	cachedSignedJWT string
+
+	gotParsedClientCert    bool
+	cachedParsedClientCert *x509.Certificate
 }
 
 func newHeadersEvaluatorEvaluation(evaluator *HeadersEvaluator, request *Request, now time.Time) *headersEvaluatorEvaluation {
@@ -182,6 +186,10 @@ func (e *headersEvaluatorEvaluation) fillSetRequestHeaders(ctx context.Context) 
 			case slices.Equal(ref, []string{"pomerium", "access_token"}):
 				s, _ := e.getSessionOrServiceAccount(ctx)
 				return s.GetOauthToken().GetAccessToken()
+			case slices.Equal(ref, []string{"pomerium", "client_cert_san_dns"}):
+				return e.getClientCertDNSNames()
+			case slices.Equal(ref, []string{"pomerium", "client_cert_san_email"}):
+				return e.getClientCertEmailAddresses()
 			case slices.Equal(ref, []string{"pomerium", "client_cert_fingerprint"}):
 				return e.getClientCertFingerprint()
 			case slices.Equal(ref, []string{"pomerium", "id_token"}):
@@ -248,9 +256,35 @@ func (e *headersEvaluatorEvaluation) getUser(ctx context.Context) *user.User {
 	return e.cachedUser
 }
 
+func (e *headersEvaluatorEvaluation) getParsedClientCert() *x509.Certificate {
+	if e.gotParsedClientCert {
+		return e.cachedParsedClientCert
+	}
+
+	e.gotParsedClientCert = true
+	e.cachedParsedClientCert, _ = cryptutil.ParsePEMCertificate([]byte(e.request.HTTP.ClientCertificate.Leaf))
+	return e.cachedParsedClientCert
+}
+
+func (e *headersEvaluatorEvaluation) getClientCertDNSNames() string {
+	cert := e.getParsedClientCert()
+	if cert == nil {
+		return ""
+	}
+	return strings.Join(cert.DNSNames, ",")
+}
+
+func (e *headersEvaluatorEvaluation) getClientCertEmailAddresses() string {
+	cert := e.getParsedClientCert()
+	if cert == nil {
+		return ""
+	}
+	return strings.Join(cert.EmailAddresses, ",")
+}
+
 func (e *headersEvaluatorEvaluation) getClientCertFingerprint() string {
-	cert, err := cryptutil.ParsePEMCertificate([]byte(e.request.HTTP.ClientCertificate.Leaf))
-	if err != nil {
+	cert := e.getParsedClientCert()
+	if cert == nil {
 		return ""
 	}
 	return cryptoSHA256(cert.Raw)

--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -271,7 +271,7 @@ func (e *headersEvaluatorEvaluation) getClientCertDNSNames() string {
 	if cert == nil {
 		return ""
 	}
-	return strings.Join(cert.DNSNames, ",")
+	return commaSeparatedList(cert.DNSNames)
 }
 
 func (e *headersEvaluatorEvaluation) getClientCertEmailAddresses() string {
@@ -279,7 +279,28 @@ func (e *headersEvaluatorEvaluation) getClientCertEmailAddresses() string {
 	if cert == nil {
 		return ""
 	}
-	return strings.Join(cert.EmailAddresses, ",")
+	return commaSeparatedList(cert.EmailAddresses)
+}
+
+func commaSeparatedList(s []string) string {
+	// Scrub any elements of s that contain a comma, to avoid parsing ambiguity.
+	// Valid DNS names cannot contain a comma. Email addresses may technically
+	// contain a comma in the local-part if quoted, but this is unlikely to be
+	// well supported in practice.
+	var scrubbed []string
+	var i int
+	for j := range s {
+		if strings.Contains(s[j], ",") {
+			scrubbed = append(scrubbed, s[i:j]...)
+			i = j + 1
+		}
+	}
+	if i > 0 {
+		scrubbed = append(scrubbed, s[i:]...)
+	} else {
+		scrubbed = s // no elements of s contain a comma
+	}
+	return strings.Join(scrubbed, ",")
 }
 
 func (e *headersEvaluatorEvaluation) getClientCertFingerprint() string {

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -344,13 +345,13 @@ func TestHeadersEvaluator(t *testing.T) {
 				},
 				Policy: &config.Policy{
 					SetRequestHeaders: map[string]string{
-						"Client-Cert-San-Dns": "${pomerium.client_cert_san_email}",
+						"Client-Cert-San-Email": "${pomerium.client_cert_san_email}",
 					},
 				},
 				Session: RequestSession{ID: "s1"},
 			})
 		require.NoError(t, err)
-		assert.Equal(t, "client4@example.com", output.Headers.Get("Client-Cert-San-Dns"))
+		assert.Equal(t, "client4@example.com", output.Headers.Get("Client-Cert-San-Email"))
 	})
 
 	t.Run("kubernetes", func(t *testing.T) {
@@ -814,6 +815,32 @@ func TestHeadersEvaluator_JWTGroupsFilter(t *testing.T) {
 			} else {
 				assert.Nil(t, resp.AdditionalLogFields[logfields.AuthorizeLogFieldRemovedGroupsCount])
 			}
+		})
+	}
+}
+
+func TestCommaSeparatedList(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		label  string
+		input  []string
+		output string
+	}{
+		{"nil", nil, ""},
+		{"empty", []string{}, ""},
+		{"ok", []string{"foo", "bar", "baz"}, "foo,bar,baz"},
+		{"scrubbed_1", []string{"foo", "bar", ",baz", "quux", "fizz,buzz"}, "foo,bar,quux"},
+		{"scrubbed_2", []string{"foo,", "bar", "baz", "qu,ux", "fizzbuzz"}, "bar,baz,fizzbuzz"},
+		{"all scrubbed", []string{"foo,", ",bar", "ba,z"}, ""},
+	}
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			originalInput := slices.Clone(c.input)
+
+			actual := commaSeparatedList(c.input)
+			assert.Equal(t, c.output, actual)
+			assert.Equal(t, originalInput, c.input) // should not mutate the input
 		})
 	}
 }

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -304,13 +304,53 @@ func TestHeadersEvaluator(t *testing.T) {
 			&Request{
 				Policy: &config.Policy{
 					SetRequestHeaders: map[string]string{
+						"dns":         "${pomerium.client_cert_san_dns}",
+						"email":       "${pomerium.client_cert_san_email}",
 						"fingerprint": "${pomerium.client_cert_fingerprint}",
 					},
 				},
 			})
 		require.NoError(t, err)
 
+		assert.Equal(t, "", output.Headers.Get("dns"))
+		assert.Equal(t, "", output.Headers.Get("email"))
 		assert.Equal(t, "", output.Headers.Get("fingerprint"))
+	})
+
+	t.Run("client_cert_san_dns", func(t *testing.T) {
+		output, err := eval(t,
+			nil,
+			&Request{
+				HTTP: RequestHTTP{
+					ClientCertificate: ClientCertificateInfo{Leaf: testValidCertWithDNSSANs},
+				},
+				Policy: &config.Policy{
+					SetRequestHeaders: map[string]string{
+						"Client-Cert-San-Dns": "${pomerium.client_cert_san_dns}",
+					},
+				},
+				Session: RequestSession{ID: "s1"},
+			})
+		require.NoError(t, err)
+		assert.Equal(t, "a.client3.example.com,b.client3.example.com", output.Headers.Get("Client-Cert-San-Dns"))
+	})
+
+	t.Run("client_cert_san_email", func(t *testing.T) {
+		output, err := eval(t,
+			nil,
+			&Request{
+				HTTP: RequestHTTP{
+					ClientCertificate: ClientCertificateInfo{Leaf: testValidCertWithEmailSAN},
+				},
+				Policy: &config.Policy{
+					SetRequestHeaders: map[string]string{
+						"Client-Cert-San-Dns": "${pomerium.client_cert_san_email}",
+					},
+				},
+				Session: RequestSession{ID: "s1"},
+			})
+		require.NoError(t, err)
+		assert.Equal(t, "client4@example.com", output.Headers.Get("Client-Cert-San-Dns"))
 	})
 
 	t.Run("kubernetes", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Add two new substitution tokens for the `set_request_headers` option related to the client certificate Subject Alternate Name (SAN):

* `client_cert_san_dns`: comma-separated list of the DNS names
* `client_cert_san_email`: comma-separated list of the email addresses

## Related issues

https://linear.app/pomerium/issue/ENG-4026/feature-request-headers-for-mtls

## User Explanation

Allows two additional pieces of data to be extracted from a client certificate and passed to upstream services in the HTTP request headers.

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
