### PR TITLE
proxy: guard support for pomerium_redirect_uri

### DIFF
--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -6,6 +6,9 @@ var (
 	// RuntimeFlagAddExtraMetricsLabels enables adding extra labels to metrics (host and installation id)
 	RuntimeFlagAddExtraMetricsLabels = runtimeFlag("add_extra_metrics_labels", true)
 
+	// RuntimeFlagAllowAnySignOutRedirectURI allows arbitrary sign-out redirects.
+	RuntimeFlagAllowAnySignOutRedirectURI = runtimeFlag("allow_any_sign_out_redirect_uri", false)
+
 	// RuntimeFlagAuthorizeUseSyncedData enables synced data for querying the databroker for
 	// certain types of data.
 	RuntimeFlagAuthorizeUseSyncedData = runtimeFlag("authorize_use_synced_data", true)

--- a/proxy/handlers_sign_out.go
+++ b/proxy/handlers_sign_out.go
@@ -6,6 +6,7 @@ import (
 
 	"go.opentelemetry.io/otel"
 
+	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/httputil"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/endpoints"
@@ -17,17 +18,21 @@ import (
 // the authenticate service's session handle.
 func (p *Proxy) SignOut(w http.ResponseWriter, r *http.Request) error {
 	state := p.state.Load()
+	options := p.currentConfig.Load().Options
 
 	var redirectURL *url.URL
-	signOutURL, err := p.currentConfig.Load().Options.GetSignOutRedirectURL()
+	signOutURL, err := options.GetSignOutRedirectURL()
 	if err != nil {
 		return httputil.NewError(http.StatusInternalServerError, err)
 	}
 	if signOutURL != nil {
 		redirectURL = signOutURL
 	}
-	if uri, err := urlutil.ParseAndValidateURL(r.FormValue(urlutil.QueryRedirectURI)); err == nil && uri.String() != "" {
-		redirectURL = uri
+	if options.IsRuntimeFlagSet(config.RuntimeFlagAllowAnySignOutRedirectURI) {
+		uri, err := urlutil.ParseAndValidateURL(r.FormValue(urlutil.QueryRedirectURI))
+		if err == nil && uri.String() != "" {
+			redirectURL = uri
+		}
 	}
 
 	dashboardURL := state.authenticateDashboardURL.ResolveReference(&url.URL{

--- a/proxy/handlers_test.go
+++ b/proxy/handlers_test.go
@@ -68,6 +68,62 @@ func TestProxy_SignOut(t *testing.T) {
 	}
 }
 
+func TestProxy_SignOutRedirect(t *testing.T) {
+	t.Parallel()
+
+	nop := func(*config.Options) {}
+
+	cases := []struct {
+		label               string
+		optsModifier        func(*config.Options)
+		requestURI          string
+		expectedRedirectURI string
+	}{
+		// By default no pomerium_redirect_uri parameter should be set...
+		{"default", nop, "/.pomerium/sign_out", ""},
+		// ...even if a pomerium_redirect_uri parameter is present on the incoming request.
+		{"redirect param ignored", nop, "/.pomerium/sign_out?pomerium_redirect_uri=https%3A%2F%2Fexample.com", ""},
+
+		// If the global sign-out redirect setting is present, it should be honored...
+		{"global setting", func(opts *config.Options) {
+			opts.SignOutRedirectURLString = "https://example.com/custom"
+		}, "/.pomerium/sign_out", "https://example.com/custom"},
+		// ...even if a pomerium_redirect_uri parameter is present on the incoming request.
+		{"redirect param still ignored", func(opts *config.Options) {
+			opts.SignOutRedirectURLString = "https://example.com/custom"
+		}, "/.pomerium/sign_out?pomerium_redirect_uri=https%3A%2F%2Fexample.com%2Fother", "https://example.com/custom"},
+
+		// The pomerium_redirect_uri parameter should be honored only if explicitly allowed...
+		{"redirect param allowed", func(opts *config.Options) {
+			opts.RuntimeFlags[config.RuntimeFlagAllowAnySignOutRedirectURI] = true
+		}, "/.pomerium/sign_out?pomerium_redirect_uri=https%3A%2F%2Fexample.com", "https://example.com"},
+		// ...and when allowed, it should take precedence over the global setting.
+		{"redirect param and global setting", func(opts *config.Options) {
+			opts.SignOutRedirectURLString = "https://example.com/global-setting"
+			opts.RuntimeFlags[config.RuntimeFlagAllowAnySignOutRedirectURI] = true
+		}, "/.pomerium/sign_out?pomerium_redirect_uri=https%3A%2F%2Fexample.com", "https://example.com"},
+	}
+	for _, c := range cases {
+		t.Run(c.label, func(t *testing.T) {
+			opts := testOptions(t)
+			c.optsModifier(opts)
+			p, err := New(t.Context(), config.New(opts))
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			r := httptest.NewRequest(http.MethodGet, c.requestURI, nil)
+
+			p.SignOut(w, r)
+
+			res := w.Result()
+			assert.Equal(t, http.StatusFound, res.StatusCode)
+			u, err := url.Parse(res.Header.Get("Location"))
+			require.NoError(t, err, "couldn't parse redirect URL")
+			assert.Equal(t, c.expectedRedirectURI, u.Query().Get("pomerium_redirect_uri"))
+		})
+	}
+}
+
 func TestProxy_ProgrammaticLogin(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Introduce a runtime flag for the behavior of the `pomerium_redirect_uri` query parameter on the proxy /.pomerium/sign_out handler. Unless this runtime flag is explicitly enabled, the query parameter will no longer be honored.

## Related issues

https://linear.app/pomerium/issue/ENG-4017

## User Explanation

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
