### PR TITLE
fix(docs): blob_storage.managed_prefix docstring

### DIFF
--- a/pkg/grpc/config/config.openapi.yaml
+++ b/pkg/grpc/config/config.openapi.yaml
@@ -1511,8 +1511,9 @@ components:
             - "null"
           title: managed_prefix
           description: |-
-            Optional path prefix within the bucket where Pomerium stores managed
-             objects, isolating them from other tenants of the same bucket.
+            Prefix assigned by a connected Pomerium Enterprise instance. End users
+             should not set or modify this field unless they know exactly what they
+             are doing or are working around a specific issue.
       title: BlobStorageSettings
       additionalProperties: false
       description: |-

--- a/pkg/grpc/config/config.pb.go
+++ b/pkg/grpc/config/config.pb.go
@@ -4442,8 +4442,9 @@ type BlobStorageSettings struct {
 	// URI of the object-storage bucket (e.g. "s3://my-bucket",
 	// "gs://my-bucket"). Empty disables blob storage.
 	BucketUri *string `protobuf:"bytes,1,opt,name=bucket_uri,json=bucketUri,proto3,oneof" json:"bucket_uri,omitempty"`
-	// Optional path prefix within the bucket where Pomerium stores managed
-	// objects, isolating them from other tenants of the same bucket.
+	// Prefix assigned by a connected Pomerium Enterprise instance. End users
+	// should not set or modify this field unless they know exactly what they
+	// are doing or are working around a specific issue.
 	ManagedPrefix *string `protobuf:"bytes,2,opt,name=managed_prefix,json=managedPrefix,proto3,oneof" json:"managed_prefix,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/pkg/grpc/config/config.pb.json
+++ b/pkg/grpc/config/config.pb.json
@@ -433,7 +433,7 @@
             },
             {
               "name": "managed_prefix",
-              "description": "Optional path prefix within the bucket where Pomerium stores managed\nobjects, isolating them from other tenants of the same bucket.",
+              "description": "Prefix assigned by a connected Pomerium Enterprise instance. End users\nshould not set or modify this field unless they know exactly what they\nare doing or are working around a specific issue.",
               "label": "optional",
               "type": "string",
               "longType": "string",

--- a/pkg/grpc/config/config.proto
+++ b/pkg/grpc/config/config.proto
@@ -1115,8 +1115,9 @@ message BlobStorageSettings {
   // URI of the object-storage bucket (e.g. "s3://my-bucket",
   // "gs://my-bucket"). Empty disables blob storage.
   optional string bucket_uri = 1;
-  // Optional path prefix within the bucket where Pomerium stores managed
-  // objects, isolating them from other tenants of the same bucket.
+  // Prefix assigned by a connected Pomerium Enterprise instance. End users
+  // should not set or modify this field unless they know exactly what they
+  // are doing or are working around a specific issue.
   optional string managed_prefix = 2;
 }
 


### PR DESCRIPTION
## Summary

The previous generated docstring was dangerously incorrect.

This field should not be set by end-users, and is already showing up in LLM generated guides https://github.com/pomerium/documentation/pull/2269/changes.

It is important for this field to stay empty as bootstrap / initializing conditions around being ready to upload depend on it going from unset to set. It must also match a specific ids in Enterprise for querying and replay.

## Related issues

N/A

## User Explanation

clarify that end-users should never set `blob_storage.managed_prefix` setting in config files.

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
