### PR TITLE
ssh: use xds route configuration

### DIFF
--- a/config/envoyconfig/listeners_ssh.go
+++ b/config/envoyconfig/listeners_ssh.go
@@ -1,23 +1,16 @@
 package envoyconfig
 
 import (
-	"fmt"
-	"net/url"
 	"strings"
 
-	xds_core_v3 "github.com/cncf/xds/go/xds/core/v3"
-	xds_matcher_v3 "github.com/cncf/xds/go/xds/type/matcher/v3"
 	xds_type_v3 "github.com/cncf/xds/go/xds/type/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/config/ratelimit/v3"
 	envoy_common_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/common/ratelimit/v3"
-	envoy_generic_proxy_action_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/action/v3"
-	envoy_generic_proxy_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/matcher/v3"
 	envoy_generic_router_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/router/v3"
 	envoy_generic_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/v3"
 	envoy_generic_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/ratelimit/v3"
-	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -50,10 +43,6 @@ func newRateLimitEntries() []*envoy_common_ratelimit_v3.RateLimitDescriptor_Entr
 func buildSSHListener(cfg *config.Config, extensionsToLoad []string) (*envoy_config_listener_v3.Listener, error) {
 	if cfg.Options.SSHAddr == "" {
 		return nil, nil
-	}
-	rc, err := buildRouteConfig(cfg)
-	if err != nil {
-		return nil, err
 	}
 
 	authorizeService := &envoy_config_core_v3.GrpcService{
@@ -187,8 +176,16 @@ func buildSSHListener(cfg *config.Config, extensionsToLoad []string) (*envoy_con
 							}),
 						},
 					},
-					RouteSpecifier: &envoy_generic_proxy_v3.GenericProxy_RouteConfig{
-						RouteConfig: rc,
+					RouteSpecifier: &envoy_generic_proxy_v3.GenericProxy_GenericRds{
+						GenericRds: &envoy_generic_proxy_v3.GenericRds{
+							ConfigSource: &envoy_config_core_v3.ConfigSource{
+								ResourceApiVersion:    envoy_config_core_v3.ApiVersion_V3,
+								ConfigSourceSpecifier: &envoy_config_core_v3.ConfigSource_Ads{},
+							},
+							// Matches the ssh generic proxy RouteConfiguration created by
+							// buildSSHRouteConfiguration in route_configurations.go.
+							RouteConfigName: "ssh",
+						},
 					},
 				}),
 			},
@@ -206,87 +203,6 @@ func buildSSHListener(cfg *config.Config, extensionsToLoad []string) (*envoy_con
 	}
 	li.Address, li.AdditionalAddresses = buildTCPListenAddresses(cfg.Options.SSHAddr, 22)
 	return li, nil
-}
-
-func buildRouteConfig(cfg *config.Config) (*envoy_generic_proxy_v3.RouteConfiguration, error) {
-	var routeMatchers []*xds_matcher_v3.Matcher_MatcherList_FieldMatcher
-	for route := range cfg.Options.GetAllPolicies() {
-		if !route.IsSSH() {
-			continue
-		}
-		from, err := url.Parse(route.From)
-		if err != nil {
-			return nil, err
-		}
-		fromHost := from.Hostname()
-		if len(route.To) > 1 {
-			return nil, fmt.Errorf("only one 'to' entry allowed for ssh routes")
-		}
-		to := route.To[0].URL
-		if to.Scheme != "ssh" {
-			return nil, fmt.Errorf("'to' route url must have ssh scheme")
-		}
-		clusterID := GetClusterID(route)
-		routeMatchers = append(routeMatchers, &xds_matcher_v3.Matcher_MatcherList_FieldMatcher{
-			Predicate: &xds_matcher_v3.Matcher_MatcherList_Predicate{
-				MatchType: &xds_matcher_v3.Matcher_MatcherList_Predicate_SinglePredicate_{
-					SinglePredicate: &xds_matcher_v3.Matcher_MatcherList_Predicate_SinglePredicate{
-						Input: &xds_core_v3.TypedExtensionConfig{
-							Name:        "request",
-							TypedConfig: marshalAny(&envoy_generic_proxy_matcher_v3.RequestMatchInput{}),
-						},
-						Matcher: &xds_matcher_v3.Matcher_MatcherList_Predicate_SinglePredicate_CustomMatch{
-							CustomMatch: &xds_core_v3.TypedExtensionConfig{
-								Name: "request",
-								TypedConfig: marshalAny(&envoy_generic_proxy_matcher_v3.RequestMatcher{
-									Host: &matcherv3.StringMatcher{
-										MatchPattern: &matcherv3.StringMatcher_Exact{
-											Exact: fromHost,
-										},
-									},
-								}),
-							},
-						},
-					},
-				},
-			},
-			OnMatch: &xds_matcher_v3.Matcher_OnMatch{
-				OnMatch: &xds_matcher_v3.Matcher_OnMatch_Action{
-					Action: &xds_core_v3.TypedExtensionConfig{
-						Name: "route",
-						TypedConfig: marshalAny(&envoy_generic_proxy_action_v3.RouteAction{
-							Name: route.ID,
-							ClusterSpecifier: &envoy_generic_proxy_action_v3.RouteAction_Cluster{
-								Cluster: clusterID,
-							},
-							Timeout: durationpb.New(0),
-						}),
-					},
-				},
-			},
-		})
-	}
-	if len(routeMatchers) == 0 {
-		return &envoy_generic_proxy_v3.RouteConfiguration{
-			Name: "route_config",
-		}, nil
-	}
-	return &envoy_generic_proxy_v3.RouteConfiguration{
-		Name: "route_config",
-		VirtualHosts: []*envoy_generic_proxy_v3.VirtualHost{
-			{
-				Name:  "ssh",
-				Hosts: []string{"*"},
-				Routes: &xds_matcher_v3.Matcher{
-					MatcherType: &xds_matcher_v3.Matcher_MatcherList_{
-						MatcherList: &xds_matcher_v3.Matcher_MatcherList{
-							Matchers: routeMatchers,
-						},
-					},
-				},
-			},
-		},
-	}, nil
 }
 
 func shouldStartSSHListener(options *config.Options) bool {

--- a/config/envoyconfig/listeners_ssh_test.go
+++ b/config/envoyconfig/listeners_ssh_test.go
@@ -100,34 +100,6 @@ func TestBuildSSHListener(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NoError(t, l.ValidateAll())
 	})
-	t.Run("invalid From url", func(t *testing.T) {
-		cfg := config.New(config.NewDefaultOptions())
-		cfg.Options.SSHAddr = "0.0.0.0:22"
-		cfg.Options.Policies = []config.Policy{
-			{From: "ssh://\x7f", To: mustParseWeightedURLs(t, "ssh://to1:22")},
-		}
-		_, err := buildSSHListener(cfg, []string{})
-		assert.Error(t, err)
-	})
-	t.Run("multiple To urls", func(t *testing.T) {
-		cfg := config.New(config.NewDefaultOptions())
-		cfg.Options.SSHAddr = "0.0.0.0:22"
-		cfg.Options.Policies = []config.Policy{
-			{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://to1:22", "ssh://to2:22")},
-		}
-		_, err := buildSSHListener(cfg, []string{})
-		assert.Error(t, err)
-	})
-	t.Run("To url missing scheme", func(t *testing.T) {
-		cfg := config.New(config.NewDefaultOptions())
-		cfg.Options.SSHAddr = "0.0.0.0:22"
-		cfg.Options.Policies = []config.Policy{
-			{From: "ssh://host1", To: mustParseWeightedURLs(t, "http://to1:22")},
-		}
-		_, err := buildSSHListener(cfg, []string{})
-		assert.Error(t, err)
-	})
-
 	t.Run("connection buffer limits", func(t *testing.T) {
 		cfg := config.New(config.NewDefaultOptions())
 		cfg.Options.SSHAddr = "0.0.0.0:22"

--- a/config/envoyconfig/route_configurations.go
+++ b/config/envoyconfig/route_configurations.go
@@ -3,12 +3,20 @@ package envoyconfig
 import (
 	"cmp"
 	"context"
+	"fmt"
 	"net/url"
 	"slices"
 	"strings"
 
+	xds_core_v3 "github.com/cncf/xds/go/xds/core/v3"
+	xds_matcher_v3 "github.com/cncf/xds/go/xds/type/matcher/v3"
 	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	envoy_generic_proxy_action_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/action/v3"
+	envoy_generic_proxy_matcher_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/matcher/v3"
+	envoy_generic_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/v3"
 	"github.com/hashicorp/go-set/v3"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/pomerium/pomerium/config"
@@ -16,22 +24,43 @@ import (
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
+type RouteConfiguration struct {
+	Name   string
+	Config proto.Message
+}
+
 // BuildRouteConfigurations builds the route configurations for the RDS service.
 func (b *Builder) BuildRouteConfigurations(
 	ctx context.Context,
 	cfg *config.Config,
-) ([]*envoy_config_route_v3.RouteConfiguration, error) {
+) ([]RouteConfiguration, error) {
+	if !config.IsAuthenticate(cfg.Options.Services) && !config.IsProxy(cfg.Options.Services) {
+		return nil, nil
+	}
+
 	ctx, span := trace.Continue(ctx, "envoyconfig.Builder.BuildRouteConfigurations")
 	defer span.End()
 
-	var routeConfigurations []*envoy_config_route_v3.RouteConfiguration
-
-	if config.IsAuthenticate(cfg.Options.Services) || config.IsProxy(cfg.Options.Services) {
+	var routeConfigurations []RouteConfiguration
+	{
 		rc, err := b.buildMainRouteConfiguration(ctx, cfg)
 		if err != nil {
 			return nil, err
 		}
-		routeConfigurations = append(routeConfigurations, rc)
+		routeConfigurations = append(routeConfigurations, RouteConfiguration{
+			Name:   "main",
+			Config: rc,
+		})
+	}
+	{
+		rc, err := buildSSHRouteConfiguration(cfg)
+		if err != nil {
+			return nil, err
+		}
+		routeConfigurations = append(routeConfigurations, RouteConfiguration{
+			Name:   "ssh",
+			Config: rc,
+		})
 	}
 
 	return routeConfigurations, nil
@@ -105,6 +134,73 @@ func (b *Builder) buildMainRouteConfiguration(
 
 	rc := newRouteConfiguration("main", virtualHosts)
 	return rc, nil
+}
+
+func buildSSHRouteConfiguration(cfg *config.Config) (*envoy_generic_proxy_v3.RouteConfiguration, error) {
+	var matchers []*xds_matcher_v3.Matcher_MatcherList_FieldMatcher
+	for policy := range cfg.Options.GetAllPolicies() {
+		if !policy.IsSSH() {
+			continue
+		}
+		fromURL, err := urlutil.ParseAndValidateURL(policy.From)
+		if err != nil {
+			return nil, err
+		}
+		fromHost := fromURL.Hostname()
+		if len(policy.To) > 1 {
+			return nil, fmt.Errorf("only one 'to' entry allowed for ssh routes")
+		}
+		to := policy.To[0].URL
+		if to.Scheme != "ssh" {
+			return nil, fmt.Errorf("'to' route url must have ssh scheme")
+		}
+		matchers = append(matchers, &xds_matcher_v3.Matcher_MatcherList_FieldMatcher{
+			Predicate: &xds_matcher_v3.Matcher_MatcherList_Predicate{
+				MatchType: &xds_matcher_v3.Matcher_MatcherList_Predicate_SinglePredicate_{
+					SinglePredicate: &xds_matcher_v3.Matcher_MatcherList_Predicate_SinglePredicate{
+						Input: &xds_core_v3.TypedExtensionConfig{
+							Name:        "host",
+							TypedConfig: marshalAny(&envoy_generic_proxy_matcher_v3.HostMatchInput{}),
+						},
+						Matcher: &xds_matcher_v3.Matcher_MatcherList_Predicate_SinglePredicate_ValueMatch{
+							ValueMatch: &xds_matcher_v3.StringMatcher{
+								MatchPattern: &xds_matcher_v3.StringMatcher_Exact{
+									Exact: fromHost,
+								},
+							},
+						},
+					},
+				},
+			},
+			OnMatch: &xds_matcher_v3.Matcher_OnMatch{
+				OnMatch: &xds_matcher_v3.Matcher_OnMatch_Action{
+					Action: &xds_core_v3.TypedExtensionConfig{
+						Name: "route",
+						TypedConfig: marshalAny(&envoy_generic_proxy_action_v3.RouteAction{
+							Name: policy.ID,
+							ClusterSpecifier: &envoy_generic_proxy_action_v3.RouteAction_Cluster{
+								Cluster: GetClusterID(policy),
+							},
+							Timeout: durationpb.New(0),
+						}),
+					},
+				},
+			},
+		})
+	}
+
+	// Note that this is a separate xds resource type than the standard route
+	// configuration type used for http routes.
+	return &envoy_generic_proxy_v3.RouteConfiguration{
+		Name: "ssh", // matches the generic rds route_config_name
+		Routes: &xds_matcher_v3.Matcher{
+			MatcherType: &xds_matcher_v3.Matcher_MatcherList_{
+				MatcherList: &xds_matcher_v3.Matcher_MatcherList{
+					Matchers: matchers,
+				},
+			},
+		},
+	}, nil
 }
 
 func getAllRouteableHosts(options *config.Options, addr string) ([]string, map[string]bool, error) {

--- a/config/envoyconfig/route_configurations_test.go
+++ b/config/envoyconfig/route_configurations_test.go
@@ -29,6 +29,10 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 				From: "https://*.example.com",
 				To:   mustParseWeightedURLs(t, "https://www.example.com"),
 			},
+			{
+				From: "ssh://should-be-ignored",
+				To:   mustParseWeightedURLs(t, "ssh://ignored:22"),
+			},
 		},
 	})
 	b := New("connect", "grpc", "http", "debug", "metrics", filemgr.NewManager(), nil, true)
@@ -171,6 +175,124 @@ func TestBuilder_buildMainRouteConfiguration(t *testing.T) {
 		]
 
 	}`, routeConfiguration)
+}
+
+func TestBuilder_buildSSHRouteConfiguration(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.New(&config.Options{
+		CookieName:             "pomerium",
+		DefaultUpstreamTimeout: time.Second * 3,
+		SharedKey:              cryptutil.NewBase64Key(),
+		Services:               "proxy",
+		Policies: []config.Policy{
+			{
+				From: "https://should-be-ignored.example.com",
+				To:   mustParseWeightedURLs(t, "https://ignored"),
+			},
+			{
+				From: "ssh://host1",
+				To:   mustParseWeightedURLs(t, "ssh://target1:22"),
+			},
+			{
+				From: "ssh://host2",
+				To:   mustParseWeightedURLs(t, "ssh://target2:22"),
+			},
+		},
+	})
+	routeConfiguration, err := buildSSHRouteConfiguration(cfg)
+	assert.NoError(t, err)
+	testutil.AssertProtoJSONEqual(t, `{
+		"name": "ssh",
+		"routes": {
+			"matcherList": {
+				"matchers": [
+					{
+						"predicate": {
+							"singlePredicate": {
+								"input": {
+									"name": "host",
+									"typedConfig": {
+										"@type": "type.googleapis.com/envoy.extensions.filters.network.generic_proxy.matcher.v3.HostMatchInput"
+									}
+								},
+								"valueMatch": {
+									"exact": "host1"
+								}
+							}
+						},
+						"onMatch": {
+							"action": {
+								"name": "route",
+								"typedConfig": {
+									"@type": "type.googleapis.com/envoy.extensions.filters.network.generic_proxy.action.v3.RouteAction",
+									"cluster": "`+GetClusterID(&cfg.Options.Policies[1])+`",
+									"timeout": "0s"
+								}
+							}
+						}
+					},
+					{
+						"predicate": {
+							"singlePredicate": {
+								"input": {
+									"name": "host",
+									"typedConfig": {
+										"@type": "type.googleapis.com/envoy.extensions.filters.network.generic_proxy.matcher.v3.HostMatchInput"
+									}
+								},
+								"valueMatch": {
+									"exact": "host2"
+								}
+							}
+						},
+						"onMatch": {
+							"action": {
+								"name": "route",
+								"typedConfig": {
+									"@type": "type.googleapis.com/envoy.extensions.filters.network.generic_proxy.action.v3.RouteAction",
+									"cluster": "`+GetClusterID(&cfg.Options.Policies[2])+`",
+									"timeout": "0s"
+								}
+							}
+						}
+					}
+				]
+			}
+		}
+	}`, routeConfiguration)
+}
+
+func TestBuilder_buildSSHRouteConfigurationErrors(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid From url", func(t *testing.T) {
+		cfg := config.New(config.NewDefaultOptions())
+		cfg.Options.SSHAddr = "0.0.0.0:22"
+		cfg.Options.Policies = []config.Policy{
+			{From: "ssh://\x7f", To: mustParseWeightedURLs(t, "ssh://to1:22")},
+		}
+		_, err := buildSSHRouteConfiguration(cfg)
+		assert.Error(t, err)
+	})
+	t.Run("multiple To urls", func(t *testing.T) {
+		cfg := config.New(config.NewDefaultOptions())
+		cfg.Options.SSHAddr = "0.0.0.0:22"
+		cfg.Options.Policies = []config.Policy{
+			{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://to1:22", "ssh://to2:22")},
+		}
+		_, err := buildSSHRouteConfiguration(cfg)
+		assert.Error(t, err)
+	})
+	t.Run("To url missing scheme", func(t *testing.T) {
+		cfg := config.New(config.NewDefaultOptions())
+		cfg.Options.SSHAddr = "0.0.0.0:22"
+		cfg.Options.Policies = []config.Policy{
+			{From: "ssh://host1", To: mustParseWeightedURLs(t, "http://to1:22")},
+		}
+		_, err := buildSSHRouteConfiguration(cfg)
+		assert.Error(t, err)
+	})
 }
 
 func Test_getAllDomains(t *testing.T) {

--- a/config/options.go
+++ b/config/options.go
@@ -1351,6 +1351,10 @@ func (o *Options) GetAllRouteableHTTPHosts() ([]string, map[string]bool, error) 
 	// policy urls
 	if IsProxy(o.Services) {
 		for policy := range o.GetAllPolicies() {
+			if policy.IsSSH() {
+				// SSH routes are not part of the main route configuration
+				continue
+			}
 			fromURL, err := urlutil.ParseAndValidateURL(policy.From)
 			if err != nil {
 				return nil, nil, err

--- a/internal/controlplane/xds.go
+++ b/internal/controlplane/xds.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"maps"
 
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
 	"golang.org/x/sync/errgroup"
@@ -14,9 +15,8 @@ import (
 )
 
 const (
-	clusterTypeURL            = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
-	listenerTypeURL           = "type.googleapis.com/envoy.config.listener.v3.Listener"
-	routeConfigurationTypeURL = "type.googleapis.com/envoy.config.route.v3.RouteConfiguration"
+	clusterTypeURL  = "type.googleapis.com/envoy.config.cluster.v3.Cluster"
+	listenerTypeURL = "type.googleapis.com/envoy.config.listener.v3.Listener"
 )
 
 func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*envoy_service_discovery_v3.Resource, error) {
@@ -61,17 +61,18 @@ func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*e
 		return nil
 	})
 
-	var routeConfigurationResources []*envoy_service_discovery_v3.Resource
+	routeConfigurationResources := map[string][]*envoy_service_discovery_v3.Resource{}
 	eg.Go(func() error {
 		routeConfigurations, err := srv.Builder.BuildRouteConfigurations(ctx, cfg)
 		if err != nil {
 			return fmt.Errorf("error building route configurations: %w", err)
 		}
 		for _, routeConfiguration := range routeConfigurations {
-			routeConfigurationResources = append(routeConfigurationResources, &envoy_service_discovery_v3.Resource{
+			typeURL := protoutil.GetTypeURL(routeConfiguration.Config)
+			routeConfigurationResources[typeURL] = append(routeConfigurationResources[typeURL], &envoy_service_discovery_v3.Resource{
 				Name:     routeConfiguration.Name,
-				Version:  hex.EncodeToString(cryptutil.HashProto(routeConfiguration)),
-				Resource: protoutil.NewAny(routeConfiguration),
+				Version:  hex.EncodeToString(cryptutil.HashProto(routeConfiguration.Config)),
+				Resource: protoutil.NewAny(routeConfiguration.Config),
 			})
 		}
 		return nil
@@ -88,9 +89,10 @@ func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*e
 		Int("route-configuration-count", len(routeConfigurationResources)).
 		Msg("controlplane: built discovery resources")
 
-	return map[string][]*envoy_service_discovery_v3.Resource{
-		clusterTypeURL:            clusterResources,
-		listenerTypeURL:           listenerResources,
-		routeConfigurationTypeURL: routeConfigurationResources,
-	}, nil
+	resources := map[string][]*envoy_service_discovery_v3.Resource{
+		clusterTypeURL:  clusterResources,
+		listenerTypeURL: listenerResources,
+	}
+	maps.Copy(resources, routeConfigurationResources)
+	return resources, nil
 }


### PR DESCRIPTION
## Summary

This changes the generic proxy filter config for the ssh listener to obtain its route configuration over XDS instead of using a static route list, which was previously causing envoy to drain and recreate the ssh listener whenever ssh routes were changed. 

SSH routes are grouped into a separate route configuration, which uses a different xds resource type `envoy.extensions.filters.network.generic_proxy.v3.RouteConfiguration` specific to generic proxy. When specifying a route config name in the generic proxy config, those names only reference resources of this type. 

Previously the SSH routes were also present in the regular http route configuration, though they don't actually do anything, so this was also cleaned up. 

This change does not require any changes on the envoy side. It still uses the "host" string to match routes, which is implementation-defined (we happen to define it as the `from` host, but the string is opaque). It may be better to change this to match against a generic property of the request frame and compute a stable identifier for the route based on the `from` and `to` addresses, but that can be done as a follow up. There is some inefficient logic in the auth handler that iterates over all routes to match ssh route hostnames to policies, which needs to be improved, and that refactor might be easier if we can come up with a ssh route id scheme to build a cache with.

## Related issues

Fixes https://github.com/pomerium/pomerium/issues/6324

## User Explanation

Updating SSH routes will no longer cause active SSH connections to be closed after some period of time.

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
