### PR TITLE
databroker: redact sensitive fields in debug browser

### DIFF
--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -18,6 +18,18 @@ var (
 	RuntimeFlagConfigHotReload = runtimeFlag("config_hot_reload", true)
 
 	// RuntimeFlagDebugAdminEndpoints enables the admin endpoints for the debug listener.
+	//
+	// These endpoints are an operator-facing diagnostic surface, off by
+	// default and served from a listener bound to 127.0.0.1 (reachable beyond
+	// loopback only if the operator explicitly exposes it via debug_address).
+	// They intentionally expose internal state — config dumps, databroker
+	// records, raft status — to the operator who opted in, who already has
+	// full access to the host, its config, and its secrets. Internal state
+	// being reachable through these endpoints is by design and is not, by
+	// itself, an information-disclosure vulnerability: there is no trust
+	// boundary between the debug listener and the local operator. Fields
+	// annotated [(pomerium.config.sensitive) = true] are still redacted in
+	// rendered output so secrets don't leak into copy-pasted diagnostics.
 	RuntimeFlagDebugAdminEndpoints = runtimeFlag("debug_admin_endpoints", false)
 
 	// RuntimeFlagEnvoyResourceManager enables Envoy overload settings based on

--- a/go.work.sum
+++ b/go.work.sum
@@ -126,8 +126,11 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.20.0/go.mod h1:YD5h/ldMsG0XiIw7P
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/azkeys v0.10.0/go.mod h1:Pu5Zksi2KrU7LPbZbNINx6fuVrUp/ffvpxdDj+i8LeE=
 github.com/Azure/azure-sdk-for-go/sdk/keyvault/internal v0.7.1/go.mod h1:9V2j0jn9jDEkCkv8w/bKTNppX/d0FVA1ud77xCIP4KA=
 github.com/Azure/azure-sdk-for-go/sdk/messaging/azservicebus v1.10.0/go.mod h1:IAN3Z0DMtehoxoQQnfqg1891z1P7GNoDryKtFcAyMBI=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azkeys v1.4.0/go.mod h1:Y2b/1clN4zsAoUd/pgNAQHjLDnTis/6ROkUfyob6psM=
+github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal v1.2.0/go.mod h1:ucUjca2JtSZboY8IoUqyQyuuXvwbMBVwFOm0vdQPNhA=
 github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3/go.mod h1:URuDvhmATVKqHBH9/0nOiNKk0+YcwfQ3WkK5PqHKxc8=
 github.com/Azure/go-amqp v1.5.0/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
+github.com/Azure/go-amqp v1.5.1/go.mod h1:vZAogwdrkbyK3Mla8m/CxSc/aKdnTZ4IbPxl51Y5WZE=
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v1.4.1-0.20240526193622-a339e1f7089c/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/CloudyKit/fastprinter v0.0.0-20200109182630-33d98a066a53/go.mod h1:+3IMCy2vIlbG1XG/0ggNQv0SvxCAIpPM5b1nCz56Xno=

--- a/internal/controlplane/server_debug.go
+++ b/internal/controlplane/server_debug.go
@@ -432,6 +432,7 @@ func (srv *debugServer) serveDatabrokerRecord(w http.ResponseWriter, r *http.Req
 		http.Error(w, "record not found", http.StatusNotFound)
 		return
 	}
+	protoutil.RedactSensitive(res.Record)
 
 	o := protojson.MarshalOptions{
 		Multiline:     true,
@@ -548,6 +549,7 @@ func (v *versionedConfigData) RenderVersionedConfig(cfg *configpb.VersionedConfi
 	conditions := cfg.Conditions
 	cfg = proto.Clone(cfg).(*configpb.VersionedConfig)
 	cfg.Conditions = nil
+	protoutil.RedactSensitive(cfg)
 
 	marshaled, err := protojson.MarshalOptions{
 		Multiline:     true,

--- a/internal/controlplane/server_debug_test.go
+++ b/internal/controlplane/server_debug_test.go
@@ -3,6 +3,7 @@ package controlplane
 import (
 	"context"
 	"io"
+	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
@@ -10,7 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
 	"github.com/pomerium/pomerium/config"
@@ -85,7 +85,7 @@ func TestDebugServer_DatabrokerRecord_RedactsSensitiveFields(t *testing.T) {
 	cfg := &configpb.Config{
 		Name: "test-config",
 		Settings: &configpb.Settings{
-			SharedSecret: proto.String("super-secret-shared-key"),
+			SharedSecret: new("super-secret-shared-key"),
 		},
 		Routes: []*configpb.Route{{
 			From:         "https://from.example.com",
@@ -98,7 +98,7 @@ func TestDebugServer_DatabrokerRecord_RedactsSensitiveFields(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	srv.ServeHTTP(w, httptest.NewRequest("GET",
+	srv.ServeHTTP(w, httptest.NewRequest(http.MethodGet,
 		"/databroker/"+url.PathEscape(record.Type)+"/test-id", nil))
 
 	require.Equal(t, 200, w.Code)
@@ -139,7 +139,7 @@ func TestDebugServer_DatabrokerRecord_RedactsSessionTokens(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	srv.ServeHTTP(w, httptest.NewRequest("GET",
+	srv.ServeHTTP(w, httptest.NewRequest(http.MethodGet,
 		"/databroker/"+url.PathEscape(record.Type)+"/"+url.PathEscape(record.Id), nil))
 
 	require.Equal(t, 200, w.Code)
@@ -159,7 +159,7 @@ func TestDebugServer_VersionedConfig_RedactsSensitiveFields(t *testing.T) {
 		Config: &configpb.Config{
 			Name: "versioned-config",
 			Settings: &configpb.Settings{
-				SharedSecret: proto.String("super-secret-shared-key"),
+				SharedSecret: new("super-secret-shared-key"),
 			},
 		},
 	}
@@ -179,7 +179,7 @@ func TestDebugServer_VersionedConfig_RedactsSensitiveFields(t *testing.T) {
 	})
 
 	w := httptest.NewRecorder()
-	srv.ServeHTTP(w, httptest.NewRequest("GET", "/versioned_config", nil))
+	srv.ServeHTTP(w, httptest.NewRequest(http.MethodGet, "/versioned_config", nil))
 
 	require.Equal(t, 200, w.Code)
 	body := w.Body.String()

--- a/internal/controlplane/server_debug_test.go
+++ b/internal/controlplane/server_debug_test.go
@@ -1,0 +1,188 @@
+package controlplane
+
+import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/pomerium/pomerium/config"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	sessionpb "github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+type stubDataBrokerClient struct {
+	databroker.DataBrokerServiceClient
+
+	getResponse *databroker.GetResponse
+	syncLatest  []*databroker.SyncLatestResponse
+}
+
+func (c *stubDataBrokerClient) Get(_ context.Context, _ *databroker.GetRequest, _ ...grpc.CallOption) (*databroker.GetResponse, error) {
+	return c.getResponse, nil
+}
+
+func (c *stubDataBrokerClient) SyncLatest(_ context.Context, _ *databroker.SyncLatestRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[databroker.SyncLatestResponse], error) {
+	return &stubSyncLatestStream{responses: c.syncLatest}, nil
+}
+
+type stubSyncLatestStream struct {
+	grpc.ClientStream
+
+	responses []*databroker.SyncLatestResponse
+}
+
+func (s *stubSyncLatestStream) Recv() (*databroker.SyncLatestResponse, error) {
+	if len(s.responses) == 0 {
+		return nil, io.EOF
+	}
+	res := s.responses[0]
+	s.responses = s.responses[1:]
+	return res, nil
+}
+
+type stubDataBrokerClientProvider struct {
+	client databroker.DataBrokerServiceClient
+}
+
+func (p *stubDataBrokerClientProvider) GetLocalDatabrokerServiceClient() databroker.DataBrokerServiceClient {
+	return p.client
+}
+
+func newTestDebugServer(t *testing.T, client databroker.DataBrokerServiceClient) *debugServer {
+	t.Helper()
+	opts := config.NewDefaultOptions()
+	opts.RuntimeFlags[config.RuntimeFlagDebugAdminEndpoints] = true
+	srv := newDebugServer(&config.Config{Options: opts}, nil)
+	srv.SetDataBrokerClient(DataBrokerClientProvider(&stubDataBrokerClientProvider{client: client}))
+	return srv
+}
+
+func newConfigRecord(t *testing.T, cfg *configpb.Config, id string) *databroker.Record {
+	t.Helper()
+	data, err := anypb.New(cfg)
+	require.NoError(t, err)
+	return &databroker.Record{
+		Version: 1,
+		Type:    protoutil.GetTypeURL(cfg),
+		Id:      id,
+		Data:    data,
+	}
+}
+
+func TestDebugServer_DatabrokerRecord_RedactsSensitiveFields(t *testing.T) {
+	t.Parallel()
+
+	cfg := &configpb.Config{
+		Name: "test-config",
+		Settings: &configpb.Settings{
+			SharedSecret: proto.String("super-secret-shared-key"),
+		},
+		Routes: []*configpb.Route{{
+			From:         "https://from.example.com",
+			TlsClientKey: "super-secret-tls-key",
+		}},
+	}
+	record := newConfigRecord(t, cfg, "test-id")
+	srv := newTestDebugServer(t, &stubDataBrokerClient{
+		getResponse: &databroker.GetResponse{Record: record},
+	})
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, httptest.NewRequest("GET",
+		"/databroker/"+url.PathEscape(record.Type)+"/test-id", nil))
+
+	require.Equal(t, 200, w.Code)
+	body := w.Body.String()
+	assert.NotContains(t, body, "super-secret-shared-key")
+	assert.NotContains(t, body, "super-secret-tls-key")
+	assert.Contains(t, body, protoutil.Redacted)
+	assert.Contains(t, body, "test-config", "non-sensitive fields must remain visible")
+	assert.Contains(t, body, "from.example.com", "non-sensitive fields must remain visible")
+}
+
+func TestDebugServer_DatabrokerRecord_RedactsSessionTokens(t *testing.T) {
+	t.Parallel()
+
+	s := &sessionpb.Session{
+		Id:     "session-id",
+		UserId: "user-id",
+		IdToken: &sessionpb.IDToken{
+			Issuer: "https://idp.example.com",
+			Raw:    "raw-id-token-jwt",
+		},
+		OauthToken: &sessionpb.OAuthToken{
+			AccessToken:  "oauth-access-token-secret",
+			TokenType:    "Bearer",
+			RefreshToken: "oauth-refresh-token-secret",
+		},
+	}
+	data, err := anypb.New(s)
+	require.NoError(t, err)
+	record := &databroker.Record{
+		Version: 1,
+		Type:    protoutil.GetTypeURL(s),
+		Id:      s.Id,
+		Data:    data,
+	}
+	srv := newTestDebugServer(t, &stubDataBrokerClient{
+		getResponse: &databroker.GetResponse{Record: record},
+	})
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, httptest.NewRequest("GET",
+		"/databroker/"+url.PathEscape(record.Type)+"/"+url.PathEscape(record.Id), nil))
+
+	require.Equal(t, 200, w.Code)
+	body := w.Body.String()
+	assert.NotContains(t, body, "oauth-access-token-secret")
+	assert.NotContains(t, body, "oauth-refresh-token-secret")
+	assert.NotContains(t, body, "raw-id-token-jwt")
+	assert.Contains(t, body, "user-id", "non-sensitive fields must remain visible")
+	assert.Contains(t, body, "idp.example.com", "non-sensitive fields must remain visible")
+	assert.Contains(t, body, "Bearer", "non-sensitive fields must remain visible")
+}
+
+func TestDebugServer_VersionedConfig_RedactsSensitiveFields(t *testing.T) {
+	t.Parallel()
+
+	vc := &configpb.VersionedConfig{
+		Config: &configpb.Config{
+			Name: "versioned-config",
+			Settings: &configpb.Settings{
+				SharedSecret: proto.String("super-secret-shared-key"),
+			},
+		},
+	}
+	data, err := anypb.New(vc)
+	require.NoError(t, err)
+	srv := newTestDebugServer(t, &stubDataBrokerClient{
+		syncLatest: []*databroker.SyncLatestResponse{{
+			Response: &databroker.SyncLatestResponse_Record{
+				Record: &databroker.Record{
+					Version: 1,
+					Type:    protoutil.GetTypeURL(vc),
+					Id:      "test-id",
+					Data:    data,
+				},
+			},
+		}},
+	})
+
+	w := httptest.NewRecorder()
+	srv.ServeHTTP(w, httptest.NewRequest("GET", "/versioned_config", nil))
+
+	require.Equal(t, 200, w.Code)
+	body := w.Body.String()
+	assert.NotContains(t, body, "super-secret-shared-key")
+	assert.Contains(t, body, "versioned-config", "non-sensitive fields must remain visible")
+}

--- a/pkg/grpc/identity/identity.pb.go
+++ b/pkg/grpc/identity/identity.pb.go
@@ -7,6 +7,7 @@
 package identity
 
 import (
+	_ "github.com/pomerium/pomerium/pkg/grpc/config"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	structpb "google.golang.org/protobuf/types/known/structpb"
@@ -247,12 +248,12 @@ var File_identity_proto protoreflect.FileDescriptor
 
 const file_identity_proto_rawDesc = "" +
 	"\n" +
-	"\x0eidentity.proto\x12\x11pomerium.identity\x1a\x1cgoogle/protobuf/struct.proto\"\xa8\x04\n" +
+	"\x0eidentity.proto\x12\x11pomerium.identity\x1a\x1cgoogle/protobuf/struct.proto\x1a\roptions.proto\"\xae\x04\n" +
 	"\bProvider\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x128\n" +
 	"\x18authenticate_service_url\x18\t \x01(\tR\x16authenticateServiceUrl\x12\x1b\n" +
-	"\tclient_id\x18\x02 \x01(\tR\bclientId\x12#\n" +
-	"\rclient_secret\x18\x03 \x01(\tR\fclientSecret\x12\x12\n" +
+	"\tclient_id\x18\x02 \x01(\tR\bclientId\x12)\n" +
+	"\rclient_secret\x18\x03 \x01(\tB\x04\xe8\xd6,\x01R\fclientSecret\x12\x12\n" +
 	"\x04type\x18\x04 \x01(\tR\x04type\x12\x16\n" +
 	"\x06scopes\x18\x05 \x03(\tR\x06scopes\x12\x10\n" +
 	"\x03url\x18\a \x01(\tR\x03url\x12U\n" +
@@ -265,12 +266,12 @@ const file_identity_proto_rawDesc = "" +
 	"\x12RequestParamsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
 	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01B!\n" +
-	"\x1f_access_token_allowed_audiences\"\x97\x01\n" +
+	"\x1f_access_token_allowed_audiences\"\xa3\x01\n" +
 	"\aProfile\x12\x1f\n" +
 	"\vprovider_id\x18\x01 \x01(\tR\n" +
-	"providerId\x12\x19\n" +
-	"\bid_token\x18\x02 \x01(\fR\aidToken\x12\x1f\n" +
-	"\voauth_token\x18\x03 \x01(\fR\n" +
+	"providerId\x12\x1f\n" +
+	"\bid_token\x18\x02 \x01(\fB\x04\xe8\xd6,\x01R\aidToken\x12%\n" +
+	"\voauth_token\x18\x03 \x01(\fB\x04\xe8\xd6,\x01R\n" +
 	"oauthToken\x12/\n" +
 	"\x06claims\x18\x04 \x01(\v2\x17.google.protobuf.StructR\x06claimsB0Z.github.com/pomerium/pomerium/pkg/grpc/identityb\x06proto3"
 

--- a/pkg/grpc/identity/identity.proto
+++ b/pkg/grpc/identity/identity.proto
@@ -4,13 +4,14 @@ package pomerium.identity;
 option go_package = "github.com/pomerium/pomerium/pkg/grpc/identity";
 
 import "google/protobuf/struct.proto";
+import "options.proto";
 
 message Provider {
   message StringList { repeated string values = 1; }
   string id = 1;
   string authenticate_service_url = 9;
   string client_id = 2;
-  string client_secret = 3;
+  string client_secret = 3 [(pomerium.config.sensitive) = true];
   string type = 4;
   repeated string scopes = 5;
   // string service_account = 6;
@@ -21,7 +22,7 @@ message Provider {
 
 message Profile {
   string provider_id = 1;
-  bytes id_token = 2;
-  bytes oauth_token = 3;
+  bytes id_token = 2 [(pomerium.config.sensitive) = true];
+  bytes oauth_token = 3 [(pomerium.config.sensitive) = true];
   google.protobuf.Struct claims = 4;
 }

--- a/pkg/grpc/identity/sensitive_test.go
+++ b/pkg/grpc/identity/sensitive_test.go
@@ -1,0 +1,36 @@
+package identity_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/pomerium/pomerium/pkg/grpc/identity"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+// TestSensitiveFieldAnnotations verifies that fields carrying secret
+// material are annotated with [(pomerium.config.sensitive) = true] so they
+// are redacted wherever sensitive-aware tooling (e.g. the databroker debug
+// browser) renders identity records.
+func TestSensitiveFieldAnnotations(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		msg   proto.Message
+		field protoreflect.Name
+	}{
+		{&identity.Provider{}, "client_secret"},
+		{&identity.Profile{}, "id_token"},
+		{&identity.Profile{}, "oauth_token"},
+	} {
+		fd := tc.msg.ProtoReflect().Descriptor().Fields().ByName(tc.field)
+		if assert.NotNil(t, fd, "field %s not found", tc.field) {
+			assert.True(t, protoutil.IsSensitive(fd),
+				"%s.%s must be annotated [(pomerium.config.sensitive) = true]",
+				tc.msg.ProtoReflect().Descriptor().FullName(), tc.field)
+		}
+	}
+}

--- a/pkg/grpc/protoc.bash
+++ b/pkg/grpc/protoc.bash
@@ -23,6 +23,7 @@ _dirs=(
 for _d in "${_dirs[@]}"; do
 	../../scripts/protoc \
 		-I "./$_d/" \
+		-I "./config/" \
 		-I "./" \
 		--go_out="./$_d" \
 		--go_opt="paths=source_relative" \

--- a/pkg/grpc/session/sensitive_test.go
+++ b/pkg/grpc/session/sensitive_test.go
@@ -1,0 +1,36 @@
+package session_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+// TestSensitiveFieldAnnotations verifies that fields carrying secret
+// material are annotated with [(pomerium.config.sensitive) = true] so they
+// are redacted wherever sensitive-aware tooling (e.g. the databroker debug
+// browser) renders session records.
+func TestSensitiveFieldAnnotations(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		msg   proto.Message
+		field protoreflect.Name
+	}{
+		{&session.OAuthToken{}, "access_token"},
+		{&session.OAuthToken{}, "refresh_token"},
+		{&session.IDToken{}, "raw"},
+	} {
+		fd := tc.msg.ProtoReflect().Descriptor().Fields().ByName(tc.field)
+		if assert.NotNil(t, fd, "field %s not found", tc.field) {
+			assert.True(t, protoutil.IsSensitive(fd),
+				"%s.%s must be annotated [(pomerium.config.sensitive) = true]",
+				tc.msg.ProtoReflect().Descriptor().FullName(), tc.field)
+		}
+	}
+}

--- a/pkg/grpc/session/session.pb.go
+++ b/pkg/grpc/session/session.pb.go
@@ -7,6 +7,7 @@
 package session
 
 import (
+	_ "github.com/pomerium/pomerium/pkg/grpc/config"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
@@ -830,22 +831,22 @@ var File_session_proto protoreflect.FileDescriptor
 
 const file_session_proto_rawDesc = "" +
 	"\n" +
-	"\rsession.proto\x12\asession\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc1\x01\n" +
+	"\rsession.proto\x12\asession\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\x1a\roptions.proto\"\xc7\x01\n" +
 	"\aIDToken\x12\x16\n" +
 	"\x06issuer\x18\x01 \x01(\tR\x06issuer\x12\x18\n" +
 	"\asubject\x18\x02 \x01(\tR\asubject\x129\n" +
 	"\n" +
 	"expires_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x127\n" +
-	"\tissued_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\bissuedAt\x12\x10\n" +
-	"\x03raw\x18\x05 \x01(\tR\x03raw\"\xae\x01\n" +
+	"\tissued_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\bissuedAt\x12\x16\n" +
+	"\x03raw\x18\x05 \x01(\tB\x04\xe8\xd6,\x01R\x03raw\"\xba\x01\n" +
 	"\n" +
-	"OAuthToken\x12!\n" +
-	"\faccess_token\x18\x01 \x01(\tR\vaccessToken\x12\x1d\n" +
+	"OAuthToken\x12'\n" +
+	"\faccess_token\x18\x01 \x01(\tB\x04\xe8\xd6,\x01R\vaccessToken\x12\x1d\n" +
 	"\n" +
 	"token_type\x18\x02 \x01(\tR\ttokenType\x129\n" +
 	"\n" +
-	"expires_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12#\n" +
-	"\rrefresh_token\x18\x04 \x01(\tR\frefreshToken\"\xfd\x06\n" +
+	"expires_at\x18\x03 \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12)\n" +
+	"\rrefresh_token\x18\x04 \x01(\tB\x04\xe8\xd6,\x01R\frefreshToken\"\xfd\x06\n" +
 	"\aSession\x12\x18\n" +
 	"\aversion\x18\x01 \x01(\tR\aversion\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x12\x17\n" +

--- a/pkg/grpc/session/session.proto
+++ b/pkg/grpc/session/session.proto
@@ -5,6 +5,7 @@ package session;
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
 import "google/protobuf/timestamp.proto";
+import "options.proto";
 
 option go_package = "github.com/pomerium/pomerium/pkg/grpc/session";
 
@@ -13,14 +14,14 @@ message IDToken {
   string                    subject    = 2;
   google.protobuf.Timestamp expires_at = 3;
   google.protobuf.Timestamp issued_at  = 4;
-  string                    raw        = 5;
+  string                    raw        = 5 [(pomerium.config.sensitive) = true];
 }
 
 message OAuthToken {
-  string                    access_token  = 1;
+  string                    access_token  = 1 [(pomerium.config.sensitive) = true];
   string                    token_type    = 2;
   google.protobuf.Timestamp expires_at    = 3;
-  string                    refresh_token = 4;
+  string                    refresh_token = 4 [(pomerium.config.sensitive) = true];
 }
 
 message Session {

--- a/pkg/protoutil/redact.go
+++ b/pkg/protoutil/redact.go
@@ -1,0 +1,154 @@
+package protoutil
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+)
+
+// Redacted is the placeholder value substituted for string and bytes fields
+// annotated with [(pomerium.config.sensitive) = true].
+const Redacted = "[REDACTED]"
+
+var anyFullName = (&anypb.Any{}).ProtoReflect().Descriptor().FullName()
+
+// RedactSensitive walks msg in place and redacts every field annotated with
+// [(pomerium.config.sensitive) = true]. String and bytes values (including
+// list elements and map values) are replaced with the Redacted placeholder so
+// a reader can tell the field was set; values of any other kind are cleared.
+// google.protobuf.Any fields are unpacked, redacted, and re-packed; Any
+// payloads whose type is not registered are left untouched.
+func RedactSensitive(msg proto.Message) {
+	if msg == nil {
+		return
+	}
+	redactMessage(msg.ProtoReflect())
+}
+
+func redactMessage(m protoreflect.Message) {
+	if !m.IsValid() {
+		return
+	}
+	fields := m.Descriptor().Fields()
+	for i := 0; i < fields.Len(); i++ {
+		fd := fields.Get(i)
+		if !m.Has(fd) {
+			continue
+		}
+		if IsSensitive(fd) {
+			redactField(m, fd)
+			continue
+		}
+		switch {
+		case fd.IsMap():
+			if fd.MapValue().Kind() != protoreflect.MessageKind {
+				continue
+			}
+			m.Get(fd).Map().Range(func(_ protoreflect.MapKey, v protoreflect.Value) bool {
+				redactMessageValue(v.Message())
+				return true
+			})
+		case fd.IsList():
+			if fd.Kind() != protoreflect.MessageKind {
+				continue
+			}
+			list := m.Get(fd).List()
+			for i := 0; i < list.Len(); i++ {
+				redactMessageValue(list.Get(i).Message())
+			}
+		case fd.Kind() == protoreflect.MessageKind:
+			redactMessageValue(m.Mutable(fd).Message())
+		}
+	}
+}
+
+// redactMessageValue redacts a nested message, special-casing
+// google.protobuf.Any by unpacking, redacting, and re-packing its payload.
+func redactMessageValue(m protoreflect.Message) {
+	if m.Descriptor().FullName() == anyFullName {
+		redactAny(m)
+		return
+	}
+	redactMessage(m)
+}
+
+func redactAny(m protoreflect.Message) {
+	fds := m.Descriptor().Fields()
+	typeURLFD := fds.ByName("type_url")
+	valueFD := fds.ByName("value")
+
+	typeURL := m.Get(typeURLFD).String()
+	if typeURL == "" {
+		return
+	}
+	mt, err := protoregistry.GlobalTypes.FindMessageByURL(typeURL)
+	if err != nil {
+		// unknown payload type: nothing to inspect; leave it as is
+		return
+	}
+	inner := mt.New().Interface()
+	if err := proto.Unmarshal(m.Get(valueFD).Bytes(), inner); err != nil {
+		return
+	}
+	redactMessage(inner.ProtoReflect())
+	bs, err := proto.Marshal(inner)
+	if err != nil {
+		return
+	}
+	m.Set(valueFD, protoreflect.ValueOfBytes(bs))
+}
+
+// redactField overwrites a sensitive field that is set. String and bytes
+// values become the Redacted placeholder; other kinds are cleared since they
+// have no meaningful placeholder representation.
+func redactField(m protoreflect.Message, fd protoreflect.FieldDescriptor) {
+	switch {
+	case fd.IsMap():
+		mv := fd.MapValue()
+		if v, ok := redactedScalar(mv.Kind()); ok {
+			mm := m.Mutable(fd).Map()
+			mm.Range(func(k protoreflect.MapKey, _ protoreflect.Value) bool {
+				mm.Set(k, v)
+				return true
+			})
+			return
+		}
+		m.Clear(fd)
+	case fd.IsList():
+		if v, ok := redactedScalar(fd.Kind()); ok {
+			list := m.Mutable(fd).List()
+			for i := 0; i < list.Len(); i++ {
+				list.Set(i, v)
+			}
+			return
+		}
+		m.Clear(fd)
+	default:
+		if v, ok := redactedScalar(fd.Kind()); ok {
+			m.Set(fd, v)
+			return
+		}
+		m.Clear(fd)
+	}
+}
+
+func redactedScalar(kind protoreflect.Kind) (protoreflect.Value, bool) {
+	switch kind {
+	case protoreflect.StringKind:
+		return protoreflect.ValueOfString(Redacted), true
+	case protoreflect.BytesKind:
+		return protoreflect.ValueOfBytes([]byte(Redacted)), true
+	default:
+		return protoreflect.Value{}, false
+	}
+}
+
+// IsSensitive reports whether fd carries the (pomerium.config.sensitive)
+// field option.
+func IsSensitive(fd protoreflect.FieldDescriptor) bool {
+	v, ok := proto.GetExtension(fd.Options(), configpb.E_Sensitive).(bool)
+	return ok && v
+}

--- a/pkg/protoutil/redact_test.go
+++ b/pkg/protoutil/redact_test.go
@@ -1,0 +1,144 @@
+package protoutil_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+func TestRedactSensitive_Scalars(t *testing.T) {
+	t.Parallel()
+
+	settings := &configpb.Settings{
+		SharedSecret: proto.String("shared-secret-value"),
+		CookieSecret: proto.String("cookie-secret-value"),
+		CookieName:   proto.String("my-cookie"),
+	}
+	protoutil.RedactSensitive(settings)
+
+	assert.Equal(t, "[REDACTED]", settings.GetSharedSecret())
+	assert.Equal(t, "[REDACTED]", settings.GetCookieSecret())
+	assert.Equal(t, "my-cookie", settings.GetCookieName(), "non-sensitive fields must be left intact")
+}
+
+func TestRedactSensitive_NestedMessages(t *testing.T) {
+	t.Parallel()
+
+	cfg := &configpb.Config{
+		Name: "test-config",
+		Settings: &configpb.Settings{
+			SharedSecret:         proto.String("shared-secret-value"),
+			CertificateAuthority: proto.String("not-a-secret"),
+		},
+		Routes: []*configpb.Route{{
+			From:         "https://from.example.com",
+			TlsClientKey: "tls-client-key-value",
+		}},
+	}
+	protoutil.RedactSensitive(cfg)
+
+	assert.Equal(t, "test-config", cfg.GetName())
+	assert.Equal(t, "[REDACTED]", cfg.GetSettings().GetSharedSecret())
+	assert.Equal(t, "not-a-secret", cfg.GetSettings().GetCertificateAuthority())
+	assert.Equal(t, "[REDACTED]", cfg.GetRoutes()[0].GetTlsClientKey())
+	assert.Equal(t, "https://from.example.com", cfg.GetRoutes()[0].GetFrom())
+}
+
+func TestRedactSensitive_Bytes(t *testing.T) {
+	t.Parallel()
+
+	settings := &configpb.Settings{
+		Certificates: []*configpb.Settings_Certificate{{
+			CertBytes: []byte("public-cert"),
+			KeyBytes:  []byte("private-key-bytes"),
+		}},
+	}
+	protoutil.RedactSensitive(settings)
+
+	assert.Equal(t, []byte("public-cert"), settings.GetCertificates()[0].GetCertBytes())
+	assert.Equal(t, []byte("[REDACTED]"), settings.GetCertificates()[0].GetKeyBytes())
+}
+
+func TestRedactSensitive_MessageKindCleared(t *testing.T) {
+	t.Parallel()
+
+	// ssh_host_keys is a sensitive message-kind field (StringList) carrying
+	// inline SSH host private keys: no placeholder representation exists, so
+	// it must be cleared entirely.
+	settings := &configpb.Settings{
+		SshHostKeys: &configpb.Settings_StringList{
+			Values: []string{"-----BEGIN PRIVATE KEY-----"},
+		},
+		SshUserCaKey: proto.String("ssh-user-ca-private-key"),
+	}
+	protoutil.RedactSensitive(settings)
+
+	assert.Nil(t, settings.GetSshHostKeys(),
+		"sensitive message-kind fields must be cleared, not recursed")
+	assert.Equal(t, "[REDACTED]", settings.GetSshUserCaKey())
+}
+
+func TestRedactSensitive_DescendsIntoAny(t *testing.T) {
+	t.Parallel()
+
+	cfg := &configpb.Config{
+		Settings: &configpb.Settings{
+			SharedSecret: proto.String("shared-secret-value"),
+		},
+	}
+	data, err := anypb.New(cfg)
+	require.NoError(t, err)
+	record := &databrokerpb.Record{
+		Type: protoutil.GetTypeURL(cfg),
+		Id:   "test-id",
+		Data: data,
+	}
+	protoutil.RedactSensitive(record)
+
+	var got configpb.Config
+	require.NoError(t, record.GetData().UnmarshalTo(&got))
+	assert.Equal(t, "[REDACTED]", got.GetSettings().GetSharedSecret())
+	assert.Equal(t, "test-id", record.GetId())
+}
+
+func TestRedactSensitive_UnknownAnyTypeLeftIntact(t *testing.T) {
+	t.Parallel()
+
+	record := &databrokerpb.Record{
+		Type: "type.googleapis.com/not.a.RealType",
+		Id:   "test-id",
+		Data: &anypb.Any{
+			TypeUrl: "type.googleapis.com/not.a.RealType",
+			Value:   []byte("opaque"),
+		},
+	}
+	protoutil.RedactSensitive(record)
+
+	assert.Equal(t, []byte("opaque"), record.GetData().GetValue())
+}
+
+func TestRedactSensitive_Nil(t *testing.T) {
+	t.Parallel()
+
+	assert.NotPanics(t, func() {
+		protoutil.RedactSensitive(nil)
+		protoutil.RedactSensitive((*configpb.Settings)(nil))
+	})
+}
+
+func TestRedactSensitive_NonMessageWrapper(t *testing.T) {
+	t.Parallel()
+
+	// messages without any sensitive fields pass through unchanged
+	v := wrapperspb.String("hello")
+	protoutil.RedactSensitive(v)
+	assert.Equal(t, "hello", v.GetValue())
+}

--- a/pkg/protoutil/redact_test.go
+++ b/pkg/protoutil/redact_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
@@ -18,9 +17,9 @@ func TestRedactSensitive_Scalars(t *testing.T) {
 	t.Parallel()
 
 	settings := &configpb.Settings{
-		SharedSecret: proto.String("shared-secret-value"),
-		CookieSecret: proto.String("cookie-secret-value"),
-		CookieName:   proto.String("my-cookie"),
+		SharedSecret: new("shared-secret-value"),
+		CookieSecret: new("cookie-secret-value"),
+		CookieName:   new("my-cookie"),
 	}
 	protoutil.RedactSensitive(settings)
 
@@ -35,8 +34,8 @@ func TestRedactSensitive_NestedMessages(t *testing.T) {
 	cfg := &configpb.Config{
 		Name: "test-config",
 		Settings: &configpb.Settings{
-			SharedSecret:         proto.String("shared-secret-value"),
-			CertificateAuthority: proto.String("not-a-secret"),
+			SharedSecret:         new("shared-secret-value"),
+			CertificateAuthority: new("not-a-secret"),
 		},
 		Routes: []*configpb.Route{{
 			From:         "https://from.example.com",
@@ -77,7 +76,7 @@ func TestRedactSensitive_MessageKindCleared(t *testing.T) {
 		SshHostKeys: &configpb.Settings_StringList{
 			Values: []string{"-----BEGIN PRIVATE KEY-----"},
 		},
-		SshUserCaKey: proto.String("ssh-user-ca-private-key"),
+		SshUserCaKey: new("ssh-user-ca-private-key"),
 	}
 	protoutil.RedactSensitive(settings)
 
@@ -91,7 +90,7 @@ func TestRedactSensitive_DescendsIntoAny(t *testing.T) {
 
 	cfg := &configpb.Config{
 		Settings: &configpb.Settings{
-			SharedSecret: proto.String("shared-secret-value"),
+			SharedSecret: new("shared-secret-value"),
 		},
 	}
 	data, err := anypb.New(cfg)


### PR DESCRIPTION
The databroker debug browser rendered records as raw protojson, including session OAuth tokens, ID-token JWTs, and IdP client secrets. Redact fields annotated `[(pomerium.config.sensitive) = true]` (replacing string/bytes values with `[REDACTED]`, descending into `Any` payloads) and annotate the session and identity record types.

Linear: [ENG-4132](https://linear.app/pomerium/issue/ENG-4132/redact-sensitive-fields-in-the-databroker-debug-browser)