### PR TITLE
core/config: fix generated bool setter

### DIFF
--- a/config/config.gen.go
+++ b/config/config.gen.go
@@ -595,7 +595,7 @@ func setOutlierDetectionToProto(dst **configpb.OutlierDetection, src *OutlierDet
 		setNullableUInt32ValueToProto(&obj.MaxEjectionPercent, src.MaxEjectionPercent),
 		setNullableDurationToProto(&obj.MaxEjectionTime, src.MaxEjectionTime),
 		setNullableDurationToProto(&obj.MaxEjectionTimeJitter, src.MaxEjectionTimeJitter),
-		setNullableBoolToProto(new(&obj.SplitExternalLocalOriginErrors), src.SplitExternalLocalOriginErrors),
+		setBoolToProto(&obj.SplitExternalLocalOriginErrors, src.SplitExternalLocalOriginErrors),
 		setNullableUInt32ValueToProto(&obj.SuccessRateMinimumHosts, src.SuccessRateMinimumHosts),
 		setNullableUInt32ValueToProto(&obj.SuccessRateRequestVolume, src.SuccessRateRequestVolume),
 		setNullableUInt32ValueToProto(&obj.SuccessRateStdevFactor, src.SuccessRateStdevFactor),
@@ -672,8 +672,8 @@ func setRouteDirectResponseToProto(dst **configpb.RouteDirectResponse, src *Rout
 	}
 	obj := *dst
 	return errors.Join(
-		setNullableStringToProto(new(&obj.Body), src.Body),
-		setNullableUInt32ToProto(new(&obj.Status), src.Status),
+		setStringToProto(&obj.Body, src.Body),
+		setUInt32ToProto(&obj.Status, src.Status),
 	)
 }
 
@@ -750,9 +750,9 @@ func setRouteRewriteHeaderToProto(dst **configpb.RouteRewriteHeader, src *RouteR
 	}
 	obj := *dst
 	return errors.Join(
-		setNullableStringToProto(new(&obj.Header), src.Header),
+		setStringToProto(&obj.Header, src.Header),
 		setOneOf(&obj.Matcher, &configpb.RouteRewriteHeader_Prefix{Prefix: src.Prefix.Value}, src.Prefix),
-		setNullableStringToProto(new(&obj.Value), src.Value),
+		setStringToProto(&obj.Value, src.Value),
 	)
 }
 
@@ -826,9 +826,9 @@ func setSettings_CertificateToProto(dst **configpb.Settings_Certificate, src *Se
 	}
 	obj := *dst
 	return errors.Join(
-		setNullableSliceOfByteToProto(new(&obj.CertBytes), src.CertBytes),
-		setNullableStringToProto(new(&obj.Id), src.ID),
-		setNullableSliceOfByteToProto(new(&obj.KeyBytes), src.KeyBytes),
+		setSliceOfByteToProto(&obj.CertBytes, src.CertBytes),
+		setStringToProto(&obj.Id, src.ID),
+		setSliceOfByteToProto(&obj.KeyBytes, src.KeyBytes),
 	)
 }
 
@@ -863,8 +863,8 @@ func setSettings_DataBrokerClusterNodeToProto(dst **configpb.Settings_DataBroker
 	}
 	obj := *dst
 	return errors.Join(
-		setNullableStringToProto(new(&obj.GrpcAddress), src.GRPCAddress),
-		setNullableStringToProto(new(&obj.Id), src.ID),
+		setStringToProto(&obj.GrpcAddress, src.GRPCAddress),
+		setStringToProto(&obj.Id, src.ID),
 		setNullableStringToProto(&obj.RaftAddress, src.RaftAddress),
 	)
 }
@@ -933,11 +933,11 @@ func setNullableBoolToProto(dst **bool, src Value[bool]) error {
 	return nil
 }
 
-func setBoolToProto(dst **bool, src *bool) error {
-	if src == nil {
+func setBoolToProto(dst *bool, src Value[bool]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -970,11 +970,11 @@ func setNullableByteToProto(dst **byte, src Value[byte]) error {
 	return nil
 }
 
-func setByteToProto(dst **byte, src *byte) error {
-	if src == nil {
+func setByteToProto(dst *byte, src Value[byte]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1007,11 +1007,11 @@ func setNullableFloatToProto(dst **float32, src Value[float32]) error {
 	return nil
 }
 
-func setFloatToProto(dst **float32, src *float32) error {
-	if src == nil {
+func setFloatToProto(dst *float32, src Value[float32]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1044,11 +1044,11 @@ func setNullableDoubleToProto(dst **float64, src Value[float64]) error {
 	return nil
 }
 
-func setDoubleToProto(dst **float64, src *float64) error {
-	if src == nil {
+func setDoubleToProto(dst *float64, src Value[float64]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1081,11 +1081,11 @@ func setNullableInt16ToProto(dst **int16, src Value[int16]) error {
 	return nil
 }
 
-func setInt16ToProto(dst **int16, src *int16) error {
-	if src == nil {
+func setInt16ToProto(dst *int16, src Value[int16]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1118,11 +1118,11 @@ func setNullableInt32ToProto(dst **int32, src Value[int32]) error {
 	return nil
 }
 
-func setInt32ToProto(dst **int32, src *int32) error {
-	if src == nil {
+func setInt32ToProto(dst *int32, src Value[int32]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1155,11 +1155,11 @@ func setNullableInt64ToProto(dst **int64, src Value[int64]) error {
 	return nil
 }
 
-func setInt64ToProto(dst **int64, src *int64) error {
-	if src == nil {
+func setInt64ToProto(dst *int64, src Value[int64]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1192,11 +1192,11 @@ func setNullableStringToProto(dst **string, src Value[string]) error {
 	return nil
 }
 
-func setStringToProto(dst **string, src *string) error {
-	if src == nil {
+func setStringToProto(dst *string, src Value[string]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1229,11 +1229,11 @@ func setNullableUInt16ToProto(dst **uint16, src Value[uint16]) error {
 	return nil
 }
 
-func setUInt16ToProto(dst **uint16, src *uint16) error {
-	if src == nil {
+func setUInt16ToProto(dst *uint16, src Value[uint16]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1266,11 +1266,11 @@ func setNullableUInt32ToProto(dst **uint32, src Value[uint32]) error {
 	return nil
 }
 
-func setUInt32ToProto(dst **uint32, src *uint32) error {
-	if src == nil {
+func setUInt32ToProto(dst *uint32, src Value[uint32]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1303,11 +1303,11 @@ func setNullableUInt64ToProto(dst **uint64, src Value[uint64]) error {
 	return nil
 }
 
-func setUInt64ToProto(dst **uint64, src *uint64) error {
-	if src == nil {
+func setUInt64ToProto(dst *uint64, src Value[uint64]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1340,11 +1340,11 @@ func setNullableSliceOfBoolToProto(dst **[]bool, src Value[[]bool]) error {
 	return nil
 }
 
-func setSliceOfBoolToProto(dst **[]bool, src *[]bool) error {
-	if src == nil {
+func setSliceOfBoolToProto(dst *[]bool, src Value[[]bool]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1377,11 +1377,11 @@ func setNullableSliceOfByteToProto(dst **[]byte, src Value[[]byte]) error {
 	return nil
 }
 
-func setSliceOfByteToProto(dst **[]byte, src *[]byte) error {
-	if src == nil {
+func setSliceOfByteToProto(dst *[]byte, src Value[[]byte]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1414,11 +1414,11 @@ func setNullableSliceOfFloatToProto(dst **[]float32, src Value[[]float32]) error
 	return nil
 }
 
-func setSliceOfFloatToProto(dst **[]float32, src *[]float32) error {
-	if src == nil {
+func setSliceOfFloatToProto(dst *[]float32, src Value[[]float32]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1451,11 +1451,11 @@ func setNullableSliceOfDoubleToProto(dst **[]float64, src Value[[]float64]) erro
 	return nil
 }
 
-func setSliceOfDoubleToProto(dst **[]float64, src *[]float64) error {
-	if src == nil {
+func setSliceOfDoubleToProto(dst *[]float64, src Value[[]float64]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1488,11 +1488,11 @@ func setNullableSliceOfInt16ToProto(dst **[]int16, src Value[[]int16]) error {
 	return nil
 }
 
-func setSliceOfInt16ToProto(dst **[]int16, src *[]int16) error {
-	if src == nil {
+func setSliceOfInt16ToProto(dst *[]int16, src Value[[]int16]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1525,11 +1525,11 @@ func setNullableSliceOfInt32ToProto(dst **[]int32, src Value[[]int32]) error {
 	return nil
 }
 
-func setSliceOfInt32ToProto(dst **[]int32, src *[]int32) error {
-	if src == nil {
+func setSliceOfInt32ToProto(dst *[]int32, src Value[[]int32]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1562,11 +1562,11 @@ func setNullableSliceOfInt64ToProto(dst **[]int64, src Value[[]int64]) error {
 	return nil
 }
 
-func setSliceOfInt64ToProto(dst **[]int64, src *[]int64) error {
-	if src == nil {
+func setSliceOfInt64ToProto(dst *[]int64, src Value[[]int64]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1599,11 +1599,11 @@ func setNullableSliceOfStringToProto(dst **[]string, src Value[[]string]) error 
 	return nil
 }
 
-func setSliceOfStringToProto(dst **[]string, src *[]string) error {
-	if src == nil {
+func setSliceOfStringToProto(dst *[]string, src Value[[]string]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1636,11 +1636,11 @@ func setNullableSliceOfUInt16ToProto(dst **[]uint16, src Value[[]uint16]) error 
 	return nil
 }
 
-func setSliceOfUInt16ToProto(dst **[]uint16, src *[]uint16) error {
-	if src == nil {
+func setSliceOfUInt16ToProto(dst *[]uint16, src Value[[]uint16]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1673,11 +1673,11 @@ func setNullableSliceOfUInt32ToProto(dst **[]uint32, src Value[[]uint32]) error 
 	return nil
 }
 
-func setSliceOfUInt32ToProto(dst **[]uint32, src *[]uint32) error {
-	if src == nil {
+func setSliceOfUInt32ToProto(dst *[]uint32, src Value[[]uint32]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 
@@ -1710,11 +1710,11 @@ func setNullableSliceOfUInt64ToProto(dst **[]uint64, src Value[[]uint64]) error 
 	return nil
 }
 
-func setSliceOfUInt64ToProto(dst **[]uint64, src *[]uint64) error {
-	if src == nil {
+func setSliceOfUInt64ToProto(dst *[]uint64, src Value[[]uint64]) error {
+	if !src.IsSet {
 		return nil
 	}
-	*dst = new(*src)
+	*dst = src.Value
 	return nil
 }
 

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -352,6 +352,18 @@ func TestPolicy_FromToPb(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, p.Redirect.HTTPSRedirect, policyFromProto.Redirect.HTTPSRedirect)
 	})
+
+	t.Run("outlier detection", func(t *testing.T) {
+		src := &OutlierDetection{
+			SplitExternalLocalOriginErrors: nullable.From(true),
+		}
+		dst := new(config.OutlierDetection)
+		require.NoError(t, setOutlierDetectionToProto(&dst, src))
+		assert.True(t, dst.GetSplitExternalLocalOriginErrors())
+		result := new(OutlierDetection)
+		require.NoError(t, setOutlierDetectionFromProto(result, dst))
+		assert.True(t, result.SplitExternalLocalOriginErrors.Value)
+	})
 }
 
 func TestPolicy_Matches(t *testing.T) {

--- a/internal/generate/generate.go
+++ b/internal/generate/generate.go
@@ -349,8 +349,8 @@ func generateConfigToProtoFuncs(_ context.Context, g *jen.Group, mds []protorefl
 								jen.Id("src").Dot(goName),
 							)
 						} else {
-							g.Line().Id("setNullable"+setterName+"ToProto").Call(
-								jen.New(jen.Op("&").Id("obj").Dot(protoGoName)),
+							g.Line().Id("set"+setterName+"ToProto").Call(
+								jen.Op("&").Id("obj").Dot(protoGoName),
 								jen.Id("src").Dot(goName),
 							)
 						}
@@ -439,15 +439,15 @@ func generateBasicSetters(_ context.Context, g *jen.Group) error {
 
 		g.Func().Id("set"+def.methodName+"ToProto").
 			Params(
-				jen.Id("dst").Op("**").Id(def.typeName),
-				jen.Id("src").Op("*").Id(def.typeName),
+				jen.Id("dst").Op("*").Id(def.typeName),
+				jen.Id("src").Qual("github.com/pomerium/pomerium/pkg/nullable", "Value").Index(jen.Id(def.typeName)),
 			).
 			Error().
 			BlockFunc(func(g *jen.Group) {
-				g.If(jen.Id("src").Op("==").Nil()).BlockFunc(func(g *jen.Group) {
+				g.If(jen.Op("!").Id("src").Dot("IsSet")).BlockFunc(func(g *jen.Group) {
 					g.Return(jen.Nil())
 				})
-				g.Op("*").Id("dst").Op("=").New(jen.Op("*").Id("src"))
+				g.Op("*").Id("dst").Op("=").Id("src").Dot("Value")
 				g.Return(jen.Nil())
 			})
 		g.Line()

--- a/pkg/nullable/value.go
+++ b/pkg/nullable/value.go
@@ -29,6 +29,13 @@ func FromPtr[T any](ptr *T) Value[T] {
 	return NewValue(true, *ptr)
 }
 
+func (v Value[T]) Or(ifNotSet T) T {
+	if v.IsSet {
+		return v.Value
+	}
+	return ifNotSet
+}
+
 func (v Value[T]) Equal(other Value[T]) bool {
 	return (!v.IsSet && !other.IsSet) || reflect.DeepEqual(v.Value, other.Value)
 }


### PR DESCRIPTION
## Summary
Fix a bug in the generated protobuf/go config conversion code.

## Details
When working with a protobuf type with a non-nullable bool:

```proto
message OutlierDetection {
  bool split_external_local_origin_errors = 12;
}
```

The `ToProto` conversion would use the `setNullableBoolToProto` function:

```go
setNullableBoolToProto(new(&obj.SplitExternalLocalOriginErrors), src.SplitExternalLocalOriginErrors)
```

Because we were using `new` the value would then immediately be discarded and the actual boolean never set. So instead we will now call the non-nullable `setBoolToProto` which will set the value properly, and that method was updated to take a `nullable.Value` instead of a pointer:

```go
func setBoolToProto(dst *bool, src Value[bool]) error {
	if !src.IsSet {
		return nil
	}
	*dst = src.Value
	return nil
}
```

## Related issues

## AI disclosure

none
## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
