### PR TITLE
tracing: fix otel resource initialization

### DIFF
--- a/pkg/telemetry/trace/trace.go
+++ b/pkg/telemetry/trace/trace.go
@@ -10,6 +10,7 @@ import (
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace"
+	otelsdk "go.opentelemetry.io/otel/sdk"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.40.0"
@@ -73,17 +74,14 @@ func NewTracerProvider(ctx context.Context, serviceName string, opts ...sdktrace
 	if err != nil {
 		panic(err)
 	}
-	r, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName(serviceName),
-			attribute.String("provider.created_at", fmt.Sprintf("%s:%d", file, line)),
-		),
+	r := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.TelemetrySDKName("opentelemetry"),      // resource.telemetrySDK
+		semconv.TelemetrySDKLanguageGo,                 // resource.telemetrySDK
+		semconv.TelemetrySDKVersion(otelsdk.Version()), // resource.telemetrySDK
+		semconv.ServiceName(serviceName),
+		attribute.String("provider.created_at", fmt.Sprintf("%s:%d", file, line)),
 	)
-	if err != nil {
-		panic(err)
-	}
 	options := []sdktrace.TracerProviderOption{}
 	if sys.options.DebugFlags.Check(TrackSpanCallers) {
 		options = append(options, sdktrace.WithSpanProcessor(&stackTraceProcessor{}))


### PR DESCRIPTION
## Summary

This fixes initialization of the otel tracer `Resource` to not merge with `resources.Default()`, which may have a different schema version than the one from `semconv.SchemaURL` that we import with a specific version. The default attributes that were used from resources.Default() are added manually instead (the default detectors are not exported).

In `go.opentelemetry.io/otel` v1.44.0, the default schema url was changed to 1.41.0, which was conflicting with the imported version and caused an error on startup. 


## Related issues

<!-- For example...
- #159
-->

## User Explanation

N/A

## AI disclosure

none

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
