### PR TITLE
mcp: support HTTPS proxy for the SSRF-safe upstream client

### DIFF
--- a/internal/mcp/e2e/mcp_upstream_dcr_fallback_test.go
+++ b/internal/mcp/e2e/mcp_upstream_dcr_fallback_test.go
@@ -40,6 +40,7 @@ func TestMCPUpstreamOAuthDCRFallback(t *testing.T) {
 		cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = true
 		cfg.Options.MCPAllowedClientIDDomains = []string{"*.localhost.pomerium.io"}
 		cfg.Options.MCPAllowedASMetadataDomains = []string{"127.0.0.1", "localhost"}
+		cfg.Options.InsecureSkipMCPMetadataSSRFCheck = true
 	}))
 
 	idp := scenarios.NewIDP([]*scenarios.User{{Email: "user@example.com"}})

--- a/internal/mcp/e2e/mcp_upstream_pre_registered_test.go
+++ b/internal/mcp/e2e/mcp_upstream_pre_registered_test.go
@@ -48,6 +48,7 @@ func TestMCPUpstreamOAuthPreRegistered(t *testing.T) {
 		cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = true
 		cfg.Options.MCPAllowedClientIDDomains = []string{"*.localhost.pomerium.io"}
 		cfg.Options.MCPAllowedASMetadataDomains = []string{"127.0.0.1", "localhost"}
+		cfg.Options.InsecureSkipMCPMetadataSSRFCheck = true
 	}))
 
 	idp := scenarios.NewIDP([]*scenarios.User{{Email: "user@example.com"}})

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -123,13 +123,9 @@ func New(
 	// Create domain matcher from config for client ID metadata URL validation
 	domainMatcher := NewDomainMatcher(cfg.Options.MCPAllowedClientIDDomains)
 
-	// Use the SSRF-safe client by default; skip for testing environments
-	// where test servers run on localhost.
-	var cimdHTTPClient *http.Client
-	if cfg.Options.InsecureSkipMCPMetadataSSRFCheck {
-		cimdHTTPClient = http.DefaultClient
-	} else {
-		cimdHTTPClient = NewSSRFSafeClient()
+	ssrfHTTPClient, err := NewSSRFSafeClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create ssrf-protected http client: %w", err)
 	}
 
 	asDomainMatcher := NewDomainMatcher(cfg.Options.GetMCPAllowedAsMetadataDomains())
@@ -139,10 +135,10 @@ func New(
 		trace:                   tracerProvider,
 		storage:                 NewStorage(client),
 		cipher:                  cipher,
-		hosts:                   NewHostInfo(cfg, http.DefaultClient),
-		clientMetadataFetcher:   NewClientMetadataFetcher(cimdHTTPClient, domainMatcher),
+		hosts:                   NewHostInfo(cfg),
+		clientMetadataFetcher:   NewClientMetadataFetcher(ssrfHTTPClient, domainMatcher),
 		sessionExpiry:           cfg.Options.CookieExpire,
-		httpClient:              http.DefaultClient,
+		httpClient:              ssrfHTTPClient,
 		asMetadataDomainMatcher: asDomainMatcher,
 	}
 

--- a/internal/mcp/handler_cimd_test.go
+++ b/internal/mcp/handler_cimd_test.go
@@ -39,7 +39,7 @@ func TestGenerateClientIDMetadata(t *testing.T) {
 		},
 	})
 
-	hostInfo := NewHostInfo(cfg, nil)
+	hostInfo := NewHostInfo(cfg)
 	handler := &Handler{
 		hosts: hostInfo,
 	}
@@ -112,7 +112,7 @@ func TestGenerateClientIDMetadata(t *testing.T) {
 			},
 		})
 
-		hostInfoNoName := NewHostInfo(cfgNoName, nil)
+		hostInfoNoName := NewHostInfo(cfgNoName)
 		handlerNoName := &Handler{
 			hosts: hostInfoNoName,
 		}
@@ -140,7 +140,7 @@ func TestClientIDMetadataHandler(t *testing.T) {
 		},
 	})
 
-	hostInfo := NewHostInfo(cfg, nil)
+	hostInfo := NewHostInfo(cfg)
 	handler := &Handler{
 		hosts: hostInfo,
 	}

--- a/internal/mcp/host_info.go
+++ b/internal/mcp/host_info.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"iter"
 	"maps"
-	"net/http"
 	"net/url"
 	"path"
 	"sync/atomic"
@@ -14,8 +13,6 @@ import (
 )
 
 type HostInfo struct {
-	httpClient *http.Client
-
 	servers atomic.Pointer[map[string]ServerHostInfo]
 	clients atomic.Pointer[map[string]ClientHostInfo]
 }
@@ -78,9 +75,8 @@ type ClientHostInfo struct{}
 
 func NewHostInfo(
 	cfg *config.Config,
-	httpClient *http.Client,
 ) *HostInfo {
-	h := &HostInfo{httpClient: httpClient}
+	h := new(HostInfo)
 	h.OnConfigChange(cfg)
 	return h
 }

--- a/internal/mcp/host_info_test.go
+++ b/internal/mcp/host_info_test.go
@@ -104,7 +104,7 @@ func TestHostInfo_IsMCPClientForHost(t *testing.T) {
 		},
 	})
 
-	hostInfo := mcp.NewHostInfo(cfg, nil)
+	hostInfo := mcp.NewHostInfo(cfg)
 
 	require.True(t, hostInfo.IsMCPClientForHost("client.example.com"))
 	require.False(t, hostInfo.IsMCPClientForHost("server.example.com"))
@@ -317,7 +317,7 @@ func TestHostInfo_UsesAutoDiscovery(t *testing.T) {
 		},
 	})
 
-	hostInfo := mcp.NewHostInfo(cfg, nil)
+	hostInfo := mcp.NewHostInfo(cfg)
 
 	tests := []struct {
 		name     string
@@ -376,7 +376,7 @@ func TestHostInfo_GetServerHostInfo(t *testing.T) {
 		},
 	})
 
-	hostInfo := mcp.NewHostInfo(cfg, nil)
+	hostInfo := mcp.NewHostInfo(cfg)
 
 	t.Run("returns info for MCP server host", func(t *testing.T) {
 		info, ok := hostInfo.GetServerHostInfo("mcp.example.com")
@@ -483,7 +483,7 @@ func TestServerHostInfo_UpstreamURL(t *testing.T) {
 			},
 		})
 
-		hostInfo := mcp.NewHostInfo(cfg, nil)
+		hostInfo := mcp.NewHostInfo(cfg)
 		info, ok := hostInfo.GetServerHostInfo("proxy.example.com")
 		require.True(t, ok)
 		require.Equal(t, "https://api.upstream.com", info.UpstreamURL)

--- a/internal/mcp/ssrf.go
+++ b/internal/mcp/ssrf.go
@@ -3,12 +3,19 @@ package mcp
 import (
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/netip"
+	"net/url"
 	"time"
+
+	"golang.org/x/net/http/httpproxy"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
 // ErrSSRFBlocked is returned when a request is blocked by SSRF protection.
@@ -76,19 +83,64 @@ func (t *httpsOnlyTransport) RoundTrip(req *http.Request) (*http.Response, error
 // RFC 9728 §3.2) require a successful response to use 200 OK. Following
 // redirects would also undermine SSRF protection by allowing an attacker-
 // controlled endpoint to bounce requests to internal services.
-func NewSSRFSafeClient() *http.Client {
+//
+// HTTP(S) proxies are honored from the environment (HTTPS_PROXY / NO_PROXY),
+// read once when the client is constructed. (HTTP_PROXY never applies: every
+// request is forced to https, and that variable governs http:// targets only.)
+// Direct connections — where no proxy applies — still flow through
+// DialTLSContext and get full internal-IP validation. When a proxy IS
+// configured, Go tunnels via CONNECT and the proxy performs DNS resolution, so
+// dial-time IP validation no longer applies on that path; egress filtering is
+// then delegated to the operator-controlled proxy. HTTPS-only enforcement and
+// the redirect ban still hold regardless of the proxy, and the upstream domain
+// allowlist is checked (by hostname) at the application layer before any
+// request is made.
+//
+// rootCAs, when non-nil, is used to verify server certificates on both the
+// direct and proxied paths (e.g. for upstream servers using a private CA from
+// the Pomerium configuration). A nil pool uses the system roots.
+func NewSSRFSafeClient(cfg *config.Config) (*http.Client, error) {
+	// skip for testing environments
+	// where test servers run on localhost.
+	if cfg.Options.InsecureSkipMCPMetadataSSRFCheck {
+		return http.DefaultClient, nil
+	}
+
+	var rootCAs *x509.CertPool
+	if cfg.Options.CA != "" || cfg.Options.CAFile != "" {
+		pool, caErr := cryptutil.GetCertPool(cfg.Options.CA, cfg.Options.CAFile)
+		if caErr != nil {
+			return nil, fmt.Errorf("failed to load CA certificates: %w", caErr)
+		}
+		rootCAs = pool
+	}
+
 	dialer := &net.Dialer{
 		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}
 
+	proxyFunc := httpproxy.FromEnvironment().ProxyFunc()
+
+	baseTLS := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+		RootCAs:    rootCAs,
+	}
+
 	transport := &http.Transport{
-		Proxy:                 nil, // disable proxy to prevent bypass
+		Proxy: func(req *http.Request) (*url.URL, error) {
+			if req.URL.Scheme != "https" {
+				return nil, fmt.Errorf("%w: only https is allowed", ErrSSRFBlocked)
+			}
+			return proxyFunc(req.URL)
+		},
+		DialContext:           dialer.DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          10,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
+		TLSClientConfig:       baseTLS.Clone(),
 		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
 			host, port, err := net.SplitHostPort(addr)
 			if err != nil {
@@ -105,10 +157,8 @@ func NewSSRFSafeClient() *http.Client {
 				return nil, err
 			}
 
-			cfg := &tls.Config{
-				MinVersion: tls.VersionTLS12,
-				ServerName: host,
-			}
+			cfg := baseTLS.Clone()
+			cfg.ServerName = host
 
 			tlsConn := tls.Client(rawConn, cfg)
 			if err := tlsConn.HandshakeContext(ctx); err != nil {
@@ -128,5 +178,5 @@ func NewSSRFSafeClient() *http.Client {
 			return fmt.Errorf("%w: redirects are not allowed", ErrSSRFBlocked)
 		},
 		Timeout: 30 * time.Second,
-	}
+	}, nil
 }

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -22,7 +21,6 @@ import (
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/mcp/extproc"
 	oauth21proto "github.com/pomerium/pomerium/internal/oauth21/gen"
-	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
@@ -142,25 +140,14 @@ func NewUpstreamAuthHandlerFromConfig(
 
 	storage := NewStorage(databroker.NewDataBrokerServiceClient(dataBrokerConn))
 
-	httpClient := http.DefaultClient
-	if cfg.Options.CA != "" || cfg.Options.CAFile != "" {
-		rootCAs, caErr := cryptutil.GetCertPool(cfg.Options.CA, cfg.Options.CAFile)
-		if caErr != nil {
-			log.Ctx(ctx).Warn().Err(caErr).Msg("mcp_upstream_auth: error loading custom CA, using system defaults")
-		} else {
-			transport := http.DefaultTransport.(*http.Transport).Clone()
-			transport.TLSClientConfig = &tls.Config{
-				RootCAs:    rootCAs,
-				MinVersion: tls.VersionTLS12,
-			}
-			httpClient = &http.Client{Transport: transport}
-		}
-	}
-
-	hosts := NewHostInfo(cfg, httpClient)
+	hosts := NewHostInfo(cfg)
 	asDomainMatcher := NewDomainMatcher(cfg.Options.GetMCPAllowedAsMetadataDomains())
 
-	return NewUpstreamAuthHandler(storage, hosts, httpClient, asDomainMatcher), nil
+	ssrfHTTPClient, err := NewSSRFSafeClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create ssrf-protected http client: %w", err)
+	}
+	return NewUpstreamAuthHandler(storage, hosts, ssrfHTTPClient, asDomainMatcher), nil
 }
 
 // GetUpstreamToken looks up a cached upstream token for the given route context and host.

--- a/internal/mcp/upstream_auth_onconfigchange_test.go
+++ b/internal/mcp/upstream_auth_onconfigchange_test.go
@@ -18,7 +18,7 @@ func TestUpstreamAuthHandler_OnConfigChange_RefreshesDomainMatcher(t *testing.T)
 
 	h := NewUpstreamAuthHandler(
 		nil,
-		NewHostInfo(old, nil),
+		NewHostInfo(old),
 		nil,
 		NewDomainMatcher(old.Options.GetMCPAllowedAsMetadataDomains()),
 	)

--- a/internal/mcp/upstream_auth_test.go
+++ b/internal/mcp/upstream_auth_test.go
@@ -76,7 +76,7 @@ func TestHandleUpstreamResponse_DownstreamHostRouting(t *testing.T) {
 				},
 			},
 		})
-		hosts := NewHostInfo(cfg, nil)
+		hosts := NewHostInfo(cfg)
 
 		// Verify HostInfo is set up correctly
 		assert.True(t, hosts.UsesAutoDiscovery("proxy.example.com"),
@@ -150,7 +150,7 @@ func TestHandleUpstreamResponse_DownstreamHostRouting(t *testing.T) {
 				},
 			},
 		})
-		hosts := NewHostInfo(cfg, nil)
+		hosts := NewHostInfo(cfg)
 
 		handler := &UpstreamAuthHandler{
 			hosts: hosts,
@@ -627,7 +627,7 @@ func TestHandle401_ResourceParamStoredInPending(t *testing.T) {
 				},
 			},
 		})
-		hosts := NewHostInfo(cfg, nil)
+		hosts := NewHostInfo(cfg)
 
 		var capturedPending *oauth21proto.PendingUpstreamAuth
 		store := &testUpstreamAuthStorage{
@@ -743,7 +743,7 @@ func TestHandle401_EmptyUserID(t *testing.T) {
 			},
 		},
 	})
-	hosts := NewHostInfo(cfg, nil)
+	hosts := NewHostInfo(cfg)
 
 	handler := &UpstreamAuthHandler{
 		hosts: hosts,
@@ -901,7 +901,7 @@ func TestHandleUpstreamResponse_ExpiresAtHandling(t *testing.T) {
 				},
 			},
 		})
-		hosts := NewHostInfo(cfg, nil)
+		hosts := NewHostInfo(cfg)
 
 		handler := &UpstreamAuthHandler{
 			storage: fullStore,
@@ -965,7 +965,7 @@ func TestHandleUpstreamResponse_ExpiresAtHandling(t *testing.T) {
 				},
 			},
 		})
-		hosts := NewHostInfo(cfg, nil)
+		hosts := NewHostInfo(cfg)
 
 		handler := &UpstreamAuthHandler{
 			storage:    fullStore,
@@ -1050,7 +1050,7 @@ func TestRefreshOrClearToken_ErrorClassification(t *testing.T) {
 		})
 		return &UpstreamAuthHandler{
 			storage:    store,
-			hosts:      NewHostInfo(cfg, nil),
+			hosts:      NewHostInfo(cfg),
 			httpClient: httpClient,
 		}
 	}


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

<!-- If this PR was assisted by AI (Claude, Copilot, Cursor, Amp, etc.),
state which tool and roughly how much of the work was AI-assisted (e.g.
"Cursor autocomplete only", "Claude Code drafted scaffolding, I rewrote
the auth path"). If no AI was used, write "none". See AI_POLICY.md. -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
