### PR TITLE
ci: upgrade Go toolchain to 1.26.5

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golangci-lint 2.12.2
-golang 1.26.4
+golang 1.26.5
 goreleaser 2.16.0
 nodejs 24.18.0
 protoc 35.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN make npm-install
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.26.4-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS build
+FROM golang:1.26-bookworm AS build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \

--- a/examples/mutual-tls/Dockerfile
+++ b/examples/mutual-tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4-bookworm@sha256:b305420a68d0f229d91eb3b3ed9e519fcf2cf5461da4bef997bf927e8c0bfd2b AS build-env
+FROM golang:1.26-bookworm AS build-env
 
 WORKDIR /go/src/app
 ADD . /go/src/app


### PR DESCRIPTION
## What

This keeps Core CI on Go 1.26.5 and changes its two builder images to the floating golang:1.26-bookworm tag.

## Why

GO-2026-5856 is fixed in Go 1.26.5. CI needs the exact patched compiler, while the approved 1.26 image tag keeps release images on future compatible Go patch releases without another source change.

## Testing

The root Dockerfile BuildKit check passed against the floating tag. Focused Core Go tests and govulncheck passed with Go 1.26.5.

## Related issue

- [ENG-4243](https://linear.app/pomerium/issue/ENG-4243)

## AI assistance

Codex made the toolchain-only edits and ran validation. Bobby directed the scope.