### PR TITLE
fix(session_recording): recording content type should be protobuf

### DIFF
--- a/internal/recording/protocol_test.go
+++ b/internal/recording/protocol_test.go
@@ -511,7 +511,7 @@ func testProtocolConformance(t *testing.T, envF func(*testing.T, uint32) *testRe
 				expectedObjs,
 				initialObjDir+"/metadata.proto",
 				initialObjDir+"/metadata.json",
-				initialObjDir+"/recording_0000000000.json",
+				initialObjDir+"/recording_0000000000",
 			)
 		}
 		bucket, _, err := LoadStreamConfigForTest(env.server)
@@ -594,7 +594,7 @@ func testProtocolConformance(t *testing.T, envF func(*testing.T, uint32) *testRe
 				expectedObjs,
 				initialObjDir+"/metadata.proto",
 				initialObjDir+"/metadata.json",
-				initialObjDir+"/recording_0000000000.json",
+				initialObjDir+"/recording_0000000000",
 			)
 		}
 		wg.Wait()

--- a/pkg/storage/blob/schema.go
+++ b/pkg/storage/blob/schema.go
@@ -8,9 +8,8 @@ import (
 )
 
 const (
-	ContentTypeJSON      = "application/json"
-	ContentTypeProtobuf  = "application/protobuf"
-	ContentTypeProtojson = "application/json+protobuf"
+	ContentTypeJSON     = "application/json"
+	ContentTypeProtobuf = "application/protobuf"
 )
 
 // SchemaV1 constructs a filepath structure like:
@@ -69,7 +68,7 @@ func (c SchemaV1) SignaturePath(key string) (fullPath string, contentType string
 }
 
 func (c SchemaV1) ChunkPath(key string, id chunkID) (fullPath string, contentType string) {
-	return path.Join(c.ObjectDir(key), "recording_"+AsIDStr(id)+".json"), ContentTypeProtojson
+	return path.Join(c.ObjectDir(key), "recording_"+AsIDStr(id)), ContentTypeProtobuf
 }
 
 func (c SchemaV1) Validate() error {

--- a/pkg/storage/blob/schema_test.go
+++ b/pkg/storage/blob/schema_test.go
@@ -56,11 +56,11 @@ func TestSchemaV1_ChunkPath(t *testing.T) {
 	s := blob.SchemaV1{ClusterID: "c1", RecordingType: "ssh"}
 
 	p, ct := s.ChunkPath("rec-1", 0)
-	assert.Equal(t, "c1/ssh/v1/rec-1/recording_0000000000.json", p)
-	assert.Equal(t, blob.ContentTypeProtojson, ct)
+	assert.Equal(t, "c1/ssh/v1/rec-1/recording_0000000000", p)
+	assert.Equal(t, blob.ContentTypeProtobuf, ct)
 
 	p, _ = s.ChunkPath("rec-1", 42)
-	assert.Equal(t, "c1/ssh/v1/rec-1/recording_0000000042.json", p)
+	assert.Equal(t, "c1/ssh/v1/rec-1/recording_0000000042", p)
 }
 
 func TestAsIDStr(t *testing.T) {
@@ -95,6 +95,6 @@ func TestSchemaV1WithKey(t *testing.T) {
 	assert.Equal(t, blob.ContentTypeProtobuf, ct)
 
 	p, ct = s.ChunkPath(5)
-	assert.Equal(t, "c1/ssh/v1/rec-1/recording_0000000005.json", p)
-	assert.Equal(t, blob.ContentTypeProtojson, ct)
+	assert.Equal(t, "c1/ssh/v1/rec-1/recording_0000000005", p)
+	assert.Equal(t, blob.ContentTypeProtobuf, ct)
 }

--- a/pkg/storage/blob/testutil/object.go
+++ b/pkg/storage/blob/testutil/object.go
@@ -71,9 +71,9 @@ func TestFullObjectMatches(
 
 	var concatenated []byte
 	for i := range manifestProto.GetItems() {
-		chunkPath := fmt.Sprintf("%s/recording_%010d.json", schema.ObjectDir(), i)
+		chunkPath := fmt.Sprintf("%s/recording_%010d", schema.ObjectDir(), i)
 		chunkBytes, chunkAttrs := readWithAttrs(ctx, t, bucket, chunkPath)
-		assert.Equal(t, blob.ContentTypeProtojson, chunkAttrs.ContentType, "chunk %d content type", i)
+		assert.Equal(t, blob.ContentTypeProtobuf, chunkAttrs.ContentType, "chunk %d content type", i)
 		concatenated = append(concatenated, chunkBytes...)
 	}
 	assert.Equal(t, fullObject, concatenated, "concatenated chunk bytes")


### PR DESCRIPTION
## Summary

Recording contents are available as JSON encoded asciicast in enterprise. The original intent was to rewrite everything in protojson in the hot path, but was never implemented because it causes extra latency and storage size.  The real advantage of JSON is indexing by analytics tools, but without passing the contents through terminal emulation, that would not produce meaningful analytics.

## Related issues

N/A

## User Explanation

N/A

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
