### PR TITLE
chore(ui): upgrade to React 19

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -18,8 +18,8 @@
         "@mui/material": "^5.4.0",
         "lodash": "^4.18.1",
         "markdown-to-jsx": "^9.8.1",
-        "react": "^17.0.2",
-        "react-dom": "^17.0.2",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "react-feather": "^2.0.10"
       },
       "devDependencies": {
@@ -27,8 +27,8 @@
         "@trivago/prettier-plugin-sort-imports": "^6.0.2",
         "@types/lodash": "^4.17.24",
         "@types/node": "^25.9.1",
-        "@types/react": "^17.0.34",
-        "@types/react-dom": "^17.0.11",
+        "@types/react": "^19.2.16",
+        "@types/react-dom": "^19.2.3",
         "esbuild": "^0.28.0",
         "eslint": "9.39.1",
         "eslint-plugin-react": "^7.37.0",
@@ -1527,24 +1527,22 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "17.0.93",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.93.tgz",
-      "integrity": "sha512-KM4Ty/ZTLZupiYxZVAlP+InNJS3De6uBMdq0ePa6/04+eG9Y7ftnWfst1xTLQ5rwAhgHwQ4momt/O4KepdGBTw==",
+      "version": "19.2.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
-        "@types/scheduler": "^0.16",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "17.0.26",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.26.tgz",
-      "integrity": "sha512-Z+2VcYXJwOqQ79HreLU/1fyQ88eXSSFh6I3JdrEHQIfYSI0kCQpTGvOrbE6jFGGYXKsHuwY9tBa/w5Uo6KzrEg==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^17.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -1555,12 +1553,6 @@
       "peerDependencies": {
         "@types/react": "*"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.60.1",
@@ -4497,30 +4489,24 @@
       }
     },
     "node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
-      "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "scheduler": "^0.20.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "17.0.2"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-feather": {
@@ -4686,14 +4672,10 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.2.tgz",
-      "integrity": "sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,8 +32,8 @@
     "@mui/material": "^5.4.0",
     "lodash": "^4.18.1",
     "markdown-to-jsx": "^9.8.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "react-feather": "^2.0.10"
   },
   "devDependencies": {
@@ -41,8 +41,8 @@
     "@trivago/prettier-plugin-sort-imports": "^6.0.2",
     "@types/lodash": "^4.17.24",
     "@types/node": "^25.9.1",
-    "@types/react": "^17.0.34",
-    "@types/react-dom": "^17.0.11",
+    "@types/react": "^19.2.16",
+    "@types/react-dom": "^19.2.3",
     "esbuild": "^0.28.0",
     "eslint": "9.39.1",
     "eslint-plugin-react": "^7.37.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -68,13 +68,13 @@ const App: FC = () => {
 
   useLayoutEffect(() => {
     const favicon = document.getElementById(
-      "favicon"
+      "favicon",
     ) as HTMLAnchorElement | null;
     if (favicon) {
       favicon.href = data?.faviconUrl || "/.pomerium/favicon.ico";
     }
     const extraFaviconLinks = document.getElementsByClassName(
-      "pomerium_favicon"
+      "pomerium_favicon",
     ) as HTMLCollectionOf<HTMLAnchorElement> | null;
     for (const link of extraFaviconLinks) {
       link.style.display = data?.faviconUrl ? "none" : "";

--- a/ui/src/components/Avatar.tsx
+++ b/ui/src/components/Avatar.tsx
@@ -1,6 +1,6 @@
 import { Avatar as MuiAvatar } from "@mui/material";
 import isArray from "lodash/isArray";
-import React from "react";
+import type { JSX } from "react";
 import { User } from "react-feather";
 
 type AvatarProps = {

--- a/ui/src/components/ExperimentalIcon.tsx
+++ b/ui/src/components/ExperimentalIcon.tsx
@@ -11,6 +11,6 @@ const ExperimentalIcon = createSvgIcon(
       transform="scale(.83333)"
     />
   </svg>,
-  "Experimental"
+  "Experimental",
 );
 export default ExperimentalIcon;

--- a/ui/src/components/JwtIcon.tsx
+++ b/ui/src/components/JwtIcon.tsx
@@ -54,6 +54,6 @@ const JwtIcon = createSvgIcon(
       d="m4.543 9.578-2.344 3.238 1.797 1.309 2.36-3.238V9ZM10.383 5.348l2.344-3.239L10.93.801 8.586 4.039v1.887Zm0 0"
     />
   </svg>,
-  "JWT"
+  "JWT",
 );
 export default JwtIcon;

--- a/ui/src/components/MCPRouteCard.tsx
+++ b/ui/src/components/MCPRouteCard.tsx
@@ -27,7 +27,7 @@ const mcpLogoDataURI =
       '<path d="M25 97.8528L92.8822 29.9706C102.255 20.598 117.451 20.598 126.823 29.9706V29.9706C136.196 39.3431 136.196 54.5391 126.823 63.9117L75.5581 115.177" stroke="#000" stroke-width="12" stroke-linecap="round" fill="none"/>' +
       '<path d="M76.2652 114.47L126.823 63.9117C136.196 54.5391 151.392 54.5391 160.765 63.9117L161.118 64.2652C170.491 73.6378 170.491 88.8338 161.118 98.2063L99.7248 159.6C96.6006 162.724 96.6006 167.789 99.7248 170.913L112.331 183.52" stroke="#000" stroke-width="12" stroke-linecap="round" fill="none"/>' +
       '<path d="M109.853 46.9411L59.6482 97.1457C50.2756 106.518 50.2756 121.714 59.6482 131.087V131.087C69.0208 140.459 84.2167 140.459 93.5893 131.087L143.794 80.8822" stroke="#000" stroke-width="12" stroke-linecap="round" fill="none"/>' +
-      "</g></svg>"
+      "</g></svg>",
   );
 
 type MCPRouteCardProps = {
@@ -49,7 +49,7 @@ const MCPRouteCard: FC<MCPRouteCardProps> = ({ route }) => {
       if (!resp.ok) {
         const text = await resp.text().catch(() => "");
         setErrorMessage(
-          `Failed to disconnect (${resp.status}): ${text || "unknown error"}`
+          `Failed to disconnect (${resp.status}): ${text || "unknown error"}`,
         );
         return;
       }
@@ -58,7 +58,7 @@ const MCPRouteCard: FC<MCPRouteCardProps> = ({ route }) => {
       setErrorMessage(
         `Failed to disconnect: ${
           err instanceof Error ? err.message : "network error"
-        }`
+        }`,
       );
     } finally {
       setPending(false);

--- a/ui/src/components/SessionBindingInfo.tsx
+++ b/ui/src/components/SessionBindingInfo.tsx
@@ -78,7 +78,7 @@ const SessionBindingInfoContent: FC<SessionBindingInfoProps> = ({ data }) => {
                         size="small"
                         onClick={() => {
                           navigator.clipboard.writeText(
-                            s.DetailsSSH.FingerprintID
+                            s.DetailsSSH.FingerprintID,
                           );
                         }}
                       >

--- a/ui/src/components/SessionDetails.tsx
+++ b/ui/src/components/SessionDetails.tsx
@@ -65,7 +65,7 @@ export const SessionDetails: FC<SessionDetailsProps> = ({
                         claimKey={key}
                         claimValue={values}
                       />
-                    )
+                    ),
                   )}
                   {Object.entries(profile?.claims || {}).map(([key, value]) => (
                     <ClaimRow

--- a/ui/src/components/SidebarPage.tsx
+++ b/ui/src/components/SidebarPage.tsx
@@ -1,12 +1,12 @@
 import { Box, Container, Drawer, useMediaQuery, useTheme } from "@mui/material";
-import type { FC } from "react";
-import React from "react";
+import type { FC, ReactNode } from "react";
 
 import type { SidebarData } from "../types";
 import { ToolbarOffset } from "./ToolbarOffset";
 import UserSidebarContent from "./UserSidebarContent";
 
 type SidebarPageProps = {
+  children?: ReactNode;
   data?: SidebarData;
 };
 

--- a/ui/src/components/SignInVerifyPage.tsx
+++ b/ui/src/components/SignInVerifyPage.tsx
@@ -34,14 +34,14 @@ const SignInVerifyPage: FC<SignInVerifyPageProps> = ({ data }) => {
 
   const expiresDate = parseToDate(data.expiresAt);
   const [remainingSeconds, setRemainingSeconds] = useState<number>(
-    Math.max(0, Math.round((expiresDate.getTime() - Date.now()) / 1000))
+    Math.max(0, Math.round((expiresDate.getTime() - Date.now()) / 1000)),
   );
 
   useEffect(() => {
     const id = setInterval(() => {
       const secs = Math.max(
         0,
-        Math.round((expiresDate.getTime() - Date.now()) / 1000)
+        Math.round((expiresDate.getTime() - Date.now()) / 1000),
       );
       setRemainingSeconds(secs);
     }, 1000);
@@ -113,7 +113,7 @@ const SignInVerifyPage: FC<SignInVerifyPageProps> = ({ data }) => {
               t.palette.getContrastText(
                 remainingSeconds === 0
                   ? t.palette.error.light
-                  : t.palette.primary.light
+                  : t.palette.primary.light,
               ),
             boxShadow: 1,
             mb: 1,

--- a/ui/src/components/UserSidebarContent.tsx
+++ b/ui/src/components/UserSidebarContent.tsx
@@ -5,8 +5,8 @@ import {
   ListItemIcon,
   ListItemText,
 } from "@mui/material";
-import type { FC, ReactNode } from "react";
-import React, { useContext } from "react";
+import type { FC, ReactNode, JSX } from "react";
+import { useContext } from "react";
 import { Link, Lock, User, Users } from "react-feather";
 
 import { SubpageContext } from "../context/Subpage";

--- a/ui/src/components/WebAuthnAuthenticateButton.tsx
+++ b/ui/src/components/WebAuthnAuthenticateButton.tsx
@@ -19,7 +19,7 @@ type CredentialForAuthenticate = {
 };
 
 async function authenticateCredential(
-  requestOptions: WebAuthnRequestOptions
+  requestOptions: WebAuthnRequestOptions,
 ): Promise<CredentialForAuthenticate> {
   const credential = await navigator.credentials.get({
     publicKey: {

--- a/ui/src/components/WebAuthnButton.tsx
+++ b/ui/src/components/WebAuthnButton.tsx
@@ -20,8 +20,8 @@ export const WebAuthnButton: FC<WebAuthnButtonProps> = ({
   url,
   ...props
 }) => {
-  const formRef = useRef<HTMLFormElement>();
-  const responseRef = useRef<HTMLInputElement>();
+  const formRef = useRef<HTMLFormElement>(null);
+  const responseRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string>(null);
 
   function handleClickButton(evt: React.MouseEvent): void {

--- a/ui/src/components/WebAuthnRegisterButton.tsx
+++ b/ui/src/components/WebAuthnRegisterButton.tsx
@@ -17,7 +17,7 @@ type CredentialForCreate = {
 };
 
 async function createCredential(
-  creationOptions: WebAuthnCreationOptions
+  creationOptions: WebAuthnCreationOptions,
 ): Promise<CredentialForCreate> {
   const credential = await navigator.credentials.create({
     publicKey: {

--- a/ui/src/context/Subpage.tsx
+++ b/ui/src/context/Subpage.tsx
@@ -1,5 +1,5 @@
-import type { FC } from "react";
-import React, { createContext, useState } from "react";
+import type { FC, ReactNode } from "react";
+import { createContext, useState } from "react";
 
 export interface SubpageContextValue {
   subpage: string;
@@ -12,6 +12,7 @@ export const SubpageContext = createContext<SubpageContextValue>({
 });
 
 export type SubpageContextProviderProps = {
+  children?: ReactNode;
   page: string;
 };
 export const SubpageContextProvider: FC<SubpageContextProviderProps> = ({
@@ -29,12 +30,12 @@ export const SubpageContextProvider: FC<SubpageContextProviderProps> = ({
       page === "DeviceEnrolled"
         ? "Devices Info"
         : page === "Routes"
-        ? "Routes"
-        : hashParams.get("subpage") === "Groups Info"
-        ? "Groups Info"
-        : hashParams.get("subpage") === "Devices Info"
-        ? "Devices Info"
-        : "User",
+          ? "Routes"
+          : hashParams.get("subpage") === "Groups Info"
+            ? "Groups Info"
+            : hashParams.get("subpage") === "Devices Info"
+              ? "Devices Info"
+              : "User",
     setSubpage,
   };
 

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -1,6 +1,6 @@
-import React from "react";
-import ReactDOM from "react-dom";
+import { createRoot } from "react-dom/client";
 
 import App from "./App";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+const root = createRoot(document.getElementById("root"));
+root.render(<App />);

--- a/ui/src/theme/index.ts
+++ b/ui/src/theme/index.ts
@@ -8,7 +8,7 @@ import { softShadows } from "./shadows";
 
 export const createTheme = (
   primaryColor: string,
-  secondaryColor: string
+  secondaryColor: string,
 ): MuiTheme => {
   return muiCreateTheme({
     components: {

--- a/ui/src/util/base64.ts
+++ b/ui/src/util/base64.ts
@@ -41,7 +41,7 @@ base64Lookup[95 /* _ */] = 63;
 export function encode(
   buffer: ArrayBuffer,
   chars = base64Chars,
-  padding = "="
+  padding = "=",
 ): string {
   const bytes = new Uint8Array(buffer);
   const length = bytes.length;


### PR DESCRIPTION
## Summary

Bump `react`, `react-dom` and their `@types` to 19. The app compiles and
builds; changes were mostly type-level:

- index: switch to createRoot from react-dom/client (ReactDOM.render was removed in React 19)
- Avatar/UserSidebarContent: import JSX as a type from react instead of relying on the global namespace
- SidebarPage/Subpage: declare children explicitly (React 19's FC no longer includes children implicitly)
- WebAuthnButton: pass an initial null to useRef (required arg)

## Related issues

Closes #6415
Relates to #6395

## User Explanation

Did a routine upgrade of React. Main changes were types and also how the root of the app is mounted in React 19.

## AI disclosure

Paired with Claude Code, Opus 4.8 model. It did the initial sweep and then I did some manual tweaks before committin.

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
