### PR TITLE
authorize: index policy route IDs in authorize state

### DIFF
--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -45,7 +45,7 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 	requestID := requestid.FromHTTPHeader(hreq.Header)
 	ctx = requestid.WithValue(ctx, requestID)
 
-	req, err := a.getEvaluatorRequestFromCheckRequest(ctx, in, mcpEnabled)
+	req, err := a.getEvaluatorRequestFromCheckRequest(ctx, state, in, mcpEnabled)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Str("request-id", requestID).Msg("error building evaluator request")
 		return nil, err
@@ -211,6 +211,7 @@ func (a *Authorize) getMCPSession(
 
 func (a *Authorize) getEvaluatorRequestFromCheckRequest(
 	ctx context.Context,
+	state *authorizeState,
 	in *envoy_service_auth_v3.CheckRequest,
 	mcpEnabled bool,
 ) (*evaluator.Request, error) {
@@ -221,7 +222,7 @@ func (a *Authorize) getEvaluatorRequestFromCheckRequest(
 		EnvoyRouteChecksum: envoyconfig.ExtAuthzContextExtensionsRouteChecksum(attrs.GetContextExtensions()),
 		EnvoyRouteID:       envoyconfig.ExtAuthzContextExtensionsRouteID(attrs.GetContextExtensions()),
 	}
-	req.Policy = a.getMatchingPolicy(req.EnvoyRouteID)
+	req.Policy = state.getMatchingPolicy(req.EnvoyRouteID)
 
 	if mcpEnabled && req.Policy.IsMCPServer() {
 		var err error
@@ -237,17 +238,10 @@ func (a *Authorize) getEvaluatorRequestFromCheckRequest(
 	return req, nil
 }
 
-func (a *Authorize) getMatchingPolicy(routeID string) *config.Policy {
-	options := a.currentConfig.Load().Options
-
-	for p := range options.GetAllPolicies() {
-		id, _ := p.RouteID()
-		if id == routeID {
-			return p
-		}
-	}
-
-	return nil
+// getMatchingPolicy returns the policy for the request's route ID, using the
+// index built from the same config snapshot as the rest of this state.
+func (s *authorizeState) getMatchingPolicy(routeID string) *config.Policy {
+	return s.policiesByRouteID[routeID]
 }
 
 func (a *Authorize) withQuerierForCheckRequest(ctx context.Context) context.Context {

--- a/authorize/grpc_bench_test.go
+++ b/authorize/grpc_bench_test.go
@@ -7,9 +7,8 @@ import (
 	"github.com/pomerium/pomerium/config"
 )
 
-// BenchmarkGetMatchingPolicy measures a.getMatchingPolicy, which linearly
-// scans every configured policy computing its RouteID until it finds the one
-// matching the request's route ID.
+// BenchmarkGetMatchingPolicy measures getMatchingPolicy, the per-request
+// lookup of the policy matching the request's route ID.
 func BenchmarkGetMatchingPolicy(b *testing.B) {
 	for _, idType := range []struct {
 		name     string
@@ -37,10 +36,12 @@ func BenchmarkGetMatchingPolicy(b *testing.B) {
 					}
 
 					a := &Authorize{}
-					a.currentConfig.Store(config.New(&config.Options{Policies: policies}))
+					a.state.Store(&authorizeState{
+						policiesByRouteID: indexPoliciesByRouteID(b.Context(), &config.Options{Policies: policies}),
+					})
 
 					// Look up a route in the middle of the set so every benchmark
-					// pays for roughly half of a full scan.
+					// pays for roughly half of a full scan when the lookup is linear.
 					mid := n / 2
 					routeID, err := policies[mid].RouteID()
 					if err != nil {
@@ -50,7 +51,7 @@ func BenchmarkGetMatchingPolicy(b *testing.B) {
 					b.ReportAllocs()
 					b.ResetTimer()
 					for b.Loop() {
-						if p := a.getMatchingPolicy(routeID); p != &policies[mid] {
+						if p := a.state.Load().getMatchingPolicy(routeID); p != &policies[mid] {
 							b.Fatal("matched the wrong policy")
 						}
 					}

--- a/authorize/grpc_differential_test.go
+++ b/authorize/grpc_differential_test.go
@@ -1,0 +1,115 @@
+package authorize
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+)
+
+// getMatchingPolicyByScan preserves the behavior of the linear scan replaced
+// by indexPoliciesByRouteID.
+func getMatchingPolicyByScan(opts *config.Options, routeID string) *config.Policy {
+	for p := range opts.GetAllPolicies() {
+		id, _ := p.RouteID()
+		if id == routeID {
+			return p
+		}
+	}
+	return nil
+}
+
+func TestPolicyRouteIDIndexMatchesScan(t *testing.T) {
+	t.Parallel()
+
+	// dup.example.com/to1 hashes to one route ID; three policies share it,
+	// deliberately spread across the three GetAllPolicies slices so that
+	// first-wins has to reach across slice boundaries. AllowedUsers differ so
+	// the "wrong" policy would be observable as an authz change.
+	dupFrom := "https://dup.example.com"
+	opts := &config.Options{
+		Policies: []config.Policy{
+			{
+				From: dupFrom, AllowedUsers: []string{"alice@example.com"},
+				To: mustParseWeightedURLs(t, "https://to1.example.com"),
+			}, // FIRST duplicate -> should win
+			{
+				From: dupFrom, AllowedUsers: []string{"mallory@example.com"},
+				To: mustParseWeightedURLs(t, "https://to1.example.com"),
+			}, // second duplicate
+		},
+		Routes: []config.Policy{
+			{
+				From: "https://uniq.example.com",
+				To:   mustParseWeightedURLs(t, "https://to2.example.com"),
+			},
+		},
+		AdditionalPolicies: []config.Policy{
+			{
+				From: dupFrom, AllowedUsers: []string{"bob@example.com"},
+				To: mustParseWeightedURLs(t, "https://to1.example.com"),
+			}, // third duplicate
+		},
+	}
+
+	idx := indexPoliciesByRouteID(t.Context(), opts)
+
+	// For every buildable policy's route ID, the map must return exactly what
+	// the old scan returned (identity, not just value equality).
+	checked := 0
+	for p := range opts.GetAllPolicies() {
+		id, err := p.RouteID()
+		if err != nil {
+			continue
+		}
+		checked++
+		want := getMatchingPolicyByScan(opts, id)
+		got := idx[id]
+		require.Samef(t, want, got, "route id %q: map returned a different policy than the scan", id)
+	}
+	require.Positive(t, checked)
+
+	// The duplicate route ID must resolve to the FIRST policy in GetAllPolicies
+	// order (Policies[0], the alice policy) under both scan and map.
+	dupID, err := opts.Policies[0].RouteID()
+	require.NoError(t, err)
+	require.Same(t, &opts.Policies[0], idx[dupID])
+	require.Same(t, &opts.Policies[0], getMatchingPolicyByScan(opts, dupID))
+	require.Equal(t, []string{"alice@example.com"}, idx[dupID].AllowedUsers,
+		"first-wins must pick alice, not mallory or bob")
+}
+
+// TestPolicyRouteIDIndexSkipsInvalidPolicyForEmptyRoute documents the one
+// intentional difference from the old scan: a policy without a route action
+// contributed an empty ID and could be selected for an internal route, even
+// though the empty ID does not identify a policy.
+func TestPolicyRouteIDIndexSkipsInvalidPolicyForEmptyRoute(t *testing.T) {
+	t.Parallel()
+
+	bad := config.Policy{From: "https://no-dest.example.com"} // no To/Redirect/Response
+	_, err := bad.RouteID()
+	require.Error(t, err, "sanity: this policy's RouteID must error")
+
+	opts := &config.Options{
+		Policies: []config.Policy{
+			bad,
+			{From: "https://ok.example.com", To: mustParseWeightedURLs(t, "https://to.example.com")},
+		},
+	}
+	idx := indexPoliciesByRouteID(t.Context(), opts)
+
+	// The errored policy is absent from the map for every non-error key.
+	okID, err := opts.Policies[1].RouteID()
+	require.NoError(t, err)
+	require.Same(t, &opts.Policies[1], idx[okID])
+
+	// The map has exactly one entry (the buildable policy); the errored one is skipped.
+	require.Len(t, idx, 1)
+
+	// Divergence is confined to the empty route ID used by internal routes: the
+	// old scan returned the errored policy, while the map correctly returns no
+	// policy because the empty ID does not identify one.
+	require.Same(t, &opts.Policies[0], getMatchingPolicyByScan(opts, ""), "old scan matches errored policy on empty id")
+	require.Nil(t, idx[""], "map returns nil on empty id")
+}

--- a/authorize/grpc_test.go
+++ b/authorize/grpc_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/pomerium/pomerium/authorize/evaluator"
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/config/envoyconfig"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
@@ -49,19 +50,22 @@ func Test_getEvaluatorRequest(t *testing.T) {
 	t.Parallel()
 
 	a := &Authorize{}
-	a.currentConfig.Store(config.New(&config.Options{
+	options := &config.Options{
 		Policies: []config.Policy{{
+			ID:   "route-id-1",
 			From: "https://example.com",
 			SubPolicies: []config.SubPolicy{{
 				Rego: []string{"allow = true"},
 			}},
 		}},
-	}))
-	a.state.Store(new(authorizeState))
+	}
+	a.currentConfig.Store(config.New(options))
+	a.state.Store(&authorizeState{policiesByRouteID: indexPoliciesByRouteID(t.Context(), options)})
 
-	actual, err := a.getEvaluatorRequestFromCheckRequest(t.Context(),
+	actual, err := a.getEvaluatorRequestFromCheckRequest(t.Context(), a.state.Load(),
 		&envoy_service_auth_v3.CheckRequest{
 			Attributes: &envoy_service_auth_v3.AttributeContext{
+				ContextExtensions: envoyconfig.MakeExtAuthzContextExtensions(false, "route-id-1", 0),
 				Request: &envoy_service_auth_v3.AttributeContext_Request{
 					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 						Id:     "id-1234",
@@ -92,7 +96,8 @@ func Test_getEvaluatorRequest(t *testing.T) {
 	)
 	require.NoError(t, err)
 	expect := &evaluator.Request{
-		Policy: &a.currentConfig.Load().Options.Policies[0],
+		Policy:       &a.currentConfig.Load().Options.Policies[0],
+		EnvoyRouteID: "route-id-1",
 		HTTP: evaluator.RequestHTTP{
 			Method:   http.MethodGet,
 			Host:     "example.com",
@@ -121,19 +126,22 @@ func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 	t.Parallel()
 
 	a := &Authorize{}
-	a.currentConfig.Store(config.New(&config.Options{
+	options := &config.Options{
 		Policies: []config.Policy{{
+			ID:   "route-id-1",
 			From: "https://example.com",
 			SubPolicies: []config.SubPolicy{{
 				Rego: []string{"allow = true"},
 			}},
 		}},
-	}))
-	a.state.Store(new(authorizeState))
+	}
+	a.currentConfig.Store(config.New(options))
+	a.state.Store(&authorizeState{policiesByRouteID: indexPoliciesByRouteID(t.Context(), options)})
 
-	actual, err := a.getEvaluatorRequestFromCheckRequest(t.Context(),
+	actual, err := a.getEvaluatorRequestFromCheckRequest(t.Context(), a.state.Load(),
 		&envoy_service_auth_v3.CheckRequest{
 			Attributes: &envoy_service_auth_v3.AttributeContext{
+				ContextExtensions: envoyconfig.MakeExtAuthzContextExtensions(false, "route-id-1", 0),
 				Request: &envoy_service_auth_v3.AttributeContext_Request{
 					Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{
 						Id:     "id-1234",
@@ -152,8 +160,9 @@ func Test_getEvaluatorRequestWithPortInHostHeader(t *testing.T) {
 		}, false) // mcp disabled
 	require.NoError(t, err)
 	expect := &evaluator.Request{
-		Policy:  &a.currentConfig.Load().Options.Policies[0],
-		Session: evaluator.RequestSession{},
+		Policy:       &a.currentConfig.Load().Options.Policies[0],
+		EnvoyRouteID: "route-id-1",
+		Session:      evaluator.RequestSession{},
 		HTTP: evaluator.RequestHTTP{
 			Method:   http.MethodGet,
 			Host:     "example.com:80",
@@ -268,4 +277,83 @@ func (m mockDataBrokerServiceClient) Patch(ctx context.Context, in *databroker.P
 		ServerVersion: putResponse.GetServerVersion(),
 		Records:       putResponse.GetRecords(),
 	}, nil
+}
+
+func TestGetMatchingPolicy_OnConfigChange(t *testing.T) {
+	t.Parallel()
+
+	p1 := config.Policy{From: "https://route-1.example.com", To: mustParseWeightedURLs(t, "https://to-1.example.com")}
+	p2 := config.Policy{From: "https://route-2.example.com", To: mustParseWeightedURLs(t, "https://to-2.example.com")}
+	require.NoError(t, p1.Validate())
+	require.NoError(t, p2.Validate())
+	id1, err := p1.RouteID()
+	require.NoError(t, err)
+	id2, err := p2.RouteID()
+	require.NoError(t, err)
+
+	newConfig := func(policies ...config.Policy) *config.Config {
+		return config.New(&config.Options{
+			AuthenticateURLString: "https://authn.example.com",
+			DataBroker:            config.DataBrokerOptions{ServiceURL: "https://databroker.example.com"},
+			CookieSecret:          "15WXae6fvK9Hal0RGZ600JlCaflYHtNy9bAyOLTlvmc=",
+			SharedKey:             "2p/Wi2Q6bYDfzmoSEbKqYKtg+DUoLWTEHHs7vOhvL7w=",
+			Policies:              policies,
+		})
+	}
+
+	a, err := New(t.Context(), newConfig(p1))
+	require.NoError(t, err)
+
+	matched := a.state.Load().getMatchingPolicy(id1)
+	require.NotNil(t, matched)
+	assert.Equal(t, p1.From, matched.From)
+	assert.Nil(t, a.state.Load().getMatchingPolicy(id2))
+
+	a.OnConfigChange(t.Context(), newConfig(p2))
+
+	assert.Nil(t, a.state.Load().getMatchingPolicy(id1))
+	matched = a.state.Load().getMatchingPolicy(id2)
+	require.NotNil(t, matched)
+	assert.Equal(t, p2.From, matched.From)
+}
+
+func TestGetEvaluatorRequestUsesStateSnapshot(t *testing.T) {
+	t.Parallel()
+
+	oldOptions := &config.Options{Policies: []config.Policy{{
+		ID:           "shared-route-id",
+		From:         "https://old.example.com",
+		To:           mustParseWeightedURLs(t, "https://old-upstream.example.com"),
+		AllowedUsers: []string{"old@example.com"},
+	}}}
+	newOptions := &config.Options{Policies: []config.Policy{{
+		ID:           "shared-route-id",
+		From:         "https://new.example.com",
+		To:           mustParseWeightedURLs(t, "https://new-upstream.example.com"),
+		AllowedUsers: []string{"new@example.com"},
+	}}}
+
+	a := new(Authorize)
+	// Simulate the window in OnConfigChange after currentConfig advances but
+	// before the derived authorizeState is swapped.
+	a.currentConfig.Store(config.New(newOptions))
+	oldState := &authorizeState{policiesByRouteID: indexPoliciesByRouteID(t.Context(), oldOptions)}
+
+	checkRequest := &envoy_service_auth_v3.CheckRequest{
+		Attributes: &envoy_service_auth_v3.AttributeContext{
+			ContextExtensions: envoyconfig.MakeExtAuthzContextExtensions(false, "shared-route-id", 0),
+			Request: &envoy_service_auth_v3.AttributeContext_Request{
+				Http: &envoy_service_auth_v3.AttributeContext_HttpRequest{},
+			},
+		},
+	}
+
+	req, err := a.getEvaluatorRequestFromCheckRequest(t.Context(), oldState, checkRequest, false)
+	require.NoError(t, err)
+	require.Same(t, &oldOptions.Policies[0], req.Policy)
+
+	newState := &authorizeState{policiesByRouteID: indexPoliciesByRouteID(t.Context(), newOptions)}
+	req, err = a.getEvaluatorRequestFromCheckRequest(t.Context(), newState, checkRequest, false)
+	require.NoError(t, err)
+	require.Same(t, &newOptions.Policies[0], req.Policy)
 }

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -38,6 +38,29 @@ type authorizeState struct {
 	authenticateFlow           authenticateFlow
 	syncQueriers               map[string]storage.Querier
 	mcp                        *mcp.Handler
+	policiesByRouteID          map[string]*config.Policy
+}
+
+// indexPoliciesByRouteID builds a route ID -> policy index so that per-request
+// policy lookups don't scan every policy computing its route ID. The first
+// policy wins for duplicate route IDs, matching the linear scan it replaces.
+// Policies whose route ID can't be computed are skipped. The old scan ignored
+// the error and could select such a policy for an empty route ID, which is used
+// by internal routes but does not identify a policy.
+func indexPoliciesByRouteID(ctx context.Context, options *config.Options) map[string]*config.Policy {
+	m := make(map[string]*config.Policy, options.NumPolicies())
+	for p := range options.GetAllPolicies() {
+		id, err := p.RouteID()
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Str("policy", p.String()).
+				Msg("authorize: skipping policy with invalid route id")
+			continue
+		}
+		if _, ok := m[id]; !ok {
+			m[id] = p
+		}
+	}
+	return m
 }
 
 func newAuthorizeStateFromConfig(
@@ -53,6 +76,7 @@ func newAuthorizeStateFromConfig(
 	}
 
 	state := new(authorizeState)
+	state.policiesByRouteID = indexPoliciesByRouteID(ctx, cfg.Options)
 
 	var err error
 	var previousEvaluator *evaluator.Evaluator


### PR DESCRIPTION

## Summary

Each ext_authz `Check` located its policy by scanning `currentConfig` until one produced the route ID supplied by Envoy, while evaluation used the separately loaded `authorizeState`. Besides growing with policy count, those independent snapshots could pair a policy from one config generation with an evaluator from another. Policies without an explicit `id` make the scan more expensive because each candidate hashes its routing fields.

This builds a route-ID-to-policy map when `authorizeState` is created, then uses the state already loaded by `Check` for both policy lookup and evaluation. Duplicate route IDs keep the lookup's old first-match behavior. Policies whose route ID cannot be computed are not indexed; valid route policies already require `to`, `redirect`, or `response`.

`BenchmarkGetMatchingPolicy` looks up the middle policy in each set. Results are from 10 same-machine runs on an Apple M3 Max with Go 1.26.5:

| Policies | Generated ID before | Explicit ID before | Indexed lookup | Generated-ID allocations/op |
| ---: | ---: | ---: | ---: | ---: |
| 100 | 8.306 us | 112.7 ns | 5.4-5.7 ns | 102 -> 0 |
| 1,000 | 83.49 us | 1.001 us | 5.4-5.5 ns | 1,002 -> 0 |
| 10,000 | 813.1 us | 11.69 us | 5.4-5.5 ns | 10,002 -> 0 |

These are policy-lookup CPU measurements, not end-to-end `Check` latency. Index construction is outside the timed loop and runs when an `authorizeState` is created. The generated-ID lookup grows from about 8 us at 100 policies to 0.81 ms at 10,000. Explicit IDs make the old scan much cheaper, but it still grows with policy count; the indexed lookup remains constant in both cases.

Tests compare the index with the old scan, preserve the lookup's first-match behavior for duplicate IDs, cover invalid IDs and config changes, and verify policy selection follows the supplied state snapshot.

## Related issues

- None

## User Explanation

## AI disclosure

Claude Code using the Fable model drafted the initial implementation and benchmarks. Codex revised the code and tests and reproduced the benchmark results. I reviewed and edited the final diff and description.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`)
- [x] disclosed AI usage per AI_POLICY.md
- [x] ready for review

