### PR TITLE
ssh: use TypedStruct for enabled channel filter configs

### DIFF
--- a/config/envoyconfig/listeners_ssh.go
+++ b/config/envoyconfig/listeners_ssh.go
@@ -7,6 +7,7 @@ import (
 
 	xds_core_v3 "github.com/cncf/xds/go/xds/core/v3"
 	xds_matcher_v3 "github.com/cncf/xds/go/xds/type/matcher/v3"
+	xds_type_v3 "github.com/cncf/xds/go/xds/type/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	envoy_config_listener_v3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoy_config_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/config/ratelimit/v3"
@@ -17,7 +18,9 @@ import (
 	envoy_generic_proxy_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/generic_proxy/v3"
 	envoy_generic_ratelimit_v3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/ratelimit/v3"
 	matcherv3 "github.com/envoyproxy/go-control-plane/envoy/type/matcher/v3"
+	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
 	xssh "github.com/pomerium/envoy-custom/api/x/recording/formats/ssh"
@@ -142,9 +145,21 @@ func buildSSHListener(cfg *config.Config, extensionsToLoad []string) (*envoy_con
 
 	var enabledChannelFilters []*envoy_config_core_v3.TypedExtensionConfig
 	if slices.Contains(extensionsToLoad, ExtensionSSHSessionRecording) {
+		ext := &xssh.ChannelFilterConfig{}
+		ts := &xds_type_v3.TypedStruct{
+			TypeUrl: "type.googleapis.com/" + string(ext.ProtoReflect().Descriptor().FullName()),
+			Value:   &structpb.Struct{},
+		}
+		data, err := protojson.Marshal(ext)
+		if err != nil {
+			return nil, err
+		}
+		if err := protojson.Unmarshal(data, ts.Value); err != nil {
+			return nil, err
+		}
 		enabledChannelFilters = append(enabledChannelFilters, &envoy_config_core_v3.TypedExtensionConfig{
 			Name:        "session_recording",
-			TypedConfig: marshalAny(&xssh.ChannelFilterConfig{}),
+			TypedConfig: marshalAny(ts),
 		})
 	}
 


### PR DESCRIPTION
## Summary

The config messages for enabled channel filters in the ssh codec configuration need to use xds.type.v3.TypedStruct instead of directly wrapping the actual type in an Any. TypedStruct is a special case in Envoy that allows delaying proto validation for message types that may not yet be known at the time a config update is received over XDS. Normally it will recurse into Any fields and error if the type of the Any is not known. In the case of session recording, the config types are only known after the dynamic extension is loaded. If the extension loader is enabled at the same time the ssh listener filter codec config is updated and references these config types, envoy will fail to apply the new configuration. 

## Related issues

Related change in envoy-custom https://github.com/pomerium/envoy-custom/pull/245
Fixes https://linear.app/pomerium/issue/ENG-4096

## User Explanation

not user-facing

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
