### PR TITLE
feat: embedded enterprise console

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -307,6 +307,7 @@ type Options struct {
 	// Forcibly disables systemd health checks. Systemd health checks are run automatically based on auto-detection
 	HealthCheckSystemdDisabled bool                `mapstructure:"health_check_systemd_disabled" yaml:"health_check_systemd_disabled"`
 	BlobStorage                *blob.StorageConfig `mapstructure:"blob_storage" yaml:"blob_storage,omitempty"`
+	Enterprise                 map[string]any      `mapstructure:"enterprise" yaml:"enterprise,omitempty"`
 }
 
 type certificateFilePair struct {

--- a/config/options.go
+++ b/config/options.go
@@ -314,6 +314,7 @@ type Options struct {
 	// Forcibly disables systemd health checks. Systemd health checks are run automatically based on auto-detection
 	HealthCheckSystemdDisabled bool                `mapstructure:"health_check_systemd_disabled" yaml:"health_check_systemd_disabled"`
 	BlobStorage                *blob.StorageConfig `mapstructure:"blob_storage" yaml:"blob_storage,omitempty"`
+	Enterprise                 map[string]any      `mapstructure:"enterprise" yaml:"enterprise,omitempty"`
 }
 
 type certificateFilePair struct {

--- a/go.work.sum
+++ b/go.work.sum
@@ -825,10 +825,7 @@ google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4J
 google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6/go.mod h1:6ytKWczdvnpnO+m+JiG9NjEDzR1FJfsnmJdG7B8QVZ8=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
-<<<<<<< Updated upstream
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
-=======
->>>>>>> Stashed changes
 gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
 gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=

--- a/go.work.sum
+++ b/go.work.sum
@@ -825,7 +825,10 @@ google.golang.org/grpc v1.83.0/go.mod h1:kDyl6SKsiHKt0uylY5gtn5cEjkrIOhQOGDgIc4J
 google.golang.org/grpc/examples v0.0.0-20250407062114-b368379ef8f6/go.mod h1:6ytKWczdvnpnO+m+JiG9NjEDzR1FJfsnmJdG7B8QVZ8=
 google.golang.org/protobuf v1.33.0/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHhKbcUYpos=
 google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+<<<<<<< Updated upstream
 google.golang.org/protobuf v1.36.11/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
+=======
+>>>>>>> Stashed changes
 gopkg.in/ini.v1 v1.67.1 h1:tVBILHy0R6e4wkYOn3XmiITt/hEVH4TFMYvAX2Ytz6k=
 gopkg.in/ini.v1 v1.67.1/go.mod h1:x/cyOwCgZqOkJoDIJ3c1KNHMo10+nLGAhh+kn3Zizss=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=

--- a/internal/fileutil/directories.go
+++ b/internal/fileutil/directories.go
@@ -35,3 +35,13 @@ func DataDir() string {
 
 	return "/var/tmp/pomerium/data"
 }
+
+// EnterpriseConsoleCacheDir returns the directory for the enterprise console cache.
+func EnterpriseConsoleCacheDir() string {
+	return filepath.Join(CacheDir(), "enterprise-console")
+}
+
+// EnterpriseConsoleDataDir returns the directory for the enterprise console data.
+func EnterpriseConsoleDataDir() string {
+	return filepath.Join(DataDir(), "enterprise-console")
+}

--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -1,5 +1,5 @@
 {
-  "config": "v0.37.0",
+  "config": "v0.38.0",
   "hosted-authenticate-oidc": "v0.1.0",
   "mcp": "v0.32.0",
   "ssh": "v0.19.0"

--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -1,5 +1,5 @@
 {
-  "config": "v0.38.0",
+  "config": "v0.39.0",
   "hosted-authenticate-oidc": "v0.1.0",
   "mcp": "v0.33.0",
   "ssh": "v0.22.0"

--- a/pkg/cmd/pomerium/pomerium.go
+++ b/pkg/cmd/pomerium/pomerium.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pomerium/pomerium/internal/version"
 	"github.com/pomerium/pomerium/pkg/contextutil"
 	derivecert_config "github.com/pomerium/pomerium/pkg/derivecert/config"
+	"github.com/pomerium/pomerium/pkg/enterprise"
 	"github.com/pomerium/pomerium/pkg/envoy"
 	"github.com/pomerium/pomerium/pkg/envoy/files"
 	"github.com/pomerium/pomerium/pkg/health"
@@ -147,6 +148,9 @@ func (p *Pomerium) Start(ctx context.Context, tracerProvider oteltrace.TracerPro
 
 	// trigger changes when underlying files are changed
 	src = config.NewFileWatcherSource(ctx, src)
+
+	// possibly run the embedded enterprise console
+	src = enterprise.New(src)
 
 	src, err = autocert.New(ctx, src)
 	if err != nil {

--- a/pkg/cmd/pomerium/pomerium.go
+++ b/pkg/cmd/pomerium/pomerium.go
@@ -150,7 +150,11 @@ func (p *Pomerium) Start(ctx context.Context, tracerProvider oteltrace.TracerPro
 	src = config.NewFileWatcherSource(ctx, src)
 
 	// possibly run the embedded enterprise console
-	src = enterprise.New(src)
+	enterpriseManager := enterprise.New(ctx, src)
+	context.AfterFunc(ctx, func() {
+		enterpriseManager.Close()
+	})
+	src = enterpriseManager
 
 	src, err = autocert.New(ctx, src)
 	if err != nil {

--- a/pkg/enterprise/manager.go
+++ b/pkg/enterprise/manager.go
@@ -3,16 +3,22 @@ package enterprise
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"os/exec"
+	"path"
 	"sync"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/rs/zerolog"
 
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/fileutil"
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/pkg/logutil"
 )
 
 // A Manager manages an enterprise installation.
@@ -28,10 +34,10 @@ type Manager struct {
 // New creates a new enterprise manager.
 func New(src config.Source) *Manager {
 	mgr := new(Manager)
-	src.OnConfigChange(context.Background(), func(_ context.Context, cfg *config.Config) {
-		mgr.update(cfg)
+	src.OnConfigChange(context.Background(), func(ctx context.Context, cfg *config.Config) {
+		mgr.update(ctx, cfg)
 	})
-	mgr.update(src.GetConfig())
+	mgr.update(context.Background(), src.GetConfig())
 	return mgr
 }
 
@@ -42,7 +48,7 @@ func (mgr *Manager) GetConfig() *config.Config {
 	return mgr.cfg
 }
 
-func (mgr *Manager) update(cfg *config.Config) {
+func (mgr *Manager) update(ctx context.Context, cfg *config.Config) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
 
@@ -50,6 +56,8 @@ func (mgr *Manager) update(cfg *config.Config) {
 	if err := mgr.updateLocked(); err != nil {
 		log.Error().Err(err).Msg("enterprise: error updating console")
 	}
+
+	mgr.ChangeDispatcher.Trigger(ctx, mgr.cfg)
 }
 
 func (mgr *Manager) updateLocked() error {
@@ -70,13 +78,48 @@ func (mgr *Manager) updateLocked() error {
 
 	// start a new one
 	if mgr.process == nil && enabled {
-		log.Info().Msg("enterprise: starting console process")
-		cmd := exec.Command("pomerium-console")
+		cacheDir := fileutil.EnterpriseConsoleCacheDir()
+		dataDir := fileutil.EnterpriseConsoleDataDir()
 
-		err := cmd.Start()
+		// create the directories
+		if err := os.MkdirAll(cacheDir, 0o700); err != nil {
+			return fmt.Errorf("error creating enterprise console cache directory: %w", err)
+		}
+		if err := os.MkdirAll(dataDir, 0o700); err != nil {
+			return fmt.Errorf("error creating enterprise console data directory: %w", err)
+		}
+
+		// write the config file
+		bs, err := json.Marshal(options)
+		if err != nil {
+			return fmt.Errorf("error marshaling enterprise console options: %w", err)
+		}
+		if err := os.WriteFile(path.Join(dataDir, "config.yaml"), bs, 0o600); err != nil {
+			return fmt.Errorf("error writing enterprise console config: %w", err)
+		}
+
+		log.Info().Msg("enterprise: starting console process")
+
+		cmd := exec.Command("pomerium-console", "serve", "--config", path.Join(dataDir, "config.yaml")) //nolint:gosec
+
+		// handle logs
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			return fmt.Errorf("error opening stderr pipe: %w", err)
+		}
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			_ = stderr.Close()
+			return fmt.Errorf("error opening stdout pipe: %w", err)
+		}
+		go handleLogs(stderr)
+		go handleLogs(stdout)
+
+		err = cmd.Start()
 		if err != nil {
 			return fmt.Errorf("error starting enterprise console process: %w", err)
 		}
+		mgr.process = cmd.Process
 	}
 
 	mgr.options = options
@@ -90,12 +133,83 @@ func buildOptions(cfg *config.Config) (options map[string]any, enabled bool, err
 	}
 
 	_, enabled = options["url"]
-
-	sharedKey, err := cfg.Options.GetSharedKey()
-	if err != nil {
-		return nil, false, fmt.Errorf("error getting shared key: %w", err)
+	if !enabled {
+		return options, enabled, nil
 	}
-	options["shared_key"] = base64.StdEncoding.EncodeToString(sharedKey)
+
+	cacheDir := fileutil.EnterpriseConsoleCacheDir()
+	dataDir := fileutil.EnterpriseConsoleDataDir()
+
+	if _, ok := options["shared_secret"]; !ok {
+		sharedKey, err := cfg.Options.GetSharedKey()
+		if err != nil {
+			return nil, false, fmt.Errorf("error getting shared key: %w", err)
+		}
+		options["shared_secret"] = base64.StdEncoding.EncodeToString(sharedKey)
+	}
+
+	if _, ok := options["signing_key"]; !ok {
+		signingKey, err := cfg.Options.GetSigningKey()
+		if err != nil {
+			return nil, false, fmt.Errorf("error getting signing key: %w", err)
+		}
+		options["signing_key"] = base64.StdEncoding.EncodeToString(signingKey)
+	}
+
+	if _, ok := options["cache_dir"]; !ok {
+		options["cache_dir"] = cacheDir
+	}
+
+	// if no database encryption key is set, use the shared secret as the database encryption key
+	if _, ok := options["database_encryption_key"]; !ok {
+		options["database_encryption_key"] = options["shared_secret"]
+	}
+
+	if _, ok := options["databroker_service_url"]; !ok {
+		options["databroker_service_url"] = "http://localhost:5443"
+	}
+
+	if _, ok := options["database_url"]; !ok {
+		options["database_url"] = "sqlite://" + path.Join(dataDir, "data.sqlite")
+	}
+
+	if _, ok := options["prometheus_data_dir"]; !ok {
+		if _, ok := options["prometheus_url"]; !ok {
+			options["prometheus_data_dir"] = path.Join(dataDir, "prometheus")
+		}
+	}
+
+	if _, ok := options["validation_mode"]; !ok {
+		options["validation_mode"] = "static"
+	}
 
 	return options, enabled, nil
+}
+
+func handleLogs(r io.ReadCloser) {
+	defer r.Close()
+
+	for ln := range logutil.IterateLines(r) {
+		msg := ln
+		lvl := zerolog.InfoLevel
+
+		m := map[string]any{}
+		if json.Unmarshal([]byte(ln), &m) == nil {
+			msg, _ = m["message"].(string)
+			delete(m, "message")
+			delete(m, "time")
+
+			lvlStr, _ := m["level"].(string)
+			delete(m, "level")
+			if l, err := zerolog.ParseLevel(lvlStr); err == nil {
+				lvl = l
+			}
+		}
+
+		log.Logger().
+			WithLevel(lvl).
+			Str("service", "enterprise-console").
+			Fields(m).
+			Msg(msg)
+	}
 }

--- a/pkg/enterprise/manager.go
+++ b/pkg/enterprise/manager.go
@@ -1,0 +1,101 @@
+package enterprise
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/log"
+)
+
+// A Manager manages an enterprise installation.
+type Manager struct {
+	config.ChangeDispatcher
+
+	mu      sync.RWMutex
+	cfg     *config.Config
+	options map[string]any
+	process *os.Process
+}
+
+// New creates a new enterprise manager.
+func New(src config.Source) *Manager {
+	mgr := new(Manager)
+	src.OnConfigChange(context.Background(), func(_ context.Context, cfg *config.Config) {
+		mgr.update(cfg)
+	})
+	mgr.update(src.GetConfig())
+	return mgr
+}
+
+// GetConfig returns the current config.
+func (mgr *Manager) GetConfig() *config.Config {
+	mgr.mu.RLock()
+	defer mgr.mu.RUnlock()
+	return mgr.cfg
+}
+
+func (mgr *Manager) update(cfg *config.Config) {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+
+	mgr.cfg = cfg.Clone()
+	if err := mgr.updateLocked(); err != nil {
+		log.Error().Err(err).Msg("enterprise: error updating console")
+	}
+}
+
+func (mgr *Manager) updateLocked() error {
+	options, enabled, err := buildOptions(mgr.cfg)
+	if err != nil {
+		return fmt.Errorf("error building enterprise options: %w", err)
+	}
+
+	// stop the current process
+	if mgr.process != nil && (!enabled || !cmp.Equal(mgr.options, options)) {
+		log.Info().Msg("enterprise: stopping console process")
+		err := mgr.process.Kill()
+		mgr.process = nil
+		if err != nil {
+			return fmt.Errorf("error killing enterprise console process: %w", err)
+		}
+	}
+
+	// start a new one
+	if mgr.process == nil && enabled {
+		log.Info().Msg("enterprise: starting console process")
+		cmd := exec.Command("pomerium-console")
+
+		err := cmd.Start()
+		if err != nil {
+			return fmt.Errorf("error starting enterprise console process: %w", err)
+		}
+	}
+
+	mgr.options = options
+	return nil
+}
+
+func buildOptions(cfg *config.Config) (options map[string]any, enabled bool, err error) {
+	options = maps.Clone(cfg.Options.Enterprise)
+	if options == nil {
+		options = make(map[string]any)
+	}
+
+	_, enabled = options["url"]
+
+	sharedKey, err := cfg.Options.GetSharedKey()
+	if err != nil {
+		return nil, false, fmt.Errorf("error getting shared key: %w", err)
+	}
+	options["shared_key"] = base64.StdEncoding.EncodeToString(sharedKey)
+
+	return options, enabled, nil
+}

--- a/pkg/enterprise/manager.go
+++ b/pkg/enterprise/manager.go
@@ -10,8 +10,11 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"strings"
 	"sync"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/google/go-cmp/cmp"
 	"github.com/rs/zerolog"
 
@@ -26,15 +29,17 @@ type Manager struct {
 	config.ChangeDispatcher
 	ctx context.Context
 
-	mu      sync.RWMutex
-	cfg     *config.Config
-	options map[string]any
-	process *os.Process
+	mu             sync.RWMutex
+	cfg            *config.Config
+	options        map[string]any
+	process        *os.Process
+	restartBackoff *backoff.ExponentialBackOff
 }
 
 // New creates a new enterprise manager.
 func New(ctx context.Context, src config.Source) *Manager {
 	mgr := &Manager{ctx: ctx}
+	mgr.restartBackoff = backoff.NewExponentialBackOff(backoff.WithMaxElapsedTime(0))
 	src.OnConfigChange(context.Background(), func(ctx context.Context, cfg *config.Config) {
 		mgr.update(ctx, cfg)
 	})
@@ -60,6 +65,8 @@ func (mgr *Manager) GetConfig() *config.Config {
 func (mgr *Manager) update(ctx context.Context, cfg *config.Config) {
 	mgr.mu.Lock()
 	defer mgr.mu.Unlock()
+
+	mgr.restartBackoff.Reset()
 
 	mgr.cfg = cfg.Clone()
 	if err := mgr.updateLocked(); err != nil {
@@ -132,10 +139,29 @@ func (mgr *Manager) updateLocked() error {
 			return fmt.Errorf("error starting enterprise console process: %w", err)
 		}
 		mgr.process = cmd.Process
+		go mgr.watchStartedCommand(cmd)
 	}
 
 	mgr.options = options
 	return nil
+}
+
+func (mgr *Manager) watchStartedCommand(cmd *exec.Cmd) {
+	err := cmd.Wait()
+
+	mgr.mu.Lock()
+	if cmd.Process == mgr.process {
+		log.Error().Err(err).Msg("enterprise: console process exited, restarting")
+		mgr.process = nil
+		time.AfterFunc(mgr.restartBackoff.NextBackOff(), func() {
+			mgr.mu.Lock()
+			if err := mgr.updateLocked(); err != nil {
+				log.Error().Err(err).Msg("enterprise: error restarting console")
+			}
+			mgr.mu.Unlock()
+		})
+	}
+	mgr.mu.Unlock()
 }
 
 func buildOptions(cfg *config.Config) (options map[string]any, enabled bool, err error) {
@@ -184,7 +210,9 @@ func buildOptions(cfg *config.Config) (options map[string]any, enabled bool, err
 		} else if len(urls) == 0 {
 			return nil, false, fmt.Errorf("no internal databroker service urls defined")
 		}
-		options["databroker_service_url"] = urls[0].String()
+		// the enterprise console seems to prefer localhost to 127.0.0.1 for this
+		rawURL := strings.ReplaceAll(urls[0].String(), "127.0.0.1:", "localhost:")
+		options["databroker_service_url"] = rawURL
 	}
 
 	if _, ok := options["database_url"]; !ok {

--- a/pkg/enterprise/manager.go
+++ b/pkg/enterprise/manager.go
@@ -52,6 +52,7 @@ func (mgr *Manager) Close() {
 	defer mgr.mu.Unlock()
 	if mgr.process != nil {
 		_ = mgr.process.Kill()
+		mgr.process = nil
 	}
 }
 

--- a/pkg/enterprise/manager.go
+++ b/pkg/enterprise/manager.go
@@ -175,7 +175,13 @@ func buildOptions(cfg *config.Config) (options map[string]any, enabled bool, err
 	}
 
 	if _, ok := options["databroker_service_url"]; !ok {
-		options["databroker_service_url"] = "http://localhost:5443"
+		urls, err := cfg.Options.GetInternalDataBrokerURLs()
+		if err != nil {
+			return nil, false, fmt.Errorf("error getting internal databroker service urls: %w", err)
+		} else if len(urls) == 0 {
+			return nil, false, fmt.Errorf("no internal databroker service urls defined")
+		}
+		options["databroker_service_url"] = urls[0].String()
 	}
 
 	if _, ok := options["database_url"]; !ok {

--- a/pkg/enterprise/manager.go
+++ b/pkg/enterprise/manager.go
@@ -24,6 +24,7 @@ import (
 // A Manager manages an enterprise installation.
 type Manager struct {
 	config.ChangeDispatcher
+	ctx context.Context
 
 	mu      sync.RWMutex
 	cfg     *config.Config
@@ -32,13 +33,21 @@ type Manager struct {
 }
 
 // New creates a new enterprise manager.
-func New(src config.Source) *Manager {
-	mgr := new(Manager)
+func New(ctx context.Context, src config.Source) *Manager {
+	mgr := &Manager{ctx: ctx}
 	src.OnConfigChange(context.Background(), func(ctx context.Context, cfg *config.Config) {
 		mgr.update(ctx, cfg)
 	})
 	mgr.update(context.Background(), src.GetConfig())
 	return mgr
+}
+
+func (mgr *Manager) Close() {
+	mgr.mu.Lock()
+	defer mgr.mu.Unlock()
+	if mgr.process != nil {
+		_ = mgr.process.Kill()
+	}
 }
 
 // GetConfig returns the current config.
@@ -100,7 +109,7 @@ func (mgr *Manager) updateLocked() error {
 
 		log.Info().Msg("enterprise: starting console process")
 
-		cmd := exec.Command("pomerium-console", "serve", "--config", path.Join(dataDir, "config.yaml")) //nolint:gosec
+		cmd := exec.CommandContext(mgr.ctx, "pomerium-console", "serve", "--config", path.Join(dataDir, "config.yaml")) //nolint:gosec
 
 		// handle logs
 		stderr, err := cmd.StderrPipe()

--- a/pkg/enterprise/manager.go
+++ b/pkg/enterprise/manager.go
@@ -94,6 +94,9 @@ func (mgr *Manager) updateLocked() error {
 		if err := os.MkdirAll(cacheDir, 0o700); err != nil {
 			return fmt.Errorf("error creating enterprise console cache directory: %w", err)
 		}
+		if err := os.RemoveAll(dataDir); err != nil {
+			return fmt.Errorf("error deleting enterprise console data directory: %w", err)
+		}
 		if err := os.MkdirAll(dataDir, 0o700); err != nil {
 			return fmt.Errorf("error creating enterprise console data directory: %w", err)
 		}

--- a/pkg/enterprise/manager_test.go
+++ b/pkg/enterprise/manager_test.go
@@ -1,0 +1,47 @@
+package enterprise
+
+import (
+	"bytes"
+	"encoding/base64"
+	"path"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/config"
+)
+
+func TestBuildOptions(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(dir, "cache"))
+	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "data"))
+	t.Run("disabled", func(t *testing.T) {
+		cfg := config.New(config.NewDefaultOptions())
+		options, enabled, err := buildOptions(cfg)
+		assert.NoError(t, err)
+		assert.False(t, enabled)
+		assert.Empty(t, options)
+	})
+	t.Run("enabled", func(t *testing.T) {
+		cfg := config.New(config.NewDefaultOptions())
+		cfg.Options.SharedKey = base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0xA0}, 32))
+		cfg.Options.Enterprise = map[string]any{
+			"url": "https://example.com",
+		}
+		options, enabled, err := buildOptions(cfg)
+		assert.NoError(t, err)
+		assert.True(t, enabled)
+		assert.Equal(t, map[string]any{
+			"cache_dir":               filepath.Join(dir, "cache", "pomerium", "enterprise-console"),
+			"database_encryption_key": "oKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKA=",
+			"database_url":            "sqlite://" + path.Join(dir, "data", "pomerium", "enterprise-console", "data.sqlite"),
+			"databroker_service_url":  "http://localhost:5443",
+			"prometheus_data_dir":     filepath.Join(dir, "data", "pomerium", "enterprise-console", "prometheus"),
+			"url":                     "https://example.com",
+			"shared_secret":           "oKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKA=",
+			"signing_key":             "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUlSMHFBTklRUlJvNTNyaFpIRGwyRG9iYXFUMnlXMk0xWlgvOHdyQ05wUFlvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFT0tSS2tkRmZjY2FRcVFqaUEvQ0t1NHZTM3IyUVVQZUtoS2ZxbkxiVFRic09PcjRGN1h3UQovYWpmWFdVcFhUUWFQdDZncW1oeGREMHp0VFVQYm10NUp3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=",
+			"validation_mode":         "static",
+		}, options)
+	})
+}

--- a/pkg/enterprise/manager_test.go
+++ b/pkg/enterprise/manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/fileutil"
 )
 
 func TestBuildOptions(t *testing.T) {
@@ -34,11 +35,11 @@ func TestBuildOptions(t *testing.T) {
 		assert.NoError(t, err)
 		assert.True(t, enabled)
 		assert.Equal(t, map[string]any{
-			"cache_dir":               filepath.Join(dir, "cache", "pomerium", "enterprise-console"),
+			"cache_dir":               fileutil.EnterpriseConsoleCacheDir(),
 			"database_encryption_key": "oKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKA=",
-			"database_url":            "sqlite://" + path.Join(dir, "data", "pomerium", "enterprise-console", "data.sqlite"),
+			"database_url":            "sqlite://" + path.Join(fileutil.EnterpriseConsoleDataDir(), "data.sqlite"),
 			"databroker_service_url":  "http://localhost:5443",
-			"prometheus_data_dir":     filepath.Join(dir, "data", "pomerium", "enterprise-console", "prometheus"),
+			"prometheus_data_dir":     filepath.Join(fileutil.EnterpriseConsoleDataDir(), "prometheus"),
 			"url":                     "https://example.com",
 			"shared_secret":           "oKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKCgoKA=",
 			"signing_key":             "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1IY0NBUUVFSUlSMHFBTklRUlJvNTNyaFpIRGwyRG9iYXFUMnlXMk0xWlgvOHdyQ05wUFlvQW9HQ0NxR1NNNDkKQXdFSG9VUURRZ0FFT0tSS2tkRmZjY2FRcVFqaUEvQ0t1NHZTM3IyUVVQZUtoS2ZxbkxiVFRic09PcjRGN1h3UQovYWpmWFdVcFhUUWFQdDZncW1oeGREMHp0VFVQYm10NUp3PT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=",

--- a/pkg/enterprise/manager_test.go
+++ b/pkg/enterprise/manager_test.go
@@ -16,6 +16,7 @@ func TestBuildOptions(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(dir, "cache"))
 	t.Setenv("XDG_DATA_HOME", filepath.Join(dir, "data"))
+	t.Setenv("HOME", filepath.Join(dir, "home"))
 	t.Run("disabled", func(t *testing.T) {
 		cfg := config.New(config.NewDefaultOptions())
 		options, enabled, err := buildOptions(cfg)


### PR DESCRIPTION
## Summary
Add support for running the enterprise console directly from core.

A new option `enterprise` is available that contains options that will be passed to an instance of the enterprise. When the `enterprise.url` option is set, we will look for a `pomerium-console` binary and run it, passing the options. Some options are given default values based on the current configuration.

This PR will wait until after v0.33 is released.

## Related issues



## AI disclosure
No AI was used

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
