### PR TITLE
ci: segregate all TUI ecosystem deps into dependabot tui group

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -47,8 +47,15 @@ updates:
           - "github.com/exaring/otelpgx"
           - "charm.land/*"
           - "github.com/charmbracelet/*"
-          - "github.com/muesli/termenv"
+          - "github.com/muesli/*"
           - "github.com/mattn/go-runewidth"
+          - "github.com/lucasb-eyer/go-colorful"
+          - "github.com/rivo/uniseg"
+          - "github.com/aymanbagabas/go-osc52/*"
+          - "github.com/xo/terminfo"
+          - "github.com/atotto/clipboard"
+          - "github.com/sahilm/fuzzy"
+          - "github.com/creack/pty"
       otel:
         patterns:
           - "go.opentelemetry.io/*"
@@ -57,8 +64,15 @@ updates:
         patterns:
           - "charm.land/*"
           - "github.com/charmbracelet/*"
-          - "github.com/muesli/termenv"
+          - "github.com/muesli/*"
           - "github.com/mattn/go-runewidth"
+          - "github.com/lucasb-eyer/go-colorful"
+          - "github.com/rivo/uniseg"
+          - "github.com/aymanbagabas/go-osc52/*"
+          - "github.com/xo/terminfo"
+          - "github.com/atotto/clipboard"
+          - "github.com/sahilm/fuzzy"
+          - "github.com/creack/pty"
   - package-ecosystem: "gomod"
     directory: "/pkg/grpc/config/"
     schedule:


### PR DESCRIPTION
## What

Expands the dependabot `tui` group (and the corresponding `go` group `exclude-patterns`) to cover the **complete** TUI dependency subtree, not just the explicitly-named charm packages.

Added packages:
- `github.com/muesli/*` (was `github.com/muesli/termenv` — now also covers `cancelreader`)
- `github.com/lucasb-eyer/go-colorful`
- `github.com/rivo/uniseg`
- `github.com/aymanbagabas/go-osc52/*`
- `github.com/xo/terminfo`
- `github.com/atotto/clipboard`
- `github.com/sahilm/fuzzy`
- `github.com/creack/pty`

## Why

The `go` group's `exclude-patterns` and the `tui` group only named the charm packages (`charm.land/*`, `github.com/charmbracelet/*`, `termenv`, `go-runewidth`). The TUI ecosystem's other transitive dependencies were left ungrouped.

As a result, when the `go` group runs `go mod tidy`, those ungrouped transitive deps get their versions rewritten, which drags the "excluded" charm packages (lipgloss, colorprofile, x/ansi, runewidth) along into the regular `go` PR. That produces a half-bumped TUI stack and the version skew that breaks `make build` (e.g. #6456).

Putting the entire TUI subtree in one group ensures TUI updates land in a single, self-consistent PR.

## Notes

`github.com/rivo/uniseg` and `github.com/creack/pty` are also pulled by non-TUI deps (OPA/buf and moby, respectively). They're grouped as TUI here deliberately: their versions are co-constrained with the charm stack, so keeping them in the TUI PR prevents recurring skew. The tradeoff is a rare non-TUI-driven bump landing in the `tui` PR — harmless.

Verified all added packages are pulled exclusively (or, for the two shared ones, primarily) through the charm/TUI stack via `go mod why` / `go mod graph`.