### PR TITLE
storage: skip unnecessary query clone when building cache keys

### DIFF
--- a/pkg/storage/querier_caching.go
+++ b/pkg/storage/querier_caching.go
@@ -53,8 +53,13 @@ func (q *cachingQuerier) Query(ctx context.Context, in *databroker.QueryRequest,
 func (*cachingQuerier) Stop() {}
 
 func (q *cachingQuerier) getCacheKey(in *databroker.QueryRequest) ([]byte, error) {
-	in = proto.Clone(in).(*databroker.QueryRequest)
-	in.MinimumRecordVersionHint = nil
+	// the minimum record version hint is a freshness requirement, not part of
+	// the query identity, so it is excluded from the cache key. Cloning is only
+	// needed to strip it.
+	if in.MinimumRecordVersionHint != nil {
+		in = proto.Clone(in).(*databroker.QueryRequest)
+		in.MinimumRecordVersionHint = nil
+	}
 	return MarshalQueryRequest(in)
 }
 

--- a/pkg/storage/querier_caching_internal_test.go
+++ b/pkg/storage/querier_caching_internal_test.go
@@ -1,0 +1,38 @@
+package storage
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+func TestCachingQuerierGetCacheKey(t *testing.T) {
+	t.Parallel()
+
+	q := new(cachingQuerier)
+	withoutHint := &databroker.QueryRequest{
+		Type:  "type.googleapis.com/example.Record",
+		Limit: 1,
+	}
+	withoutHint.SetFilterByIDOrIndex("record-1")
+
+	withoutHintBefore := proto.Clone(withoutHint).(*databroker.QueryRequest)
+	want, err := MarshalQueryRequest(withoutHint)
+	require.NoError(t, err)
+	got, err := q.getCacheKey(withoutHint)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(want, got))
+	require.True(t, proto.Equal(withoutHintBefore, withoutHint), "request without hint was mutated")
+
+	withHint := proto.Clone(withoutHint).(*databroker.QueryRequest)
+	withHint.MinimumRecordVersionHint = proto.Uint64(42)
+	withHintBefore := proto.Clone(withHint).(*databroker.QueryRequest)
+	got, err = q.getCacheKey(withHint)
+	require.NoError(t, err)
+	require.True(t, bytes.Equal(want, got), "minimum record version hint changed the cache key")
+	require.True(t, proto.Equal(withHintBefore, withHint), "request with hint was mutated")
+}


### PR DESCRIPTION

## Summary

`cachingQuerier.getCacheKey` cloned every protobuf query request so it could clear `MinimumRecordVersionHint` before deterministic marshaling. The hint is a freshness requirement rather than part of query identity. When it is unset, cloning the request changes neither the key nor the caller's request.

This marshals the request directly when the hint is nil. When the hint is present, it retains the existing clone-and-clear path. Freshness behavior is unchanged: `Query` still checks the hint against the cached response version and invalidates and retries when necessary.

Benchstat results from 10 same-machine runs on an Apple M3 Max with Go 1.26.5:

| Benchmark | Before | After | Allocations/op |
| --- | ---: | ---: | ---: |
| Cache key | 3.097 us | 1.492 us (-52%) | 39 -> 13 |
| Cache hit | 3.929 us | 2.260 us (-42%) | 50 -> 24 |

This is a constant reduction for hint-free cached queries, not a route-count scaling change or an end-to-end latency measurement.

A direct regression test verifies identical keys with and without the freshness hint and verifies that neither branch mutates the caller's request. Existing cache freshness tests continue to pass.

## Related issues

- None

## User Explanation

## AI disclosure

Claude Code using the Fable model drafted the initial implementation and benchmarks. Codex revised the code and tests and reproduced the benchmark results. I reviewed and edited the final diff and description.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`)
- [x] disclosed AI usage per AI_POLICY.md
- [x] ready for review

