### PR TITLE
mcp: allow CIMD query params

### DIFF
--- a/internal/mcp/client_id_metadata.go
+++ b/internal/mcp/client_id_metadata.go
@@ -94,8 +94,10 @@ func NewClientMetadataFetcher(httpClient *http.Client, domainMatcher *DomainMatc
 // - MUST NOT contain single-dot or double-dot path segments
 // - MUST NOT contain a fragment component
 // - MUST NOT contain username or password
-// - SHOULD NOT include a query string component
 // - MAY contain a port
+//
+// A query string SHOULD NOT be included per the draft, but because that is a
+// recommendation rather than a requirement we tolerate it.
 //
 // Returns (false, nil) if clientID is not a URL (e.g., a regular client ID string).
 // Returns (false, error) if clientID is a URL but violates RFC requirements.
@@ -141,11 +143,6 @@ func IsClientIDMetadataURL(clientID string) (bool, error) {
 	// Must not have username or password
 	if u.User != nil {
 		return false, fmt.Errorf("%w: client_id URL must not contain username or password", ErrClientMetadataValidation)
-	}
-
-	// SHOULD NOT include a query string - we treat this as an error per RFC guidance
-	if u.RawQuery != "" {
-		return false, fmt.Errorf("%w: client_id URL should not include a query string", ErrClientMetadataValidation)
 	}
 
 	return true, nil

--- a/internal/mcp/client_id_metadata_test.go
+++ b/internal/mcp/client_id_metadata_test.go
@@ -79,10 +79,16 @@ func TestIsClientIDMetadataURL(t *testing.T) {
 			expectError: true,
 		},
 		{
-			name:        "contains query string - RFC violation",
+			name:        "contains query string - tolerated (RFC SHOULD NOT)",
 			clientID:    "https://example.com/oauth/client.json?foo=bar",
-			expectIsURL: false,
-			expectError: true,
+			expectIsURL: true,
+			expectError: false,
+		},
+		{
+			name:        "real-world client_id URL with query string",
+			clientID:    "https://chatgpt.com/oauth/XXXXXXXXXX/client.json?token_endpoint_auth_method=none",
+			expectIsURL: true,
+			expectError: false,
 		},
 		{
 			name:        "UUID-style client ID - not a URL",


### PR DESCRIPTION
## Summary

Tolerate query params in MCP CIMD. 

## Related issues

https://linear.app/pomerium/issue/ENG-4097/mcp-relax-client-id-metadata-url-validation-to-allow-a-query-string

## User Explanation
w
<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

<!-- If this PR was assisted by AI (Claude, Copilot, Cursor, Amp, etc.),
state which tool and roughly how much of the work was AI-assisted (e.g.
"Cursor autocomplete only", "Claude Code drafted scaffolding, I rewrote
the auth path"). If no AI was used, write "none". See AI_POLICY.md. -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
