### PR TITLE
fix: expected health checks must be recomputed when config changes

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -426,7 +426,7 @@ func (srv *Server) Run(ctx context.Context) error {
 func (srv *Server) OnConfigChange(ctx context.Context, cfg *config.Config) error {
 	ctx, span := srv.tracer.Start(ctx, "controlplane.Server.OnConfigChange")
 	defer span.End()
-
+	srv.updateHealthProviders(ctx, cfg)
 	select {
 	case <-ctx.Done():
 		return context.Cause(ctx)


### PR DESCRIPTION
## Summary

Expected health checks (the internal components we expected to be healthy) are computed from the config options.

It was intended for those health checks to be re-evaluated on every config change, but looks like that was omitted accidentally from:
https://github.com/pomerium/pomerium/pull/5822/changes#diff-2d0f38bfdd9e32988fcb2ac5c1ae9764f1aab4836766e0fd320bf44bb73859e0


## Related issues

[ENG-4154](https://linear.app/pomerium/issue/ENG-4154/health-checks-are-not-reloading-based-on-config)

## User Explanation

health checks now correctly account for hot-reload configurations

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
