### PR TITLE
build xds discovery resources synchronously

### DIFF
--- a/internal/controlplane/xds.go
+++ b/internal/controlplane/xds.go
@@ -7,7 +7,6 @@ import (
 	"maps"
 
 	envoy_service_discovery_v3 "github.com/envoyproxy/go-control-plane/envoy/service/discovery/v3"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
@@ -27,60 +26,44 @@ func (srv *Server) buildDiscoveryResources(ctx context.Context) (map[string][]*e
 
 	log.Ctx(ctx).Debug().Msg("controlplane: building discovery resources")
 
-	eg, ctx := errgroup.WithContext(ctx)
-
 	var clusterResources []*envoy_service_discovery_v3.Resource
-	eg.Go(func() error {
-		clusters, err := srv.Builder.BuildClusters(ctx, cfg)
-		if err != nil {
-			return fmt.Errorf("error building clusters: %w", err)
-		}
-		for _, cluster := range clusters {
-			clusterResources = append(clusterResources, &envoy_service_discovery_v3.Resource{
-				Name:     cluster.Name,
-				Version:  hex.EncodeToString(cryptutil.HashProto(cluster)),
-				Resource: protoutil.NewAny(cluster),
-			})
-		}
-		return nil
-	})
+	clusters, err := srv.Builder.BuildClusters(ctx, cfg)
+	if err != nil {
+		return nil, fmt.Errorf("error building clusters: %w", err)
+	}
+	for _, cluster := range clusters {
+		clusterResources = append(clusterResources, &envoy_service_discovery_v3.Resource{
+			Name:     cluster.Name,
+			Version:  hex.EncodeToString(cryptutil.HashProto(cluster)),
+			Resource: protoutil.NewAny(cluster),
+		})
+	}
 
 	var listenerResources []*envoy_service_discovery_v3.Resource
-	eg.Go(func() error {
-		listeners, err := srv.Builder.BuildListeners(ctx, cfg, false)
-		if err != nil {
-			return fmt.Errorf("error building listeners: %w", err)
-		}
-		for _, listener := range listeners {
-			listenerResources = append(listenerResources, &envoy_service_discovery_v3.Resource{
-				Name:     listener.Name,
-				Version:  hex.EncodeToString(cryptutil.HashProto(listener)),
-				Resource: protoutil.NewAny(listener),
-			})
-		}
-		return nil
-	})
+	listeners, err := srv.Builder.BuildListeners(ctx, cfg, false)
+	if err != nil {
+		return nil, fmt.Errorf("error building listeners: %w", err)
+	}
+	for _, listener := range listeners {
+		listenerResources = append(listenerResources, &envoy_service_discovery_v3.Resource{
+			Name:     listener.Name,
+			Version:  hex.EncodeToString(cryptutil.HashProto(listener)),
+			Resource: protoutil.NewAny(listener),
+		})
+	}
 
 	routeConfigurationResources := map[string][]*envoy_service_discovery_v3.Resource{}
-	eg.Go(func() error {
-		routeConfigurations, err := srv.Builder.BuildRouteConfigurations(ctx, cfg)
-		if err != nil {
-			return fmt.Errorf("error building route configurations: %w", err)
-		}
-		for _, routeConfiguration := range routeConfigurations {
-			typeURL := protoutil.GetTypeURL(routeConfiguration.Config)
-			routeConfigurationResources[typeURL] = append(routeConfigurationResources[typeURL], &envoy_service_discovery_v3.Resource{
-				Name:     routeConfiguration.Name,
-				Version:  hex.EncodeToString(cryptutil.HashProto(routeConfiguration.Config)),
-				Resource: protoutil.NewAny(routeConfiguration.Config),
-			})
-		}
-		return nil
-	})
-
-	err := eg.Wait()
+	routeConfigurations, err := srv.Builder.BuildRouteConfigurations(ctx, cfg)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("error building route configurations: %w", err)
+	}
+	for _, routeConfiguration := range routeConfigurations {
+		typeURL := protoutil.GetTypeURL(routeConfiguration.Config)
+		routeConfigurationResources[typeURL] = append(routeConfigurationResources[typeURL], &envoy_service_discovery_v3.Resource{
+			Name:     routeConfiguration.Name,
+			Version:  hex.EncodeToString(cryptutil.HashProto(routeConfiguration.Config)),
+			Resource: protoutil.NewAny(routeConfiguration.Config),
+		})
 	}
 
 	log.Ctx(ctx).Debug().


### PR DESCRIPTION
## Summary

This changes xds discovery resources to be built synchronously instead of in background goroutines with a waitgroup. The process of constructing some of the messages involves using hashstructure across the entire Policy object, which can race with proto marshal/unmarshal operations that happen when converting between pomerium/envoy HealthCheck and OutlierDetection messages. This can happen on startup when loading routes that have health checks enabled, for example.

## User Explanation

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
