### PR TITLE
feat(session_recording): health checks

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -144,6 +144,8 @@ type Server struct {
 	channelZClient         atomic.Pointer[grpc_channelz_v1.ChannelzClient]
 	channelZCleanup        func()
 
+	extraHealthChecks []health.Checker
+
 	options *Options
 }
 
@@ -595,6 +597,9 @@ func (srv *Server) getExpectedHealthChecks(cfg *config.Config) (ret []health.Che
 			health.XDSRouteConfiguration,
 		)
 	}
+	for _, extraCheckers := range srv.extraHealthChecks {
+		ret = append(ret, extraCheckers.GetExpectedHealthChecks()...)
+	}
 
 	ret = append(
 		ret,
@@ -614,4 +619,9 @@ func (srv *Server) SyncHealth(in *healthpb.HealthStreamRequest, remote grpc.Serv
 		return status.Error(codes.Unavailable, "health streaming server not yet available")
 	}
 	return p.SyncHealth(in, remote)
+}
+
+func (srv *Server) RegisterAdditionalExpectedChecks(ctx context.Context, cfg *config.Config, checkers ...health.Checker) {
+	srv.extraHealthChecks = checkers
+	srv.updateHealthProviders(ctx, cfg)
 }

--- a/pkg/cmd/pomerium/pomerium.go
+++ b/pkg/cmd/pomerium/pomerium.go
@@ -245,6 +245,8 @@ func (p *Pomerium) Start(ctx context.Context, tracerProvider oteltrace.TracerPro
 		}
 	}
 
+	controlPlane.RegisterAdditionalExpectedChecks(ctx, cfg, p.envoyServer)
+
 	// run everything
 	p.errGroup, ctx = errgroup.WithContext(ctx)
 	if authorizeServer != nil {

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -583,3 +583,15 @@ func preserveRlimitNofile() error {
 	}
 	return syscall.Setrlimit(syscall.RLIMIT_NOFILE, &lim)
 }
+
+// GetExpectedHealthChecks implements the health.Check interface.
+// It must be safe for concurrent use
+func (srv *Server) GetExpectedHealthChecks() []health.Check {
+	if srv.recordingServer.Load() != nil {
+		return []health.Check{
+			health.BlobStorage,
+			health.RecordingHandler,
+		}
+	}
+	return []health.Check{}
+}

--- a/pkg/grpc/config/config.pb.go
+++ b/pkg/grpc/config/config.pb.go
@@ -2911,7 +2911,7 @@ type Settings struct {
 	AutoApplyChangesets *bool `protobuf:"varint,180,opt,name=auto_apply_changesets,json=autoApplyChangesets,proto3,oneof" json:"auto_apply_changesets,omitempty"`
 	// Allows HTTP upgrade requests to be forwarded upstream.
 	AllowUpgrades *Settings_StringList `protobuf:"bytes,181,opt,name=allow_upgrades,json=allowUpgrades,proto3,oneof" json:"allow_upgrades,omitempty"`
-	// Maps dynamic extension id to the path where it should be loaded from
+	// File paths to the plugins to be loaded by envoy.
 	PluginsEnvoy *Settings_StringList `protobuf:"bytes,182,opt,name=plugins_envoy,json=pluginsEnvoy,proto3" json:"plugins_envoy,omitempty"`
 	// When the settings were created.
 	CreatedAt *timestamppb.Timestamp `protobuf:"bytes,169,opt,name=created_at,json=createdAt,proto3" json:"created_at,omitempty"`

--- a/pkg/grpc/config/config.pb.json
+++ b/pkg/grpc/config/config.pb.json
@@ -7074,7 +7074,7 @@
             },
             {
               "name": "plugins_envoy",
-              "description": "Maps dynamic extension id to the path where it should be loaded from",
+              "description": "File paths to the plugins to be loaded by envoy.",
               "label": "",
               "type": "StringList",
               "longType": "Settings.StringList",

--- a/pkg/health/http.go
+++ b/pkg/health/http.go
@@ -180,10 +180,11 @@ func (h *HTTPProvider) Status(w http.ResponseWriter, r *http.Request) {
 		}
 		m[string(id)] = entry
 	}
-
+	requiredChecks := stdslices.Collect(maps.Keys(h.expectedStatusesFn()))
+	stdslices.Sort(requiredChecks)
 	statusP := httpStatusPayload{
 		Statuses: m,
-		Required: stdslices.Collect(maps.Keys(h.expectedStatusesFn())),
+		Required: requiredChecks,
 	}
 
 	payload, err := json.MarshalIndent(statusP, "", "  ")

--- a/pkg/health/manager.go
+++ b/pkg/health/manager.go
@@ -21,6 +21,13 @@ const (
 
 var defaultProviderManager = NewManager()
 
+type Checker interface {
+	// GetExpectedHealthChecks implementations must be non-blocking and safe for concurrent use.
+	// This method is used to register additional checks that are not known directly in the OnConfigChange
+	// lifecycle and need to be evaluated based on other criteria
+	GetExpectedHealthChecks() []Check
+}
+
 type ProviderManager interface {
 	// Register adds a provider to the manager.
 	// When a provider is registered, all tracked health conditions by the ProviderManager


### PR DESCRIPTION

## Summary

Adds a new health.Checker interface for the control plane to evaluate dynamic health checks.

Envoy servers implements the health.Checker interface for evaluating whether or not we need to include the blob store & recording handler in the aggregated health checks.

## Related issues
Requires 
https://github.com/pomerium/pomerium/pull/6352

## User Explanation

session recording features now integrates with startup and health checks depending on if the feature is enabled or not.

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
