### PR TITLE
fix(config): isolate runtime overlays and watch all policy sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ _testmain.go
 
 # Other dirs
 /bin/
+/pomerium
 
 # Without this, the *.[568vq] above ignores this folder.
 !**/graphrbac/1.6

--- a/config/config_source.go
+++ b/config/config_source.go
@@ -305,7 +305,7 @@ func getAllConfigFilePaths(cfg *Config) []string {
 		fs = append(fs, pair.CertFile, pair.KeyFile)
 	}
 
-	for _, policy := range cfg.Options.Policies {
+	for policy := range cfg.Options.GetAllPolicies() {
 		fs = append(fs,
 			policy.KubernetesServiceAccountTokenFile,
 			policy.TLSClientCertFile,

--- a/config/config_source_test.go
+++ b/config/config_source_test.go
@@ -108,6 +108,35 @@ func TestFileWatcherSource(t *testing.T) {
 	t.Run("Hot Reload Disabled", newTest(false))
 }
 
+func TestFileWatcherSourceWatchesRouteAndAdditionalPolicyFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	routeFile := filepath.Join(dir, "route-ca.pem")
+	additionalFile := filepath.Join(dir, "additional-client-cert.pem")
+	require.NoError(t, os.WriteFile(routeFile, []byte("route-a"), 0o600))
+	require.NoError(t, os.WriteFile(additionalFile, []byte("additional-a"), 0o600))
+
+	options := NewDefaultOptions()
+	options.RuntimeFlags[RuntimeFlagConfigHotReload] = true
+	options.Routes = []Policy{{TLSCustomCAFile: routeFile}}
+	options.AdditionalPolicies = []Policy{{TLSClientCertFile: additionalFile}}
+	src := NewFileWatcherSource(t.Context(), NewStaticSource(New(options)))
+	changed := make(chan struct{}, 2)
+	src.OnConfigChange(t.Context(), func(context.Context, *Config) { changed <- struct{}{} })
+
+	for path, contents := range map[string][]byte{
+		routeFile:      []byte("route-b"),
+		additionalFile: []byte("additional-b"),
+	} {
+		require.NoError(t, os.WriteFile(path, contents, 0o600))
+		select {
+		case <-changed:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("no config event after changing policy material %q", path)
+		}
+	}
+}
+
 func TestFileOrEnvironmentSource(t *testing.T) {
 	t.Parallel()
 

--- a/config/options.go
+++ b/config/options.go
@@ -1669,7 +1669,7 @@ func (o *Options) ApplySettings(ctx context.Context, certsIndex *cryptutil.Certi
 	if settings.HasBrandingOptions() {
 		o.BrandingOptions = settings
 	}
-	copyMap(&o.RuntimeFlags, settings.RuntimeFlags, func(k string, v bool) (RuntimeFlag, bool) {
+	mergeMap(&o.RuntimeFlags, settings.RuntimeFlags, func(k string, v bool) (RuntimeFlag, bool) {
 		return RuntimeFlag(k), v
 	})
 	if settings.Http3AdvertisePort != nil {
@@ -2086,6 +2086,27 @@ func copyMap[T1Key comparable, T1Value any, T2Key comparable, T2Value any, TMap1
 		k1, v1 := convert(k, v)
 		(*dst)[k1] = v1
 	}
+}
+
+// mergeMap overlays src on a clone of dst. Options maps can be shared by
+// immutable config snapshots, so callers must never mutate dst in place.
+func mergeMap[T1Key comparable, T1Value any, T2Key comparable, T2Value any, TMap1 ~map[T1Key]T1Value, TMap2 ~map[T2Key]T2Value](
+	dst *TMap1,
+	src TMap2,
+	convert func(T2Key, T2Value) (T1Key, T1Value),
+) {
+	if len(src) == 0 {
+		return
+	}
+	next := maps.Clone(*dst)
+	if next == nil {
+		next = make(TMap1, len(src))
+	}
+	for k, v := range src {
+		k1, v1 := convert(k, v)
+		next[k1] = v1
+	}
+	*dst = next
 }
 
 func setCertificate(

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1063,6 +1063,33 @@ func TestOptions_ApplySettings(t *testing.T) {
 			"should not erase existing circuit breaker thresholds")
 	})
 
+	t.Run("runtime_flags overlay", func(t *testing.T) {
+		t.Parallel()
+
+		options := NewDefaultOptions()
+		options.RuntimeFlags[RuntimeFlagMCP] = true
+
+		options.ApplySettings(ctx, nil, &configpb.Settings{
+			SshAddress: new("127.0.0.1:2222"),
+		})
+		assert.True(t, options.IsRuntimeFlagSet(RuntimeFlagMCP),
+			"settings without runtime flags should preserve a static flag")
+		assert.Equal(t, "127.0.0.1:2222", options.SSHAddr)
+
+		options.ApplySettings(ctx, nil, &configpb.Settings{
+			RuntimeFlags: map[string]bool{string(RuntimeFlagAllowAnySignOutRedirectURI): true},
+		})
+		assert.True(t, options.IsRuntimeFlagSet(RuntimeFlagMCP),
+			"an unrelated settings flag should not clear the static flag")
+		assert.True(t, options.IsRuntimeFlagSet(RuntimeFlagAllowAnySignOutRedirectURI))
+
+		options.ApplySettings(ctx, nil, &configpb.Settings{
+			RuntimeFlags: map[string]bool{string(RuntimeFlagMCP): false},
+		})
+		assert.False(t, options.IsRuntimeFlagSet(RuntimeFlagMCP),
+			"an explicit settings value should override the static flag")
+	})
+
 	t.Run("ssh", func(t *testing.T) {
 		t.Parallel()
 

--- a/internal/databroker/config_source_test.go
+++ b/internal/databroker/config_source_test.go
@@ -150,3 +150,121 @@ func TestAllDBConfigs(t *testing.T) {
 		versionedConfig3.Config,
 	}, slices.Collect(src.allSortedDBConfigsLocked()))
 }
+
+func TestConfigSourceSettingsRuntimeFlagsOverlay(t *testing.T) {
+	t.Parallel()
+
+	route := &configpb.Route{
+		From: "https://app.example.com",
+		To:   []string{"https://app.internal"},
+	}
+
+	options := config.NewDefaultOptions()
+	options.RuntimeFlags[config.RuntimeFlagMCP] = true
+	underlying := config.New(options)
+	address := "127.0.0.1:2222"
+	src := &ConfigSource{
+		underlyingConfig: underlying,
+		dbConfigs: map[string]dbConfig{
+			"dashboard-settings": {
+				Config: &configpb.Config{
+					Settings: &configpb.Settings{SshAddress: &address},
+				},
+			},
+			"dashboard-route": {
+				Config: &configpb.Config{Routes: []*configpb.Route{route}},
+			},
+		},
+		dbVersionedConfigs:  map[string]dbConfig{},
+		standardConfigReady: true,
+		enableValidation:    true,
+	}
+
+	rebuild := func(t *testing.T) *config.Config {
+		t.Helper()
+		computed := underlying.Clone()
+		require.NoError(t, src.buildNewConfigLocked(t.Context(), computed))
+		assert.Equal(t, address, computed.Options.SSHAddr)
+		assert.Len(t, computed.Options.AdditionalPolicies, 1)
+		return computed
+	}
+	assertUnderlyingUnchanged := func(t *testing.T) {
+		t.Helper()
+		assert.True(t, underlying.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP))
+		assert.False(t, underlying.Options.IsRuntimeFlagSet(config.RuntimeFlagAllowAnySignOutRedirectURI))
+		assert.Empty(t, underlying.Options.SSHAddr)
+		assert.Empty(t, underlying.Options.AdditionalPolicies)
+	}
+
+	t.Run("absent", func(t *testing.T) {
+		computed := rebuild(t)
+		assert.True(t, computed.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP))
+		assertUnderlyingUnchanged(t)
+	})
+
+	t.Run("explicit override is removed", func(t *testing.T) {
+		src.dbConfigs["runtime-flags"] = dbConfig{Config: &configpb.Config{
+			Settings: &configpb.Settings{RuntimeFlags: map[string]bool{
+				string(config.RuntimeFlagMCP): false,
+			}},
+		}}
+		computed := rebuild(t)
+		assert.False(t, computed.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP))
+		assertUnderlyingUnchanged(t)
+
+		delete(src.dbConfigs, "runtime-flags")
+		computed = rebuild(t)
+		assert.True(t, computed.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP))
+		assertUnderlyingUnchanged(t)
+	})
+
+	t.Run("unrelated override is removed", func(t *testing.T) {
+		src.dbConfigs["runtime-flags"] = dbConfig{Config: &configpb.Config{
+			Settings: &configpb.Settings{RuntimeFlags: map[string]bool{
+				string(config.RuntimeFlagAllowAnySignOutRedirectURI): true,
+			}},
+		}}
+		computed := rebuild(t)
+		assert.True(t, computed.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP))
+		assert.True(t, computed.Options.IsRuntimeFlagSet(config.RuntimeFlagAllowAnySignOutRedirectURI))
+		assertUnderlyingUnchanged(t)
+
+		delete(src.dbConfigs, "runtime-flags")
+		computed = rebuild(t)
+		assert.True(t, computed.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP))
+		assert.False(t, computed.Options.IsRuntimeFlagSet(config.RuntimeFlagAllowAnySignOutRedirectURI))
+		assertUnderlyingUnchanged(t)
+	})
+}
+
+func TestConfigSourceSettingsRuntimeFlagsSortedPrecedence(t *testing.T) {
+	t.Parallel()
+
+	underlying := config.New(config.NewDefaultOptions())
+	src := &ConfigSource{
+		underlyingConfig: underlying,
+		dbConfigs: map[string]dbConfig{
+			"z-later": {Config: &configpb.Config{Settings: &configpb.Settings{RuntimeFlags: map[string]bool{
+				string(config.RuntimeFlagAllowAnySignOutRedirectURI): true,
+				string(config.RuntimeFlagPomeriumJWTEndpoint):        true,
+			}}}},
+			"a-first": {Config: &configpb.Config{Settings: &configpb.Settings{RuntimeFlags: map[string]bool{
+				string(config.RuntimeFlagAllowAnySignOutRedirectURI): false,
+				string(config.RuntimeFlagMCP):                        true,
+			}}}},
+		},
+		dbVersionedConfigs:  map[string]dbConfig{},
+		standardConfigReady: true,
+	}
+
+	computed := underlying.Clone()
+	require.NoError(t, src.buildNewConfigLocked(t.Context(), computed))
+	assert.True(t, computed.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP),
+		"disjoint flags from earlier records must accumulate")
+	assert.True(t, computed.Options.IsRuntimeFlagSet(config.RuntimeFlagPomeriumJWTEndpoint),
+		"disjoint flags from later records must accumulate")
+	assert.True(t, computed.Options.IsRuntimeFlagSet(config.RuntimeFlagAllowAnySignOutRedirectURI),
+		"the later lexically sorted settings record must win conflicts")
+	assert.False(t, underlying.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP),
+		"building the computed snapshot must not mutate the shared underlying map")
+}


### PR DESCRIPTION
## What

This makes DataBroker runtime settings a copy-on-write overlay on static configuration. It also watches certificate and key files referenced by every policy source, including routes and additional policies.

## Why

Previously, a settings record could replace the entire runtime-flag map and silently discard unrelated static values. The configuration clone could also share maps with its source, letting one computed generation mutate the baseline used by later reloads. Separately, file-backed policies outside the top-level policy list did not trigger reloads when their certificates changed.

## Review notes

The overlay retains static values, supports an explicit `false`, and applies conflicting settings in lexical record-ID order. Removing an override reveals the original static value. Neither the source map nor a previous computed generation is mutated.

## Testing

```sh
go test -count=1 -race ./config -run '^(TestFileWatcherSourceWatchesRouteAndAdditionalPolicyFiles|TestOptions_ApplySettings)$'
go test -count=1 -race ./internal/databroker -run '^TestConfigSourceSettingsRuntimeFlags(Overlay|SortedPrecedence)$'
```

Both commands passed on the staged slice. They cover explicit `false`, override removal, deterministic precedence, source-map isolation, and policy-file discovery.

## Related issue

- [ENG-4241](https://linear.app/pomerium/issue/ENG-4241)

## AI assistance

Codex assisted with implementation and test authoring. Claude reviewed the merge and reload invariants. Bobby defined the expected precedence behavior and reviewed the final change.
