### PR TITLE
fix: add AI-assisted report policy to SECURITY.md and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -35,3 +35,8 @@ about: Let us know about a bug!
 ## Additional context
 
 Add any other context about the problem here.
+
+## AI disclosure
+
+If AI tools helped draft this report, note which tool and confirm you have
+personally reproduced the bug. See [AI_POLICY.md](../../AI_POLICY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,3 +9,13 @@ See https://www.pomerium.com/docs/releases.
 ## Reporting a Vulnerability
 
 See https://www.pomerium.com/docs/internals/security#reporting-a-security-bug for how to report a vulnerability.
+
+## AI-assisted reports
+
+AI-assisted security reports are welcome when they include enough detail for
+us to reproduce the issue and assess impact.
+
+Please disclose any AI tools used and distinguish between tool-generated
+analysis and behavior you personally verified. Reports that are speculative,
+lack a working proof of concept, or contain generic remediation text without
+project-specific evidence may be closed without further triage.


### PR DESCRIPTION
## Summary

- SECURITY.md: new "AI-assisted reports" section -- requires PoC, disclosure of AI tools used, and project-specific evidence; speculative or generic reports may be closed without further triage
- bug_report.md: lightweight AI disclosure section asking reporters to note AI tool and confirm personal reproduction
- AGENTS.md: replaced teapot trap with direct, non-hostile policy language for AI agent contributors

Extends the AI policy work from #6333 (AI_POLICY.md, PR template, CONTRIBUTING.md) into the security and issue reporting surfaces.

## AI assistance

Claude Code (Opus 4.6) researched AI contribution policies across OSS projects (curl, Ghostty, Linux kernel, Django), drafted section language. Bobby directed scope, tone, and template choices. Codex reviewed wording.

## Reviewer feedback

- Subagent review: fixed broken `/AI_POLICY.md` link in bug_report.md (GitHub resolves `/` from domain root, not repo root -- changed to `../../AI_POLICY.md`). Tone approved as balanced.
- review-major-change.sh: no material issues flagged.