### PR TITLE
config: additional jwt_claims_headers validation

### DIFF
--- a/config/custom.go
+++ b/config/custom.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"reflect"
+	"regexp"
 	"slices"
 	"strconv"
 	"strings"
@@ -116,12 +117,18 @@ func NewJWTClaimHeaders(claims ...string) JWTClaimHeaders {
 	return hdrs
 }
 
+// from https://httpwg.org/specs/rfc9110.html#tokens
+var tokenRegExp = regexp.MustCompile("^[!#$%&'*+\\-.^_`|~0-9a-zA-Z]+$")
+
 // UnmarshalJSON unmarshals JSON data into the JWTClaimHeaders.
 func (hdrs *JWTClaimHeaders) UnmarshalJSON(data []byte) error {
 	var m map[string]any
 	if json.Unmarshal(data, &m) == nil {
 		*hdrs = make(map[string]string)
 		for k, v := range m {
+			if !tokenRegExp.MatchString(k) {
+				return fmt.Errorf("has invalid header name %q", k)
+			}
 			str := fmt.Sprint(v)
 			(*hdrs)[k] = str
 		}
@@ -132,6 +139,9 @@ func (hdrs *JWTClaimHeaders) UnmarshalJSON(data []byte) error {
 	if json.Unmarshal(data, &a) == nil {
 		var vs []string
 		for _, v := range a {
+			if _, isMap := v.(map[string]any); isMap {
+				return fmt.Errorf("syntax error: found nested object in array of values")
+			}
 			vs = append(vs, fmt.Sprint(v))
 		}
 		*hdrs = NewJWTClaimHeaders(vs...)

--- a/config/custom_test.go
+++ b/config/custom_test.go
@@ -106,6 +106,38 @@ func TestDecodeJWTClaimHeadersHookFunc(t *testing.T) {
 			"x-pomerium-claim-c": "c",
 		}, withClaims.Claims)
 	})
+
+	t.Run("string", func(t *testing.T) {
+		err := decoder.Decode(struct {
+			Claims any `mapstructure:"claims"`
+		}{
+			Claims: "a,b,c",
+		})
+		assert.NoError(t, err)
+		assert.Equal(t, JWTClaimHeaders{
+			"x-pomerium-claim-a": "a",
+			"x-pomerium-claim-b": "b",
+			"x-pomerium-claim-c": "c",
+		}, withClaims.Claims)
+	})
+
+	t.Run("array of objects", func(t *testing.T) {
+		err := decoder.Decode(struct {
+			Claims any `mapstructure:"claims"`
+		}{
+			Claims: []map[string]string{{"a": "a"}, {"b": "b"}, {"c": "c"}},
+		})
+		assert.ErrorContains(t, err, "'claims' syntax error: found nested object in array of values")
+	})
+
+	t.Run("invalid header name", func(t *testing.T) {
+		err := decoder.Decode(struct {
+			Claims any `mapstructure:"claims"`
+		}{
+			Claims: map[string]string{"a": "a", "b:not:ok": "b", "c": "c"},
+		})
+		assert.ErrorContains(t, err, `'claims' has invalid header name "b:not:ok"`)
+	})
 }
 
 func TestStringSlice_UnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

Currently it's possible to mix up the `jwt_claims_headers` option syntax in such a way that the config parses successfully, but then Pomerium serves a completely blank error web page. This can happen if you accidentally include a '-' before the headers, like this:

    jwt_claims_headers:
      - X-Pomerium-Claim-Email: email

This validates without an error, but results in the HTTP header name `x-pomerium-claim-map[x-pomerium-claim-email:email]`, which Envoy then rejects with a confusing error.

Add an explicit check to catch this mistake, in order to fail early with a clearer error message.

A similar situation occurs if you explicitly include some invalid character in a header name, e.g.:

    jwt_claims_headers:
      - X:Not:OK: email

Add a check for this case as well.

## Related issues

https://linear.app/pomerium/issue/ENG-4098/core-jwt-claims-headers-syntax-error-leads-to-blank-error-page

## User Explanation

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
