### PR TITLE
chore(logs): add iterate method for log reader

### DIFF
--- a/pkg/envoy/envoy.go
+++ b/pkg/envoy/envoy.go
@@ -2,7 +2,6 @@
 package envoy
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"errors"
@@ -24,7 +23,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/google/go-cmp/cmp"
 	"github.com/natefinch/atomic"
 	"github.com/rs/zerolog"
@@ -38,6 +36,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/envoy/files"
 	"github.com/pomerium/pomerium/pkg/health"
 	"github.com/pomerium/pomerium/pkg/ipc"
+	"github.com/pomerium/pomerium/pkg/logutil"
 	"github.com/pomerium/pomerium/pkg/netutil"
 )
 
@@ -453,25 +452,8 @@ func (srv *Server) parseLog(line string) (name string, logLevel string, msg stri
 }
 
 func (srv *Server) handleLogs(ctx context.Context, rc io.ReadCloser) {
-	defer rc.Close()
-
 	l := log.Ctx(ctx).With().Str("service", "envoy").Logger()
-	bo := backoff.NewExponentialBackOff()
-
-	s := bufio.NewReader(rc)
-	for {
-		ln, err := s.ReadString('\n')
-		if err != nil {
-			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
-				break
-			}
-			log.Ctx(ctx).Error().Err(err).Msg("failed to read log")
-			time.Sleep(bo.NextBackOff())
-			continue
-		}
-		ln = strings.TrimRight(ln, "\r\n")
-		bo.Reset()
-
+	for ln := range logutil.IterateLines(rc) {
 		name, logLevel, msg := srv.parseLog(ln)
 		if name == "" {
 			name = "envoy"

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -1,2 +1,44 @@
 // Package logutil contains functionality for working with logs.
 package logutil
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"iter"
+	"os"
+	"strings"
+
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+// IterateLines iterates over all the lines of a log reader. The log reader
+// will be closed after iteration.
+func IterateLines(rc io.ReadCloser) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		defer rc.Close()
+
+		br := bufio.NewReader(rc)
+		for {
+			ln, err := br.ReadString('\n')
+
+			// ln may not be empty even if there's an error, so we process ln
+			// unconditionally
+
+			// remove trailing newlines
+			ln = strings.TrimRight(ln, "\r\n")
+			// ignore empty strings
+			if ln != "" {
+				if !yield(ln) {
+					return
+				}
+			}
+
+			if errors.Is(err, io.EOF) || errors.Is(err, os.ErrClosed) {
+				return
+			} else if err != nil {
+				log.Error().Err(err).Msg("logutil: unexpected error while reading log line")
+			}
+		}
+	}
+}

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -38,6 +38,7 @@ func IterateLines(rc io.ReadCloser) iter.Seq[string] {
 				return
 			} else if err != nil {
 				log.Error().Err(err).Msg("logutil: unexpected error while reading log line")
+				return
 			}
 		}
 	}

--- a/pkg/logutil/logutil_test.go
+++ b/pkg/logutil/logutil_test.go
@@ -1,0 +1,19 @@
+package logutil_test
+
+import (
+	"io"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/pkg/logutil"
+)
+
+func TestIterateLines(t *testing.T) {
+	t.Parallel()
+
+	result := slices.Collect(logutil.IterateLines(io.NopCloser(strings.NewReader("a\nb\r\nc"))))
+	assert.Equal(t, []string{"a", "b", "c"}, result)
+}

--- a/pkg/logutil/logutil_test.go
+++ b/pkg/logutil/logutil_test.go
@@ -1,6 +1,7 @@
 package logutil_test
 
 import (
+	"errors"
 	"io"
 	"slices"
 	"strings"
@@ -16,4 +17,16 @@ func TestIterateLines(t *testing.T) {
 
 	result := slices.Collect(logutil.IterateLines(io.NopCloser(strings.NewReader("a\nb\r\nc"))))
 	assert.Equal(t, []string{"a", "b", "c"}, result)
+
+	t.Run("error", func(t *testing.T) {
+		e := errors.New("test error")
+		pr, pw := io.Pipe()
+		pw.CloseWithError(e)
+
+		cnt := 0
+		for range logutil.IterateLines(pr) {
+			cnt++
+		}
+		assert.Equal(t, 0, cnt)
+	})
 }


### PR DESCRIPTION
## Summary
Add an `Iterate` method to `logutil` that will read log lines and yield them as an iterator.

## Related issues
- [ENG-4185](https://linear.app/pomerium/issue/ENG-4185/core-generalize-log-reading-from-envoy)


## AI disclosure
No AI was used for this PR.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
