### PR TITLE
core/zero: default envoy admin internal address in bootstrap config

### DIFF
--- a/internal/zero/bootstrap/new.go
+++ b/internal/zero/bootstrap/new.go
@@ -35,7 +35,7 @@ type Source struct {
 
 // New creates a new bootstrap config source
 func New(secret []byte, fileCachePath *string, writer writers.ConfigWriter, api *sdk.API) (*Source, error) {
-	cfg := new(config.Config)
+	cfg := config.New(config.NewDefaultOptions())
 
 	err := setConfigDefaults(cfg)
 	if err != nil {
@@ -76,8 +76,6 @@ func New(secret []byte, fileCachePath *string, writer writers.ConfigWriter, api 
 }
 
 func setConfigDefaults(cfg *config.Config) error {
-	cfg.Options = config.NewDefaultOptions()
-
 	ports, err := netutil.AllocatePorts(7)
 	if err != nil {
 		return fmt.Errorf("allocating ports: %w", err)

--- a/internal/zero/bootstrap/new_test.go
+++ b/internal/zero/bootstrap/new_test.go
@@ -28,3 +28,21 @@ func TestConfigDeterministic(t *testing.T) {
 
 	require.Equal(t, cfg.Options, cfg2.Options)
 }
+
+// TestNewSetsEnvoyAdminInternalAddress guards against a regression where the
+// zero bootstrap config was built via new(config.Config) and never had its
+// EnvoyAdminInternalAddress defaulted. The empty address caused EnvoyAddress()
+// to hit its panic branch ("unsupported internal address") when the control
+// plane built the envoy admin cluster, crash-looping the zero data plane.
+func TestNewSetsEnvoyAdminInternalAddress(t *testing.T) {
+	src, err := bootstrap.New([]byte("secret"), nil, nil, nil)
+	require.NoError(t, err)
+	cfg := src.GetConfig()
+	require.NotNil(t, cfg)
+
+	require.NotEmpty(t, cfg.EnvoyAdminInternalAddress.URL.Scheme,
+		"EnvoyAdminInternalAddress must be defaulted in zero bootstrap config")
+	require.NotPanics(t, func() {
+		_ = cfg.EnvoyAdminInternalAddress.EnvoyAddress()
+	}, "building the envoy admin address must not panic")
+}


### PR DESCRIPTION
## Summary

The Pomerium Zero data plane crash-loops on startup:

```
panic: unsupported internal address:
pkg/netutil.(*InternalAddress).EnvoyAddress            pkg/netutil/internal.go:103
config/envoyconfig.(*Builder).buildEnvoyAdminCluster   config/envoyconfig/clusters_envoy_admin.go:22
```

#6353 added `Config.EnvoyAdminInternalAddress` but defaulted it only in `config.New()`. The zero bootstrap source builds its config via `new(config.Config)` instead, so the field stays empty and `EnvoyAddress()` hits its `default: panic` branch when building the envoy admin cluster. Only Zero mode is affected; the file/env path uses `config.New()`.

## Fix

Apply the `*netutil.NewInternalAddress()` default in `setConfigDefaults`, matching `config.New()`. Test `TestNewSetsEnvoyAdminInternalAddress` is red before / green after.

## AI disclosure

Investigation and fix drafted with Claude Code.

## Checklist

- [x] reference any related issues (ENG-4068)
- [x] updated unit tests
- [x] add appropriate label (`bug`)
- [x] disclosed AI usage per AI_POLICY.md
- [ ] ready for review (draft)