### PR TITLE
feat(mcp): add recommended iss flow metadata to authorization flows

### DIFF
--- a/internal/mcp/DESIGN.md
+++ b/internal/mcp/DESIGN.md
@@ -154,7 +154,7 @@ sequenceDiagram
     UpstreamAS->>UpstreamAS: User consent
     UpstreamAS->>PomHTTP: Redirect callback?code=XXX&state=YYY
 
-    Note over PomHTTP: ClientOAuthCallback():<br/>1. Look up PendingUpstreamAuth by state<br/>2. Exchange code for tokens (+ resource param)<br/>3. Store UpstreamMCPToken<br/>4. Delete PendingUpstreamAuth<br/>5. Complete Pomerium auth flow (issue auth code)
+    Note over PomHTTP: ClientOAuthCallback():<br/>1. Look up PendingUpstreamAuth by state<br/>2. Validate iss vs recorded issuer (RFC 9207)<br/>3. Exchange code for tokens (+ resource param)<br/>4. Store UpstreamMCPToken<br/>5. Delete PendingUpstreamAuth<br/>6. Complete Pomerium auth flow (issue auth code)
 
     PomHTTP->>Client: 302 Redirect with Pomerium auth code
     Client->>PomHTTP: POST /.pomerium/mcp/token (exchange code)
@@ -186,6 +186,46 @@ callback was initiated through the MCP client's OAuth flow against Pomerium
 (proactive), while its absence indicates the callback was triggered by
 ext_proc intercepting a 401 from the upstream (reactive).
 
+---
+
+## Issuer Validation (RFC 9207)
+
+[RFC 9207](https://datatracker.ietf.org/doc/html/rfc9207) defines the `iss`
+authorization-response parameter, which lets an OAuth client detect mix-up
+attacks where an authorization response is replayed against the wrong
+authorization server. Per the MCP spec ([SEP-2468]), an AS **SHOULD** include
+`iss` in authorization responses, and a client **MUST** validate a present
+`iss` against the recorded issuer before redeeming the code. Because Pomerium
+plays both OAuth roles, it acts on `iss` in both directions.
+
+[SEP-2468]: https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2468
+
+### Pomerium as Authorization Server (downstream)
+
+When Pomerium issues an authorization code back to the MCP client
+(`AuthorizationResponse` in `handler_authorization.go`), it appends
+`iss=https://{downstream_host}` to the redirect. This value is identical to the
+`issuer` Pomerium advertises in its AS metadata, so the MCP client's RFC 9207
+check succeeds. Pomerium also advertises
+`authorization_response_iss_parameter_supported: true` in its AS metadata
+(`handler_metadata.go`) so spec-aware clients know to expect and validate the
+parameter.
+
+`AuthorizationResponse` is reached from both the plain downstream authorize
+path and the upstream-callback completion path (proactive flow); in both cases
+the request host is the Pomerium downstream host, so the emitted `iss` is
+consistent.
+
+### Pomerium as OAuth Client (upstream)
+
+When the upstream AS redirects back to
+`/.pomerium/mcp/client/oauth/callback`, `ClientOAuthCallback` validates any
+`iss` query parameter against `PendingUpstreamAuth.AuthorizationServerIssuer`
+(the issuer recorded from the upstream AS metadata during discovery). On
+mismatch the pending state is deleted and the callback fails with `400`.
+
+In fully-static mode the route supplies the OAuth endpoints directly, so
+discovery never runs and no issuer is recorded. Issuer validation is disregarded.
 ---
 
 ## Downstream Token Refresh Lifecycle

--- a/internal/mcp/e2e/mcp_auth_flow_test.go
+++ b/internal/mcp/e2e/mcp_auth_flow_test.go
@@ -193,6 +193,11 @@ func runMCPAuthorizationFlow(t *testing.T, mode registrationMode) {
 		// authorization server identifier the client discovered (authorization_servers[0]).
 		require.Equal(t, authServerIssuer, ts.asMetadata.Issuer,
 			"issuer in AS metadata must match authorization_servers entry from protected resource metadata")
+
+		// RFC 9207: the AS advertises that it includes the iss parameter in
+		// authorization responses so clients know to validate it.
+		require.True(t, ts.asMetadata.AuthorizationResponseISSParameterSupported,
+			"AS metadata must advertise authorization_response_iss_parameter_supported (RFC 9207)")
 	})
 
 	t.Run("step 4: client registration", func(t *testing.T) {
@@ -243,11 +248,17 @@ func runMCPAuthorizationFlow(t *testing.T, mode registrationMode) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		var returnedState string
-		ts.authCode, returnedState = parseCallbackParams(t, resp.Header.Get("Location"))
+		var returnedState, returnedIss string
+		ts.authCode, returnedState, returnedIss = parseCallbackParams(t, resp.Header.Get("Location"))
 		require.NotEmpty(t, ts.authCode, "expected authorization code")
 		assert.Equal(t, ts.state, returnedState, "state parameter should match")
-		t.Logf("Received authorization code: %s", ts.authCode)
+
+		// RFC 9207 / SEP-2468: the AS MUST include the iss parameter in the
+		// authorization response, and it MUST equal the recorded issuer so the
+		// client can validate it before redeeming the code.
+		assert.Equal(t, ts.asMetadata.Issuer, returnedIss,
+			"authorization response iss must match the AS metadata issuer (RFC 9207)")
+		t.Logf("Received authorization code: %s (iss=%s)", ts.authCode, returnedIss)
 	})
 
 	t.Run("step 6: exchange authorization code for token", func(t *testing.T) {
@@ -327,7 +338,7 @@ func parseResourceMetadataFromWWWAuthenticate(t *testing.T, header string) strin
 	return ""
 }
 
-func parseCallbackParams(t *testing.T, callbackURL string) (code, state string) {
+func parseCallbackParams(t *testing.T, callbackURL string) (code, state, iss string) {
 	t.Helper()
 	t.Logf("Parsing callback URL: %s", callbackURL)
 
@@ -336,5 +347,6 @@ func parseCallbackParams(t *testing.T, callbackURL string) (code, state string) 
 
 	code = parsed.Query().Get("code")
 	state = parsed.Query().Get("state")
-	return code, state
+	iss = parsed.Query().Get("iss")
+	return code, state, iss
 }

--- a/internal/mcp/e2e/mcp_client_id_metadata_test.go
+++ b/internal/mcp/e2e/mcp_client_id_metadata_test.go
@@ -224,7 +224,7 @@ func TestMCPServer_AcceptsExternalClientCIMD(t *testing.T) {
 		defer resp.Body.Close()
 
 		var returnedState string
-		ts.authCode, returnedState = parseCallbackParams(t, resp.Header.Get("Location"))
+		ts.authCode, returnedState, _ = parseCallbackParams(t, resp.Header.Get("Location"))
 		require.NotEmpty(t, ts.authCode, "expected authorization code")
 		assert.Equal(t, ts.state, returnedState, "state parameter should match")
 		t.Logf("Received authorization code: %s", ts.authCode)

--- a/internal/mcp/e2e/mcp_conformance_test.go
+++ b/internal/mcp/e2e/mcp_conformance_test.go
@@ -170,7 +170,7 @@ func runMCPConformance(t *testing.T, mode registrationMode) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		code, _ := parseCallbackParams(t, resp.Header.Get("Location"))
+		code, _, _ := parseCallbackParams(t, resp.Header.Get("Location"))
 		require.NotEmpty(t, code)
 		return code
 	}

--- a/internal/mcp/e2e/mcp_cors_test.go
+++ b/internal/mcp/e2e/mcp_cors_test.go
@@ -313,7 +313,7 @@ func TestMCPCORSHeaders(t *testing.T) {
 		require.NoError(t, err)
 		defer resp.Body.Close()
 
-		authCode, returnedState := parseCallbackParams(t, resp.Header.Get("Location"))
+		authCode, returnedState, _ := parseCallbackParams(t, resp.Header.Get("Location"))
 		require.NotEmpty(t, authCode, "expected authorization code")
 		assert.Equal(t, state, returnedState, "state parameter should match")
 

--- a/internal/mcp/e2e/mcp_upstream_dcr_fallback_test.go
+++ b/internal/mcp/e2e/mcp_upstream_dcr_fallback_test.go
@@ -99,6 +99,7 @@ func TestMCPUpstreamOAuthDCRFallback(t *testing.T) {
 			q := u.Query()
 			q.Set("code", code)
 			q.Set("state", state)
+			q.Set("iss", asServer.URL)
 			u.RawQuery = q.Encode()
 			http.Redirect(w, r, u.String(), http.StatusFound)
 		case "/token":

--- a/internal/mcp/handler_authorization.go
+++ b/internal/mcp/handler_authorization.go
@@ -304,6 +304,7 @@ func (srv *Handler) AuthorizationResponse(
 	q := to.Query()
 	q.Set("code", code)
 	q.Set("state", req.GetState())
+	q.Set("iss", (&url.URL{Scheme: "https", Host: r.Host}).String())
 	to.RawQuery = q.Encode()
 
 	log.Ctx(ctx).Debug().

--- a/internal/mcp/handler_client_oauth_callback.go
+++ b/internal/mcp/handler_client_oauth_callback.go
@@ -72,20 +72,25 @@ func (srv *Handler) ClientOAuthCallback(w http.ResponseWriter, r *http.Request) 
 	}
 
 	// RFC 9207: validate a present iss against the recorded issuer.
-	if iss != "" &&
-		// The issuer is only empty when the oauth2 parameters are specified on the route and
-		// do not have to go through discovery
-		pending.AuthorizationServerIssuer != "" &&
-		iss != pending.AuthorizationServerIssuer {
-		log.Ctx(ctx).Error().Str("state_id", stateID).
-			Str("issuer", pending.AuthorizationServerIssuer).
-			Str("received-issuer", iss).
-			Msg("mcp/client-oauth-callback: issuer mismatch")
-		if delErr := srv.storage.DeletePendingUpstreamAuth(ctx, pending.UserId, pending.DownstreamHost); delErr != nil {
-			log.Ctx(ctx).Warn().Err(delErr).Str("state_id", stateID).Msg("mcp/client-oauth-callback: failed to clean up expired pending auth state")
+	if pending.MustValidateIssuer {
+		if pending.AuthorizationServerIssuer == "" || iss == "" {
+			log.Ctx(ctx).Error().Str("state_id", stateID).
+				Str("issuer", pending.AuthorizationServerIssuer).
+				Str("received-issuer", iss).
+				Msg("mcp/client-oauth-callback: issuer not specified")
+			http.Error(w, "Invalid issuer", http.StatusBadRequest)
 		}
-		http.Error(w, "Invalid issuer", http.StatusBadRequest)
-		return
+		if pending.AuthorizationServerIssuer != "" && iss != pending.AuthorizationServerIssuer {
+			log.Ctx(ctx).Error().Str("state_id", stateID).
+				Str("issuer", pending.AuthorizationServerIssuer).
+				Str("received-issuer", iss).
+				Msg("mcp/client-oauth-callback: issuer mismatch")
+			if delErr := srv.storage.DeletePendingUpstreamAuth(ctx, pending.UserId, pending.DownstreamHost); delErr != nil {
+				log.Ctx(ctx).Warn().Err(delErr).Str("state_id", stateID).Msg("mcp/client-oauth-callback: failed to clean up expired pending auth state")
+			}
+			http.Error(w, "Invalid issuer", http.StatusBadRequest)
+			return
+		}
 	}
 
 	// Exchange authorization code for tokens

--- a/internal/mcp/handler_client_oauth_callback.go
+++ b/internal/mcp/handler_client_oauth_callback.go
@@ -78,7 +78,11 @@ func (srv *Handler) ClientOAuthCallback(w http.ResponseWriter, r *http.Request) 
 				Str("issuer", pending.AuthorizationServerIssuer).
 				Str("received-issuer", iss).
 				Msg("mcp/client-oauth-callback: issuer not specified")
+			if delErr := srv.storage.DeletePendingUpstreamAuth(ctx, pending.UserId, pending.DownstreamHost); delErr != nil {
+				log.Ctx(ctx).Warn().Err(delErr).Str("state_id", stateID).Msg("mcp/client-oauth-callback: failed to clean up expired pending auth state")
+			}
 			http.Error(w, "Invalid issuer", http.StatusBadRequest)
+			return
 		}
 		if pending.AuthorizationServerIssuer != "" && iss != pending.AuthorizationServerIssuer {
 			log.Ctx(ctx).Error().Str("state_id", stateID).

--- a/internal/mcp/handler_client_oauth_callback.go
+++ b/internal/mcp/handler_client_oauth_callback.go
@@ -27,6 +27,7 @@ func (srv *Handler) ClientOAuthCallback(w http.ResponseWriter, r *http.Request) 
 
 	code := r.URL.Query().Get("code")
 	stateID := r.URL.Query().Get("state")
+	iss := r.URL.Query().Get("iss")
 
 	if code == "" || stateID == "" {
 		errParam := r.URL.Query().Get("error")
@@ -67,6 +68,23 @@ func (srv *Handler) ClientOAuthCallback(w http.ResponseWriter, r *http.Request) 
 			log.Ctx(ctx).Warn().Err(delErr).Str("state_id", stateID).Msg("mcp/client-oauth-callback: failed to clean up expired pending auth state")
 		}
 		http.Error(w, "Authorization state expired, please retry", http.StatusBadRequest)
+		return
+	}
+
+	// RFC 9207: validate a present iss against the recorded issuer.
+	if iss != "" &&
+		// The issuer is only empty when the oauth2 parameters are specified on the route and
+		// do not have to go through discovery
+		pending.AuthorizationServerIssuer != "" &&
+		iss != pending.AuthorizationServerIssuer {
+		log.Ctx(ctx).Error().Str("state_id", stateID).
+			Str("issuer", pending.AuthorizationServerIssuer).
+			Str("received-issuer", iss).
+			Msg("mcp/client-oauth-callback: issuer mismatch")
+		if delErr := srv.storage.DeletePendingUpstreamAuth(ctx, pending.UserId, pending.DownstreamHost); delErr != nil {
+			log.Ctx(ctx).Warn().Err(delErr).Str("state_id", stateID).Msg("mcp/client-oauth-callback: failed to clean up expired pending auth state")
+		}
+		http.Error(w, "Invalid issuer", http.StatusBadRequest)
 		return
 	}
 

--- a/internal/mcp/handler_client_oauth_callback_test.go
+++ b/internal/mcp/handler_client_oauth_callback_test.go
@@ -455,7 +455,7 @@ func TestClientOAuthCallback(t *testing.T) {
 		}
 
 		req := httptest.NewRequest(http.MethodGet,
-			"/oauth_callback?code=code123&state=test-state-id&issuer=https://malicious.example.com", nil)
+			"/oauth_callback?code=code123&state=test-state-id&iss=https://malicious.example.com", nil)
 		rr := httptest.NewRecorder()
 		srv.ClientOAuthCallback(rr, req)
 

--- a/internal/mcp/handler_client_oauth_callback_test.go
+++ b/internal/mcp/handler_client_oauth_callback_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -414,5 +415,74 @@ func TestClientOAuthCallback(t *testing.T) {
 		r2 := httptest.NewRequest(http.MethodGet, "/callback?code=auth-code&state=test-state-id", nil)
 		srv.ClientOAuthCallback(w2, r2)
 		assert.Equal(t, http.StatusBadRequest, w2.Code)
+	})
+
+	t.Run("happy path authorization server issuer comparison", func(t *testing.T) {
+		storage := setupTestDatabroker(ctx, t)
+		tokenServer, _ := newTokenServer(t, successfulTokenResponse)
+		pending := newTestPendingAuth(tokenServer.URL)
+		pending.MustValidateIssuer = true
+		require.NoError(t, storage.PutPendingUpstreamAuth(ctx, pending))
+
+		srv := &Handler{
+			storage:    storage,
+			httpClient: tokenServer.Client(),
+		}
+
+		req := httptest.NewRequest(
+			http.MethodGet,
+			fmt.Sprintf("/oauth_callback?code=code123&state=test-state-id&iss=%s", pending.AuthorizationServerIssuer),
+			nil,
+		)
+		rr := httptest.NewRecorder()
+		srv.ClientOAuthCallback(rr, req)
+
+		require.Equal(t, http.StatusFound, rr.Code)
+	})
+
+	t.Run("issuer mismatch from remote should be rejected", func(t *testing.T) {
+		storage := setupTestDatabroker(ctx, t)
+		tokenServer, _ := newTokenServer(t, successfulTokenResponse)
+
+		pending := newTestPendingAuth(tokenServer.URL)
+		pending.MustValidateIssuer = true
+
+		require.NoError(t, storage.PutPendingUpstreamAuth(ctx, pending))
+
+		srv := &Handler{
+			storage:    storage,
+			httpClient: tokenServer.Client(),
+		}
+
+		req := httptest.NewRequest(http.MethodGet,
+			"/oauth_callback?code=code123&state=test-state-id&issuer=https://malicious.example.com", nil)
+		rr := httptest.NewRecorder()
+		srv.ClientOAuthCallback(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code,
+			"mismatched iss with a known issuer must be rejected (RFC 9207 MUST)")
+	})
+
+	t.Run("absent issuer from remote should be rejected", func(t *testing.T) {
+		storage := setupTestDatabroker(ctx, t)
+		tokenServer, _ := newTokenServer(t, successfulTokenResponse)
+
+		pending := newTestPendingAuth(tokenServer.URL)
+		pending.MustValidateIssuer = true
+
+		require.NoError(t, storage.PutPendingUpstreamAuth(ctx, pending))
+
+		srv := &Handler{
+			storage:    storage,
+			httpClient: tokenServer.Client(),
+		}
+
+		req := httptest.NewRequest(http.MethodGet,
+			"/oauth_callback?code=code123&state=test-state-id", nil)
+		rr := httptest.NewRecorder()
+		srv.ClientOAuthCallback(rr, req)
+
+		require.Equal(t, http.StatusBadRequest, rr.Code,
+			"absent iss with a known issuer should be rejected (RFC 9207 SHOULD)")
 	})
 }

--- a/internal/mcp/handler_metadata.go
+++ b/internal/mcp/handler_metadata.go
@@ -84,6 +84,10 @@ type AuthorizationServerMetadata struct {
 	// ClientIDMetadataDocumentSupported is OPTIONAL. Boolean value specifying whether the authorization server
 	// supports retrieving client metadata from a client_id URL as described in draft-ietf-oauth-client-id-metadata-document.
 	ClientIDMetadataDocumentSupported bool `json:"client_id_metadata_document_supported,omitempty"`
+
+	// AuthorizationResponseISSParameterSupported is OPTIONAL. Boolean value indicating whether the authorization server
+	// provides the iss parameter in the authorization response as defined in RFC 9207. If omitted, the default value is false.
+	AuthorizationResponseISSParameterSupported bool `json:"authorization_response_iss_parameter_supported"`
 }
 
 // ProtectedResourceMetadata represents OAuth Protected Resource Metadata.
@@ -154,17 +158,18 @@ func getAuthorizationServerMetadata(r *http.Request, prefix string, dcrEnabled b
 	issuer := (&url.URL{Scheme: "https", Host: r.Host}).String()
 
 	md := AuthorizationServerMetadata{
-		Issuer:                                 issuer,
-		ServiceDocumentation:                   "https://pomerium.com/docs",
-		AuthorizationEndpoint:                  P(path.Join(prefix, authorizationEndpoint)),
-		ResponseTypesSupported:                 []string{"code"},
-		CodeChallengeMethodsSupported:          []string{"S256"},
-		TokenEndpoint:                          P(path.Join(prefix, tokenEndpoint)),
-		TokenEndpointAuthMethodsSupported:      []string{"client_secret_basic", "none"},
-		GrantTypesSupported:                    []string{"authorization_code", "refresh_token"},
-		RevocationEndpoint:                     P(path.Join(prefix, revocationEndpoint)),
-		RevocationEndpointAuthMethodsSupported: []string{"client_secret_post"},
-		ClientIDMetadataDocumentSupported:      true,
+		Issuer:                                     issuer,
+		ServiceDocumentation:                       "https://pomerium.com/docs",
+		AuthorizationEndpoint:                      P(path.Join(prefix, authorizationEndpoint)),
+		ResponseTypesSupported:                     []string{"code"},
+		CodeChallengeMethodsSupported:              []string{"S256"},
+		TokenEndpoint:                              P(path.Join(prefix, tokenEndpoint)),
+		TokenEndpointAuthMethodsSupported:          []string{"client_secret_basic", "none"},
+		GrantTypesSupported:                        []string{"authorization_code", "refresh_token"},
+		RevocationEndpoint:                         P(path.Join(prefix, revocationEndpoint)),
+		RevocationEndpointAuthMethodsSupported:     []string{"client_secret_post"},
+		ClientIDMetadataDocumentSupported:          true,
+		AuthorizationResponseISSParameterSupported: true,
 	}
 	if dcrEnabled {
 		md.RegistrationEndpoint = P(path.Join(prefix, registerEndpoint))

--- a/internal/mcp/handler_metadata.go
+++ b/internal/mcp/handler_metadata.go
@@ -87,7 +87,7 @@ type AuthorizationServerMetadata struct {
 
 	// AuthorizationResponseISSParameterSupported is OPTIONAL. Boolean value indicating whether the authorization server
 	// provides the iss parameter in the authorization response as defined in RFC 9207. If omitted, the default value is false.
-	AuthorizationResponseISSParameterSupported bool `json:"authorization_response_iss_parameter_supported"`
+	AuthorizationResponseISSParameterSupported bool `json:"authorization_response_iss_parameter_supported,omitempty"`
 }
 
 // ProtectedResourceMetadata represents OAuth Protected Resource Metadata.

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -70,6 +70,7 @@ func newPendingUpstreamAuth(p newPendingUpstreamAuthParams, setup *upstreamOAuth
 		CreatedAt:                 timestamppb.New(now),
 		ExpiresAt:                 timestamppb.New(now.Add(pendingAuthExpiry)),
 		ResourceParam:             setup.Discovery.Resource,
+		MustValidateIssuer:        setup.Discovery.MustValidateIssuer,
 	}
 }
 

--- a/internal/mcp/upstream_oauth_setup.go
+++ b/internal/mcp/upstream_oauth_setup.go
@@ -232,6 +232,8 @@ type discoveryResult struct {
 	// When PRM is available, this is prm.Resource (authoritative).
 	// When PRM is unavailable (fallback), this is the origin of the upstream URL.
 	Resource string
+	// Indicates whether the upstream oauth server responds with its issuer
+	MustValidateIssuer bool
 }
 
 // runDiscovery fetches Protected Resource Metadata (RFC 9728) and Authorization Server Metadata.
@@ -443,6 +445,7 @@ func runDiscoveryFromPRM(
 		ScopesSupported:                   prm.ScopesSupported,
 		ClientIDMetadataDocumentSupported: asm.ClientIDMetadataDocumentSupported,
 		Resource:                          prm.Resource,
+		MustValidateIssuer:                asm.AuthorizationResponseISSParameterSupported,
 	}, nil
 }
 
@@ -486,6 +489,7 @@ func runDiscoveryFromFallbackAS(
 		Issuer:                            asm.Issuer,
 		ClientIDMetadataDocumentSupported: asm.ClientIDMetadataDocumentSupported,
 		Resource:                          resource,
+		MustValidateIssuer:                true,
 	}, nil
 }
 

--- a/internal/mcp/upstream_oauth_setup.go
+++ b/internal/mcp/upstream_oauth_setup.go
@@ -489,7 +489,7 @@ func runDiscoveryFromFallbackAS(
 		Issuer:                            asm.Issuer,
 		ClientIDMetadataDocumentSupported: asm.ClientIDMetadataDocumentSupported,
 		Resource:                          resource,
-		MustValidateIssuer:                true,
+		MustValidateIssuer:                asm.AuthorizationResponseISSParameterSupported,
 	}, nil
 }
 

--- a/internal/oauth21/gen/pending_upstream_auth.pb.go
+++ b/internal/oauth21/gen/pending_upstream_auth.pb.go
@@ -70,8 +70,10 @@ type PendingUpstreamAuth struct {
 	// Used in both authorization and token exchange requests.
 	// Falls back to upstream_server if empty (backwards compatibility).
 	ResourceParam string `protobuf:"bytes,19,opt,name=resource_param,json=resourceParam,proto3" json:"resource_param,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Whether the issuer presented in the callback must be validated per RFC 9207.
+	MustValidateIssuer bool `protobuf:"varint,20,opt,name=must_validate_issuer,json=mustValidateIssuer,proto3" json:"must_validate_issuer,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *PendingUpstreamAuth) Reset() {
@@ -237,11 +239,18 @@ func (x *PendingUpstreamAuth) GetResourceParam() string {
 	return ""
 }
 
+func (x *PendingUpstreamAuth) GetMustValidateIssuer() bool {
+	if x != nil {
+		return x.MustValidateIssuer
+	}
+	return false
+}
+
 var File_pending_upstream_auth_proto protoreflect.FileDescriptor
 
 const file_pending_upstream_auth_proto_rawDesc = "" +
 	"\n" +
-	"\x1bpending_upstream_auth.proto\x12\aoauth21\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xd1\x06\n" +
+	"\x1bpending_upstream_auth.proto\x12\aoauth21\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\x83\a\n" +
 	"\x13PendingUpstreamAuth\x12%\n" +
 	"\bstate_id\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\astateId\x12#\n" +
@@ -271,7 +280,8 @@ const file_pending_upstream_auth_proto_rawDesc = "" +
 	"\vauth_req_id\x18\x10 \x01(\tR\tauthReqId\x12%\n" +
 	"\x0epkce_challenge\x18\x11 \x01(\tR\rpkceChallenge\x12#\n" +
 	"\rclient_secret\x18\x12 \x01(\tR\fclientSecret\x12%\n" +
-	"\x0eresource_param\x18\x13 \x01(\tR\rresourceParamB\x96\x01\n" +
+	"\x0eresource_param\x18\x13 \x01(\tR\rresourceParam\x120\n" +
+	"\x14must_validate_issuer\x18\x14 \x01(\bR\x12mustValidateIssuerB\x96\x01\n" +
 	"\vcom.oauth21B\x18PendingUpstreamAuthProtoP\x01Z1github.com/pomerium/pomerium/internal/oauth21/gen\xa2\x02\x03OXX\xaa\x02\aOauth21\xca\x02\aOauth21\xe2\x02\x13Oauth21\\GPBMetadata\xea\x02\aOauth21b\x06proto3"
 
 var (

--- a/internal/oauth21/proto/pending_upstream_auth.proto
+++ b/internal/oauth21/proto/pending_upstream_auth.proto
@@ -89,4 +89,7 @@ message PendingUpstreamAuth {
   // Used in both authorization and token exchange requests.
   // Falls back to upstream_server if empty (backwards compatibility).
   string resource_param = 19;
+
+  // Whether the issuer presented in the callback must be validated per RFC 9207.
+  bool must_validate_issuer = 20;
 }


### PR DESCRIPTION
## Summary

The incoming MCP spec for 2026-07-28 indicates the authorization servers SHOULD explicitly include the issuer in the authorization flows as per RFC 9207.

We return the pomerium host as the issuer and validate remote issuers when oauth bridging with the upstream mcp server is required.


## Related issues

[ENG-4204](https://linear.app/pomerium/issue/ENG-4204/mcp-support-for-iss-in-authorization-server)

## User Explanation

Pomerium returns its host as the issuer during authorization flows.

## AI disclosure

opus 4.8 was used to update DESIGN.md and some of the e2e tests.

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
