### PR TITLE
chore: rename plugins_envoy to envoy_dynamic_extensions for consistency with logs

### DIFF
--- a/config/config.gen.go
+++ b/config/config.gen.go
@@ -80,8 +80,8 @@ type GlobalOptions struct {
 	AutoApplyChangesets         Value[bool]                       `json:"auto_apply_changesets,omitzero" mapstructure:"auto_apply_changesets" yaml:"auto_apply_changesets,omitempty"`
 	BearerTokenFormat           Value[configpb.BearerTokenFormat] `json:"bearer_token_format,omitzero" mapstructure:"bearer_token_format" yaml:"bearer_token_format,omitempty"`
 	CodecType                   Value[configpb.CodecType]         `json:"codec_type,omitzero" mapstructure:"codec_type" yaml:"codec_type,omitempty"`
+	EnvoyDynamicExtensions      Value[[]string]                   `json:"envoy_dynamic_extensions,omitzero" mapstructure:"envoy_dynamic_extensions" yaml:"envoy_dynamic_extensions,omitempty"`
 	JWTIssuerFormat             Value[configpb.IssuerFormat]      `json:"jwt_issuer_format,omitzero" mapstructure:"jwt_issuer_format" yaml:"jwt_issuer_format,omitempty"`
-	PluginsEnvoy                Value[[]string]                   `json:"plugins_envoy,omitzero" mapstructure:"plugins_envoy" yaml:"plugins_envoy,omitempty"`
 	SessionRecordingConcurrency Value[uint32]                     `json:"session_recording_concurrency,omitzero" mapstructure:"session_recording_concurrency" yaml:"session_recording_concurrency,omitempty"`
 }
 
@@ -435,8 +435,8 @@ func setGlobalOptionsFromProto(dst *GlobalOptions, src *configpb.Settings) error
 		setNullableBoolFromProto(&dst.AutoApplyChangesets, src.AutoApplyChangesets),
 		setNullableBearerTokenFormatFromProto(&dst.BearerTokenFormat, src.BearerTokenFormat),
 		setNullableCodecTypeFromProto(&dst.CodecType, src.CodecType),
+		setNullableStringListFromProto(&dst.EnvoyDynamicExtensions, src.EnvoyDynamicExtensions),
 		setNullableIssuerFormatFromProto(&dst.JWTIssuerFormat, src.JwtIssuerFormat),
-		setNullableStringListFromProto(&dst.PluginsEnvoy, src.PluginsEnvoy),
 		setNullableUInt32FromProto(&dst.SessionRecordingConcurrency, src.SessionRecordingConcurrency),
 	)
 }
@@ -874,8 +874,8 @@ func setGlobalOptionsToProto(dst **configpb.Settings, src *GlobalOptions) error 
 		setNullableBoolToProto(&obj.AutoApplyChangesets, src.AutoApplyChangesets),
 		setNullableBearerTokenFormatToProto(&obj.BearerTokenFormat, src.BearerTokenFormat),
 		setNullableCodecTypeToProto(&obj.CodecType, src.CodecType),
+		setNullableStringListToProto(&obj.EnvoyDynamicExtensions, src.EnvoyDynamicExtensions),
 		setNullableIssuerFormatToProto(&obj.JwtIssuerFormat, src.JWTIssuerFormat),
-		setNullableStringListToProto(&obj.PluginsEnvoy, src.PluginsEnvoy),
 		setNullableUInt32ToProto(&obj.SessionRecordingConcurrency, src.SessionRecordingConcurrency),
 	)
 }

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -261,12 +261,11 @@ func (srv *Server) update(ctx context.Context, cfg *config.Config) {
 	opts := srv.ServerOptions
 	// log level is managed via config
 	opts.logLevel = firstNonEmpty(cfg.Options.ProxyLogLevel, cfg.Options.LogLevel, config.LogLevelDebug)
-
+	opts.dynamicExtensionPaths = cfg.Options.EnvoyDynamicExtensions.Or([]string{})
 	if cmp.Equal(srv.ServerOptions, opts, cmp.AllowUnexported(ServerOptions{})) {
 		log.Ctx(ctx).Debug().Str("service", "envoy").Msg("envoy: no config changes detected")
 		return
 	}
-	opts.dynamicExtensionPaths = cfg.Options.PluginsEnvoy.Or([]string{})
 	srv.ServerOptions = opts
 	log.Ctx(ctx).Debug().Msg("envoy: starting envoy process")
 	if err := srv.run(ctx, cfg); err != nil {

--- a/pkg/grpc/config/config.pb.go
+++ b/pkg/grpc/config/config.pb.go
@@ -2966,8 +2966,8 @@ type Settings struct {
 	AutoApplyChangesets *bool `protobuf:"varint,180,opt,name=auto_apply_changesets,json=autoApplyChangesets,proto3,oneof" json:"auto_apply_changesets,omitempty"`
 	// Allows HTTP upgrade requests to be forwarded upstream.
 	AllowUpgrades *Settings_StringList `protobuf:"bytes,181,opt,name=allow_upgrades,json=allowUpgrades,proto3,oneof" json:"allow_upgrades,omitempty"`
-	// File paths to the plugins to be loaded by envoy.
-	PluginsEnvoy *Settings_StringList `protobuf:"bytes,182,opt,name=plugins_envoy,json=pluginsEnvoy,proto3" json:"plugins_envoy,omitempty"`
+	// File paths to the extensions to be loaded by envoy at runtime.
+	EnvoyDynamicExtensions *Settings_StringList `protobuf:"bytes,182,opt,name=envoy_dynamic_extensions,json=envoyDynamicExtensions,proto3" json:"envoy_dynamic_extensions,omitempty"`
 	// Tunes the maximum number of worker threads that envoy allocates for session recording
 	// uploading
 	SessionRecordingConcurrency *uint32 `protobuf:"varint,183,opt,name=session_recording_concurrency,json=sessionRecordingConcurrency,proto3,oneof" json:"session_recording_concurrency,omitempty"`
@@ -3982,9 +3982,9 @@ func (x *Settings) GetAllowUpgrades() *Settings_StringList {
 	return nil
 }
 
-func (x *Settings) GetPluginsEnvoy() *Settings_StringList {
+func (x *Settings) GetEnvoyDynamicExtensions() *Settings_StringList {
 	if x != nil {
-		return x.PluginsEnvoy
+		return x.EnvoyDynamicExtensions
 	}
 	return nil
 }
@@ -8992,7 +8992,7 @@ const file_config_proto_rawDesc = "" +
 	"\v_source_pplB\x0e\n" +
 	"\f_explanationB\x0e\n" +
 	"\f_remediationB\x11\n" +
-	"\x0f_namespace_nameJ\x04\b\x04\x10\x05\"\x86d\n" +
+	"\x0f_namespace_nameJ\x04\b\x04\x10\x05\"\x9bd\n" +
 	"\bSettings\x12\x14\n" +
 	"\x02id\x18\x9e\x01 \x01(\tH\x00R\x02id\x88\x01\x01\x12'\n" +
 	"\fnamespace_id\x18\x9f\x01 \x01(\tH\x01R\vnamespaceId\x88\x01\x01\x12#\n" +
@@ -9142,8 +9142,8 @@ const file_config_proto_rawDesc = "" +
 	"\"directory_provider_refresh_timeout\x18\xae\x01 \x01(\v2\x19.google.protobuf.DurationHvR\x1fdirectoryProviderRefreshTimeout\x88\x01\x01\x12M\n" +
 	"\fblob_storage\x18\xb3\x01 \x01(\v2$.pomerium.config.BlobStorageSettingsHwR\vblobStorage\x88\x01\x01\x128\n" +
 	"\x15auto_apply_changesets\x18\xb4\x01 \x01(\bHxR\x13autoApplyChangesets\x88\x01\x01\x12Q\n" +
-	"\x0eallow_upgrades\x18\xb5\x01 \x01(\v2$.pomerium.config.Settings.StringListHyR\rallowUpgrades\x88\x01\x01\x12J\n" +
-	"\rplugins_envoy\x18\xb6\x01 \x01(\v2$.pomerium.config.Settings.StringListR\fpluginsEnvoy\x12H\n" +
+	"\x0eallow_upgrades\x18\xb5\x01 \x01(\v2$.pomerium.config.Settings.StringListHyR\rallowUpgrades\x88\x01\x01\x12_\n" +
+	"\x18envoy_dynamic_extensions\x18\xb6\x01 \x01(\v2$.pomerium.config.Settings.StringListR\x16envoyDynamicExtensions\x12H\n" +
 	"\x1dsession_recording_concurrency\x18\xb7\x01 \x01(\rHzR\x1bsessionRecordingConcurrency\x88\x01\x01\x12:\n" +
 	"\n" +
 	"created_at\x18\xa9\x01 \x01(\v2\x1a.google.protobuf.TimestampR\tcreatedAt\x12<\n" +
@@ -9943,7 +9943,7 @@ var file_config_proto_depIdxs = []int32{
 	112, // 73: pomerium.config.Settings.directory_provider_refresh_timeout:type_name -> google.protobuf.Duration
 	30,  // 74: pomerium.config.Settings.blob_storage:type_name -> pomerium.config.BlobStorageSettings
 	100, // 75: pomerium.config.Settings.allow_upgrades:type_name -> pomerium.config.Settings.StringList
-	100, // 76: pomerium.config.Settings.plugins_envoy:type_name -> pomerium.config.Settings.StringList
+	100, // 76: pomerium.config.Settings.envoy_dynamic_extensions:type_name -> pomerium.config.Settings.StringList
 	111, // 77: pomerium.config.Settings.created_at:type_name -> google.protobuf.Timestamp
 	111, // 78: pomerium.config.Settings.modified_at:type_name -> google.protobuf.Timestamp
 	3,   // 79: pomerium.config.DownstreamMtlsSettings.enforcement:type_name -> pomerium.config.MtlsEnforcementMode

--- a/pkg/grpc/config/config.pb.json
+++ b/pkg/grpc/config/config.pb.json
@@ -7097,8 +7097,8 @@
               "defaultValue": ""
             },
             {
-              "name": "plugins_envoy",
-              "description": "File paths to the plugins to be loaded by envoy.",
+              "name": "envoy_dynamic_extensions",
+              "description": "File paths to the extensions to be loaded by envoy at runtime.",
               "label": "",
               "type": "StringList",
               "longType": "Settings.StringList",

--- a/pkg/grpc/config/config.pb.validate.go
+++ b/pkg/grpc/config/config.pb.validate.go
@@ -3287,11 +3287,11 @@ func (m *Settings) validate(all bool) error {
 	// no validation rules for RuntimeFlags
 
 	if all {
-		switch v := interface{}(m.GetPluginsEnvoy()).(type) {
+		switch v := interface{}(m.GetEnvoyDynamicExtensions()).(type) {
 		case interface{ ValidateAll() error }:
 			if err := v.ValidateAll(); err != nil {
 				errors = append(errors, SettingsValidationError{
-					field:  "PluginsEnvoy",
+					field:  "EnvoyDynamicExtensions",
 					reason: "embedded message failed validation",
 					cause:  err,
 				})
@@ -3299,16 +3299,16 @@ func (m *Settings) validate(all bool) error {
 		case interface{ Validate() error }:
 			if err := v.Validate(); err != nil {
 				errors = append(errors, SettingsValidationError{
-					field:  "PluginsEnvoy",
+					field:  "EnvoyDynamicExtensions",
 					reason: "embedded message failed validation",
 					cause:  err,
 				})
 			}
 		}
-	} else if v, ok := interface{}(m.GetPluginsEnvoy()).(interface{ Validate() error }); ok {
+	} else if v, ok := interface{}(m.GetEnvoyDynamicExtensions()).(interface{ Validate() error }); ok {
 		if err := v.Validate(); err != nil {
 			return SettingsValidationError{
-				field:  "PluginsEnvoy",
+				field:  "EnvoyDynamicExtensions",
 				reason: "embedded message failed validation",
 				cause:  err,
 			}

--- a/pkg/grpc/config/config.proto
+++ b/pkg/grpc/config/config.proto
@@ -712,8 +712,8 @@ message Settings {
   optional bool auto_apply_changesets = 180;
   // Allows HTTP upgrade requests to be forwarded upstream.
   optional StringList allow_upgrades = 181;
-  // File paths to the plugins to be loaded by envoy.
-  StringList plugins_envoy = 182;
+  // File paths to the extensions to be loaded by envoy at runtime.
+  StringList envoy_dynamic_extensions = 182;
   // Tunes the maximum number of worker threads that envoy allocates for session recording
   // uploading
   optional uint32 session_recording_concurrency = 183;


### PR DESCRIPTION
## Summary

The config option `envoy_plugins` might be immediately more clear to end users what it is they're configuring, the majority of the code & logs across envoy-custom and core use the term dynamic extensions, for consistency it might make more sense to use `envoy_dynamic_extensions`


## User Explanation

N/A

## AI disclosure

none
## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
