### PR TITLE
feat(blob): file provider will always set no_tmp_dir to prevent issues in containerized environments

### DIFF
--- a/pkg/storage/blob/providers/providers.go
+++ b/pkg/storage/blob/providers/providers.go
@@ -38,6 +38,13 @@ func OpenBucket(ctx context.Context, bucketURI string) (*blob.Bucket, error) {
 		if u.User != nil {
 			return openMinioBucket(ctx, u)
 		}
+	case "file":
+		q := u.Query()
+		if !q.Has("no_tmp_dir") {
+			q.Set("no_tmp_dir", "true")
+			u.RawQuery = q.Encode()
+			bucketURI = u.String()
+		}
 	}
 	return blob.OpenBucket(ctx, bucketURI)
 }


### PR DESCRIPTION


## Summary


Sets saner defaults for fileblob provider

## Related issues

[ENG-4070/](https://linear.app/pomerium/issue/ENG-4070/filesystem-session-recording-fails-on-cross-device-rename-poor-default)

## User Explanation

N/A

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
