### PR TITLE
add protoreflect byteskind to storage indexing

### DIFF
--- a/pkg/storage/index.go
+++ b/pkg/storage/index.go
@@ -129,6 +129,8 @@ func kindToValue(kind protoreflect.Kind, v protoreflect.Value) any {
 		return v.Bool()
 	case protoreflect.StringKind:
 		return v.String()
+	case protoreflect.BytesKind:
+		return v.Bytes()
 	case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind:
 		return int32(v.Int())
 	case protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:


### PR DESCRIPTION
## Summary

One of the nested structs we use in Enterprise requires filtering on protoreflect.BytesKind

## Related issues

Related to [ENG-4059](https://linear.app/pomerium/issue/ENG-4059/bug-upstream-host-name)

## User Explanation

N/A

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
