### PR TITLE
test: e2e coverage for IdP claim propagation to JWT claim headers

### DIFF
--- a/internal/authenticateflow/jwt_claims_headers_int_test.go
+++ b/internal/authenticateflow/jwt_claims_headers_int_test.go
@@ -1,0 +1,114 @@
+package authenticateflow_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/scenarios"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	"github.com/pomerium/pomerium/internal/testenv/values"
+)
+
+// TestJWTClaimHeadersPropagation verifies that claims supplied by the identity
+// provider propagate end-to-end: through the login flow, into both the
+// X-Pomerium-Claim-* request headers and the signed X-Pomerium-Jwt-Assertion
+// header presented to the upstream.
+func TestJWTClaimHeadersPropagation(t *testing.T) {
+	env := testenv.New(t)
+
+	// The IdP returns standard profile claims plus a few custom claims in the
+	// id_token and userinfo response.
+	env.Add(scenarios.NewIDP([]*scenarios.User{{
+		Email:     "user@example.com",
+		FirstName: "Test",
+		LastName:  "User",
+		Claims: map[string]any{
+			"department": "engineering",
+			"scope":      "session:role:analyst",
+			"roles":      []string{"admin", "viewer"},
+		},
+	}}))
+
+	// Forward a mix of standard and custom claims as headers. The same payload
+	// also backs the signed assertion, so these claims appear there too.
+	env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
+		cfg.Options.JWTClaimsHeaders = config.NewJWTClaimHeaders(
+			"email", "department", "scope", "roles",
+		)
+	}))
+
+	// The upstream echoes the request headers it received back as JSON.
+	up := upstreams.HTTP(nil)
+	up.Handle("/headers", func(w http.ResponseWriter, r *http.Request) {
+		hdrs := make(map[string]string, len(r.Header))
+		for k := range r.Header {
+			hdrs[strings.ToLower(k)] = r.Header.Get(k)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(hdrs)
+	})
+	passIdentityHeaders := true
+	route := up.Route().
+		From(env.SubdomainURL("claims")).
+		To(values.Bind(up.Addr(), func(addr string) string {
+			return fmt.Sprintf("http://%s", addr)
+		})).
+		Policy(func(p *config.Policy) {
+			p.AllowAnyAuthenticatedUser = true
+			p.PassIdentityHeaders = &passIdentityHeaders
+		})
+	env.AddUpstream(up)
+
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	resp, err := up.Get(route,
+		upstreams.AuthenticateAs("user@example.com"),
+		upstreams.Path("/headers"))
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	var hdrs map[string]string
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&hdrs))
+
+	// Claims arrive as individual X-Pomerium-Claim-* headers. Standard and
+	// custom claims are treated the same way, and a multi-valued claim is joined
+	// into a single comma-separated string.
+	assert.Equal(t, "user@example.com", hdrs["x-pomerium-claim-email"])
+	assert.Equal(t, "engineering", hdrs["x-pomerium-claim-department"])
+	assert.Equal(t, "session:role:analyst", hdrs["x-pomerium-claim-scope"])
+	assert.Equal(t, "admin,viewer", hdrs["x-pomerium-claim-roles"])
+
+	// The same claims are present in the signed assertion JWT.
+	assertion := hdrs["x-pomerium-jwt-assertion"]
+	require.NotEmpty(t, assertion, "missing assertion header")
+	payload := decodeJWTPayload(t, assertion)
+
+	assert.Equal(t, "user@example.com", payload["email"])
+	assert.Equal(t, "engineering", payload["department"])
+	assert.Equal(t, "session:role:analyst", payload["scope"])
+	assert.Equal(t, "admin,viewer", payload["roles"])
+}
+
+// decodeJWTPayload decodes the (unverified) payload section of a compact JWS.
+func decodeJWTPayload(t *testing.T, token string) map[string]any {
+	t.Helper()
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3, "unexpected JWT format")
+	raw, err := base64.RawURLEncoding.DecodeString(parts[1])
+	require.NoError(t, err)
+	var m map[string]any
+	require.NoError(t, json.Unmarshal(raw, &m))
+	return m
+}

--- a/internal/testutil/mockidp/mockidp.go
+++ b/internal/testutil/mockidp/mockidp.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"io"
+	"maps"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -482,6 +483,7 @@ func (state state) GetUserInfo(users map[string]*User) *userInfo {
 			userInfo.Name = strings.TrimSpace(u.FirstName + " " + u.LastName)
 			userInfo.FamilyName = u.LastName
 			userInfo.GivenName = u.FirstName
+			userInfo.extra = u.Claims
 		}
 	}
 
@@ -494,6 +496,29 @@ type userInfo struct {
 	Email      string `json:"email"`
 	FamilyName string `json:"family_name"`
 	GivenName  string `json:"given_name"`
+
+	// extra holds additional custom claims to merge into the JSON output.
+	extra map[string]any
+}
+
+// claims returns the standard profile claims merged with any extra custom
+// claims as top-level fields.
+func (u *userInfo) claims() map[string]any {
+	m := map[string]any{
+		"sub":         u.Subject,
+		"name":        u.Name,
+		"email":       u.Email,
+		"family_name": u.FamilyName,
+		"given_name":  u.GivenName,
+	}
+	maps.Copy(m, u.extra)
+	return m
+}
+
+// MarshalJSON renders the standard profile claims and merges in any extra
+// custom claims as top-level fields.
+func (u *userInfo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(u.claims())
 }
 
 type idToken struct {
@@ -503,6 +528,19 @@ type idToken struct {
 	Audience string           `json:"aud"`
 	Expiry   *jwt.NumericDate `json:"exp"`
 	IssuedAt *jwt.NumericDate `json:"iat"`
+}
+
+// MarshalJSON merges the userinfo claims (including any custom claims) with the
+// id_token's registered claims. It is defined explicitly because embedding
+// *userInfo would otherwise promote userInfo.MarshalJSON and drop the
+// iss/aud/exp/iat fields.
+func (token *idToken) MarshalJSON() ([]byte, error) {
+	m := token.userInfo.claims()
+	m["iss"] = token.Issuer
+	m["aud"] = token.Audience
+	m["exp"] = token.Expiry
+	m["iat"] = token.IssuedAt
+	return json.Marshal(m)
 }
 
 func (token *idToken) Encode(signingKey jose.SigningKey) string {
@@ -523,4 +561,7 @@ type User struct {
 	Email     string `json:"email"`
 	FirstName string `json:"first_name,omitempty"`
 	LastName  string `json:"last_name,omitempty"`
+	// Claims are additional claims to include in the id_token and the
+	// userinfo response, beyond the standard profile claims above.
+	Claims map[string]any `json:"claims,omitempty"`
 }


### PR DESCRIPTION
## Summary

Adds end-to-end coverage (testenv + mock IdP) for identity-provider claim propagation into Pomerium's JWT claim headers and signed assertion. Previously there was no Go test asserting that an arbitrary IdP claim reaches the upstream — `TestPomeriumJWT` (the docker-compose integration suite) only checks the structural claims (`iss`, `aud`, `iat`, `exp`).

## What it tests

`TestJWTClaimHeadersPropagation` (`internal/authenticateflow/jwt_claims_headers_int_test.go`):

- brings up `testenv` with the mock IdP, a user carrying custom claims (`department`, `scope`, and a multi-valued `roles`), and `jwt_claims_headers` set to forward a mix of standard and custom claims
- authenticates through the real login flow and routes to an upstream (with `pass_identity_headers` enabled) that echoes its request headers
- asserts that:
  - claims arrive as individual `X-Pomerium-Claim-*` headers (standard and custom treated identically)
  - a multi-valued claim is joined into a single comma-separated string (`roles` → `admin,viewer`)
  - the same claims are present in the signed `X-Pomerium-Jwt-Assertion` payload

## Supporting change to the mock IdP

The mock IdP (`internal/testutil/mockidp`) previously emitted only a fixed set of profile claims (`sub`, `name`, `email`, `family_name`, `given_name`), so custom-claim propagation could not be exercised at all. This adds:

- a `Claims map[string]any` field on `mockidp.User`
- `userInfo.MarshalJSON` that merges custom claims into the **UserInfo** response
- `idToken.MarshalJSON` that merges them into the **id_token** alongside the registered claims (defined explicitly because embedding `*userInfo` would otherwise promote its `MarshalJSON` and drop `iss`/`aud`/`exp`/`iat`)

The change is backward compatible: with no custom claims, `extra` is nil and the JSON output is identical to before. Existing `mockidp` consumers (e.g. `internal/authenticateflow`, `internal/mcp/e2e`) are unaffected.
