### PR TITLE
chore: better errors for reading recordings

### DIFF
--- a/pkg/storage/blob/chunk.go
+++ b/pkg/storage/blob/chunk.go
@@ -418,13 +418,20 @@ func NewChunkReader(ctx context.Context, schema SchemaV1WithKey, bucket *blob.Bu
 	readerOpts.Apply(opts...)
 
 	if readerOpts.validateSignature {
-		path, _ := schema.SignaturePath()
-		ok, err := bucket.Exists(ctx, path)
-		if err != nil {
-			return nil, err
+		sigPath, _ := schema.SignaturePath()
+		mdPath, _ := schema.MetadataPath()
+		mdOk, mdErr := bucket.Exists(ctx, mdPath)
+		if mdErr != nil {
+			return nil, fmt.Errorf("failed to check existence for bucket : %w", mdErr)
 		}
-
-		if !ok {
+		if !mdOk {
+			return nil, fmt.Errorf("recording not found")
+		}
+		sigOk, sigErr := bucket.Exists(ctx, sigPath)
+		if sigErr != nil {
+			return nil, fmt.Errorf("failed to check existence for bucket: %w", sigErr)
+		}
+		if !sigOk {
 			return nil, ErrNotYetFinalized
 		}
 	}

--- a/pkg/storage/blob/chunk_test.go
+++ b/pkg/storage/blob/chunk_test.go
@@ -288,11 +288,15 @@ func testChunkReaderWriterConformance(t *testing.T,
 				RecordingType: "ssh",
 				ClusterID:     uuid.New().String(),
 			}, "in-progress")
+			mdPathJSON, ctMd0 := schema.MetadataJSON()
+			require.NoError(t, bk.WriteAll(ctx, mdPathJSON, []byte("mdJSON"), &gblob.WriterOptions{ContentType: ctMd0}))
+			mdPathProto, ctMd1 := schema.MetadataPath()
+			require.NoError(t, bk.WriteAll(ctx, mdPathProto, []byte("mdProto"), &gblob.WriterOptions{ContentType: ctMd1}))
 
 			chunk0Path, ct0 := schema.ChunkPath(0)
 			require.NoError(t, bk.WriteAll(ctx, chunk0Path, []byte("chunk0"), &gblob.WriterOptions{ContentType: ct0}))
-			chunk2Path, ct2 := schema.ChunkPath(1)
-			require.NoError(t, bk.WriteAll(ctx, chunk2Path, []byte("chunk2"), &gblob.WriterOptions{ContentType: ct2}))
+			chunk1Path, ct1 := schema.ChunkPath(1)
+			require.NoError(t, bk.WriteAll(ctx, chunk1Path, []byte("chunk1"), &gblob.WriterOptions{ContentType: ct1}))
 
 			_, err := rF(schema)
 			assert.Error(t, err)


### PR DESCRIPTION
## Summary

More informative errors when attempting to read recordings from session recording storage.

## Related issues

[ENG-4113](https://linear.app/pomerium/issue/ENG-4113/open-recording-by-id-with-invalid-id-shows-blank-replay-screen-and)
## User Explanation

N/A

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
