### PR TITLE
fix(dependabot): remove duplicate npm ecosystem entries

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -79,30 +79,6 @@ updates:
     directory: "/ui"
     schedule:
       interval: "weekly"
-    groups:
-      npm:
-        patterns:
-          - "*"
-  - package-ecosystem: "npm"
-    directory: "/internal/acceptance/browser"
-    schedule:
-      interval: "weekly"
-    groups:
-      npm:
-        patterns:
-          - "*"
-  - package-ecosystem: "npm"
-    directory: "/internal/acceptance/ws-server"
-    schedule:
-      interval: "weekly"
-    groups:
-      npm:
-        patterns:
-          - "*"
-  - package-ecosystem: "npm"
-    directory: "/ui"
-    schedule:
-      interval: "weekly"
     open-pull-requests-limit: 50
     groups:
       npm:


### PR DESCRIPTION
## Summary

Fixes a regression merged in #6227. That PR's rebase auto-merged `.github/dependabot.yaml` and kept **two** npm entries for each of `/ui`, `/internal/acceptance/browser`, and `/internal/acceptance/ws-server` -- one set carried over from main (no explicit `open-pull-requests-limit`) and one set from the PR (with `open-pull-requests-limit: 50`).

Dependabot rejects duplicate `package-ecosystem` + `directory` pairs, so the Dependabot config validator now fails on main and dependency-update runs for those directories are blocked.

This removes the duplicate entries, keeping the `open-pull-requests-limit: 50` variants to stay consistent with every other ecosystem in the file. Net: 12 update entries -> 9, no duplicate pairs.

## Validation

- Parsed the file and confirmed 0 duplicate `(package-ecosystem, directory)` pairs (9 entries total).

## AI assistance

Drafted by Claude Code (Opus 4.8). The duplicate was introduced by an AI-assisted rebase of #6227; this PR is the follow-up fix. Claude wrote the change and PR body; the dedupe choice (keep the limit-50 variants) was verified by parsing the resulting config. A human should confirm before merge.