### PR TITLE
ssh: fix connection buffer limits

### DIFF
--- a/config/envoyconfig/clusters.go
+++ b/config/envoyconfig/clusters.go
@@ -263,6 +263,10 @@ func (b *Builder) buildPolicyCluster(ctx context.Context, cfg *config.Config, po
 	}
 	cluster.LbPolicy = policy.LoadBalancingPolicy.Value.ToEnvoy()
 
+	if policy.IsSSHUpstream() {
+		cluster.PerConnectionBufferLimitBytes = wrapperspb.UInt32(sshConnectionBufferLimit)
+	}
+
 	// Keep last
 	if policy.UpstreamTunnel != nil {
 		if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagSSHUpstreamTunnel) {

--- a/config/envoyconfig/clusters_test.go
+++ b/config/envoyconfig/clusters_test.go
@@ -1378,3 +1378,38 @@ func Test_buildPolicyCluster(t *testing.T) {
 		assert.Equal(t, "stat-name", cluster.AltStatName)
 	})
 }
+
+func TestSshConnectionBufferLimits(t *testing.T) {
+	t.Parallel()
+
+	cfg := config.New(config.NewDefaultOptions())
+	b := New("local-connect", "local-grpc", "local-http", "local-debug", "local-metrics", filemgr.NewManager(), nil, true)
+
+	{
+		cluster, err := b.buildPolicyCluster(t.Context(), cfg, &config.Policy{
+			From: "ssh://route1",
+			To:   mustParseWeightedURLs(t, "ssh://dest1"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, sshConnectionBufferLimit, cluster.PerConnectionBufferLimitBytes.GetValue())
+	}
+
+	{
+		cluster, err := b.buildPolicyCluster(t.Context(), cfg, &config.Policy{
+			From: "http://route2",
+			To:   mustParseWeightedURLs(t, "http://dest2"),
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, connectionBufferLimit, cluster.PerConnectionBufferLimitBytes.GetValue())
+	}
+	{
+		cluster, err := b.buildPolicyCluster(t.Context(), cfg, &config.Policy{
+			From:           "http://route3",
+			To:             mustParseWeightedURLs(t, "http://dest3"),
+			UpstreamTunnel: &config.UpstreamTunnel{},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, sshConnectionBufferLimit, cluster.PerConnectionBufferLimitBytes.GetValue())
+	}
+}

--- a/config/envoyconfig/listeners_ssh.go
+++ b/config/envoyconfig/listeners_ssh.go
@@ -21,6 +21,7 @@ import (
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
 	xssh "github.com/pomerium/envoy-custom/api/x/recording/formats/ssh"
@@ -201,6 +202,7 @@ func buildSSHListener(cfg *config.Config, extensionsToLoad []string) (*envoy_con
 				Filters: filters,
 			},
 		},
+		PerConnectionBufferLimitBytes: wrapperspb.UInt32(sshConnectionBufferLimit),
 	}
 	li.Address, li.AdditionalAddresses = buildTCPListenAddresses(cfg.Options.SSHAddr, 22)
 	return li, nil

--- a/config/envoyconfig/listeners_ssh_test.go
+++ b/config/envoyconfig/listeners_ssh_test.go
@@ -128,5 +128,14 @@ func TestBuildSSHListener(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	// TODO: tests
+	t.Run("connection buffer limits", func(t *testing.T) {
+		cfg := config.New(config.NewDefaultOptions())
+		cfg.Options.SSHAddr = "0.0.0.0:22"
+		cfg.Options.Policies = []config.Policy{
+			{From: "ssh://host1", To: mustParseWeightedURLs(t, "ssh://to:22")},
+		}
+		l, err := buildSSHListener(cfg, []string{})
+		assert.NoError(t, err)
+		assert.Equal(t, sshConnectionBufferLimit, l.PerConnectionBufferLimitBytes.GetValue())
+	})
 }

--- a/config/envoyconfig/protocols.go
+++ b/config/envoyconfig/protocols.go
@@ -31,6 +31,11 @@ const (
 	maxConcurrentStreams             uint32 = 100
 	initialStreamWindowSizeLimit     uint32 = 64 * 1024
 	initialConnectionWindowSizeLimit uint32 = 1 * 1024 * 1024
+
+	// For ssh connections, the minimum safe buffer size is 524288. See
+	// envoy-custom/source/extensions/filters/network/ssh/transport_base.h
+	// for additional details.
+	sshConnectionBufferLimit uint32 = 524288
 )
 
 var http1ProtocolOptions = &envoy_config_core_v3.Http1ProtocolOptions{

--- a/config/policy.go
+++ b/config/policy.go
@@ -993,6 +993,12 @@ func (p *Policy) IsSSH() bool {
 	return strings.HasPrefix(p.From, "ssh://")
 }
 
+// IsSSHUpstream returns true if the route has an upstream SSH connection or
+// is backed by a reverse tunnel.
+func (p *Policy) IsSSHUpstream() bool {
+	return (len(p.To) > 0 && p.To[0].URL.Scheme == "ssh") || p.UpstreamTunnel != nil
+}
+
 // AllAllowedDomains returns all the allowed domains.
 func (p *Policy) AllAllowedDomains() []string {
 	var ads []string

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -532,6 +532,27 @@ func TestPolicy_IsSSH(t *testing.T) {
 	assert.True(t, p2.IsSSH())
 }
 
+func TestPolicy_IsSSHUpstream(t *testing.T) {
+	p1 := Policy{
+		From: "ssh://example.com",
+		To:   mustParseWeightedURLs(t, "ssh://to"),
+	}
+	assert.True(t, p1.IsSSHUpstream())
+
+	p2 := Policy{
+		From:           "ssh://example.com",
+		To:             mustParseWeightedURLs(t, "http://to"),
+		UpstreamTunnel: &UpstreamTunnel{},
+	}
+	assert.True(t, p2.IsSSHUpstream())
+
+	p3 := Policy{
+		From: "http://example.com",
+		To:   mustParseWeightedURLs(t, "http://to"),
+	}
+	assert.False(t, p3.IsSSHUpstream())
+}
+
 func mustParseWeightedURLs(t testing.TB, urls ...string) WeightedURLs {
 	wu, err := ParseWeightedUrls(urls...)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

For SSH clusters, set connection buffer high watermark limits to the minimum safe value of 524288. The same limit is also used for the ssh listener (it was previously unset, which used the 1MB default). 

See the linked envoy-custom PR for more details on where that number comes from.

## Related issues

Fixes https://github.com/pomerium/pomerium/issues/6285

Related: https://github.com/pomerium/envoy-custom/pull/251/changes

## User Explanation

The default connection buffer limit, which was applied globally, is 32768. This is suitable for HTTP, but is too small for SSH connections. This could cause connections to get stuck in some use cases, such as during large file transfer.

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
