### PR TITLE
ci: add govulncheck workflow for Go vulnerability scanning

### DIFF
--- a/.github/workflows/govulncheck.yaml
+++ b/.github/workflows/govulncheck.yaml
@@ -1,0 +1,33 @@
+name: govulncheck
+permissions:
+  contents: read
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - "**/go.mod"
+      - "**/go.sum"
+      - go.work
+      - go.work.sum
+      - Makefile
+      - .github/workflows/govulncheck.yaml
+  schedule:
+    - cron: "17 6 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version-file: .tool-versions
+          cache: false
+
+      - run: make deps-build
+
+      - run: make govulncheck

--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,14 @@ lint:
 	$(GO) run ./pkg/tools/get-tools.go && \
 	./bin/golangci-lint run --fix --timeout=10m ./...
 
+.PHONY: govulncheck
+govulncheck: ## Scan for known Go vulnerabilities (all workspace modules)
+	@echo "==> $@"
+	@for dir in $$($(GO) list -m -f '{{.Dir}}'); do \
+		echo "==> govulncheck $$dir"; \
+		( cd "$$dir" && $(GO) run golang.org/x/vuln/cmd/govulncheck@v1.5.0 ./... ) || exit 1; \
+	done
+
 .PHONY: test
 test: get-envoy ## Runs the go tests.
 	@echo "==> $@"


### PR DESCRIPTION
## What

Adds a `make govulncheck` target and a workflow that runs [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) across all Go workspace modules (root + `pkg/grpc/config` + `pkg/grpc/databroker`) to scan for known vulnerabilities in stdlib and dependencies.

## Why

Adds reachable-vulnerability detection for Go, complementing the existing CodeQL and gosec (golangci-lint) checks. Runs on push to `main`, a weekly schedule, manual dispatch, and on PRs that change dependency files — so a newly disclosed third-party CVE does not block unrelated open PRs.

## AI assistance

Drafted with Claude (Opus 4.8): the workflow and Makefile target. Verified: `actionlint` clean, govulncheck green in CI across all workspace modules. Human-reviewed before merge.
