### PR TITLE
feat(envoy): configure dynamic extensions for envoy

### DIFF
--- a/config/config.gen.go
+++ b/config/config.gen.go
@@ -71,12 +71,12 @@ type RouteRewriteHeader struct {
 }
 
 type GlobalOptions struct {
-	AllowUpgrades          Value[[]string]                   `json:"allow_upgrades,omitzero" mapstructure:"allow_upgrades" yaml:"allow_upgrades,omitempty"`
-	AutoApplyChangesets    Value[bool]                       `json:"auto_apply_changesets,omitzero" mapstructure:"auto_apply_changesets" yaml:"auto_apply_changesets,omitempty"`
-	BearerTokenFormat      Value[configpb.BearerTokenFormat] `json:"bearer_token_format,omitzero" mapstructure:"bearer_token_format" yaml:"bearer_token_format,omitempty"`
-	CodecType              Value[configpb.CodecType]         `json:"codec_type,omitzero" mapstructure:"codec_type" yaml:"codec_type,omitempty"`
-	EnvoyDynamicExtensions Value[[]string]                   `json:"envoy_dynamic_extensions,omitzero" mapstructure:"envoy_dynamic_extensions" yaml:"envoy_dynamic_extensions,omitempty"`
-	JWTIssuerFormat        Value[configpb.IssuerFormat]      `json:"jwt_issuer_format,omitzero" mapstructure:"jwt_issuer_format" yaml:"jwt_issuer_format,omitempty"`
+	AllowUpgrades       Value[[]string]                   `json:"allow_upgrades,omitzero" mapstructure:"allow_upgrades" yaml:"allow_upgrades,omitempty"`
+	AutoApplyChangesets Value[bool]                       `json:"auto_apply_changesets,omitzero" mapstructure:"auto_apply_changesets" yaml:"auto_apply_changesets,omitempty"`
+	BearerTokenFormat   Value[configpb.BearerTokenFormat] `json:"bearer_token_format,omitzero" mapstructure:"bearer_token_format" yaml:"bearer_token_format,omitempty"`
+	CodecType           Value[configpb.CodecType]         `json:"codec_type,omitzero" mapstructure:"codec_type" yaml:"codec_type,omitempty"`
+	JWTIssuerFormat     Value[configpb.IssuerFormat]      `json:"jwt_issuer_format,omitzero" mapstructure:"jwt_issuer_format" yaml:"jwt_issuer_format,omitempty"`
+	PluginsEnvoy        Value[[]string]                   `json:"plugins_envoy,omitzero" mapstructure:"plugins_envoy" yaml:"plugins_envoy,omitempty"`
 }
 
 type Settings_Certificate struct {
@@ -391,8 +391,8 @@ func setGlobalOptionsFromProto(dst *GlobalOptions, src *configpb.Settings) error
 		setNullableBoolFromProto(&dst.AutoApplyChangesets, src.AutoApplyChangesets),
 		setNullableBearerTokenFormatFromProto(&dst.BearerTokenFormat, src.BearerTokenFormat),
 		setNullableCodecTypeFromProto(&dst.CodecType, src.CodecType),
-		setNullableStringListFromProto(&dst.EnvoyDynamicExtensions, src.EnvoyDynamicExtensions),
 		setNullableIssuerFormatFromProto(&dst.JWTIssuerFormat, src.JwtIssuerFormat),
+		setNullableStringListFromProto(&dst.PluginsEnvoy, src.PluginsEnvoy),
 	)
 }
 
@@ -793,8 +793,8 @@ func setGlobalOptionsToProto(dst **configpb.Settings, src *GlobalOptions) error 
 		setNullableBoolToProto(&obj.AutoApplyChangesets, src.AutoApplyChangesets),
 		setNullableBearerTokenFormatToProto(&obj.BearerTokenFormat, src.BearerTokenFormat),
 		setNullableCodecTypeToProto(&obj.CodecType, src.CodecType),
-		setNullableStringListToProto(&obj.EnvoyDynamicExtensions, src.EnvoyDynamicExtensions),
 		setNullableIssuerFormatToProto(&obj.JwtIssuerFormat, src.JWTIssuerFormat),
+		setNullableStringListToProto(&obj.PluginsEnvoy, src.PluginsEnvoy),
 	)
 }
 

--- a/config/config.gen.go
+++ b/config/config.gen.go
@@ -71,11 +71,12 @@ type RouteRewriteHeader struct {
 }
 
 type GlobalOptions struct {
-	AllowUpgrades       Value[[]string]                   `json:"allow_upgrades,omitzero" mapstructure:"allow_upgrades" yaml:"allow_upgrades,omitempty"`
-	AutoApplyChangesets Value[bool]                       `json:"auto_apply_changesets,omitzero" mapstructure:"auto_apply_changesets" yaml:"auto_apply_changesets,omitempty"`
-	BearerTokenFormat   Value[configpb.BearerTokenFormat] `json:"bearer_token_format,omitzero" mapstructure:"bearer_token_format" yaml:"bearer_token_format,omitempty"`
-	CodecType           Value[configpb.CodecType]         `json:"codec_type,omitzero" mapstructure:"codec_type" yaml:"codec_type,omitempty"`
-	JWTIssuerFormat     Value[configpb.IssuerFormat]      `json:"jwt_issuer_format,omitzero" mapstructure:"jwt_issuer_format" yaml:"jwt_issuer_format,omitempty"`
+	AllowUpgrades          Value[[]string]                   `json:"allow_upgrades,omitzero" mapstructure:"allow_upgrades" yaml:"allow_upgrades,omitempty"`
+	AutoApplyChangesets    Value[bool]                       `json:"auto_apply_changesets,omitzero" mapstructure:"auto_apply_changesets" yaml:"auto_apply_changesets,omitempty"`
+	BearerTokenFormat      Value[configpb.BearerTokenFormat] `json:"bearer_token_format,omitzero" mapstructure:"bearer_token_format" yaml:"bearer_token_format,omitempty"`
+	CodecType              Value[configpb.CodecType]         `json:"codec_type,omitzero" mapstructure:"codec_type" yaml:"codec_type,omitempty"`
+	EnvoyDynamicExtensions Value[[]string]                   `json:"envoy_dynamic_extensions,omitzero" mapstructure:"envoy_dynamic_extensions" yaml:"envoy_dynamic_extensions,omitempty"`
+	JWTIssuerFormat        Value[configpb.IssuerFormat]      `json:"jwt_issuer_format,omitzero" mapstructure:"jwt_issuer_format" yaml:"jwt_issuer_format,omitempty"`
 }
 
 type Settings_Certificate struct {
@@ -390,6 +391,7 @@ func setGlobalOptionsFromProto(dst *GlobalOptions, src *configpb.Settings) error
 		setNullableBoolFromProto(&dst.AutoApplyChangesets, src.AutoApplyChangesets),
 		setNullableBearerTokenFormatFromProto(&dst.BearerTokenFormat, src.BearerTokenFormat),
 		setNullableCodecTypeFromProto(&dst.CodecType, src.CodecType),
+		setNullableStringListFromProto(&dst.EnvoyDynamicExtensions, src.EnvoyDynamicExtensions),
 		setNullableIssuerFormatFromProto(&dst.JWTIssuerFormat, src.JwtIssuerFormat),
 	)
 }
@@ -791,6 +793,7 @@ func setGlobalOptionsToProto(dst **configpb.Settings, src *GlobalOptions) error 
 		setNullableBoolToProto(&obj.AutoApplyChangesets, src.AutoApplyChangesets),
 		setNullableBearerTokenFormatToProto(&obj.BearerTokenFormat, src.BearerTokenFormat),
 		setNullableCodecTypeToProto(&obj.CodecType, src.CodecType),
+		setNullableStringListToProto(&obj.EnvoyDynamicExtensions, src.EnvoyDynamicExtensions),
 		setNullableIssuerFormatToProto(&obj.JwtIssuerFormat, src.JWTIssuerFormat),
 	)
 }

--- a/config/envoyconfig/bootstrap.go
+++ b/config/envoyconfig/bootstrap.go
@@ -47,7 +47,7 @@ func (b *Builder) BuildBootstrap(
 	ctx, span := trace.Continue(ctx, "envoyconfig.Builder.BuildBootstrap")
 	defer span.End()
 	bootstrap = new(envoy_config_bootstrap_v3.Bootstrap)
-	if dynCfg != nil {
+	if dynCfg != nil && len(dynCfg.ExtensionsToLoad) > 0 {
 		bootstrap.BootstrapExtensions = append(bootstrap.BootstrapExtensions, dynCfg.DynamicExtensions)
 		b.extensionsToLoad = dynCfg.ExtensionsToLoad
 	}

--- a/config/envoyconfig/bootstrap.go
+++ b/config/envoyconfig/bootstrap.go
@@ -26,18 +26,31 @@ import (
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
+const (
+	ExtensionSSHSessionRecording = "pomerium.ssh.session_recording"
+)
+
 const maxActiveDownstreamConnections = 50000
+
+type DynamicExtensionsConfig struct {
+	ExtensionsToLoad  []string
+	DynamicExtensions *envoy_config_core_v3.TypedExtensionConfig
+}
 
 // BuildBootstrap builds the bootstrap config.
 func (b *Builder) BuildBootstrap(
 	ctx context.Context,
 	cfg *config.Config,
 	fullyStatic bool,
+	dynCfg *DynamicExtensionsConfig,
 ) (bootstrap *envoy_config_bootstrap_v3.Bootstrap, err error) {
 	ctx, span := trace.Continue(ctx, "envoyconfig.Builder.BuildBootstrap")
 	defer span.End()
-
 	bootstrap = new(envoy_config_bootstrap_v3.Bootstrap)
+	if dynCfg != nil {
+		bootstrap.BootstrapExtensions = append(bootstrap.BootstrapExtensions, dynCfg.DynamicExtensions)
+		b.extensionsToLoad = dynCfg.ExtensionsToLoad
+	}
 
 	bootstrap.Admin, err = b.BuildBootstrapAdmin(cfg)
 	if err != nil {

--- a/config/envoyconfig/bootstrap_test.go
+++ b/config/envoyconfig/bootstrap_test.go
@@ -154,7 +154,7 @@ func TestBuilder_BuildBootstrap(t *testing.T) {
 	t.Run("OverloadManager", func(t *testing.T) {
 		bootstrap, err := b.BuildBootstrap(t.Context(), config.New(&config.Options{
 			EnvoyAdminAddress: "localhost:9901",
-		}), false)
+		}), false, nil)
 		assert.NoError(t, err)
 		testutil.AssertProtoJSONEqual(t, `
 			{

--- a/config/envoyconfig/builder.go
+++ b/config/envoyconfig/builder.go
@@ -15,6 +15,10 @@ type Builder struct {
 	filemgr               *filemgr.Manager
 	reproxy               *reproxy.Handler
 	addIPV6InternalRanges bool
+
+	// dynamic extensions detected by the dynamic extension config
+	// passed to BuildBootstrap
+	extensionsToLoad []string
 }
 
 // New creates a new Builder.
@@ -40,5 +44,6 @@ func New(
 		filemgr:               fileManager,
 		reproxy:               reproxyHandler,
 		addIPV6InternalRanges: addIPV6InternalRanges,
+		extensionsToLoad:      []string{},
 	}
 }

--- a/config/envoyconfig/dyn_extensions.go
+++ b/config/envoyconfig/dyn_extensions.go
@@ -1,0 +1,50 @@
+package envoyconfig
+
+import (
+	"bytes"
+	"context"
+	"debug/elf"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+// ReadDynamicExtensionID reads the extension ID embedded in the .dx_metadata
+// ELF section of a pomerium-envoy dynamic extension shared object
+func ReadDynamicExtensionID(ctx context.Context, path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("error reading extension %s: %w", path, err)
+	}
+	defer f.Close()
+	ef, err := elf.NewFile(f)
+	if err != nil {
+		return "", fmt.Errorf("error reading extension %s: %w", path, err)
+	}
+	defer ef.Close()
+
+	section := ef.Section(".dx_metadata")
+	if section == nil {
+		return "", fmt.Errorf("extension is missing metadata: %s", path)
+	}
+	data, err := section.Data()
+	if err != nil {
+		return "", fmt.Errorf("error reading metadata for extension %s: %w", path, err)
+	}
+	for kv := range bytes.SplitSeq(data, []byte{0}) {
+		if len(kv) == 0 {
+			continue
+		}
+		k, v, ok := strings.Cut(string(kv), "=")
+		if !ok {
+			return "", fmt.Errorf("error reading metadata for extension %s: invalid format", path)
+		}
+		if k == "id" {
+			log.Ctx(ctx).Debug().Str("path", path).Str("id", v).Msg("found extension id")
+			return v, nil
+		}
+	}
+	return "", fmt.Errorf("could not find id in extension metadata: %s", path)
+}

--- a/config/envoyconfig/listeners.go
+++ b/config/envoyconfig/listeners.go
@@ -75,7 +75,7 @@ func (b *Builder) BuildListeners(
 	}
 
 	if shouldStartSSHListener(cfg.Options) {
-		li, err := buildSSHListener(cfg)
+		li, err := buildSSHListener(cfg, b.extensionsToLoad)
 		if err != nil {
 			return nil, err
 		}

--- a/config/envoyconfig/listeners_ssh.go
+++ b/config/envoyconfig/listeners_ssh.go
@@ -18,9 +18,9 @@ import (
 	envoy_generic_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/ratelimit/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
+	xssh "github.com/pomerium/envoy-custom/api/x/recording/formats/ssh"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/slices"
 	"github.com/pomerium/pomerium/pkg/ssh/ratelimit"
@@ -144,7 +144,7 @@ func buildSSHListener(cfg *config.Config, extensionsToLoad []string) (*envoy_con
 	if slices.Contains(extensionsToLoad, ExtensionSSHSessionRecording) {
 		enabledChannelFilters = append(enabledChannelFilters, &envoy_config_core_v3.TypedExtensionConfig{
 			Name:        "session_recording",
-			TypedConfig: marshalAny(&wrapperspb.StringValue{}),
+			TypedConfig: marshalAny(&xssh.ChannelFilterConfig{}),
 		})
 	}
 

--- a/config/envoyconfig/listeners_ssh.go
+++ b/config/envoyconfig/listeners_ssh.go
@@ -18,6 +18,7 @@ import (
 	envoy_generic_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/ratelimit/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
 	"github.com/pomerium/pomerium/config"
@@ -42,7 +43,7 @@ func newRateLimitEntries() []*envoy_common_ratelimit_v3.RateLimitDescriptor_Entr
 	}
 }
 
-func buildSSHListener(cfg *config.Config) (*envoy_config_listener_v3.Listener, error) {
+func buildSSHListener(cfg *config.Config, extensionsToLoad []string) (*envoy_config_listener_v3.Listener, error) {
 	if cfg.Options.SSHAddr == "" {
 		return nil, nil
 	}
@@ -139,6 +140,14 @@ func buildSSHListener(cfg *config.Config) (*envoy_config_listener_v3.Listener, e
 		})
 	}
 
+	var enabledChannelFilters []*envoy_config_core_v3.TypedExtensionConfig
+	if slices.Contains(extensionsToLoad, ExtensionSSHSessionRecording) {
+		enabledChannelFilters = append(enabledChannelFilters, &envoy_config_core_v3.TypedExtensionConfig{
+			Name:        "session_recording",
+			TypedConfig: marshalAny(&wrapperspb.StringValue{}),
+		})
+	}
+
 	filters = append(
 		filters, &envoy_config_listener_v3.Filter{
 			Name: "generic_proxy",
@@ -148,9 +157,10 @@ func buildSSHListener(cfg *config.Config) (*envoy_config_listener_v3.Listener, e
 					CodecConfig: &envoy_config_core_v3.TypedExtensionConfig{
 						Name: "envoy.generic_proxy.codecs.ssh",
 						TypedConfig: marshalAny(&extensions_ssh.CodecConfig{
-							HostKeys:    hostKeyDataSources,
-							UserCaKey:   userCaKeyDataSource,
-							GrpcService: authorizeService,
+							HostKeys:                      hostKeyDataSources,
+							UserCaKey:                     userCaKeyDataSource,
+							GrpcService:                   authorizeService,
+							EnabledChannelFilterFactories: enabledChannelFilters,
 						}),
 					},
 					Filters: []*envoy_config_core_v3.TypedExtensionConfig{

--- a/config/envoyconfig/listeners_ssh_test.go
+++ b/config/envoyconfig/listeners_ssh_test.go
@@ -13,7 +13,7 @@ func TestBuildSSHListener(t *testing.T) {
 
 	t.Run("no ssh routes or address set", func(t *testing.T) {
 		cfg := config.New(config.NewDefaultOptions())
-		l, err := buildSSHListener(cfg)
+		l, err := buildSSHListener(cfg, []string{})
 		assert.NoError(t, err)
 		assert.Nil(t, l)
 	})
@@ -23,7 +23,7 @@ func TestBuildSSHListener(t *testing.T) {
 			{From: "https://not-ssh", To: mustParseWeightedURLs(t, "https://dest:22")},
 		}
 		cfg.Options.SSHAddr = "0.0.0.0:22"
-		l, err := buildSSHListener(cfg)
+		l, err := buildSSHListener(cfg, []string{})
 		assert.NoError(t, err)
 		assert.NotNil(t, l)
 	})
@@ -32,7 +32,7 @@ func TestBuildSSHListener(t *testing.T) {
 		cfg.Options.Policies = []config.Policy{
 			{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://to:22")},
 		}
-		l, err := buildSSHListener(cfg)
+		l, err := buildSSHListener(cfg, []string{})
 		assert.NoError(t, err)
 		assert.Nil(t, l)
 	})
@@ -42,7 +42,7 @@ func TestBuildSSHListener(t *testing.T) {
 		cfg.Options.Policies = []config.Policy{
 			{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://to:22")},
 		}
-		l, err := buildSSHListener(cfg)
+		l, err := buildSSHListener(cfg, []string{})
 		assert.NoError(t, err)
 		assert.NoError(t, l.ValidateAll())
 	})
@@ -54,7 +54,7 @@ func TestBuildSSHListener(t *testing.T) {
 			{From: "ssh://host2", To: mustParseWeightedURLs(t, "ssh://to2:22")},
 			{From: "ssh://host3", To: mustParseWeightedURLs(t, "ssh://to3:22")},
 		}
-		l, err := buildSSHListener(cfg)
+		l, err := buildSSHListener(cfg, []string{})
 		assert.NoError(t, err)
 		assert.NoError(t, l.ValidateAll())
 	})
@@ -75,7 +75,7 @@ func TestBuildSSHListener(t *testing.T) {
 			{From: "ssh://host2", To: mustParseWeightedURLs(t, "ssh://to2:22")},
 			{From: "ssh://host3", To: mustParseWeightedURLs(t, "ssh://to3:22")},
 		}
-		l, err := buildSSHListener(cfg)
+		l, err := buildSSHListener(cfg, []string{})
 		assert.NoError(t, err)
 		assert.NoError(t, l.ValidateAll())
 	})
@@ -96,7 +96,7 @@ func TestBuildSSHListener(t *testing.T) {
 			{From: "ssh://host2", To: mustParseWeightedURLs(t, "ssh://to2:22")},
 			{From: "ssh://host3", To: mustParseWeightedURLs(t, "ssh://to3:22")},
 		}
-		l, err := buildSSHListener(cfg)
+		l, err := buildSSHListener(cfg, []string{})
 		assert.NoError(t, err)
 		assert.NoError(t, l.ValidateAll())
 	})
@@ -106,7 +106,7 @@ func TestBuildSSHListener(t *testing.T) {
 		cfg.Options.Policies = []config.Policy{
 			{From: "ssh://\x7f", To: mustParseWeightedURLs(t, "ssh://to1:22")},
 		}
-		_, err := buildSSHListener(cfg)
+		_, err := buildSSHListener(cfg, []string{})
 		assert.Error(t, err)
 	})
 	t.Run("multiple To urls", func(t *testing.T) {
@@ -115,7 +115,7 @@ func TestBuildSSHListener(t *testing.T) {
 		cfg.Options.Policies = []config.Policy{
 			{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://to1:22", "ssh://to2:22")},
 		}
-		_, err := buildSSHListener(cfg)
+		_, err := buildSSHListener(cfg, []string{})
 		assert.Error(t, err)
 	})
 	t.Run("To url missing scheme", func(t *testing.T) {
@@ -124,7 +124,9 @@ func TestBuildSSHListener(t *testing.T) {
 		cfg.Options.Policies = []config.Policy{
 			{From: "ssh://host1", To: mustParseWeightedURLs(t, "http://to1:22")},
 		}
-		_, err := buildSSHListener(cfg)
+		_, err := buildSSHListener(cfg, []string{})
 		assert.Error(t, err)
 	})
+
+	// TODO: tests
 }

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.11.0
 	github.com/pomerium/datasource v0.18.2-0.20260513141340-e0e123819aa8
-	github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260513231418-69e0f8fdd0d0
+	github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260515204034-8f0647435d48
 	github.com/pomerium/protoutil v0.0.0-20260508203012-e09f8af90da5
 	github.com/pomerium/webauthn v0.0.0-20260508203114-e4bd6034c565
 	github.com/prometheus/client_golang v1.23.2

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.11.0
 	github.com/pomerium/datasource v0.18.2-0.20260513141340-e0e123819aa8
-	github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260515204034-8f0647435d48
+	github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260519214603-7724aff26b06
 	github.com/pomerium/protoutil v0.0.0-20260508203012-e09f8af90da5
 	github.com/pomerium/webauthn v0.0.0-20260508203114-e4bd6034c565
 	github.com/prometheus/client_golang v1.23.2

--- a/go.mod
+++ b/go.mod
@@ -83,7 +83,7 @@ require (
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.11.0
 	github.com/pomerium/datasource v0.18.2-0.20260513141340-e0e123819aa8
-	github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260512225211-15289e9512f0
+	github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260513231418-69e0f8fdd0d0
 	github.com/pomerium/protoutil v0.0.0-20260508203012-e09f8af90da5
 	github.com/pomerium/webauthn v0.0.0-20260508203114-e4bd6034c565
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pomerium/datasource v0.18.2-0.20260513141340-e0e123819aa8 h1:ZUcfU8vHIlWnpPvBS+SnNQ+8r37mKU8rNjU+x5ukXLM=
 github.com/pomerium/datasource v0.18.2-0.20260513141340-e0e123819aa8/go.mod h1:AvH9IIKbQA9S6MTFHc5YL/xaJf/wLfVd8dWenK5B7TI=
-github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260513231418-69e0f8fdd0d0 h1:BYUmeA69XTpBlUT97nJez2DvczsgJkRnbjSWEq+Of0Q=
-github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260513231418-69e0f8fdd0d0/go.mod h1:7Svo/CaRt9vfJ22sEC+T/q/y2WNi/cZTlugNYUS7xwI=
+github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260515204034-8f0647435d48 h1:ND7Wxte0Ee2ZPkCTUohg1XKA7o41a1wEAHE+B2tx9oA=
+github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260515204034-8f0647435d48/go.mod h1:7Svo/CaRt9vfJ22sEC+T/q/y2WNi/cZTlugNYUS7xwI=
 github.com/pomerium/protoutil v0.0.0-20260508203012-e09f8af90da5 h1:qn/jJOvNR6xx9Wynx0VkHjZ/z3WCm5U+BTzQEMYWkuI=
 github.com/pomerium/protoutil v0.0.0-20260508203012-e09f8af90da5/go.mod h1:ERFmbEXYDOhFJjgzLJJ2AJkYKmm/naM7Isul3u5pGtI=
 github.com/pomerium/webauthn v0.0.0-20260508203114-e4bd6034c565 h1:e85Sl28YgnyTwqnFDVvqOugsp4FHG6x6d8whkVu8ET4=

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pomerium/datasource v0.18.2-0.20260513141340-e0e123819aa8 h1:ZUcfU8vHIlWnpPvBS+SnNQ+8r37mKU8rNjU+x5ukXLM=
 github.com/pomerium/datasource v0.18.2-0.20260513141340-e0e123819aa8/go.mod h1:AvH9IIKbQA9S6MTFHc5YL/xaJf/wLfVd8dWenK5B7TI=
-github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260515204034-8f0647435d48 h1:ND7Wxte0Ee2ZPkCTUohg1XKA7o41a1wEAHE+B2tx9oA=
-github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260515204034-8f0647435d48/go.mod h1:7Svo/CaRt9vfJ22sEC+T/q/y2WNi/cZTlugNYUS7xwI=
+github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260519214603-7724aff26b06 h1:03u4+2HwelwofsKH2dGyeqD4Rm78xEQ00FNKKcSvfdY=
+github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260519214603-7724aff26b06/go.mod h1:7Svo/CaRt9vfJ22sEC+T/q/y2WNi/cZTlugNYUS7xwI=
 github.com/pomerium/protoutil v0.0.0-20260508203012-e09f8af90da5 h1:qn/jJOvNR6xx9Wynx0VkHjZ/z3WCm5U+BTzQEMYWkuI=
 github.com/pomerium/protoutil v0.0.0-20260508203012-e09f8af90da5/go.mod h1:ERFmbEXYDOhFJjgzLJJ2AJkYKmm/naM7Isul3u5pGtI=
 github.com/pomerium/webauthn v0.0.0-20260508203114-e4bd6034c565 h1:e85Sl28YgnyTwqnFDVvqOugsp4FHG6x6d8whkVu8ET4=

--- a/go.sum
+++ b/go.sum
@@ -752,8 +752,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pomerium/datasource v0.18.2-0.20260513141340-e0e123819aa8 h1:ZUcfU8vHIlWnpPvBS+SnNQ+8r37mKU8rNjU+x5ukXLM=
 github.com/pomerium/datasource v0.18.2-0.20260513141340-e0e123819aa8/go.mod h1:AvH9IIKbQA9S6MTFHc5YL/xaJf/wLfVd8dWenK5B7TI=
-github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260512225211-15289e9512f0 h1:f8apGhxEn6P/8SeTmSoRKLCHksyOkIXrsqs5vWJdDow=
-github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260512225211-15289e9512f0/go.mod h1:7Svo/CaRt9vfJ22sEC+T/q/y2WNi/cZTlugNYUS7xwI=
+github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260513231418-69e0f8fdd0d0 h1:BYUmeA69XTpBlUT97nJez2DvczsgJkRnbjSWEq+Of0Q=
+github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260513231418-69e0f8fdd0d0/go.mod h1:7Svo/CaRt9vfJ22sEC+T/q/y2WNi/cZTlugNYUS7xwI=
 github.com/pomerium/protoutil v0.0.0-20260508203012-e09f8af90da5 h1:qn/jJOvNR6xx9Wynx0VkHjZ/z3WCm5U+BTzQEMYWkuI=
 github.com/pomerium/protoutil v0.0.0-20260508203012-e09f8af90da5/go.mod h1:ERFmbEXYDOhFJjgzLJJ2AJkYKmm/naM7Isul3u5pGtI=
 github.com/pomerium/webauthn v0.0.0-20260508203114-e4bd6034c565 h1:e85Sl28YgnyTwqnFDVvqOugsp4FHG6x6d8whkVu8ET4=

--- a/pkg/envoy/dynamic_extensions.go
+++ b/pkg/envoy/dynamic_extensions.go
@@ -1,0 +1,117 @@
+package envoy
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	xds_type_v3 "github.com/cncf/xds/go/xds/type/v3"
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	dynamic_extension_loader "github.com/pomerium/envoy-custom/api/extensions/bootstrap/dynamic_extension_loader"
+	xrecording "github.com/pomerium/envoy-custom/api/x/recording"
+	xssh "github.com/pomerium/envoy-custom/api/x/recording/formats/ssh"
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/config/envoyconfig"
+	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/pkg/ipc"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+type DynamicExtensionsConfig struct {
+	RecordingPipes    []*ipc.ProtoPipeWorker[*xrecording.RecordingData, *xrecording.RecordingCheckpoint]
+	DynamicExtensions *envoy_config_core_v3.TypedExtensionConfig
+	extensionIDs      []string
+}
+
+func (d *DynamicExtensionsConfig) isSessionRecordingEnabled() bool {
+	return slices.Contains(d.extensionIDs, envoyconfig.ExtensionSSHSessionRecording)
+}
+
+func (srv *Server) configureDynamicExtensions(ctx context.Context, cfg *config.Config, paths []string) (*DynamicExtensionsConfig, error) {
+	out := &DynamicExtensionsConfig{}
+	extensionLoaderCfg := &dynamic_extension_loader.Config{
+		Paths:            paths,
+		ExtensionConfigs: map[string]*anypb.Any{},
+	}
+	for _, filepath := range paths {
+		extID, err := envoyconfig.ReadDynamicExtensionID(ctx, filepath)
+		if err != nil {
+			return nil, err
+		}
+		switch extID {
+		case envoyconfig.ExtensionSSHSessionRecording:
+			pipes, err := srv.configureSessionRecordingExtension(ctx, cfg, extensionLoaderCfg, extID)
+			if err != nil {
+				log.Ctx(ctx).Err(err).Msg("failed to configure ssh dynamic extension")
+				if pipes != nil {
+					log.Ctx(ctx).Debug().Msg("cleaning up constructed pipes for session recording due to config failure")
+					errs := []error{}
+					for _, pipe := range pipes {
+						errs = append(errs, pipe.Close())
+					}
+					if closeErr := errors.Join(errs...); closeErr != nil {
+						log.Ctx(ctx).Err(closeErr).Msg("failed to cleanup pipes")
+					}
+				}
+			}
+			out.RecordingPipes = pipes
+		}
+		out.extensionIDs = append(out.extensionIDs, extID)
+	}
+	out.DynamicExtensions = &envoy_config_core_v3.TypedExtensionConfig{
+		Name:        "envoy.bootstrap.dynamic_extension_loader",
+		TypedConfig: marshalAny(extensionLoaderCfg),
+	}
+	return out, nil
+}
+
+// mutates the extension loader in place
+func (srv *Server) configureSessionRecordingExtension(
+	_ context.Context,
+	_ *config.Config,
+	dynCfg *dynamic_extension_loader.Config,
+	extID string,
+) ([]*ipc.ProtoPipeWorker[*xrecording.RecordingData, *xrecording.RecordingCheckpoint], error) {
+	// TODO : in follow-up PR that sets ssh specific config options
+	conc := 8
+	workers, err := ipc.NewPipeWorkers[*xrecording.RecordingData, *xrecording.RecordingCheckpoint](conc)
+	if err != nil {
+		return nil, fmt.Errorf("configuring %s extension: %w", extID, err)
+	}
+
+	sshCfg := &xssh.Config{
+		UploadConfig: &xssh.UploadConfig{
+			DefaultBufferSize: 1024 * 1024 * 32,
+			Concurrency: &wrapperspb.UInt32Value{
+				Value: uint32(conc),
+			},
+			IpcMode: &xssh.UploadConfig_PipeIpc_{
+				PipeIpc: &xssh.UploadConfig_PipeIpc{},
+			},
+		},
+	}
+	ext := protoutil.NewAny(sshCfg)
+	ts := &xds_type_v3.TypedStruct{
+		TypeUrl: ext.TypeUrl,
+		Value:   &structpb.Struct{},
+	}
+	msg, err := ext.UnmarshalNew()
+	if err != nil {
+		return workers, fmt.Errorf("unmarshalling %s extension config: %w", extID, err)
+	}
+	data, err := protojson.Marshal(msg)
+	if err != nil {
+		return workers, fmt.Errorf("marshalling %s extension config: %w", extID, err)
+	}
+	if err := protojson.Unmarshal(data, ts.Value); err != nil {
+		return workers, err
+	}
+	dynCfg.ExtensionConfigs[extID] = marshalAny(ts)
+	return workers, nil
+}

--- a/pkg/envoy/dynamic_extensions.go
+++ b/pkg/envoy/dynamic_extensions.go
@@ -87,7 +87,7 @@ func (srv *Server) configureSessionRecordingExtension(
 
 	sshCfg := &xssh.Config{
 		UploadConfig: &xssh.UploadConfig{
-			DefaultBufferSize: 1024 * 1024 * 32,
+			DefaultBufferSize: 1024 * 1024 * 8,
 			Concurrency: &wrapperspb.UInt32Value{
 				Value: uint32(conc),
 			},

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/envoyconfig"
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/recording"
 	"github.com/pomerium/pomerium/pkg/envoy/files"
 	"github.com/pomerium/pomerium/pkg/health"
 	"github.com/pomerium/pomerium/pkg/netutil"
@@ -60,12 +61,16 @@ type Server struct {
 
 	mu        sync.Mutex
 	shutdownC chan error
+
+	recordingServer     stdatomic.Pointer[recording.Server]
+	recordingServerErrC chan error
 }
 
 type ServerOptions struct {
-	extraEnvVars    []string
-	logLevel        config.LogLevel
-	exitGracePeriod time.Duration
+	extraEnvVars          []string
+	logLevel              config.LogLevel
+	exitGracePeriod       time.Duration
+	dynamicExtensionPaths []string
 }
 
 func (o *ServerOptions) ExitGracePeriod() time.Duration {
@@ -121,6 +126,8 @@ func NewServer(
 		envoyPath:            envoyPath,
 		shutdownC:            shutdown,
 		monitorProcessCancel: func() {},
+		recordingServer:      stdatomic.Pointer[recording.Server]{},
+		recordingServerErrC:  make(chan error, 1),
 	}
 	go srv.runProcessCollector(ctx)
 
@@ -247,6 +254,8 @@ func (srv *Server) onConfigChange(ctx context.Context, cfg *config.Config) {
 func (srv *Server) update(ctx context.Context, cfg *config.Config) {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
+	// must pass in new config options in case envoy doesn't require a hot restart
+	srv.onConfigChangeRecordingServer(ctx, cfg)
 
 	opts := srv.ServerOptions
 	// log level is managed via config
@@ -257,7 +266,7 @@ func (srv *Server) update(ctx context.Context, cfg *config.Config) {
 		return
 	}
 	srv.ServerOptions = opts
-
+	opts.dynamicExtensionPaths = cfg.Options.EnvoyDynamicExtensions.Or([]string{})
 	log.Ctx(ctx).Debug().Msg("envoy: starting envoy process")
 	if err := srv.run(ctx, cfg); err != nil {
 		log.Ctx(ctx).Error().Err(err).Str("service", "envoy").Msg("envoy: failed to run envoy process")
@@ -269,7 +278,21 @@ func (srv *Server) run(ctx context.Context, cfg *config.Config) error {
 	// cancel any process monitor since we will be killing the previous process
 	srv.monitorProcessCancel()
 
-	if err := srv.writeConfig(ctx, cfg); err != nil {
+	dynCfg, err := srv.configureDynamicExtensions(ctx, cfg, srv.ServerOptions.dynamicExtensionPaths)
+	if err != nil {
+		panic(err)
+	}
+
+	if dynCfg.isSessionRecordingEnabled() {
+		srv.enableOrUpdateSessionRecording(ctx, cfg, dynCfg.RecordingPipes)
+	} else {
+		srv.disableSessionRecording(ctx)
+	}
+
+	if err := srv.writeConfig(ctx, cfg, &envoyconfig.DynamicExtensionsConfig{
+		ExtensionsToLoad:  dynCfg.extensionIDs,
+		DynamicExtensions: dynCfg.DynamicExtensions,
+	}); err != nil {
 		log.Ctx(ctx).Error().Err(err).Str("service", "envoy").Msg("envoy: failed to write envoy config")
 		return err
 	}
@@ -370,8 +393,8 @@ func (srv *Server) run(ctx context.Context, cfg *config.Config) error {
 	return nil
 }
 
-func (srv *Server) writeConfig(ctx context.Context, cfg *config.Config) error {
-	confBytes, err := srv.buildBootstrapConfig(ctx, cfg)
+func (srv *Server) writeConfig(ctx context.Context, cfg *config.Config, dynCfg *envoyconfig.DynamicExtensionsConfig) error {
+	confBytes, err := srv.buildBootstrapConfig(ctx, cfg, dynCfg)
 	if err != nil {
 		return err
 	}
@@ -382,8 +405,8 @@ func (srv *Server) writeConfig(ctx context.Context, cfg *config.Config) error {
 	return atomic.WriteFile(cfgPath, bytes.NewReader(confBytes))
 }
 
-func (srv *Server) buildBootstrapConfig(ctx context.Context, cfg *config.Config) ([]byte, error) {
-	bootstrapCfg, err := srv.builder.BuildBootstrap(ctx, cfg, false)
+func (srv *Server) buildBootstrapConfig(ctx context.Context, cfg *config.Config, dynCfg *envoyconfig.DynamicExtensionsConfig) ([]byte, error) {
+	bootstrapCfg, err := srv.builder.BuildBootstrap(ctx, cfg, false, dynCfg)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pomerium/pomerium/internal/recording"
 	"github.com/pomerium/pomerium/pkg/envoy/files"
 	"github.com/pomerium/pomerium/pkg/health"
+	"github.com/pomerium/pomerium/pkg/ipc"
 	"github.com/pomerium/pomerium/pkg/netutil"
 )
 
@@ -313,9 +314,14 @@ func (srv *Server) run(ctx context.Context, cfg *config.Config) error {
 	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagSetEnvoyConcurrencyToGoMaxProcs) {
 		args = append(args, "--concurrency", strconv.Itoa(runtime.GOMAXPROCS(0)))
 	}
+	extraFiles := []*os.File{}
+	if len(dynCfg.RecordingPipes) > 0 {
+		extraFiles = ipc.PipeClients(dynCfg.RecordingPipes)
+	}
 
 	exePath, args := srv.prepareRunEnvoyCommand(ctx, args)
 	cmd := exec.Command(exePath, args...)
+	cmd.ExtraFiles = extraFiles
 	cmd.Dir = srv.wd
 	cmd.Env = append(cmd.Env, srv.extraEnvVars...)
 

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -267,7 +267,7 @@ func (srv *Server) update(ctx context.Context, cfg *config.Config) {
 		return
 	}
 	srv.ServerOptions = opts
-	opts.dynamicExtensionPaths = cfg.Options.EnvoyDynamicExtensions.Or([]string{})
+	opts.dynamicExtensionPaths = cfg.Options.PluginsEnvoy.Or([]string{})
 	log.Ctx(ctx).Debug().Msg("envoy: starting envoy process")
 	if err := srv.run(ctx, cfg); err != nil {
 		log.Ctx(ctx).Error().Err(err).Str("service", "envoy").Msg("envoy: failed to run envoy process")
@@ -281,7 +281,7 @@ func (srv *Server) run(ctx context.Context, cfg *config.Config) error {
 
 	dynCfg, err := srv.configureDynamicExtensions(ctx, cfg, srv.ServerOptions.dynamicExtensionPaths)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("envoy: failed to configure dynamic extensions: %w", err)
 	}
 
 	if dynCfg.isSessionRecordingEnabled() {

--- a/pkg/envoy/misc.go
+++ b/pkg/envoy/misc.go
@@ -1,5 +1,19 @@
 package envoy
 
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+)
+
+func marshalAny(msg proto.Message) *anypb.Any {
+	data := new(anypb.Any)
+	_ = anypb.MarshalFrom(data, msg, proto.MarshalOptions{
+		AllowPartial:  true,
+		Deterministic: true,
+	})
+	return data
+}
+
 func firstNonEmpty[T interface{ ~string }](args ...T) T {
 	for _, a := range args {
 		if a != "" {

--- a/pkg/envoy/recording.go
+++ b/pkg/envoy/recording.go
@@ -1,0 +1,64 @@
+package envoy
+
+import (
+	"context"
+
+	xrecording "github.com/pomerium/envoy-custom/api/x/recording"
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/recording"
+	"github.com/pomerium/pomerium/pkg/ipc"
+)
+
+func (srv *Server) disableSessionRecording(ctx context.Context) {
+	recSrv := srv.recordingServer.Load()
+	if recSrv != nil {
+		log.Ctx(ctx).Info().Msg("disabling session recording server")
+		if err := (*recSrv).Shutdown(ctx); err != nil {
+			log.Ctx(ctx).Err(err).Msg("failed to shutdown sesssion recording server")
+		}
+		srv.recordingServer.Store(nil)
+	}
+}
+
+func (srv *Server) shouldCreateRecordingServer() bool {
+	if srv.recordingServer.Load() == nil {
+		return true
+	}
+	select {
+	case <-srv.recordingServerErrC:
+		return true
+	default:
+	}
+	return false
+}
+
+func (srv *Server) onConfigChangeRecordingServer(ctx context.Context, cfg *config.Config) {
+	if recSrv := srv.recordingServer.Load(); recSrv != nil {
+		(*recSrv).OnConfigChange(ctx, cfg)
+	}
+}
+
+func (srv *Server) enableOrUpdateSessionRecording(
+	ctx context.Context, cfg *config.Config, workers []*ipc.ProtoPipeWorker[*xrecording.RecordingData, *xrecording.RecordingCheckpoint],
+) {
+	if srv.shouldCreateRecordingServer() {
+		log.Ctx(ctx).Info().Msg("initializing session recording server")
+		newSrv, err := recording.NewRecordingServer(ctx, cfg, workers)
+		if err != nil {
+			panic(err)
+		}
+		go func() {
+			srv.recordingServerErrC <- newSrv.Serve(ctx)
+		}()
+		srv.recordingServer.Store(&newSrv)
+	} else {
+		recSrv := srv.recordingServer.Load()
+		if recSrv == nil {
+			panic("bug: unreachable, the recording server should always be set in this code path")
+		}
+		log.Ctx(ctx).Info().Msg("updating session recording server")
+		(*recSrv).OnConfigChange(ctx, cfg)
+		(*recSrv).OnTransportChange(ctx, workers)
+	}
+}

--- a/pkg/envoy/resource_monitor_linux.go
+++ b/pkg/envoy/resource_monitor_linux.go
@@ -25,7 +25,6 @@ import (
 	typev3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
 	atomicfs "github.com/natefinch/atomic"
 	"golang.org/x/sys/unix"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/pomerium/pomerium/config"
@@ -653,15 +652,6 @@ func findMountpoint(fsys fs.FS) (mountpoint string, isV2 bool, err error) {
 		return "", false, errors.New("no cgroup mount found")
 	}
 	return cgv1Root, false, nil
-}
-
-func marshalAny(msg proto.Message) *anypb.Any {
-	data := new(anypb.Any)
-	_ = anypb.MarshalFrom(data, msg, proto.MarshalOptions{
-		AllowPartial:  true,
-		Deterministic: true,
-	})
-	return data
 }
 
 type memoryLimitWatcher struct {

--- a/pkg/envoy/resource_monitor_test.go
+++ b/pkg/envoy/resource_monitor_test.go
@@ -726,7 +726,7 @@ func TestBootstrapConfig(t *testing.T) {
 
 	bootstrap, err := b.BuildBootstrap(t.Context(), config.New(&config.Options{
 		EnvoyAdminAddress: "localhost:9901",
-	}), false)
+	}), false, nil)
 	assert.NoError(t, err)
 
 	monitor.ApplyBootstrapConfig(bootstrap)

--- a/pkg/grpc/config/config.pb.go
+++ b/pkg/grpc/config/config.pb.go
@@ -2911,6 +2911,8 @@ type Settings struct {
 	AutoApplyChangesets *bool `protobuf:"varint,180,opt,name=auto_apply_changesets,json=autoApplyChangesets,proto3,oneof" json:"auto_apply_changesets,omitempty"`
 	// Allows HTTP upgrade requests to be forwarded upstream.
 	AllowUpgrades *Settings_StringList `protobuf:"bytes,181,opt,name=allow_upgrades,json=allowUpgrades,proto3,oneof" json:"allow_upgrades,omitempty"`
+	// Maps dynamic extension id to the path where it should be loaded from
+	EnvoyDynamicExtensions *Settings_StringList `protobuf:"bytes,182,opt,name=envoy_dynamic_extensions,json=envoyDynamicExtensions,proto3" json:"envoy_dynamic_extensions,omitempty"`
 	// When the settings were created.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,169,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// When the settings were last modified.
@@ -3925,6 +3927,13 @@ func (x *Settings) GetAutoApplyChangesets() bool {
 func (x *Settings) GetAllowUpgrades() *Settings_StringList {
 	if x != nil {
 		return x.AllowUpgrades
+	}
+	return nil
+}
+
+func (x *Settings) GetEnvoyDynamicExtensions() *Settings_StringList {
+	if x != nil {
+		return x.EnvoyDynamicExtensions
 	}
 	return nil
 }
@@ -8921,7 +8930,7 @@ const file_config_proto_rawDesc = "" +
 	"\v_source_pplB\x0e\n" +
 	"\f_explanationB\x0e\n" +
 	"\f_remediationB\x11\n" +
-	"\x0f_namespace_nameJ\x04\b\x04\x10\x05\"\xa6c\n" +
+	"\x0f_namespace_nameJ\x04\b\x04\x10\x05\"\x87d\n" +
 	"\bSettings\x12\x14\n" +
 	"\x02id\x18\x9e\x01 \x01(\tH\x00R\x02id\x88\x01\x01\x12'\n" +
 	"\fnamespace_id\x18\x9f\x01 \x01(\tH\x01R\vnamespaceId\x88\x01\x01\x12#\n" +
@@ -9072,7 +9081,8 @@ const file_config_proto_rawDesc = "" +
 	"\x19session_recording_enabled\x18\xb2\x01 \x01(\bHwR\x17sessionRecordingEnabled\x88\x01\x01\x12M\n" +
 	"\fblob_storage\x18\xb3\x01 \x01(\v2$.pomerium.config.BlobStorageSettingsHxR\vblobStorage\x88\x01\x01\x128\n" +
 	"\x15auto_apply_changesets\x18\xb4\x01 \x01(\bHyR\x13autoApplyChangesets\x88\x01\x01\x12Q\n" +
-	"\x0eallow_upgrades\x18\xb5\x01 \x01(\v2$.pomerium.config.Settings.StringListHzR\rallowUpgrades\x88\x01\x01\x12:\n" +
+	"\x0eallow_upgrades\x18\xb5\x01 \x01(\v2$.pomerium.config.Settings.StringListHzR\rallowUpgrades\x88\x01\x01\x12_\n" +
+	"\x18envoy_dynamic_extensions\x18\xb6\x01 \x01(\v2$.pomerium.config.Settings.StringListR\x16envoyDynamicExtensions\x12:\n" +
 	"\n" +
 	"created_at\x18\xa9\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12<\n" +
 	"\vmodified_at\x18\xaa\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
@@ -9869,166 +9879,167 @@ var file_config_proto_depIdxs = []int32{
 	111, // 72: pomerium.config.Settings.directory_provider_refresh_timeout:type_name -> google.protobuf.Duration
 	29,  // 73: pomerium.config.Settings.blob_storage:type_name -> pomerium.config.BlobStorageSettings
 	99,  // 74: pomerium.config.Settings.allow_upgrades:type_name -> pomerium.config.Settings.StringList
-	110, // 75: pomerium.config.Settings.created_at:type_name -> google.protobuf.Timestamp
-	110, // 76: pomerium.config.Settings.modified_at:type_name -> google.protobuf.Timestamp
-	3,   // 77: pomerium.config.DownstreamMtlsSettings.enforcement:type_name -> pomerium.config.MtlsEnforcementMode
-	31,  // 78: pomerium.config.DownstreamMtlsSettings.match_subject_alt_names:type_name -> pomerium.config.SANMatcher
-	9,   // 79: pomerium.config.SANMatcher.san_type:type_name -> pomerium.config.SANMatcher.SANType
-	110, // 80: pomerium.config.KeyPair.created_at:type_name -> google.protobuf.Timestamp
-	110, // 81: pomerium.config.KeyPair.modified_at:type_name -> google.protobuf.Timestamp
-	5,   // 82: pomerium.config.KeyPair.status:type_name -> pomerium.config.KeyPairStatus
-	4,   // 83: pomerium.config.KeyPair.origin:type_name -> pomerium.config.KeyPairOrigin
-	35,  // 84: pomerium.config.KeyPair.certificate_info:type_name -> pomerium.config.CertificateInfo
-	34,  // 85: pomerium.config.CertificateInfo.issuer:type_name -> pomerium.config.Name
-	34,  // 86: pomerium.config.CertificateInfo.subject:type_name -> pomerium.config.Name
-	110, // 87: pomerium.config.CertificateInfo.not_before:type_name -> google.protobuf.Timestamp
-	110, // 88: pomerium.config.CertificateInfo.not_after:type_name -> google.protobuf.Timestamp
-	33,  // 89: pomerium.config.CertificateInfo.key_usage:type_name -> pomerium.config.KeyUsage
-	110, // 90: pomerium.config.ServiceAccount.expires_at:type_name -> google.protobuf.Timestamp
-	110, // 91: pomerium.config.ServiceAccount.created_at:type_name -> google.protobuf.Timestamp
-	110, // 92: pomerium.config.ServiceAccount.modified_at:type_name -> google.protobuf.Timestamp
-	110, // 93: pomerium.config.ServiceAccount.accessed_at:type_name -> google.protobuf.Timestamp
-	32,  // 94: pomerium.config.CreateKeyPairRequest.key_pair:type_name -> pomerium.config.KeyPair
-	32,  // 95: pomerium.config.CreateKeyPairResponse.key_pair:type_name -> pomerium.config.KeyPair
-	27,  // 96: pomerium.config.CreatePolicyRequest.policy:type_name -> pomerium.config.Policy
-	27,  // 97: pomerium.config.CreatePolicyResponse.policy:type_name -> pomerium.config.Policy
-	19,  // 98: pomerium.config.CreateRouteRequest.route:type_name -> pomerium.config.Route
-	19,  // 99: pomerium.config.CreateRouteResponse.route:type_name -> pomerium.config.Route
-	36,  // 100: pomerium.config.CreateServiceAccountRequest.service_account:type_name -> pomerium.config.ServiceAccount
-	36,  // 101: pomerium.config.CreateServiceAccountResponse.service_account:type_name -> pomerium.config.ServiceAccount
-	32,  // 102: pomerium.config.GetKeyPairResponse.key_pair:type_name -> pomerium.config.KeyPair
-	27,  // 103: pomerium.config.GetPolicyResponse.policy:type_name -> pomerium.config.Policy
-	19,  // 104: pomerium.config.GetRouteResponse.route:type_name -> pomerium.config.Route
-	36,  // 105: pomerium.config.GetServiceAccountResponse.service_account:type_name -> pomerium.config.ServiceAccount
-	28,  // 106: pomerium.config.GetSettingsResponse.settings:type_name -> pomerium.config.Settings
-	112, // 107: pomerium.config.ListKeyPairsRequest.filter:type_name -> google.protobuf.Struct
-	32,  // 108: pomerium.config.ListKeyPairsResponse.key_pairs:type_name -> pomerium.config.KeyPair
-	112, // 109: pomerium.config.ListPoliciesRequest.filter:type_name -> google.protobuf.Struct
-	27,  // 110: pomerium.config.ListPoliciesResponse.policies:type_name -> pomerium.config.Policy
-	112, // 111: pomerium.config.ListRoutesRequest.filter:type_name -> google.protobuf.Struct
-	19,  // 112: pomerium.config.ListRoutesResponse.routes:type_name -> pomerium.config.Route
-	112, // 113: pomerium.config.ListServiceAccountsRequest.filter:type_name -> google.protobuf.Struct
-	36,  // 114: pomerium.config.ListServiceAccountsResponse.service_accounts:type_name -> pomerium.config.ServiceAccount
-	112, // 115: pomerium.config.ListSettingsRequest.filter:type_name -> google.protobuf.Struct
-	28,  // 116: pomerium.config.ListSettingsResponse.settings:type_name -> pomerium.config.Settings
-	6,   // 117: pomerium.config.GetServerInfoResponse.server_type:type_name -> pomerium.config.ServerType
-	32,  // 118: pomerium.config.UpdateKeyPairRequest.key_pair:type_name -> pomerium.config.KeyPair
-	32,  // 119: pomerium.config.UpdateKeyPairResponse.key_pair:type_name -> pomerium.config.KeyPair
-	27,  // 120: pomerium.config.UpdatePolicyRequest.policy:type_name -> pomerium.config.Policy
-	27,  // 121: pomerium.config.UpdatePolicyResponse.policy:type_name -> pomerium.config.Policy
-	19,  // 122: pomerium.config.UpdateRouteRequest.route:type_name -> pomerium.config.Route
-	19,  // 123: pomerium.config.UpdateRouteResponse.route:type_name -> pomerium.config.Route
-	36,  // 124: pomerium.config.UpdateServiceAccountRequest.service_account:type_name -> pomerium.config.ServiceAccount
-	36,  // 125: pomerium.config.UpdateServiceAccountResponse.service_account:type_name -> pomerium.config.ServiceAccount
-	28,  // 126: pomerium.config.UpdateSettingsRequest.settings:type_name -> pomerium.config.Settings
-	28,  // 127: pomerium.config.UpdateSettingsResponse.settings:type_name -> pomerium.config.Settings
-	111, // 128: pomerium.config.HealthCheck.timeout:type_name -> google.protobuf.Duration
-	111, // 129: pomerium.config.HealthCheck.interval:type_name -> google.protobuf.Duration
-	111, // 130: pomerium.config.HealthCheck.initial_jitter:type_name -> google.protobuf.Duration
-	111, // 131: pomerium.config.HealthCheck.interval_jitter:type_name -> google.protobuf.Duration
-	113, // 132: pomerium.config.HealthCheck.unhealthy_threshold:type_name -> google.protobuf.UInt32Value
-	113, // 133: pomerium.config.HealthCheck.healthy_threshold:type_name -> google.protobuf.UInt32Value
-	113, // 134: pomerium.config.HealthCheck.alt_port:type_name -> google.protobuf.UInt32Value
-	114, // 135: pomerium.config.HealthCheck.reuse_connection:type_name -> google.protobuf.BoolValue
-	107, // 136: pomerium.config.HealthCheck.http_health_check:type_name -> pomerium.config.HealthCheck.HttpHealthCheck
-	108, // 137: pomerium.config.HealthCheck.tcp_health_check:type_name -> pomerium.config.HealthCheck.TcpHealthCheck
-	109, // 138: pomerium.config.HealthCheck.grpc_health_check:type_name -> pomerium.config.HealthCheck.GrpcHealthCheck
-	111, // 139: pomerium.config.HealthCheck.no_traffic_interval:type_name -> google.protobuf.Duration
-	111, // 140: pomerium.config.HealthCheck.no_traffic_healthy_interval:type_name -> google.protobuf.Duration
-	111, // 141: pomerium.config.HealthCheck.unhealthy_interval:type_name -> google.protobuf.Duration
-	111, // 142: pomerium.config.HealthCheck.unhealthy_edge_interval:type_name -> google.protobuf.Duration
-	111, // 143: pomerium.config.HealthCheck.healthy_edge_interval:type_name -> google.protobuf.Duration
-	112, // 144: pomerium.config.HealthCheck.transport_socket_match_criteria:type_name -> google.protobuf.Struct
-	113, // 145: pomerium.config.OutlierDetection.consecutive_5xx:type_name -> google.protobuf.UInt32Value
-	111, // 146: pomerium.config.OutlierDetection.interval:type_name -> google.protobuf.Duration
-	111, // 147: pomerium.config.OutlierDetection.base_ejection_time:type_name -> google.protobuf.Duration
-	113, // 148: pomerium.config.OutlierDetection.max_ejection_percent:type_name -> google.protobuf.UInt32Value
-	113, // 149: pomerium.config.OutlierDetection.enforcing_consecutive_5xx:type_name -> google.protobuf.UInt32Value
-	113, // 150: pomerium.config.OutlierDetection.enforcing_success_rate:type_name -> google.protobuf.UInt32Value
-	113, // 151: pomerium.config.OutlierDetection.success_rate_minimum_hosts:type_name -> google.protobuf.UInt32Value
-	113, // 152: pomerium.config.OutlierDetection.success_rate_request_volume:type_name -> google.protobuf.UInt32Value
-	113, // 153: pomerium.config.OutlierDetection.success_rate_stdev_factor:type_name -> google.protobuf.UInt32Value
-	113, // 154: pomerium.config.OutlierDetection.consecutive_gateway_failure:type_name -> google.protobuf.UInt32Value
-	113, // 155: pomerium.config.OutlierDetection.enforcing_consecutive_gateway_failure:type_name -> google.protobuf.UInt32Value
-	113, // 156: pomerium.config.OutlierDetection.consecutive_local_origin_failure:type_name -> google.protobuf.UInt32Value
-	113, // 157: pomerium.config.OutlierDetection.enforcing_consecutive_local_origin_failure:type_name -> google.protobuf.UInt32Value
-	113, // 158: pomerium.config.OutlierDetection.enforcing_local_origin_success_rate:type_name -> google.protobuf.UInt32Value
-	113, // 159: pomerium.config.OutlierDetection.failure_percentage_threshold:type_name -> google.protobuf.UInt32Value
-	113, // 160: pomerium.config.OutlierDetection.enforcing_failure_percentage:type_name -> google.protobuf.UInt32Value
-	113, // 161: pomerium.config.OutlierDetection.enforcing_failure_percentage_local_origin:type_name -> google.protobuf.UInt32Value
-	113, // 162: pomerium.config.OutlierDetection.failure_percentage_minimum_hosts:type_name -> google.protobuf.UInt32Value
-	113, // 163: pomerium.config.OutlierDetection.failure_percentage_request_volume:type_name -> google.protobuf.UInt32Value
-	111, // 164: pomerium.config.OutlierDetection.max_ejection_time:type_name -> google.protobuf.Duration
-	111, // 165: pomerium.config.OutlierDetection.max_ejection_time_jitter:type_name -> google.protobuf.Duration
-	114, // 166: pomerium.config.OutlierDetection.successful_active_health_check_uneject_host:type_name -> google.protobuf.BoolValue
-	114, // 167: pomerium.config.OutlierDetection.always_eject_one_host:type_name -> google.protobuf.BoolValue
-	115, // 168: pomerium.config.Route.AllowedIdpClaimsEntry.value:type_name -> google.protobuf.ListValue
-	115, // 169: pomerium.config.Policy.AllowedIdpClaimsEntry.value:type_name -> google.protobuf.ListValue
-	97,  // 170: pomerium.config.Settings.DataBrokerClusterNodes.nodes:type_name -> pomerium.config.Settings.DataBrokerClusterNode
-	10,  // 171: pomerium.config.HealthCheck.HealthStatusSet.statuses:type_name -> pomerium.config.HealthCheck.HealthStatus
-	106, // 172: pomerium.config.HealthCheck.HttpHealthCheck.send:type_name -> pomerium.config.HealthCheck.Payload
-	106, // 173: pomerium.config.HealthCheck.HttpHealthCheck.receive:type_name -> pomerium.config.HealthCheck.Payload
-	116, // 174: pomerium.config.HealthCheck.HttpHealthCheck.response_buffer_size:type_name -> google.protobuf.UInt64Value
-	105, // 175: pomerium.config.HealthCheck.HttpHealthCheck.expected_statuses:type_name -> pomerium.config.HealthCheck.Int64Range
-	105, // 176: pomerium.config.HealthCheck.HttpHealthCheck.retriable_statuses:type_name -> pomerium.config.HealthCheck.Int64Range
-	11,  // 177: pomerium.config.HealthCheck.HttpHealthCheck.codec_client_type:type_name -> pomerium.config.HealthCheck.CodecClientType
-	106, // 178: pomerium.config.HealthCheck.TcpHealthCheck.send:type_name -> pomerium.config.HealthCheck.Payload
-	106, // 179: pomerium.config.HealthCheck.TcpHealthCheck.receive:type_name -> pomerium.config.HealthCheck.Payload
-	37,  // 180: pomerium.config.ConfigService.CreateKeyPair:input_type -> pomerium.config.CreateKeyPairRequest
-	39,  // 181: pomerium.config.ConfigService.CreatePolicy:input_type -> pomerium.config.CreatePolicyRequest
-	41,  // 182: pomerium.config.ConfigService.CreateRoute:input_type -> pomerium.config.CreateRouteRequest
-	43,  // 183: pomerium.config.ConfigService.CreateServiceAccount:input_type -> pomerium.config.CreateServiceAccountRequest
-	45,  // 184: pomerium.config.ConfigService.DeleteKeyPair:input_type -> pomerium.config.DeleteKeyPairRequest
-	47,  // 185: pomerium.config.ConfigService.DeletePolicy:input_type -> pomerium.config.DeletePolicyRequest
-	49,  // 186: pomerium.config.ConfigService.DeleteRoute:input_type -> pomerium.config.DeleteRouteRequest
-	51,  // 187: pomerium.config.ConfigService.DeleteServiceAccount:input_type -> pomerium.config.DeleteServiceAccountRequest
-	53,  // 188: pomerium.config.ConfigService.GetKeyPair:input_type -> pomerium.config.GetKeyPairRequest
-	55,  // 189: pomerium.config.ConfigService.GetPolicy:input_type -> pomerium.config.GetPolicyRequest
-	57,  // 190: pomerium.config.ConfigService.GetRoute:input_type -> pomerium.config.GetRouteRequest
-	75,  // 191: pomerium.config.ConfigService.GetServerInfo:input_type -> pomerium.config.GetServerInfoRequest
-	59,  // 192: pomerium.config.ConfigService.GetServiceAccount:input_type -> pomerium.config.GetServiceAccountRequest
-	61,  // 193: pomerium.config.ConfigService.GetSettings:input_type -> pomerium.config.GetSettingsRequest
-	63,  // 194: pomerium.config.ConfigService.ListAvailableLogFields:input_type -> pomerium.config.ListAvailableLogFieldsRequest
-	65,  // 195: pomerium.config.ConfigService.ListKeyPairs:input_type -> pomerium.config.ListKeyPairsRequest
-	67,  // 196: pomerium.config.ConfigService.ListPolicies:input_type -> pomerium.config.ListPoliciesRequest
-	69,  // 197: pomerium.config.ConfigService.ListRoutes:input_type -> pomerium.config.ListRoutesRequest
-	71,  // 198: pomerium.config.ConfigService.ListServiceAccounts:input_type -> pomerium.config.ListServiceAccountsRequest
-	73,  // 199: pomerium.config.ConfigService.ListSettings:input_type -> pomerium.config.ListSettingsRequest
-	77,  // 200: pomerium.config.ConfigService.UpdateKeyPair:input_type -> pomerium.config.UpdateKeyPairRequest
-	79,  // 201: pomerium.config.ConfigService.UpdatePolicy:input_type -> pomerium.config.UpdatePolicyRequest
-	81,  // 202: pomerium.config.ConfigService.UpdateRoute:input_type -> pomerium.config.UpdateRouteRequest
-	83,  // 203: pomerium.config.ConfigService.UpdateServiceAccount:input_type -> pomerium.config.UpdateServiceAccountRequest
-	85,  // 204: pomerium.config.ConfigService.UpdateSettings:input_type -> pomerium.config.UpdateSettingsRequest
-	38,  // 205: pomerium.config.ConfigService.CreateKeyPair:output_type -> pomerium.config.CreateKeyPairResponse
-	40,  // 206: pomerium.config.ConfigService.CreatePolicy:output_type -> pomerium.config.CreatePolicyResponse
-	42,  // 207: pomerium.config.ConfigService.CreateRoute:output_type -> pomerium.config.CreateRouteResponse
-	44,  // 208: pomerium.config.ConfigService.CreateServiceAccount:output_type -> pomerium.config.CreateServiceAccountResponse
-	46,  // 209: pomerium.config.ConfigService.DeleteKeyPair:output_type -> pomerium.config.DeleteKeyPairResponse
-	48,  // 210: pomerium.config.ConfigService.DeletePolicy:output_type -> pomerium.config.DeletePolicyResponse
-	50,  // 211: pomerium.config.ConfigService.DeleteRoute:output_type -> pomerium.config.DeleteRouteResponse
-	52,  // 212: pomerium.config.ConfigService.DeleteServiceAccount:output_type -> pomerium.config.DeleteServiceAccountResponse
-	54,  // 213: pomerium.config.ConfigService.GetKeyPair:output_type -> pomerium.config.GetKeyPairResponse
-	56,  // 214: pomerium.config.ConfigService.GetPolicy:output_type -> pomerium.config.GetPolicyResponse
-	58,  // 215: pomerium.config.ConfigService.GetRoute:output_type -> pomerium.config.GetRouteResponse
-	76,  // 216: pomerium.config.ConfigService.GetServerInfo:output_type -> pomerium.config.GetServerInfoResponse
-	60,  // 217: pomerium.config.ConfigService.GetServiceAccount:output_type -> pomerium.config.GetServiceAccountResponse
-	62,  // 218: pomerium.config.ConfigService.GetSettings:output_type -> pomerium.config.GetSettingsResponse
-	64,  // 219: pomerium.config.ConfigService.ListAvailableLogFields:output_type -> pomerium.config.ListAvailableLogFieldsResponse
-	66,  // 220: pomerium.config.ConfigService.ListKeyPairs:output_type -> pomerium.config.ListKeyPairsResponse
-	68,  // 221: pomerium.config.ConfigService.ListPolicies:output_type -> pomerium.config.ListPoliciesResponse
-	70,  // 222: pomerium.config.ConfigService.ListRoutes:output_type -> pomerium.config.ListRoutesResponse
-	72,  // 223: pomerium.config.ConfigService.ListServiceAccounts:output_type -> pomerium.config.ListServiceAccountsResponse
-	74,  // 224: pomerium.config.ConfigService.ListSettings:output_type -> pomerium.config.ListSettingsResponse
-	78,  // 225: pomerium.config.ConfigService.UpdateKeyPair:output_type -> pomerium.config.UpdateKeyPairResponse
-	80,  // 226: pomerium.config.ConfigService.UpdatePolicy:output_type -> pomerium.config.UpdatePolicyResponse
-	82,  // 227: pomerium.config.ConfigService.UpdateRoute:output_type -> pomerium.config.UpdateRouteResponse
-	84,  // 228: pomerium.config.ConfigService.UpdateServiceAccount:output_type -> pomerium.config.UpdateServiceAccountResponse
-	86,  // 229: pomerium.config.ConfigService.UpdateSettings:output_type -> pomerium.config.UpdateSettingsResponse
-	205, // [205:230] is the sub-list for method output_type
-	180, // [180:205] is the sub-list for method input_type
-	180, // [180:180] is the sub-list for extension type_name
-	180, // [180:180] is the sub-list for extension extendee
-	0,   // [0:180] is the sub-list for field type_name
+	99,  // 75: pomerium.config.Settings.envoy_dynamic_extensions:type_name -> pomerium.config.Settings.StringList
+	110, // 76: pomerium.config.Settings.created_at:type_name -> google.protobuf.Timestamp
+	110, // 77: pomerium.config.Settings.modified_at:type_name -> google.protobuf.Timestamp
+	3,   // 78: pomerium.config.DownstreamMtlsSettings.enforcement:type_name -> pomerium.config.MtlsEnforcementMode
+	31,  // 79: pomerium.config.DownstreamMtlsSettings.match_subject_alt_names:type_name -> pomerium.config.SANMatcher
+	9,   // 80: pomerium.config.SANMatcher.san_type:type_name -> pomerium.config.SANMatcher.SANType
+	110, // 81: pomerium.config.KeyPair.created_at:type_name -> google.protobuf.Timestamp
+	110, // 82: pomerium.config.KeyPair.modified_at:type_name -> google.protobuf.Timestamp
+	5,   // 83: pomerium.config.KeyPair.status:type_name -> pomerium.config.KeyPairStatus
+	4,   // 84: pomerium.config.KeyPair.origin:type_name -> pomerium.config.KeyPairOrigin
+	35,  // 85: pomerium.config.KeyPair.certificate_info:type_name -> pomerium.config.CertificateInfo
+	34,  // 86: pomerium.config.CertificateInfo.issuer:type_name -> pomerium.config.Name
+	34,  // 87: pomerium.config.CertificateInfo.subject:type_name -> pomerium.config.Name
+	110, // 88: pomerium.config.CertificateInfo.not_before:type_name -> google.protobuf.Timestamp
+	110, // 89: pomerium.config.CertificateInfo.not_after:type_name -> google.protobuf.Timestamp
+	33,  // 90: pomerium.config.CertificateInfo.key_usage:type_name -> pomerium.config.KeyUsage
+	110, // 91: pomerium.config.ServiceAccount.expires_at:type_name -> google.protobuf.Timestamp
+	110, // 92: pomerium.config.ServiceAccount.created_at:type_name -> google.protobuf.Timestamp
+	110, // 93: pomerium.config.ServiceAccount.modified_at:type_name -> google.protobuf.Timestamp
+	110, // 94: pomerium.config.ServiceAccount.accessed_at:type_name -> google.protobuf.Timestamp
+	32,  // 95: pomerium.config.CreateKeyPairRequest.key_pair:type_name -> pomerium.config.KeyPair
+	32,  // 96: pomerium.config.CreateKeyPairResponse.key_pair:type_name -> pomerium.config.KeyPair
+	27,  // 97: pomerium.config.CreatePolicyRequest.policy:type_name -> pomerium.config.Policy
+	27,  // 98: pomerium.config.CreatePolicyResponse.policy:type_name -> pomerium.config.Policy
+	19,  // 99: pomerium.config.CreateRouteRequest.route:type_name -> pomerium.config.Route
+	19,  // 100: pomerium.config.CreateRouteResponse.route:type_name -> pomerium.config.Route
+	36,  // 101: pomerium.config.CreateServiceAccountRequest.service_account:type_name -> pomerium.config.ServiceAccount
+	36,  // 102: pomerium.config.CreateServiceAccountResponse.service_account:type_name -> pomerium.config.ServiceAccount
+	32,  // 103: pomerium.config.GetKeyPairResponse.key_pair:type_name -> pomerium.config.KeyPair
+	27,  // 104: pomerium.config.GetPolicyResponse.policy:type_name -> pomerium.config.Policy
+	19,  // 105: pomerium.config.GetRouteResponse.route:type_name -> pomerium.config.Route
+	36,  // 106: pomerium.config.GetServiceAccountResponse.service_account:type_name -> pomerium.config.ServiceAccount
+	28,  // 107: pomerium.config.GetSettingsResponse.settings:type_name -> pomerium.config.Settings
+	112, // 108: pomerium.config.ListKeyPairsRequest.filter:type_name -> google.protobuf.Struct
+	32,  // 109: pomerium.config.ListKeyPairsResponse.key_pairs:type_name -> pomerium.config.KeyPair
+	112, // 110: pomerium.config.ListPoliciesRequest.filter:type_name -> google.protobuf.Struct
+	27,  // 111: pomerium.config.ListPoliciesResponse.policies:type_name -> pomerium.config.Policy
+	112, // 112: pomerium.config.ListRoutesRequest.filter:type_name -> google.protobuf.Struct
+	19,  // 113: pomerium.config.ListRoutesResponse.routes:type_name -> pomerium.config.Route
+	112, // 114: pomerium.config.ListServiceAccountsRequest.filter:type_name -> google.protobuf.Struct
+	36,  // 115: pomerium.config.ListServiceAccountsResponse.service_accounts:type_name -> pomerium.config.ServiceAccount
+	112, // 116: pomerium.config.ListSettingsRequest.filter:type_name -> google.protobuf.Struct
+	28,  // 117: pomerium.config.ListSettingsResponse.settings:type_name -> pomerium.config.Settings
+	6,   // 118: pomerium.config.GetServerInfoResponse.server_type:type_name -> pomerium.config.ServerType
+	32,  // 119: pomerium.config.UpdateKeyPairRequest.key_pair:type_name -> pomerium.config.KeyPair
+	32,  // 120: pomerium.config.UpdateKeyPairResponse.key_pair:type_name -> pomerium.config.KeyPair
+	27,  // 121: pomerium.config.UpdatePolicyRequest.policy:type_name -> pomerium.config.Policy
+	27,  // 122: pomerium.config.UpdatePolicyResponse.policy:type_name -> pomerium.config.Policy
+	19,  // 123: pomerium.config.UpdateRouteRequest.route:type_name -> pomerium.config.Route
+	19,  // 124: pomerium.config.UpdateRouteResponse.route:type_name -> pomerium.config.Route
+	36,  // 125: pomerium.config.UpdateServiceAccountRequest.service_account:type_name -> pomerium.config.ServiceAccount
+	36,  // 126: pomerium.config.UpdateServiceAccountResponse.service_account:type_name -> pomerium.config.ServiceAccount
+	28,  // 127: pomerium.config.UpdateSettingsRequest.settings:type_name -> pomerium.config.Settings
+	28,  // 128: pomerium.config.UpdateSettingsResponse.settings:type_name -> pomerium.config.Settings
+	111, // 129: pomerium.config.HealthCheck.timeout:type_name -> google.protobuf.Duration
+	111, // 130: pomerium.config.HealthCheck.interval:type_name -> google.protobuf.Duration
+	111, // 131: pomerium.config.HealthCheck.initial_jitter:type_name -> google.protobuf.Duration
+	111, // 132: pomerium.config.HealthCheck.interval_jitter:type_name -> google.protobuf.Duration
+	113, // 133: pomerium.config.HealthCheck.unhealthy_threshold:type_name -> google.protobuf.UInt32Value
+	113, // 134: pomerium.config.HealthCheck.healthy_threshold:type_name -> google.protobuf.UInt32Value
+	113, // 135: pomerium.config.HealthCheck.alt_port:type_name -> google.protobuf.UInt32Value
+	114, // 136: pomerium.config.HealthCheck.reuse_connection:type_name -> google.protobuf.BoolValue
+	107, // 137: pomerium.config.HealthCheck.http_health_check:type_name -> pomerium.config.HealthCheck.HttpHealthCheck
+	108, // 138: pomerium.config.HealthCheck.tcp_health_check:type_name -> pomerium.config.HealthCheck.TcpHealthCheck
+	109, // 139: pomerium.config.HealthCheck.grpc_health_check:type_name -> pomerium.config.HealthCheck.GrpcHealthCheck
+	111, // 140: pomerium.config.HealthCheck.no_traffic_interval:type_name -> google.protobuf.Duration
+	111, // 141: pomerium.config.HealthCheck.no_traffic_healthy_interval:type_name -> google.protobuf.Duration
+	111, // 142: pomerium.config.HealthCheck.unhealthy_interval:type_name -> google.protobuf.Duration
+	111, // 143: pomerium.config.HealthCheck.unhealthy_edge_interval:type_name -> google.protobuf.Duration
+	111, // 144: pomerium.config.HealthCheck.healthy_edge_interval:type_name -> google.protobuf.Duration
+	112, // 145: pomerium.config.HealthCheck.transport_socket_match_criteria:type_name -> google.protobuf.Struct
+	113, // 146: pomerium.config.OutlierDetection.consecutive_5xx:type_name -> google.protobuf.UInt32Value
+	111, // 147: pomerium.config.OutlierDetection.interval:type_name -> google.protobuf.Duration
+	111, // 148: pomerium.config.OutlierDetection.base_ejection_time:type_name -> google.protobuf.Duration
+	113, // 149: pomerium.config.OutlierDetection.max_ejection_percent:type_name -> google.protobuf.UInt32Value
+	113, // 150: pomerium.config.OutlierDetection.enforcing_consecutive_5xx:type_name -> google.protobuf.UInt32Value
+	113, // 151: pomerium.config.OutlierDetection.enforcing_success_rate:type_name -> google.protobuf.UInt32Value
+	113, // 152: pomerium.config.OutlierDetection.success_rate_minimum_hosts:type_name -> google.protobuf.UInt32Value
+	113, // 153: pomerium.config.OutlierDetection.success_rate_request_volume:type_name -> google.protobuf.UInt32Value
+	113, // 154: pomerium.config.OutlierDetection.success_rate_stdev_factor:type_name -> google.protobuf.UInt32Value
+	113, // 155: pomerium.config.OutlierDetection.consecutive_gateway_failure:type_name -> google.protobuf.UInt32Value
+	113, // 156: pomerium.config.OutlierDetection.enforcing_consecutive_gateway_failure:type_name -> google.protobuf.UInt32Value
+	113, // 157: pomerium.config.OutlierDetection.consecutive_local_origin_failure:type_name -> google.protobuf.UInt32Value
+	113, // 158: pomerium.config.OutlierDetection.enforcing_consecutive_local_origin_failure:type_name -> google.protobuf.UInt32Value
+	113, // 159: pomerium.config.OutlierDetection.enforcing_local_origin_success_rate:type_name -> google.protobuf.UInt32Value
+	113, // 160: pomerium.config.OutlierDetection.failure_percentage_threshold:type_name -> google.protobuf.UInt32Value
+	113, // 161: pomerium.config.OutlierDetection.enforcing_failure_percentage:type_name -> google.protobuf.UInt32Value
+	113, // 162: pomerium.config.OutlierDetection.enforcing_failure_percentage_local_origin:type_name -> google.protobuf.UInt32Value
+	113, // 163: pomerium.config.OutlierDetection.failure_percentage_minimum_hosts:type_name -> google.protobuf.UInt32Value
+	113, // 164: pomerium.config.OutlierDetection.failure_percentage_request_volume:type_name -> google.protobuf.UInt32Value
+	111, // 165: pomerium.config.OutlierDetection.max_ejection_time:type_name -> google.protobuf.Duration
+	111, // 166: pomerium.config.OutlierDetection.max_ejection_time_jitter:type_name -> google.protobuf.Duration
+	114, // 167: pomerium.config.OutlierDetection.successful_active_health_check_uneject_host:type_name -> google.protobuf.BoolValue
+	114, // 168: pomerium.config.OutlierDetection.always_eject_one_host:type_name -> google.protobuf.BoolValue
+	115, // 169: pomerium.config.Route.AllowedIdpClaimsEntry.value:type_name -> google.protobuf.ListValue
+	115, // 170: pomerium.config.Policy.AllowedIdpClaimsEntry.value:type_name -> google.protobuf.ListValue
+	97,  // 171: pomerium.config.Settings.DataBrokerClusterNodes.nodes:type_name -> pomerium.config.Settings.DataBrokerClusterNode
+	10,  // 172: pomerium.config.HealthCheck.HealthStatusSet.statuses:type_name -> pomerium.config.HealthCheck.HealthStatus
+	106, // 173: pomerium.config.HealthCheck.HttpHealthCheck.send:type_name -> pomerium.config.HealthCheck.Payload
+	106, // 174: pomerium.config.HealthCheck.HttpHealthCheck.receive:type_name -> pomerium.config.HealthCheck.Payload
+	116, // 175: pomerium.config.HealthCheck.HttpHealthCheck.response_buffer_size:type_name -> google.protobuf.UInt64Value
+	105, // 176: pomerium.config.HealthCheck.HttpHealthCheck.expected_statuses:type_name -> pomerium.config.HealthCheck.Int64Range
+	105, // 177: pomerium.config.HealthCheck.HttpHealthCheck.retriable_statuses:type_name -> pomerium.config.HealthCheck.Int64Range
+	11,  // 178: pomerium.config.HealthCheck.HttpHealthCheck.codec_client_type:type_name -> pomerium.config.HealthCheck.CodecClientType
+	106, // 179: pomerium.config.HealthCheck.TcpHealthCheck.send:type_name -> pomerium.config.HealthCheck.Payload
+	106, // 180: pomerium.config.HealthCheck.TcpHealthCheck.receive:type_name -> pomerium.config.HealthCheck.Payload
+	37,  // 181: pomerium.config.ConfigService.CreateKeyPair:input_type -> pomerium.config.CreateKeyPairRequest
+	39,  // 182: pomerium.config.ConfigService.CreatePolicy:input_type -> pomerium.config.CreatePolicyRequest
+	41,  // 183: pomerium.config.ConfigService.CreateRoute:input_type -> pomerium.config.CreateRouteRequest
+	43,  // 184: pomerium.config.ConfigService.CreateServiceAccount:input_type -> pomerium.config.CreateServiceAccountRequest
+	45,  // 185: pomerium.config.ConfigService.DeleteKeyPair:input_type -> pomerium.config.DeleteKeyPairRequest
+	47,  // 186: pomerium.config.ConfigService.DeletePolicy:input_type -> pomerium.config.DeletePolicyRequest
+	49,  // 187: pomerium.config.ConfigService.DeleteRoute:input_type -> pomerium.config.DeleteRouteRequest
+	51,  // 188: pomerium.config.ConfigService.DeleteServiceAccount:input_type -> pomerium.config.DeleteServiceAccountRequest
+	53,  // 189: pomerium.config.ConfigService.GetKeyPair:input_type -> pomerium.config.GetKeyPairRequest
+	55,  // 190: pomerium.config.ConfigService.GetPolicy:input_type -> pomerium.config.GetPolicyRequest
+	57,  // 191: pomerium.config.ConfigService.GetRoute:input_type -> pomerium.config.GetRouteRequest
+	75,  // 192: pomerium.config.ConfigService.GetServerInfo:input_type -> pomerium.config.GetServerInfoRequest
+	59,  // 193: pomerium.config.ConfigService.GetServiceAccount:input_type -> pomerium.config.GetServiceAccountRequest
+	61,  // 194: pomerium.config.ConfigService.GetSettings:input_type -> pomerium.config.GetSettingsRequest
+	63,  // 195: pomerium.config.ConfigService.ListAvailableLogFields:input_type -> pomerium.config.ListAvailableLogFieldsRequest
+	65,  // 196: pomerium.config.ConfigService.ListKeyPairs:input_type -> pomerium.config.ListKeyPairsRequest
+	67,  // 197: pomerium.config.ConfigService.ListPolicies:input_type -> pomerium.config.ListPoliciesRequest
+	69,  // 198: pomerium.config.ConfigService.ListRoutes:input_type -> pomerium.config.ListRoutesRequest
+	71,  // 199: pomerium.config.ConfigService.ListServiceAccounts:input_type -> pomerium.config.ListServiceAccountsRequest
+	73,  // 200: pomerium.config.ConfigService.ListSettings:input_type -> pomerium.config.ListSettingsRequest
+	77,  // 201: pomerium.config.ConfigService.UpdateKeyPair:input_type -> pomerium.config.UpdateKeyPairRequest
+	79,  // 202: pomerium.config.ConfigService.UpdatePolicy:input_type -> pomerium.config.UpdatePolicyRequest
+	81,  // 203: pomerium.config.ConfigService.UpdateRoute:input_type -> pomerium.config.UpdateRouteRequest
+	83,  // 204: pomerium.config.ConfigService.UpdateServiceAccount:input_type -> pomerium.config.UpdateServiceAccountRequest
+	85,  // 205: pomerium.config.ConfigService.UpdateSettings:input_type -> pomerium.config.UpdateSettingsRequest
+	38,  // 206: pomerium.config.ConfigService.CreateKeyPair:output_type -> pomerium.config.CreateKeyPairResponse
+	40,  // 207: pomerium.config.ConfigService.CreatePolicy:output_type -> pomerium.config.CreatePolicyResponse
+	42,  // 208: pomerium.config.ConfigService.CreateRoute:output_type -> pomerium.config.CreateRouteResponse
+	44,  // 209: pomerium.config.ConfigService.CreateServiceAccount:output_type -> pomerium.config.CreateServiceAccountResponse
+	46,  // 210: pomerium.config.ConfigService.DeleteKeyPair:output_type -> pomerium.config.DeleteKeyPairResponse
+	48,  // 211: pomerium.config.ConfigService.DeletePolicy:output_type -> pomerium.config.DeletePolicyResponse
+	50,  // 212: pomerium.config.ConfigService.DeleteRoute:output_type -> pomerium.config.DeleteRouteResponse
+	52,  // 213: pomerium.config.ConfigService.DeleteServiceAccount:output_type -> pomerium.config.DeleteServiceAccountResponse
+	54,  // 214: pomerium.config.ConfigService.GetKeyPair:output_type -> pomerium.config.GetKeyPairResponse
+	56,  // 215: pomerium.config.ConfigService.GetPolicy:output_type -> pomerium.config.GetPolicyResponse
+	58,  // 216: pomerium.config.ConfigService.GetRoute:output_type -> pomerium.config.GetRouteResponse
+	76,  // 217: pomerium.config.ConfigService.GetServerInfo:output_type -> pomerium.config.GetServerInfoResponse
+	60,  // 218: pomerium.config.ConfigService.GetServiceAccount:output_type -> pomerium.config.GetServiceAccountResponse
+	62,  // 219: pomerium.config.ConfigService.GetSettings:output_type -> pomerium.config.GetSettingsResponse
+	64,  // 220: pomerium.config.ConfigService.ListAvailableLogFields:output_type -> pomerium.config.ListAvailableLogFieldsResponse
+	66,  // 221: pomerium.config.ConfigService.ListKeyPairs:output_type -> pomerium.config.ListKeyPairsResponse
+	68,  // 222: pomerium.config.ConfigService.ListPolicies:output_type -> pomerium.config.ListPoliciesResponse
+	70,  // 223: pomerium.config.ConfigService.ListRoutes:output_type -> pomerium.config.ListRoutesResponse
+	72,  // 224: pomerium.config.ConfigService.ListServiceAccounts:output_type -> pomerium.config.ListServiceAccountsResponse
+	74,  // 225: pomerium.config.ConfigService.ListSettings:output_type -> pomerium.config.ListSettingsResponse
+	78,  // 226: pomerium.config.ConfigService.UpdateKeyPair:output_type -> pomerium.config.UpdateKeyPairResponse
+	80,  // 227: pomerium.config.ConfigService.UpdatePolicy:output_type -> pomerium.config.UpdatePolicyResponse
+	82,  // 228: pomerium.config.ConfigService.UpdateRoute:output_type -> pomerium.config.UpdateRouteResponse
+	84,  // 229: pomerium.config.ConfigService.UpdateServiceAccount:output_type -> pomerium.config.UpdateServiceAccountResponse
+	86,  // 230: pomerium.config.ConfigService.UpdateSettings:output_type -> pomerium.config.UpdateSettingsResponse
+	206, // [206:231] is the sub-list for method output_type
+	181, // [181:206] is the sub-list for method input_type
+	181, // [181:181] is the sub-list for extension type_name
+	181, // [181:181] is the sub-list for extension extendee
+	0,   // [0:181] is the sub-list for field type_name
 }
 
 func init() { file_config_proto_init() }

--- a/pkg/grpc/config/config.pb.go
+++ b/pkg/grpc/config/config.pb.go
@@ -2912,7 +2912,7 @@ type Settings struct {
 	// Allows HTTP upgrade requests to be forwarded upstream.
 	AllowUpgrades *Settings_StringList `protobuf:"bytes,181,opt,name=allow_upgrades,json=allowUpgrades,proto3,oneof" json:"allow_upgrades,omitempty"`
 	// Maps dynamic extension id to the path where it should be loaded from
-	EnvoyDynamicExtensions *Settings_StringList `protobuf:"bytes,182,opt,name=envoy_dynamic_extensions,json=envoyDynamicExtensions,proto3" json:"envoy_dynamic_extensions,omitempty"`
+	PluginsEnvoy *Settings_StringList `protobuf:"bytes,182,opt,name=plugins_envoy,json=pluginsEnvoy,proto3" json:"plugins_envoy,omitempty"`
 	// When the settings were created.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,169,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`
 	// When the settings were last modified.
@@ -3931,9 +3931,9 @@ func (x *Settings) GetAllowUpgrades() *Settings_StringList {
 	return nil
 }
 
-func (x *Settings) GetEnvoyDynamicExtensions() *Settings_StringList {
+func (x *Settings) GetPluginsEnvoy() *Settings_StringList {
 	if x != nil {
-		return x.EnvoyDynamicExtensions
+		return x.PluginsEnvoy
 	}
 	return nil
 }
@@ -8930,7 +8930,7 @@ const file_config_proto_rawDesc = "" +
 	"\v_source_pplB\x0e\n" +
 	"\f_explanationB\x0e\n" +
 	"\f_remediationB\x11\n" +
-	"\x0f_namespace_nameJ\x04\b\x04\x10\x05\"\x87d\n" +
+	"\x0f_namespace_nameJ\x04\b\x04\x10\x05\"\xf2c\n" +
 	"\bSettings\x12\x14\n" +
 	"\x02id\x18\x9e\x01 \x01(\tH\x00R\x02id\x88\x01\x01\x12'\n" +
 	"\fnamespace_id\x18\x9f\x01 \x01(\tH\x01R\vnamespaceId\x88\x01\x01\x12#\n" +
@@ -9081,8 +9081,8 @@ const file_config_proto_rawDesc = "" +
 	"\x19session_recording_enabled\x18\xb2\x01 \x01(\bHwR\x17sessionRecordingEnabled\x88\x01\x01\x12M\n" +
 	"\fblob_storage\x18\xb3\x01 \x01(\v2$.pomerium.config.BlobStorageSettingsHxR\vblobStorage\x88\x01\x01\x128\n" +
 	"\x15auto_apply_changesets\x18\xb4\x01 \x01(\bHyR\x13autoApplyChangesets\x88\x01\x01\x12Q\n" +
-	"\x0eallow_upgrades\x18\xb5\x01 \x01(\v2$.pomerium.config.Settings.StringListHzR\rallowUpgrades\x88\x01\x01\x12_\n" +
-	"\x18envoy_dynamic_extensions\x18\xb6\x01 \x01(\v2$.pomerium.config.Settings.StringListR\x16envoyDynamicExtensions\x12:\n" +
+	"\x0eallow_upgrades\x18\xb5\x01 \x01(\v2$.pomerium.config.Settings.StringListHzR\rallowUpgrades\x88\x01\x01\x12J\n" +
+	"\rplugins_envoy\x18\xb6\x01 \x01(\v2$.pomerium.config.Settings.StringListR\fpluginsEnvoy\x12:\n" +
 	"\n" +
 	"created_at\x18\xa9\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12<\n" +
 	"\vmodified_at\x18\xaa\x01 \x01(\v2\x1a.google.protobuf.TimestampR\n" +
@@ -9879,7 +9879,7 @@ var file_config_proto_depIdxs = []int32{
 	111, // 72: pomerium.config.Settings.directory_provider_refresh_timeout:type_name -> google.protobuf.Duration
 	29,  // 73: pomerium.config.Settings.blob_storage:type_name -> pomerium.config.BlobStorageSettings
 	99,  // 74: pomerium.config.Settings.allow_upgrades:type_name -> pomerium.config.Settings.StringList
-	99,  // 75: pomerium.config.Settings.envoy_dynamic_extensions:type_name -> pomerium.config.Settings.StringList
+	99,  // 75: pomerium.config.Settings.plugins_envoy:type_name -> pomerium.config.Settings.StringList
 	110, // 76: pomerium.config.Settings.created_at:type_name -> google.protobuf.Timestamp
 	110, // 77: pomerium.config.Settings.modified_at:type_name -> google.protobuf.Timestamp
 	3,   // 78: pomerium.config.DownstreamMtlsSettings.enforcement:type_name -> pomerium.config.MtlsEnforcementMode

--- a/pkg/grpc/config/config.pb.json
+++ b/pkg/grpc/config/config.pb.json
@@ -7073,7 +7073,7 @@
               "defaultValue": ""
             },
             {
-              "name": "envoy_dynamic_extensions",
+              "name": "plugins_envoy",
               "description": "Maps dynamic extension id to the path where it should be loaded from",
               "label": "",
               "type": "StringList",

--- a/pkg/grpc/config/config.pb.json
+++ b/pkg/grpc/config/config.pb.json
@@ -7073,6 +7073,18 @@
               "defaultValue": ""
             },
             {
+              "name": "envoy_dynamic_extensions",
+              "description": "Maps dynamic extension id to the path where it should be loaded from",
+              "label": "",
+              "type": "StringList",
+              "longType": "Settings.StringList",
+              "fullType": "pomerium.config.Settings.StringList",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
               "name": "created_at",
               "description": "When the settings were created.",
               "label": "",

--- a/pkg/grpc/config/config.pb.validate.go
+++ b/pkg/grpc/config/config.pb.validate.go
@@ -3152,11 +3152,11 @@ func (m *Settings) validate(all bool) error {
 	// no validation rules for RuntimeFlags
 
 	if all {
-		switch v := interface{}(m.GetEnvoyDynamicExtensions()).(type) {
+		switch v := interface{}(m.GetPluginsEnvoy()).(type) {
 		case interface{ ValidateAll() error }:
 			if err := v.ValidateAll(); err != nil {
 				errors = append(errors, SettingsValidationError{
-					field:  "EnvoyDynamicExtensions",
+					field:  "PluginsEnvoy",
 					reason: "embedded message failed validation",
 					cause:  err,
 				})
@@ -3164,16 +3164,16 @@ func (m *Settings) validate(all bool) error {
 		case interface{ Validate() error }:
 			if err := v.Validate(); err != nil {
 				errors = append(errors, SettingsValidationError{
-					field:  "EnvoyDynamicExtensions",
+					field:  "PluginsEnvoy",
 					reason: "embedded message failed validation",
 					cause:  err,
 				})
 			}
 		}
-	} else if v, ok := interface{}(m.GetEnvoyDynamicExtensions()).(interface{ Validate() error }); ok {
+	} else if v, ok := interface{}(m.GetPluginsEnvoy()).(interface{ Validate() error }); ok {
 		if err := v.Validate(); err != nil {
 			return SettingsValidationError{
-				field:  "EnvoyDynamicExtensions",
+				field:  "PluginsEnvoy",
 				reason: "embedded message failed validation",
 				cause:  err,
 			}

--- a/pkg/grpc/config/config.pb.validate.go
+++ b/pkg/grpc/config/config.pb.validate.go
@@ -3152,6 +3152,35 @@ func (m *Settings) validate(all bool) error {
 	// no validation rules for RuntimeFlags
 
 	if all {
+		switch v := interface{}(m.GetEnvoyDynamicExtensions()).(type) {
+		case interface{ ValidateAll() error }:
+			if err := v.ValidateAll(); err != nil {
+				errors = append(errors, SettingsValidationError{
+					field:  "EnvoyDynamicExtensions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		case interface{ Validate() error }:
+			if err := v.Validate(); err != nil {
+				errors = append(errors, SettingsValidationError{
+					field:  "EnvoyDynamicExtensions",
+					reason: "embedded message failed validation",
+					cause:  err,
+				})
+			}
+		}
+	} else if v, ok := interface{}(m.GetEnvoyDynamicExtensions()).(interface{ Validate() error }); ok {
+		if err := v.Validate(); err != nil {
+			return SettingsValidationError{
+				field:  "EnvoyDynamicExtensions",
+				reason: "embedded message failed validation",
+				cause:  err,
+			}
+		}
+	}
+
+	if all {
 		switch v := interface{}(m.GetCreatedAt()).(type) {
 		case interface{ ValidateAll() error }:
 			if err := v.ValidateAll(); err != nil {

--- a/pkg/grpc/config/config.proto
+++ b/pkg/grpc/config/config.proto
@@ -702,8 +702,8 @@ message Settings {
   optional bool auto_apply_changesets = 180;
   // Allows HTTP upgrade requests to be forwarded upstream.
   optional StringList allow_upgrades = 181;
-  // Maps dynamic extension id to the path where it should be loaded from
-  StringList envoy_dynamic_extensions = 182;
+  // File paths to the plugins to be loaded by envoy.
+  StringList plugins_envoy = 182;
 
   // computed properties
 

--- a/pkg/grpc/config/config.proto
+++ b/pkg/grpc/config/config.proto
@@ -702,6 +702,8 @@ message Settings {
   optional bool auto_apply_changesets = 180;
   // Allows HTTP upgrade requests to be forwarded upstream.
   optional StringList allow_upgrades = 181;
+  // Maps dynamic extension id to the path where it should be loaded from
+  StringList envoy_dynamic_extensions = 182;
 
   // computed properties
 

--- a/pkg/ipc/pipe_workers.go
+++ b/pkg/ipc/pipe_workers.go
@@ -39,6 +39,14 @@ func NewPipeWorkers[Recv proto.Message, Send proto.Message](
 	return ret, nil
 }
 
+func PipeClients[Recv proto.Message, Send proto.Message](workers []*ProtoPipeWorker[Recv, Send]) []*os.File {
+	files := []*os.File{}
+	for _, worker := range workers {
+		files = append(files, worker.Sender.Read, worker.Receiver.Write)
+	}
+	return files
+}
+
 func createWorker[Recv proto.Message, Send proto.Message]() (*ProtoPipeWorker[Recv, Send], error) {
 	recvRead, recvWrite, err := os.Pipe()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Adds dynamic extensions as a configuration target
- Parses and constructs ssh dynamic extension config
- Enables/disables the recording server depending on the presence of the session recording extension
- Loads the extensions into envoy
- Smartly reconstructs the pipe transports for the recording protocol when envoy hot-restarts


## Related issues

[ENG-3945](https://linear.app/pomerium/issue/ENG-3945/core-configure-envoy-dynamic-extensions)

Splits out the logic for configuring dynamic extensions in from https://github.com/pomerium/pomerium/pull/6283

Requires:
- [x] https://github.com/pomerium/pomerium/pull/6335
- [x] https://github.com/pomerium/envoy-custom/pull/219

## User Explanation

End users can configure enterprise dynamic extensions by setting the `envoy_dynamic_extensions` field in the config file.

Example:
```yaml
envoy_dynamic_extensions:
  - <path-to-extension>/<extension>.so
```


## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
