### PR TITLE
feat(ipc):  generic protobuf communication via pipes

### DIFF
--- a/pkg/ipc/helpers_test.go
+++ b/pkg/ipc/helpers_test.go
@@ -3,6 +3,7 @@ package ipc
 import (
 	"bufio"
 	"context"
+	"io"
 	"os"
 	"sync"
 	"testing"
@@ -11,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/encoding/protodelim"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/pkg/grpc/testproto"
 )
 
 type testPipeClient[Req, Resp proto.Message] struct {
@@ -44,15 +47,23 @@ func (c *testPipeClient[Req, Resp]) send(t *testing.T, msg Req) {
 	require.NoError(t, err)
 }
 
+func (c *testPipeClient[Req, Resp]) sendRaw(t *testing.T, data []byte) {
+	t.Helper()
+	_, err := c.write.Write(data)
+	require.NoError(t, err)
+}
+
+func (c *testPipeClient[Req, Resp]) recvRaw(t *testing.T, buf []byte) {
+	t.Helper()
+	_, err := c.read.Read(buf)
+	require.NoError(t, err)
+}
+
 func (c *testPipeClient[Req, Resp]) recv(t *testing.T) Resp {
 	t.Helper()
 	msg := newProtoMessage[Resp]()
 	require.NoError(t, protodelim.UnmarshalFrom(c.read, msg))
 	return msg
-}
-
-func (c *testPipeClient[Req, Resp]) closeWrite() error {
-	return c.write.Close()
 }
 
 type serversClient[Req, Resp proto.Message] struct {
@@ -62,11 +73,9 @@ type serversClient[Req, Resp proto.Message] struct {
 	serveErr chan error
 }
 
-func newServersClient[Req, Resp proto.Message](
-	t *testing.T,
-	n int,
-	handler ServerHandler[Req, Resp],
-) *serversClient[Req, Resp] {
+func makeClients[Req, Resp proto.Message](
+	t *testing.T, n int,
+) ([]*testPipeClient[Req, Resp], []*ProtoPipeWorker[Req, Resp]) {
 	t.Helper()
 	clients := make([]*testPipeClient[Req, Resp], n)
 	workers := make([]*ProtoPipeWorker[Req, Resp], n)
@@ -74,6 +83,16 @@ func newServersClient[Req, Resp proto.Message](
 		clients[i] = newTestPipeClient[Req, Resp](t)
 		workers[i] = clients[i].worker()
 	}
+	return clients, workers
+}
+
+func newServersClient[Req, Resp proto.Message](
+	t *testing.T,
+	n int,
+	handler ServerHandler[Req, Resp],
+) *serversClient[Req, Resp] {
+	t.Helper()
+	clients, workers := makeClients[Req, Resp](t, n)
 	return &serversClient[Req, Resp]{
 		t: t,
 		server: NewProtoPipeServer(workers, handler, ServerOptions{
@@ -101,7 +120,28 @@ func (sc *serversClient[Req, Resp]) runClients(fn func(i int, c *testPipeClient[
 	wg.Wait()
 }
 
-func (sc *serversClient[Req, Resp]) waitServer(timeout time.Duration) error {
-	sc.t.Helper()
-	return waitForErr(sc.t, sc.serveErr, timeout, "ListenAndServe to return")
+type testServerHandler struct {
+	handler      func(ctx context.Context, msg *testproto.Test) (*testproto.Test, error)
+	handshakeIn  func(context.Context, io.Reader) error
+	handshakeOut func(context.Context, io.Writer) error
 }
+
+func (t *testServerHandler) RecvHandshake(ctx context.Context, rd io.Reader) error {
+	if t.handshakeIn != nil {
+		return t.handshakeIn(ctx, rd)
+	}
+	return nil
+}
+
+func (t *testServerHandler) SendHandshake(ctx context.Context, wr io.Writer) error {
+	if t.handshakeOut != nil {
+		return t.handshakeOut(ctx, wr)
+	}
+	return nil
+}
+
+func (t *testServerHandler) Handler(ctx context.Context, msg *testproto.Test) (*testproto.Test, error) {
+	return t.handler(ctx, msg)
+}
+
+var _ ServerHandler[*testproto.Test, *testproto.Test] = (*testServerHandler)(nil)

--- a/pkg/ipc/pipe_client_test.go
+++ b/pkg/ipc/pipe_client_test.go
@@ -75,8 +75,11 @@ func newServersClient[Req, Resp proto.Message](
 		workers[i] = clients[i].worker()
 	}
 	return &serversClient[Req, Resp]{
-		t:        t,
-		server:   NewProtoPipeServer(workers, handler),
+		t: t,
+		server: NewProtoPipeServer(workers, handler, ServerOptions{
+			ShutdownTimeout: time.Second * 15,
+			Name:            "test",
+		}),
 		clients:  clients,
 		serveErr: make(chan error, 1),
 	}

--- a/pkg/ipc/pipe_client_test.go
+++ b/pkg/ipc/pipe_client_test.go
@@ -1,0 +1,104 @@
+package ipc
+
+import (
+	"bufio"
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protodelim"
+	"google.golang.org/protobuf/proto"
+)
+
+type testPipeClient[Req, Resp proto.Message] struct {
+	receiver *ProtoPipeReceiver[Req]
+	sender   *ProtoPipeSender[Resp]
+	write    *os.File
+	read     protodelim.Reader
+}
+
+func newTestPipeClient[Req, Resp proto.Message](t *testing.T) *testPipeClient[Req, Resp] {
+	t.Helper()
+	serverRead, testWrite, err := os.Pipe()
+	require.NoError(t, err)
+	testRead, serverWrite, err := os.Pipe()
+	require.NoError(t, err)
+	return &testPipeClient[Req, Resp]{
+		receiver: NewProtoPipeReceiver[Req](NewPipePair(serverRead, testWrite)),
+		sender:   NewProtoPipeSender[Resp](NewPipePair(testRead, serverWrite)),
+		write:    testWrite,
+		read:     bufio.NewReader(testRead),
+	}
+}
+
+func (c *testPipeClient[Req, Resp]) worker() *ProtoPipeWorker[Req, Resp] {
+	return NewProtoPipeWorker(c.receiver, c.sender)
+}
+
+func (c *testPipeClient[Req, Resp]) send(t *testing.T, msg Req) {
+	t.Helper()
+	_, err := protodelim.MarshalTo(c.write, msg)
+	require.NoError(t, err)
+}
+
+func (c *testPipeClient[Req, Resp]) recv(t *testing.T) Resp {
+	t.Helper()
+	msg := newProtoMessage[Resp]()
+	require.NoError(t, protodelim.UnmarshalFrom(c.read, msg))
+	return msg
+}
+
+func (c *testPipeClient[Req, Resp]) closeWrite() error {
+	return c.write.Close()
+}
+
+type serversClient[Req, Resp proto.Message] struct {
+	t        *testing.T
+	server   *ProtoPipeServer[Req, Resp]
+	clients  []*testPipeClient[Req, Resp]
+	serveErr chan error
+}
+
+func newServersClient[Req, Resp proto.Message](
+	t *testing.T,
+	n int,
+	handler ServerHandler[Req, Resp],
+) *serversClient[Req, Resp] {
+	t.Helper()
+	clients := make([]*testPipeClient[Req, Resp], n)
+	workers := make([]*ProtoPipeWorker[Req, Resp], n)
+	for i := range clients {
+		clients[i] = newTestPipeClient[Req, Resp](t)
+		workers[i] = clients[i].worker()
+	}
+	return &serversClient[Req, Resp]{
+		t:        t,
+		server:   NewProtoPipeServer(workers, handler),
+		clients:  clients,
+		serveErr: make(chan error, 1),
+	}
+}
+
+func (sc *serversClient[Req, Resp]) start(ctx context.Context) {
+	go func() {
+		sc.serveErr <- sc.server.Serve(ctx)
+	}()
+}
+
+func (sc *serversClient[Req, Resp]) runClients(fn func(i int, c *testPipeClient[Req, Resp])) {
+	var wg sync.WaitGroup
+	for i, c := range sc.clients {
+		wg.Go(func() {
+			fn(i, c)
+		})
+	}
+	wg.Wait()
+}
+
+func (sc *serversClient[Req, Resp]) waitServer(timeout time.Duration) error {
+	sc.t.Helper()
+	return waitForErr(sc.t, sc.serveErr, timeout, "ListenAndServe to return")
+}

--- a/pkg/ipc/pipe_darwin.go
+++ b/pkg/ipc/pipe_darwin.go
@@ -1,0 +1,7 @@
+//go:build darwin
+
+package ipc
+
+// not defined anywhere in any std / sys packages in go for darwin for some reason.
+// https://github.com/apple-oss-distributions/xnu/blob/f6217f891ac0bb64f3d375211650a4c1ff8ca1ea/bsd/sys/filio.h#L77
+const FIONREAD = 0x4004667f

--- a/pkg/ipc/pipe_linux.go
+++ b/pkg/ipc/pipe_linux.go
@@ -1,0 +1,7 @@
+//go:build linux
+
+package ipc
+
+import "golang.org/x/sys/unix"
+
+const FIONREAD = unix.TIOCINQ

--- a/pkg/ipc/pipe_server.go
+++ b/pkg/ipc/pipe_server.go
@@ -1,234 +1,26 @@
 package ipc
 
 import (
-	"bufio"
 	"context"
 	"errors"
 	"fmt"
 	"io"
-	"os"
-	"reflect"
-	"sync"
-	"sync/atomic"
 	"time"
 
+	"github.com/rs/zerolog"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/sys/unix"
-	"google.golang.org/protobuf/encoding/protodelim"
-	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/internal/log"
 )
 
-func NewPipeWorkers[Recv proto.Message, Send proto.Message](
-	num int,
-) ([]*ProtoPipeWorker[Recv, Send], error) {
-	ret := []*ProtoPipeWorker[Recv, Send]{}
-	for range num {
-		recvRead, recvWrite, err := os.Pipe()
-		if err != nil {
-			return nil, err
-		}
-
-		sendRead, sendWrite, err := os.Pipe()
-		if err != nil {
-			return nil, err
-		}
-
-		receiver := NewProtoPipeReceiver[Recv](
-			NewPipePair(recvRead, recvWrite),
-		)
-		sender := NewProtoPipeSender[Send](
-			NewPipePair(sendRead, sendWrite),
-		)
-
-		ret = append(ret, NewProtoPipeWorker(
-			receiver,
-			sender,
-		))
-	}
-	return ret, nil
-}
-
-// PipePair encapsulates the read/write ends of a pipe.
-type PipePair struct {
-	Read  *os.File
-	Write *os.File
-
-	closeF func() error
-}
-
-func NewPipePair(readEnd *os.File, writeEnd *os.File) *PipePair {
-	return &PipePair{
-		Read:  readEnd,
-		Write: writeEnd,
-		closeF: sync.OnceValue(func() error {
-			readCloseErr := readEnd.Close()
-			writeCloseErr := writeEnd.Close()
-			return errors.Join(readCloseErr, writeCloseErr)
-		}),
-	}
-}
-
-func (p *PipePair) Close() error {
-	return p.closeF()
-}
-
-// ProtoPipeReceiver receives length-delimited protobuf messages from the read
-// end of a PipePair.
-type ProtoPipeReceiver[Recv proto.Message] struct {
-	*PipePair
-	rd             protodelim.Reader
-	shouldShutdown atomic.Bool
-}
-
-func NewProtoPipeReceiver[Recv proto.Message](pair *PipePair) *ProtoPipeReceiver[Recv] {
-	return &ProtoPipeReceiver[Recv]{
-		PipePair: pair,
-		rd:       bufio.NewReader(pair.Read),
-	}
-}
-
-// Shutdown signals the receiver to stop after draining any data currently
-// queued in the kernel pipe buffer. Setting a past read deadline unblocks
-// pending reads immediately.
-func (r *ProtoPipeReceiver[Recv]) Shutdown() error {
-	r.shouldShutdown.Store(true)
-	return r.Read.SetReadDeadline(time.Unix(1, 0))
-}
-
-func (r *ProtoPipeReceiver[Recv]) shutdownRequested() bool {
-	return r.shouldShutdown.Load()
-}
-
-func (r *ProtoPipeReceiver[Recv]) recvMsg(_ context.Context) (Recv, error) {
-	if r.shutdownRequested() {
-		n, err := unix.IoctlGetInt(int(r.Read.Fd()), FIONREAD)
-		if err != nil {
-			var zero Recv
-			return zero, err
-		}
-		if n == 0 {
-			// nothing queued up, safe to signal close
-			if err := r.Close(); err != nil {
-				var zero Recv
-				return zero, err
-			}
-			var zero Recv
-			return zero, io.EOF
-		}
-		// otherwise, continues to drain
-	}
-	msg := newProtoMessage[Recv]()
-	if err := protodelim.UnmarshalFrom(r.rd, msg); err != nil {
-		return msg, err
-	}
-	return msg, nil
-}
-
-// ProtoPipeSender sends length-delimited protobuf messages to the write end of
-// a PipePair.
-type ProtoPipeSender[Send proto.Message] struct {
-	*PipePair
-}
-
-func NewProtoPipeSender[Send proto.Message](pair *PipePair) *ProtoPipeSender[Send] {
-	return &ProtoPipeSender[Send]{PipePair: pair}
-}
-
-func (s *ProtoPipeSender[Send]) sendMsg(_ context.Context, msg Send) error {
-	if _, err := protodelim.MarshalTo(s.Write, msg); err != nil {
-		return err
-	}
-	return nil
-}
-
-// ProtoPipeWorker handles bi-directional communication between receivers and senders.
-type ProtoPipeWorker[Recv proto.Message, Send proto.Message] struct {
-	receiver *ProtoPipeReceiver[Recv]
-	sender   *ProtoPipeSender[Send]
-}
-
-func NewProtoPipeWorker[Recv proto.Message, Send proto.Message](
-	receiver *ProtoPipeReceiver[Recv],
-	sender *ProtoPipeSender[Send],
-) *ProtoPipeWorker[Recv, Send] {
-	return &ProtoPipeWorker[Recv, Send]{
-		receiver: receiver,
-		sender:   sender,
-	}
-}
-
-func (w *ProtoPipeWorker[Recv, Send]) run(ctx context.Context, handler ServerHandler[Recv, Send]) error {
-	for {
-		msg, err := w.receiver.recvMsg(ctx)
-		if err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
-				return nil
-			}
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			return err
-		}
-		resp, err := handler(msg)
-		if err != nil {
-			return err
-		}
-		if err := w.sender.sendMsg(ctx, resp); err != nil {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
-			return err
-		}
-	}
-}
-
-func (w *ProtoPipeWorker[Recv, Send]) Close() error {
-	receiverCloseErr := w.receiver.Close()
-	senderCloseErr := w.sender.Close()
-	return errors.Join(receiverCloseErr, senderCloseErr)
-}
-
-type ServerHandler[Recv proto.Message, Send proto.Message] = func(Recv) (Send, error)
-
-// ProtoPipeServer handles a bidirectional streaming server implementation for [req,resp] proto pairs
-// on top of unix pipe transports.
-// It is meant to be long-lived and the underlying workers can be swapped out for
-// new-ones on demand.
-type ProtoPipeServer[Recv proto.Message, Send proto.Message] struct {
-	workers []*ProtoPipeWorker[Recv, Send]
-
-	updateC chan []*ProtoPipeWorker[Recv, Send]
-
-	handler ServerHandler[Recv, Send]
-
-	serveC          chan error
-	shutdownTimeout time.Duration
-}
-
-func NewProtoPipeServer[Recv proto.Message, Send proto.Message](
-	workers []*ProtoPipeWorker[Recv, Send],
-	handler ServerHandler[Recv, Send],
-) *ProtoPipeServer[Recv, Send] {
-	return &ProtoPipeServer[Recv, Send]{
-		workers:         workers,
-		updateC:         make(chan []*ProtoPipeWorker[Recv, Send], 8),
-		handler:         handler,
-		serveC:          make(chan error, 1),
-		shutdownTimeout: time.Minute,
-	}
-}
-
-func (srv *ProtoPipeServer[Recv, Send]) serve(ctx context.Context) error {
-	eg, eCtx := errgroup.WithContext(ctx)
-	for _, worker := range srv.workers {
-		eg.Go(func() error {
-			return worker.run(eCtx, srv.handler)
-		})
-	}
-	return eg.Wait()
+func (srv *ProtoPipeServer[Recv, Send]) logWithFields(ctx context.Context) context.Context {
+	return log.WithContext(ctx, func(c zerolog.Context) zerolog.Context {
+		return c.Str("server", srv.Name).Str("service", serviceName)
+	})
 }
 
 func (srv *ProtoPipeServer[Recv, Send]) Serve(ctx context.Context) error {
+	ctx = srv.logWithFields(ctx)
 	for {
 		go func() {
 			srv.serveC <- srv.serve(ctx)
@@ -236,14 +28,14 @@ func (srv *ProtoPipeServer[Recv, Send]) Serve(ctx context.Context) error {
 		select {
 		case <-ctx.Done():
 			<-srv.serveC
-			return fmt.Errorf("proto pipe server done : %w", ctx.Err())
+			return fmt.Errorf("server done : %w", ctx.Err())
 		case newWorkers := <-srv.updateC:
 			if err := srv.Shutdown(ctx); err != nil {
-				return err
+				log.Ctx(ctx).Err(err).Msg("failed to shutdown pipe server workers")
 			}
 			srv.workers = newWorkers
 		case err := <-srv.serveC:
-			if err != nil && !errors.Is(err, context.Canceled) {
+			if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
 				return fmt.Errorf("unexpected serve error : %w", err)
 			}
 			return nil
@@ -251,10 +43,32 @@ func (srv *ProtoPipeServer[Recv, Send]) Serve(ctx context.Context) error {
 	}
 }
 
+func (srv *ProtoPipeServer[Recv, Send]) serve(ctx context.Context) error {
+	eg, eCtx := errgroup.WithContext(ctx)
+	for i, worker := range srv.workers {
+		eg.Go(func() error {
+			workerCtx := log.WithContext(eCtx, func(c zerolog.Context) zerolog.Context {
+				return c.Int("worker", i)
+			})
+			log.Ctx(workerCtx).Debug().Msg("starting worker")
+			return worker.run(workerCtx, srv.handler)
+		})
+	}
+	return eg.Wait()
+}
+
 func (srv *ProtoPipeServer[Recv, Send]) OnChange(
+	ctx context.Context,
 	workers []*ProtoPipeWorker[Recv, Send],
 ) {
-	srv.updateC <- workers
+	ctx = srv.logWithFields(ctx)
+	select {
+	case srv.updateC <- workers:
+		log.Ctx(ctx).Debug().Str("server", srv.Name).Msg("reloading workers")
+	default:
+		// do not block
+		log.Ctx(ctx).Warn().Str("server", srv.Name).Msg("failed to signal worker change")
+	}
 }
 
 func (srv *ProtoPipeServer[Recv, Send]) Shutdown(_ context.Context) error {
@@ -265,21 +79,12 @@ func (srv *ProtoPipeServer[Recv, Send]) Shutdown(_ context.Context) error {
 		}
 	}
 	select {
-	case <-time.After(srv.shutdownTimeout):
+	case <-time.After(srv.ShutdownTimeout):
 		return fmt.Errorf("proto pipe server shutdown timed out: %w", errors.Join(errs...))
 	case err := <-srv.serveC:
-		if err != nil && !errors.Is(err, context.Canceled) {
+		if err != nil && !errors.Is(err, context.Canceled) && errors.Is(err, io.EOF) {
 			return err
 		}
 		return nil
 	}
-}
-
-func newProtoMessage[T proto.Message]() T {
-	var zero T
-	t := reflect.TypeOf(zero)
-	if t.Kind() == reflect.Pointer {
-		return reflect.New(t.Elem()).Interface().(T)
-	}
-	return zero
 }

--- a/pkg/ipc/pipe_server.go
+++ b/pkg/ipc/pipe_server.go
@@ -21,20 +21,18 @@ func (srv *ProtoPipeServer[Recv, Send]) logWithFields(ctx context.Context) conte
 
 func (srv *ProtoPipeServer[Recv, Send]) Serve(ctx context.Context) error {
 	ctx = srv.logWithFields(ctx)
+	defer close(srv.doneC)
+
 	for {
+		serveC := make(chan error, 1)
 		go func() {
-			srv.serveC <- srv.serve(ctx)
+			serveC <- srv.serve(ctx)
 		}()
 		select {
 		case <-ctx.Done():
-			<-srv.serveC
+			<-serveC
 			return fmt.Errorf("server done : %w", ctx.Err())
-		case newWorkers := <-srv.updateC:
-			if err := srv.Shutdown(ctx); err != nil {
-				log.Ctx(ctx).Err(err).Msg("failed to shutdown pipe server workers")
-			}
-			srv.workers = newWorkers
-		case err := <-srv.serveC:
+		case err := <-serveC:
 			if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, io.EOF) {
 				return fmt.Errorf("unexpected serve error : %w", err)
 			}
@@ -57,34 +55,29 @@ func (srv *ProtoPipeServer[Recv, Send]) serve(ctx context.Context) error {
 	return eg.Wait()
 }
 
-func (srv *ProtoPipeServer[Recv, Send]) OnChange(
-	ctx context.Context,
-	workers []*ProtoPipeWorker[Recv, Send],
-) {
-	ctx = srv.logWithFields(ctx)
-	select {
-	case srv.updateC <- workers:
-		log.Ctx(ctx).Debug().Str("server", srv.Name).Msg("reloading workers")
-	default:
-		// do not block
-		log.Ctx(ctx).Warn().Str("server", srv.Name).Msg("failed to signal worker change")
+func (srv *ProtoPipeServer[Recv, Send]) shutdown(ctx context.Context) error {
+	errs := []error{}
+	for i, worker := range srv.workers {
+		log.Ctx(ctx).Info().Int("worker", i).
+			Msg("signaled worker shutdown")
+		rErr := worker.receiver.Shutdown()
+		sErr := worker.sender.Shutdown()
+		if rErr != nil {
+			errs = append(errs, rErr)
+		}
+		if sErr != nil {
+			errs = append(errs, sErr)
+		}
 	}
+	return errors.Join(errs...)
 }
 
-func (srv *ProtoPipeServer[Recv, Send]) Shutdown(_ context.Context) error {
-	errs := []error{}
-	for _, worker := range srv.workers {
-		if err := worker.receiver.Shutdown(); err != nil {
-			errs = append(errs, err)
-		}
-	}
+func (srv *ProtoPipeServer[Recv, Send]) Shutdown(ctx context.Context) error {
+	err := srv.shutdown(ctx)
 	select {
-	case <-time.After(srv.ShutdownTimeout):
-		return fmt.Errorf("proto pipe server shutdown timed out: %w", errors.Join(errs...))
-	case err := <-srv.serveC:
-		if err != nil && !errors.Is(err, context.Canceled) && errors.Is(err, io.EOF) {
-			return err
-		}
+	case <-srv.doneC:
 		return nil
+	case <-time.After(srv.ShutdownTimeout):
+		return fmt.Errorf("proto pipe server shutdown timed out: %w", err)
 	}
 }

--- a/pkg/ipc/pipe_server.go
+++ b/pkg/ipc/pipe_server.go
@@ -1,0 +1,285 @@
+package ipc
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"golang.org/x/sys/unix"
+	"google.golang.org/protobuf/encoding/protodelim"
+	"google.golang.org/protobuf/proto"
+)
+
+func NewPipeWorkers[Recv proto.Message, Send proto.Message](
+	num int,
+) ([]*ProtoPipeWorker[Recv, Send], error) {
+	ret := []*ProtoPipeWorker[Recv, Send]{}
+	for range num {
+		recvRead, recvWrite, err := os.Pipe()
+		if err != nil {
+			return nil, err
+		}
+
+		sendRead, sendWrite, err := os.Pipe()
+		if err != nil {
+			return nil, err
+		}
+
+		receiver := NewProtoPipeReceiver[Recv](
+			NewPipePair(recvRead, recvWrite),
+		)
+		sender := NewProtoPipeSender[Send](
+			NewPipePair(sendRead, sendWrite),
+		)
+
+		ret = append(ret, NewProtoPipeWorker(
+			receiver,
+			sender,
+		))
+	}
+	return ret, nil
+}
+
+// PipePair encapsulates the read/write ends of a pipe.
+type PipePair struct {
+	Read  *os.File
+	Write *os.File
+
+	closeF func() error
+}
+
+func NewPipePair(readEnd *os.File, writeEnd *os.File) *PipePair {
+	return &PipePair{
+		Read:  readEnd,
+		Write: writeEnd,
+		closeF: sync.OnceValue(func() error {
+			readCloseErr := readEnd.Close()
+			writeCloseErr := writeEnd.Close()
+			return errors.Join(readCloseErr, writeCloseErr)
+		}),
+	}
+}
+
+func (p *PipePair) Close() error {
+	return p.closeF()
+}
+
+// ProtoPipeReceiver receives length-delimited protobuf messages from the read
+// end of a PipePair.
+type ProtoPipeReceiver[Recv proto.Message] struct {
+	*PipePair
+	rd             protodelim.Reader
+	shouldShutdown atomic.Bool
+}
+
+func NewProtoPipeReceiver[Recv proto.Message](pair *PipePair) *ProtoPipeReceiver[Recv] {
+	return &ProtoPipeReceiver[Recv]{
+		PipePair: pair,
+		rd:       bufio.NewReader(pair.Read),
+	}
+}
+
+// Shutdown signals the receiver to stop after draining any data currently
+// queued in the kernel pipe buffer. Setting a past read deadline unblocks
+// pending reads immediately.
+func (r *ProtoPipeReceiver[Recv]) Shutdown() error {
+	r.shouldShutdown.Store(true)
+	return r.Read.SetReadDeadline(time.Unix(1, 0))
+}
+
+func (r *ProtoPipeReceiver[Recv]) shutdownRequested() bool {
+	return r.shouldShutdown.Load()
+}
+
+func (r *ProtoPipeReceiver[Recv]) recvMsg(_ context.Context) (Recv, error) {
+	if r.shutdownRequested() {
+		n, err := unix.IoctlGetInt(int(r.Read.Fd()), FIONREAD)
+		if err != nil {
+			var zero Recv
+			return zero, err
+		}
+		if n == 0 {
+			// nothing queued up, safe to signal close
+			if err := r.Close(); err != nil {
+				var zero Recv
+				return zero, err
+			}
+			var zero Recv
+			return zero, io.EOF
+		}
+		// otherwise, continues to drain
+	}
+	msg := newProtoMessage[Recv]()
+	if err := protodelim.UnmarshalFrom(r.rd, msg); err != nil {
+		return msg, err
+	}
+	return msg, nil
+}
+
+// ProtoPipeSender sends length-delimited protobuf messages to the write end of
+// a PipePair.
+type ProtoPipeSender[Send proto.Message] struct {
+	*PipePair
+}
+
+func NewProtoPipeSender[Send proto.Message](pair *PipePair) *ProtoPipeSender[Send] {
+	return &ProtoPipeSender[Send]{PipePair: pair}
+}
+
+func (s *ProtoPipeSender[Send]) sendMsg(_ context.Context, msg Send) error {
+	if _, err := protodelim.MarshalTo(s.Write, msg); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ProtoPipeWorker handles bi-directional communication between receivers and senders.
+type ProtoPipeWorker[Recv proto.Message, Send proto.Message] struct {
+	receiver *ProtoPipeReceiver[Recv]
+	sender   *ProtoPipeSender[Send]
+}
+
+func NewProtoPipeWorker[Recv proto.Message, Send proto.Message](
+	receiver *ProtoPipeReceiver[Recv],
+	sender *ProtoPipeSender[Send],
+) *ProtoPipeWorker[Recv, Send] {
+	return &ProtoPipeWorker[Recv, Send]{
+		receiver: receiver,
+		sender:   sender,
+	}
+}
+
+func (w *ProtoPipeWorker[Recv, Send]) run(ctx context.Context, handler ServerHandler[Recv, Send]) error {
+	for {
+		msg, err := w.receiver.recvMsg(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
+				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return err
+		}
+		resp, err := handler(msg)
+		if err != nil {
+			return err
+		}
+		if err := w.sender.sendMsg(ctx, resp); err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return err
+		}
+	}
+}
+
+func (w *ProtoPipeWorker[Recv, Send]) Close() error {
+	receiverCloseErr := w.receiver.Close()
+	senderCloseErr := w.sender.Close()
+	return errors.Join(receiverCloseErr, senderCloseErr)
+}
+
+type ServerHandler[Recv proto.Message, Send proto.Message] = func(Recv) (Send, error)
+
+// ProtoPipeServer handles a bidirectional streaming server implementation for [req,resp] proto pairs
+// on top of unix pipe transports.
+// It is meant to be long-lived and the underlying workers can be swapped out for
+// new-ones on demand.
+type ProtoPipeServer[Recv proto.Message, Send proto.Message] struct {
+	workers []*ProtoPipeWorker[Recv, Send]
+
+	updateC chan []*ProtoPipeWorker[Recv, Send]
+
+	handler ServerHandler[Recv, Send]
+
+	serveC          chan error
+	shutdownTimeout time.Duration
+}
+
+func NewProtoPipeServer[Recv proto.Message, Send proto.Message](
+	workers []*ProtoPipeWorker[Recv, Send],
+	handler ServerHandler[Recv, Send],
+) *ProtoPipeServer[Recv, Send] {
+	return &ProtoPipeServer[Recv, Send]{
+		workers:         workers,
+		updateC:         make(chan []*ProtoPipeWorker[Recv, Send], 8),
+		handler:         handler,
+		serveC:          make(chan error, 1),
+		shutdownTimeout: time.Minute,
+	}
+}
+
+func (srv *ProtoPipeServer[Recv, Send]) serve(ctx context.Context) error {
+	eg, eCtx := errgroup.WithContext(ctx)
+	for _, worker := range srv.workers {
+		eg.Go(func() error {
+			return worker.run(eCtx, srv.handler)
+		})
+	}
+	return eg.Wait()
+}
+
+func (srv *ProtoPipeServer[Recv, Send]) Serve(ctx context.Context) error {
+	for {
+		go func() {
+			srv.serveC <- srv.serve(ctx)
+		}()
+		select {
+		case <-ctx.Done():
+			<-srv.serveC
+			return fmt.Errorf("proto pipe server done : %w", ctx.Err())
+		case newWorkers := <-srv.updateC:
+			if err := srv.Shutdown(ctx); err != nil {
+				return err
+			}
+			srv.workers = newWorkers
+		case err := <-srv.serveC:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				return fmt.Errorf("unexpected serve error : %w", err)
+			}
+			return nil
+		}
+	}
+}
+
+func (srv *ProtoPipeServer[Recv, Send]) OnChange(
+	workers []*ProtoPipeWorker[Recv, Send],
+) {
+	srv.updateC <- workers
+}
+
+func (srv *ProtoPipeServer[Recv, Send]) Shutdown(_ context.Context) error {
+	errs := []error{}
+	for _, worker := range srv.workers {
+		if err := worker.receiver.Shutdown(); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	select {
+	case <-time.After(srv.shutdownTimeout):
+		return fmt.Errorf("proto pipe server shutdown timed out: %w", errors.Join(errs...))
+	case err := <-srv.serveC:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			return err
+		}
+		return nil
+	}
+}
+
+func newProtoMessage[T proto.Message]() T {
+	var zero T
+	t := reflect.TypeOf(zero)
+	if t.Kind() == reflect.Pointer {
+		return reflect.New(t.Elem()).Interface().(T)
+	}
+	return zero
+}

--- a/pkg/ipc/pipe_server_test.go
+++ b/pkg/ipc/pipe_server_test.go
@@ -1,0 +1,120 @@
+package ipc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+)
+
+// TODO : prefer not to do this. synctest?
+func waitForErr(t *testing.T, ch <-chan error, timeout time.Duration, msg string) error {
+	t.Helper()
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(timeout):
+		t.Fatalf("timed out waiting for %s", msg)
+		return nil
+	}
+}
+
+func TestPipePair(t *testing.T) {
+	t.Parallel()
+
+	t.Run("close once", func(t *testing.T) {
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		pair := NewPipePair(r, w)
+
+		first := pair.Close()
+		second := pair.Close()
+		assert.NoError(t, first)
+		assert.Equal(t, first, second, "second close should be the same")
+	})
+}
+
+func TestProtoPipeWorker(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round-trip", func(t *testing.T) {
+		client := newTestPipeClient[*wrapperspb.StringValue, *wrapperspb.StringValue](t)
+		worker := client.worker()
+		t.Cleanup(func() { _ = worker.Close() })
+
+		handler := func(msg *wrapperspb.StringValue) (*wrapperspb.StringValue, error) {
+			return &wrapperspb.StringValue{Value: msg.GetValue() + "!"}, nil
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		errC := make(chan error, 1)
+		go func() {
+			errC <- worker.run(ctx, handler)
+		}()
+
+		client.send(t, &wrapperspb.StringValue{Value: "hello"})
+		assert.Equal(t, "hello!", client.recv(t).GetValue())
+
+		for i := range 8 {
+			client.send(t, &wrapperspb.StringValue{
+				Value: fmt.Sprintf("msg-%d", i),
+			})
+		}
+
+		for i := range 8 {
+			assert.Equal(t, fmt.Sprintf("msg-%d!", i), client.recv(t).GetValue())
+		}
+
+		assert.NoError(t, worker.Close())
+		assert.NoError(t, waitForErr(t, errC, 2*time.Second, "worker should exit"))
+	})
+
+	// TODO : test more edge cases
+	// - around invalid proto typed messages
+	// - around corrupted messages / completely random messages
+	// - context cancellation
+	// - send failures
+	// - handler errors
+}
+
+func TestProtoPipeServer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("round-trip", func(t *testing.T) {
+		t.Parallel()
+		sc := newServersClient(t, 4,
+			func(msg *wrapperspb.Int32Value) (*wrapperspb.Int32Value, error) {
+				return &wrapperspb.Int32Value{Value: msg.GetValue() + 1000}, nil
+			},
+		)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		sc.start(ctx)
+
+		sc.runClients(func(i int, c *testPipeClient[*wrapperspb.Int32Value, *wrapperspb.Int32Value]) {
+			for j := range 3 {
+				val := int32(i*100 + j)
+				c.send(t, &wrapperspb.Int32Value{Value: val})
+				resp := c.recv(t)
+				assert.Equal(t, val+1000, resp.GetValue(),
+					"client %d round %d: response mismatch", i, j)
+			}
+			require.NoError(t, c.closeWrite())
+		})
+
+		assert.NoError(t, sc.waitServer(2*time.Second))
+	})
+
+	t.Run("on transport change", func(_ *testing.T) {
+		// TODO :
+	})
+
+	// TODO : edgecases around context cancellation, et al
+}

--- a/pkg/ipc/pipe_server_test.go
+++ b/pkg/ipc/pipe_server_test.go
@@ -1,18 +1,20 @@
 package ipc
 
 import (
+	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/pomerium/pomerium/pkg/grpc/testproto"
 )
 
-// TODO : prefer not to do this. synctest?
 func waitForErr(t *testing.T, ch <-chan error, timeout time.Duration, msg string) error {
 	t.Helper()
 	select {
@@ -43,44 +45,93 @@ func TestProtoPipeWorker(t *testing.T) {
 	t.Parallel()
 
 	t.Run("round-trip", func(t *testing.T) {
-		client := newTestPipeClient[*wrapperspb.StringValue, *wrapperspb.StringValue](t)
+		client := newTestPipeClient[*testproto.Test, *testproto.Test](t)
 		worker := client.worker()
 		t.Cleanup(func() { _ = worker.Close() })
 
-		handler := func(msg *wrapperspb.StringValue) (*wrapperspb.StringValue, error) {
-			return &wrapperspb.StringValue{Value: msg.GetValue() + "!"}, nil
+		echoHandler := &testServerHandler{
+			handler: func(_ context.Context, msg *testproto.Test) (*testproto.Test, error) {
+				msg.StringField = msg.StringField + "!"
+				return msg, nil
+			},
 		}
 
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		errC := make(chan error, 1)
 		go func() {
-			errC <- worker.run(ctx, handler)
+			errC <- worker.run(ctx, echoHandler)
 		}()
 
-		client.send(t, &wrapperspb.StringValue{Value: "hello"})
-		assert.Equal(t, "hello!", client.recv(t).GetValue())
+		client.send(t, &testproto.Test{
+			StringField: "hello",
+		})
+		assert.Equal(t, "hello!", client.recv(t).GetStringField())
 
 		for i := range 8 {
-			client.send(t, &wrapperspb.StringValue{
-				Value: fmt.Sprintf("msg-%d", i),
+			client.send(t, &testproto.Test{
+				StringField: fmt.Sprintf("msg-%d", i),
 			})
 		}
-
 		for i := range 8 {
-			assert.Equal(t, fmt.Sprintf("msg-%d!", i), client.recv(t).GetValue())
+			assert.Equal(t, fmt.Sprintf("msg-%d!", i), client.recv(t).GetStringField())
 		}
 
 		assert.NoError(t, worker.Close())
 		assert.NoError(t, waitForErr(t, errC, 2*time.Second, "worker should exit"))
 	})
 
-	// TODO : test more edge cases
-	// - around invalid proto typed messages
-	// - around corrupted messages / completely random messages
-	// - context cancellation
-	// - send failures
-	// - handler errors
+	t.Run("handshake", func(t *testing.T) {
+		client := newTestPipeClient[*testproto.Test, *testproto.Test](t)
+		worker := client.worker()
+
+		echoHandlerWithHandshake := &testServerHandler{
+			handler: func(_ context.Context, msg *testproto.Test) (*testproto.Test, error) {
+				msg.StringField = msg.StringField + "!"
+				return msg, nil
+			},
+			handshakeIn: func(_ context.Context, r io.Reader) error {
+				buf := [4]byte{}
+				n, err := r.Read(buf[:])
+				if err != nil {
+					return err
+				}
+				if n != len(buf) {
+					return fmt.Errorf("failed to read required number of bytes")
+				}
+				if !bytes.Equal(buf[:], []byte("aaaa")) {
+					return fmt.Errorf("invalid handshake data")
+				}
+				return nil
+			},
+			handshakeOut: func(_ context.Context, w io.Writer) error {
+				_, err := w.Write([]byte("bbbb"))
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+		}
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		errC := make(chan error, 1)
+		go func() {
+			errC <- worker.run(ctx, echoHandlerWithHandshake)
+		}()
+
+		client.sendRaw(t, []byte("aaaa"))
+		readBuf := [4]byte{}
+		client.recvRaw(t, readBuf[:])
+		assert.Equal(t, []byte("bbbb"), readBuf[:])
+
+		client.send(t, &testproto.Test{
+			StringField: "hello",
+		})
+		assert.Equal(t, "hello!", client.recv(t).GetStringField())
+
+		assert.NoError(t, worker.Close())
+		assert.NoError(t, waitForErr(t, errC, 2*time.Second, "worker should exit"))
+	})
 }
 
 func TestProtoPipeServer(t *testing.T) {
@@ -88,33 +139,86 @@ func TestProtoPipeServer(t *testing.T) {
 
 	t.Run("round-trip", func(t *testing.T) {
 		t.Parallel()
-		sc := newServersClient(t, 4,
-			func(msg *wrapperspb.Int32Value) (*wrapperspb.Int32Value, error) {
-				return &wrapperspb.Int32Value{Value: msg.GetValue() + 1000}, nil
+		echoHandler := &testServerHandler{
+			handler: func(_ context.Context, msg *testproto.Test) (*testproto.Test, error) {
+				return msg, nil
 			},
+		}
+		sc := newServersClient(t, 4,
+			echoHandler,
 		)
 
 		ctx, cancel := context.WithCancel(t.Context())
 		defer cancel()
 		sc.start(ctx)
 
-		sc.runClients(func(i int, c *testPipeClient[*wrapperspb.Int32Value, *wrapperspb.Int32Value]) {
+		sc.runClients(func(i int, c *testPipeClient[*testproto.Test, *testproto.Test]) {
 			for j := range 3 {
 				val := int32(i*100 + j)
-				c.send(t, &wrapperspb.Int32Value{Value: val})
+				c.send(t, &testproto.Test{StringField: fmt.Sprintf("msg-%d", val)})
 				resp := c.recv(t)
-				assert.Equal(t, val+1000, resp.GetValue(),
+				assert.Equal(t, fmt.Sprintf("msg-%d", val), resp.GetStringField(),
 					"client %d round %d: response mismatch", i, j)
 			}
-			require.NoError(t, c.closeWrite())
+		})
+		assert.NoError(t, sc.server.Shutdown(t.Context()))
+	})
+
+	t.Run("handshake", func(t *testing.T) {
+		t.Parallel()
+		echoHandlerWithHandshake := &testServerHandler{
+			handler: func(_ context.Context, msg *testproto.Test) (*testproto.Test, error) {
+				msg.StringField = msg.StringField + "!"
+				return msg, nil
+			},
+			handshakeIn: func(_ context.Context, r io.Reader) error {
+				buf := [4]byte{}
+				n, err := r.Read(buf[:])
+				if err != nil {
+					return err
+				}
+				if n != len(buf) {
+					return fmt.Errorf("failed to read required number of bytes")
+				}
+				if !bytes.Equal(buf[:], []byte("aaaa")) {
+					return fmt.Errorf("invalid handshake data")
+				}
+				return nil
+			},
+			handshakeOut: func(_ context.Context, w io.Writer) error {
+				_, err := w.Write([]byte("bbbb"))
+				if err != nil {
+					return err
+				}
+				return nil
+			},
+		}
+
+		sc := newServersClient(t, 4,
+			echoHandlerWithHandshake,
+		)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		defer cancel()
+		sc.start(ctx)
+
+		sc.runClients(func(_ int, c *testPipeClient[*testproto.Test, *testproto.Test]) {
+			c.sendRaw(t, []byte("aaaa"))
+			readBuf := [4]byte{}
+			c.recvRaw(t, readBuf[:])
+			assert.Equal(t, []byte("bbbb"), readBuf[:])
 		})
 
-		assert.NoError(t, sc.waitServer(2*time.Second))
-	})
+		sc.runClients(func(i int, c *testPipeClient[*testproto.Test, *testproto.Test]) {
+			for j := range 3 {
+				val := int32(i*100 + j)
+				c.send(t, &testproto.Test{StringField: fmt.Sprintf("msg-%d", val)})
+				resp := c.recv(t)
+				assert.Equal(t, fmt.Sprintf("msg-%d!", val), resp.GetStringField(),
+					"client %d round %d: response mismatch", i, j)
+			}
+		})
 
-	t.Run("on transport change", func(_ *testing.T) {
-		// TODO :
+		assert.NoError(t, sc.server.Shutdown(t.Context()))
 	})
-
-	// TODO : edgecases around context cancellation, et al
 }

--- a/pkg/ipc/pipe_workers.go
+++ b/pkg/ipc/pipe_workers.go
@@ -1,0 +1,128 @@
+package ipc
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"time"
+
+	"github.com/pomerium/pomerium/internal/log"
+	"golang.org/x/sys/unix"
+	"google.golang.org/protobuf/encoding/protodelim"
+	"google.golang.org/protobuf/proto"
+)
+
+func NewPipeWorkers[Recv proto.Message, Send proto.Message](
+	num int,
+) ([]*ProtoPipeWorker[Recv, Send], error) {
+	ret := []*ProtoPipeWorker[Recv, Send]{}
+	for range num {
+		recvRead, recvWrite, err := os.Pipe()
+		if err != nil {
+			return nil, err
+		}
+
+		sendRead, sendWrite, err := os.Pipe()
+		if err != nil {
+			return nil, err
+		}
+
+		receiver := NewProtoPipeReceiver[Recv](
+			NewPipePair(recvRead, recvWrite),
+		)
+		sender := NewProtoPipeSender[Send](
+			NewPipePair(sendRead, sendWrite),
+		)
+
+		ret = append(ret, NewProtoPipeWorker(
+			receiver,
+			sender,
+		))
+	}
+	return ret, nil
+}
+
+func (p *PipePair) Close() error {
+	return p.closeF()
+}
+
+// Shutdown signals the receiver to stop after draining any data currently
+// queued in the kernel pipe buffer. Setting a past read deadline unblocks
+// pending reads immediately.
+func (r *ProtoPipeReceiver[Recv]) Shutdown() error {
+	r.shouldShutdown.Store(true)
+	return r.Read.SetReadDeadline(time.Unix(1, 0))
+}
+
+func (r *ProtoPipeReceiver[Recv]) shutdownRequested() bool {
+	return r.shouldShutdown.Load()
+}
+
+func (r *ProtoPipeReceiver[Recv]) recvMsg(_ context.Context) (Recv, error) {
+	if r.shutdownRequested() {
+		n, err := unix.IoctlGetInt(int(r.Read.Fd()), FIONREAD)
+		if err != nil {
+			var zero Recv
+			return zero, err
+		}
+		if n == 0 {
+			// nothing queued up, safe to signal close
+			if err := r.Close(); err != nil {
+				var zero Recv
+				return zero, err
+			}
+			var zero Recv
+			return zero, io.EOF
+		}
+		// otherwise, continues to drain
+	}
+	msg := newProtoMessage[Recv]()
+	if err := protodelim.UnmarshalFrom(r.rd, msg); err != nil {
+		return msg, err
+	}
+	return msg, nil
+}
+
+func (s *ProtoPipeSender[Send]) sendMsg(_ context.Context, msg Send) error {
+	if _, err := protodelim.MarshalTo(s.Write, msg); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w *ProtoPipeWorker[Recv, Send]) run(ctx context.Context, handler ServerHandler[Recv, Send]) error {
+	for {
+		log.Ctx(ctx).Trace().Msg("waiting for message")
+		msg, err := w.receiver.recvMsg(ctx)
+		if err != nil {
+			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
+				return nil
+			}
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return err
+		}
+		log.Ctx(ctx).Trace().Msg("passing received message to handler")
+		resp, err := handler(msg)
+		if err != nil {
+			return err
+		}
+		log.Ctx(ctx).Trace().Msg("sending response message")
+		if err := w.sender.sendMsg(ctx, resp); err != nil {
+			// TODO : handle this differently
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return err
+		}
+		log.Ctx(ctx).Trace().Msg("sent response message")
+	}
+}
+
+func (w *ProtoPipeWorker[Recv, Send]) Close() error {
+	receiverCloseErr := w.receiver.Close()
+	senderCloseErr := w.sender.Close()
+	return errors.Join(receiverCloseErr, senderCloseErr)
+}

--- a/pkg/ipc/pipe_workers.go
+++ b/pkg/ipc/pipe_workers.go
@@ -3,14 +3,17 @@ package ipc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"time"
 
-	"github.com/pomerium/pomerium/internal/log"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/encoding/protodelim"
 	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/internal/log"
 )
 
 func NewPipeWorkers[Recv proto.Message, Send proto.Message](
@@ -59,42 +62,90 @@ func (r *ProtoPipeReceiver[Recv]) shutdownRequested() bool {
 	return r.shouldShutdown.Load()
 }
 
-func (r *ProtoPipeReceiver[Recv]) recvMsg(_ context.Context) (Recv, error) {
-	if r.shutdownRequested() {
-		n, err := unix.IoctlGetInt(int(r.Read.Fd()), FIONREAD)
-		if err != nil {
+// recvMsg cannot handle corrupted data / invalid protobuf since protodelim expects
+// a varint to delim the next message size. Since an invalid parse can get "confused" and tell the
+// protodelim reader to read a set number of bytes which may never come, we have to treat
+// any parse error as non-recoverable.
+// The only way to prevent this is to add something like PING frames so that the reader,
+// when combined with a generic ReadDeadline can seek ahead and discard bytes it cannot
+// read before the occasional PING frames.
+func (r *ProtoPipeReceiver[Recv]) recvMsg() (Recv, error) {
+	for {
+		msg := newProtoMessage[Recv]()
+		err := protodelim.UnmarshalFrom(r.rd, msg)
+		if err == nil {
+			return msg, nil
+		}
+		if !r.shutdownRequested() || !errors.Is(err, os.ErrDeadlineExceeded) {
+			return msg, err
+		}
+		n, ferr := unix.IoctlGetInt(int(r.Read.Fd()), FIONREAD)
+		if ferr != nil {
 			var zero Recv
-			return zero, err
+			return zero, ferr
 		}
 		if n == 0 {
-			// nothing queued up, safe to signal close
-			if err := r.Close(); err != nil {
+			if cerr := r.Close(); cerr != nil {
 				var zero Recv
-				return zero, err
+				return zero, cerr
 			}
 			var zero Recv
 			return zero, io.EOF
 		}
-		// otherwise, continues to drain
+		// clear the deadline so the next read can drain them
+		if derr := r.Read.SetReadDeadline(time.Time{}); derr != nil {
+			var zero Recv
+			return zero, derr
+		}
 	}
-	msg := newProtoMessage[Recv]()
-	if err := protodelim.UnmarshalFrom(r.rd, msg); err != nil {
-		return msg, err
-	}
-	return msg, nil
 }
 
 func (s *ProtoPipeSender[Send]) sendMsg(_ context.Context, msg Send) error {
+	if s.shutdownRequested() {
+		if err := s.Close(); err != nil {
+			return err
+		}
+	}
 	if _, err := protodelim.MarshalTo(s.Write, msg); err != nil {
 		return err
 	}
 	return nil
 }
 
+func (s *ProtoPipeSender[Send]) shutdownRequested() bool {
+	return s.shouldShutdown.Load()
+}
+
+func (s *ProtoPipeSender[Send]) Shutdown() error {
+	s.shouldShutdown.Store(true)
+	return s.Write.SetWriteDeadline(time.Unix(1, 0))
+}
+
+func (w *ProtoPipeWorker[Recv, Send]) doHandshake(ctx context.Context, handler ServerHandler[Recv, Send]) error {
+	eg, eCtx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		if err := handler.RecvHandshake(eCtx, w.receiver.Read); err != nil {
+			log.Ctx(ctx).Err(err).Msg("server handshake failed")
+			return fmt.Errorf("receive handshake failed")
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		if err := handler.SendHandshake(eCtx, w.sender.Write); err != nil {
+			return fmt.Errorf("send handshake failed")
+		}
+		return nil
+	})
+	return eg.Wait()
+}
+
 func (w *ProtoPipeWorker[Recv, Send]) run(ctx context.Context, handler ServerHandler[Recv, Send]) error {
+	if err := w.doHandshake(ctx, handler); err != nil {
+		return err
+	}
 	for {
 		log.Ctx(ctx).Trace().Msg("waiting for message")
-		msg, err := w.receiver.recvMsg(ctx)
+		msg, err := w.receiver.recvMsg()
 		if err != nil {
 			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
 				return nil
@@ -105,16 +156,12 @@ func (w *ProtoPipeWorker[Recv, Send]) run(ctx context.Context, handler ServerHan
 			return err
 		}
 		log.Ctx(ctx).Trace().Msg("passing received message to handler")
-		resp, err := handler(msg)
+		resp, err := handler.Handler(ctx, msg)
 		if err != nil {
 			return err
 		}
 		log.Ctx(ctx).Trace().Msg("sending response message")
 		if err := w.sender.sendMsg(ctx, resp); err != nil {
-			// TODO : handle this differently
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
 			return err
 		}
 		log.Ctx(ctx).Trace().Msg("sent response message")

--- a/pkg/ipc/types.go
+++ b/pkg/ipc/types.go
@@ -2,7 +2,9 @@ package ipc
 
 import (
 	"bufio"
+	"context"
 	"errors"
+	"io"
 	"os"
 	"reflect"
 	"sync"
@@ -35,6 +37,7 @@ type ProtoPipeReceiver[Recv proto.Message] struct {
 // a PipePair.
 type ProtoPipeSender[Send proto.Message] struct {
 	*PipePair
+	shouldShutdown atomic.Bool
 }
 
 // ProtoPipeWorker handles bi-directional communication between receivers and senders.
@@ -43,8 +46,16 @@ type ProtoPipeWorker[Recv proto.Message, Send proto.Message] struct {
 	sender   *ProtoPipeSender[Send]
 }
 
-// ServerHandler runs application logic processing the Recv proto into Send proto
-type ServerHandler[Recv proto.Message, Send proto.Message] = func(Recv) (Send, error)
+// ServerHandler is the interface contract for implementing the application logic
+// for the bidirectional proto pipe server.
+// Before serving the handler both the Recv and Send handshakes must succeed.
+type ServerHandler[Recv proto.Message, Send proto.Message] interface {
+	RecvHandshake(context.Context, io.Reader) error
+	SendHandshake(context.Context, io.Writer) error
+	// Handler errors are treated as non-recoverable, so implementations
+	// of this interface should be careful to only return on fatal errors
+	Handler(context.Context, Recv) (Send, error)
+}
 
 type ServerOptions struct {
 	ShutdownTimeout time.Duration
@@ -59,11 +70,10 @@ type ServerOptions struct {
 type ProtoPipeServer[Recv proto.Message, Send proto.Message] struct {
 	workers []*ProtoPipeWorker[Recv, Send]
 
-	updateC chan []*ProtoPipeWorker[Recv, Send]
-
 	handler ServerHandler[Recv, Send]
 
 	serveC chan error
+	doneC  chan struct{}
 	ServerOptions
 }
 
@@ -107,10 +117,10 @@ func NewProtoPipeServer[Recv proto.Message, Send proto.Message](
 ) *ProtoPipeServer[Recv, Send] {
 	return &ProtoPipeServer[Recv, Send]{
 		workers:       workers,
-		updateC:       make(chan []*ProtoPipeWorker[Recv, Send], 8),
 		handler:       handler,
 		serveC:        make(chan error, 1),
 		ServerOptions: options,
+		doneC:         make(chan struct{}, 1),
 	}
 }
 

--- a/pkg/ipc/types.go
+++ b/pkg/ipc/types.go
@@ -1,0 +1,124 @@
+package ipc
+
+import (
+	"bufio"
+	"errors"
+	"os"
+	"reflect"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/protobuf/encoding/protodelim"
+	"google.golang.org/protobuf/proto"
+)
+
+const serviceName = "pipe-ipc"
+
+// PipePair encapsulates the read/write ends of a pipe.
+type PipePair struct {
+	Read  *os.File
+	Write *os.File
+
+	closeF func() error
+}
+
+// ProtoPipeReceiver receives length-delimited protobuf messages from the read
+// end of a PipePair.
+type ProtoPipeReceiver[Recv proto.Message] struct {
+	*PipePair
+	rd             protodelim.Reader
+	shouldShutdown atomic.Bool
+}
+
+// ProtoPipeSender sends length-delimited protobuf messages to the write end of
+// a PipePair.
+type ProtoPipeSender[Send proto.Message] struct {
+	*PipePair
+}
+
+// ProtoPipeWorker handles bi-directional communication between receivers and senders.
+type ProtoPipeWorker[Recv proto.Message, Send proto.Message] struct {
+	receiver *ProtoPipeReceiver[Recv]
+	sender   *ProtoPipeSender[Send]
+}
+
+// ServerHandler runs application logic processing the Recv proto into Send proto
+type ServerHandler[Recv proto.Message, Send proto.Message] = func(Recv) (Send, error)
+
+type ServerOptions struct {
+	ShutdownTimeout time.Duration
+	// Name is used for telemetry
+	Name string
+}
+
+// ProtoPipeServer handles a bidirectional streaming server implementation for [req,resp] proto pairs
+// on top of unix pipe transports.
+// It is meant to be long-lived and the underlying workers can be swapped out for
+// new-ones on demand.
+type ProtoPipeServer[Recv proto.Message, Send proto.Message] struct {
+	workers []*ProtoPipeWorker[Recv, Send]
+
+	updateC chan []*ProtoPipeWorker[Recv, Send]
+
+	handler ServerHandler[Recv, Send]
+
+	serveC chan error
+	ServerOptions
+}
+
+func NewPipePair(readEnd *os.File, writeEnd *os.File) *PipePair {
+	return &PipePair{
+		Read:  readEnd,
+		Write: writeEnd,
+		closeF: sync.OnceValue(func() error {
+			readCloseErr := readEnd.Close()
+			writeCloseErr := writeEnd.Close()
+			return errors.Join(readCloseErr, writeCloseErr)
+		}),
+	}
+}
+
+func NewProtoPipeReceiver[Recv proto.Message](pair *PipePair) *ProtoPipeReceiver[Recv] {
+	return &ProtoPipeReceiver[Recv]{
+		PipePair: pair,
+		rd:       bufio.NewReader(pair.Read),
+	}
+}
+
+func NewProtoPipeSender[Send proto.Message](pair *PipePair) *ProtoPipeSender[Send] {
+	return &ProtoPipeSender[Send]{PipePair: pair}
+}
+
+func NewProtoPipeWorker[Recv proto.Message, Send proto.Message](
+	receiver *ProtoPipeReceiver[Recv],
+	sender *ProtoPipeSender[Send],
+) *ProtoPipeWorker[Recv, Send] {
+	return &ProtoPipeWorker[Recv, Send]{
+		receiver: receiver,
+		sender:   sender,
+	}
+}
+
+func NewProtoPipeServer[Recv proto.Message, Send proto.Message](
+	workers []*ProtoPipeWorker[Recv, Send],
+	handler ServerHandler[Recv, Send],
+	options ServerOptions,
+) *ProtoPipeServer[Recv, Send] {
+	return &ProtoPipeServer[Recv, Send]{
+		workers:       workers,
+		updateC:       make(chan []*ProtoPipeWorker[Recv, Send], 8),
+		handler:       handler,
+		serveC:        make(chan error, 1),
+		ServerOptions: options,
+	}
+}
+
+func newProtoMessage[T proto.Message]() T {
+	var zero T
+	t := reflect.TypeOf(zero)
+	if t.Kind() == reflect.Pointer {
+		return reflect.New(t.Elem()).Interface().(T)
+	}
+	return zero
+}


### PR DESCRIPTION
## Summary

Splitting out pipe logic from https://github.com/pomerium/pomerium/pull/6335

## Related issues
[ENG-3933](
https://linear.app/pomerium/issue/ENG-3933/session-recording-server-unix-pipe-transport)


## User Explanation

N/A

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
