### PR TITLE
databrokerutil: add Reconciler unit tests

### DIFF
--- a/pkg/databrokerutil/reconciler_test.go
+++ b/pkg/databrokerutil/reconciler_test.go
@@ -62,10 +62,10 @@ func TestReconciler(t *testing.T) {
 
 		r := NewReconciler(
 			client,
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return target, nil
 			},
 			setCurrentState,
@@ -100,10 +100,10 @@ func TestReconciler(t *testing.T) {
 
 		r := NewReconciler(
 			client,
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return target, nil
 			},
 			setCurrentState,
@@ -138,10 +138,10 @@ func TestReconciler(t *testing.T) {
 
 		r := NewReconciler(
 			client,
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return target, nil
 			},
 			setCurrentState,
@@ -182,10 +182,10 @@ func TestReconciler(t *testing.T) {
 
 		r := NewReconciler(
 			client,
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return target, nil
 			},
 			setCurrentState,
@@ -230,10 +230,10 @@ func TestReconciler(t *testing.T) {
 
 		r := NewReconciler(
 			client,
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return target, nil
 			},
 			setCurrentState,
@@ -256,13 +256,13 @@ func TestReconciler(t *testing.T) {
 
 		r := NewReconciler(
 			client,
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return nil, builderErr
 			},
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return databroker.RecordSetBundle{}, nil
 			},
-			func(records []*databroker.Record) {},
+			func([]*databroker.Record) {},
 			cmpFn,
 		)
 
@@ -282,13 +282,13 @@ func TestReconciler(t *testing.T) {
 
 		r := NewReconciler(
 			client,
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return databroker.RecordSetBundle{}, nil
 			},
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return nil, builderErr
 			},
-			func(records []*databroker.Record) {},
+			func([]*databroker.Record) {},
 			cmpFn,
 		)
 
@@ -318,10 +318,10 @@ func TestReconciler(t *testing.T) {
 
 		r := NewReconciler(
 			client,
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return current, nil
 			},
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return target, nil
 			},
 			setCurrentState,
@@ -346,13 +346,13 @@ func TestReconciler(t *testing.T) {
 
 		r := NewReconciler(
 			client,
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return nil, ctx.Err()
 			},
-			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+			func(context.Context) (databroker.RecordSetBundle, error) {
 				return databroker.RecordSetBundle{}, nil
 			},
-			func(records []*databroker.Record) {},
+			func([]*databroker.Record) {},
 			cmpFn,
 		)
 

--- a/pkg/databrokerutil/reconciler_test.go
+++ b/pkg/databrokerutil/reconciler_test.go
@@ -1,0 +1,382 @@
+package databrokerutil
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/testing/protocmp"
+
+	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker/mock_databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+func TestReconciler(t *testing.T) {
+	t.Parallel()
+
+	cmpFn := func(r1, r2 *databroker.Record) bool {
+		return cmp.Equal(r1, r2, protocmp.Transform())
+	}
+
+	initCurrent := func() (databroker.RecordSetBundle, func(records []*databroker.Record)) {
+		current := databroker.RecordSetBundle{}
+		setCurrentState := func(records []*databroker.Record) {
+			clear(current)
+			for _, r := range records {
+				if r.DeletedAt == nil {
+					current.Add(r)
+				}
+			}
+		}
+		return current, setCurrentState
+	}
+
+	t.Run("no changes", func(t *testing.T) {
+		t.Parallel()
+
+		exampleRecord := &databroker.Record{
+			Type: "test.Type",
+			Id:   "record-1",
+			Data: protoutil.ToAny(map[string]any{"name": "test"}),
+		}
+
+		// Current and target both contain the same record, with the same data.
+		current, setCurrentState := initCurrent()
+		current.Add(exampleRecord)
+		target := databroker.RecordSetBundle{}
+		target.Add(proto.CloneOf(exampleRecord))
+
+		// No databroker calls expected because there are no changes.
+		ctrl := gomock.NewController(t)
+		client := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+
+		r := NewReconciler(
+			client,
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return current, nil
+			},
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return target, nil
+			},
+			setCurrentState,
+			cmpFn,
+		)
+
+		err := r.Reconcile(t.Context())
+		require.NoError(t, err)
+		assert.Empty(t, current)
+	})
+
+	t.Run("add record", func(t *testing.T) {
+		t.Parallel()
+
+		exampleRecord := &databroker.Record{
+			Type: "test.Type",
+			Id:   "record-1",
+			Data: protoutil.ToAny(map[string]any{"name": "test"}),
+		}
+
+		// Current empty, target has one record.
+		current, setCurrentState := initCurrent()
+		target := databroker.RecordSetBundle{}
+		target.Add(exampleRecord)
+
+		// This should result in a request to add the one target record.
+		ctrl := gomock.NewController(t)
+		client := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+		client.EXPECT().
+			Put(gomock.Any(), mock_databroker.PutRequestFor(exampleRecord)).
+			Return(&databroker.PutResponse{}, nil)
+
+		r := NewReconciler(
+			client,
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return current, nil
+			},
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return target, nil
+			},
+			setCurrentState,
+			cmpFn,
+		)
+
+		err := r.Reconcile(t.Context())
+		require.NoError(t, err)
+		testutil.AssertProtoEqual(t, target, current)
+	})
+
+	t.Run("delete record", func(t *testing.T) {
+		t.Parallel()
+
+		exampleRecord := &databroker.Record{
+			Type: "test.Type",
+			Id:   "record-1",
+			Data: protoutil.ToAny(map[string]any{"name": "test"}),
+		}
+
+		// Current has one record, target empty.
+		current, setCurrentState := initCurrent()
+		current.Add(exampleRecord)
+		target := databroker.RecordSetBundle{}
+
+		// This should result in a request to delete the one current record.
+		ctrl := gomock.NewController(t)
+		client := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+		client.EXPECT().
+			Put(gomock.Any(), mock_databroker.DeleteRequestFor(exampleRecord)).
+			Return(&databroker.PutResponse{}, nil)
+
+		r := NewReconciler(
+			client,
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return current, nil
+			},
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return target, nil
+			},
+			setCurrentState,
+			cmpFn,
+		)
+
+		err := r.Reconcile(t.Context())
+		require.NoError(t, err)
+		assert.Empty(t, current)
+	})
+
+	t.Run("modify record", func(t *testing.T) {
+		t.Parallel()
+
+		oldRecord := &databroker.Record{
+			Type: "test.Type",
+			Id:   "record-1",
+			Data: protoutil.ToAny(map[string]any{"name": "old-value"}),
+		}
+		newRecord := &databroker.Record{
+			Type: "test.Type",
+			Id:   "record-1",
+			Data: protoutil.ToAny(map[string]any{"name": "new-value"}),
+		}
+
+		// Current and target both contain the same record, but with different data.
+		current, setCurrentState := initCurrent()
+		current.Add(oldRecord)
+		target := databroker.RecordSetBundle{}
+		target.Add(newRecord)
+
+		// This should result in a Put call to update the record.
+		ctrl := gomock.NewController(t)
+		client := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+		client.EXPECT().
+			Put(gomock.Any(), mock_databroker.PutRequestFor(newRecord)).
+			Return(&databroker.PutResponse{}, nil)
+
+		r := NewReconciler(
+			client,
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return current, nil
+			},
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return target, nil
+			},
+			setCurrentState,
+			cmpFn,
+		)
+
+		err := r.Reconcile(t.Context())
+		require.NoError(t, err)
+		testutil.AssertProtoEqual(t, target, current)
+	})
+
+	t.Run("multiple record types", func(t *testing.T) {
+		t.Parallel()
+
+		a1 := &databroker.Record{
+			Type: "type.A",
+			Id:   "record-1",
+			Data: protoutil.ToAny(map[string]any{"value": "a1"}),
+		}
+		a1Modified := &databroker.Record{
+			Type: "type.A",
+			Id:   "record-1",
+			Data: protoutil.ToAny(map[string]any{"value": "a1-modified"}),
+		}
+		b1 := &databroker.Record{
+			Type: "type.B",
+			Id:   "record-2",
+			Data: protoutil.ToAny(map[string]any{"value": "b1"}),
+		}
+
+		current, setCurrentState := initCurrent()
+		current.Add(a1)
+		target := databroker.RecordSetBundle{}
+		target.Add(a1Modified)
+		target.Add(b1)
+
+		ctrl := gomock.NewController(t)
+		client := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+		client.EXPECT().
+			Put(gomock.Any(), mock_databroker.PutRequestFor(a1Modified, b1)).
+			Return(&databroker.PutResponse{}, nil)
+
+		r := NewReconciler(
+			client,
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return current, nil
+			},
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return target, nil
+			},
+			setCurrentState,
+			cmpFn,
+		)
+
+		err := r.Reconcile(t.Context())
+		require.NoError(t, err)
+		testutil.AssertProtoEqual(t, target, current)
+	})
+
+	t.Run("current state builder error", func(t *testing.T) {
+		t.Parallel()
+
+		// No databroker calls expected if state building fails.
+		ctrl := gomock.NewController(t)
+		client := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+
+		builderErr := errors.New("failed to build current state")
+
+		r := NewReconciler(
+			client,
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return nil, builderErr
+			},
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return databroker.RecordSetBundle{}, nil
+			},
+			func(records []*databroker.Record) {},
+			cmpFn,
+		)
+
+		err := r.Reconcile(t.Context())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, builderErr)
+	})
+
+	t.Run("target state builder error", func(t *testing.T) {
+		t.Parallel()
+
+		// No databroker calls expected if state building fails.
+		ctrl := gomock.NewController(t)
+		client := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+
+		builderErr := errors.New("failed to build target state")
+
+		r := NewReconciler(
+			client,
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return databroker.RecordSetBundle{}, nil
+			},
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return nil, builderErr
+			},
+			func(records []*databroker.Record) {},
+			cmpFn,
+		)
+
+		err := r.Reconcile(t.Context())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, builderErr)
+	})
+
+	t.Run("put error", func(t *testing.T) {
+		t.Parallel()
+
+		current, setCurrentState := initCurrent()
+		target := databroker.RecordSetBundle{}
+		target.Add(&databroker.Record{
+			Type: "test.Type",
+			Id:   "record-1",
+			Data: protoutil.ToAny(map[string]any{"name": "test"}),
+		})
+
+		ctrl := gomock.NewController(t)
+
+		putErr := errors.New("failed to put records")
+		client := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+		client.EXPECT().
+			Put(gomock.Any(), gomock.Any()).
+			Return(nil, putErr)
+
+		r := NewReconciler(
+			client,
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return current, nil
+			},
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return target, nil
+			},
+			setCurrentState,
+			cmpFn,
+		)
+
+		err := r.Reconcile(t.Context())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, putErr)
+		assert.Empty(t, current) // current state should not be updated if there was an error
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		t.Parallel()
+
+		ctrl := gomock.NewController(t)
+
+		client := mock_databroker.NewMockDataBrokerServiceClient(ctrl)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel() // cancel immediately
+
+		r := NewReconciler(
+			client,
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return nil, ctx.Err()
+			},
+			func(ctx context.Context) (databroker.RecordSetBundle, error) {
+				return databroker.RecordSetBundle{}, nil
+			},
+			func(records []*databroker.Record) {},
+			cmpFn,
+		)
+
+		err := r.Reconcile(ctx)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("reconciler options", func(t *testing.T) {
+		t.Parallel()
+
+		attr := attribute.String("test", "value")
+		interval := 123 * time.Second
+		traceProvider := noop.NewTracerProvider()
+
+		r := NewReconciler(nil, nil, nil, nil, nil,
+			WithAttributes(attr),
+			WithInterval(interval),
+			WithReconcilerErrorHandler(func(error) {}),
+			WithReconcilerTracerProvider(traceProvider),
+		).(*reconciler)
+		assert.Equal(t, []attribute.KeyValue{attr}, r.attributes)
+		assert.Equal(t, interval, r.interval)
+		assert.NotNil(t, r.errorHandler)
+		assert.Equal(t, traceProvider, r.tracerProvider)
+	})
+}

--- a/pkg/grpc/databroker/mock_databroker/matchers.go
+++ b/pkg/grpc/databroker/mock_databroker/matchers.go
@@ -9,15 +9,20 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
+func PutRequestFor(records ...*databroker.Record) gomock.Matcher {
+	return putRequestMatcher{expected: records}
+}
+
 func DeleteRequestFor(records ...*databroker.Record) gomock.Matcher {
-	return deleteRequestMatcher{records}
+	return putRequestMatcher{expected: records, wantDeleted: true}
 }
 
-type deleteRequestMatcher struct {
-	expected []*databroker.Record
+type putRequestMatcher struct {
+	expected    []*databroker.Record
+	wantDeleted bool
 }
 
-func (m deleteRequestMatcher) Matches(x any) bool {
+func (m putRequestMatcher) Matches(x any) bool {
 	p, ok := x.(*databroker.PutRequest)
 	if !ok {
 		return false
@@ -28,13 +33,17 @@ func (m deleteRequestMatcher) Matches(x any) bool {
 		if !proto.Equal(p.Records[i].Data, m.expected[i].Data) {
 			return false
 		}
-		if p.Records[i].DeletedAt == nil {
+		hasDeletedAt := p.Records[i].DeletedAt != nil
+		if hasDeletedAt != m.wantDeleted {
 			return false
 		}
 	}
 	return true
 }
 
-func (m deleteRequestMatcher) String() string {
-	return fmt.Sprintf("is PutRequest to delete %v", m.expected)
+func (m putRequestMatcher) String() string {
+	if m.wantDeleted {
+		return fmt.Sprintf("is PutRequest to delete %v", m.expected)
+	}
+	return fmt.Sprintf("is PutRequest for %v", m.expected)
 }


### PR DESCRIPTION
## Summary

It looks like currently the `databrokerutil.Reconciler` type does not have any unit test coverage. Let's add some tests.

## Related issues

In preparation for https://linear.app/pomerium/issue/ENG-4116/enterprise-core-reconcilers-may-not-respond-to-databroker-client.

## User Explanation

## AI disclosure

Claude Code drafted these tests. I reworked the `current` state setup, added specific databroker mock expectations, and simplified the assertions around `current` state updates.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
