### PR TITLE
databrokerutil: let Reconciler accept a ClientGetter

### DIFF
--- a/internal/zero/reconciler/sync.go
+++ b/internal/zero/reconciler/sync.go
@@ -261,7 +261,7 @@ func (c *service) syncBundleToDatabroker(ctx context.Context, src io.Reader, cur
 	}
 
 	err = databrokerutil.NewReconciler(
-		c.config.databrokerClient,
+		databroker.NewStaticClientGetter(c.config.databrokerClient),
 		func(_ context.Context) (databroker.RecordSetBundle, error) {
 			return databrokerRecords, nil
 		},

--- a/pkg/databrokerutil/reconciler.go
+++ b/pkg/databrokerutil/reconciler.go
@@ -21,8 +21,7 @@ type Reconciler interface {
 }
 
 type reconciler struct {
-	reconcilerConfig
-	client              databrokerpb.DataBrokerServiceClient
+	client              databrokerpb.ClientGetter
 	currentStateBuilder StateBuilderFn
 	cmpFn               databrokerpb.RecordCompareFn
 	targetStateBuilder  StateBuilderFn
@@ -86,7 +85,7 @@ type StateBuilderFn func(ctx context.Context) (databrokerpb.RecordSetBundle, err
 
 // NewReconciler creates a new reconciler
 func NewReconciler(
-	client databrokerpb.DataBrokerServiceClient,
+	client databrokerpb.ClientGetter,
 	currentStateBuilder StateBuilderFn,
 	targetStateBuilder StateBuilderFn,
 	setCurrentState func([]*databrokerpb.Record),
@@ -95,7 +94,6 @@ func NewReconciler(
 ) Reconciler {
 	cfg := getReconcilerConfig(opts...)
 	return &reconciler{
-		reconcilerConfig:    cfg,
 		client:              client,
 		currentStateBuilder: currentStateBuilder,
 		targetStateBuilder:  targetStateBuilder,
@@ -169,7 +167,7 @@ func (r *reconciler) applyChanges(ctx context.Context, updates []*databrokerpb.R
 	ctx, op := r.telemetry.Start(ctx, "ApplyChanges")
 	defer op.Complete()
 
-	err := databrokerpb.PutMulti(ctx, r.client, updates...)
+	err := databrokerpb.PutMulti(ctx, r.client.GetDataBrokerServiceClient(), updates...)
 	if err != nil {
 		return op.Failure(fmt.Errorf("apply databroker changes: %w", err))
 	}

--- a/pkg/databrokerutil/reconciler_runner.go
+++ b/pkg/databrokerutil/reconciler_runner.go
@@ -18,9 +18,9 @@ type ReconcilerRunner interface {
 }
 
 type reconcilerRunner struct {
+	databrokerpb.ClientGetter
 	reconcilerConfig
 	reconciler Reconciler
-	client     databrokerpb.DataBrokerServiceClient
 	name       string
 	trigger    chan struct{}
 	telemetry  *telemetry.Component
@@ -30,14 +30,14 @@ type reconcilerRunner struct {
 func NewReconcilerRunner(
 	reconciler Reconciler,
 	leaseName string, // must be unique across pomerium ecosystem
-	client databrokerpb.DataBrokerServiceClient,
+	client databrokerpb.ClientGetter,
 	opts ...ReconcilerOption,
 ) ReconcilerRunner {
 	cfg := getReconcilerConfig(opts...)
 	return &reconcilerRunner{
+		ClientGetter:     client,
 		reconcilerConfig: cfg,
 		reconciler:       reconciler,
-		client:           client,
 		name:             fmt.Sprintf("%s-reconciler", leaseName),
 		trigger:          make(chan struct{}, 1),
 		telemetry:        telemetry.NewComponent(cfg.tracerProvider, zerolog.InfoLevel, "databroker-reconciler", cfg.attributes...),
@@ -56,11 +56,6 @@ func (rr *reconcilerRunner) TriggerSync() {
 func (rr *reconcilerRunner) Run(ctx context.Context) error {
 	leaser := NewLeaser(rr.name, rr.interval, rr, WithLeaserErrorHandler(rr.errorHandler))
 	return leaser.Run(ctx)
-}
-
-// GetDataBrokerServiceClient implements the LeaseHandler interface.
-func (rr *reconcilerRunner) GetDataBrokerServiceClient() databrokerpb.DataBrokerServiceClient {
-	return rr.client
 }
 
 // RunLeased implements the LeaseHandler interface.

--- a/pkg/databrokerutil/reconciler_runner_test.go
+++ b/pkg/databrokerutil/reconciler_runner_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/mock/gomock"
+
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker/mock_databroker"
 )
 
 func TestReconcilerRunner(t *testing.T) {
@@ -114,6 +118,25 @@ func TestReconcilerRunnerErrorLogging(t *testing.T) {
 		synctest.Wait()
 		assert.ErrorIs(t, runError, context.Canceled)
 	})
+}
+
+func TestReconcilerRunnerClientGetter(t *testing.T) {
+	t.Parallel()
+
+	var client databroker.DataBrokerServiceClient
+	clientGetter := databroker.ClientGetterFunc(func() databroker.DataBrokerServiceClient { return client })
+	rr := NewReconcilerRunner(nil, "test", clientGetter)
+
+	ctrl := gomock.NewController(t)
+	client1 := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+	client2 := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+
+	// GetDataBrokerServiceClient() should always return the latest client.
+	client = client1
+	assert.Equal(t, client1, rr.GetDataBrokerServiceClient())
+
+	client = client2
+	assert.Equal(t, client2, rr.GetDataBrokerServiceClient())
 }
 
 func TestReconcilerRunnerOptionsSet(t *testing.T) {

--- a/pkg/databrokerutil/reconciler_test.go
+++ b/pkg/databrokerutil/reconciler_test.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace/noop"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
@@ -61,7 +59,7 @@ func TestReconciler(t *testing.T) {
 		client := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
 
 		r := NewReconciler(
-			client,
+			databroker.NewStaticClientGetter(client),
 			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
@@ -99,7 +97,7 @@ func TestReconciler(t *testing.T) {
 			Return(&databroker.PutResponse{}, nil)
 
 		r := NewReconciler(
-			client,
+			databroker.NewStaticClientGetter(client),
 			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
@@ -137,7 +135,7 @@ func TestReconciler(t *testing.T) {
 			Return(&databroker.PutResponse{}, nil)
 
 		r := NewReconciler(
-			client,
+			databroker.NewStaticClientGetter(client),
 			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
@@ -181,7 +179,7 @@ func TestReconciler(t *testing.T) {
 			Return(&databroker.PutResponse{}, nil)
 
 		r := NewReconciler(
-			client,
+			databroker.NewStaticClientGetter(client),
 			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
@@ -229,7 +227,7 @@ func TestReconciler(t *testing.T) {
 			Return(&databroker.PutResponse{}, nil)
 
 		r := NewReconciler(
-			client,
+			databroker.NewStaticClientGetter(client),
 			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
@@ -245,6 +243,64 @@ func TestReconciler(t *testing.T) {
 		testutil.AssertProtoEqual(t, target, current)
 	})
 
+	t.Run("databroker client change", func(t *testing.T) {
+		t.Parallel()
+
+		exampleRecord := &databroker.Record{
+			Type: "test.Type",
+			Id:   "record-1",
+			Data: protoutil.ToAny(map[string]any{"name": "test"}),
+		}
+
+		current, setCurrentState := initCurrent()
+		target := databroker.RecordSetBundle{}
+
+		var currentClient databroker.DataBrokerServiceClient
+		clientGetter := databroker.ClientGetterFunc(
+			func() databroker.DataBrokerServiceClient { return currentClient })
+
+		ctrl := gomock.NewController(t)
+
+		r := NewReconciler(
+			clientGetter,
+			func(context.Context) (databroker.RecordSetBundle, error) {
+				return current, nil
+			},
+			func(context.Context) (databroker.RecordSetBundle, error) {
+				return target, nil
+			},
+			setCurrentState,
+			cmpFn,
+		)
+
+		// First add a databroker record.
+		target.Add(exampleRecord)
+
+		client1 := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+		client1.EXPECT().
+			Put(gomock.Any(), mock_databroker.PutRequestFor(exampleRecord)).
+			Return(&databroker.PutResponse{}, nil)
+		currentClient = client1
+
+		err := r.Reconcile(t.Context())
+		require.NoError(t, err)
+		testutil.AssertProtoEqual(t, target, current)
+
+		// Then delete this record after changing the databroker client.
+		// The Reconcile() method should use the updated client.
+		clear(target)
+
+		client2 := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+		client2.EXPECT().
+			Put(gomock.Any(), mock_databroker.DeleteRequestFor(exampleRecord)).
+			Return(&databroker.PutResponse{}, nil)
+		currentClient = client2
+
+		err = r.Reconcile(t.Context())
+		require.NoError(t, err)
+		testutil.AssertProtoEqual(t, target, current)
+	})
+
 	t.Run("current state builder error", func(t *testing.T) {
 		t.Parallel()
 
@@ -255,7 +311,7 @@ func TestReconciler(t *testing.T) {
 		builderErr := errors.New("failed to build current state")
 
 		r := NewReconciler(
-			client,
+			databroker.NewStaticClientGetter(client),
 			func(context.Context) (databroker.RecordSetBundle, error) {
 				return nil, builderErr
 			},
@@ -281,7 +337,7 @@ func TestReconciler(t *testing.T) {
 		builderErr := errors.New("failed to build target state")
 
 		r := NewReconciler(
-			client,
+			databroker.NewStaticClientGetter(client),
 			func(context.Context) (databroker.RecordSetBundle, error) {
 				return databroker.RecordSetBundle{}, nil
 			},
@@ -317,7 +373,7 @@ func TestReconciler(t *testing.T) {
 			Return(nil, putErr)
 
 		r := NewReconciler(
-			client,
+			databroker.NewStaticClientGetter(client),
 			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
@@ -345,7 +401,7 @@ func TestReconciler(t *testing.T) {
 		cancel() // cancel immediately
 
 		r := NewReconciler(
-			client,
+			databroker.NewStaticClientGetter(client),
 			func(context.Context) (databroker.RecordSetBundle, error) {
 				return nil, ctx.Err()
 			},
@@ -361,22 +417,14 @@ func TestReconciler(t *testing.T) {
 		assert.ErrorIs(t, err, context.Canceled)
 	})
 
-	t.Run("reconciler options", func(t *testing.T) {
+	t.Run("trace provider option", func(t *testing.T) {
 		t.Parallel()
 
-		attr := attribute.String("test", "value")
-		interval := 123 * time.Second
 		traceProvider := noop.NewTracerProvider()
 
 		r := NewReconciler(nil, nil, nil, nil, nil,
-			WithAttributes(attr),
-			WithInterval(interval),
-			WithReconcilerErrorHandler(func(error) {}),
 			WithReconcilerTracerProvider(traceProvider),
 		).(*reconciler)
-		assert.Equal(t, []attribute.KeyValue{attr}, r.attributes)
-		assert.Equal(t, interval, r.interval)
-		assert.NotNil(t, r.errorHandler)
-		assert.Equal(t, traceProvider, r.tracerProvider)
+		assert.Equal(t, traceProvider, r.telemetry.GetTracerProvider())
 	})
 }

--- a/pkg/grpc/databroker/client.go
+++ b/pkg/grpc/databroker/client.go
@@ -5,15 +5,11 @@ type ClientGetter interface {
 }
 
 func NewStaticClientGetter(client DataBrokerServiceClient) ClientGetter {
-	return staticClientGetter{
-		client: client,
-	}
+	return ClientGetterFunc(func() DataBrokerServiceClient { return client })
 }
 
-type staticClientGetter struct {
-	client DataBrokerServiceClient
-}
+type ClientGetterFunc func() DataBrokerServiceClient
 
-func (w staticClientGetter) GetDataBrokerServiceClient() DataBrokerServiceClient {
-	return w.client
+func (f ClientGetterFunc) GetDataBrokerServiceClient() DataBrokerServiceClient {
+	return f()
 }


### PR DESCRIPTION
## Summary

Refactor the `databroker.Reconciler` and `databroker.ReconcilerRunner` types to accept a `ClientGetter` rather than a databroker client itself. In some use cases the databroker client may need to change during runtime, so this way the `Reconciler` can be robust to these changes.

## Related issues

https://linear.app/pomerium/issue/ENG-4116/enterprise-core-reconcilers-may-not-respond-to-databroker-client

## User Explanation

## AI disclosure

Claude Code suggested test cases for `ReconcilerRunner` and drafted a couple of the unit tests. I simplified one of these tests by using the `synctest` package and expanded it to cover additional cases.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
