### PR TITLE
fix(config): redact secrets from configuration presentation

### DIFF
--- a/config/constants.go
+++ b/config/constants.go
@@ -17,6 +17,7 @@ const (
 var (
 	errKeysMustBeStrings                    = errors.New("cannot convert nested map: all keys must be strings")
 	errZeroWeight                           = errors.New("zero load balancing weight not permitted")
+	errInvalidUpstreamWeight                = errors.New("invalid upstream weight")
 	errEndpointWeightsSpec                  = errors.New("either no weights should be provided, or all endpoints must have non-zero weight specified")
 	errHostnameMustBeSpecified              = errors.New("endpoint hostname must be specified")
 	errSchemeMustBeSpecified                = errors.New("url scheme must be provided")

--- a/config/custom.go
+++ b/config/custom.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"reflect"
@@ -310,7 +311,17 @@ func ParseWeightedURL(dst string) (*WeightedURL, error) {
 
 	u, err := urlutil.ParseAndValidateURL(to)
 	if err != nil {
-		return nil, fmt.Errorf("%s: %w", to, err)
+		// net/url parse errors include the original input, which may contain
+		// credentials. Retain stable, useful categories when they can be
+		// determined without returning the raw input.
+		parsed, parseErr := url.Parse(to)
+		if parseErr == nil && parsed.Scheme == "" {
+			return nil, errSchemeMustBeSpecified
+		}
+		if parseErr == nil && parsed.Hostname() == "" && !urlutil.IsUnixScheme(parsed.Scheme) {
+			return nil, errHostnameMustBeSpecified
+		}
+		return nil, errors.New("invalid upstream URL")
 	}
 
 	if u.Hostname() == "" && !urlutil.IsUnixScheme(u.Scheme) {
@@ -322,7 +333,7 @@ func ParseWeightedURL(dst string) (*WeightedURL, error) {
 
 // String returns the WeightedURL as a string.
 func (u *WeightedURL) String() string {
-	str := u.URL.String()
+	str := urlutil.Redacted(&u.URL)
 	if u.LbWeight == 0 {
 		return str
 	}
@@ -541,7 +552,7 @@ func weightedString(str string) (string, uint32, error) {
 
 	w, err := strconv.ParseUint(str[i+1:], 10, 32)
 	if err != nil {
-		return "", 0, err
+		return "", 0, errInvalidUpstreamWeight
 	}
 
 	if w == 0 {

--- a/config/custom_test.go
+++ b/config/custom_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/base64"
 	"encoding/json"
+	"net/url"
 	"testing"
 	"time"
 
@@ -20,6 +21,32 @@ import (
 	"github.com/pomerium/pomerium/pkg/nullable"
 	"github.com/pomerium/pomerium/pkg/policy/parser"
 )
+
+func TestParseWeightedURLRedactsCredentialsOnError(t *testing.T) {
+	const canary = "UPSTREAM_URL_PASSWORD_CANARY"
+	_, err := ParseWeightedURL("https://user:" + canary + "@[::1")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), canary)
+}
+
+func TestParseWeightedURLRedactsCredentialsOnInvalidWeight(t *testing.T) {
+	const canary = "UPSTREAM_WEIGHT_PARSE_SECRET_CANARY"
+	_, err := ParseWeightedURL("https://user:prefix," + canary + "@upstream.example.com")
+	require.ErrorIs(t, err, errInvalidUpstreamWeight)
+	assert.NotContains(t, err.Error(), canary)
+}
+
+func TestWeightedURLStringRedactsCredentials(t *testing.T) {
+	const usernameCanary = "UPSTREAM_URL_USERNAME_CANARY"
+	const passwordCanary = "UPSTREAM_URL_PASSWORD_CANARY"
+	u := WeightedURL{
+		URL:      url.URL{Scheme: "https", Host: "upstream.example.com", User: url.UserPassword(usernameCanary, passwordCanary)},
+		LbWeight: 10,
+	}
+	assert.NotContains(t, u.String(), usernameCanary)
+	assert.NotContains(t, u.String(), passwordCanary)
+	assert.Contains(t, u.String(), "xxxxx")
+}
 
 func TestJWTClaimHeaders_UnmarshalJSON(t *testing.T) {
 	t.Run("object", func(t *testing.T) {

--- a/config/custom_test.go
+++ b/config/custom_test.go
@@ -29,6 +29,26 @@ func TestParseWeightedURLRedactsCredentialsOnError(t *testing.T) {
 	assert.NotContains(t, err.Error(), canary)
 }
 
+func TestParseWeightedURLErrorCategories(t *testing.T) {
+	const canary = "UPSTREAM_URL_PASSWORD_CANARY"
+	cases := []struct {
+		name    string
+		in      string
+		wantErr error
+	}{
+		{"missing scheme", "upstream.example.com", errSchemeMustBeSpecified},
+		{"missing hostname with userinfo", "https://user:" + canary + "@", errHostnameMustBeSpecified},
+		{"missing hostname with port only", "https://:8080", errHostnameMustBeSpecified},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := ParseWeightedURL(tc.in)
+			require.ErrorIs(t, err, tc.wantErr)
+			assert.NotContains(t, err.Error(), canary)
+		})
+	}
+}
+
 func TestParseWeightedURLRedactsCredentialsOnInvalidWeight(t *testing.T) {
 	const canary = "UPSTREAM_WEIGHT_PARSE_SECRET_CANARY"
 	_, err := ParseWeightedURL("https://user:prefix," + canary + "@upstream.example.com")
@@ -46,6 +66,9 @@ func TestWeightedURLStringRedactsCredentials(t *testing.T) {
 	assert.NotContains(t, u.String(), usernameCanary)
 	assert.NotContains(t, u.String(), passwordCanary)
 	assert.Contains(t, u.String(), "xxxxx")
+
+	u.LbWeight = 0
+	assert.Equal(t, "https://xxxxx@upstream.example.com", u.String())
 }
 
 func TestJWTClaimHeaders_UnmarshalJSON(t *testing.T) {

--- a/config/policy.go
+++ b/config/policy.go
@@ -693,7 +693,7 @@ func (p *Policy) Validate() error {
 	toSchemes := make(map[string]struct{})
 	for _, u := range p.To {
 		if err = u.Validate(); err != nil {
-			return fmt.Errorf("config: %s: %w", u.URL.String(), err)
+			return fmt.Errorf("config: %s: %w", urlutil.Redacted(&u.URL), err)
 		}
 		toSchemes[u.URL.Scheme] = struct{}{}
 	}
@@ -912,7 +912,7 @@ func (p *Policy) String() string {
 	if len(p.To) > 0 {
 		var dsts []string
 		for _, dst := range p.To {
-			dsts = append(dsts, dst.URL.String())
+			dsts = append(dsts, urlutil.Redacted(&dst.URL))
 		}
 		to = strings.Join(dsts, ",")
 	}

--- a/config/policy_test.go
+++ b/config/policy_test.go
@@ -75,6 +75,50 @@ func Test_PolicyValidate(t *testing.T) {
 	}
 }
 
+func TestPolicyPresentationRedactsUpstreamCredentials(t *testing.T) {
+	const usernameCanary = "POLICY_UPSTREAM_USERNAME_CANARY"
+	const passwordCanary = "POLICY_UPSTREAM_PASSWORD_CANARY"
+	p := Policy{
+		From: "https://app.example.com",
+		To: WeightedURLs{{URL: url.URL{
+			Scheme: "https",
+			User:   url.UserPassword(usernameCanary, passwordCanary),
+		}}},
+	}
+
+	err := p.Validate()
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), usernameCanary)
+	assert.NotContains(t, err.Error(), passwordCanary)
+	assert.NotContains(t, p.String(), usernameCanary)
+	assert.NotContains(t, p.String(), passwordCanary)
+	assert.Contains(t, p.String(), "xxxxx")
+}
+
+func TestPolicyRuntimeUpstreamCredentialsAreNotRedacted(t *testing.T) {
+	const usernameCanary = "RUNTIME_UPSTREAM_USERNAME_CANARY"
+	const passwordCanary = "RUNTIME_UPSTREAM_PASSWORD_CANARY"
+	const tokenCanary = "RUNTIME_UPSTREAM_TOKEN_CANARY"
+	p := Policy{
+		From: "https://app.example.com",
+		To: mustParseWeightedURLs(t,
+			"https://"+usernameCanary+":"+passwordCanary+"@first.internal",
+			"https://"+tokenCanary+"@second.internal",
+		),
+	}
+
+	flattened, _, err := p.To.Flatten()
+	require.NoError(t, err)
+	require.Len(t, flattened, 2)
+	assert.Contains(t, flattened[0], usernameCanary)
+	assert.Contains(t, flattened[0], passwordCanary)
+	assert.Contains(t, flattened[1], tokenCanary)
+
+	pb, err := p.ToProto()
+	require.NoError(t, err)
+	assert.Equal(t, flattened, pb.GetTo(), "runtime route material must retain upstream credentials")
+}
+
 func Test_PolicyValidate_RedirectResponseCode(t *testing.T) {
 	t.Parallel()
 

--- a/internal/controlplane/server_debug.go
+++ b/internal/controlplane/server_debug.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/envoy/files"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	mcpconfigapi "github.com/pomerium/pomerium/pkg/mcp/configapi"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
@@ -98,13 +99,15 @@ func (srv *debugServer) Update(cfg *config.Config) {
 
 func (srv *debugServer) configDumpHandler(cfg *config.Config) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
+		presentation := proto.Clone(cfg.Options.ToProto()).(*configpb.Config)
+		mcpconfigapi.ScrubSensitive(presentation)
 		o := protojson.MarshalOptions{
 			Multiline:     true,
 			Indent:        "  ",
 			AllowPartial:  true,
 			UseProtoNames: true,
 		}
-		bs, err := o.Marshal(cfg.Options.ToProto())
+		bs, err := o.Marshal(presentation)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
@@ -422,13 +425,20 @@ func (srv *debugServer) serveDatabrokerRecord(w http.ResponseWriter, r *http.Req
 		AllowPartial:  true,
 		UseProtoNames: true,
 	}
-	bs, err := o.Marshal(res.Record)
+	presentation := scrubSensitiveDatabrokerRecord(res.Record)
+	bs, err := o.Marshal(presentation)
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	_, _ = w.Write(bs)
+}
+
+func scrubSensitiveDatabrokerRecord(record *databroker.Record) *databroker.Record {
+	presentation := proto.Clone(record).(*databroker.Record)
+	mcpconfigapi.ScrubSensitive(presentation)
+	return presentation
 }
 
 type versionedConfigData struct {
@@ -531,6 +541,7 @@ func (v *versionedConfigData) RenderVersionedConfig(cfg *configpb.VersionedConfi
 	conditions := cfg.Conditions
 	cfg = proto.Clone(cfg).(*configpb.VersionedConfig)
 	cfg.Conditions = nil
+	mcpconfigapi.ScrubSensitive(cfg)
 
 	marshaled, err := protojson.MarshalOptions{
 		Multiline:     true,

--- a/internal/controlplane/server_debug_sensitive_test.go
+++ b/internal/controlplane/server_debug_sensitive_test.go
@@ -64,14 +64,12 @@ func TestConfigDumpConcurrentScrubbingDoesNotMutateLiveConfig(t *testing.T) {
 
 	var wg sync.WaitGroup
 	for range 16 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			recorder := httptest.NewRecorder()
 			handler(recorder, httptest.NewRequest(http.MethodGet, "/config_dump", nil))
 			assert.Equal(t, http.StatusOK, recorder.Code)
 			assert.NotContains(t, recorder.Body.String(), canary)
-		}()
+		})
 	}
 	wg.Wait()
 	require.Equal(t, canary, cfg.Options.Policies[0].IDPClientSecret)

--- a/internal/controlplane/server_debug_sensitive_test.go
+++ b/internal/controlplane/server_debug_sensitive_test.go
@@ -1,0 +1,215 @@
+package controlplane
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	"github.com/pomerium/pomerium/config"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+func TestConfigDumpScrubsSensitiveFields(t *testing.T) {
+	const canary = "DEBUG_IDP_CLIENT_SECRET_CANARY"
+	const upstreamUsernameCanary = "DEBUG_UPSTREAM_USERNAME_CANARY"
+	const upstreamPasswordCanary = "DEBUG_UPSTREAM_PASSWORD_CANARY"
+	const upstreamTokenCanary = "DEBUG_UPSTREAM_TOKEN_CANARY"
+
+	options := config.NewDefaultOptions()
+	policy := config.Policy{
+		From: "https://app.example.com",
+		To: mustDebugWeightedURLs(t,
+			"https://"+upstreamUsernameCanary+":"+upstreamPasswordCanary+"@app.internal",
+			"https://"+upstreamTokenCanary+"@backup.internal",
+		),
+	}
+	policy.IDPClientID = "public-client-id"
+	policy.IDPClientSecret = canary
+	options.Policies = []config.Policy{policy}
+	cfg := &config.Config{Options: options}
+
+	recorder := httptest.NewRecorder()
+	new(debugServer).configDumpHandler(cfg)(recorder, httptest.NewRequest(http.MethodGet, "/config_dump", nil))
+
+	assert.Equal(t, 200, recorder.Code)
+	assert.NotContains(t, recorder.Body.String(), canary)
+	assert.NotContains(t, recorder.Body.String(), upstreamUsernameCanary)
+	assert.NotContains(t, recorder.Body.String(), upstreamPasswordCanary)
+	assert.NotContains(t, recorder.Body.String(), upstreamTokenCanary)
+	assert.Contains(t, recorder.Body.String(), "public-client-id")
+	require.Equal(t, canary, cfg.Options.Policies[0].IDPClientSecret,
+		"presentation scrubbing must not mutate live configuration")
+}
+
+func TestConfigDumpConcurrentScrubbingDoesNotMutateLiveConfig(t *testing.T) {
+	const canary = "CONCURRENT_IDP_CLIENT_SECRET_CANARY"
+	options := config.NewDefaultOptions()
+	policy := config.Policy{
+		From: "https://app.example.com",
+		To:   mustDebugWeightedURLs(t, "https://app.internal"),
+	}
+	policy.IDPClientSecret = canary
+	options.Policies = []config.Policy{policy}
+	cfg := &config.Config{Options: options}
+	handler := new(debugServer).configDumpHandler(cfg)
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			recorder := httptest.NewRecorder()
+			handler(recorder, httptest.NewRequest(http.MethodGet, "/config_dump", nil))
+			assert.Equal(t, http.StatusOK, recorder.Code)
+			assert.NotContains(t, recorder.Body.String(), canary)
+		}()
+	}
+	wg.Wait()
+	require.Equal(t, canary, cfg.Options.Policies[0].IDPClientSecret)
+}
+
+func TestVersionedConfigRenderingScrubsSensitiveFields(t *testing.T) {
+	const canary = "VERSIONED_IDP_CLIENT_SECRET_CANARY"
+	const upstreamUsernameCanary = "VERSIONED_UPSTREAM_USERNAME_CANARY"
+	const upstreamPasswordCanary = "VERSIONED_UPSTREAM_PASSWORD_CANARY"
+	const upstreamTokenCanary = "VERSIONED_UPSTREAM_TOKEN_CANARY"
+	clientID := "public-client-id"
+	secret := canary
+
+	data := &versionedConfigData{}
+	rendered := data.RenderVersionedConfig(&configpb.VersionedConfig{
+		Config: &configpb.Config{Routes: []*configpb.Route{{
+			From: "https://app.example.com",
+			To: []string{
+				"https://" + upstreamUsernameCanary + ":" + upstreamPasswordCanary + "@app.internal",
+				"https://" + upstreamTokenCanary + "@backup.internal",
+			},
+			IdpClientId:     &clientID,
+			IdpClientSecret: &secret,
+		}}},
+	})
+
+	assert.NotContains(t, string(rendered), canary)
+	assert.NotContains(t, string(rendered), upstreamUsernameCanary)
+	assert.NotContains(t, string(rendered), upstreamPasswordCanary)
+	assert.NotContains(t, string(rendered), upstreamTokenCanary)
+	assert.Contains(t, string(rendered), "public-client-id")
+}
+
+func TestDatabrokerRecordRenderingScrubsSensitiveFields(t *testing.T) {
+	const canary = "DATABROKER_IDP_CLIENT_SECRET_CANARY"
+	const upstreamUsernameCanary = "DATABROKER_UPSTREAM_USERNAME_CANARY"
+	const upstreamPasswordCanary = "DATABROKER_UPSTREAM_PASSWORD_CANARY"
+	const upstreamTokenCanary = "DATABROKER_UPSTREAM_TOKEN_CANARY"
+	clientID := "public-client-id"
+	secret := canary
+
+	configData, err := anypb.New(&configpb.Config{Routes: []*configpb.Route{{
+		From: "https://app.example.com",
+		To: []string{
+			"https://" + upstreamUsernameCanary + ":" + upstreamPasswordCanary + "@app.internal",
+			"https://" + upstreamTokenCanary + "@backup.internal",
+		},
+		IdpClientId:     &clientID,
+		IdpClientSecret: &secret,
+	}}})
+	require.NoError(t, err)
+	record := &databroker.Record{Type: "type.googleapis.com/pomerium.config.Config", Id: "config", Data: configData}
+
+	presentation := scrubSensitiveDatabrokerRecord(record)
+	rendered, err := protojson.Marshal(presentation)
+	require.NoError(t, err)
+	assert.NotContains(t, string(rendered), canary)
+	assert.NotContains(t, string(rendered), upstreamUsernameCanary)
+	assert.NotContains(t, string(rendered), upstreamPasswordCanary)
+	assert.NotContains(t, string(rendered), upstreamTokenCanary)
+	assert.Contains(t, string(rendered), "public-client-id")
+
+	original, err := protojson.Marshal(record)
+	require.NoError(t, err)
+	assert.Contains(t, string(original), canary, "presentation scrubbing must not mutate the live record")
+}
+
+func TestDatabrokerRecordRenderingScrubsDoubleWrappedAny(t *testing.T) {
+	const canary = "DOUBLE_WRAPPED_ANY_IDP_CLIENT_SECRET_CANARY"
+	clientID := "public-client-id"
+	secret := canary
+
+	configData, err := anypb.New(&configpb.Config{Routes: []*configpb.Route{{
+		From:            "https://app.example.com",
+		To:              []string{"https://app.internal"},
+		IdpClientId:     &clientID,
+		IdpClientSecret: &secret,
+	}}})
+	require.NoError(t, err)
+	doubleWrapped, err := anypb.New(configData)
+	require.NoError(t, err)
+	record := &databroker.Record{
+		Type: "type.googleapis.com/google.protobuf.Any",
+		Id:   "nested-config",
+		Data: doubleWrapped,
+	}
+
+	presentation := scrubSensitiveDatabrokerRecord(record)
+	rendered, err := protojson.Marshal(presentation)
+	require.NoError(t, err)
+	assert.NotContains(t, string(rendered), canary)
+	assert.Contains(t, string(rendered), "public-client-id")
+
+	original, err := protojson.Marshal(record)
+	require.NoError(t, err)
+	assert.Contains(t, string(original), canary, "presentation scrubbing must not mutate the live nested Any")
+}
+
+func TestDatabrokerRecordRenderingDropsUnknownWireFieldsWithoutMutation(t *testing.T) {
+	const canary = "UNKNOWN_WIRE_SECRET_CANARY"
+	unknown := protowire.AppendTag(nil, 65000, protowire.BytesType)
+	unknown = protowire.AppendBytes(unknown, []byte(canary))
+	cfg := &configpb.Config{Routes: []*configpb.Route{{
+		From: "https://app.example.com",
+	}}}
+	cfg.Routes[0].ProtoReflect().SetUnknown(unknown)
+	configData, err := anypb.New(cfg)
+	require.NoError(t, err)
+	record := &databroker.Record{
+		Type: "type.googleapis.com/pomerium.config.Config",
+		Id:   "version-skewed-config",
+		Data: configData,
+	}
+	record.ProtoReflect().SetUnknown(unknown)
+	originalWire, err := proto.MarshalOptions{Deterministic: true}.Marshal(record)
+	require.NoError(t, err)
+	require.Contains(t, string(originalWire), canary)
+
+	first := scrubSensitiveDatabrokerRecord(record)
+	second := scrubSensitiveDatabrokerRecord(record)
+	firstWire, err := proto.MarshalOptions{Deterministic: true}.Marshal(first)
+	require.NoError(t, err)
+	secondWire, err := proto.MarshalOptions{Deterministic: true}.Marshal(second)
+	require.NoError(t, err)
+	assert.Equal(t, firstWire, secondWire, "presentation scrubbing must be deterministic")
+	assert.NotContains(t, string(firstWire), canary)
+
+	afterWire, err := proto.MarshalOptions{Deterministic: true}.Marshal(record)
+	require.NoError(t, err)
+	assert.Equal(t, originalWire, afterWire, "presentation scrubbing must not mutate the live record")
+	assert.Contains(t, string(afterWire), canary)
+}
+
+func mustDebugWeightedURLs(t testing.TB, values ...string) config.WeightedURLs {
+	t.Helper()
+	urls, err := config.ParseWeightedUrls(values...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return urls
+}

--- a/internal/urlutil/redacted.go
+++ b/internal/urlutil/redacted.go
@@ -1,0 +1,18 @@
+package urlutil
+
+import "net/url"
+
+// Redacted removes all upstream URL userinfo while preserving the rest of the
+// URL for presentation. url.URL.Redacted keeps the username, which is unsafe
+// for token-in-username configurations and other credential-bearing userinfo.
+func Redacted(u *url.URL) string {
+	if u == nil {
+		return ""
+	}
+	if u.User == nil {
+		return u.String()
+	}
+	cp := *u
+	cp.User = url.User("xxxxx")
+	return cp.String()
+}

--- a/internal/urlutil/redacted_test.go
+++ b/internal/urlutil/redacted_test.go
@@ -8,6 +8,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestRedactedNilAndNoUserInfo(t *testing.T) {
+	assert.Empty(t, Redacted(nil))
+
+	u, err := url.Parse("https://upstream.example.com/path?q=1")
+	require.NoError(t, err)
+	assert.Equal(t, "https://upstream.example.com/path?q=1", Redacted(u))
+}
+
 func TestRedactedRemovesAllUserInfo(t *testing.T) {
 	for _, raw := range []string{
 		"https://username-canary:password-canary@upstream.example.com/path",

--- a/internal/urlutil/redacted_test.go
+++ b/internal/urlutil/redacted_test.go
@@ -1,0 +1,26 @@
+package urlutil
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactedRemovesAllUserInfo(t *testing.T) {
+	for _, raw := range []string{
+		"https://username-canary:password-canary@upstream.example.com/path",
+		"https://token-canary@upstream.example.com/path",
+	} {
+		t.Run(raw, func(t *testing.T) {
+			u, err := url.Parse(raw)
+			require.NoError(t, err)
+			got := Redacted(u)
+			assert.NotContains(t, got, "username-canary")
+			assert.NotContains(t, got, "password-canary")
+			assert.NotContains(t, got, "token-canary")
+			assert.Contains(t, got, "xxxxx@upstream.example.com/path")
+		})
+	}
+}

--- a/pkg/mcp/configapi/internal_test.go
+++ b/pkg/mcp/configapi/internal_test.go
@@ -458,7 +458,7 @@ func TestScrubSensitiveAnyFailsClosedAtBounds(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Empty(t, SensitiveFieldsSet(tt.msg))
+			assert.Equal(t, []string{"value"}, SensitiveFieldsSet(tt.msg))
 			ScrubSensitive(tt.msg)
 			assert.Empty(t, tt.msg.Value)
 		})
@@ -475,11 +475,22 @@ func TestScrubSensitiveAnyFailsClosedBeyondDepthBound(t *testing.T) {
 	}
 	outer := msg.(*anypb.Any)
 
-	assert.Empty(t, SensitiveFieldsSet(outer))
+	assert.Equal(t, []string{"value"}, SensitiveFieldsSet(outer))
 	ScrubSensitive(outer)
 	wire, err := proto.MarshalOptions{Deterministic: true}.Marshal(outer)
 	require.NoError(t, err)
 	assert.NotContains(t, string(wire), canary)
+}
+
+func TestSensitiveFieldsSetReportsClearedNestedAny(t *testing.T) {
+	msg := &statuspb.Status{Details: []*anypb.Any{{
+		TypeUrl: "type.googleapis.com/unknown.Secret",
+		Value:   []byte("UNKNOWN_ANY_SECRET_CANARY"),
+	}}}
+
+	assert.Equal(t, []string{"details[].value"}, SensitiveFieldsSet(msg))
+	ScrubSensitive(msg)
+	assert.Empty(t, msg.GetDetails()[0].GetValue())
 }
 
 func TestScrubSensitiveAnyEnforcesCumulativeByteBound(t *testing.T) {

--- a/pkg/mcp/configapi/internal_test.go
+++ b/pkg/mcp/configapi/internal_test.go
@@ -1,17 +1,28 @@
 package configapi
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"testing"
 
 	"connectrpc.com/connect"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	statuspb "google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/encoding/protowire"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protodesc"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/dynamicpb"
+	"google.golang.org/protobuf/types/known/anypb"
 
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	registrypb "github.com/pomerium/pomerium/pkg/grpc/registry"
 )
 
 // TestParseConnectError_AllCodes round-trips every documented connect.Code
@@ -242,6 +253,338 @@ func TestScrubSensitive_NilAndInvalid(t *testing.T) {
 	// Same shape for the sensitive-fields collector.
 	assert.Nil(t, SensitiveFieldsSet(nil))
 	assert.Nil(t, SensitiveFieldsSet(route))
+}
+
+func TestRestoreRedactedRouteUpstreams(t *testing.T) {
+	password := "https://alice:password-secret@one.example.com/path?q=1"
+	token := "https://token-secret@two.example.com/other?q=2"
+	maskedPassword := "https://xxxxx@one.example.com/path?q=1"
+	maskedToken := "https://xxxxx@two.example.com/other?q=2"
+
+	tests := []struct {
+		name     string
+		original []string
+		incoming []string
+		want     []string
+		wantErr  bool
+	}{
+		{name: "unchanged round trip", original: []string{password, token}, incoming: []string{maskedPassword, maskedToken}, want: []string{password, token}},
+		{name: "host edit", original: []string{password}, incoming: []string{"https://xxxxx@edited.example.com/path?q=1"}, wantErr: true},
+		{name: "scheme edit", original: []string{password}, incoming: []string{"http://xxxxx@one.example.com/path?q=1"}, wantErr: true},
+		{name: "path edit", original: []string{password}, incoming: []string{"https://xxxxx@one.example.com/edited?q=1"}, wantErr: true},
+		{name: "query edit", original: []string{password}, incoming: []string{"https://xxxxx@one.example.com/path?q=edited"}, wantErr: true},
+		{name: "reordered", original: []string{password, token}, incoming: []string{maskedToken, maskedPassword}, wantErr: true},
+		{name: "insert shifts masked entries", original: []string{password, token}, incoming: []string{"https://new.example.com", maskedPassword, maskedToken}, wantErr: true},
+		{name: "delete shifts masked entries", original: []string{password, token}, incoming: []string{maskedToken}, wantErr: true},
+		{
+			name: "duplicate presentations stay index bound",
+			original: []string{
+				"https://first-secret@same.example.com/path",
+				"https://second-secret@same.example.com/path",
+			},
+			incoming: []string{
+				"https://xxxxx@same.example.com/path",
+				"https://xxxxx@same.example.com/path",
+			},
+			want: []string{
+				"https://first-secret@same.example.com/path",
+				"https://second-secret@same.example.com/path",
+			},
+		},
+		{name: "explicit no userinfo removes credentials", original: []string{password}, incoming: []string{"https://one.example.com/path?q=1"}, want: []string{"https://one.example.com/path?q=1"}},
+		{name: "explicit credentials replace", original: []string{password}, incoming: []string{"https://bob:new-secret@one.example.com/path?q=1"}, want: []string{"https://bob:new-secret@one.example.com/path?q=1"}},
+		{name: "literal xxxxx with no hidden original stays explicit", original: []string{"https://one.example.com/path"}, incoming: []string{"https://xxxxx@one.example.com/path"}, want: []string{"https://xxxxx@one.example.com/path"}},
+		{name: "xxxxx password form disambiguates replacement", original: []string{password}, incoming: []string{"https://xxxxx:@one.example.com/path?q=1"}, want: []string{"https://xxxxx:@one.example.com/path?q=1"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalBefore := append([]string(nil), tt.original...)
+			incomingBefore := append([]string(nil), tt.incoming...)
+			got, err := RestoreRedactedRouteUpstreams(tt.original, tt.incoming)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+			assert.Equal(t, originalBefore, tt.original, "original runtime values must not be mutated")
+			assert.Equal(t, incomingBefore, tt.incoming, "incoming presentation values must not be mutated")
+		})
+	}
+}
+
+func TestRestoreRedactedRouteUpstreamsErrorsDoNotEchoInput(t *testing.T) {
+	const incomingCanary = "INCOMING_PARSE_SECRET_CANARY"
+	_, err := RestoreRedactedRouteUpstreams(nil, []string{"https://xxxxx:" + incomingCanary + "@[::1"})
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), incomingCanary)
+
+	const existingCanary = "EXISTING_PARSE_SECRET_CANARY"
+	_, err = RestoreRedactedRouteUpstreams(
+		[]string{"https://user:" + existingCanary + "@[::1"},
+		[]string{"https://xxxxx@one.example.com"},
+	)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), existingCanary)
+
+	const mismatchExistingCanary = "MISMATCH_EXISTING_SECRET_CANARY"
+	const mismatchIncomingCanary = "MISMATCH_INCOMING_HOST_CANARY"
+	_, err = RestoreRedactedRouteUpstreams(
+		[]string{"https://user:" + mismatchExistingCanary + "@one.example.com"},
+		[]string{"https://xxxxx@" + mismatchIncomingCanary + ".example.com"},
+	)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), mismatchExistingCanary)
+	assert.NotContains(t, err.Error(), mismatchIncomingCanary)
+}
+
+func TestScrubSensitiveRouteUpstreamsAcrossDescriptors(t *testing.T) {
+	t.Run("core route", func(t *testing.T) {
+		route := &configpb.Route{To: []string{
+			"https://user:password-canary@one.example.com",
+			"https://token-canary@two.example.com",
+		}}
+		assert.Contains(t, SensitiveFieldsSet(route), "to[]")
+		ScrubSensitive(route)
+		assert.Equal(t, []string{
+			"https://xxxxx@one.example.com",
+			"https://xxxxx@two.example.com",
+		}, route.GetTo())
+	})
+
+	t.Run("dashboard route", func(t *testing.T) {
+		file, err := protodesc.NewFile(&descriptorpb.FileDescriptorProto{
+			Syntax:  proto.String("proto3"),
+			Name:    proto.String("dashboard_route_test.proto"),
+			Package: proto.String("pomerium.dashboard"),
+			MessageType: []*descriptorpb.DescriptorProto{{
+				Name: proto.String("Route"),
+				Field: []*descriptorpb.FieldDescriptorProto{{
+					Name:   proto.String("to"),
+					Number: proto.Int32(1),
+					Label:  descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+					Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+				}},
+			}},
+		}, nil)
+		require.NoError(t, err)
+		route := dynamicpb.NewMessage(file.Messages().ByName("Route"))
+		toField := route.Descriptor().Fields().ByName("to")
+		to := route.Mutable(toField).List()
+		to.Append(protoreflect.ValueOfString("https://dashboard-token-canary@dashboard.example.com/path?q=1"))
+
+		assert.Contains(t, SensitiveFieldsSet(route), "to[]")
+		ScrubSensitive(route)
+		assert.Equal(t, "https://xxxxx@dashboard.example.com/path?q=1", route.Get(toField).List().Get(0).String())
+	})
+}
+
+func TestSensitiveAnyTraversal(t *testing.T) {
+	const canary = "NESTED_ANY_IDP_CLIENT_SECRET_CANARY"
+
+	tests := []struct {
+		name     string
+		newMsg   func(*anypb.Any) proto.Message
+		wantPath string
+	}{
+		{
+			name:     "direct",
+			newMsg:   func(a *anypb.Any) proto.Message { return a },
+			wantPath: "routes[].idpClientSecret",
+		},
+		{
+			name: "map",
+			newMsg: func(a *anypb.Any) proto.Message {
+				return &registrypb.RegisterRequest{Metadata: map[string]*anypb.Any{"config": a}}
+			},
+			wantPath: "metadata[].routes[].idpClientSecret",
+		},
+		{
+			name: "list",
+			newMsg: func(a *anypb.Any) proto.Message {
+				return &statuspb.Status{Details: []*anypb.Any{a}}
+			},
+			wantPath: "details[].routes[].idpClientSecret",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			first := tt.newMsg(mustSensitiveConfigAny(t, canary))
+			second := tt.newMsg(mustSensitiveConfigAny(t, canary))
+
+			assert.Contains(t, SensitiveFieldsSet(first), tt.wantPath)
+			ScrubSensitive(first)
+			ScrubSensitive(second)
+
+			firstJSON, err := protojson.Marshal(first)
+			require.NoError(t, err)
+			assert.NotContains(t, string(firstJSON), canary)
+			firstWire, err := proto.MarshalOptions{Deterministic: true}.Marshal(first)
+			require.NoError(t, err)
+			secondWire, err := proto.MarshalOptions{Deterministic: true}.Marshal(second)
+			require.NoError(t, err)
+			assert.Equal(t, firstWire, secondWire, "Any payload repacking must be deterministic")
+		})
+	}
+}
+
+func TestScrubSensitiveAnyFailsClosedAtBounds(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  *anypb.Any
+	}{
+		{
+			name: "unknown type",
+			msg: &anypb.Any{
+				TypeUrl: "type.googleapis.com/unknown.Secret",
+				Value:   []byte("UNKNOWN_ANY_SECRET_CANARY"),
+			},
+		},
+		{
+			name: "malformed payload",
+			msg: &anypb.Any{
+				TypeUrl: mustSensitiveConfigAny(t, "").TypeUrl,
+				Value:   []byte{0xff},
+			},
+		},
+		{
+			name: "oversized payload",
+			msg: &anypb.Any{
+				TypeUrl: mustSensitiveConfigAny(t, "").TypeUrl,
+				Value:   bytes.Repeat([]byte{'x'}, maxSensitiveAnyBytes+1),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Empty(t, SensitiveFieldsSet(tt.msg))
+			ScrubSensitive(tt.msg)
+			assert.Empty(t, tt.msg.Value)
+		})
+	}
+}
+
+func TestScrubSensitiveAnyFailsClosedBeyondDepthBound(t *testing.T) {
+	const canary = "OVER_DEPTH_ANY_IDP_CLIENT_SECRET_CANARY"
+	var msg proto.Message = sensitiveConfig(canary)
+	for range maxSensitiveAnyDepth + 1 {
+		var err error
+		msg, err = anypb.New(msg)
+		require.NoError(t, err)
+	}
+	outer := msg.(*anypb.Any)
+
+	assert.Empty(t, SensitiveFieldsSet(outer))
+	ScrubSensitive(outer)
+	wire, err := proto.MarshalOptions{Deterministic: true}.Marshal(outer)
+	require.NoError(t, err)
+	assert.NotContains(t, string(wire), canary)
+}
+
+func TestScrubSensitiveAnyEnforcesCumulativeByteBound(t *testing.T) {
+	largeName := strings.Repeat("x", maxSensitiveAnyBytes/2+1)
+	newLargeAny := func(password string) *anypb.Any {
+		cfg := sensitiveConfig(password)
+		cfg.Routes[0].Name = &largeName
+		return mustSensitiveConfigAnyFromMessage(t, cfg)
+	}
+	msg := &statuspb.Status{Details: []*anypb.Any{
+		newLargeAny("FIRST_ANY_PASSWORD_CANARY"),
+		newLargeAny("SECOND_ANY_PASSWORD_CANARY"),
+	}}
+
+	ScrubSensitive(msg)
+	require.NotEmpty(t, msg.Details[0].Value)
+	assert.Empty(t, msg.Details[1].Value, "aggregate Any input beyond the byte budget must fail closed")
+	wire, err := proto.MarshalOptions{Deterministic: true}.Marshal(msg)
+	require.NoError(t, err)
+	assert.NotContains(t, string(wire), "FIRST_ANY_PASSWORD_CANARY")
+	assert.NotContains(t, string(wire), "SECOND_ANY_PASSWORD_CANARY")
+}
+
+func TestScrubSensitiveDropsUnknownWireFields(t *testing.T) {
+	tests := []struct {
+		name      string
+		newMsg    func(string) proto.Message
+		unknownAt func(proto.Message) protoreflect.Message
+	}{
+		{
+			name:   "root",
+			newMsg: func(string) proto.Message { return sensitiveConfig("") },
+			unknownAt: func(msg proto.Message) protoreflect.Message {
+				return msg.ProtoReflect()
+			},
+		},
+		{
+			name:   "nested",
+			newMsg: func(string) proto.Message { return sensitiveConfig("") },
+			unknownAt: func(msg proto.Message) protoreflect.Message {
+				return msg.(*configpb.Config).Routes[0].ProtoReflect()
+			},
+		},
+		{
+			name: "Any payload",
+			newMsg: func(canary string) proto.Message {
+				cfg := sensitiveConfig("")
+				cfg.ProtoReflect().SetUnknown(sensitiveUnknownWire(canary))
+				return mustSensitiveConfigAnyFromMessage(t, cfg)
+			},
+			unknownAt: func(msg proto.Message) protoreflect.Message {
+				var cfg configpb.Config
+				require.NoError(t, msg.(*anypb.Any).UnmarshalTo(&cfg))
+				return cfg.ProtoReflect()
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			canary := "UNKNOWN_WIRE_SECRET_CANARY_" + tt.name
+			first := tt.newMsg(canary)
+			second := tt.newMsg(canary)
+			if tt.name != "Any payload" {
+				tt.unknownAt(first).SetUnknown(sensitiveUnknownWire(canary))
+				tt.unknownAt(second).SetUnknown(sensitiveUnknownWire(canary))
+			}
+
+			assert.Empty(t, SensitiveFieldsSet(first), "unknown fields cannot produce a trustworthy redaction path")
+			ScrubSensitive(first)
+			ScrubSensitive(second)
+
+			assert.Empty(t, tt.unknownAt(first).GetUnknown())
+			firstWire, err := proto.MarshalOptions{Deterministic: true}.Marshal(first)
+			require.NoError(t, err)
+			secondWire, err := proto.MarshalOptions{Deterministic: true}.Marshal(second)
+			require.NoError(t, err)
+			assert.Equal(t, firstWire, secondWire)
+			assert.NotContains(t, string(firstWire), canary)
+		})
+	}
+}
+
+func mustSensitiveConfigAny(t testing.TB, password string) *anypb.Any {
+	t.Helper()
+	return mustSensitiveConfigAnyFromMessage(t, sensitiveConfig(password))
+}
+
+func mustSensitiveConfigAnyFromMessage(t testing.TB, msg proto.Message) *anypb.Any {
+	t.Helper()
+	a, err := anypb.New(msg)
+	require.NoError(t, err)
+	return a
+}
+
+func sensitiveConfig(secret string) *configpb.Config {
+	route := &configpb.Route{}
+	if secret != "" {
+		route.IdpClientSecret = &secret
+	}
+	return &configpb.Config{Routes: []*configpb.Route{route}}
+}
+
+func sensitiveUnknownWire(value string) []byte {
+	wire := protowire.AppendTag(nil, 65000, protowire.BytesType)
+	return protowire.AppendBytes(wire, []byte(value))
 }
 
 // TestParseConnectError_PreservesCodeWhenMessageEmpty locks the contract

--- a/pkg/mcp/configapi/internal_test.go
+++ b/pkg/mcp/configapi/internal_test.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/protobuf/types/descriptorpb"
 	"google.golang.org/protobuf/types/dynamicpb"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	registrypb "github.com/pomerium/pomerium/pkg/grpc/registry"
@@ -276,6 +277,7 @@ func TestRestoreRedactedRouteUpstreams(t *testing.T) {
 		{name: "reordered", original: []string{password, token}, incoming: []string{maskedToken, maskedPassword}, wantErr: true},
 		{name: "insert shifts masked entries", original: []string{password, token}, incoming: []string{"https://new.example.com", maskedPassword, maskedToken}, wantErr: true},
 		{name: "delete shifts masked entries", original: []string{password, token}, incoming: []string{maskedToken}, wantErr: true},
+		{name: "no original entry for redacted placeholder", original: nil, incoming: []string{"https://xxxxx@one.example.com/path"}, wantErr: true},
 		{
 			name: "duplicate presentations stay index bound",
 			original: []string{
@@ -312,6 +314,12 @@ func TestRestoreRedactedRouteUpstreams(t *testing.T) {
 			assert.Equal(t, incomingBefore, tt.incoming, "incoming presentation values must not be mutated")
 		})
 	}
+
+	t.Run("unmatched index is named in the error", func(t *testing.T) {
+		_, err := RestoreRedactedRouteUpstreams(nil, []string{"https://xxxxx@one.example.com/path"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unmatched redacted route upstream at index 0")
+	})
 }
 
 func TestRestoreRedactedRouteUpstreamsErrorsDoNotEchoInput(t *testing.T) {
@@ -616,4 +624,343 @@ func TestParseConnectError_PreservesCodeWhenMessageEmpty(t *testing.T) {
 	require.True(t, errors.As(err, &ce),
 		"parseConnectError must return a typed *connect.Error when wire.Code is set")
 	assert.Equal(t, connect.CodeUnauthenticated, ce.Code())
+}
+
+// TestScrubSensitiveAnyAtExactDepthBound pins the passing side of the Any
+// nesting bound: exactly maxSensitiveAnyDepth layers still unpacks, scrubs,
+// and repacks every layer in place. TestScrubSensitiveAnyFailsClosedBeyondDepthBound
+// pins the failing side one layer deeper.
+func TestScrubSensitiveAnyAtExactDepthBound(t *testing.T) {
+	const canary = "DEPTH_BOUND_CANARY"
+	var msg proto.Message = sensitiveConfig(canary)
+	for range maxSensitiveAnyDepth {
+		var err error
+		msg, err = anypb.New(msg)
+		require.NoError(t, err)
+	}
+	outer := msg.(*anypb.Any)
+
+	ScrubSensitive(outer)
+
+	layer := outer
+	for i := range maxSensitiveAnyDepth - 1 {
+		require.NotEmptyf(t, layer.GetValue(), "layer %d must be scrubbed in place, not wholesale-cleared", i)
+		var next anypb.Any
+		require.NoError(t, layer.UnmarshalTo(&next))
+		layer = &next
+	}
+	require.NotEmpty(t, layer.GetValue())
+	var cfg configpb.Config
+	require.NoError(t, layer.UnmarshalTo(&cfg))
+	assert.Empty(t, cfg.GetRoutes()[0].GetIdpClientSecret())
+}
+
+// TestScrubSensitiveAnyAtExactByteBound pins the passing side of the
+// cumulative Any byte budget: a Value exactly maxSensitiveAnyBytes long is
+// still unpacked, scrubbed, and repacked, since unpackAny's budget check is
+// a strict ">" and only fails closed once the input exceeds the bound.
+func TestScrubSensitiveAnyAtExactByteBound(t *testing.T) {
+	const canary = "BYTE_BOUND_CANARY"
+	cfgBytes, err := proto.Marshal(sensitiveConfig(canary))
+	require.NoError(t, err)
+
+	const unknownField protowire.Number = 65000
+	tagSize := protowire.SizeTag(unknownField)
+	remaining := maxSensitiveAnyBytes - len(cfgBytes) - tagSize
+
+	// SizeBytes(n) = SizeVarint(n) + n is a step function of n, so solve for
+	// the payload length whose own varint-size is self-consistent with the
+	// remaining budget.
+	var payloadLen int
+	found := false
+	for varintSize := 1; varintSize <= 10; varintSize++ {
+		n := remaining - varintSize
+		if n >= 0 && protowire.SizeVarint(uint64(n)) == varintSize {
+			payloadLen = n
+			found = true
+			break
+		}
+	}
+	require.True(t, found, "could not compute an exact padding length")
+
+	wire := protowire.AppendTag(append([]byte(nil), cfgBytes...), unknownField, protowire.BytesType)
+	wire = protowire.AppendBytes(wire, bytes.Repeat([]byte{'p'}, payloadLen))
+	require.Len(t, wire, maxSensitiveAnyBytes)
+
+	a := &anypb.Any{
+		TypeUrl: mustSensitiveConfigAny(t, "").TypeUrl,
+		Value:   wire,
+	}
+
+	ScrubSensitive(a)
+
+	assert.NotEmpty(t, a.Value)
+	assert.Less(t, len(a.Value), maxSensitiveAnyBytes, "discarding the unknown padding field must shrink the repacked value")
+	assert.NotContains(t, string(a.Value), canary)
+}
+
+// TestScrubSensitiveMapBudgetIsDeterministicAcrossWalkers pins that
+// SensitiveFieldsSet and ScrubSensitive, run in production order over the
+// same map, spend their independent byte budgets identically. Map iteration
+// order is otherwise undefined, so without rangeMessageMap's key sort the two
+// walks could fail closed on different entries and scrubbedFields metadata
+// would misreport what ScrubSensitive actually cleared.
+func TestScrubSensitiveMapBudgetIsDeterministicAcrossWalkers(t *testing.T) {
+	largeName := strings.Repeat("x", maxSensitiveAnyBytes/2+1)
+	newLargeAny := func(password string) *anypb.Any {
+		cfg := sensitiveConfig(password)
+		cfg.Routes[0].Name = &largeName
+		return mustSensitiveConfigAnyFromMessage(t, cfg)
+	}
+	build := func() *registrypb.RegisterRequest {
+		return &registrypb.RegisterRequest{Metadata: map[string]*anypb.Any{
+			"a": newLargeAny("MAP_BUDGET_A_CANARY"),
+			"b": newLargeAny("MAP_BUDGET_B_CANARY"),
+		}}
+	}
+
+	first := build()
+	paths := SensitiveFieldsSet(first)
+	assert.Contains(t, paths, "metadata[].value", "sorted key order charges \"b\" second, so it fails closed and reports as opaque")
+	ScrubSensitive(first)
+
+	require.NotEmpty(t, first.Metadata["a"].Value, "sorted key order charges \"a\" first")
+	assert.Empty(t, first.Metadata["b"].Value, "\"b\" exhausts the shared budget after \"a\"")
+
+	wire, err := proto.MarshalOptions{Deterministic: true}.Marshal(first)
+	require.NoError(t, err)
+	assert.NotContains(t, string(wire), "MAP_BUDGET_A_CANARY")
+	assert.NotContains(t, string(wire), "MAP_BUDGET_B_CANARY")
+
+	second := build()
+	ScrubSensitive(second)
+	secondWire, err := proto.MarshalOptions{Deterministic: true}.Marshal(second)
+	require.NoError(t, err)
+	assert.Equal(t, wire, secondWire, "the budget walk must be deterministic across separately-built instances")
+}
+
+// TestScrubSensitiveEmptyAnyIsNoOp pins that an Any with a TypeUrl but no
+// Value (m.Has(valueField) is false for an empty byte string) is treated as
+// "nothing embedded" rather than a decode failure: unpackAny returns ok=true
+// with a nil embedded message, so neither field is touched.
+func TestScrubSensitiveEmptyAnyIsNoOp(t *testing.T) {
+	typeURL := mustSensitiveConfigAny(t, "").TypeUrl
+	a := &anypb.Any{TypeUrl: typeURL}
+
+	assert.Nil(t, SensitiveFieldsSet(a))
+	ScrubSensitive(a)
+	assert.Equal(t, typeURL, a.TypeUrl)
+	assert.Empty(t, a.Value)
+}
+
+// TestScrubSensitiveAnyMissingTypeURLFailsClosed pins that an Any carrying a
+// Value but no TypeUrl fails closed: with no type to resolve, the payload
+// cannot be classified, so ScrubSensitive clears it and SensitiveFieldsSet
+// reports it as a redacted "value" path rather than passing it through.
+func TestScrubSensitiveAnyMissingTypeURLFailsClosed(t *testing.T) {
+	a := &anypb.Any{Value: []byte("NO_TYPE_URL_SECRET_CANARY")}
+
+	assert.Equal(t, []string{"value"}, SensitiveFieldsSet(a))
+	ScrubSensitive(a)
+	assert.Empty(t, a.Value)
+}
+
+// TestScrubSensitiveInvalidRouteUpstream pins that an unparseable "to" entry
+// is reported as sensitive (it may be hiding credentials the parser could
+// not recover) and is replaced with a fixed placeholder rather than echoed
+// back verbatim.
+func TestScrubSensitiveInvalidRouteUpstream(t *testing.T) {
+	const canary = "invalid-canary"
+	route := &configpb.Route{To: []string{"https://user:" + canary + "@[::1"}}
+
+	assert.Contains(t, SensitiveFieldsSet(route), "to[]")
+	ScrubSensitive(route)
+	require.Len(t, route.GetTo(), 1)
+	assert.Equal(t, "invalid upstream URL", route.GetTo()[0])
+}
+
+// TestRangeMessageMapKeyKindOrdering directly pins rangeMessageMap's sort
+// order for the three integer-ish map key kinds it special-cases: bool
+// (false before true), signed (ascending, including negatives), and
+// unsigned (ascending). ScrubSensitive and SensitiveFieldsSet only exercise
+// this through string- and message-keyed config maps; this covers the
+// dynamic-descriptor path for the others directly.
+func TestRangeMessageMapKeyKindOrdering(t *testing.T) {
+	const pkg = "pomerium.configapi.maptest"
+	mapEntry := func(name string, keyType descriptorpb.FieldDescriptorProto_Type) *descriptorpb.DescriptorProto {
+		return &descriptorpb.DescriptorProto{
+			Name: new(name),
+			Field: []*descriptorpb.FieldDescriptorProto{
+				{
+					Name:   new("key"),
+					Number: proto.Int32(1),
+					Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+					Type:   keyType.Enum(),
+				},
+				{
+					Name:     new("value"),
+					Number:   proto.Int32(2),
+					Label:    descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+					TypeName: new("." + pkg + ".Container.Inner"),
+				},
+			},
+			Options: &descriptorpb.MessageOptions{MapEntry: new(true)},
+		}
+	}
+
+	file, err := protodesc.NewFile(&descriptorpb.FileDescriptorProto{
+		Syntax:  new("proto3"),
+		Name:    new("range_message_map_test.proto"),
+		Package: new(pkg),
+		MessageType: []*descriptorpb.DescriptorProto{{
+			Name: new("Container"),
+			Field: []*descriptorpb.FieldDescriptorProto{
+				{
+					Name:     new("bool_map"),
+					Number:   proto.Int32(1),
+					Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+					TypeName: new("." + pkg + ".Container.BoolMapEntry"),
+				},
+				{
+					Name:     new("int64_map"),
+					Number:   proto.Int32(2),
+					Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+					TypeName: new("." + pkg + ".Container.Int64MapEntry"),
+				},
+				{
+					Name:     new("uint64_map"),
+					Number:   proto.Int32(3),
+					Label:    descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
+					Type:     descriptorpb.FieldDescriptorProto_TYPE_MESSAGE.Enum(),
+					TypeName: new("." + pkg + ".Container.Uint64MapEntry"),
+				},
+			},
+			NestedType: []*descriptorpb.DescriptorProto{
+				{
+					Name: new("Inner"),
+					Field: []*descriptorpb.FieldDescriptorProto{{
+						Name:   new("tag"),
+						Number: proto.Int32(1),
+						Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(),
+						Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+					}},
+				},
+				mapEntry("BoolMapEntry", descriptorpb.FieldDescriptorProto_TYPE_BOOL),
+				mapEntry("Int64MapEntry", descriptorpb.FieldDescriptorProto_TYPE_INT64),
+				mapEntry("Uint64MapEntry", descriptorpb.FieldDescriptorProto_TYPE_UINT64),
+			},
+		}},
+	}, nil)
+	require.NoError(t, err)
+
+	containerDesc := file.Messages().ByName("Container")
+	innerDesc := containerDesc.Messages().ByName("Inner")
+	tagField := innerDesc.Fields().ByName("tag")
+	container := dynamicpb.NewMessage(containerDesc)
+	fields := container.Descriptor().Fields()
+
+	setEntry := func(fieldName string, key protoreflect.Value, tag string) {
+		fd := fields.ByName(protoreflect.Name(fieldName))
+		inner := dynamicpb.NewMessage(innerDesc)
+		inner.Set(tagField, protoreflect.ValueOfString(tag))
+		container.Mutable(fd).Map().Set(key.MapKey(), protoreflect.ValueOfMessage(inner))
+	}
+
+	// Insert out of sorted order so a passing test can only be explained by
+	// rangeMessageMap doing the sorting, not incidental map iteration order.
+	setEntry("bool_map", protoreflect.ValueOfBool(true), "true")
+	setEntry("bool_map", protoreflect.ValueOfBool(false), "false")
+	setEntry("int64_map", protoreflect.ValueOfInt64(5), "5")
+	setEntry("int64_map", protoreflect.ValueOfInt64(-3), "-3")
+	setEntry("int64_map", protoreflect.ValueOfInt64(0), "0")
+	setEntry("uint64_map", protoreflect.ValueOfUint64(42), "42")
+	setEntry("uint64_map", protoreflect.ValueOfUint64(1), "1")
+	setEntry("uint64_map", protoreflect.ValueOfUint64(1000), "1000")
+
+	visit := func(fieldName string) []string {
+		fd := fields.ByName(protoreflect.Name(fieldName))
+		var order []string
+		rangeMessageMap(container.Get(fd).Map(), fd.MapKey().Kind(), func(_ protoreflect.MapKey, v protoreflect.Value) {
+			order = append(order, v.Message().Get(tagField).String())
+		})
+		return order
+	}
+
+	assert.Equal(t, []string{"false", "true"}, visit("bool_map"))
+	assert.Equal(t, []string{"-3", "0", "5"}, visit("int64_map"))
+	assert.Equal(t, []string{"1", "42", "1000"}, visit("uint64_map"))
+}
+
+// TestScrubSensitiveAnyOverUnmarshalRecursionLimitFailsClosed pins that a
+// plain (non-Any) message nested far beyond proto's default unmarshal
+// recursion limit fails closed rather than panicking. Plain-message
+// recursion has no depth counter of its own in scrubMessage; proto's
+// unmarshal recursion limit is the guard that actually bites here, since
+// unpackAny re-decodes the embedded bytes with DiscardUnknown rather than
+// walking the already-parsed message.
+func TestScrubSensitiveAnyOverUnmarshalRecursionLimitFailsClosed(t *testing.T) {
+	inner := &structpb.Struct{Fields: map[string]*structpb.Value{"k": structpb.NewNumberValue(1)}}
+	for range 10000 {
+		inner = &structpb.Struct{Fields: map[string]*structpb.Value{"k": structpb.NewStructValue(inner)}}
+	}
+
+	a, err := anypb.New(inner)
+	require.NoError(t, err)
+
+	ScrubSensitive(a)
+	assert.Empty(t, a.Value)
+}
+
+// TestScrubSensitiveSkipsScalarMaps pins that a scalar-valued map (string ->
+// string, not message-valued) is left alone by both walkers: fd.MapValue().Kind()
+// is not MessageKind, so it can never carry a nested sensitive field, and
+// scrubMessage's map branch explicitly skips it rather than trying to
+// recurse into a non-message value.
+func TestScrubSensitiveSkipsScalarMaps(t *testing.T) {
+	secret := "SCALAR_MAP_CANARY"
+	route := &configpb.Route{
+		IdpClientSecret:   &secret,
+		SetRequestHeaders: map[string]string{"X-Foo": "bar"},
+	}
+
+	assert.Equal(t, []string{"idpClientSecret"}, SensitiveFieldsSet(route))
+
+	ScrubSensitive(route)
+	assert.Empty(t, route.GetIdpClientSecret())
+	assert.Equal(t, map[string]string{"X-Foo": "bar"}, route.GetSetRequestHeaders())
+}
+
+// TestScrubSensitiveRouteMessageWithMalformedToField pins the defensive
+// guard shared by scrubConfigRouteUpstreams and collectRouteUpstreamSensitive:
+// isRouteMessage matches pomerium.config.Route/pomerium.dashboard.Route by
+// name only, so a hand-built or version-skewed descriptor that carries that
+// name but whose "to" field isn't a repeated string must be left alone
+// rather than assumed safe to redact.
+func TestScrubSensitiveRouteMessageWithMalformedToField(t *testing.T) {
+	file, err := protodesc.NewFile(&descriptorpb.FileDescriptorProto{
+		Syntax:  new("proto3"),
+		Name:    new("malformed_dashboard_route_test.proto"),
+		Package: new("pomerium.dashboard"),
+		MessageType: []*descriptorpb.DescriptorProto{{
+			Name: new("Route"),
+			Field: []*descriptorpb.FieldDescriptorProto{{
+				Name:   new("to"),
+				Number: proto.Int32(1),
+				Label:  descriptorpb.FieldDescriptorProto_LABEL_OPTIONAL.Enum(), // singular, not repeated
+				Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),
+			}},
+		}},
+	}, nil)
+	require.NoError(t, err)
+	route := dynamicpb.NewMessage(file.Messages().ByName("Route"))
+	toField := route.Descriptor().Fields().ByName("to")
+	const canary = "https://user:MALFORMED_TO_FIELD_CANARY@example.com"
+	route.Set(toField, protoreflect.ValueOfString(canary))
+
+	assert.Nil(t, SensitiveFieldsSet(route))
+	ScrubSensitive(route)
+	assert.Equal(t, canary, route.Get(toField).String())
 }

--- a/pkg/mcp/configapi/internal_test.go
+++ b/pkg/mcp/configapi/internal_test.go
@@ -488,9 +488,11 @@ func TestSensitiveFieldsSetReportsClearedNestedAny(t *testing.T) {
 		Value:   []byte("UNKNOWN_ANY_SECRET_CANARY"),
 	}}}
 
-	assert.Equal(t, []string{"details[].value"}, SensitiveFieldsSet(msg))
+	redacted := SensitiveFieldsSet(msg)
+	assert.Equal(t, []string{"details[].value"}, redacted)
 	ScrubSensitive(msg)
 	assert.Empty(t, msg.GetDetails()[0].GetValue())
+	assert.Equal(t, []string{"details[].value"}, buildMeta(nil, nil, msg, redacted, nil)["scrubbedFields"])
 }
 
 func TestScrubSensitiveAnyEnforcesCumulativeByteBound(t *testing.T) {

--- a/pkg/mcp/configapi/internal_test.go
+++ b/pkg/mcp/configapi/internal_test.go
@@ -355,13 +355,13 @@ func TestScrubSensitiveRouteUpstreamsAcrossDescriptors(t *testing.T) {
 
 	t.Run("dashboard route", func(t *testing.T) {
 		file, err := protodesc.NewFile(&descriptorpb.FileDescriptorProto{
-			Syntax:  proto.String("proto3"),
-			Name:    proto.String("dashboard_route_test.proto"),
-			Package: proto.String("pomerium.dashboard"),
+			Syntax:  new("proto3"),
+			Name:    new("dashboard_route_test.proto"),
+			Package: new("pomerium.dashboard"),
 			MessageType: []*descriptorpb.DescriptorProto{{
-				Name: proto.String("Route"),
+				Name: new("Route"),
 				Field: []*descriptorpb.FieldDescriptorProto{{
-					Name:   proto.String("to"),
+					Name:   new("to"),
 					Number: proto.Int32(1),
 					Label:  descriptorpb.FieldDescriptorProto_LABEL_REPEATED.Enum(),
 					Type:   descriptorpb.FieldDescriptorProto_TYPE_STRING.Enum(),

--- a/pkg/mcp/configapi/merge.go
+++ b/pkg/mcp/configapi/merge.go
@@ -313,6 +313,17 @@ func mergeInto(merged, incoming protoreflect.Message, keyTree jsonKeyNode, pathP
 			merged.Clear(fd)
 			continue
 		}
+		if isRouteMessage(merged.Descriptor()) && fd.Name() == "to" && fd.IsList() && fd.Kind() == protoreflect.StringKind {
+			restored, err := RestoreRedactedRouteUpstreams(
+				stringList(merged.Get(fd).List()),
+				stringList(incoming.Get(fd).List()),
+			)
+			if err != nil {
+				return fmt.Errorf("cannot sparse-update field %q: %w", joinPath(pathPrefix, fd.JSONName()), err)
+			}
+			setStringList(merged.Mutable(fd).List(), restored)
+			continue
+		}
 		if sub != nil && fd.Kind() == protoreflect.MessageKind && !fd.IsList() && !fd.IsMap() {
 			if err := mergeInto(
 				merged.Mutable(fd).Message(),
@@ -327,6 +338,21 @@ func mergeInto(merged, incoming protoreflect.Message, keyTree jsonKeyNode, pathP
 		merged.Set(fd, incoming.Get(fd))
 	}
 	return nil
+}
+
+func stringList(list protoreflect.List) []string {
+	values := make([]string, list.Len())
+	for i := 0; i < list.Len(); i++ {
+		values[i] = list.Get(i).String()
+	}
+	return values
+}
+
+func setStringList(list protoreflect.List, values []string) {
+	list.Truncate(0)
+	for _, value := range values {
+		list.Append(protoreflect.ValueOfString(value))
+	}
 }
 
 // messageHasSensitiveDescendant reports whether md or any message reachable

--- a/pkg/mcp/configapi/schema.go
+++ b/pkg/mcp/configapi/schema.go
@@ -51,7 +51,8 @@ var metaSchema = map[string]any{
 			"description": "JSON paths of sensitive fields that have values " +
 				"configured on this entity but whose values are not shown here " +
 				"(e.g. 'route.idpClientSecret'). Tell the user these fields are " +
-				"set; they can retrieve or change the values from the console at " +
+				"set; opaque Any payloads removed for safe presentation are also " +
+				"listed. They can retrieve or change values from the console at " +
 				"links.canonical.",
 		},
 		"links": map[string]any{

--- a/pkg/mcp/configapi/sensitive.go
+++ b/pkg/mcp/configapi/sensitive.go
@@ -1,13 +1,51 @@
 package configapi
 
 import (
+	"fmt"
+	"net/url"
 	"sort"
+	"strings"
 
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/reflect/protoregistry"
+	"google.golang.org/protobuf/types/dynamicpb"
 
+	"github.com/pomerium/pomerium/internal/urlutil"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 )
+
+const (
+	// Any payloads are recursively decoded so descriptor annotations inside the
+	// payload cannot bypass sensitive-field scrubbing. Bound both nesting and
+	// cumulative encoded input to keep presentation paths from becoming an
+	// allocation or stack-exhaustion surface. Payloads outside either bound are
+	// cleared by ScrubSensitive.
+	maxSensitiveAnyDepth = 16
+	maxSensitiveAnyBytes = 5 << 20
+)
+
+const anyMessageFullName protoreflect.FullName = "google.protobuf.Any"
+
+const redactedRouteUpstreamUsername = "xxxxx"
+
+type sensitiveTraversal struct {
+	anyBytes int
+}
+
+var sensitiveConfigMessageDescriptors = func() map[protoreflect.FullName]protoreflect.MessageDescriptor {
+	descriptors := make(map[protoreflect.FullName]protoreflect.MessageDescriptor)
+	var add func(protoreflect.MessageDescriptors)
+	add = func(messages protoreflect.MessageDescriptors) {
+		for i := 0; i < messages.Len(); i++ {
+			message := messages.Get(i)
+			descriptors[message.FullName()] = message
+			add(message.Messages())
+		}
+	}
+	add(configpb.File_config_proto.Messages())
+	return descriptors
+}()
 
 // IsSensitive reports whether fd carries the (pomerium.config.sensitive)
 // option. Sensitive fields are stripped from MCP request/response schemas,
@@ -19,20 +57,44 @@ func IsSensitive(fd protoreflect.FieldDescriptor) bool {
 }
 
 // ScrubSensitive walks msg recursively and clears every field whose
-// descriptor is marked sensitive. Maps and lists are descended; scalar
-// sensitive fields are cleared via Message.Clear; sensitive message-typed
-// fields are cleared rather than recursed.
+// descriptor is marked sensitive. Maps, lists, and bounded google.protobuf.Any
+// payloads are descended; scalar sensitive fields are cleared via
+// Message.Clear; sensitive message-typed fields are cleared rather than
+// recursed. Any payloads that cannot be inspected safely are cleared.
 func ScrubSensitive(msg proto.Message) {
 	if msg == nil {
 		return
 	}
-	scrubMessage(msg.ProtoReflect())
+	scrubMessage(msg.ProtoReflect(), 0, new(sensitiveTraversal))
 }
 
-func scrubMessage(m protoreflect.Message) {
+func scrubMessage(m protoreflect.Message, anyDepth int, traversal *sensitiveTraversal) {
 	if !m.IsValid() {
 		return
 	}
+	// Unknown wire fields have no descriptor options, so version-skewed fields
+	// cannot be classified as safe. Drop them on every known message before any
+	// presentation serialization.
+	m.SetUnknown(nil)
+	if m.Descriptor().FullName() == anyMessageFullName {
+		embedded, ok := traversal.unpackAny(m, anyDepth)
+		if !ok {
+			clearAnyValue(m)
+			return
+		}
+		if embedded == nil {
+			return
+		}
+		scrubMessage(embedded.ProtoReflect(), anyDepth+1, traversal)
+		encoded, err := proto.MarshalOptions{Deterministic: true}.Marshal(embedded)
+		if err != nil || len(encoded) > maxSensitiveAnyBytes {
+			clearAnyValue(m)
+			return
+		}
+		setAnyValue(m, encoded)
+		return
+	}
+	scrubConfigRouteUpstreams(m)
 	fields := m.Descriptor().Fields()
 	for i := 0; i < fields.Len(); i++ {
 		fd := fields.Get(i)
@@ -48,9 +110,8 @@ func scrubMessage(m protoreflect.Message) {
 			if fd.MapValue().Kind() != protoreflect.MessageKind {
 				continue
 			}
-			m.Get(fd).Map().Range(func(_ protoreflect.MapKey, v protoreflect.Value) bool {
-				scrubMessage(v.Message())
-				return true
+			rangeMessageMap(m.Get(fd).Map(), fd.MapKey().Kind(), func(_ protoreflect.MapKey, v protoreflect.Value) {
+				scrubMessage(v.Message(), anyDepth, traversal)
 			})
 		case fd.IsList():
 			if fd.Kind() != protoreflect.MessageKind {
@@ -58,11 +119,190 @@ func scrubMessage(m protoreflect.Message) {
 			}
 			list := m.Get(fd).List()
 			for i := 0; i < list.Len(); i++ {
-				scrubMessage(list.Get(i).Message())
+				scrubMessage(list.Get(i).Message(), anyDepth, traversal)
 			}
 		case fd.Kind() == protoreflect.MessageKind:
-			scrubMessage(m.Get(fd).Message())
+			scrubMessage(m.Get(fd).Message(), anyDepth, traversal)
 		}
+	}
+}
+
+func scrubConfigRouteUpstreams(m protoreflect.Message) {
+	if !isRouteMessage(m.Descriptor()) {
+		return
+	}
+	toField := m.Descriptor().Fields().ByName("to")
+	if toField == nil || !toField.IsList() || toField.Kind() != protoreflect.StringKind {
+		return
+	}
+	to := m.Get(toField).List()
+	for i := 0; i < to.Len(); i++ {
+		redacted, _, ok := redactedRouteUpstream(to.Get(i).String())
+		if !ok {
+			to.Set(i, protoreflect.ValueOfString("invalid upstream URL"))
+			continue
+		}
+		to.Set(i, protoreflect.ValueOfString(redacted))
+	}
+}
+
+// RestoreRedactedRouteUpstreams restores credential-bearing upstream strings
+// after a presentation round trip. A redaction placeholder is accepted only
+// when it exactly matches the presentation of the original entry at the same
+// index. This binds restored credentials to the original scheme, destination,
+// path, and query and prevents edits or reordering from forwarding credentials
+// to a different upstream.
+//
+// The returned slice is always a clone. Neither input is mutated. Errors name
+// only the failing index; parser errors and URL contents are never returned.
+// An explicit URL without userinfo removes credentials, while explicit
+// userinfo replaces them. The otherwise ambiguous literal username "xxxxx"
+// remains explicit when the original entry has no userinfo. To replace an
+// existing credential with that username, use an explicit password form such
+// as "xxxxx:" so it cannot be mistaken for the presentation placeholder.
+func RestoreRedactedRouteUpstreams(original, incoming []string) ([]string, error) {
+	restored := append([]string(nil), incoming...)
+	for i, raw := range incoming {
+		incomingURL, err := urlutil.ParseAndValidateURL(raw)
+		if err != nil {
+			return nil, fmt.Errorf("invalid incoming route upstream at index %d", i)
+		}
+		if !isRouteUpstreamPlaceholder(incomingURL) {
+			continue
+		}
+		if i >= len(original) {
+			return nil, fmt.Errorf("unmatched redacted route upstream at index %d", i)
+		}
+		redacted, hadUserInfo, ok := redactedRouteUpstream(original[i])
+		if !ok {
+			return nil, fmt.Errorf("invalid existing route upstream at index %d", i)
+		}
+		if !hadUserInfo {
+			// With no hidden original value, xxxxx is an explicit username rather
+			// than a presentation placeholder.
+			continue
+		}
+		if raw != redacted {
+			return nil, fmt.Errorf("redacted route upstream does not match existing entry at index %d", i)
+		}
+		restored[i] = original[i]
+	}
+	return restored, nil
+}
+
+func redactedRouteUpstream(raw string) (redacted string, hadUserInfo, ok bool) {
+	u, err := urlutil.ParseAndValidateURL(raw)
+	if err != nil {
+		return "", false, false
+	}
+	return urlutil.Redacted(u), u.User != nil, true
+}
+
+func isRouteUpstreamPlaceholder(u *url.URL) bool {
+	if u == nil || u.User == nil || u.User.Username() != redactedRouteUpstreamUsername {
+		return false
+	}
+	_, hasPassword := u.User.Password()
+	return !hasPassword
+}
+
+func isRouteMessage(md protoreflect.MessageDescriptor) bool {
+	switch md.FullName() {
+	case "pomerium.config.Route", "pomerium.dashboard.Route":
+		return true
+	default:
+		return false
+	}
+}
+
+func (traversal *sensitiveTraversal) unpackAny(
+	m protoreflect.Message,
+	anyDepth int,
+) (proto.Message, bool) {
+	if anyDepth >= maxSensitiveAnyDepth {
+		return nil, false
+	}
+	fields := m.Descriptor().Fields()
+	typeURLField := fields.ByName("type_url")
+	valueField := fields.ByName("value")
+	if typeURLField == nil || valueField == nil || !m.Has(valueField) {
+		return nil, true
+	}
+	value := m.Get(valueField).Bytes()
+	if len(value) > maxSensitiveAnyBytes-traversal.anyBytes {
+		return nil, false
+	}
+	traversal.anyBytes += len(value)
+	if !m.Has(typeURLField) {
+		return nil, false
+	}
+	messageType, err := sensitiveAnyMessageType(m.Get(typeURLField).String())
+	if err != nil {
+		return nil, false
+	}
+	embedded := messageType.New().Interface()
+	err = (proto.UnmarshalOptions{
+		AllowPartial:   true,
+		DiscardUnknown: true,
+		Resolver:       protoregistry.GlobalTypes,
+	}).Unmarshal(value, embedded)
+	if err != nil {
+		return nil, false
+	}
+	return embedded, true
+}
+
+func sensitiveAnyMessageType(typeURL string) (protoreflect.MessageType, error) {
+	name := typeURL
+	if index := strings.LastIndexByte(name, '/'); index >= 0 {
+		name = name[index+1:]
+	}
+	if descriptor := sensitiveConfigMessageDescriptors[protoreflect.FullName(name)]; descriptor != nil {
+		// Prefer the config descriptor compiled into this module. A duplicate
+		// global protobuf registration can otherwise resolve an equivalent type
+		// whose field options omit our sensitive annotation.
+		return dynamicpb.NewMessageType(descriptor), nil
+	}
+	return protoregistry.GlobalTypes.FindMessageByURL(typeURL)
+}
+
+func clearAnyValue(m protoreflect.Message) {
+	if valueField := m.Descriptor().Fields().ByName("value"); valueField != nil {
+		m.Clear(valueField)
+	}
+}
+
+func setAnyValue(m protoreflect.Message, value []byte) {
+	if valueField := m.Descriptor().Fields().ByName("value"); valueField != nil {
+		m.Set(valueField, protoreflect.ValueOfBytes(value))
+	}
+}
+
+func rangeMessageMap(
+	m protoreflect.Map,
+	keyKind protoreflect.Kind,
+	fn func(protoreflect.MapKey, protoreflect.Value),
+) {
+	keys := make([]protoreflect.MapKey, 0, m.Len())
+	m.Range(func(key protoreflect.MapKey, _ protoreflect.Value) bool {
+		keys = append(keys, key)
+		return true
+	})
+	sort.Slice(keys, func(i, j int) bool {
+		switch keyKind {
+		case protoreflect.BoolKind:
+			return !keys[i].Bool() && keys[j].Bool()
+		case protoreflect.StringKind:
+			return keys[i].String() < keys[j].String()
+		case protoreflect.Int32Kind, protoreflect.Sint32Kind, protoreflect.Sfixed32Kind,
+			protoreflect.Int64Kind, protoreflect.Sint64Kind, protoreflect.Sfixed64Kind:
+			return keys[i].Int() < keys[j].Int()
+		default:
+			return keys[i].Uint() < keys[j].Uint()
+		}
+	})
+	for _, key := range keys {
+		fn(key, m.Get(key))
 	}
 }
 
@@ -72,6 +312,11 @@ func scrubMessage(m protoreflect.Message) {
 // carry a sensitive sub-field collapse to a glob ("certificates[].keyBytes")
 // rather than per-index paths, which would balloon under large lists and
 // don't tell the LLM anything actionable beyond "some elements have it".
+// Bounded google.protobuf.Any payloads are transparent to path construction;
+// payloads that cannot be inspected safely contribute no paths and are cleared
+// by the subsequent ScrubSensitive pass. Unknown wire fields likewise
+// contribute no paths and are removed by ScrubSensitive because their missing
+// descriptors make sensitivity impossible to determine safely.
 //
 // Returns nil when no sensitive fields are populated. Result is sorted for
 // stable presentation.
@@ -80,7 +325,7 @@ func SensitiveFieldsSet(msg proto.Message) []string {
 		return nil
 	}
 	out := map[string]struct{}{}
-	collectSensitive(msg.ProtoReflect(), "", out)
+	collectSensitive(msg.ProtoReflect(), "", 0, new(sensitiveTraversal), out)
 	if len(out) == 0 {
 		return nil
 	}
@@ -92,10 +337,25 @@ func SensitiveFieldsSet(msg proto.Message) []string {
 	return paths
 }
 
-func collectSensitive(m protoreflect.Message, prefix string, out map[string]struct{}) {
+func collectSensitive(
+	m protoreflect.Message,
+	prefix string,
+	anyDepth int,
+	traversal *sensitiveTraversal,
+	out map[string]struct{},
+) {
 	if !m.IsValid() {
 		return
 	}
+	if m.Descriptor().FullName() == anyMessageFullName {
+		embedded, ok := traversal.unpackAny(m, anyDepth)
+		if !ok || embedded == nil {
+			return
+		}
+		collectSensitive(embedded.ProtoReflect(), prefix, anyDepth+1, traversal, out)
+		return
+	}
+	collectRouteUpstreamSensitive(m, prefix, out)
 	fields := m.Descriptor().Fields()
 	for i := 0; i < fields.Len(); i++ {
 		fd := fields.Get(i)
@@ -123,9 +383,8 @@ func collectSensitive(m protoreflect.Message, prefix string, out map[string]stru
 				continue
 			}
 			child := joinPath(path, "[]")
-			m.Get(fd).Map().Range(func(_ protoreflect.MapKey, v protoreflect.Value) bool {
-				collectSensitive(v.Message(), child, out)
-				return true
+			rangeMessageMap(m.Get(fd).Map(), fd.MapKey().Kind(), func(_ protoreflect.MapKey, v protoreflect.Value) {
+				collectSensitive(v.Message(), child, anyDepth, traversal, out)
 			})
 		case fd.IsList():
 			if fd.Kind() != protoreflect.MessageKind {
@@ -134,10 +393,28 @@ func collectSensitive(m protoreflect.Message, prefix string, out map[string]stru
 			child := joinPath(path, "[]")
 			list := m.Get(fd).List()
 			for i := 0; i < list.Len(); i++ {
-				collectSensitive(list.Get(i).Message(), child, out)
+				collectSensitive(list.Get(i).Message(), child, anyDepth, traversal, out)
 			}
 		case fd.Kind() == protoreflect.MessageKind:
-			collectSensitive(m.Get(fd).Message(), path, out)
+			collectSensitive(m.Get(fd).Message(), path, anyDepth, traversal, out)
+		}
+	}
+}
+
+func collectRouteUpstreamSensitive(m protoreflect.Message, prefix string, out map[string]struct{}) {
+	if !isRouteMessage(m.Descriptor()) {
+		return
+	}
+	toField := m.Descriptor().Fields().ByName("to")
+	if toField == nil || !toField.IsList() || toField.Kind() != protoreflect.StringKind {
+		return
+	}
+	to := m.Get(toField).List()
+	for i := 0; i < to.Len(); i++ {
+		_, hadUserInfo, ok := redactedRouteUpstream(to.Get(i).String())
+		if !ok || hadUserInfo {
+			out[joinPath(prefix, "to[]")] = struct{}{}
+			return
 		}
 	}
 }

--- a/pkg/mcp/configapi/sensitive.go
+++ b/pkg/mcp/configapi/sensitive.go
@@ -312,11 +312,11 @@ func rangeMessageMap(
 // carry a sensitive sub-field collapse to a glob ("certificates[].keyBytes")
 // rather than per-index paths, which would balloon under large lists and
 // don't tell the LLM anything actionable beyond "some elements have it".
-// Bounded google.protobuf.Any payloads are transparent to path construction;
-// payloads that cannot be inspected safely contribute no paths and are cleared
-// by the subsequent ScrubSensitive pass. Unknown wire fields likewise
-// contribute no paths and are removed by ScrubSensitive because their missing
-// descriptors make sensitivity impossible to determine safely.
+// Bounded google.protobuf.Any payloads are transparent to path construction.
+// Payloads that cannot be inspected safely report their value path because the
+// subsequent ScrubSensitive pass clears that opaque payload. Unknown wire
+// fields contribute no paths and are removed by ScrubSensitive because their
+// missing descriptors make sensitivity impossible to determine safely.
 //
 // Returns nil when no sensitive fields are populated. Result is sorted for
 // stable presentation.
@@ -349,7 +349,11 @@ func collectSensitive(
 	}
 	if m.Descriptor().FullName() == anyMessageFullName {
 		embedded, ok := traversal.unpackAny(m, anyDepth)
-		if !ok || embedded == nil {
+		if !ok {
+			out[joinPath(prefix, "value")] = struct{}{}
+			return
+		}
+		if embedded == nil {
 			return
 		}
 		collectSensitive(embedded.ProtoReflect(), prefix, anyDepth+1, traversal, out)

--- a/pkg/mcp/configapi/sensitive.go
+++ b/pkg/mcp/configapi/sensitive.go
@@ -3,6 +3,7 @@ package configapi
 import (
 	"fmt"
 	"net/url"
+	"slices"
 	"sort"
 	"strings"
 
@@ -37,7 +38,7 @@ var sensitiveConfigMessageDescriptors = func() map[protoreflect.FullName]protore
 	descriptors := make(map[protoreflect.FullName]protoreflect.MessageDescriptor)
 	var add func(protoreflect.MessageDescriptors)
 	add = func(messages protoreflect.MessageDescriptors) {
-		for i := 0; i < messages.Len(); i++ {
+		for i := range messages.Len() {
 			message := messages.Get(i)
 			descriptors[message.FullName()] = message
 			add(message.Messages())
@@ -96,7 +97,7 @@ func scrubMessage(m protoreflect.Message, anyDepth int, traversal *sensitiveTrav
 	}
 	scrubConfigRouteUpstreams(m)
 	fields := m.Descriptor().Fields()
-	for i := 0; i < fields.Len(); i++ {
+	for i := range fields.Len() {
 		fd := fields.Get(i)
 		if IsSensitive(fd) {
 			m.Clear(fd)
@@ -118,7 +119,7 @@ func scrubMessage(m protoreflect.Message, anyDepth int, traversal *sensitiveTrav
 				continue
 			}
 			list := m.Get(fd).List()
-			for i := 0; i < list.Len(); i++ {
+			for i := range list.Len() {
 				scrubMessage(list.Get(i).Message(), anyDepth, traversal)
 			}
 		case fd.Kind() == protoreflect.MessageKind:
@@ -136,7 +137,7 @@ func scrubConfigRouteUpstreams(m protoreflect.Message) {
 		return
 	}
 	to := m.Get(toField).List()
-	for i := 0; i < to.Len(); i++ {
+	for i := range to.Len() {
 		redacted, _, ok := redactedRouteUpstream(to.Get(i).String())
 		if !ok {
 			to.Set(i, protoreflect.ValueOfString("invalid upstream URL"))
@@ -278,6 +279,12 @@ func setAnyValue(m protoreflect.Message, value []byte) {
 	}
 }
 
+// rangeMessageMap visits m in sorted key order. ScrubSensitive and
+// SensitiveFieldsSet are separate walks, each accumulating its own
+// sensitiveTraversal.anyBytes budget over the same message; deterministic
+// order is what keeps them charging Any payloads in the same sequence, so
+// they agree on which entry crosses the budget and gets dropped, and the
+// scrubbedFields metadata matches what ScrubSensitive actually clears.
 func rangeMessageMap(
 	m protoreflect.Map,
 	keyKind protoreflect.Kind,
@@ -333,7 +340,7 @@ func SensitiveFieldsSet(msg proto.Message) []string {
 	for p := range out {
 		paths = append(paths, p)
 	}
-	sort.Strings(paths)
+	slices.Sort(paths)
 	return paths
 }
 
@@ -361,7 +368,7 @@ func collectSensitive(
 	}
 	collectRouteUpstreamSensitive(m, prefix, out)
 	fields := m.Descriptor().Fields()
-	for i := 0; i < fields.Len(); i++ {
+	for i := range fields.Len() {
 		fd := fields.Get(i)
 		path := joinPath(prefix, fd.JSONName())
 
@@ -396,7 +403,7 @@ func collectSensitive(
 			}
 			child := joinPath(path, "[]")
 			list := m.Get(fd).List()
-			for i := 0; i < list.Len(); i++ {
+			for i := range list.Len() {
 				collectSensitive(list.Get(i).Message(), child, anyDepth, traversal, out)
 			}
 		case fd.Kind() == protoreflect.MessageKind:
@@ -414,7 +421,7 @@ func collectRouteUpstreamSensitive(m protoreflect.Message, prefix string, out ma
 		return
 	}
 	to := m.Get(toField).List()
-	for i := 0; i < to.Len(); i++ {
+	for i := range to.Len() {
 		_, hadUserInfo, ok := redactedRouteUpstream(to.Get(i).String())
 		if !ok || hadUserInfo {
 			out[joinPath(prefix, "to[]")] = struct{}{}

--- a/pkg/mcp/configapi/sensitive_bench_test.go
+++ b/pkg/mcp/configapi/sensitive_bench_test.go
@@ -1,0 +1,129 @@
+package configapi
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/anypb"
+
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	registrypb "github.com/pomerium/pomerium/pkg/grpc/registry"
+)
+
+func benchConfig100Routes() *configpb.Config {
+	routes := make([]*configpb.Route, 100)
+	for i := range routes {
+		routes[i] = &configpb.Route{
+			To: []string{"https://user:password@upstream.example.com/path"},
+			Mcp: &configpb.MCP{Mode: &configpb.MCP_Server{Server: &configpb.MCPServer{
+				UpstreamOauth2: &configpb.UpstreamOAuth2{ClientSecret: "benchmark-oauth2-client-secret"},
+			}}},
+		}
+	}
+	return &configpb.Config{Routes: routes}
+}
+
+func benchAnyDepth16() *anypb.Any {
+	var msg proto.Message = sensitiveConfig("benchmark-depth-secret")
+	for range maxSensitiveAnyDepth {
+		var err error
+		msg, err = anypb.New(msg)
+		if err != nil {
+			panic(err)
+		}
+	}
+	return msg.(*anypb.Any)
+}
+
+// benchAnyNear5MiBCap builds a single Any whose Value sits just under the
+// cumulative byte cap — the worst case the budget check still has to
+// unmarshal, scrub, and repack.
+func benchAnyNear5MiBCap() *anypb.Any {
+	largeName := strings.Repeat("x", maxSensitiveAnyBytes-1024)
+	cfg := sensitiveConfig("benchmark-near-cap-secret")
+	cfg.Routes[0].Name = &largeName
+	a, err := anypb.New(cfg)
+	if err != nil {
+		panic(err)
+	}
+	return a
+}
+
+func benchRegisterRequest1000Entries() *registrypb.RegisterRequest {
+	metadata := make(map[string]*anypb.Any, 1000)
+	for i := range 1000 {
+		a, err := anypb.New(sensitiveConfig("benchmark-map-entry-secret"))
+		if err != nil {
+			panic(err)
+		}
+		metadata[strconv.Itoa(i)] = a
+	}
+	return &registrypb.RegisterRequest{Metadata: metadata}
+}
+
+func BenchmarkScrubSensitive(b *testing.B) {
+	b.Run("config-100-routes", func(b *testing.B) {
+		b.ReportAllocs()
+		base := benchConfig100Routes()
+		clones := make([]*configpb.Config, b.N)
+		for i := range clones {
+			clones[i] = proto.Clone(base).(*configpb.Config)
+		}
+		b.ResetTimer()
+		for i := range b.N {
+			ScrubSensitive(clones[i])
+		}
+	})
+
+	b.Run("any-depth-16", func(b *testing.B) {
+		b.ReportAllocs()
+		base := benchAnyDepth16()
+		clones := make([]*anypb.Any, b.N)
+		for i := range clones {
+			clones[i] = proto.Clone(base).(*anypb.Any)
+		}
+		b.ResetTimer()
+		for i := range b.N {
+			ScrubSensitive(clones[i])
+		}
+	})
+
+	b.Run("any-near-5mib-cap", func(b *testing.B) {
+		// Clone per iteration outside the timer: pre-building b.N multi-MiB
+		// clones would balloon memory, and timing the clone would dominate.
+		b.ReportAllocs()
+		base := benchAnyNear5MiBCap()
+		for range b.N {
+			b.StopTimer()
+			clone := proto.Clone(base).(*anypb.Any)
+			b.StartTimer()
+			ScrubSensitive(clone)
+		}
+	})
+
+	b.Run("map-1000-entries", func(b *testing.B) {
+		b.ReportAllocs()
+		base := benchRegisterRequest1000Entries()
+		clones := make([]*registrypb.RegisterRequest, b.N)
+		for i := range clones {
+			clones[i] = proto.Clone(base).(*registrypb.RegisterRequest)
+		}
+		b.ResetTimer()
+		for i := range b.N {
+			ScrubSensitive(clones[i])
+		}
+	})
+}
+
+func BenchmarkSensitiveFieldsSet(b *testing.B) {
+	b.Run("config-100-routes", func(b *testing.B) {
+		b.ReportAllocs()
+		cfg := benchConfig100Routes()
+		b.ResetTimer()
+		for range b.N {
+			SensitiveFieldsSet(cfg)
+		}
+	})
+}

--- a/pkg/mcp/configapi/sensitive_test.go
+++ b/pkg/mcp/configapi/sensitive_test.go
@@ -151,6 +151,10 @@ func TestGetRouteScrubsNestedOAuthClientSecret(t *testing.T) {
 	impl.stored.Store(&configpb.Route{
 		Id:   &id,
 		Name: new("github"),
+		To: []string{
+			"https://upstream-user-canary:upstream-password-canary@one.example.com",
+			"https://upstream-token-canary@two.example.com",
+		},
 		Mcp: &configpb.MCP{
 			Mode: &configpb.MCP_Server{
 				Server: &configpb.MCPServer{
@@ -179,6 +183,9 @@ func TestGetRouteScrubsNestedOAuthClientSecret(t *testing.T) {
 
 	assert.NotContains(t, body, secret,
 		"upstreamOauth2.client_secret VALUE leaked through MCP — sensitive scrub failed for the nested oneof + non-optional scalar case")
+	assert.NotContains(t, body, "upstream-user-canary")
+	assert.NotContains(t, body, "upstream-password-canary")
+	assert.NotContains(t, body, "upstream-token-canary")
 
 	require.NotNil(t, resp.StructuredContent)
 	structured := resp.StructuredContent.(map[string]any)
@@ -191,6 +198,8 @@ func TestGetRouteScrubsNestedOAuthClientSecret(t *testing.T) {
 	}
 	assert.Contains(t, paths, "route.mcp.server.upstreamOauth2.clientSecret",
 		"the redacted-fields list must name the path even when the value is properly scrubbed")
+	assert.Contains(t, paths, "route.to[]",
+		"MCP metadata must declare hidden upstream URL userinfo")
 }
 
 type routeCRUDForGet struct {
@@ -278,6 +287,7 @@ func TestUpdatePreservesExistingSensitive(t *testing.T) {
 	impl.stored.Store(&configpb.Route{
 		Id:              &id,
 		From:            "https://existing.example",
+		To:              []string{"https://upstream-user:upstream-password@upstream.example.com/path?q=1"},
 		Description:     &existingDesc,
 		TlsClientKey:    "PRIVATE-KEY-XYZ",
 		IdpClientSecret: &existingClientSecret,
@@ -303,8 +313,60 @@ func TestUpdatePreservesExistingSensitive(t *testing.T) {
 	require.NotNil(t, got)
 	assert.Equal(t, "updated", got.GetDescription(), "description should be updated")
 	assert.Equal(t, "https://existing.example", got.GetFrom(), "from should be preserved (sparse patch)")
+	assert.Equal(t, []string{"https://upstream-user:upstream-password@upstream.example.com/path?q=1"}, got.GetTo(),
+		"omitted to must preserve the credential-bearing runtime upstream")
 	assert.Equal(t, "PRIVATE-KEY-XYZ", got.GetTlsClientKey(), "tls_client_key must be preserved")
 	assert.Equal(t, existingClientSecret, got.GetIdpClientSecret(), "idp_client_secret must be preserved")
+}
+
+func TestUpdateRouteRestoresRedactedUpstreamRoundTrip(t *testing.T) {
+	const (
+		id               = "route-upstream-roundtrip"
+		passwordUpstream = "https://user-secret:password-secret@one.example.com/path?q=1"
+		tokenUpstream    = "https://token-secret@two.example.com/other?q=2"
+		maskedPassword   = "https://xxxxx@one.example.com/path?q=1"
+		maskedToken      = "https://xxxxx@two.example.com/other?q=2"
+	)
+
+	t.Run("unchanged masked values restore by index", func(t *testing.T) {
+		impl := &routeCRUDWithUpdate{}
+		impl.stored.Store(&configpb.Route{Id: new(id), To: []string{passwordUpstream, tokenUpstream}})
+		session := connectMCP(t, newTestServer(t, impl))
+
+		resp, err := session.CallTool(t.Context(), &mcp.CallToolParams{
+			Name: "update_route",
+			Arguments: map[string]any{"route": map[string]any{
+				"id": id,
+				"to": []string{maskedPassword, maskedToken},
+			}},
+		})
+		require.NoError(t, err)
+		require.False(t, resp.IsError, "%+v", resp.Content)
+		assert.Equal(t, []string{passwordUpstream, tokenUpstream}, impl.stored.Load().GetTo())
+	})
+
+	t.Run("destination edit cannot inherit credentials", func(t *testing.T) {
+		impl := &routeCRUDWithUpdate{}
+		impl.stored.Store(&configpb.Route{Id: new(id), To: []string{passwordUpstream}})
+		session := connectMCP(t, newTestServer(t, impl))
+
+		resp, err := session.CallTool(t.Context(), &mcp.CallToolParams{
+			Name: "update_route",
+			Arguments: map[string]any{"route": map[string]any{
+				"id": id,
+				"to": []string{"https://xxxxx@attacker.example.com/path?q=1"},
+			}},
+		})
+		require.NoError(t, err)
+		require.True(t, resp.IsError, "mismatched placeholder must fail closed")
+		require.NotEmpty(t, resp.Content)
+		errorText := resp.Content[0].(*mcp.TextContent).Text
+		assert.Contains(t, errorText, "index 0")
+		assert.NotContains(t, errorText, "attacker.example.com")
+		assert.NotContains(t, errorText, "password-secret")
+		assert.Equal(t, []string{passwordUpstream}, impl.stored.Load().GetTo(),
+			"failed merge must not dispatch an update")
+	})
 }
 
 // TestUpdatePreservesNestedSensitive_OAuthClientSecret pins down the


### PR DESCRIPTION
## What

This redacts credentials from configuration presentation paths without changing the live configuration used for routing. It covers route URL userinfo in policy rendering and errors, configuration dumps, MCP responses, versioned configuration, and DataBroker records.

## Why

A route destination can contain `user:password@host`. Before this change, administrative and diagnostic views could render those credentials in cleartext. The existing protobuf scrubber also did not safely handle values inside `google.protobuf.Any` or unknown wire fields, allowing otherwise-hidden data to escape through presentation surfaces.

## Review notes

Presentation now uses a fixed URL-userinfo placeholder, recursively scrubs bounded `Any` payloads, and drops unknown protobuf fields. Malformed, oversized, or too-deep values are cleared rather than returned. Debug handlers clone before scrubbing, so the original destination remains available to the runtime.

Redacted route updates preserve a credential only when the placeholder still refers to the same upstream at the same list position. Reordering or changing a destination cannot transfer a credential to another host.

## Testing

```sh
go test -race ./internal/urlutil ./config ./pkg/mcp/configapi
go test -race -tags=debug_local_envoy ./internal/controlplane -run 'Test(ConfigDump|VersionedConfigRendering|DatabrokerRecordRendering)'
```

Both commands passed on the staged slice. A fresh worktree still needs the repository's generated embedded Envoy asset for the complete control-plane suite.

## Related issue

- [ENG-4240](https://linear.app/pomerium/issue/ENG-4240)

## AI assistance

Codex assisted with implementation and test authoring. Claude performed adversarial review of secret handling. Bobby defined the security invariant and reviewed the final change.
