### PR TITLE
feat: health checks for envoy dynamic extensions

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -597,6 +597,11 @@ func (srv *Server) getExpectedHealthChecks(cfg *config.Config) (ret []health.Che
 			health.XDSRouteConfiguration,
 		)
 	}
+
+	if len(cfg.Options.EnvoyDynamicExtensions.Or([]string{})) > 0 {
+		ret = append(ret, health.EnvoyDynamicExtensions)
+	}
+
 	for _, extraCheckers := range srv.extraHealthChecks {
 		ret = append(ret, extraCheckers.GetExpectedHealthChecks()...)
 	}

--- a/pkg/envoy/dynamic_extensions.go
+++ b/pkg/envoy/dynamic_extensions.go
@@ -2,12 +2,17 @@ package envoy
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"slices"
+	"time"
 
 	xds_type_v3 "github.com/cncf/xds/go/xds/type/v3"
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/hashicorp/go-set/v3"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/structpb"
@@ -19,18 +24,49 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/envoyconfig"
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/pkg/health"
 	"github.com/pomerium/pomerium/pkg/ipc"
 	"github.com/pomerium/pomerium/pkg/protoutil"
+	slicesutil "github.com/pomerium/pomerium/pkg/slices"
 )
+
+type dynamicExtension struct {
+	id   string
+	path string
+}
+
+type extensionStatusInfo struct {
+	Loaded []extensionLoadedInfo `json:"loaded,omitempty"`
+	Failed []extensionFailedInfo `json:"failed,omitempty"`
+}
+
+type extensionLoadedInfo struct {
+	ID string `json:"id"`
+}
+
+type extensionFailedInfo struct {
+	Info extensionInfo `json:"info"`
+	Err  string        `json:"err"`
+}
+
+type extensionInfo struct {
+	Path string `json:"path"`
+}
 
 type DynamicExtensionsConfig struct {
 	RecordingPipes    []*ipc.ProtoPipeWorker[*xrecording.RecordingData, *xrecording.RecordingCheckpoint]
 	DynamicExtensions *envoy_config_core_v3.TypedExtensionConfig
-	extensionIDs      []string
+	extensions        []dynamicExtension
+}
+
+func (d *DynamicExtensionsConfig) extensionIDs() []string {
+	return slicesutil.Map(d.extensions, func(d dynamicExtension) string {
+		return d.id
+	})
 }
 
 func (d *DynamicExtensionsConfig) isSessionRecordingEnabled() bool {
-	return slices.Contains(d.extensionIDs, envoyconfig.ExtensionSSHSessionRecording)
+	return slices.Contains(d.extensionIDs(), envoyconfig.ExtensionSSHSessionRecording)
 }
 
 func (srv *Server) configureDynamicExtensions(ctx context.Context, cfg *config.Config, paths []string) (*DynamicExtensionsConfig, error) {
@@ -39,8 +75,8 @@ func (srv *Server) configureDynamicExtensions(ctx context.Context, cfg *config.C
 		Paths:            paths,
 		ExtensionConfigs: map[string]*anypb.Any{},
 	}
-	for _, filepath := range paths {
-		extID, err := envoyconfig.ReadDynamicExtensionID(ctx, filepath)
+	for _, extPath := range paths {
+		extID, err := envoyconfig.ReadDynamicExtensionID(ctx, extPath)
 		if err != nil {
 			return nil, err
 		}
@@ -62,13 +98,25 @@ func (srv *Server) configureDynamicExtensions(ctx context.Context, cfg *config.C
 			}
 			out.RecordingPipes = pipes
 		}
-		out.extensionIDs = append(out.extensionIDs, extID)
+		out.extensions = append(out.extensions, dynamicExtension{
+			id:   extID,
+			path: extPath,
+		})
 	}
 	out.DynamicExtensions = &envoy_config_core_v3.TypedExtensionConfig{
 		Name:        "envoy.bootstrap.dynamic_extension_loader",
 		TypedConfig: marshalAny(extensionLoaderCfg),
 	}
 	return out, nil
+}
+
+func (srv *Server) startDynExtHealthProbeLocked(ctx context.Context, dynCfg *DynamicExtensionsConfig) {
+	if srv.dynamicExtensionHealthProbeCancel != nil {
+		srv.dynamicExtensionHealthProbeCancel()
+	}
+	ctxca, ca := context.WithCancel(ctx)
+	srv.dynamicExtensionHealthProbeCancel = ca
+	go srv.probeExtensionHealth(ctxca, dynCfg.extensions)
 }
 
 // mutates the extension loader in place
@@ -113,4 +161,112 @@ func (srv *Server) configureSessionRecordingExtension(
 	}
 	dynCfg.ExtensionConfigs[extID] = marshalAny(ts)
 	return workers, nil
+}
+
+func (srv *Server) probeExtensionHealth(ctx context.Context, configuredExtensions []dynamicExtension) {
+	log.Ctx(ctx).Debug().Msg("starting envoy dynamic extension health probe")
+	defer func() {
+		log.Ctx(ctx).Debug().Msg("envoy dynamic extension health probe done")
+	}()
+	if len(configuredExtensions) == 0 {
+		health.ReportRunning(health.EnvoyDynamicExtensions)
+		return
+	}
+	health.ReportError(health.EnvoyDynamicExtensions, fmt.Errorf("waiting for status to be reported"))
+	t := time.NewTicker(5 * time.Second)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			info, err := srv.envoyDynamicExtStatus(ctx)
+			if err != nil {
+				health.ReportError(health.EnvoyDynamicExtensions, fmt.Errorf("failed to check extension status : %w", err))
+			} else {
+				remaining, md, err := srv.compareExtensions(configuredExtensions, info)
+				if err != nil {
+					health.ReportError(health.EnvoyDynamicExtensions, err, md...)
+				} else {
+					health.ReportRunning(health.EnvoyDynamicExtensions, md...)
+				}
+				if len(remaining) == 0 {
+					return
+				}
+			}
+		}
+	}
+}
+
+func (srv *Server) envoyDynamicExtStatus(ctx context.Context) (*extensionStatusInfo, error) {
+	srv.mu.Lock()
+	adminAddress := srv.adminAddress
+	srv.mu.Unlock()
+
+	u := &url.URL{
+		Scheme: "http",
+		Host:   "unix",
+		Path:   "/dynamic_extensions/status",
+	}
+	client := envoyAdminClient(adminAddress)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected http status code from dynamic extensions status : %d", resp.StatusCode)
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	info := &extensionStatusInfo{}
+	if err := dec.Decode(info); err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+func (srv *Server) compareExtensions(configuredExtensions []dynamicExtension, info *extensionStatusInfo) (notReported []string, metadata []health.Attr, err error) {
+	if len(configuredExtensions) == 0 {
+		return []string{}, []health.Attr{}, nil
+	}
+
+	extIDsToCheck := set.New[string](len(configuredExtensions))
+	filePathsToID := map[string]string{}
+	for _, ext := range configuredExtensions {
+		extIDsToCheck.Insert(ext.id)
+		filePathsToID[ext.path] = ext.id
+	}
+
+	for _, loadedExt := range info.Loaded {
+		_ = extIDsToCheck.Remove(loadedExt.ID)
+	}
+
+	if extIDsToCheck.Size() == 0 {
+		return []string{}, slicesutil.Map(configuredExtensions, func(ext dynamicExtension) health.Attr {
+			return health.StrAttr(ext.id, "loaded")
+		}), nil
+	}
+	retAttrs := []health.Attr{}
+	for _, failedExt := range info.Failed {
+		id, ok := filePathsToID[failedExt.Info.Path]
+		if !ok {
+			continue
+		}
+		_ = extIDsToCheck.Remove(id)
+		if failedExt.Err != "" {
+			retAttrs = append(retAttrs, health.StrAttr(id, fmt.Sprintf("extension failed to load : %s", failedExt.Err)))
+		} else {
+			retAttrs = append(retAttrs, health.StrAttr(id, "extension failed to load"))
+		}
+	}
+	for _, remainingID := range extIDsToCheck.Slice() {
+		retAttrs = append(retAttrs, health.StrAttr(remainingID, "health not reported"))
+	}
+	return extIDsToCheck.Slice(), retAttrs, fmt.Errorf("not all configured extensions loaded")
 }

--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -60,13 +60,13 @@ type Server struct {
 
 	monitorProcessCancel context.CancelFunc
 
-	mu        sync.Mutex
-	shutdownC chan error
+	mu                                sync.Mutex
+	shutdownC                         chan error
+	dynamicExtensionHealthProbeCancel context.CancelFunc
 
 	recordingServer     stdatomic.Pointer[recording.Server]
 	recordingServerErrC chan error
 }
-
 type ServerOptions struct {
 	extraEnvVars          []string
 	logLevel              config.LogLevel
@@ -220,6 +220,9 @@ func (srv *Server) Close() error {
 
 	srv.mu.Lock()
 	defer srv.mu.Unlock()
+	if srv.dynamicExtensionHealthProbeCancel != nil {
+		srv.dynamicExtensionHealthProbeCancel()
+	}
 
 	var err error
 	if srv.cmd != nil && srv.cmd.Process != nil {
@@ -290,6 +293,7 @@ func (srv *Server) run(ctx context.Context, cfg *config.Config) error {
 	if err != nil {
 		return fmt.Errorf("envoy: failed to configure dynamic extensions: %w", err)
 	}
+	srv.startDynExtHealthProbeLocked(ctx, dynCfg)
 
 	if dynCfg.isSessionRecordingEnabled() {
 		srv.enableOrUpdateSessionRecording(ctx, cfg, dynCfg.RecordingPipes)
@@ -298,7 +302,7 @@ func (srv *Server) run(ctx context.Context, cfg *config.Config) error {
 	}
 
 	if err := srv.writeConfig(ctx, cfg, &envoyconfig.DynamicExtensionsConfig{
-		ExtensionsToLoad:  dynCfg.extensionIDs,
+		ExtensionsToLoad:  dynCfg.extensionIDs(),
 		DynamicExtensions: dynCfg.DynamicExtensions,
 	}); err != nil {
 		log.Ctx(ctx).Error().Err(err).Str("service", "envoy").Msg("envoy: failed to write envoy config")
@@ -521,7 +525,7 @@ func (srv *Server) envoyReady(ctx context.Context) error {
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("unexpected http status code from ready point : %d", resp.StatusCode)
+		return fmt.Errorf("unexpected http status code from ready endpoint : %d", resp.StatusCode)
 	}
 	return nil
 }

--- a/pkg/health/check.go
+++ b/pkg/health/check.go
@@ -24,6 +24,10 @@ const (
 	// DatabrokerCluster checks whether members of the databroker cluster are healthy
 	DatabrokerCluster = Check("databroker.cluster")
 
+	// EnvoyDynamicExtensions checks that the set of expected extensions configured
+	// are actually successfully initialized in envoy
+	EnvoyDynamicExtensions = Check("envoy.extensions")
+
 	// StorageBackend checks whether the storage backend is healthy
 	StorageBackend = Check("storage.backend")
 	// StorageBackendCleanup checks the storage backend cleanup tasks are healthy


### PR DESCRIPTION
## Summary

Adds health probes for envoy dynamic extensions.

It uses the envoy admin endpoint `/dynamic_extensions/status` on the envoy admin address. Extensions are always reported on load, and status is not updated after they load.

The health is evaluated in a background goroutine, until all extensions are reported at which point we stop polling.  In flight configuration changes / envoy server reloads cancel the health probe and start a new one.


## Related issues

[ENG-4138](https://linear.app/pomerium/issue/ENG-4138/session-recording-dynamic-extensions-health-check-integration)

## User Explanation

Status of loaded envoy extensions is now reflected in the health probes

## AI disclosure

opus 4.8 was used for code review / PR review

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
