### PR TITLE
Makefile: refactor deps-build + deps-release

### DIFF
--- a/.github/goreleaser-mac.yaml
+++ b/.github/goreleaser-mac.yaml
@@ -16,9 +16,7 @@ env:
 before:
   hooks:
     - go mod download
-    - make get-envoy
-    - make build-deps
-    - make build-ui
+    - make deps-build deps-release build-ui
 
 builds:
   - id: pomerium

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -16,9 +16,7 @@ env:
 before:
   hooks:
     - go mod download
-    - make get-envoy
-    - make build-deps
-    - make build-ui
+    - make deps-build deps-release build-ui
 
 builds:
   - id: pomerium

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -64,9 +64,7 @@ jobs:
           node-version-file: .tool-versions
 
       - name: build
-        run: |
-          make build-deps
-          make build
+        run: make build
 
       - name: save binary
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ ENVOY_OCI_REPO ?= "ghcr.io/pomerium/envoy-custom"
 GET_ENVOY_DEBUG :=
 
 .PHONY: all
-all: clean build-deps test lint build ## Runs a clean, build, fmt, lint, test, and vet.
+all: clean deps-build test lint build ## Runs a clean, build, fmt, lint, test, and vet.
 
 .PHONY: setup-merge-driver
 setup-merge-driver: ## Configure git merge driver for components.json (run once after cloning)
@@ -67,10 +67,6 @@ deps-build: get-envoy ## Install build dependencies
 deps-release: get-envoy ## Install release dependencies
 	@echo "==> $@"
 	@$(GO) install github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}
-
-.PHONY: build-deps
-build-deps: deps-build deps-release
-	@echo "==> $@"
 
 .PHONY: proto-before
 proto-before:
@@ -100,12 +96,12 @@ build: build-ui build-go
 	@echo "==> $@"
 
 .PHONY: build-debug
-build-debug: build-deps ## Builds binaries appropriate for debugging
+build-debug: deps-build ## Builds binaries appropriate for debugging
 	@echo "==> $@"
 	@CGO_ENABLED=0 $(GO) build -gcflags="all=-N -l" -o $(BINDIR)/$(NAME) ./cmd/"$(NAME)"
 
 .PHONY: build-go
-build-go: build-deps
+build-go: deps-build
 	@echo "==> $@"
 	@CGO_ENABLED=0 $(GO) build -tags "$(BUILDTAGS)" ${GO_LDFLAGS} -o $(BINDIR)/$(NAME) ./cmd/"$(NAME)"
 
@@ -121,7 +117,7 @@ build-ui: npm-install
 	@cd ui; npm run build
 
 .PHONY: go-fix
-go-fix: build-deps
+go-fix: deps-build
 	@echo "==> $@"
 	$(GO) fix ./...
 
@@ -183,7 +179,7 @@ clean: ## Cleanup any build binaries or packages.
 	$(RM) -r /tmp/pomerium-protoc-3pp
 
 .PHONY: snapshot
-snapshot: build-deps ## Builds the cross-compiled binaries, naming them in such a way for release (eg. binary-GOOS-GOARCH)
+snapshot: deps-build deps-release ## Builds the cross-compiled binaries, naming them in such a way for release (eg. binary-GOOS-GOARCH)
 	@echo "==> $@"
 	@goreleaser release --clean -f .github/goreleaser.yaml --snapshot
 


### PR DESCRIPTION
## Summary

The `deps-release` target is not needed for a dev build. Also, it's confusing that there is both a `deps-build` and `build-deps` target. Refactor these targets to simplify this and remove `deps-release` from the main build path.

Update the goreleaser configuration files to explicitly invoke the `deps-release` target during the release process.

## Related issues

## User Explanation

## AI disclosure

none

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
