### PR TITLE
core/config: switch gRPC port when 5443 is not available

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -896,7 +896,7 @@ func (o *Options) SupportsUserRefresh() bool {
 // GetAuthorizeURLs returns the AuthorizeURLs in the options or 127.0.0.1:5443.
 func (o *Options) GetAuthorizeURLs() ([]*url.URL, error) {
 	if (IsAuthenticate(o.Services) || IsProxy(o.Services)) && o.AuthorizeURLString == "" && len(o.AuthorizeURLStrings) == 0 {
-		u, err := urlutil.ParseAndValidateURL("http://127.0.0.1" + o.GetAlternativePort())
+		u, err := urlutil.ParseAndValidateURL("http://127.0.0.1:" + o.GetAlternativePort())
 		if err != nil {
 			return nil, err
 		}

--- a/config/options.go
+++ b/config/options.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"iter"
 	"maps"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -52,11 +53,6 @@ import (
 
 // DisableHeaderKey is the key used to check whether to disable setting header
 const DisableHeaderKey = "disable"
-
-// DefaultAlternativeAddr is the address used is two services are competing over
-// the same listener. Typically this is invisible to the end user (e.g. localhost)
-// gRPC server, or is used for healthchecks (authorize only service)
-const DefaultAlternativeAddr = ":5443"
 
 // The randomSharedKey is used if no shared key is supplied in all-in-one mode.
 var randomSharedKey = cryptutil.NewBase64Key()
@@ -900,7 +896,7 @@ func (o *Options) SupportsUserRefresh() bool {
 // GetAuthorizeURLs returns the AuthorizeURLs in the options or 127.0.0.1:5443.
 func (o *Options) GetAuthorizeURLs() ([]*url.URL, error) {
 	if (IsAuthenticate(o.Services) || IsProxy(o.Services)) && o.AuthorizeURLString == "" && len(o.AuthorizeURLStrings) == 0 {
-		u, err := urlutil.ParseAndValidateURL("http://127.0.0.1" + DefaultAlternativeAddr)
+		u, err := urlutil.ParseAndValidateURL("http://127.0.0.1" + o.GetAlternativePort())
 		if err != nil {
 			return nil, err
 		}
@@ -921,7 +917,7 @@ func (o *Options) GetInternalAuthorizeURLs() ([]*url.URL, error) {
 // GetDataBrokerURLs returns the DataBrokerURLs in the options or 127.0.0.1:5443.
 func (o *Options) GetDataBrokerURLs() ([]*url.URL, error) {
 	if (IsAuthenticate(o.Services) || IsProxy(o.Services)) && o.DataBroker.ServiceURL == "" && len(o.DataBroker.ServiceURLs) == 0 {
-		u, err := urlutil.ParseAndValidateURL("http://127.0.0.1" + DefaultAlternativeAddr)
+		u, err := urlutil.ParseAndValidateURL("http://127.0.0.1:" + o.GetAlternativePort())
 		if err != nil {
 			return nil, err
 		}
@@ -954,17 +950,28 @@ func (o *Options) getURLs(strs ...string) ([]*url.URL, error) {
 		}
 	}
 	if len(urls) == 0 {
-		u, _ := url.Parse("http://127.0.0.1" + DefaultAlternativeAddr)
+		u, _ := url.Parse("http://127.0.0.1:" + o.GetAlternativePort())
 		urls = append(urls, u)
 	}
 	return urls, nil
+}
+
+// GetAlternativePort gets the alternative port when running both an HTTP
+// listener and a gRPC listener.
+func (o *Options) GetAlternativePort() string {
+	_, httpPort, _ := net.SplitHostPort(o.Addr)
+	// 5443 is not available, so switch to 5444
+	if httpPort == "5443" {
+		return "5444"
+	}
+	return "5443"
 }
 
 // GetGRPCAddr gets the gRPC address.
 func (o *Options) GetGRPCAddr() string {
 	// to avoid port collision when running on localhost
 	if (IsAuthenticate(o.Services) || IsProxy(o.Services)) && o.GRPCAddr == defaultOptions.GRPCAddr {
-		return DefaultAlternativeAddr
+		return ":" + o.GetAlternativePort()
 	}
 	return o.GRPCAddr
 }

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1453,6 +1453,14 @@ func TestOptions_GetCSRFSameSite(t *testing.T) {
 	}
 }
 
+func TestOptions_GetAlternativePort(t *testing.T) {
+	t.Parallel()
+	assert.Equal(t, "5443", NewDefaultOptions().GetAlternativePort())
+	o := NewDefaultOptions()
+	o.Addr = "127.0.0.1:5443"
+	assert.Equal(t, "5444", o.GetAlternativePort())
+}
+
 func TestOptions_GetMCPAllowedAsMetadataDomains(t *testing.T) {
 	t.Parallel()
 	o := NewDefaultOptions()

--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -1,5 +1,5 @@
 {
-  "config": "v0.35.0",
+  "config": "v0.36.0",
   "hosted-authenticate-oidc": "v0.1.0",
   "mcp": "v0.31.0",
   "ssh": "v0.17.0"


### PR DESCRIPTION
## Summary
If `:5443` is used as the main listener address, Envoy will fail to start because `:5443` is also used for the gRPC port (in all-in-one mode). This PR updates the code to switch to `:5444` when this happens.

## Related issues
- [ENG-4085](https://linear.app/pomerium/issue/ENG-4085/zeroconfig-builder-applychangeset-fails-grpc-ingress-duplicate-address)

## AI disclosure
No AI was used for this PR.

## Checklist
- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
