### PR TITLE
feat(mcp): add mcp_dynamic_client_registration runtime flag

### DIFF
--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -33,6 +33,10 @@ var (
 	// RuntimeFlagMCP enables the MCP services for the authorize service
 	RuntimeFlagMCP = runtimeFlag("mcp", false)
 
+	// RuntimeFlagMCPDynamicClientRegistration enables Dynamic Client Registration as an authorization
+	// method for upstream MCP servers
+	RuntimeFlagMCPDynamicClientRegistration = runtimeFlag("mcp_dynamic_client_registration", false)
+
 	// RuntimeFlagPomeriumJWTEndpoint enables the /.pomerium/jwt endpoint, for retrieving
 	// signed user info claims from an upstream single-page web application. This endpoint
 	// is deprecated pending removal in a future release, but this flag allows a temporary

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -80,14 +80,14 @@ func (srv *Server) mountCommonEndpoints(root *mux.Router, cfg *config.Config) er
 	root.Handle(endpoints.PathWellKnownPomerium+"/", traceHandler(handlers.WellKnownPomerium(authenticateURL)))
 	root.Path(endpoints.PathJWKS).Methods(http.MethodGet).Handler(traceHandler(handlers.JWKSHandler(signingKey)))
 	root.Path(endpoints.PathHPKEPublicKey).Methods(http.MethodGet).Handler(traceHandler(hpke_handlers.HPKEPublicKeyHandler(hpkePublicKey)))
-
+	dcrEnabled := cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCPDynamicClientRegistration)
 	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
 		root.Path(mcp.WellKnownAuthorizationServerEndpoint).
 			Methods(http.MethodGet, http.MethodOptions).
-			Handler(mcp.AuthorizationServerMetadataHandler(mcp.DefaultPrefix))
+			Handler(mcp.AuthorizationServerMetadataHandler(mcp.DefaultPrefix, dcrEnabled))
 		root.PathPrefix(mcp.WellKnownProtectedResourceEndpoint).
 			Methods(http.MethodGet, http.MethodOptions).
-			Handler(mcp.ProtectedResourceMetadataHandler(mcp.DefaultPrefix))
+			Handler(mcp.ProtectedResourceMetadataHandler(mcp.DefaultPrefix, dcrEnabled))
 	}
 
 	return nil

--- a/internal/mcp/e2e/mcp_auth_flow_test.go
+++ b/internal/mcp/e2e/mcp_auth_flow_test.go
@@ -28,15 +28,23 @@ import (
 
 // TestMCPAuthorizationFlow tests the complete MCP authorization flow
 func TestMCPAuthorizationFlow(t *testing.T) {
+	for _, mode := range registrationModes {
+		t.Run(mode.name, func(t *testing.T) {
+			runMCPAuthorizationFlow(t, mode)
+		})
+	}
+}
+
+func runMCPAuthorizationFlow(t *testing.T, mode registrationMode) {
 	env := testenv.New(t)
 
 	env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
-		if cfg.Options.RuntimeFlags == nil {
-			cfg.Options.RuntimeFlags = make(config.RuntimeFlags)
+		enableMCP(cfg, mode.dcr)
+		cfg.Options.MCPAllowedClientIDDomains = []string{"*.localhost.pomerium.io"}
+		if !mode.dcr {
+			// CIMD fetches reach test servers on localhost.
+			cfg.Options.InsecureSkipMCPMetadataSSRFCheck = true
 		}
-		cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = true
-		// Allow all domains for testing - in production this should be restricted
-		cfg.Options.MCPAllowedClientIDDomains = []string{"*"}
 	}))
 
 	idp := scenarios.NewIDP([]*scenarios.User{
@@ -66,7 +74,7 @@ func TestMCPAuthorizationFlow(t *testing.T) {
 	serverUpstream.Handle("/", serverHandler.ServeHTTP)
 
 	serverRoute := serverUpstream.Route().
-		From(env.SubdomainURL("mcp-auth-test")).
+		From(env.SubdomainURL("mcp-auth-test-" + mode.name)).
 		Policy(func(p *config.Policy) {
 			p.AllowedDomains = []string{"example.com"}
 			p.MCP = &config.MCP{
@@ -74,6 +82,21 @@ func TestMCPAuthorizationFlow(t *testing.T) {
 			}
 		})
 	env.AddUpstream(serverUpstream)
+
+	// In CIMD mode the client registers by hosting a metadata document on a
+	// publicly accessible upstream rather than via the /register endpoint.
+	var clientMetadataUpstream upstreams.HTTPUpstream
+	var clientMetadataBaseURL func() string
+	if !mode.dcr {
+		clientMetadataUpstream = upstreams.HTTP(nil, upstreams.WithDisplayName("Client Metadata Server"))
+		route := clientMetadataUpstream.Route().
+			From(env.SubdomainURL("client-metadata-auth-" + mode.name)).
+			PPL(`- allow:
+    or:
+      - accept: true`)
+		env.AddUpstream(clientMetadataUpstream)
+		clientMetadataBaseURL = func() string { return route.URL().Value() }
+	}
 
 	env.Start()
 	snippets.WaitStartupComplete(env)
@@ -156,7 +179,12 @@ func TestMCPAuthorizationFlow(t *testing.T) {
 		require.NoError(t, err)
 		t.Logf("Authorization Server Metadata: %+v", ts.asMetadata)
 
-		require.NotEmpty(t, ts.asMetadata.RegistrationEndpoint, "expected registration_endpoint")
+		// registration_endpoint is advertised only when downstream DCR is enabled.
+		if mode.dcr {
+			require.NotEmpty(t, ts.asMetadata.RegistrationEndpoint, "expected registration_endpoint when DCR enabled")
+		} else {
+			require.Empty(t, ts.asMetadata.RegistrationEndpoint, "registration_endpoint must not be advertised when DCR disabled")
+		}
 		require.NotEmpty(t, ts.asMetadata.AuthorizationEndpoint, "expected authorization_endpoint")
 		require.NotEmpty(t, ts.asMetadata.TokenEndpoint, "expected token_endpoint")
 		require.Contains(t, ts.asMetadata.CodeChallengeMethodsSupported, "S256", "expected S256 PKCE support")
@@ -167,34 +195,16 @@ func TestMCPAuthorizationFlow(t *testing.T) {
 			"issuer in AS metadata must match authorization_servers entry from protected resource metadata")
 	})
 
-	t.Run("step 4: dynamic client registration (RFC 7591)", func(t *testing.T) {
-		clientMetadata := map[string]any{
-			"redirect_uris":              []string{"http://localhost:8080/callback"},
-			"client_name":                "Test MCP Client",
-			"token_endpoint_auth_method": "none",
-			"grant_types":                []string{"authorization_code"},
-			"response_types":             []string{"code"},
+	t.Run("step 4: client registration", func(t *testing.T) {
+		const redirectURI = "http://localhost:8080/callback"
+		var register clientRegistrar
+		if mode.dcr {
+			register = newDCRRegistrar(ctx, &ts.asMetadata, func() *http.Client { return ts.httpClient }, redirectURI)
+		} else {
+			register = newCIMDRegistrar(clientMetadataUpstream, clientMetadataBaseURL(), redirectURI)
 		}
-		clientMetadataJSON, err := json.Marshal(clientMetadata)
-		require.NoError(t, err)
-
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, ts.asMetadata.RegistrationEndpoint,
-			strings.NewReader(string(clientMetadataJSON)))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := ts.httpClient.Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-
-		var registrationResponse map[string]any
-		err = json.NewDecoder(resp.Body).Decode(&registrationResponse)
-		require.NoError(t, err)
-		t.Logf("Client Registration Response: %+v", registrationResponse)
-
-		var ok bool
-		ts.clientID, ok = registrationResponse["client_id"].(string)
-		require.True(t, ok && ts.clientID != "", "expected client_id in registration response")
+		ts.clientID, _ = register(t, "none")
+		require.NotEmpty(t, ts.clientID, "expected client_id from registration")
 		t.Logf("Registered client_id: %s", ts.clientID)
 	})
 

--- a/internal/mcp/e2e/mcp_conformance_test.go
+++ b/internal/mcp/e2e/mcp_conformance_test.go
@@ -28,14 +28,23 @@ import (
 // These tests verify security-critical behavior that maps to the MCP conformance suite:
 // https://github.com/modelcontextprotocol/conformance
 func TestMCPConformance(t *testing.T) {
+	for _, mode := range registrationModes {
+		t.Run(mode.name, func(t *testing.T) {
+			runMCPConformance(t, mode)
+		})
+	}
+}
+
+func runMCPConformance(t *testing.T, mode registrationMode) {
 	env := testenv.New(t)
 
 	env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
-		if cfg.Options.RuntimeFlags == nil {
-			cfg.Options.RuntimeFlags = make(config.RuntimeFlags)
+		enableMCP(cfg, mode.dcr)
+		cfg.Options.MCPAllowedClientIDDomains = []string{"*.localhost.pomerium.io"}
+		if !mode.dcr {
+			// CIMD fetches reach test servers on localhost.
+			cfg.Options.InsecureSkipMCPMetadataSSRFCheck = true
 		}
-		cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = true
-		cfg.Options.MCPAllowedClientIDDomains = []string{"*"}
 	}))
 
 	idp := scenarios.NewIDP([]*scenarios.User{
@@ -63,12 +72,27 @@ func TestMCPConformance(t *testing.T) {
 	serverUpstream.Handle("/", serverHandler.ServeHTTP)
 
 	serverRoute := serverUpstream.Route().
-		From(env.SubdomainURL("mcp-conformance")).
+		From(env.SubdomainURL("mcp-conformance-" + mode.name)).
 		Policy(func(p *config.Policy) {
 			p.AllowedDomains = []string{"example.com"}
 			p.MCP = &config.MCP{Server: &config.MCPServer{}}
 		})
 	env.AddUpstream(serverUpstream)
+
+	// In CIMD mode clients register by hosting a metadata document on a
+	// publicly accessible upstream rather than via the /register endpoint.
+	var clientMetadataUpstream upstreams.HTTPUpstream
+	var clientMetadataBaseURL func() string
+	if !mode.dcr {
+		clientMetadataUpstream = upstreams.HTTP(nil, upstreams.WithDisplayName("Client Metadata Server"))
+		route := clientMetadataUpstream.Route().
+			From(env.SubdomainURL("client-metadata-" + mode.name)).
+			PPL(`- allow:
+    or:
+      - accept: true`)
+		env.AddUpstream(clientMetadataUpstream)
+		clientMetadataBaseURL = func() string { return route.URL().Value() }
+	}
 
 	env.Start()
 	snippets.WaitStartupComplete(env)
@@ -97,29 +121,22 @@ func TestMCPConformance(t *testing.T) {
 	require.NoError(t, json.NewDecoder(resp.Body).Decode(&asMetadata))
 	resp.Body.Close()
 
-	// Helper: register a client with specific auth method
-	registerClient := func(t *testing.T, authMethod string) (clientID, clientSecret string) {
-		t.Helper()
-		clientMetadata := map[string]any{
-			"redirect_uris":              []string{"http://localhost:8080/callback"},
-			"client_name":                "Conformance Test Client",
-			"token_endpoint_auth_method": authMethod,
-			"grant_types":                []string{"authorization_code", "refresh_token"},
-			"response_types":             []string{"code"},
-		}
-		body, _ := json.Marshal(clientMetadata)
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, asMetadata.RegistrationEndpoint, strings.NewReader(string(body)))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/json")
-		resp, err := baseHTTPClient().Do(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		var regResp map[string]any
-		require.NoError(t, json.NewDecoder(resp.Body).Decode(&regResp))
-		clientID, _ = regResp["client_id"].(string)
-		clientSecret, _ = regResp["client_secret"].(string)
-		return clientID, clientSecret
+	// When DCR is disabled the registration_endpoint MUST NOT be advertised,
+	// while CIMD support remains advertised.
+	if mode.dcr {
+		require.NotEmpty(t, asMetadata.RegistrationEndpoint, "expected registration_endpoint when DCR enabled")
+	} else {
+		require.Empty(t, asMetadata.RegistrationEndpoint, "registration_endpoint must not be advertised when DCR disabled")
+	}
+
+	const redirectURI = "http://localhost:8080/callback"
+
+	// registerClient obtains a client per the active registration mode.
+	var registerClient clientRegistrar
+	if mode.dcr {
+		registerClient = newDCRRegistrar(ctx, &asMetadata, baseHTTPClient, redirectURI)
+	} else {
+		registerClient = newCIMDRegistrar(clientMetadataUpstream, clientMetadataBaseURL(), redirectURI)
 	}
 
 	// Helper: get authorization code via full auth flow
@@ -127,7 +144,6 @@ func TestMCPConformance(t *testing.T) {
 		t.Helper()
 		codeChallenge := generateS256Challenge(codeVerifier)
 		state := cryptutil.NewRandomStringN(32)
-		redirectURI := "http://localhost:8080/callback"
 
 		authParams := url.Values{
 			"response_type":         {"code"},
@@ -182,63 +198,68 @@ func TestMCPConformance(t *testing.T) {
 	// ============================================================================
 	// Test #1: Token Endpoint Authentication Methods (client_secret_basic)
 	// Conformance: https://github.com/modelcontextprotocol/conformance/blob/main/src/scenarios/client/auth/token-endpoint-auth.ts
+	//
+	// Confidential clients only — CIMD clients are public, so this is skipped in
+	// CIMD mode.
 	// ============================================================================
-	t.Run("token_endpoint_auth_client_secret_basic", func(t *testing.T) {
-		clientID, clientSecret := registerClient(t, "client_secret_basic")
-		codeVerifier := cryptutil.NewRandomStringN(64)
-		authCode := getAuthCode(t, clientID, codeVerifier)
+	if mode.confidential {
+		t.Run("token_endpoint_auth_client_secret_basic", func(t *testing.T) {
+			clientID, clientSecret := registerClient(t, "client_secret_basic")
+			codeVerifier := cryptutil.NewRandomStringN(64)
+			authCode := getAuthCode(t, clientID, codeVerifier)
 
-		t.Run("valid_basic_auth_succeeds", func(t *testing.T) {
-			params := url.Values{
-				"grant_type":    {"authorization_code"},
-				"code":          {authCode},
-				"redirect_uri":  {"http://localhost:8080/callback"},
-				"client_id":     {clientID},
-				"code_verifier": {codeVerifier},
-			}
-			resp, result := doTokenRequest(t, params, &[2]string{clientID, clientSecret})
-			assert.Equal(t, http.StatusOK, resp.StatusCode)
-			assert.NotEmpty(t, result["access_token"])
-			assert.Equal(t, "Bearer", result["token_type"])
+			t.Run("valid_basic_auth_succeeds", func(t *testing.T) {
+				params := url.Values{
+					"grant_type":    {"authorization_code"},
+					"code":          {authCode},
+					"redirect_uri":  {redirectURI},
+					"client_id":     {clientID},
+					"code_verifier": {codeVerifier},
+				}
+				resp, result := doTokenRequest(t, params, &[2]string{clientID, clientSecret})
+				assert.Equal(t, http.StatusOK, resp.StatusCode)
+				assert.NotEmpty(t, result["access_token"])
+				assert.Equal(t, "Bearer", result["token_type"])
+			})
+
+			t.Run("missing_basic_auth_fails", func(t *testing.T) {
+				t.Skip("TODO: client_secret_basic validation not yet implemented in handler_token.go")
+
+				// Need a new auth code since the previous one was consumed
+				newCodeVerifier := cryptutil.NewRandomStringN(64)
+				newAuthCode := getAuthCode(t, clientID, newCodeVerifier)
+
+				params := url.Values{
+					"grant_type":    {"authorization_code"},
+					"code":          {newAuthCode},
+					"redirect_uri":  {redirectURI},
+					"client_id":     {clientID},
+					"code_verifier": {newCodeVerifier},
+				}
+				resp, result := doTokenRequest(t, params, nil) // No auth header
+				assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+				assert.Equal(t, "invalid_request", result["error"])
+			})
+
+			t.Run("wrong_secret_fails", func(t *testing.T) {
+				t.Skip("TODO: client_secret_basic validation not yet implemented in handler_token.go")
+
+				newCodeVerifier := cryptutil.NewRandomStringN(64)
+				newAuthCode := getAuthCode(t, clientID, newCodeVerifier)
+
+				params := url.Values{
+					"grant_type":    {"authorization_code"},
+					"code":          {newAuthCode},
+					"redirect_uri":  {redirectURI},
+					"client_id":     {clientID},
+					"code_verifier": {newCodeVerifier},
+				}
+				resp, result := doTokenRequest(t, params, &[2]string{clientID, "wrong-secret"})
+				assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+				assert.Equal(t, "invalid_request", result["error"])
+			})
 		})
-
-		t.Run("missing_basic_auth_fails", func(t *testing.T) {
-			t.Skip("TODO: client_secret_basic validation not yet implemented in handler_token.go")
-
-			// Need a new auth code since the previous one was consumed
-			newCodeVerifier := cryptutil.NewRandomStringN(64)
-			newAuthCode := getAuthCode(t, clientID, newCodeVerifier)
-
-			params := url.Values{
-				"grant_type":    {"authorization_code"},
-				"code":          {newAuthCode},
-				"redirect_uri":  {"http://localhost:8080/callback"},
-				"client_id":     {clientID},
-				"code_verifier": {newCodeVerifier},
-			}
-			resp, result := doTokenRequest(t, params, nil) // No auth header
-			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-			assert.Equal(t, "invalid_request", result["error"])
-		})
-
-		t.Run("wrong_secret_fails", func(t *testing.T) {
-			t.Skip("TODO: client_secret_basic validation not yet implemented in handler_token.go")
-
-			newCodeVerifier := cryptutil.NewRandomStringN(64)
-			newAuthCode := getAuthCode(t, clientID, newCodeVerifier)
-
-			params := url.Values{
-				"grant_type":    {"authorization_code"},
-				"code":          {newAuthCode},
-				"redirect_uri":  {"http://localhost:8080/callback"},
-				"client_id":     {clientID},
-				"code_verifier": {newCodeVerifier},
-			}
-			resp, result := doTokenRequest(t, params, &[2]string{clientID, "wrong-secret"})
-			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
-			assert.Equal(t, "invalid_request", result["error"])
-		})
-	})
+	}
 
 	// ============================================================================
 	// Test #2: PKCE Code Verifier Validation
@@ -257,7 +278,7 @@ func TestMCPConformance(t *testing.T) {
 			params := url.Values{
 				"grant_type":    {"authorization_code"},
 				"code":          {authCode},
-				"redirect_uri":  {"http://localhost:8080/callback"},
+				"redirect_uri":  {redirectURI},
 				"client_id":     {clientID},
 				"code_verifier": {"completely-different-verifier-that-does-not-match"},
 			}
@@ -273,7 +294,7 @@ func TestMCPConformance(t *testing.T) {
 			params := url.Values{
 				"grant_type":   {"authorization_code"},
 				"code":         {authCode},
-				"redirect_uri": {"http://localhost:8080/callback"},
+				"redirect_uri": {redirectURI},
 				"client_id":    {clientID},
 				// code_verifier intentionally omitted
 			}
@@ -289,7 +310,7 @@ func TestMCPConformance(t *testing.T) {
 			params := url.Values{
 				"grant_type":    {"authorization_code"},
 				"code":          {authCode},
-				"redirect_uri":  {"http://localhost:8080/callback"},
+				"redirect_uri":  {redirectURI},
 				"client_id":     {clientID},
 				"code_verifier": {""},
 			}
@@ -315,7 +336,7 @@ func TestMCPConformance(t *testing.T) {
 			params := url.Values{
 				"grant_type":    {"authorization_code"},
 				"code":          {authCode},
-				"redirect_uri":  {"http://localhost:8080/callback"},
+				"redirect_uri":  {redirectURI},
 				"client_id":     {clientID},
 				"code_verifier": {codeVerifier},
 			}
@@ -344,7 +365,7 @@ func TestMCPConformance(t *testing.T) {
 			params := url.Values{
 				"grant_type":    {"authorization_code"},
 				"code":          {authCode},
-				"redirect_uri":  {"http://localhost:8080/callback"},
+				"redirect_uri":  {redirectURI},
 				"client_id":     {client2ID}, // Different client!
 				"code_verifier": {codeVerifier},
 			}
@@ -371,7 +392,7 @@ func TestMCPConformance(t *testing.T) {
 		params := url.Values{
 			"grant_type":    {"authorization_code"},
 			"code":          {authCode},
-			"redirect_uri":  {"http://localhost:8080/callback"},
+			"redirect_uri":  {redirectURI},
 			"client_id":     {clientID},
 			"code_verifier": {codeVerifier},
 		}
@@ -421,7 +442,7 @@ func TestMCPConformance(t *testing.T) {
 			params := url.Values{
 				"grant_type":    {"authorization_code"},
 				"code":          {code},
-				"redirect_uri":  {"http://localhost:8080/callback"},
+				"redirect_uri":  {redirectURI},
 				"client_id":     {client1ID},
 				"code_verifier": {verifier},
 			}
@@ -496,7 +517,7 @@ func TestMCPConformance(t *testing.T) {
 			params := url.Values{
 				"grant_type":    {"authorization_code"},
 				"code":          {authCode},
-				"redirect_uri":  {"http://localhost:8080/callback"},
+				"redirect_uri":  {redirectURI},
 				"client_id":     {clientID},
 				"code_verifier": {codeVerifier},
 			}

--- a/internal/mcp/e2e/mcp_cors_test.go
+++ b/internal/mcp/e2e/mcp_cors_test.go
@@ -46,6 +46,7 @@ func TestMCPCORSHeaders(t *testing.T) {
 			cfg.Options.RuntimeFlags = make(config.RuntimeFlags)
 		}
 		cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = true
+		cfg.Options.RuntimeFlags[config.RuntimeFlagMCPDynamicClientRegistration] = true
 		cfg.Options.MCPAllowedClientIDDomains = []string{"*"}
 	}))
 

--- a/internal/mcp/e2e/mcp_dcr_disabled_test.go
+++ b/internal/mcp/e2e/mcp_dcr_disabled_test.go
@@ -1,0 +1,129 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+	mcphandler "github.com/pomerium/pomerium/internal/mcp"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/scenarios"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	"github.com/pomerium/pomerium/pkg/endpoints"
+)
+
+// TestMCPDynamicClientRegistrationDisabled verifies that when the
+// mcp_dynamic_client_registration runtime flag is off (the default), the
+// downstream /register endpoint refuses requests and the registration_endpoint
+// is not advertised, while CIMD support remains advertised.
+func TestMCPDynamicClientRegistrationDisabled(t *testing.T) {
+	env := testenv.New(t)
+
+	env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
+		enableMCP(cfg, false)
+		cfg.Options.MCPAllowedClientIDDomains = []string{"*.localhost.pomerium.io"}
+	}))
+
+	idp := scenarios.NewIDP([]*scenarios.User{
+		{Email: "user@example.com"},
+	})
+	env.Add(idp)
+
+	mcpServer := mcp.NewServer(&mcp.Implementation{
+		Name:    "test-server",
+		Version: "1.0.0",
+	}, nil)
+	mcp.AddTool(mcpServer, &mcp.Tool{
+		Name:        "ping",
+		Description: "Returns pong",
+	}, func(_ context.Context, _ *mcp.CallToolRequest, _ any) (*mcp.CallToolResult, any, error) {
+		return &mcp.CallToolResult{
+			Content: []mcp.Content{&mcp.TextContent{Text: "pong"}},
+		}, nil, nil
+	})
+
+	serverUpstream := upstreams.HTTP(nil, upstreams.WithDisplayName("MCP Server"))
+	serverHandler := mcp.NewStreamableHTTPHandler(func(_ *http.Request) *mcp.Server {
+		return mcpServer
+	}, nil)
+	serverUpstream.Handle("/", serverHandler.ServeHTTP)
+
+	serverRoute := serverUpstream.Route().
+		From(env.SubdomainURL("mcp-dcr-disabled")).
+		Policy(func(p *config.Policy) {
+			p.AllowedDomains = []string{"example.com"}
+			p.MCP = &config.MCP{Server: &config.MCPServer{}}
+		})
+	env.AddUpstream(serverUpstream)
+
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	ctx := env.Context()
+	parsedURL, err := url.Parse(serverRoute.URL().Value())
+	require.NoError(t, err)
+
+	newClient := func() *http.Client {
+		c := upstreams.NewHTTPClient(env.ServerCAs(), &upstreams.RequestOptions{})
+		c.Jar, _ = cookiejar.New(nil)
+		c.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+		return c
+	}
+
+	t.Run("metadata omits registration_endpoint but keeps CIMD", func(t *testing.T) {
+		asMetadataURL := "https://" + parsedURL.Host + mcphandler.WellKnownAuthorizationServerEndpoint
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, asMetadataURL, nil)
+		require.NoError(t, err)
+		resp, err := newClient().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var metadata map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&metadata))
+
+		_, hasRegistration := metadata["registration_endpoint"]
+		assert.False(t, hasRegistration, "registration_endpoint must not be advertised when DCR disabled")
+
+		supported, _ := metadata["client_id_metadata_document_supported"].(bool)
+		assert.True(t, supported, "client_id_metadata_document_supported should remain true")
+	})
+
+	t.Run("register endpoint returns 403", func(t *testing.T) {
+		registerURL := "https://" + parsedURL.Host + endpoints.PathPomeriumMCP + "/register"
+		clientMetadata := map[string]any{
+			"redirect_uris":              []string{"http://localhost:8080/callback"},
+			"client_name":                "Should Be Rejected",
+			"token_endpoint_auth_method": "none",
+			"grant_types":                []string{"authorization_code"},
+			"response_types":             []string{"code"},
+		}
+		body, err := json.Marshal(clientMetadata)
+		require.NoError(t, err)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, registerURL, strings.NewReader(string(body)))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := newClient().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, resp.StatusCode, "registration must be refused when DCR disabled")
+
+		var errResp map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&errResp))
+		assert.Equal(t, "access_denied", errResp["error"])
+	})
+}

--- a/internal/mcp/e2e/mcp_registration_modes_test.go
+++ b/internal/mcp/e2e/mcp_registration_modes_test.go
@@ -1,0 +1,120 @@
+package e2e
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+	mcphandler "github.com/pomerium/pomerium/internal/mcp"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+)
+
+func enableMCP(cfg *config.Config, dcr bool) {
+	if cfg.Options.RuntimeFlags == nil {
+		cfg.Options.RuntimeFlags = make(config.RuntimeFlags)
+	}
+	cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = true
+	cfg.Options.RuntimeFlags[config.RuntimeFlagMCPDynamicClientRegistration] = dcr
+}
+
+// clientRegistrar obtains an OAuth client usable against Pomerium's MCP
+// authorization server. It returns the client_id and (for confidential clients)
+// the client_secret. The authMethod is the requested token_endpoint_auth_method.
+type clientRegistrar func(t *testing.T, authMethod string) (clientID, clientSecret string)
+
+type registrationMode struct {
+	// name is the subtest name.
+	name string
+	// dcr enables Dynamic Client Registration
+	dcr bool
+	// confidential indicates whether this mode can produce confidential clients
+	// (with a client_secret). CIMD clients are always public, so confidential
+	// subtests are skipped for it.
+	confidential bool
+}
+
+// registrationModes is the standard matrix: downstream DCR enabled, and DCR
+// disabled with clients registering via Client ID Metadata Documents.
+var registrationModes = []registrationMode{
+	{name: "dcr", dcr: true, confidential: true},
+	{name: "cimd", dcr: false, confidential: false},
+}
+
+// newDCRRegistrar returns a clientRegistrar that registers clients via the
+// downstream RFC 7591 /register endpoint advertised in the AS metadata.
+func newDCRRegistrar(
+	ctx context.Context,
+	asMetadata *mcphandler.AuthorizationServerMetadata,
+	newClient func() *http.Client,
+	redirectURI string,
+) clientRegistrar {
+	return func(t *testing.T, authMethod string) (string, string) {
+		t.Helper()
+		require.NotEmpty(t, asMetadata.RegistrationEndpoint,
+			"AS metadata must advertise a registration_endpoint when DCR is enabled")
+		clientMetadata := map[string]any{
+			"redirect_uris":              []string{redirectURI},
+			"client_name":                "Matrix Test Client",
+			"token_endpoint_auth_method": authMethod,
+			"grant_types":                []string{"authorization_code", "refresh_token"},
+			"response_types":             []string{"code"},
+		}
+		body, err := json.Marshal(clientMetadata)
+		require.NoError(t, err)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, asMetadata.RegistrationEndpoint, strings.NewReader(string(body)))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := newClient().Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		var regResp map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&regResp))
+		clientID, _ := regResp["client_id"].(string)
+		clientSecret, _ := regResp["client_secret"].(string)
+		require.NotEmpty(t, clientID, "expected client_id in registration response")
+		return clientID, clientSecret
+	}
+}
+
+// newCIMDRegistrar returns a clientRegistrar that hosts a unique Client ID
+// Metadata Document for each call on the provided upstream and returns its URL
+// as the client_id. CIMD clients are public, so the returned client_secret is
+// always empty and confidential authMethods are not supported.
+func newCIMDRegistrar(
+	metadataUpstream upstreams.HTTPUpstream,
+	metadataBaseURL string,
+	redirectURI string,
+) clientRegistrar {
+	var counter atomic.Int64
+	return func(t *testing.T, authMethod string) (string, string) {
+		t.Helper()
+		require.Equal(t, "none", authMethod,
+			"CIMD clients are public; confidential auth methods are not supported")
+		n := counter.Add(1)
+		path := "/oauth/client-metadata-" + strconv.FormatInt(n, 10) + ".json"
+		clientID := metadataBaseURL + path
+		metadataUpstream.Handle(path, func(w http.ResponseWriter, _ *http.Request) {
+			metadata := map[string]any{
+				"client_id":                  clientID,
+				"client_name":                "Matrix Test Client via CIMD",
+				"client_uri":                 metadataBaseURL,
+				"redirect_uris":              []string{redirectURI},
+				"grant_types":                []string{"authorization_code", "refresh_token"},
+				"response_types":             []string{"code"},
+				"token_endpoint_auth_method": "none",
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Cache-Control", "max-age=3600")
+			_ = json.NewEncoder(w).Encode(metadata)
+		})
+		return clientID, ""
+	}
+}

--- a/internal/mcp/e2e/mcp_upstream_dcr_fallback_test.go
+++ b/internal/mcp/e2e/mcp_upstream_dcr_fallback_test.go
@@ -38,6 +38,7 @@ func TestMCPUpstreamOAuthDCRFallback(t *testing.T) {
 			cfg.Options.RuntimeFlags = make(config.RuntimeFlags)
 		}
 		cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = true
+		cfg.Options.RuntimeFlags[config.RuntimeFlagMCPDynamicClientRegistration] = true
 		cfg.Options.MCPAllowedClientIDDomains = []string{"*.localhost.pomerium.io"}
 		cfg.Options.MCPAllowedASMetadataDomains = []string{"127.0.0.1", "localhost"}
 	}))

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -59,6 +59,7 @@ type Handler struct {
 	sessionExpiry           time.Duration
 	httpClient              *http.Client // for upstream discovery fetches
 	asMetadataDomainMatcher *DomainMatcher
+	dcrEnabled              bool
 }
 
 // HandlerOption is a functional option for configuring a Handler.
@@ -144,6 +145,9 @@ func New(
 		sessionExpiry:           cfg.Options.CookieExpire,
 		httpClient:              http.DefaultClient,
 		asMetadataDomainMatcher: asDomainMatcher,
+		dcrEnabled: cfg.Options.IsRuntimeFlagSet(
+			config.RuntimeFlagMCPDynamicClientRegistration,
+		),
 	}
 
 	for _, opt := range opts {

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -582,6 +582,9 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 	downstreamHost string,
 	redirectURI string,
 ) (*oauth21proto.UpstreamOAuthClient, error) {
+	if !srv.dcrEnabled {
+		return nil, fmt.Errorf("dynamic client registration is disabled")
+	}
 	if discovery == nil {
 		return nil, fmt.Errorf("discovery result is nil")
 	}

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
+	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
 	oauth21proto "github.com/pomerium/pomerium/internal/oauth21/gen"
 	rfc7591v1 "github.com/pomerium/pomerium/internal/rfc7591"
@@ -583,7 +584,10 @@ func (srv *Handler) getOrRegisterUpstreamOAuthClient(
 	redirectURI string,
 ) (*oauth21proto.UpstreamOAuthClient, error) {
 	if !srv.dcrEnabled {
-		return nil, fmt.Errorf("dynamic client registration is disabled")
+		return nil, &DiscoveryError{Err: fmt.Errorf(
+			"dynamic client registration is disabled, enable the runtime flag : `%s`",
+			config.RuntimeFlagMCPDynamicClientRegistration,
+		)}
 	}
 	if discovery == nil {
 		return nil, fmt.Errorf("discovery result is nil")

--- a/internal/mcp/handler_connect_test.go
+++ b/internal/mcp/handler_connect_test.go
@@ -234,6 +234,7 @@ func TestResolveAutoDiscoveryAuth_ClientSecret(t *testing.T) {
 		hosts:                   hosts,
 		httpClient:              upstreamSrv.Client(),
 		asMetadataDomainMatcher: allowLocalhost(),
+		dcrEnabled:              true,
 	}
 
 	params := &autoDiscoveryAuthParams{
@@ -262,7 +263,8 @@ func TestGetOrRegisterUpstreamOAuthClient_EmptyRegistrationEndpoint(t *testing.T
 	t.Parallel()
 
 	srv := &Handler{
-		storage: &testConnectStorage{},
+		storage:    &testConnectStorage{},
+		dcrEnabled: true,
 	}
 
 	_, err := srv.getOrRegisterUpstreamOAuthClient(
@@ -276,6 +278,27 @@ func TestGetOrRegisterUpstreamOAuthClient_EmptyRegistrationEndpoint(t *testing.T
 	)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "registration_endpoint")
+}
+
+func TestGetOrRegisterUpstreamOAuthClient_DcrDisabled(t *testing.T) {
+	t.Parallel()
+
+	srv := &Handler{
+		storage:    &testConnectStorage{},
+		dcrEnabled: false,
+	}
+
+	_, err := srv.getOrRegisterUpstreamOAuthClient(
+		t.Context(),
+		&discoveryResult{
+			Issuer:               "https://auth.example.com",
+			RegistrationEndpoint: "https://registration.example.com",
+		},
+		"proxy.example.com",
+		"https://proxy.example.com/callback",
+	)
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "disabled")
 }
 
 func TestRegisterWithUpstreamAS_EmptyClientID(t *testing.T) {
@@ -301,6 +324,7 @@ func TestRegisterWithUpstreamAS_EmptyClientID(t *testing.T) {
 				return nil
 			},
 		},
+		dcrEnabled: true,
 	}
 
 	_, err := srv.getOrRegisterUpstreamOAuthClient(

--- a/internal/mcp/handler_metadata.go
+++ b/internal/mcp/handler_metadata.go
@@ -132,15 +132,15 @@ type ProtectedResourceMetadata struct {
 	DPoPBoundAccessTokensRequired bool `json:"dpop_bound_access_tokens_required,omitempty"`
 }
 
-func AuthorizationServerMetadataHandler(prefix string) http.HandlerFunc {
-	return getMetadataHandler(getAuthorizationServerMetadata, prefix)
+func AuthorizationServerMetadataHandler(prefix string, dcrEnabled bool) http.HandlerFunc {
+	return getMetadataHandler(getAuthorizationServerMetadata, prefix, dcrEnabled)
 }
 
-func ProtectedResourceMetadataHandler(prefix string) http.HandlerFunc {
-	return getMetadataHandler(getProtectedResourceMetadata, prefix)
+func ProtectedResourceMetadataHandler(prefix string, dcrEnabled bool) http.HandlerFunc {
+	return getMetadataHandler(getProtectedResourceMetadata, prefix, dcrEnabled)
 }
 
-func getAuthorizationServerMetadata(r *http.Request, prefix string) AuthorizationServerMetadata {
+func getAuthorizationServerMetadata(r *http.Request, prefix string, dcrEnabled bool) AuthorizationServerMetadata {
 	baseURL := url.URL{
 		Scheme: "https",
 		Host:   r.Host,
@@ -153,7 +153,7 @@ func getAuthorizationServerMetadata(r *http.Request, prefix string) Authorizatio
 
 	issuer := (&url.URL{Scheme: "https", Host: r.Host}).String()
 
-	return AuthorizationServerMetadata{
+	md := AuthorizationServerMetadata{
 		Issuer:                                 issuer,
 		ServiceDocumentation:                   "https://pomerium.com/docs",
 		AuthorizationEndpoint:                  P(path.Join(prefix, authorizationEndpoint)),
@@ -164,12 +164,15 @@ func getAuthorizationServerMetadata(r *http.Request, prefix string) Authorizatio
 		GrantTypesSupported:                    []string{"authorization_code", "refresh_token"},
 		RevocationEndpoint:                     P(path.Join(prefix, revocationEndpoint)),
 		RevocationEndpointAuthMethodsSupported: []string{"client_secret_post"},
-		RegistrationEndpoint:                   P(path.Join(prefix, registerEndpoint)),
 		ClientIDMetadataDocumentSupported:      true,
 	}
+	if dcrEnabled {
+		md.RegistrationEndpoint = P(path.Join(prefix, registerEndpoint))
+	}
+	return md
 }
 
-func getProtectedResourceMetadata(r *http.Request, _ string) ProtectedResourceMetadata {
+func getProtectedResourceMetadata(r *http.Request, _ string, _ bool) ProtectedResourceMetadata {
 	return ProtectedResourceMetadata{
 		Resource: (&url.URL{
 			Scheme: "https",
@@ -185,7 +188,7 @@ func getProtectedResourceMetadata(r *http.Request, _ string) ProtectedResourceMe
 	}
 }
 
-func getMetadataHandler[T any](fn func(r *http.Request, prefix string) T, prefix string) http.HandlerFunc {
+func getMetadataHandler[T any](fn func(r *http.Request, prefix string, dcrEnabled bool) T, prefix string, dcrEnabled bool) http.HandlerFunc {
 	c := cors.New(cors.Options{
 		AllowedMethods: []string{http.MethodGet, http.MethodOptions},
 		AllowedOrigins: []string{"*"},
@@ -197,7 +200,7 @@ func getMetadataHandler[T any](fn func(r *http.Request, prefix string) T, prefix
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		meta := fn(r, prefix)
+		meta := fn(r, prefix, dcrEnabled)
 		_ = json.NewEncoder(w).Encode(meta)
 	})
 	r.Methods(http.MethodOptions).HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/mcp/handler_register_client.go
+++ b/internal/mcp/handler_register_client.go
@@ -35,6 +35,12 @@ func (srv *Handler) RegisterClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !srv.dcrEnabled {
+		log.Ctx(ctx).Debug().Msg("mcp/register: dynamic client registration is disabled")
+		clientRegistrationDisabled(w)
+		return
+	}
+
 	src := io.LimitReader(r.Body, maxClientRegistrationPayload)
 	defer r.Body.Close()
 
@@ -89,6 +95,22 @@ func (srv *Handler) RegisterClient(w http.ResponseWriter, r *http.Request) {
 	log.Ctx(ctx).Debug().
 		Str("client-id", id).
 		Msg("mcp/register: registration response sent")
+}
+
+func clientRegistrationDisabled(w http.ResponseWriter) {
+	v := struct {
+		Error            string `json:"error"`
+		ErrorDescription string `json:"error_description"`
+	}{
+		Error:            "access_denied",
+		ErrorDescription: "dynamic client registration is disabled on this server",
+	}
+	data, _ := json.Marshal(v)
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	w.Header().Set("Pragma", "no-cache")
+	w.WriteHeader(http.StatusForbidden)
+	_, _ = w.Write(data)
 }
 
 func clientRegistrationBadRequest(w http.ResponseWriter, err error) {


### PR DESCRIPTION
## Summary

In the MCP specification, OAUTH2.0 Dynamic Client Registration (DCR) has moved from the default to a SHOULD support on authorization servers. It feels likely this will be deprecated and removed in future specs. Most MCP servers have moved to CIMD.

Adds the `mcp_dynamic_client_registration` runtime_flag to gate whether or not Pomerium when acting as an MCP reverse proxy can use DCR to authorize MCP servers.

Note: users authenticated with MCP servers already authorized with DCR will continue to work, but new users trying to access that MCP will fail

## Related issues

[ENG-4184](https://linear.app/pomerium/issue/ENG-4184/gate-inbound-mcp-dynamic-client-registration-dcr-behind-a-runtime-flag)

## User Explanation

```yaml
runtime_flags:
  mcp_dynamic_client_registration: true
```

is required to enable Oauth 2.0 Dynamic Client Registration flows for MCP server authorization.

## AI disclosure

opus 4.8 was used to refactor the e2e tests to support parametrized runs depending on which authorization methods are used.

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
