### PR TITLE
authorize: surface underlying error for unresolved MCP access token

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -183,7 +183,7 @@ func (a *Authorize) getMCPSession(
 	accessToken := auth[len(prefix):]
 	sessionID, sessionRecordVersion, err := a.state.Load().mcp.GetSessionAndVersionFromAccessToken(accessToken)
 	if err != nil {
-		return nil, fmt.Errorf("no session found for access token: %w", sessions.ErrNoSessionFound)
+		return nil, fmt.Errorf("no session found for access token: %w: %w", err, sessions.ErrNoSessionFound)
 	}
 
 	// Read the session with the record version captured when the token was


### PR DESCRIPTION
Wrap the underlying `err` (e.g. decrypt/expired/type-mismatch) in the "no session found for access token" path so the real cause is logged instead of a generic session-not-found.