### PR TITLE
envoyconfig: increase header size limits

### DIFF
--- a/config/envoyconfig/listeners_main.go
+++ b/config/envoyconfig/listeners_main.go
@@ -195,7 +195,9 @@ func (b *Builder) buildMainHTTPConnectionManagerFilter(
 				ToEnvoy(),
 			IdleTimeout:       durationpb.New(cfg.Options.IdleTimeout),
 			MaxStreamDuration: maxStreamDuration,
+			MaxHeadersCount:   wrapperspb.UInt32(1000),
 		},
+		MaxRequestHeadersKb: wrapperspb.UInt32(128),
 		HttpProtocolOptions: http1ProtocolOptions,
 		RequestTimeout:      durationpb.New(cfg.Options.ReadTimeout),
 		// See https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#x-forwarded-for

--- a/config/envoyconfig/testdata/main_http_connection_manager_filter.json
+++ b/config/envoyconfig/testdata/main_http_connection_manager_filter.json
@@ -40,7 +40,8 @@
     "alwaysSetRequestIdInResponse": true,
     "commonHttpProtocolOptions": {
       "headersWithUnderscoresAction": "REJECT_REQUEST",
-      "idleTimeout": "300s"
+      "idleTimeout": "300s",
+      "maxHeadersCount": 1000
     },
     "earlyHeaderMutationExtensions": [
       {
@@ -2088,6 +2089,7 @@
       }
     },
     "requestTimeout": "30s",
+    "maxRequestHeadersKb": 128,
     "mergeSlashes": true,
     "normalizePath": true,
     "pathWithEscapedSlashesAction": "REJECT_REQUEST",


### PR DESCRIPTION
## Summary

A recent Envoy security patch changes how the header size limits interact with Cookie headers. Previously, Cookie headers could potentially exceed the configured limits.

However the note in https://github.com/envoyproxy/envoy/issues/45483 suggests this patch may cause problems for legitimate traffic, and provides alternative default header size limits that should still be safe from a DoS perspective. Let's apply these new limits.

## Related issues

Related to https://linear.app/pomerium/issue/ENG-4133/upgrade-envoy-to-1367

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
