### PR TITLE
dev: makefile commands to build with a development version of envoy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,12 @@ build-go: build-deps
 	@echo "==> $@"
 	@CGO_ENABLED=0 $(GO) build -tags "$(BUILDTAGS)" ${GO_LDFLAGS} -o $(BINDIR)/$(NAME) ./cmd/"$(NAME)"
 
+DEBUG_LOCAL_ENVOY_PATH ?=
+build-local: build-ui # Builds pomerium core with a local envoy build
+	@echo "==> $@"
+	@echo "${DEBUG_LOCAL_ENVOY_PATH}"
+	@CGO_ENABLED=0 $(GO) build -tags "debug_local_envoy $(BUILDTAGS)" -ldflags "-s -w $(CTIMEVAR) -X $(PKG)/pkg/envoy.DebugLocalEnvoyPath=$(DEBUG_LOCAL_ENVOY_PATH)" -o $(BINDIR)/$(NAME) ./cmd/"$(NAME)"
+
 .PHONY: build-ui
 build-ui: npm-install
 	@echo "==> $@"

--- a/pkg/envoy/extract_debug_local.go
+++ b/pkg/envoy/extract_debug_local.go
@@ -12,7 +12,7 @@ import (
 var DebugLocalEnvoyPath string
 
 func init() {
-	files.SetFiles(nil, `{}`)
+	files.SetFiles(nil, []byte(`{}`))
 }
 
 func extract(dstName string) (err error) {


### PR DESCRIPTION
## Summary

`make build-local` that builds pomerium with envoy from the specified path.  Example:

`DEBUG_LOCAL_ENVOY_PATH=/home/repos/envoy-custom/bazel-bin/envoy make build-local`

## Related issues

N/A

## User Explanation

N/A

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
