### PR TITLE
core/databroker: add a cache invalidator and invalidate cache when the storage backend changes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,7 +7,6 @@ linters:
     - asasalint
     - bodyclose
     - copyloopvar
-    - dogsled
     - errcheck
     - errorlint
     - gocheckcompilerdirectives

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -85,12 +85,18 @@ func newAuthorizeStateFromConfig(
 		return nil, err
 	}
 
-	cc, err := outboundGrpcConn.Get(ctx, &grpc.OutboundOptions{
-		OutboundPort:   cfg.OutboundPort,
-		InstallationID: cfg.Options.InstallationID,
-		ServiceName:    cfg.Options.Services,
-		SignedJWTKey:   sharedKey,
-	}, googlegrpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(tracerProvider))))
+	cacheInvalidator := databroker.NewCacheInvalidator(storage.GlobalCache)
+	cc, err := outboundGrpcConn.Get(ctx,
+		&grpc.OutboundOptions{
+			OutboundPort:   cfg.OutboundPort,
+			InstallationID: cfg.Options.InstallationID,
+			ServiceName:    cfg.Options.Services,
+			SignedJWTKey:   sharedKey,
+		},
+		googlegrpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(tracerProvider))),
+		googlegrpc.WithChainUnaryInterceptor(cacheInvalidator.UnaryClientInterceptor),
+		googlegrpc.WithChainStreamInterceptor(cacheInvalidator.StreamClientInterceptor),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("authorize: error creating databroker connection: %w", err)
 	}

--- a/internal/databroker/server_backend.go
+++ b/internal/databroker/server_backend.go
@@ -701,6 +701,9 @@ func (srv *backendServer) OnConfigChange(ctx context.Context, cfg *config.Config
 			log.Ctx(ctx).Error().Err(err).Msg("databroker/backend: error closing backend")
 		}
 		srv.backend = nil
+
+		// clear the global cache
+		storage.GlobalCache.InvalidateAll()
 	}
 
 	if srv.registry != nil {
@@ -710,9 +713,6 @@ func (srv *backendServer) OnConfigChange(ctx context.Context, cfg *config.Config
 		}
 		srv.registry = nil
 	}
-
-	// clear the global cache
-	storage.GlobalCache.InvalidateAll()
 }
 
 func (srv *backendServer) getBackend(ctx context.Context) (backend storage.Backend, err error) {

--- a/internal/databroker/server_backend.go
+++ b/internal/databroker/server_backend.go
@@ -710,6 +710,9 @@ func (srv *backendServer) OnConfigChange(ctx context.Context, cfg *config.Config
 		}
 		srv.registry = nil
 	}
+
+	// clear the global cache
+	storage.GlobalCache.InvalidateAll()
 }
 
 func (srv *backendServer) getBackend(ctx context.Context) (backend storage.Backend, err error) {

--- a/pkg/grpc/databroker/cache.go
+++ b/pkg/grpc/databroker/cache.go
@@ -1,0 +1,63 @@
+package databroker
+
+import (
+	"context"
+	"sync/atomic"
+
+	"google.golang.org/grpc"
+)
+
+// A CacheInvalidator has interceptors that can be used to clear the cache when
+// the server version changes.
+type CacheInvalidator struct {
+	StreamClientInterceptor grpc.StreamClientInterceptor
+	UnaryClientInterceptor  grpc.UnaryClientInterceptor
+}
+
+type clientStreamRecvMsgWrapper struct {
+	grpc.ClientStream
+	recvMsg func(m any) error
+}
+
+func (s clientStreamRecvMsgWrapper) RecvMsg(m any) error {
+	return s.recvMsg(m)
+}
+
+// NewCacheInvalidator creates a new CacheInvalidator.
+func NewCacheInvalidator(cache interface{ InvalidateAll() }) *CacheInvalidator {
+	var currentServerVersion atomic.Uint64
+	maybeInvalidate := func(m any) {
+		if obj, ok := m.(interface{ GetVersions() *Versions }); ok && obj.GetVersions() != nil {
+			m = obj.GetVersions()
+		}
+		if obj, ok := m.(interface{ GetServerVersion() uint64 }); ok && obj.GetServerVersion() > 0 {
+			nv := obj.GetServerVersion()
+			ov := currentServerVersion.Swap(nv)
+			if ov > 0 && ov != nv {
+				cache.InvalidateAll()
+			}
+		}
+	}
+
+	return &CacheInvalidator{
+		StreamClientInterceptor: func(ctx context.Context, desc *grpc.StreamDesc, cc *grpc.ClientConn, method string, streamer grpc.Streamer, opts ...grpc.CallOption) (grpc.ClientStream, error) {
+			stream, err := streamer(ctx, desc, cc, method, opts...)
+			if err != nil {
+				return nil, err
+			}
+			return clientStreamRecvMsgWrapper{
+				ClientStream: stream,
+				recvMsg: func(m any) error {
+					err := stream.RecvMsg(m)
+					maybeInvalidate(m)
+					return err
+				},
+			}, err
+		},
+		UnaryClientInterceptor: func(ctx context.Context, method string, req, reply any, cc *grpc.ClientConn, invoker grpc.UnaryInvoker, opts ...grpc.CallOption) error {
+			err := invoker(ctx, method, req, reply, cc, opts...)
+			maybeInvalidate(reply)
+			return err
+		},
+	}
+}

--- a/pkg/grpc/databroker/cache_test.go
+++ b/pkg/grpc/databroker/cache_test.go
@@ -1,0 +1,67 @@
+package databroker_test
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/pomerium/pomerium/internal/databroker"
+	"github.com/pomerium/pomerium/internal/testutil"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+type mockCache struct {
+	invalidateAllInvocations atomic.Int64
+}
+
+func (c *mockCache) InvalidateAll() {
+	c.invalidateAllInvocations.Add(1)
+}
+
+func TestCacheInvalidator(t *testing.T) {
+	t.Parallel()
+
+	srv := databroker.NewBackendServer(noop.NewTracerProvider())
+	t.Cleanup(srv.Stop)
+
+	cache := new(mockCache)
+	cacheInvalidator := databrokerpb.NewCacheInvalidator(cache)
+	cc := testutil.NewGRPCServer(t,
+		func(s *grpc.Server) {
+			databrokerpb.RegisterDataBrokerServiceServer(s, srv)
+		},
+		grpc.WithChainStreamInterceptor(cacheInvalidator.StreamClientInterceptor),
+		grpc.WithChainUnaryInterceptor(cacheInvalidator.UnaryClientInterceptor))
+	t.Cleanup(func() { cc.Close() })
+
+	client := databrokerpb.NewDataBrokerServiceClient(cc)
+
+	_, _ = client.ServerInfo(t.Context(), new(emptypb.Empty))
+	assert.Equal(t, int64(0), cache.invalidateAllInvocations.Load())
+
+	client.Clear(t.Context(), new(emptypb.Empty))
+
+	_, _ = client.ServerInfo(t.Context(), new(emptypb.Empty))
+	assert.Equal(t, int64(1), cache.invalidateAllInvocations.Load())
+	_, _ = client.ServerInfo(t.Context(), new(emptypb.Empty))
+	assert.Equal(t, int64(1), cache.invalidateAllInvocations.Load())
+
+	client.Clear(t.Context(), new(emptypb.Empty))
+
+	_, _ = client.ServerInfo(t.Context(), new(emptypb.Empty))
+	assert.Equal(t, int64(2), cache.invalidateAllInvocations.Load())
+	_, _ = client.ServerInfo(t.Context(), new(emptypb.Empty))
+	assert.Equal(t, int64(2), cache.invalidateAllInvocations.Load())
+
+	_, _, _, _, _ = databrokerpb.InitialSync(t.Context(), client, &databrokerpb.SyncLatestRequest{})
+	assert.Equal(t, int64(2), cache.invalidateAllInvocations.Load())
+
+	client.Clear(t.Context(), new(emptypb.Empty))
+
+	_, _, _, _, _ = databrokerpb.InitialSync(t.Context(), client, &databrokerpb.SyncLatestRequest{})
+	assert.Equal(t, int64(3), cache.invalidateAllInvocations.Load())
+}

--- a/pkg/storage/cache.go
+++ b/pkg/storage/cache.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/metric"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 )
 
@@ -96,6 +97,7 @@ func (cache *globalCache) Invalidate(key []byte) {
 }
 
 func (cache *globalCache) InvalidateAll() {
+	log.Info().Msg("storage/cache: invalidating all data")
 	cache.invalidations.Add(context.Background(), 1)
 
 	cache.mu.Lock()

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -60,12 +60,18 @@ func newProxyStateFromConfig(ctx context.Context, tracerProvider oteltrace.Trace
 		return nil, err
 	}
 
-	dataBrokerConn, err := outboundGrpcConn.Get(ctx, &grpc.OutboundOptions{
-		OutboundPort:   cfg.OutboundPort,
-		InstallationID: cfg.Options.InstallationID,
-		ServiceName:    cfg.Options.Services,
-		SignedJWTKey:   state.sharedKey,
-	}, googlegrpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(tracerProvider))))
+	cacheInvalidator := databroker.NewCacheInvalidator(storage.GlobalCache)
+	dataBrokerConn, err := outboundGrpcConn.Get(ctx,
+		&grpc.OutboundOptions{
+			OutboundPort:   cfg.OutboundPort,
+			InstallationID: cfg.Options.InstallationID,
+			ServiceName:    cfg.Options.Services,
+			SignedJWTKey:   state.sharedKey,
+		},
+		googlegrpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(tracerProvider))),
+		googlegrpc.WithChainUnaryInterceptor(cacheInvalidator.UnaryClientInterceptor),
+		googlegrpc.WithChainStreamInterceptor(cacheInvalidator.StreamClientInterceptor),
+	)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
Clear the cache when the databroker backend changes.

- There's a new cache invalidator that adds gRPC interceptors. For any message that returns the server version, if we detect that the server version changes, we invalidate the cache.
- Also invalidate the cache in the databroker server when a new backend is created.
- Since the cache is global, invalidating it in all-in-one mode is sufficient to invalidate it for the proxy and authorize services. In split mode detecting the new server version from gRPC methods should hopefully also clear the cache fairly quickly since we do `Sync` and `SyncLatest` streams. When the backend server version changes `Sync` should abort, and we should try to do a `SyncLatest` which should return a `Versions` message where we can pick up the new server version.

## Related issues
- [ENG-4016](https://linear.app/pomerium/issue/ENG-4016/pomerium-does-not-recover-from-a-runtime-databroker-storage-type-swap)

## AI disclosure
none

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
