### PR TITLE
benchmarks: add hot-path performance harness and baseline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,11 +177,19 @@ BENCHSTAT ?= golang.org/x/perf/cmd/benchstat@v0.0.0-20260709024250-82a0b07e230d
 bench: ## Runs hot-path benchmarks and compares against the committed baseline
 	@echo "==> $@"
 	@tmp="$$(mktemp "$${TMPDIR:-/tmp}/pomerium-bench-new.XXXXXX")"; trap 'rm -f "$$tmp"' EXIT; \
+		if [ ! -r "$(BENCH_BASELINE)" ]; then \
+			echo "benchmark baseline is not readable: $(BENCH_BASELINE)"; \
+			exit 1; \
+		fi; \
 		if ! $(GO) test -p=1 -run '^$$' -short -tags "$(BUILDTAGS)" -bench '$(BENCH)' -benchmem -count $(BENCH_COUNT) -timeout 60m $(BENCH_PKGS) > "$$tmp"; then \
 			cat "$$tmp"; \
 			exit 1; \
 		fi; \
-		$(GO) run $(BENCHSTAT) "$(BENCH_BASELINE)" "$$tmp"
+		if ! $(GO) run $(BENCHSTAT) "$(BENCH_BASELINE)" "$$tmp"; then \
+			echo "benchmark output preserved at $$tmp"; \
+			trap - EXIT; \
+			exit 1; \
+		fi
 
 .PHONY: bench-baseline
 bench-baseline: ## Regenerates the committed benchmark baseline (same-machine reference)

--- a/Makefile
+++ b/Makefile
@@ -160,6 +160,39 @@ test: get-envoy ## Runs the go tests.
 	@echo "==> $@"
 	$(GO) test $(GO_TESTFLAGS) -tags "$(BUILDTAGS)" ./...
 
+BENCH ?= BenchmarkGetMatchingPolicy|BenchmarkWithQuerierForCheckRequest|BenchmarkStoreGetDataBrokerRecord|BenchmarkCachingQuerier|BenchmarkEvaluate$$|BenchmarkHeadersEvaluator|BenchmarkPolicyChecksum|BenchmarkBuildRouteConfigurations|BenchmarkGetAllRouteableHTTPHosts|BenchmarkDiscoveryResourceEncoding
+BENCH_PKGS ?= ./authorize ./authorize/internal/store ./authorize/evaluator ./pkg/storage ./config ./config/envoyconfig ./internal/controlplane
+BENCH_COUNT ?= 10
+BENCH_BASELINE ?= internal/benchmarks/baseline.txt
+BENCHSTAT ?= golang.org/x/perf/cmd/benchstat@v0.0.0-20260709024250-82a0b07e230d
+
+# Benchmarks run without -race on every platform and with -short, which skips
+# the slowest route-scaling cases (drop -short for ad-hoc quadratic runs).
+# benchstat deltas are only meaningful against a baseline generated on
+# the same machine: regenerate with `make bench-baseline` before comparing.
+# -p=1 serializes package benchmark binaries so they don't compete for CPU.
+# A failed `go test` is printed and aborts before truncated output can reach
+# benchstat (or replace the committed baseline).
+.PHONY: bench
+bench: ## Runs hot-path benchmarks and compares against the committed baseline
+	@echo "==> $@"
+	@tmp="$$(mktemp "$${TMPDIR:-/tmp}/pomerium-bench-new.XXXXXX")"; trap 'rm -f "$$tmp"' EXIT; \
+		if ! $(GO) test -p=1 -run '^$$' -short -tags "$(BUILDTAGS)" -bench '$(BENCH)' -benchmem -count $(BENCH_COUNT) -timeout 60m $(BENCH_PKGS) > "$$tmp"; then \
+			cat "$$tmp"; \
+			exit 1; \
+		fi; \
+		$(GO) run $(BENCHSTAT) "$(BENCH_BASELINE)" "$$tmp"
+
+.PHONY: bench-baseline
+bench-baseline: ## Regenerates the committed benchmark baseline (same-machine reference)
+	@echo "==> $@"
+	@tmp="$$(mktemp "$(BENCH_BASELINE).tmp.XXXXXX")"; trap 'rm -f "$$tmp"' EXIT; \
+		if ! $(GO) test -p=1 -run '^$$' -short -tags "$(BUILDTAGS)" -bench '$(BENCH)' -benchmem -count $(BENCH_COUNT) -timeout 60m $(BENCH_PKGS) > "$$tmp"; then \
+			cat "$$tmp"; \
+			exit 1; \
+		fi; \
+		mv "$$tmp" "$(BENCH_BASELINE)"
+
 .PHONY: cover
 cover: get-envoy ## Runs go test with coverage
 	@echo "==> $@"

--- a/authorize/evaluator/evaluator_bench_test.go
+++ b/authorize/evaluator/evaluator_bench_test.go
@@ -1,0 +1,92 @@
+package evaluator
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/authorize/internal/store"
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+// BenchmarkEvaluate measures a full Evaluator.Evaluate call - policy rules
+// plus the headers evaluator, including JWT signing - for one request against
+// one policy. Evaluate's cost does not scale with the total policy count
+// (per-policy Rego is compiled in New, outside the timed loop), so there is
+// no policy-count axis; this is the composite regression guard for the
+// per-request authorize path.
+func BenchmarkEvaluate(b *testing.B) {
+	prevLevel := log.GetLevel()
+	log.SetLevel(zerolog.InfoLevel)
+	defer log.SetLevel(prevLevel)
+
+	signingKey, err := cryptutil.NewSigningKey()
+	require.NoError(b, err)
+	encodedSigningKey, err := cryptutil.EncodePrivateKey(signingKey)
+	require.NoError(b, err)
+
+	policies := make([]*config.Policy, 100)
+	for i := range policies {
+		policies[i] = &config.Policy{
+			From:         fmt.Sprintf("https://from-%d.example.com", i),
+			To:           singleToURL(fmt.Sprintf("https://to-%d.example.com", i)),
+			AllowedUsers: []string{"u1@example.com"},
+			SetRequestHeaders: map[string]string{
+				"Authorization": "Bearer ${pomerium.jwt}",
+			},
+		}
+	}
+	mid := len(policies) / 2
+	policy := policies[mid]
+
+	ctx := b.Context()
+	ctx = storage.WithQuerier(ctx, storage.NewStaticQuerier([]proto.Message{
+		&session.Session{Id: "s1", UserId: "u1"},
+		&user.User{Id: "u1", Email: "u1@example.com"},
+	}...))
+
+	st := store.New()
+	st.UpdateJWTClaimHeaders(config.NewJWTClaimHeaders("email", "groups", "user"))
+
+	e, err := New(ctx, st, nil,
+		WithPolicies(policies),
+		WithSigningKey(encodedSigningKey),
+		WithAuthenticateURL("https://authenticate.example.com"),
+	)
+	require.NoError(b, err)
+
+	host := fmt.Sprintf("from-%d.example.com", mid)
+	req := &Request{
+		Policy: policy,
+		HTTP: RequestHTTP{
+			Method:   http.MethodGet,
+			Host:     host,
+			Hostname: host,
+			Path:     "/",
+			URL:      "https://" + host + "/",
+		},
+		Session: RequestSession{ID: "s1", UserID: "u1"},
+	}
+	res, err := e.Evaluate(ctx, req)
+	require.NoError(b, err)
+	require.True(b, res.Allow.Value)
+	require.NotEmpty(b, res.Headers.Get("Authorization"))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		res, err = e.Evaluate(ctx, req)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/authorize/grpc_bench_test.go
+++ b/authorize/grpc_bench_test.go
@@ -1,0 +1,79 @@
+package authorize
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/pomerium/pomerium/config"
+)
+
+// BenchmarkGetMatchingPolicy measures a.getMatchingPolicy, which linearly
+// scans every configured policy computing its RouteID until it finds the one
+// matching the request's route ID.
+func BenchmarkGetMatchingPolicy(b *testing.B) {
+	for _, idType := range []struct {
+		name     string
+		explicit bool
+	}{
+		{name: "generated"},
+		{name: "explicit", explicit: true},
+	} {
+		b.Run("id="+idType.name, func(b *testing.B) {
+			for _, n := range []int{100, 1000, 10000} {
+				b.Run(fmt.Sprintf("policies=%d", n), func(b *testing.B) {
+					policies := make([]config.Policy, n)
+					for i := range policies {
+						to, err := config.ParseWeightedUrls(fmt.Sprintf("https://to-%d.example.com", i))
+						if err != nil {
+							b.Fatal(err)
+						}
+						policies[i] = config.Policy{
+							From: fmt.Sprintf("https://from-%d.example.com", i),
+							To:   to,
+						}
+						if idType.explicit {
+							policies[i].ID = fmt.Sprintf("route-%d", i)
+						}
+					}
+
+					a := &Authorize{}
+					a.currentConfig.Store(config.New(&config.Options{Policies: policies}))
+
+					// Look up a route in the middle of the set so every benchmark
+					// pays for roughly half of a full scan.
+					mid := n / 2
+					routeID, err := policies[mid].RouteID()
+					if err != nil {
+						b.Fatal(err)
+					}
+
+					b.ReportAllocs()
+					b.ResetTimer()
+					for b.Loop() {
+						if p := a.getMatchingPolicy(routeID); p != &policies[mid] {
+							b.Fatal("matched the wrong policy")
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+// BenchmarkWithQuerierForCheckRequest measures a.withQuerierForCheckRequest,
+// which builds the NewQuerier/NewCachingQuerier (and, when sync queriers are
+// enabled, NewTypedQuerier/NewFallbackQuerier) chain used for every Check
+// call. syncQueriers is left empty here, so this measures the
+// NewQuerier+NewCachingQuerier path only, not the synced-data fallback path.
+func BenchmarkWithQuerierForCheckRequest(b *testing.B) {
+	a := &Authorize{}
+	a.state.Store(&authorizeState{})
+
+	ctx := b.Context()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		_ = a.withQuerierForCheckRequest(ctx)
+	}
+}

--- a/authorize/internal/store/store_bench_test.go
+++ b/authorize/internal/store/store_bench_test.go
@@ -1,0 +1,65 @@
+package store
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/grpcutil"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+// BenchmarkStoreGetDataBrokerRecord measures the get_databroker_record rego
+// builtin end to end: the querier round-trip, toMap's JSON marshal/unmarshal,
+// and ast.InterfaceToValue. It resolves the session and user records used by
+// a typical authenticated policy evaluation.
+func BenchmarkStoreGetDataBrokerRecord(b *testing.B) {
+	s := New()
+
+	sessionType := grpcutil.GetTypeURL(new(session.Session))
+	userType := grpcutil.GetTypeURL(new(user.User))
+
+	script := fmt.Sprintf(`package pomerium.policy
+
+session := get_databroker_record(%q, "s1")
+user := get_databroker_record(%q, "u1")
+`, sessionType, userType)
+
+	r := rego.New(
+		rego.Store(s),
+		rego.Module("pomerium.policy", script),
+		rego.Query("result = data.pomerium.policy"),
+		s.GetDataBrokerRecordOption(),
+	)
+	pq, err := r.PrepareForEval(b.Context())
+	require.NoError(b, err)
+
+	sess := &session.Session{
+		Id:       "s1",
+		UserId:   "u1",
+		IdpId:    "idp1",
+		Audience: []string{"https://from.example.com"},
+	}
+	u := &user.User{
+		Id:    "u1",
+		Name:  "Jane Doe",
+		Email: "jane@example.com",
+	}
+	ctx := storage.WithQuerier(b.Context(), storage.NewStaticQuerier(sess, u))
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for b.Loop() {
+		rs, err := pq.Eval(ctx)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(rs) == 0 {
+			b.Fatal("expected a result")
+		}
+	}
+}

--- a/config/envoyconfig/route_configurations_bench_test.go
+++ b/config/envoyconfig/route_configurations_bench_test.go
@@ -1,0 +1,114 @@
+package envoyconfig
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+)
+
+// benchOptions builds Options with n policies, each matching a distinct
+// single host in From. Distinct hosts force BuildRouteConfigurations to
+// evaluate every policy against every host, which is the O(hosts * policies)
+// path this benchmark targets.
+func benchOptions(b *testing.B, n int) *config.Options {
+	b.Helper()
+
+	policies := make([]config.Policy, n)
+	for i := range n {
+		to, err := config.ParseWeightedUrls(fmt.Sprintf("https://up%d.example.com", i))
+		if err != nil {
+			b.Fatalf("parse to url: %v", err)
+		}
+		policies[i] = config.Policy{
+			From: fmt.Sprintf("https://r%d.example.com", i),
+			To:   to,
+		}
+		if err := policies[i].Validate(); err != nil {
+			b.Fatalf("policy %d failed validation: %v", i, err)
+		}
+	}
+
+	return &config.Options{
+		CookieName:             "pomerium",
+		DefaultUpstreamTimeout: 3 * time.Second,
+		SharedKey:              cryptutil.NewBase64Key(),
+		Services:               "proxy",
+		Policies:               policies,
+	}
+}
+
+func BenchmarkBuildRouteConfigurations(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("policies=%d", n), func(b *testing.B) {
+			if n == 10000 && testing.Short() {
+				b.Skip("policies=10000 takes ~45s/op; run without -short for the full scaling curve")
+			}
+			options := benchOptions(b, n)
+			cfg := config.New(options)
+			bd := New("connect", "grpc", "http", "debug", "metrics", filemgr.NewManager(), nil, true)
+			ctx := b.Context()
+
+			routeConfigurations, err := bd.BuildRouteConfigurations(ctx, cfg)
+			if err != nil {
+				b.Fatalf("BuildRouteConfigurations: %v", err)
+			}
+			if got := countRoutes(b, routeConfigurations); got < n {
+				b.Fatalf("sanity check failed: built %d routes, want at least %d", got, n)
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, err := bd.BuildRouteConfigurations(ctx, cfg); err != nil {
+					b.Fatalf("BuildRouteConfigurations: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func BenchmarkGetAllRouteableHTTPHosts(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		b.Run(fmt.Sprintf("policies=%d", n), func(b *testing.B) {
+			options := benchOptions(b, n)
+
+			hosts, _, err := options.GetAllRouteableHTTPHosts()
+			if err != nil {
+				b.Fatalf("GetAllRouteableHTTPHosts: %v", err)
+			}
+			if len(hosts) < n {
+				b.Fatalf("sanity check failed: got %d hosts, want at least %d", len(hosts), n)
+			}
+
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, _, err := options.GetAllRouteableHTTPHosts(); err != nil {
+					b.Fatalf("GetAllRouteableHTTPHosts: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// countRoutes returns the total number of routes across all virtual hosts of
+// the "main" route configuration, which is where policy routes land.
+func countRoutes(b *testing.B, routeConfigurations []RouteConfiguration) int {
+	b.Helper()
+
+	count := 0
+	for _, rc := range routeConfigurations {
+		main, ok := rc.Config.(*envoy_config_route_v3.RouteConfiguration)
+		if !ok {
+			continue
+		}
+		for _, vh := range main.GetVirtualHosts() {
+			count += len(vh.GetRoutes())
+		}
+	}
+	return count
+}

--- a/config/policy_bench_test.go
+++ b/config/policy_bench_test.go
@@ -1,0 +1,43 @@
+package config
+
+import (
+	"testing"
+)
+
+// BenchmarkPolicyChecksum measures Policy.Checksum() on a single, realistic
+// policy. Checksum currently walks the struct via reflection
+// (hashutil.MustHash -> mitchellh/hashstructure) on every call, so this is
+// the baseline a future memoized implementation should beat.
+func BenchmarkPolicyChecksum(b *testing.B) {
+	p := &Policy{
+		From: "https://from.example.com",
+		To:   mustParseWeightedURLs(b, "https://to.example.com"),
+		AllowedUsers: []string{
+			"user1@example.com",
+			"user2@example.com",
+		},
+		AllowedDomains: []string{
+			"example.com",
+			"other-example.com",
+		},
+		SetRequestHeaders: map[string]string{
+			"X-Custom-Header-1": "value1",
+			"X-Custom-Header-2": "value2",
+		},
+		PrefixRewrite:      "/rewritten",
+		HostRewrite:        "internal.example.com",
+		PreserveHostHeader: false,
+		AllowWebsockets:    true,
+		TLSSkipVerify:      false,
+	}
+	if err := p.Validate(); err != nil {
+		b.Fatalf("policy failed validation: %v", err)
+	}
+
+	b.ReportAllocs()
+	var sink uint64
+	for b.Loop() {
+		sink = p.Checksum()
+	}
+	_ = sink
+}

--- a/internal/benchmarks/baseline.txt
+++ b/internal/benchmarks/baseline.txt
@@ -1,0 +1,232 @@
+goos: darwin
+goarch: arm64
+pkg: github.com/pomerium/pomerium/authorize
+cpu: Apple M3 Max
+BenchmarkGetMatchingPolicy/id=generated/policies=100-16         	  140590	      8582 ns/op	    1224 B/op	     102 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=100-16         	  141381	      8284 ns/op	    1224 B/op	     102 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=100-16         	  139324	      8485 ns/op	    1224 B/op	     102 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=100-16         	  144330	      8370 ns/op	    1224 B/op	     102 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=100-16         	  148250	      8141 ns/op	    1224 B/op	     102 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=100-16         	  147986	      8234 ns/op	    1224 B/op	     102 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=100-16         	  148242	      8327 ns/op	    1224 B/op	     102 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=100-16         	  141300	      8372 ns/op	    1224 B/op	     102 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=100-16         	  144781	      8132 ns/op	    1224 B/op	     102 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=100-16         	  148330	      8245 ns/op	    1224 B/op	     102 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=1000-16        	   14554	     83421 ns/op	   12024 B/op	    1002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=1000-16        	   14497	     83554 ns/op	   12024 B/op	    1002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=1000-16        	   14432	     82564 ns/op	   12024 B/op	    1002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=1000-16        	   14725	     81672 ns/op	   12024 B/op	    1002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=1000-16        	   14348	     83382 ns/op	   12024 B/op	    1002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=1000-16        	   14175	     83798 ns/op	   12024 B/op	    1002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=1000-16        	   14480	     83334 ns/op	   12024 B/op	    1002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=1000-16        	   13988	     85551 ns/op	   12024 B/op	    1002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=1000-16        	   14475	     84057 ns/op	   12024 B/op	    1002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=1000-16        	   13982	     84880 ns/op	   12024 B/op	    1002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=10000-16       	    1472	    835517 ns/op	  120027 B/op	   10002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=10000-16       	    1425	    832004 ns/op	  120024 B/op	   10002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=10000-16       	    1474	    809591 ns/op	  120024 B/op	   10002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=10000-16       	    1472	    812360 ns/op	  120024 B/op	   10002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=10000-16       	    1467	    816844 ns/op	  120024 B/op	   10002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=10000-16       	    1474	    808147 ns/op	  120024 B/op	   10002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=10000-16       	    1432	    821058 ns/op	  120024 B/op	   10002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=10000-16       	    1480	    813814 ns/op	  120024 B/op	   10002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=10000-16       	    1482	    807776 ns/op	  120024 B/op	   10002 allocs/op
+BenchmarkGetMatchingPolicy/id=generated/policies=10000-16       	    1471	    805607 ns/op	  120024 B/op	   10002 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=100-16          	10700686	       112.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=100-16          	10462724	       112.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=100-16          	10664636	       112.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=100-16          	10699263	       112.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=100-16          	10464120	       113.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=100-16          	10676785	       112.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=100-16          	10555783	       112.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=100-16          	10703156	       112.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=100-16          	10635987	       112.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=100-16          	10603156	       112.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=1000-16         	 1000000	      1001 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=1000-16         	 1000000	      1008 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=1000-16         	 1000000	      1002 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=1000-16         	 1000000	      1001 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=1000-16         	 1200397	       999.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=1000-16         	 1202078	       998.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=1000-16         	 1201591	       998.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=1000-16         	 1200896	      1001 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=1000-16         	 1000000	      1003 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=1000-16         	 1000000	      1010 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=10000-16        	  102087	     11703 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=10000-16        	  103366	     11624 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=10000-16        	  101631	     11648 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=10000-16        	  103136	     11675 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=10000-16        	   98709	     11747 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=10000-16        	  102084	     11774 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=10000-16        	  102298	     11832 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=10000-16        	  100921	     11793 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=10000-16        	  101775	     11642 ns/op	       0 B/op	       0 allocs/op
+BenchmarkGetMatchingPolicy/id=explicit/policies=10000-16        	  101690	     11686 ns/op	       0 B/op	       0 allocs/op
+BenchmarkWithQuerierForCheckRequest-16                          	24303981	        49.68 ns/op	      96 B/op	       3 allocs/op
+BenchmarkWithQuerierForCheckRequest-16                          	24681369	        49.30 ns/op	      96 B/op	       3 allocs/op
+BenchmarkWithQuerierForCheckRequest-16                          	25152574	        49.77 ns/op	      96 B/op	       3 allocs/op
+BenchmarkWithQuerierForCheckRequest-16                          	23910692	        50.01 ns/op	      96 B/op	       3 allocs/op
+BenchmarkWithQuerierForCheckRequest-16                          	22677325	        50.34 ns/op	      96 B/op	       3 allocs/op
+BenchmarkWithQuerierForCheckRequest-16                          	23226124	        51.32 ns/op	      96 B/op	       3 allocs/op
+BenchmarkWithQuerierForCheckRequest-16                          	23385220	        50.85 ns/op	      96 B/op	       3 allocs/op
+BenchmarkWithQuerierForCheckRequest-16                          	23375085	        50.89 ns/op	      96 B/op	       3 allocs/op
+BenchmarkWithQuerierForCheckRequest-16                          	23490835	        50.68 ns/op	      96 B/op	       3 allocs/op
+BenchmarkWithQuerierForCheckRequest-16                          	23774301	        49.97 ns/op	      96 B/op	       3 allocs/op
+PASS
+ok  	github.com/pomerium/pomerium/authorize	84.625s
+goos: darwin
+goarch: arm64
+pkg: github.com/pomerium/pomerium/authorize/internal/store
+cpu: Apple M3 Max
+BenchmarkStoreGetDataBrokerRecord-16    	   62061	     19274 ns/op	   17617 B/op	     361 allocs/op
+BenchmarkStoreGetDataBrokerRecord-16    	   63906	     18737 ns/op	   17607 B/op	     361 allocs/op
+BenchmarkStoreGetDataBrokerRecord-16    	   59341	     19091 ns/op	   17609 B/op	     361 allocs/op
+BenchmarkStoreGetDataBrokerRecord-16    	   64148	     19610 ns/op	   17609 B/op	     361 allocs/op
+BenchmarkStoreGetDataBrokerRecord-16    	   64228	     18660 ns/op	   17606 B/op	     361 allocs/op
+BenchmarkStoreGetDataBrokerRecord-16    	   64527	     19783 ns/op	   17610 B/op	     361 allocs/op
+BenchmarkStoreGetDataBrokerRecord-16    	   62166	     18776 ns/op	   17606 B/op	     361 allocs/op
+BenchmarkStoreGetDataBrokerRecord-16    	   57524	     19190 ns/op	   17606 B/op	     361 allocs/op
+BenchmarkStoreGetDataBrokerRecord-16    	   61615	     19414 ns/op	   17609 B/op	     361 allocs/op
+BenchmarkStoreGetDataBrokerRecord-16    	   64183	     18950 ns/op	   17606 B/op	     361 allocs/op
+PASS
+ok  	github.com/pomerium/pomerium/authorize/internal/store	12.591s
+goos: darwin
+goarch: arm64
+pkg: github.com/pomerium/pomerium/authorize/evaluator
+cpu: Apple M3 Max
+BenchmarkEvaluate-16            	    5527	    193786 ns/op	  104437 B/op	    2054 allocs/op
+BenchmarkEvaluate-16            	    5756	    195455 ns/op	  104421 B/op	    2053 allocs/op
+BenchmarkEvaluate-16            	    6140	    194337 ns/op	  104413 B/op	    2053 allocs/op
+BenchmarkEvaluate-16            	    5412	    195386 ns/op	  104429 B/op	    2054 allocs/op
+BenchmarkEvaluate-16            	    6258	    195324 ns/op	  104425 B/op	    2054 allocs/op
+BenchmarkEvaluate-16            	    6145	    195812 ns/op	  104419 B/op	    2053 allocs/op
+BenchmarkEvaluate-16            	    6153	    195754 ns/op	  104427 B/op	    2054 allocs/op
+BenchmarkEvaluate-16            	    6105	    194526 ns/op	  104408 B/op	    2053 allocs/op
+BenchmarkEvaluate-16            	    5636	    193536 ns/op	  104417 B/op	    2053 allocs/op
+BenchmarkEvaluate-16            	    6393	    194598 ns/op	  104417 B/op	    2053 allocs/op
+BenchmarkHeadersEvaluator-16    	   22524	     49261 ns/op	   41903 B/op	     764 allocs/op
+BenchmarkHeadersEvaluator-16    	   23821	     49829 ns/op	   41904 B/op	     764 allocs/op
+BenchmarkHeadersEvaluator-16    	   24363	     49774 ns/op	   41906 B/op	     764 allocs/op
+BenchmarkHeadersEvaluator-16    	   24350	     49887 ns/op	   41904 B/op	     764 allocs/op
+BenchmarkHeadersEvaluator-16    	   24465	     50160 ns/op	   41904 B/op	     764 allocs/op
+BenchmarkHeadersEvaluator-16    	   24387	     49811 ns/op	   41905 B/op	     764 allocs/op
+BenchmarkHeadersEvaluator-16    	   24087	     49162 ns/op	   41903 B/op	     764 allocs/op
+BenchmarkHeadersEvaluator-16    	   23678	     50655 ns/op	   41906 B/op	     764 allocs/op
+BenchmarkHeadersEvaluator-16    	   23755	     50192 ns/op	   41905 B/op	     764 allocs/op
+BenchmarkHeadersEvaluator-16    	   24423	     50263 ns/op	   41906 B/op	     764 allocs/op
+PASS
+ok  	github.com/pomerium/pomerium/authorize/evaluator	29.860s
+goos: darwin
+goarch: arm64
+pkg: github.com/pomerium/pomerium/pkg/storage
+cpu: Apple M3 Max
+BenchmarkCachingQuerierHit-16         	  285700	      3963 ns/op	    3896 B/op	      50 allocs/op
+BenchmarkCachingQuerierHit-16         	  308952	      3934 ns/op	    3896 B/op	      50 allocs/op
+BenchmarkCachingQuerierHit-16         	  311104	      3914 ns/op	    3896 B/op	      50 allocs/op
+BenchmarkCachingQuerierHit-16         	  308944	      3941 ns/op	    3896 B/op	      50 allocs/op
+BenchmarkCachingQuerierHit-16         	  309704	      3921 ns/op	    3896 B/op	      50 allocs/op
+BenchmarkCachingQuerierHit-16         	  297034	      3935 ns/op	    3896 B/op	      50 allocs/op
+BenchmarkCachingQuerierHit-16         	  306289	      3924 ns/op	    3896 B/op	      50 allocs/op
+BenchmarkCachingQuerierHit-16         	  296642	      3921 ns/op	    3896 B/op	      50 allocs/op
+BenchmarkCachingQuerierHit-16         	  308552	      3948 ns/op	    3896 B/op	      50 allocs/op
+BenchmarkCachingQuerierHit-16         	  305862	      3919 ns/op	    3896 B/op	      50 allocs/op
+BenchmarkCachingQuerierCacheKey-16    	  391098	      3103 ns/op	    1936 B/op	      39 allocs/op
+BenchmarkCachingQuerierCacheKey-16    	  381442	      3115 ns/op	    1936 B/op	      39 allocs/op
+BenchmarkCachingQuerierCacheKey-16    	  380835	      3101 ns/op	    1936 B/op	      39 allocs/op
+BenchmarkCachingQuerierCacheKey-16    	  394936	      3090 ns/op	    1936 B/op	      39 allocs/op
+BenchmarkCachingQuerierCacheKey-16    	  379630	      3081 ns/op	    1936 B/op	      39 allocs/op
+BenchmarkCachingQuerierCacheKey-16    	  395098	      3096 ns/op	    1936 B/op	      39 allocs/op
+BenchmarkCachingQuerierCacheKey-16    	  393984	      3098 ns/op	    1936 B/op	      39 allocs/op
+BenchmarkCachingQuerierCacheKey-16    	  377769	      3117 ns/op	    1936 B/op	      39 allocs/op
+BenchmarkCachingQuerierCacheKey-16    	  391124	      3093 ns/op	    1936 B/op	      39 allocs/op
+BenchmarkCachingQuerierCacheKey-16    	  391824	      3075 ns/op	    1936 B/op	      39 allocs/op
+PASS
+ok  	github.com/pomerium/pomerium/pkg/storage	24.738s
+goos: darwin
+goarch: arm64
+pkg: github.com/pomerium/pomerium/config
+cpu: Apple M3 Max
+BenchmarkPolicyChecksum-16    	   46225	     25665 ns/op	   16408 B/op	     752 allocs/op
+BenchmarkPolicyChecksum-16    	   47668	     25797 ns/op	   16408 B/op	     752 allocs/op
+BenchmarkPolicyChecksum-16    	   47241	     25350 ns/op	   16408 B/op	     752 allocs/op
+BenchmarkPolicyChecksum-16    	   46839	     25413 ns/op	   16408 B/op	     752 allocs/op
+BenchmarkPolicyChecksum-16    	   47479	     25507 ns/op	   16408 B/op	     752 allocs/op
+BenchmarkPolicyChecksum-16    	   47534	     25274 ns/op	   16408 B/op	     752 allocs/op
+BenchmarkPolicyChecksum-16    	   47508	     25391 ns/op	   16408 B/op	     752 allocs/op
+BenchmarkPolicyChecksum-16    	   47523	     25327 ns/op	   16408 B/op	     752 allocs/op
+BenchmarkPolicyChecksum-16    	   47278	     25523 ns/op	   16408 B/op	     752 allocs/op
+BenchmarkPolicyChecksum-16    	   46898	     25384 ns/op	   16408 B/op	     752 allocs/op
+PASS
+ok  	github.com/pomerium/pomerium/config	12.646s
+goos: darwin
+goarch: arm64
+pkg: github.com/pomerium/pomerium/config/envoyconfig
+cpu: Apple M3 Max
+BenchmarkBuildRouteConfigurations/policies=100-16         	      91	  12732733 ns/op	12800222 B/op	  297226 allocs/op
+BenchmarkBuildRouteConfigurations/policies=100-16         	      93	  12685840 ns/op	12800161 B/op	  297226 allocs/op
+BenchmarkBuildRouteConfigurations/policies=100-16         	      84	  12633515 ns/op	12800040 B/op	  297226 allocs/op
+BenchmarkBuildRouteConfigurations/policies=100-16         	      92	  12606722 ns/op	12799992 B/op	  297226 allocs/op
+BenchmarkBuildRouteConfigurations/policies=100-16         	      90	  12508306 ns/op	12800078 B/op	  297226 allocs/op
+BenchmarkBuildRouteConfigurations/policies=100-16         	      92	  12582866 ns/op	12800114 B/op	  297227 allocs/op
+BenchmarkBuildRouteConfigurations/policies=100-16         	      92	  12475479 ns/op	12800102 B/op	  297227 allocs/op
+BenchmarkBuildRouteConfigurations/policies=100-16         	      93	  12614682 ns/op	12800097 B/op	  297227 allocs/op
+BenchmarkBuildRouteConfigurations/policies=100-16         	      96	  12476923 ns/op	12800077 B/op	  297227 allocs/op
+BenchmarkBuildRouteConfigurations/policies=100-16         	      91	  12497426 ns/op	12800062 B/op	  297226 allocs/op
+BenchmarkBuildRouteConfigurations/policies=1000-16        	       2	 511067729 ns/op	545506344 B/op	10171098 allocs/op
+BenchmarkBuildRouteConfigurations/policies=1000-16        	       2	 512134521 ns/op	545503216 B/op	10171121 allocs/op
+BenchmarkBuildRouteConfigurations/policies=1000-16        	       2	 506005250 ns/op	545498972 B/op	10171096 allocs/op
+BenchmarkBuildRouteConfigurations/policies=1000-16        	       2	 510798166 ns/op	545503620 B/op	10171110 allocs/op
+BenchmarkBuildRouteConfigurations/policies=1000-16        	       2	 515708708 ns/op	545498316 B/op	10171100 allocs/op
+BenchmarkBuildRouteConfigurations/policies=1000-16        	       2	 509550125 ns/op	545499784 B/op	10171088 allocs/op
+BenchmarkBuildRouteConfigurations/policies=1000-16        	       2	 509892771 ns/op	545502028 B/op	10171103 allocs/op
+BenchmarkBuildRouteConfigurations/policies=1000-16        	       2	 506613166 ns/op	545499924 B/op	10171106 allocs/op
+BenchmarkBuildRouteConfigurations/policies=1000-16        	       2	 514092708 ns/op	545502212 B/op	10171101 allocs/op
+BenchmarkBuildRouteConfigurations/policies=1000-16        	       2	 512531562 ns/op	545503004 B/op	10171116 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=100-16         	   30376	     39469 ns/op	   39584 B/op	     805 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=100-16         	   30487	     39852 ns/op	   39584 B/op	     805 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=100-16         	   30384	     39539 ns/op	   39584 B/op	     805 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=100-16         	   30272	     39505 ns/op	   39584 B/op	     805 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=100-16         	   30420	     39725 ns/op	   39584 B/op	     805 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=100-16         	   30278	     39532 ns/op	   39584 B/op	     805 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=100-16         	   30373	     39752 ns/op	   39584 B/op	     805 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=100-16         	   30237	     39531 ns/op	   39584 B/op	     805 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=100-16         	   30264	     39525 ns/op	   39584 B/op	     805 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=100-16         	   30357	     39838 ns/op	   39584 B/op	     805 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=1000-16        	    2624	    445332 ns/op	  392896 B/op	    8005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=1000-16        	    2701	    448425 ns/op	  392896 B/op	    8005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=1000-16        	    2629	    450439 ns/op	  392896 B/op	    8005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=1000-16        	    2718	    446275 ns/op	  392896 B/op	    8005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=1000-16        	    2691	    445776 ns/op	  392896 B/op	    8005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=1000-16        	    2748	    443841 ns/op	  392896 B/op	    8005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=1000-16        	    2665	    448228 ns/op	  392896 B/op	    8005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=1000-16        	    2714	    445444 ns/op	  392896 B/op	    8005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=1000-16        	    2710	    445426 ns/op	  392896 B/op	    8005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=1000-16        	    2694	    448540 ns/op	  392896 B/op	    8005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=10000-16       	     242	   4925760 ns/op	 3927809 B/op	   80005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=10000-16       	     243	   4978965 ns/op	 3927808 B/op	   80005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=10000-16       	     229	   5207193 ns/op	 3927808 B/op	   80005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=10000-16       	     228	   5248671 ns/op	 3927808 B/op	   80005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=10000-16       	     225	   5274707 ns/op	 3927809 B/op	   80005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=10000-16       	     228	   5167403 ns/op	 3927808 B/op	   80005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=10000-16       	     243	   4949761 ns/op	 3927808 B/op	   80005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=10000-16       	     242	   4938166 ns/op	 3927809 B/op	   80005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=10000-16       	     235	   4971565 ns/op	 3927808 B/op	   80005 allocs/op
+BenchmarkGetAllRouteableHTTPHosts/policies=10000-16       	     243	   4929404 ns/op	 3927808 B/op	   80005 allocs/op
+PASS
+ok  	github.com/pomerium/pomerium/config/envoyconfig	64.717s
+goos: darwin
+goarch: arm64
+pkg: github.com/pomerium/pomerium/internal/controlplane
+cpu: Apple M3 Max
+BenchmarkDiscoveryResourceEncoding-16    	     567	   2057538 ns/op	  379365 B/op	      23 allocs/op
+BenchmarkDiscoveryResourceEncoding-16    	     592	   2020794 ns/op	  377944 B/op	      13 allocs/op
+BenchmarkDiscoveryResourceEncoding-16    	     596	   2034716 ns/op	  377944 B/op	      13 allocs/op
+BenchmarkDiscoveryResourceEncoding-16    	     585	   2124299 ns/op	  377954 B/op	      13 allocs/op
+BenchmarkDiscoveryResourceEncoding-16    	     590	   2015524 ns/op	  377944 B/op	      13 allocs/op
+BenchmarkDiscoveryResourceEncoding-16    	     604	   2024249 ns/op	  377962 B/op	      13 allocs/op
+BenchmarkDiscoveryResourceEncoding-16    	     580	   2038103 ns/op	  377944 B/op	      13 allocs/op
+BenchmarkDiscoveryResourceEncoding-16    	     600	   2019385 ns/op	  377945 B/op	      13 allocs/op
+BenchmarkDiscoveryResourceEncoding-16    	     582	   2101966 ns/op	  377944 B/op	      13 allocs/op
+BenchmarkDiscoveryResourceEncoding-16    	     552	   2051528 ns/op	  377944 B/op	      13 allocs/op
+PASS
+ok  	github.com/pomerium/pomerium/internal/controlplane	12.749s

--- a/internal/controlplane/xds_bench_test.go
+++ b/internal/controlplane/xds_bench_test.go
@@ -1,0 +1,96 @@
+package controlplane
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	envoy_config_core_v3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+// newBenchRouteConfiguration builds a RouteConfiguration with numVirtualHosts
+// virtual hosts and routesPerHost routes each, following the same
+// Match/Action shape as Builder.buildPolicyRouteRouteAction and
+// Builder.buildControlPlanePathRoute in config/envoyconfig/routes.go.
+func newBenchRouteConfiguration(numVirtualHosts, routesPerHost int) *envoy_config_route_v3.RouteConfiguration {
+	rc := &envoy_config_route_v3.RouteConfiguration{
+		Name:             "https-ingress",
+		ValidateClusters: wrapperspb.Bool(false),
+	}
+	for i := range numVirtualHosts {
+		host := fmt.Sprintf("service-%d.corp.example.com", i)
+		vh := &envoy_config_route_v3.VirtualHost{
+			Name:    fmt.Sprintf("vh-%d", i),
+			Domains: []string{host, host + ":*"},
+		}
+		for j := range routesPerHost {
+			clusterName := fmt.Sprintf("route-%d-%d", i, j)
+			vh.Routes = append(vh.Routes, &envoy_config_route_v3.Route{
+				Name: fmt.Sprintf("route-%d-%d", i, j),
+				Match: &envoy_config_route_v3.RouteMatch{
+					PathSpecifier: &envoy_config_route_v3.RouteMatch_Prefix{Prefix: fmt.Sprintf("/api/v%d/", j)},
+				},
+				Decorator: &envoy_config_route_v3.Decorator{
+					Operation: "ingress: ${method} ${host}${path}",
+					Propagate: wrapperspb.Bool(false),
+				},
+				Metadata: &envoy_config_core_v3.Metadata{},
+				Action: &envoy_config_route_v3.Route_Route{
+					Route: &envoy_config_route_v3.RouteAction{
+						ClusterSpecifier: &envoy_config_route_v3.RouteAction_Cluster{
+							Cluster: clusterName,
+						},
+						Timeout:     durationpb.New(0),
+						IdleTimeout: durationpb.New(0),
+						UpgradeConfigs: []*envoy_config_route_v3.RouteAction_UpgradeConfig{
+							{UpgradeType: "websocket", Enabled: wrapperspb.Bool(true)},
+							{UpgradeType: "spdy/3.1", Enabled: wrapperspb.Bool(false)},
+						},
+						HashPolicy: []*envoy_config_route_v3.RouteAction_HashPolicy{{
+							PolicySpecifier: &envoy_config_route_v3.RouteAction_HashPolicy_Header_{
+								Header: &envoy_config_route_v3.RouteAction_HashPolicy_Header{
+									HeaderName: "x-pomerium-routing-key",
+								},
+							},
+							Terminal: true,
+						}},
+					},
+				},
+				ResponseHeadersToAdd: []*envoy_config_core_v3.HeaderValueOption{{
+					Header: &envoy_config_core_v3.HeaderValue{
+						Key:   "x-frame-options",
+						Value: "SAMEORIGIN",
+					},
+				}},
+			})
+		}
+		rc.VirtualHosts = append(rc.VirtualHosts, vh)
+	}
+	return rc
+}
+
+// BenchmarkDiscoveryResourceEncoding times the per-resource encode pattern
+// used in Server.buildDiscoveryResources (internal/controlplane/xds.go):
+// cryptutil.HashProto followed by protoutil.NewAny, both of which
+// deterministically marshal the same message.
+var (
+	benchDiscoveryResourceVersionSink string
+	benchDiscoveryResourceAnySink     *anypb.Any
+)
+
+func BenchmarkDiscoveryResourceEncoding(b *testing.B) {
+	rc := newBenchRouteConfiguration(50, 20) // 1000 routes total
+
+	b.ReportAllocs()
+	for b.Loop() {
+		benchDiscoveryResourceVersionSink = hex.EncodeToString(cryptutil.HashProto(rc))
+		benchDiscoveryResourceAnySink = protoutil.NewAny(rc)
+	}
+}

--- a/pkg/storage/querier_caching.go
+++ b/pkg/storage/querier_caching.go
@@ -53,8 +53,13 @@ func (q *cachingQuerier) Query(ctx context.Context, in *databroker.QueryRequest,
 func (*cachingQuerier) Stop() {}
 
 func (q *cachingQuerier) getCacheKey(in *databroker.QueryRequest) ([]byte, error) {
-	in = proto.Clone(in).(*databroker.QueryRequest)
-	in.MinimumRecordVersionHint = nil
+	// the minimum record version hint is a freshness requirement, not part of
+	// the query identity, so it is excluded from the cache key. Cloning is only
+	// needed to strip it.
+	if in.MinimumRecordVersionHint != nil {
+		in = proto.Clone(in).(*databroker.QueryRequest)
+		in.MinimumRecordVersionHint = nil
+	}
 	return MarshalQueryRequest(in)
 }
 

--- a/pkg/storage/querier_caching_bench_test.go
+++ b/pkg/storage/querier_caching_bench_test.go
@@ -1,0 +1,120 @@
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+)
+
+type benchmarkCountingQuerier struct {
+	Querier
+	queryCount int
+}
+
+func (q *benchmarkCountingQuerier) Query(
+	ctx context.Context,
+	in *databroker.QueryRequest,
+	opts ...grpc.CallOption,
+) (*databroker.QueryResponse, error) {
+	q.queryCount++
+	return q.Querier.Query(ctx, in, opts...)
+}
+
+func newBenchSession() *session.Session {
+	now := time.Now()
+	return &session.Session{
+		Version:    "1",
+		Id:         "1a5e57ce-6bd0-4e00-9a1a-3f3c1b1b5b8f",
+		UserId:     "IdP-User-ID/1a5e57ce-6bd0-4e00-9a1a-3f3c1b1b5b8f",
+		IssuedAt:   timestamppb.New(now),
+		ExpiresAt:  timestamppb.New(now.Add(time.Hour)),
+		AccessedAt: timestamppb.New(now),
+		IdToken: &session.IDToken{
+			Issuer:    "https://accounts.example.com",
+			Subject:   "1a5e57ce-6bd0-4e00-9a1a-3f3c1b1b5b8f",
+			ExpiresAt: timestamppb.New(now.Add(time.Hour)),
+			IssuedAt:  timestamppb.New(now),
+			Raw:       "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature",
+		},
+		OauthToken: &session.OAuthToken{
+			AccessToken:  "ya29.a0ARrdaM-example-access-token-value",
+			TokenType:    "Bearer",
+			ExpiresAt:    timestamppb.New(now.Add(time.Hour)),
+			RefreshToken: "1//0g-example-refresh-token-value",
+		},
+		Claims: map[string]*structpb.ListValue{
+			"email":          {Values: []*structpb.Value{structpb.NewStringValue("user@example.com")}},
+			"email_verified": {Values: []*structpb.Value{structpb.NewBoolValue(true)}},
+			"groups": {Values: []*structpb.Value{
+				structpb.NewStringValue("engineering"),
+				structpb.NewStringValue("everyone"),
+				structpb.NewStringValue("admins"),
+			}},
+			"name": {Values: []*structpb.Value{structpb.NewStringValue("Example User")}},
+		},
+		Audience: []string{"pomerium-proxy", "pomerium-authenticate"},
+		IdpId:    "google",
+	}
+}
+
+func BenchmarkCachingQuerierHit(b *testing.B) {
+	ctx := b.Context()
+	sess := newBenchSession()
+	inner := &benchmarkCountingQuerier{Querier: NewStaticQuerier(sess)}
+	cache := NewGlobalCache(time.Minute)
+	q := NewCachingQuerier(inner, cache)
+
+	req := &databroker.QueryRequest{
+		Type:  "type.googleapis.com/session.Session",
+		Limit: 1,
+	}
+	req.SetFilterByIDOrIndex(sess.Id)
+
+	res, err := q.Query(ctx, req)
+	if err != nil {
+		b.Fatal(err)
+	}
+	if len(res.GetRecords()) != 1 || res.GetRecords()[0].GetId() != sess.GetId() {
+		b.Fatal("unexpected cached query response")
+	}
+	if inner.queryCount != 1 {
+		b.Fatal("expected one query to warm the cache")
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := q.Query(ctx, req); err != nil {
+			b.Fatal(err)
+		}
+	}
+	if inner.queryCount != 1 {
+		b.Fatalf("cache miss during benchmark: underlying query count = %d", inner.queryCount)
+	}
+}
+
+func BenchmarkCachingQuerierCacheKey(b *testing.B) {
+	sess := newBenchSession()
+	inner := NewStaticQuerier(sess)
+	cache := NewGlobalCache(time.Minute)
+	q := NewCachingQuerier(inner, cache).(*cachingQuerier)
+
+	req := &databroker.QueryRequest{
+		Type:  "type.googleapis.com/session.Session",
+		Limit: 1,
+	}
+	req.SetFilterByIDOrIndex(sess.Id)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := q.getCacheKey(req); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/storage/querier_caching_internal_test.go
+++ b/pkg/storage/querier_caching_internal_test.go
@@ -1,0 +1,38 @@
+package storage
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+func TestCachingQuerierGetCacheKey(t *testing.T) {
+	t.Parallel()
+
+	q := new(cachingQuerier)
+	withoutHint := &databroker.QueryRequest{
+		Type:  "type.googleapis.com/example.Record",
+		Limit: 1,
+	}
+	withoutHint.SetFilterByIDOrIndex("record-1")
+
+	withoutHintBefore := proto.Clone(withoutHint).(*databroker.QueryRequest)
+	want, err := MarshalQueryRequest(withoutHint)
+	require.NoError(t, err)
+	got, err := q.getCacheKey(withoutHint)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(want, got))
+	require.True(t, proto.Equal(withoutHintBefore, withoutHint), "request without hint was mutated")
+
+	withHint := proto.Clone(withoutHint).(*databroker.QueryRequest)
+	withHint.MinimumRecordVersionHint = proto.Uint64(42)
+	withHintBefore := proto.Clone(withHint).(*databroker.QueryRequest)
+	got, err = q.getCacheKey(withHint)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(want, got), "minimum record version hint changed the cache key")
+	require.True(t, proto.Equal(withHintBefore, withHint), "request with hint was mutated")
+}


### PR DESCRIPTION

## Summary

Existing startup, request-latency, and headers benchmarks do not isolate the component costs targeted by this work or provide a committed same-machine comparison workflow. This adds focused Go benchmarks for policy lookup and evaluation, databroker query and cache work, route configuration construction, policy checksums, and xDS resource encoding. It does not change production code.

`make bench-baseline` records a local baseline. `make bench` runs the same benchmark set and compares it with benchstat. Packages run serially with `-p=1`, and benchstat is pinned so two runs use the same comparison logic. Benchmark failures are printed and cannot replace the baseline or be passed to benchstat as partial output.

The committed baseline was recorded on an Apple M3 Max with Go 1.26.5 and `-count=10`. It is a reference, not a cross-machine performance threshold: meaningful comparisons require regenerating the baseline and measuring the change on the same machine. The standard targets use `-short`, which omits the pre-optimization 10,000-policy route-build case, and intentionally run without `-race` because the race detector changes the costs being measured.

## Related issues

- None

## User Explanation

## AI disclosure

Claude Code using the Fable model drafted the initial benchmark scaffolding. Codex revised the setup, assertions, serialization, and failure handling and regenerated the baseline. I reviewed and edited the final diff and description.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`)
- [x] disclosed AI usage per AI_POLICY.md
- [x] ready for review

