### PR TITLE
fix(controlplane): fix the debug databroker browser

### DIFF
--- a/internal/controlplane/server_debug.go
+++ b/internal/controlplane/server_debug.go
@@ -177,26 +177,8 @@ func (srv *debugServer) versionedConfigHandler() http.HandlerFunc {
 }
 
 func (srv *debugServer) indexHandler() http.HandlerFunc {
-	return func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("X-Content-Type-Options", "nosniff")
-		w.Header().Set("Content-Type", "text/html; charset=utf-8")
-		_, _ = io.WriteString(w, `<html>
-<head>
-<title>Pomerium Debug</title>
-</head>
-<body>
-		<ul>
-			<li><a href="/config_dump">Config Dump</a></li>
-			<li><a href="/versioned_config">Versioned Config</a></li>
-			<li><a href="/version">Version</a></li>
-			<li><a href="/databroker/">Databroker</a></li>
-			<li><a href="/options"> Databroker (options)</a></li>
-			<li><a href="/raft">Raft</li>
-			<li><a href="/debug/pprof/">Go PProf</a></li>
-			<li><a href="/channelz">ChannelZ</li>
-		</ul>
-</body>
-`)
+	return func(w http.ResponseWriter, r *http.Request) {
+		srv.render(w, r, "Index", map[string]any{})
 	}
 }
 
@@ -329,15 +311,25 @@ func (srv *debugServer) serveDatabrokerIndex(w http.ResponseWriter, r *http.Requ
 	}
 	sort.Strings(typeList)
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, "<html><head><title>Databroker Types</title></head><body>")
-	fmt.Fprintf(w, `<div><a href="/">Home</a> · Databroker</div>`)
-	fmt.Fprintf(w, "<ul>")
-	for _, t := range typeList {
-		fmt.Fprintf(w, "<li><a href=\"/databroker/?type=%s\">%s (%d)</a></li>", url.QueryEscape(t), html.EscapeString(t), types[t])
+	type Record struct {
+		Type  string
+		Link  string
+		Count int
 	}
-	fmt.Fprintf(w, "</ul>")
-	fmt.Fprintf(w, "</body></html>")
+	var records []Record
+	for _, t := range typeList {
+		records = append(records, Record{
+			Type: t,
+			Link: "/databroker/?" + (url.Values{
+				"type": {t},
+			}).Encode(),
+			Count: types[t],
+		})
+	}
+
+	srv.render(w, r, "DatabrokerListTypes", map[string]any{
+		"records": records,
+	})
 }
 
 func (srv *debugServer) serveDatabrokerList(w http.ResponseWriter, r *http.Request, client databroker.DataBrokerServiceClient, recordType string) {
@@ -349,28 +341,37 @@ func (srv *debugServer) serveDatabrokerList(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, "<html><head><title>Databroker %s</title></head><body>", html.EscapeString(recordType))
-	fmt.Fprintf(w, `<div><a href="/">Home</a> · <a href="/databroker/">Databroker</a> · %s</div>`, html.EscapeString(recordType))
-	fmt.Fprintf(w, "<ul>")
+	type Record struct {
+		ID   string
+		Link string
+	}
+	var records []Record
 	for {
 		res, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
 			break
-		}
-		if err != nil {
-			fmt.Fprintf(w, "<li>error: %s</li>", html.EscapeString(err.Error()))
-			break
+		} else if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 		switch r := res.Response.(type) {
 		case *databroker.SyncLatestResponse_Record:
 			if r.Record != nil {
-				fmt.Fprintf(w, "<li><a href=\"/databroker/?type=%s&id=%s\">%s</a></li>", url.QueryEscape(recordType), url.QueryEscape(r.Record.Id), html.EscapeString(r.Record.Id))
+				records = append(records, Record{
+					ID: r.Record.Id,
+					Link: "/databroker/?" + (url.Values{
+						"type": {recordType},
+						"id":   {r.Record.Id},
+					}).Encode(),
+				})
 			}
 		}
 	}
-	fmt.Fprintf(w, "</ul>")
-	fmt.Fprintf(w, "</body></html>")
+
+	srv.render(w, r, "DatabrokerListRecords", map[string]any{
+		"type":    recordType,
+		"records": records,
+	})
 }
 
 func (srv *debugServer) serveDatabrokerOptions(w http.ResponseWriter, r *http.Request, client databroker.DataBrokerServiceClient, recordType string) {

--- a/internal/controlplane/server_debug.go
+++ b/internal/controlplane/server_debug.go
@@ -281,43 +281,20 @@ func (srv *debugServer) databrokerHandler() http.HandlerFunc {
 		}
 		client := (*clientPtr).GetLocalDatabrokerServiceClient()
 
-		path := r.URL.Path
-		if r.URL.RawPath != "" {
-			path = r.URL.RawPath
-		}
-		path = strings.TrimPrefix(path, "/databroker/")
-		parts := strings.Split(path, "/")
+		recordType := r.FormValue("type")
+		recordID := r.FormValue("id")
 
-		var cleanParts []string
-		for _, p := range parts {
-			if p != "" {
-				cleanParts = append(cleanParts, p)
-			}
-		}
-		parts = cleanParts
-
-		if len(parts) == 0 {
-			srv.serveDatabrokerIndex(w, r, client)
+		if recordType != "" && recordID != "" {
+			srv.serveDatabrokerRecord(w, r, client, recordType, recordID)
 			return
 		}
 
-		recordType, err := url.PathUnescape(parts[0])
-		if err != nil {
-			http.Error(w, "invalid record type encoding", http.StatusBadRequest)
-			return
-		}
-
-		if len(parts) == 1 {
+		if recordType != "" {
 			srv.serveDatabrokerList(w, r, client, recordType)
 			return
 		}
 
-		recordID, err := url.PathUnescape(parts[1])
-		if err != nil {
-			http.Error(w, "invalid record id encoding", http.StatusBadRequest)
-			return
-		}
-		srv.serveDatabrokerRecord(w, r, client, recordType, recordID)
+		srv.serveDatabrokerIndex(w, r, client)
 	}
 }
 
@@ -353,11 +330,14 @@ func (srv *debugServer) serveDatabrokerIndex(w http.ResponseWriter, r *http.Requ
 	sort.Strings(typeList)
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, "<html><head><title>Databroker Types</title></head><body><ul>")
+	fmt.Fprintf(w, "<html><head><title>Databroker Types</title></head><body>")
+	fmt.Fprintf(w, `<div><a href="/">Home</a> · Databroker</div>`)
+	fmt.Fprintf(w, "<ul>")
 	for _, t := range typeList {
-		fmt.Fprintf(w, "<li><a href=\"/databroker/%s\">%s (%d)</a></li>", url.PathEscape(t), html.EscapeString(t), types[t])
+		fmt.Fprintf(w, "<li><a href=\"/databroker/?type=%s\">%s (%d)</a></li>", url.QueryEscape(t), html.EscapeString(t), types[t])
 	}
-	fmt.Fprintf(w, "</ul></body></html>")
+	fmt.Fprintf(w, "</ul>")
+	fmt.Fprintf(w, "</body></html>")
 }
 
 func (srv *debugServer) serveDatabrokerList(w http.ResponseWriter, r *http.Request, client databroker.DataBrokerServiceClient, recordType string) {
@@ -370,8 +350,9 @@ func (srv *debugServer) serveDatabrokerList(w http.ResponseWriter, r *http.Reque
 	}
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	fmt.Fprintf(w, "<html><head><title>Databroker %s</title></head><body><ul>", html.EscapeString(recordType))
-
+	fmt.Fprintf(w, "<html><head><title>Databroker %s</title></head><body>", html.EscapeString(recordType))
+	fmt.Fprintf(w, `<div><a href="/">Home</a> · <a href="/databroker/">Databroker</a> · %s</div>`, html.EscapeString(recordType))
+	fmt.Fprintf(w, "<ul>")
 	for {
 		res, err := stream.Recv()
 		if errors.Is(err, io.EOF) {
@@ -384,11 +365,12 @@ func (srv *debugServer) serveDatabrokerList(w http.ResponseWriter, r *http.Reque
 		switch r := res.Response.(type) {
 		case *databroker.SyncLatestResponse_Record:
 			if r.Record != nil {
-				fmt.Fprintf(w, "<li><a href=\"/databroker/%s/%s\">%s</a></li>", url.PathEscape(recordType), url.PathEscape(r.Record.Id), html.EscapeString(r.Record.Id))
+				fmt.Fprintf(w, "<li><a href=\"/databroker/?type=%s&id=%s\">%s</a></li>", url.QueryEscape(recordType), url.QueryEscape(r.Record.Id), html.EscapeString(r.Record.Id))
 			}
 		}
 	}
-	fmt.Fprintf(w, "</ul></body></html>")
+	fmt.Fprintf(w, "</ul>")
+	fmt.Fprintf(w, "</body></html>")
 }
 
 func (srv *debugServer) serveDatabrokerOptions(w http.ResponseWriter, r *http.Request, client databroker.DataBrokerServiceClient, recordType string) {

--- a/internal/controlplane/template.go
+++ b/internal/controlplane/template.go
@@ -1,0 +1,40 @@
+package controlplane
+
+import (
+	"bytes"
+	_ "embed"
+	"html/template"
+	"net/http"
+	"time"
+)
+
+//go:embed template.gohtml
+var templateSource string
+
+func (srv *debugServer) render(w http.ResponseWriter, r *http.Request, page string, data any) {
+	tpl, err := template.New("").Parse(templateSource)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	var buf bytes.Buffer
+	err = tpl.ExecuteTemplate(&buf, page, data)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	body := template.HTML(buf.String()) //nolint: gosec
+	buf.Reset()
+
+	err = tpl.ExecuteTemplate(&buf, "Layout", body)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	http.ServeContent(w, r, page+".html", time.Now(), bytes.NewReader(buf.Bytes()))
+}

--- a/internal/controlplane/template.gohtml
+++ b/internal/controlplane/template.gohtml
@@ -1,0 +1,40 @@
+{{ define "Layout" -}}
+<!doctype html>
+<html>
+  <head><title>Pomerium Debug</title></head>
+  <body>
+    {{- . }}
+  </body>
+</html>
+{{- end }}
+
+{{ define "Index" -}}
+<ul>
+  <li><a href="/config_dump">Config Dump</a></li>
+  <li><a href="/versioned_config">Versioned Config</a></li>
+  <li><a href="/version">Version</a></li>
+  <li><a href="/databroker/">Databroker</a></li>
+  <li><a href="/options"> Databroker (options)</a></li>
+  <li><a href="/raft">Raft</li>
+  <li><a href="/debug/pprof/">Go PProf</a></li>
+  <li><a href="/channelz">ChannelZ</li>
+</ul>
+{{- end }}
+
+{{ define "DatabrokerListRecords" -}}
+<div><a href="/">Home</a> · <a href="/databroker/">Databroker</a> · {{.type}}</div>
+<ul>
+{{- range .records }}
+  <li><a href="{{.Link}}">{{.ID}}</a></li>
+{{- end }}
+</ul>
+{{- end }}
+
+{{ define "DatabrokerListTypes" -}}
+<div><a href="/">Home</a> · Databroker</div>
+<ul>
+{{- range .records }}
+  <li><a href="{{.Link}}">{{.Type}}</a> ({{.Count}})</li>
+{{- end }}
+</ul>
+{{- end }}


### PR DESCRIPTION
## Summary
With #6398 we now reject requests that have an escaped `/`, which most record types will have. This PR updates the debug databroker browser to use query string parameters instead.

## Related issues
- [ENG-4189](https://linear.app/pomerium/issue/ENG-4189/core-debug-admin-databroker-browser-returns-400s)

## AI disclosure
No AI was used for this PR.

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
