### PR TITLE
envoyconfig: avoid quadratic policy scans during route building

### DIFF
--- a/config/envoyconfig/route_configurations.go
+++ b/config/envoyconfig/route_configurations.go
@@ -85,6 +85,16 @@ func (b *Builder) buildMainRouteConfiguration(
 		return nil, err
 	}
 
+	// index policies by host once so that adding policy routes to a virtual
+	// host doesn't require scanning every policy
+	var policyIdx policyHostIndex
+	if config.IsProxy(cfg.Options.Services) {
+		policyIdx, err = indexPoliciesByHost(cfg.Options)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	var virtualHosts []*envoy_config_route_v3.VirtualHost
 	for _, host := range allHosts {
 		vh, err := b.buildVirtualHost(cfg.Options, host, host, mcpHosts[host])
@@ -106,7 +116,7 @@ func (b *Builder) buildMainRouteConfiguration(
 
 		// if we're the proxy, add all the policy routes
 		if config.IsProxy(cfg.Options.Services) {
-			rs, err := b.buildRoutesForPoliciesWithHost(cfg, host)
+			rs, err := b.buildRoutesForPoliciesWithHost(cfg, policyIdx, host)
 			if err != nil {
 				return nil, err
 			}
@@ -123,7 +133,7 @@ func (b *Builder) buildMainRouteConfiguration(
 		return nil, err
 	}
 	if config.IsProxy(cfg.Options.Services) {
-		rs, err := b.buildRoutesForPoliciesWithCatchAll(cfg)
+		rs, err := b.buildRoutesForPoliciesWithCatchAll(cfg, policyIdx)
 		if err != nil {
 			return nil, err
 		}

--- a/config/envoyconfig/routes.go
+++ b/config/envoyconfig/routes.go
@@ -190,47 +190,68 @@ func getClusterStatsName(policy *config.Policy) string {
 	return policy.Name
 }
 
-func (b *Builder) buildRoutesForPoliciesWithHost(
-	cfg *config.Config,
-	host string,
-) ([]*envoy_config_route_v3.Route, error) {
-	var routes []*envoy_config_route_v3.Route
-	for i, p := range cfg.Options.GetAllPoliciesIndexed() {
-		policy := p
+// An indexedPolicy is a policy along with its position in the list of all
+// policies and its parsed From URL.
+type indexedPolicy struct {
+	policy  *config.Policy
+	fromURL *url.URL
+	index   int
+}
+
+// A policyHostIndex indexes policies by the domains their From URL matches so
+// that building routes for a host is a map lookup instead of a scan over
+// every policy. Slices preserve policy order.
+type policyHostIndex struct {
+	byHost   map[string][]indexedPolicy
+	catchAll []indexedPolicy // policies with a wildcard in the From host
+}
+
+func indexPoliciesByHost(options *config.Options) (policyHostIndex, error) {
+	idx := policyHostIndex{byHost: make(map[string][]indexedPolicy)}
+	for i, policy := range options.GetAllPoliciesIndexed() {
 		fromURL, err := urlutil.ParseAndValidateURL(policy.From)
 		if err != nil {
-			return nil, err
+			return policyHostIndex{}, err
 		}
 
-		if !urlMatchesHost(fromURL, host) {
-			continue
+		ip := indexedPolicy{policy: policy, fromURL: fromURL, index: i}
+		// the same domains urlMatchesHost compares against
+		domains := urlutil.GetDomainsForURL(fromURL, true)
+		for j, domain := range domains {
+			if slices.Contains(domains[:j], domain) {
+				continue // index each (policy, domain) pair at most once
+			}
+			idx.byHost[domain] = append(idx.byHost[domain], ip)
 		}
-
-		policyRoutes, err := b.buildRoutesForPolicy(cfg, policy, fmt.Sprintf("policy-%d", i))
-		if err != nil {
-			return nil, err
+		if strings.Contains(fromURL.Host, "*") {
+			idx.catchAll = append(idx.catchAll, ip)
 		}
-
-		routes = append(routes, policyRoutes...)
 	}
-	return routes, nil
+	return idx, nil
+}
+
+func (b *Builder) buildRoutesForPoliciesWithHost(
+	cfg *config.Config,
+	idx policyHostIndex,
+	host string,
+) ([]*envoy_config_route_v3.Route, error) {
+	return b.buildRoutesForIndexedPolicies(cfg, idx.byHost[host])
 }
 
 func (b *Builder) buildRoutesForPoliciesWithCatchAll(
 	cfg *config.Config,
+	idx policyHostIndex,
+) ([]*envoy_config_route_v3.Route, error) {
+	return b.buildRoutesForIndexedPolicies(cfg, idx.catchAll)
+}
+
+func (b *Builder) buildRoutesForIndexedPolicies(
+	cfg *config.Config,
+	policies []indexedPolicy,
 ) ([]*envoy_config_route_v3.Route, error) {
 	var routes []*envoy_config_route_v3.Route
-	for i, policy := range cfg.Options.GetAllPoliciesIndexed() {
-		fromURL, err := urlutil.ParseAndValidateURL(policy.From)
-		if err != nil {
-			return nil, err
-		}
-
-		if !strings.Contains(fromURL.Host, "*") {
-			continue
-		}
-
-		policyRoutes, err := b.buildRoutesForPolicy(cfg, policy, fmt.Sprintf("policy-%d", i))
+	for _, ip := range policies {
+		policyRoutes, err := b.buildRoutesForPolicy(cfg, ip.policy, ip.fromURL, fmt.Sprintf("policy-%d", ip.index))
 		if err != nil {
 			return nil, err
 		}
@@ -243,25 +264,21 @@ func (b *Builder) buildRoutesForPoliciesWithCatchAll(
 func (b *Builder) buildRoutesForPolicy(
 	cfg *config.Config,
 	policy *config.Policy,
+	fromURL *url.URL,
 	name string,
 ) ([]*envoy_config_route_v3.Route, error) {
-	fromURL, err := urlutil.ParseAndValidateURL(policy.From)
-	if err != nil {
-		return nil, err
-	}
-
 	var routes []*envoy_config_route_v3.Route
 	if strings.Contains(fromURL.Host, "*") {
 		// we have to match '*.example.com' and '*.example.com:443', so there are two routes
 		for _, host := range urlutil.GetDomainsForURL(fromURL, !cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMatchAnyIncomingPort)) {
-			route, err := b.buildRouteForPolicyAndMatch(cfg, policy, name, mkRouteMatchForHost(cfg.Options, policy, host))
+			route, err := b.buildRouteForPolicyAndMatch(cfg, policy, fromURL, name, mkRouteMatchForHost(cfg.Options, policy, host))
 			if err != nil {
 				return nil, err
 			}
 			routes = append(routes, route)
 		}
 	} else {
-		route, err := b.buildRouteForPolicyAndMatch(cfg, policy, name, mkRouteMatch(policy))
+		route, err := b.buildRouteForPolicyAndMatch(cfg, policy, fromURL, name, mkRouteMatch(policy))
 		if err != nil {
 			return nil, err
 		}
@@ -273,14 +290,10 @@ func (b *Builder) buildRoutesForPolicy(
 func (b *Builder) buildRouteForPolicyAndMatch(
 	cfg *config.Config,
 	policy *config.Policy,
+	fromURL *url.URL,
 	name string,
 	match *envoy_config_route_v3.RouteMatch,
 ) (*envoy_config_route_v3.Route, error) {
-	fromURL, err := urlutil.ParseAndValidateURL(policy.From)
-	if err != nil {
-		return nil, err
-	}
-
 	routeID, err := policy.RouteID()
 	if err != nil {
 		return nil, err

--- a/config/envoyconfig/routes_differential_test.go
+++ b/config/envoyconfig/routes_differential_test.go
@@ -1,0 +1,165 @@
+package envoyconfig
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	envoy_config_route_v3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/config/envoyconfig/filemgr"
+	"github.com/pomerium/pomerium/internal/httputil/reproxy"
+	"github.com/pomerium/pomerium/internal/urlutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+)
+
+// buildRoutesForPoliciesWithHostByScan preserves the linear-scan behavior
+// replaced by policyHostIndex.
+func buildRoutesForPoliciesWithHostByScan(t *testing.T, b *Builder, cfg *config.Config, host string) []*envoy_config_route_v3.Route {
+	t.Helper()
+	var routes []*envoy_config_route_v3.Route
+	for i, policy := range cfg.Options.GetAllPoliciesIndexed() {
+		fromURL, err := urlutil.ParseAndValidateURL(policy.From)
+		require.NoError(t, err)
+		if !urlMatchesHost(fromURL, host) {
+			continue
+		}
+		pr, err := b.buildRoutesForPolicy(cfg, policy, fromURL, fmt.Sprintf("policy-%d", i))
+		require.NoError(t, err)
+		routes = append(routes, pr...)
+	}
+	return routes
+}
+
+// buildRoutesForPoliciesWithCatchAllByScan preserves the catch-all scan
+// replaced by policyHostIndex.
+func buildRoutesForPoliciesWithCatchAllByScan(t *testing.T, b *Builder, cfg *config.Config) []*envoy_config_route_v3.Route {
+	t.Helper()
+	var routes []*envoy_config_route_v3.Route
+	for i, policy := range cfg.Options.GetAllPoliciesIndexed() {
+		fromURL, err := urlutil.ParseAndValidateURL(policy.From)
+		require.NoError(t, err)
+		if !strings.Contains(fromURL.Host, "*") {
+			continue
+		}
+		pr, err := b.buildRoutesForPolicy(cfg, policy, fromURL, fmt.Sprintf("policy-%d", i))
+		require.NoError(t, err)
+		routes = append(routes, pr...)
+	}
+	return routes
+}
+
+func assertRoutesEqualInOrder(t *testing.T, label string, want, got []*envoy_config_route_v3.Route) {
+	t.Helper()
+	require.Equal(t, len(want), len(got), "%s: route count differs (old=%d new=%d)", label, len(want), len(got))
+	for i := range want {
+		if !proto.Equal(want[i], got[i]) {
+			t.Errorf("%s: route[%d] differs old-vs-new\n old cluster=%s match=%v\n new cluster=%s match=%v",
+				label, i,
+				want[i].GetRoute().GetCluster(), want[i].GetMatch(),
+				got[i].GetRoute().GetCluster(), got[i].GetMatch())
+		}
+	}
+}
+
+func hostIndexTestOptions(t *testing.T) config.Options {
+	t.Helper()
+	// Policies deliberately interleave: same host different paths, exact + wildcard
+	// for the same apex, explicit default and non-default ports, and duplicates,
+	// then split across the three GetAllPolicies slices to exercise iteration order.
+	return config.Options{
+		CookieName:             "pomerium",
+		DefaultUpstreamTimeout: 3 * time.Second,
+		SharedKey:              cryptutil.NewBase64Key(),
+		Services:               "proxy",
+		Policies: []config.Policy{
+			{From: "https://foo.example.com", Path: "/a", To: mustParseWeightedURLs(t, "https://to1.example.com")},
+			{From: "https://*.example.com", To: mustParseWeightedURLs(t, "https://wild.example.com")},
+			{From: "https://foo.example.com", Path: "/b", To: mustParseWeightedURLs(t, "https://to2.example.com")},
+		},
+		Routes: []config.Policy{
+			{From: "https://foo.example.com:8443", To: mustParseWeightedURLs(t, "https://to3.example.com")},
+			{From: "https://foo.example.com:443", Path: "/c", To: mustParseWeightedURLs(t, "https://to4.example.com")},
+			{From: "https://bar.example.com", To: mustParseWeightedURLs(t, "https://to5.example.com")},
+			{
+				From: "tcp+https://proxy.example.com/db.example.com:5432/cache.example.com:6379",
+				To:   mustParseWeightedURLs(t, "tcp://upstream.example.com:5432"),
+			},
+		},
+		AdditionalPolicies: []config.Policy{
+			{From: "https://foo.example.com", Path: "/d", To: mustParseWeightedURLs(t, "https://to6.example.com")},
+			{From: "https://*.other.example.com", To: mustParseWeightedURLs(t, "https://wild2.example.com")},
+			{From: "https://example.com", To: mustParseWeightedURLs(t, "https://apex.example.com")},
+		},
+	}
+}
+
+// hostIndexCandidateHosts collects every host string that any policy could
+// conceivably be bucketed under, under either value of includeDefaultPort, so
+// the diff can't miss a host where old and new might disagree.
+func hostIndexCandidateHosts(t *testing.T, opts *config.Options) []string {
+	t.Helper()
+	seen := map[string]bool{}
+	var hosts []string
+	add := func(h string) {
+		if h == "" || strings.Contains(h, "*") || seen[h] {
+			return
+		}
+		seen[h] = true
+		hosts = append(hosts, h)
+	}
+	for p := range opts.GetAllPolicies() {
+		u, err := urlutil.ParseAndValidateURL(p.From)
+		require.NoError(t, err)
+		for _, d := range urlutil.GetDomainsForURL(u, true) {
+			add(d)
+		}
+		for _, d := range urlutil.GetDomainsForURL(u, false) {
+			add(d)
+		}
+		// concrete hosts a wildcard could expand to
+		add(strings.Replace(u.Hostname(), "*", "sub", 1))
+	}
+	slices.Sort(hosts)
+	return hosts
+}
+
+func TestPolicyHostIndexMatchesScan(t *testing.T) {
+	for _, matchAnyPort := range []bool{false, true} {
+		t.Run(fmt.Sprintf("matchAnyIncomingPort=%v", matchAnyPort), func(t *testing.T) {
+			opts := hostIndexTestOptions(t)
+			if matchAnyPort {
+				opts.RuntimeFlags = map[config.RuntimeFlag]bool{config.RuntimeFlagMatchAnyIncomingPort: true}
+			}
+			cfg := config.New(&opts)
+
+			b := &Builder{filemgr: filemgr.NewManager(), reproxy: reproxy.New()}
+
+			// New indexed path (production).
+			idx, err := indexPoliciesByHost(cfg.Options)
+			require.NoError(t, err)
+
+			hosts := hostIndexCandidateHosts(t, cfg.Options)
+			require.NotEmpty(t, hosts)
+			t.Logf("candidate hosts: %v", hosts)
+
+			for _, host := range hosts {
+				old := buildRoutesForPoliciesWithHostByScan(t, b, cfg, host)
+				got, err := b.buildRoutesForPoliciesWithHost(cfg, idx, host)
+				require.NoError(t, err)
+				assertRoutesEqualInOrder(t, "host="+host, old, got)
+			}
+
+			// Catch-all virtual host.
+			oldCatch := buildRoutesForPoliciesWithCatchAllByScan(t, b, cfg)
+			gotCatch, err := b.buildRoutesForPoliciesWithCatchAll(cfg, idx)
+			require.NoError(t, err)
+			assertRoutesEqualInOrder(t, "catch-all", oldCatch, gotCatch)
+		})
+	}
+}

--- a/config/envoyconfig/routes_test.go
+++ b/config/envoyconfig/routes_test.go
@@ -19,6 +19,16 @@ import (
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 )
 
+// buildRoutesForHost indexes cfg's policies and builds the routes for host,
+// mirroring what buildMainRouteConfiguration does per virtual host.
+func buildRoutesForHost(b *Builder, cfg *config.Config, host string) ([]*envoy_config_route_v3.Route, error) {
+	idx, err := indexPoliciesByHost(cfg.Options)
+	if err != nil {
+		return nil, err
+	}
+	return b.buildRoutesForPoliciesWithHost(cfg, idx, host)
+}
+
 func policyNameFunc() func(*config.Policy) string {
 	i := 0
 	return func(*config.Policy) string {
@@ -284,7 +294,7 @@ func TestTimeouts(t *testing.T) {
 		if tc.mcpServer {
 			policy.MCP = &config.MCP{Server: &config.MCPServer{}}
 		}
-		routes, err := b.buildRoutesForPoliciesWithHost(config.New(&config.Options{
+		routes, err := buildRoutesForHost(b, config.New(&config.Options{
 			CookieName:             "pomerium",
 			DefaultUpstreamTimeout: time.Second * 3,
 			SharedKey:              cryptutil.NewBase64Key(),
@@ -432,7 +442,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	}
 
 	b := &Builder{filemgr: filemgr.NewManager(), reproxy: reproxy.New()}
-	routes, err := b.buildRoutesForPoliciesWithHost(config.New(&config.Options{
+	routes, err := buildRoutesForHost(b, config.New(&config.Options{
 		CookieName:             "pomerium",
 		DefaultUpstreamTimeout: time.Second * 3,
 		SharedKey:              cryptutil.NewBase64Key(),
@@ -1056,7 +1066,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	`, routes)
 
 	t.Run("fronting-authenticate", func(t *testing.T) {
-		routes, err := b.buildRoutesForPoliciesWithHost(config.New(&config.Options{
+		routes, err := buildRoutesForHost(b, config.New(&config.Options{
 			AuthenticateURLString:  "https://authenticate.example.com",
 			Services:               "proxy",
 			CookieName:             "pomerium",
@@ -1146,7 +1156,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	})
 
 	t.Run("tcp", func(t *testing.T) {
-		routes, err := b.buildRoutesForPoliciesWithHost(config.New(&config.Options{
+		routes, err := buildRoutesForHost(b, config.New(&config.Options{
 			CookieName:             "pomerium",
 			DefaultUpstreamTimeout: time.Second * 3,
 			SharedKey:              cryptutil.NewBase64Key(),
@@ -1329,7 +1339,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	})
 
 	t.Run("udp", func(t *testing.T) {
-		routes, err := b.buildRoutesForPoliciesWithHost(config.New(&config.Options{
+		routes, err := buildRoutesForHost(b, config.New(&config.Options{
 			CookieName:             "pomerium",
 			DefaultUpstreamTimeout: time.Second * 3,
 			SharedKey:              cryptutil.NewBase64Key(),
@@ -1428,7 +1438,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	})
 
 	t.Run("remove-pomerium-headers", func(t *testing.T) {
-		routes, err := b.buildRoutesForPoliciesWithHost(config.New(&config.Options{
+		routes, err := buildRoutesForHost(b, config.New(&config.Options{
 			AuthenticateURLString:  "https://authenticate.example.com",
 			Services:               "proxy",
 			CookieName:             "pomerium",
@@ -1532,7 +1542,7 @@ func Test_buildPolicyRoutes(t *testing.T) {
 	})
 
 	t.Run("kubernetes", func(t *testing.T) {
-		routes, err := b.buildRoutesForPoliciesWithHost(config.New(&config.Options{
+		routes, err := buildRoutesForHost(b, config.New(&config.Options{
 			AuthenticateURLString: "https://authenticate.example.com",
 			Services:              "proxy",
 			CookieName:            "pomerium",
@@ -1655,7 +1665,7 @@ func Test_buildPolicyRoutesRewrite(t *testing.T) {
 	}(GetClusterID)
 	GetClusterID = policyNameFunc()
 	b := &Builder{filemgr: filemgr.NewManager()}
-	routes, err := b.buildRoutesForPoliciesWithHost(config.New(&config.Options{
+	routes, err := buildRoutesForHost(b, config.New(&config.Options{
 		CookieName:             "pomerium",
 		DefaultUpstreamTimeout: time.Second * 3,
 		SharedKey:              cryptutil.NewBase64Key(),


### PR DESCRIPTION

## Summary

`buildMainRouteConfiguration` previously scanned every policy for every routeable host and parsed each policy's `From` URL on each scan. With distinct policy hosts, the host-to-policy selection step therefore grew as `hosts x policies`.

This builds a policy host index once per route-configuration build, keyed by the same `urlutil.GetDomainsForURL(fromURL, true)` values used by the old `urlMatchesHost` predicate. Per-host selection becomes a map lookup, wildcard policies have a separate catch-all bucket, and every bucket preserves `GetAllPoliciesIndexed` order. That order is unchanged because it determines Envoy route precedence.

`BenchmarkBuildRouteConfigurations` uses one HTTPS policy per distinct host. Results were measured on the same Apple M3 Max with Go 1.26.5:

| Configured policies | Before | After | Allocations/op |
| ---: | ---: | ---: | ---: |
| 100 | 12.60 ms | 8.29 ms (-34%) | 297k -> 217k |
| 1,000 | 510.9 ms | 85.7 ms (-83%) | 10.17M -> 2.17M |
| 10,000 | 43.43 s | 0.843 s (about 52x) | 821.7M -> 21.72M |

The 100- and 1,000-policy rows are benchstat results from 10 runs. The 10,000-policy row is the observed median of three `-benchtime=1x` samples; three samples are not enough for a confidence interval or significance claim.

In the synthetic 10,000-policy case, route configuration construction falls below one second. This is not a complete config apply: cluster construction, validation, and the xDS push are outside the benchmark. The policy count is also not a literal Envoy route count because one policy can produce multiple routes.

A differential test reconstructs the old scans and compares all policy routes produced for an adversarial fixture with `proto.Equal` in the same order across host, port, wildcard, TCP, policy-source, and runtime-flag cases. Existing golden tests pass unchanged.

## Related issues

- None

## User Explanation

## AI disclosure

Claude Code using the Fable model drafted the initial implementation and benchmarks. Codex revised the code and tests and reproduced the benchmark results. I reviewed and edited the final diff and description.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`)
- [x] disclosed AI usage per AI_POLICY.md
- [x] ready for review

