### PR TITLE
fix(mcp): pomerium acting as the authorization server

### DIFF
--- a/internal/mcp/extproc/handler.go
+++ b/internal/mcp/extproc/handler.go
@@ -6,7 +6,16 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	ext_proc_v3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	envoy_type_v3 "github.com/envoyproxy/go-control-plane/envoy/type/v3"
+	"github.com/shogo82148/go-sfv"
 )
+
+func bearerChallenge(params ...sfv.DictMember) string {
+	txt, err := sfv.EncodeDictionary(sfv.Dictionary(params))
+	if err != nil {
+		return "Bearer"
+	}
+	return "Bearer " + txt
+}
 
 // UpstreamRequestHandler handles upstream token injection and response interception.
 // The implementation lives in the mcp package, where it has access to Storage, HostInfo,

--- a/internal/mcp/extproc/server.go
+++ b/internal/mcp/extproc/server.go
@@ -12,6 +12,7 @@ import (
 	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	ext_proc_v3 "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
 	"github.com/rs/zerolog"
+	"github.com/shogo82148/go-sfv"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	grpcstatus "google.golang.org/grpc/status"
@@ -271,6 +272,11 @@ func (s *Server) handleRequestHeaders(
 
 	token, err := handler.GetUpstreamToken(ctx, routeCtx, downstreamHost)
 	if err != nil {
+		if grpcstatus.Code(err) == codes.PermissionDenied {
+			return immediateUnauthorizedResponse(bearerChallenge(
+				sfv.DictMember{Key: "error", Item: sfv.Item{Value: "invalid_token"}},
+			))
+		}
 		log.Ctx(ctx).Error().Err(err).
 			Str("route_id", routeCtx.RouteID).
 			Str("downstream_host", downstreamHost).

--- a/internal/mcp/handler_authorization.go
+++ b/internal/mcp/handler_authorization.go
@@ -212,6 +212,7 @@ func (srv *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 			Hostname:  hostname,
 			Host:      r.Host,
 			UserID:    userID,
+			SessionID: sessionID,
 			AuthReqID: authReqID,
 			Info:      info,
 		})

--- a/internal/mcp/handler_authorization.go
+++ b/internal/mcp/handler_authorization.go
@@ -175,7 +175,8 @@ func (srv *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "internal error", http.StatusInternalServerError)
 			return
 		}
-		if tokenErr == nil && token != nil && (token.ExpiresAt == nil || token.ExpiresAt.AsTime().After(time.Now())) {
+		tokenValid := tokenErr == nil && token.Validate(sessionID) == nil
+		if tokenValid {
 			log.Ctx(ctx).Debug().
 				Str("user_id", userID).
 				Str("route_id", info.RouteID).

--- a/internal/mcp/handler_authorization_test.go
+++ b/internal/mcp/handler_authorization_test.go
@@ -38,6 +38,7 @@ type authorizeTestStorage struct {
 	putUpstreamMCPTokenFunc        func(ctx context.Context, token *oauth21proto.UpstreamMCPToken) error
 	deleteUpstreamMCPTokenFunc     func(ctx context.Context, userID, routeID, upstreamServer string) error
 	getPendingUpstreamAuthFunc     func(ctx context.Context, userID, host string) (*oauth21proto.PendingUpstreamAuth, error)
+	getSessionFunc                 func(ctx context.Context, id string) (*session.Session, error)
 }
 
 func (s *authorizeTestStorage) CreateAuthorizationRequest(ctx context.Context, req *oauth21proto.AuthorizationRequest) (string, error) {
@@ -77,7 +78,11 @@ func (s *authorizeTestStorage) GetAuthorizationRequest(context.Context, string) 
 	panic("unexpected call to GetAuthorizationRequest")
 }
 
-func (s *authorizeTestStorage) GetSession(context.Context, string) (*session.Session, uint64, error) {
+func (s *authorizeTestStorage) GetSession(ctx context.Context, id string) (*session.Session, uint64, error) {
+	if s.getSessionFunc != nil {
+		sess, err := s.getSessionFunc(ctx, id)
+		return sess, 0, err
+	}
 	panic("unexpected call to GetSession")
 }
 
@@ -328,6 +333,9 @@ func TestAuthorize_GetUpstreamMCPToken_NotFoundFallsThrough(t *testing.T) {
 			// NotFound is expected — user doesn't have a cached token yet.
 			return nil, status.Error(codes.NotFound, "not found")
 		},
+		putUpstreamMCPTokenFunc: func(_ context.Context, _ *oauth21proto.UpstreamMCPToken) error {
+			return nil
+		},
 		deleteAuthorizationRequestFunc: func(_ context.Context, _ string) error {
 			deleteAuthReqCalled = true
 			return nil
@@ -342,6 +350,9 @@ func TestAuthorize_GetUpstreamMCPToken_NotFoundFallsThrough(t *testing.T) {
 		},
 		getPendingUpstreamAuthFunc: func(_ context.Context, _, _ string) (*oauth21proto.PendingUpstreamAuth, error) {
 			return nil, fmt.Errorf("no pending auth")
+		},
+		getSessionFunc: func(_ context.Context, _ string) (*session.Session, error) {
+			return &session.Session{Id: testSessionID, ExpiresAt: timestamppb.New(time.Now().Add(time.Hour))}, nil
 		},
 	}
 
@@ -358,12 +369,20 @@ func TestAuthorize_GetUpstreamMCPToken_NotFoundFallsThrough(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.Authorize(w, r)
 
-	// A NotFound error should NOT trigger a 500 or cleanup — the flow should continue
-	// to auto-discovery (which fails gracefully with DiscoveryError) and then issue an auth code.
-	assert.NotEqual(t, http.StatusInternalServerError, w.Code,
-		"NotFound error should not cause a 500")
+	// The upstream advertises no authorization server, so there is nothing to
+	// authorize against. A NotFound cached token must not 500 or clean up the auth
+	// request — in this case the flow continues and issues an auth code back to the client,
+	// because there is no authorization server in the discovery flow
 	assert.False(t, deleteAuthReqCalled,
-		"should not clean up auth request on NotFound (flow continues)")
+		"should not clean up auth request when upstream has no AS (flow continues)")
+	require.Equal(t, http.StatusFound, w.Code,
+		"flow should continue and redirect back to the client")
+	location, err := url.Parse(w.Header().Get("Location"))
+	require.NoError(t, err)
+	assert.Equal(t, testRedirectURI, location.Scheme+"://"+location.Host+location.Path,
+		"should redirect to the client's callback")
+	assert.NotEmpty(t, location.Query().Get("code"),
+		"flow should issue an authorization code")
 }
 
 // TestAuthorize_ExpiredTokenWithRefreshToken_RefreshesSilently reproduces ENG-3927:

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -608,7 +608,7 @@ func (srv *Handler) issueNewPomeriumOauthToken(ctx context.Context, params *auto
 		params.Info.UpstreamURL,
 		params.SessionID,
 		pomeriumIssuer,
-		session.GetExpiresAt().AsTime(),
+		session.GetExpiresAt(),
 	)
 	if putErr := srv.storage.PutUpstreamMCPToken(ctx, token); putErr != nil {
 		return fmt.Errorf("storing Pomerium-issued token: %w", putErr)

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -169,6 +169,7 @@ func (srv *Handler) ConnectGet(w http.ResponseWriter, r *http.Request) {
 			Hostname:  hostname,
 			Host:      r.Host,
 			UserID:    userID,
+			SessionID: sessionID,
 			AuthReqID: authReqID,
 			Info:      info,
 		})
@@ -407,6 +408,7 @@ type autoDiscoveryAuthParams struct {
 	Hostname  string // downstream hostname (port stripped)
 	Host      string // downstream host (with optional port)
 	UserID    string
+	SessionID string
 	AuthReqID string
 	Info      ServerHostInfo // route info with RouteID and UpstreamURL
 }
@@ -499,7 +501,14 @@ func (srv *Handler) resolveAutoDiscoveryAuth(ctx context.Context, params *autoDi
 	setupOpts = append(setupOpts, upstreamOAuthSetupOptsFromConfig(params.Info.UpstreamOAuth2)...)
 	setup, setupErr := runUpstreamOAuthSetup(ctx, srv.httpClient, params.Info.UpstreamURL, params.Host, setupOpts...)
 	if setupErr != nil {
-		// Discovery failed — upstream may not need OAuth, or there's a real config issue.
+		if errors.Is(setupErr, errNoUpstreamAS) {
+			// The upstream advertises no authorization server of its own, fallback to have pomerium act
+			// as the authorization server.
+			if err := srv.issueNewPomeriumOauthToken(ctx, params); err != nil {
+				return "", err
+			}
+			return "", nil
+		}
 		log.Ctx(ctx).Warn().Err(setupErr).
 			Str("upstream_url", params.Info.UpstreamURL).
 			Str("host", params.Host).
@@ -574,6 +583,36 @@ func (srv *Handler) resolveAutoDiscoveryAuth(ctx context.Context, params *autoDi
 		Msg("mcp/auto-discovery: proactive upstream discovery succeeded, redirecting to upstream AS")
 
 	return authURL, nil
+}
+
+// The user is already authenticated, a blank upstream token is issued by Pomerium, and is tied
+// to the current session
+func (srv *Handler) issueNewPomeriumOauthToken(ctx context.Context, params *autoDiscoveryAuthParams) error {
+	log.Ctx(ctx).Debug().
+		Str("upstream_url", params.Info.UpstreamURL).
+		Str("host", params.Host).
+		Msg("mcp/auto-discovery: upstream has no authorization server, Pomerium acting as AS")
+	session, _, sessErr := srv.storage.GetSession(ctx, params.SessionID)
+	if sessErr != nil {
+		log.Ctx(ctx).Warn().Err(sessErr).
+			Str("session_id", params.SessionID).
+			Str("route_id", params.Info.RouteID).
+			Msg("mcp/auto-discovery: could not load session, skipping Pomerium-issued token")
+		return nil
+	}
+	pomeriumIssuer := (&url.URL{Scheme: "https", Host: params.Info.Host}).String()
+	token := newPomeriumAuthorizationServerToken(
+		params.UserID,
+		params.Info.RouteID,
+		params.Info.UpstreamURL,
+		params.SessionID,
+		pomeriumIssuer,
+		session.GetExpiresAt().AsTime(),
+	)
+	if putErr := srv.storage.PutUpstreamMCPToken(ctx, token); putErr != nil {
+		return fmt.Errorf("storing Pomerium-issued token: %w", putErr)
+	}
+	return nil
 }
 
 func (srv *Handler) getOrRegisterUpstreamOAuthClient(

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -120,7 +120,8 @@ func (srv *Handler) ConnectGet(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "internal server error", http.StatusInternalServerError)
 			return
 		}
-		if tokenErr == nil && token != nil && (token.ExpiresAt == nil || token.ExpiresAt.AsTime().After(time.Now())) {
+		tokenValid := tokenErr == nil && token.Validate(sessionID) == nil
+		if tokenValid {
 			log.Ctx(ctx).Debug().
 				Str("redirect-url", redirectURL).
 				Msg("mcp/connect: valid upstream MCP token exists, redirecting to client")

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -76,14 +76,14 @@ func newPendingUpstreamAuth(p newPendingUpstreamAuthParams, setup *upstreamOAuth
 // newPomeriumAuthorizationServerToken builds a Pomerium-issued token for routes where
 // the upstream has no authorization server of its own and Pomerium acts as the AS. It
 // carries no credential and is tied to the session's lifetime.
-func newPomeriumAuthorizationServerToken(userID, routeID, upstreamServer, sessionID, pomeriumIssuer string, sessionExpiry time.Time) *oauth21proto.UpstreamMCPToken {
+func newPomeriumAuthorizationServerToken(userID, routeID, upstreamServer, sessionID, pomeriumIssuer string, sessionExpiry *timestamppb.Timestamp) *oauth21proto.UpstreamMCPToken {
 	return &oauth21proto.UpstreamMCPToken{
 		UserId:                         userID,
 		RouteId:                        routeID,
 		UpstreamServer:                 upstreamServer,
 		TokenType:                      "Bearer",
 		IssuedAt:                       timestamppb.New(time.Now()),
-		ExpiresAt:                      timestamppb.New(sessionExpiry),
+		ExpiresAt:                      sessionExpiry,
 		AuthorizationServerIssuer:      pomeriumIssuer,
 		PomeriumAuthorizationSessionId: &sessionID,
 	}

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -89,10 +89,6 @@ func newPomeriumAuthorizationServerToken(userID, routeID, upstreamServer, sessio
 	}
 }
 
-func isPomeriumIssuedToken(t *oauth21proto.UpstreamMCPToken) bool {
-	return t != nil && t.GetPomeriumAuthorizationSessionId() != ""
-}
-
 // pomeriumIssuedTokenValid reports whether a Pomerium-issued token still matches the session it was issued by
 func (h *UpstreamAuthHandler) pomeriumIssuedTokenValid(ctx context.Context, sessionID string, expiresAt *timestamppb.Timestamp) (bool, error) {
 	if expiresAt != nil && !expiresAt.AsTime().After(time.Now()) {
@@ -258,7 +254,7 @@ func (h *UpstreamAuthHandler) GetUpstreamToken(
 
 	// Pomerium is the authorization server- there is no credential associated with it.
 	// This token stays valid as long as the session is valid.
-	if isPomeriumIssuedToken(token) {
+	if token.IsPomeriumIssuedToken() {
 		sessionID := token.GetPomeriumAuthorizationSessionId()
 		valid, err := h.pomeriumIssuedTokenValid(ctx, sessionID, token.ExpiresAt)
 		if err != nil {
@@ -271,7 +267,7 @@ func (h *UpstreamAuthHandler) GetUpstreamToken(
 				Str("upstream_server", info.UpstreamURL).
 				Str("session_id", sessionID).
 				Msg("mcp_upstream_auth: Pomerium-issued token no longer valid (session expired/revoked)")
-			return "", fmt.Errorf("pomerium-issued token no longer valid (session expired/revoked)")
+			return "", status.Error(codes.PermissionDenied, "pomerium-issued token no longer valid (session expired/revoked)")
 		}
 		log.Ctx(ctx).Debug().
 			Str("route_id", routeCtx.RouteID).

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -73,6 +73,43 @@ func newPendingUpstreamAuth(p newPendingUpstreamAuthParams, setup *upstreamOAuth
 	}
 }
 
+// newPomeriumAuthorizationServerToken builds a Pomerium-issued token for routes where
+// the upstream has no authorization server of its own and Pomerium acts as the AS. It
+// carries no credential and is tied to the session's lifetime.
+func newPomeriumAuthorizationServerToken(userID, routeID, upstreamServer, sessionID, pomeriumIssuer string, sessionExpiry time.Time) *oauth21proto.UpstreamMCPToken {
+	return &oauth21proto.UpstreamMCPToken{
+		UserId:                         userID,
+		RouteId:                        routeID,
+		UpstreamServer:                 upstreamServer,
+		TokenType:                      "Bearer",
+		IssuedAt:                       timestamppb.New(time.Now()),
+		ExpiresAt:                      timestamppb.New(sessionExpiry),
+		AuthorizationServerIssuer:      pomeriumIssuer,
+		PomeriumAuthorizationSessionId: &sessionID,
+	}
+}
+
+func isPomeriumIssuedToken(t *oauth21proto.UpstreamMCPToken) bool {
+	return t != nil && t.GetPomeriumAuthorizationSessionId() != ""
+}
+
+// pomeriumIssuedTokenValid reports whether a Pomerium-issued token still matches the session it was issued by
+func (h *UpstreamAuthHandler) pomeriumIssuedTokenValid(ctx context.Context, sessionID string, expiresAt *timestamppb.Timestamp) (bool, error) {
+	if expiresAt != nil && !expiresAt.AsTime().After(time.Now()) {
+		return false, nil
+	}
+	if sessionID == "" {
+		return false, nil
+	}
+	if _, _, err := h.storage.GetSession(ctx, sessionID); err != nil {
+		if isNotFound(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("validating session %s: %w", sessionID, err)
+	}
+	return true, nil
+}
+
 // UpstreamAuthHandler implements extproc.UpstreamRequestHandler for MCP upstream OAuth flows.
 // It handles token injection on the request path and 401/403 interception on the response path.
 // All upstream auth modes (auto-discovery, pre-registered, fully static) use a unified
@@ -218,6 +255,31 @@ func (h *UpstreamAuthHandler) GetUpstreamToken(
 		event.Time("expires_at", token.ExpiresAt.AsTime())
 	}
 	event.Msg("mcp_upstream_auth: loaded cached upstream token")
+
+	// Pomerium is the authorization server- there is no credential associated with it.
+	// This token stays valid as long as the session is valid.
+	if isPomeriumIssuedToken(token) {
+		sessionID := token.GetPomeriumAuthorizationSessionId()
+		valid, err := h.pomeriumIssuedTokenValid(ctx, sessionID, token.ExpiresAt)
+		if err != nil {
+			return "", fmt.Errorf("validating session for Pomerium-issued token: %w", err)
+		}
+		if !valid {
+			log.Ctx(ctx).Info().
+				Str("route_id", routeCtx.RouteID).
+				Str("user_id", userID).
+				Str("upstream_server", info.UpstreamURL).
+				Str("session_id", sessionID).
+				Msg("mcp_upstream_auth: Pomerium-issued token no longer valid (session expired/revoked)")
+			return "", fmt.Errorf("pomerium-issued token no longer valid (session expired/revoked)")
+		}
+		log.Ctx(ctx).Debug().
+			Str("route_id", routeCtx.RouteID).
+			Str("user_id", userID).
+			Str("upstream_server", info.UpstreamURL).
+			Msg("mcp_upstream_auth: upstream has no AS (Pomerium is AS), injecting no credential")
+		return "", nil
+	}
 
 	// Check if access token is expired
 	if token.ExpiresAt != nil && token.ExpiresAt.AsTime().Before(time.Now()) {
@@ -430,6 +492,16 @@ func (h *UpstreamAuthHandler) handle401(
 	setupOpts = append(setupOpts, upstreamOAuthSetupOptsFromConfig(serverInfo.UpstreamOAuth2)...)
 	setup, err := runUpstreamOAuthSetup(ctx, h.httpClient, resourceURL, host, setupOpts...)
 	if err != nil {
+		// The upstream advertises no authorization server of its own. There is
+		// nothing to discover or to authorize against, so pass the 401 through
+		// unchanged rather than treating it as an error.
+		if errors.Is(err, errNoUpstreamAS) {
+			log.Ctx(ctx).Debug().
+				Str("upstream_server", serverInfo.UpstreamURL).
+				Str("host", host).
+				Msg("mcp_upstream_auth: upstream has no authorization server, passing 401 through")
+			return nil, nil
+		}
 		return nil, fmt.Errorf("upstream OAuth setup: %w", err)
 	}
 	if setup == nil {

--- a/internal/mcp/upstream_auth_test.go
+++ b/internal/mcp/upstream_auth_test.go
@@ -927,7 +927,7 @@ func TestHandleUpstreamResponse_ExpiresAtHandling(t *testing.T) {
 		// Pomerium is the AS. While the session that established it is still valid,
 		// GetUpstreamToken must return "" so ext_proc injects nothing and the
 		// request rides the Pomerium session.
-		token := newPomeriumAuthorizationServerToken("user-1", "route-1", "https://api.example.com", "session-1", "https://proxy.example.com", time.Now().Add(time.Hour))
+		token := newPomeriumAuthorizationServerToken("user-1", "route-1", "https://api.example.com", "session-1", "https://proxy.example.com", timestamppb.New(time.Now().Add(time.Hour)))
 
 		var getTokenCalled bool
 		fullStore := &autoDiscoveryTestStorage{
@@ -984,7 +984,7 @@ func TestHandleUpstreamResponse_ExpiresAtHandling(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				t.Parallel()
 
-				token := newPomeriumAuthorizationServerToken("user-1", "route-1", "https://api.example.com", "session-1", "https://proxy.example.com", time.Now().Add(time.Hour))
+				token := newPomeriumAuthorizationServerToken("user-1", "route-1", "https://api.example.com", "session-1", "https://proxy.example.com", timestamppb.New(time.Now().Add(time.Hour)))
 
 				fullStore := &autoDiscoveryTestStorage{
 					testUpstreamAuthStorage: &testUpstreamAuthStorage{

--- a/internal/mcp/upstream_auth_test.go
+++ b/internal/mcp/upstream_auth_test.go
@@ -920,6 +920,113 @@ func TestHandleUpstreamResponse_ExpiresAtHandling(t *testing.T) {
 		assert.Equal(t, "still-valid", result, "should return the non-expired token")
 	})
 
+	t.Run("Pomerium-issued token injects no credential", func(t *testing.T) {
+		t.Parallel()
+
+		// A Pomerium-issued token means the upstream has no AS of its own and
+		// Pomerium is the AS. While the session that established it is still valid,
+		// GetUpstreamToken must return "" so ext_proc injects nothing and the
+		// request rides the Pomerium session.
+		token := newPomeriumAuthorizationServerToken("user-1", "route-1", "https://api.example.com", "session-1", "https://proxy.example.com", time.Now().Add(time.Hour))
+
+		var getTokenCalled bool
+		fullStore := &autoDiscoveryTestStorage{
+			testUpstreamAuthStorage: &testUpstreamAuthStorage{
+				getSessionFunc: func(_ context.Context, _ string) (*session.Session, error) {
+					return &session.Session{Id: "session-1", ExpiresAt: timestamppb.New(time.Now().Add(time.Hour))}, nil
+				},
+			},
+			getUpstreamMCPTokenFunc: func(_ context.Context, _, _, _ string) (*oauth21proto.UpstreamMCPToken, error) {
+				getTokenCalled = true
+				return token, nil
+			},
+		}
+
+		parsedUpstream, _ := url.Parse("https://api.example.com")
+		cfg := config.New(&config.Options{
+			Policies: []config.Policy{
+				{
+					Name: "test-mcp-server",
+					From: "https://proxy.example.com",
+					To:   config.WeightedURLs{{URL: *parsedUpstream}},
+					MCP:  &config.MCP{Server: &config.MCPServer{}},
+				},
+			},
+		})
+		hosts := NewHostInfo(cfg, nil)
+
+		handler := &UpstreamAuthHandler{
+			storage: fullStore,
+			hosts:   hosts,
+		}
+
+		routeCtx := &extproc.RouteContext{
+			RouteID: "route-1",
+			UserID:  "user-1",
+			IsMCP:   true,
+		}
+
+		result, err := handler.GetUpstreamToken(context.Background(), routeCtx, "proxy.example.com")
+		require.NoError(t, err)
+		assert.True(t, getTokenCalled, "should have called GetUpstreamMCPToken")
+		assert.Empty(t, result, "Pomerium-issued token must inject no upstream credential")
+	})
+
+	t.Run("Pomerium-issued token fails when session is not valid", func(t *testing.T) {
+		t.Parallel()
+
+		cases := map[string]error{
+			"revoked session": status.Error(codes.NotFound, "session not found"),
+			"storage error":   status.Error(codes.Unavailable, "databroker unavailable"),
+		}
+
+		for name, sessionErr := range cases {
+			t.Run(name, func(t *testing.T) {
+				t.Parallel()
+
+				token := newPomeriumAuthorizationServerToken("user-1", "route-1", "https://api.example.com", "session-1", "https://proxy.example.com", time.Now().Add(time.Hour))
+
+				fullStore := &autoDiscoveryTestStorage{
+					testUpstreamAuthStorage: &testUpstreamAuthStorage{
+						getSessionFunc: func(_ context.Context, _ string) (*session.Session, error) {
+							return nil, sessionErr
+						},
+					},
+					getUpstreamMCPTokenFunc: func(_ context.Context, _, _, _ string) (*oauth21proto.UpstreamMCPToken, error) {
+						return token, nil
+					},
+				}
+
+				parsedUpstream, _ := url.Parse("https://api.example.com")
+				cfg := config.New(&config.Options{
+					Policies: []config.Policy{
+						{
+							Name: "test-mcp-server",
+							From: "https://proxy.example.com",
+							To:   config.WeightedURLs{{URL: *parsedUpstream}},
+							MCP:  &config.MCP{Server: &config.MCPServer{}},
+						},
+					},
+				})
+				hosts := NewHostInfo(cfg, nil)
+
+				handler := &UpstreamAuthHandler{
+					storage: fullStore,
+					hosts:   hosts,
+				}
+
+				routeCtx := &extproc.RouteContext{
+					RouteID: "route-1",
+					UserID:  "user-1",
+					IsMCP:   true,
+				}
+
+				_, err := handler.GetUpstreamToken(context.Background(), routeCtx, "proxy.example.com")
+				require.Error(t, err, "must fail closed when the session cannot be confirmed")
+			})
+		}
+	})
+
 	t.Run("expired token with refresh token attempts refresh", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/mcp/upstream_discovery.go
+++ b/internal/mcp/upstream_discovery.go
@@ -181,7 +181,7 @@ func fetchJSON(ctx context.Context, client *http.Client, url string, dst any) er
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("fetching %s: unexpected status %d", url, resp.StatusCode)
+		return &httpStatusError{URL: url, Status: resp.StatusCode}
 	}
 
 	if err := json.NewDecoder(io.LimitReader(resp.Body, maxMetadataResponseBytes)).Decode(dst); err != nil {

--- a/internal/mcp/upstream_discovery.go
+++ b/internal/mcp/upstream_discovery.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -60,24 +61,25 @@ func FetchAuthorizationServerMetadata(
 		return nil, fmt.Errorf("building AS metadata URLs: %w", err)
 	}
 
-	var lastErr error
+	errs := []error{}
 	for _, u := range urls {
 		var meta AuthorizationServerMetadata
 		if err := fetchJSON(ctx, client, u, &meta); err != nil {
-			lastErr = err
+			errs = append(errs, err)
 			continue
 		}
 		if err := ValidateAuthorizationServerMetadata(&meta); err != nil {
-			lastErr = err
+			errs = append(errs, err)
 			continue
 		}
 		return &meta, nil
 	}
 
-	if lastErr != nil {
-		return nil, fmt.Errorf("authorization server metadata not found at any well-known endpoint: %w", lastErr)
+	// potentially retryable error from upstream servers
+	if slices.ContainsFunc(errs, func(err error) bool { return !isMetadataNotFound(err) }) {
+		return nil, fmt.Errorf("fetching authorization server metadata: %w", errors.Join(errs...))
 	}
-	return nil, fmt.Errorf("authorization server metadata not found at any well-known endpoint")
+	return nil, errNoUpstreamAS
 }
 
 // BuildProtectedResourceMetadataURLs returns the well-known URLs to probe for

--- a/internal/mcp/upstream_discovery_test.go
+++ b/internal/mcp/upstream_discovery_test.go
@@ -183,7 +183,7 @@ func TestFetchAuthorizationServerMetadata(t *testing.T) {
 			handler: func(w http.ResponseWriter, _ *http.Request) {
 				w.WriteHeader(http.StatusNotFound)
 			},
-			expectError: "not found",
+			expectError: "upstream has no authorization server",
 		},
 		{
 			name: "server returns invalid JSON",

--- a/internal/mcp/upstream_oauth_setup.go
+++ b/internal/mcp/upstream_oauth_setup.go
@@ -353,7 +353,7 @@ func runDiscovery(
 			// An origin-derived AS whose metadata endpoints return 404 means the
 			// upstream advertises no AS.
 			// Pomerium should act as the AS.
-			if originDerived && isMetadataNotFound(err) {
+			if originDerived && errors.Is(err, errNoUpstreamAS) {
 				log.Ctx(ctx).Debug().Err(err).
 					Str("upstream_url", upstreamServerURL).
 					Str("fallback_as_url", fallbackASURL).

--- a/internal/mcp/upstream_oauth_setup.go
+++ b/internal/mcp/upstream_oauth_setup.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -16,6 +17,28 @@ import (
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/urlutil"
 )
+
+// errNoUpstreamAS signals that the upstream MCP server has no authorization
+// server of its own: no Protected Resource Metadata, no operator-configured
+// fallback AS, and the upstream origin is not a usable https authorization
+// server. Callers should handled this as "Pomerium is the authorization server"
+var errNoUpstreamAS = errors.New("upstream has no authorization server")
+
+type httpStatusError struct {
+	URL    string
+	Status int
+}
+
+func (e *httpStatusError) Error() string {
+	return fmt.Sprintf("fetching %s: unexpected status %d", e.URL, e.Status)
+}
+
+func isMetadataNotFound(err error) bool {
+	if se, ok := errors.AsType[*httpStatusError](err); ok {
+		return se.Status == http.StatusNotFound
+	}
+	return false
+}
 
 // upstreamOAuthSetupConfig holds configuration for the upstream OAuth discovery + client_id setup workflow.
 type upstreamOAuthSetupConfig struct {
@@ -296,7 +319,8 @@ func runDiscovery(
 	// Per MCP spec: "Abort or use pre-configured values."
 	// Use explicit override if configured, otherwise try the upstream server's origin.
 	fallbackASURL := overrideASURL
-	if fallbackASURL == "" {
+	originDerived := overrideASURL == ""
+	if originDerived {
 		fallbackASURL, _ = originOf(upstreamServerURL)
 	}
 	if fallbackASURL != "" {
@@ -305,6 +329,17 @@ func runDiscovery(
 		// config or route definitions), we apply the same validation as the
 		// attacker-influenced paths for consistent security guarantees.
 		if err := validateMetadataURL(fallbackASURL, asMetadataDomainMatcher); err != nil {
+			// When the AS URL was derived from the upstream's own origin (no
+			// operator override) and that origin is not a usable https AS, the
+			// upstream simply has no authorization server of its own.
+			// Pomerium should act as the AS.
+			if originDerived {
+				log.Ctx(ctx).Debug().Err(err).
+					Str("upstream_url", upstreamServerURL).
+					Str("fallback_as_url", fallbackASURL).
+					Msg("ext_proc: no usable upstream AS at origin, treating as no-AS upstream")
+				return nil, errNoUpstreamAS
+			}
 			return nil, fmt.Errorf("fallback AS URL: %w", err)
 		}
 		log.Ctx(ctx).Info().
@@ -313,7 +348,21 @@ func runDiscovery(
 			Bool("explicit_override", overrideASURL != "").
 			AnErr("prm_error", prmErr).
 			Msg("ext_proc: PRM discovery failed, falling back to direct AS metadata discovery")
-		return runDiscoveryFromFallbackAS(ctx, httpClient, fallbackASURL, upstreamServerURL)
+		res, err := runDiscoveryFromFallbackAS(ctx, httpClient, fallbackASURL, upstreamServerURL)
+		if err != nil {
+			// An origin-derived AS whose metadata endpoints return 404 means the
+			// upstream advertises no AS.
+			// Pomerium should act as the AS.
+			if originDerived && isMetadataNotFound(err) {
+				log.Ctx(ctx).Debug().Err(err).
+					Str("upstream_url", upstreamServerURL).
+					Str("fallback_as_url", fallbackASURL).
+					Msg("ext_proc: upstream AS metadata not found, treating as no-AS upstream")
+				return nil, errNoUpstreamAS
+			}
+			return nil, err
+		}
+		return res, nil
 	}
 
 	if prmErr != nil {

--- a/internal/mcp/upstream_oauth_setup_test.go
+++ b/internal/mcp/upstream_oauth_setup_test.go
@@ -566,6 +566,46 @@ func TestRunUpstreamOAuthSetup(t *testing.T) {
 		assert.Nil(t, result)
 	})
 
+	t.Run("no AS at http origin returns errNoUpstreamAS", func(t *testing.T) {
+		t.Parallel()
+
+		// upstream server has no PRM, and no discovery.
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		result, err := runUpstreamOAuthSetup(context.Background(), srv.Client(), srv.URL, "proxy.example.com",
+			WithASMetadataDomainMatcher(allowLocalhost()),
+		)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, errNoUpstreamAS)
+	})
+
+	t.Run("upstream AS erroring", func(t *testing.T) {
+		t.Parallel()
+
+		// transient errors for a discovery server should not be re-routed to Pomerium
+		// acting as the authorization server
+		srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if strings.HasPrefix(r.URL.Path, "/.well-known/oauth-authorization-server") ||
+				strings.HasPrefix(r.URL.Path, "/.well-known/openid-configuration") {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		}))
+		defer srv.Close()
+
+		result, err := runUpstreamOAuthSetup(context.Background(), srv.Client(), srv.URL, "proxy.example.com",
+			WithASMetadataDomainMatcher(allowLocalhost()),
+		)
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.NotErrorIs(t, err, errNoUpstreamAS)
+	})
+
 	t.Run("CIMD not supported returns error", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/oauth21/gen/upstream_mcp_token.pb.go
+++ b/internal/oauth21/gen/upstream_mcp_token.pb.go
@@ -60,9 +60,12 @@ type UpstreamMCPToken struct {
 	ResourceParam string `protobuf:"bytes,14,opt,name=resource_param,json=resourceParam,proto3" json:"resource_param,omitempty"`
 	// Client secret for token refresh (populated for pre-registered clients
 	// that require client authentication via client_secret_post).
-	ClientSecret  string `protobuf:"bytes,15,opt,name=client_secret,json=clientSecret,proto3" json:"client_secret,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	ClientSecret string `protobuf:"bytes,15,opt,name=client_secret,json=clientSecret,proto3" json:"client_secret,omitempty"`
+	// When Pomerium acts as the authorization server for an upstream MCP server,
+	// this field indicates which Pomerium session it is tied to.
+	PomeriumAuthorizationSessionId *string `protobuf:"bytes,16,opt,name=pomerium_authorization_session_id,json=pomeriumAuthorizationSessionId,proto3,oneof" json:"pomerium_authorization_session_id,omitempty"`
+	unknownFields                  protoimpl.UnknownFields
+	sizeCache                      protoimpl.SizeCache
 }
 
 func (x *UpstreamMCPToken) Reset() {
@@ -200,11 +203,18 @@ func (x *UpstreamMCPToken) GetClientSecret() string {
 	return ""
 }
 
+func (x *UpstreamMCPToken) GetPomeriumAuthorizationSessionId() string {
+	if x != nil && x.PomeriumAuthorizationSessionId != nil {
+		return *x.PomeriumAuthorizationSessionId
+	}
+	return ""
+}
+
 var File_upstream_mcp_token_proto protoreflect.FileDescriptor
 
 const file_upstream_mcp_token_proto_rawDesc = "" +
 	"\n" +
-	"\x18upstream_mcp_token.proto\x12\aoauth21\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa0\x05\n" +
+	"\x18upstream_mcp_token.proto\x12\aoauth21\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x96\x06\n" +
 	"\x10UpstreamMCPToken\x12#\n" +
 	"\auser_id\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x06userId\x12%\n" +
@@ -226,7 +236,9 @@ const file_upstream_mcp_token_proto_rawDesc = "" +
 	"\x1bauthorization_server_issuer\x18\f \x01(\tR\x19authorizationServerIssuer\x12%\n" +
 	"\x0etoken_endpoint\x18\r \x01(\tR\rtokenEndpoint\x12%\n" +
 	"\x0eresource_param\x18\x0e \x01(\tR\rresourceParam\x12#\n" +
-	"\rclient_secret\x18\x0f \x01(\tR\fclientSecretB\x93\x01\n" +
+	"\rclient_secret\x18\x0f \x01(\tR\fclientSecret\x12N\n" +
+	"!pomerium_authorization_session_id\x18\x10 \x01(\tH\x00R\x1epomeriumAuthorizationSessionId\x88\x01\x01B$\n" +
+	"\"_pomerium_authorization_session_idB\x93\x01\n" +
 	"\vcom.oauth21B\x15UpstreamMcpTokenProtoP\x01Z1github.com/pomerium/pomerium/internal/oauth21/gen\xa2\x02\x03OXX\xaa\x02\aOauth21\xca\x02\aOauth21\xe2\x02\x13Oauth21\\GPBMetadata\xea\x02\aOauth21b\x06proto3"
 
 var (
@@ -262,6 +274,7 @@ func file_upstream_mcp_token_proto_init() {
 	if File_upstream_mcp_token_proto != nil {
 		return
 	}
+	file_upstream_mcp_token_proto_msgTypes[0].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{

--- a/internal/oauth21/gen/validate.go
+++ b/internal/oauth21/gen/validate.go
@@ -1,0 +1,24 @@
+package gen
+
+import (
+	"fmt"
+	"time"
+)
+
+func (t *UpstreamMCPToken) Validate(sessionID string) error {
+	if t == nil {
+		return fmt.Errorf("no token")
+	}
+	if t.ExpiresAt != nil && t.ExpiresAt.AsTime().Before(time.Now()) {
+		return fmt.Errorf("expired token")
+	}
+	if t.IsPomeriumIssuedToken() && t.GetPomeriumAuthorizationSessionId() != sessionID {
+		return fmt.Errorf("token no longer valid for session")
+	}
+
+	return nil
+}
+
+func (t *UpstreamMCPToken) IsPomeriumIssuedToken() bool {
+	return t != nil && t.PomeriumAuthorizationSessionId != nil
+}

--- a/internal/oauth21/proto/upstream_mcp_token.proto
+++ b/internal/oauth21/proto/upstream_mcp_token.proto
@@ -67,4 +67,8 @@ message UpstreamMCPToken {
   // Client secret for token refresh (populated for pre-registered clients
   // that require client authentication via client_secret_post).
   string client_secret = 15;
+
+  // When Pomerium acts as the authorization server for an upstream MCP server,
+  // this field indicates which Pomerium session it is tied to.
+  optional string pomerium_authorization_session_id = 16;
 }


### PR DESCRIPTION
## Summary

When using MCP server routes with upstream MCP servers that do not provide PRM / their own authorization servers, Pomerium should act as the MCP authorization server. 

In this case:
- pomerium issues an empty upstream oauth token that is forwarded to the upstream server
- this token (and it's validity) is tied to the session that issued it.

## Related issues

[ENG-4163](https://linear.app/pomerium/issue/ENG-4163/mcp-bridging-fails-when-remote-server-expects-pomerium-to-be-the-mcp)

## User Explanation

fixes MCP route connectivity where upstream MCP servers do not provide PRM / their own MCP authorization server

## AI disclosure

opus 4.8 was used to draft a solution. The initial draft was heavily reworked for clarity & correctness.

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
