### PR TITLE
ci: replace Coveralls PR noise with native summaries

### DIFF
--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 # A new push to a branch cancels an in-flight acceptance run for that branch.
 concurrency:
@@ -22,7 +21,7 @@ concurrency:
 # results.json. The `summary` job fans in: it downloads every results artifact,
 # merges each harness's committed feature-map.json fragment, and renders ONE
 # Feature Coverage table (Authentication / Authorization / Headers / MCP / ...)
-# posted as a single sticky PR comment.
+# written to the workflow run summary.
 #
 # To add a harness (e.g. downstream-mtls): add a job below that uploads an
 # `e2e-results-<name>` artifact, drop a feature-map.json fragment in its
@@ -79,7 +78,7 @@ jobs:
         with:
           name: e2e-results-browser
           path: internal/acceptance/artifacts/playwright/results.json
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Upload Playwright report
         if: always()
@@ -158,7 +157,7 @@ jobs:
         with:
           name: e2e-results-mcp
           path: internal/acceptance/mcp/results.json
-          if-no-files-found: warn
+          if-no-files-found: error
 
       - name: Upload Playwright report
         if: always()
@@ -183,6 +182,9 @@ jobs:
         with:
           node-version-file: .tool-versions
 
+      - name: Test summary generator
+        run: node --test internal/acceptance/scripts/generate-summary.test.mjs
+
       - name: Download harness results
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
@@ -190,19 +192,21 @@ jobs:
           path: e2e-results
 
       - name: Generate combined summary
+        if: always()
+        id: summary
+        env:
+          HARNESS_RESULTS: ${{ toJSON(needs) }}
         run: |
+          expected_results=$(node -e 'console.log(Object.keys(JSON.parse(process.env.HARNESS_RESULTS)).length)')
           node internal/acceptance/scripts/generate-summary.mjs \
             --results-dir e2e-results \
             --feature-maps-dir internal/acceptance \
+            --expected-results "$expected_results" \
             --output summary.md
-          cat summary.md >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Post PR comment
-        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false
-        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
-        with:
-          header: acceptance-summary
-          path: summary.md
+      - name: Show combined summary
+        if: always()
+        run: cat summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Fail if any harness did not succeed
         if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')

--- a/.github/workflows/ci-report.yaml
+++ b/.github/workflows/ci-report.yaml
@@ -1,0 +1,64 @@
+name: CI Report
+
+on:
+  workflow_run:
+    workflows: [Acceptance Tests]
+    types: [completed]
+
+permissions:
+  actions: read
+  pull-requests: write
+
+jobs:
+  report:
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.head_repository.full_name == github.repository && github.event.workflow_run.pull_requests[0].number
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find current pull request
+        id: report
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const run = context.payload.workflow_run;
+            const pullNumber = run.pull_requests[0].number;
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: pullNumber,
+            });
+            if (pullRequest.state !== 'open' || pullRequest.head.sha !== run.head_sha) return;
+
+            const { data: { workflow_runs: [latestRun] } } = await github.rest.actions.listWorkflowRuns({
+              owner,
+              repo,
+              workflow_id: run.workflow_id,
+              event: 'pull_request',
+              head_sha: run.head_sha,
+              per_page: 1,
+            });
+            if (!latestRun || latestRun.id !== run.id || latestRun.run_attempt !== run.run_attempt) return;
+
+            core.setOutput('number', pullNumber);
+            core.setOutput('ready', 'true');
+
+      - name: Post acceptance failure
+        if: steps.report.outputs.ready == 'true' && github.event.workflow_run.conclusion != 'success'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+        with:
+          header: acceptance-summary
+          number_force: ${{ steps.report.outputs.number }}
+          message: |
+            ## Acceptance tests did not pass
+
+            [View the ${{ github.event.workflow_run.conclusion }} workflow run](${{ github.event.workflow_run.html_url }}).
+          recreate: true
+
+      - name: Hide resolved acceptance failure
+        if: steps.report.outputs.ready == 'true' && github.event.workflow_run.conclusion == 'success'
+        uses: marocchino/sticky-pull-request-comment@0ea0beb66eb9baf113663a64ec522f60e49231c0
+        with:
+          header: acceptance-summary
+          number_force: ${{ steps.report.outputs.number }}
+          hide: true
+          hide_classify: OUTDATED

--- a/internal/acceptance/scripts/generate-summary.mjs
+++ b/internal/acceptance/scripts/generate-summary.mjs
@@ -23,7 +23,8 @@
  */
 
 import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
 // Directories that never contain harness results or fragments — skipping them
 // keeps discovery fast and avoids picking up dependencies' stray JSON.
@@ -36,6 +37,7 @@ const SKIP_DIRS = new Set([
   '.certs',
   'dist',
 ]);
+const ATTEMPT_OUTCOMES = new Set(['passed', 'failed', 'skipped', 'timedOut', 'interrupted']);
 
 /**
  * Parse command line arguments.
@@ -46,6 +48,7 @@ function parseArgs() {
     output: null,
     resultsDir: 'internal/acceptance',
     featureMapsDir: 'internal/acceptance',
+    expectedResults: null,
   };
 
   for (let i = 0; i < args.length; i++) {
@@ -55,6 +58,8 @@ function parseArgs() {
       result.resultsDir = args[++i];
     } else if (args[i] === '--feature-maps-dir' && args[i + 1]) {
       result.featureMapsDir = args[++i];
+    } else if (args[i] === '--expected-results' && args[i + 1]) {
+      result.expectedResults = Number(args[++i]);
     }
   }
 
@@ -119,6 +124,7 @@ function mergeFeatureMaps(paths) {
  * so the top-line totals reflect all harnesses together.
  */
 function combineResults(paths) {
+  const errors = [];
   const suites = [];
   const stats = { expected: 0, unexpected: 0, skipped: 0, flaky: 0, duration: 0 };
 
@@ -128,9 +134,23 @@ function combineResults(paths) {
       data = JSON.parse(readFileSync(path, 'utf8'));
     } catch (err) {
       console.error(`Warning: skipping unparseable results file ${path}: ${err.message}`);
+      errors.push({ message: `Could not parse ${path}` });
       continue;
     }
-    if (Array.isArray(data.suites)) suites.push(...data.suites);
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
+      errors.push({ message: `${path} is not a Playwright report object` });
+      continue;
+    }
+    if (!Array.isArray(data.suites) || data.suites.length === 0) {
+      errors.push({ message: `${path} contains no test suites` });
+    } else {
+      suites.push(...data.suites);
+    }
+    if (data.errors !== undefined && !Array.isArray(data.errors)) {
+      errors.push({ message: `${path} has an invalid error list` });
+    } else if (data.errors?.length > 0) {
+      errors.push(...data.errors);
+    }
     const s = data.stats || {};
     stats.expected += s.expected || 0;
     stats.unexpected += s.unexpected || 0;
@@ -140,7 +160,7 @@ function combineResults(paths) {
   }
 
   // Empty suites (nothing parsed) render as the "no results" summary downstream.
-  return { suites, stats };
+  return { errors, suites, stats };
 }
 
 /**
@@ -189,13 +209,9 @@ function getStatusEmoji(status) {
  */
 function categorizeStatus(status) {
   switch (status) {
-    case 'passed':
     case 'expected':
       return 'passed';
-    case 'failed':
     case 'unexpected':
-    case 'timedOut':
-    case 'interrupted':
       return 'failed';
     case 'skipped':
       return 'skipped';
@@ -265,7 +281,10 @@ function aggregateByCategory(suites, featureMap) {
             title: spec.title,
             file: filePath,
             status: testResult.status,
-            duration: testResult.results?.reduce((sum, r) => sum + (r.duration || 0), 0) || 0,
+            attempts: Array.isArray(testResult.results) ? testResult.results : [],
+            duration: Array.isArray(testResult.results)
+              ? testResult.results.reduce((sum, result) => sum + (result.duration || 0), 0)
+              : 0,
             fullTitle,
           };
 
@@ -343,22 +362,70 @@ function findSlowestTests(allTests, count = 3) {
 /**
  * Generate the markdown summary.
  */
-function generateMarkdown(results, featureMap) {
+function generateSummary(results, featureMap) {
   const lines = [];
 
-  // Handle missing or empty results
-  if (!results || !results.suites || results.suites.length === 0) {
-    lines.push('## ⚠️ Acceptance Test Summary\n');
-    lines.push('No test results found. Playwright may have crashed before producing output.\n');
-    return lines.join('\n');
+  if (!results || !Array.isArray(results.suites) || results.suites.length === 0) {
+    return unavailableResultsSummary('No Playwright test results were recorded. The test run may have crashed before producing output.');
   }
 
-  // Aggregate data
-  const { categories, unmappedFiles, allTests } = aggregateByCategory(results.suites, featureMap);
+  if (results.errors !== undefined && !Array.isArray(results.errors)) {
+    return unavailableResultsSummary('The Playwright report has an invalid top-level error list, so the test outcome cannot be trusted.');
+  }
 
-  // Totals come from the summed Playwright stats produced by combineResults
-  // (Playwright counts timed-out/interrupted tests as `unexpected`).
-  const { expected: passed, unexpected: failed, skipped, flaky, duration } = results.stats;
+  if (results.errors?.length > 0) {
+    return unavailableResultsSummary(
+      `Playwright reported ${results.errors.length} top-level ${results.errors.length === 1 ? 'error' : 'errors'} (for example, a global setup failure), so the test outcome cannot be trusted.`,
+    );
+  }
+
+  let aggregate;
+  try {
+    aggregate = aggregateByCategory(results.suites, featureMap);
+  } catch (err) {
+    return unavailableResultsSummary(`The Playwright report has an invalid structure: ${err.message}`);
+  }
+  const { categories, unmappedFiles, allTests } = aggregate;
+  if (allTests.length === 0) {
+    return unavailableResultsSummary('No Playwright test outcomes were recorded. The test run may have crashed before producing output.');
+  }
+
+  const unknownOutcomes = allTests.filter(
+    (test) => categorizeStatus(test.status) === 'other' ||
+      !ATTEMPT_OUTCOMES.has(test.attempts.at(-1)?.status),
+  );
+  if (unknownOutcomes.length > 0) {
+    return unavailableResultsSummary(
+      `Playwright recorded ${unknownOutcomes.length} test ${unknownOutcomes.length === 1 ? 'outcome' : 'outcomes'} with a missing or unknown status.`,
+      unknownOutcomes,
+    );
+  }
+
+  const interruptedFinalAttempts = allTests.filter(
+    (test) => test.attempts.at(-1)?.status === 'interrupted',
+  );
+  if (interruptedFinalAttempts.length > 0) {
+    return unavailableResultsSummary(
+      `Playwright recorded ${interruptedFinalAttempts.length} interrupted final ${interruptedFinalAttempts.length === 1 ? 'attempt' : 'attempts'}, so the test run did not complete.`,
+      interruptedFinalAttempts,
+    );
+  }
+
+  const incompleteFlakyTests = allTests.filter(
+    (test) => test.status === 'flaky' && test.attempts.at(-1).status !== 'passed',
+  );
+  if (incompleteFlakyTests.length > 0) {
+    return unavailableResultsSummary(
+      `Playwright recorded ${incompleteFlakyTests.length} flaky ${incompleteFlakyTests.length === 1 ? 'outcome' : 'outcomes'} without a passing final attempt.`,
+      incompleteFlakyTests,
+    );
+  }
+
+  const passed = allTests.filter((test) => categorizeStatus(test.status) === 'passed').length;
+  const failed = allTests.filter((test) => categorizeStatus(test.status) === 'failed').length;
+  const skipped = allTests.filter((test) => categorizeStatus(test.status) === 'skipped').length;
+  const flaky = allTests.filter((test) => categorizeStatus(test.status) === 'flaky').length;
+  const duration = results.stats?.duration || allTests.reduce((sum, test) => sum + test.duration, 0);
 
   // Header with overall status
   const overallStatus = failed > 0 ? '❌' : flaky > 0 ? '⚠️' : '✅';
@@ -425,7 +492,33 @@ function generateMarkdown(results, featureMap) {
 
   lines.push('</details>');
 
-  return lines.join('\n');
+  return { markdown: lines.join('\n'), failed: failed > 0 };
+}
+
+/**
+ * Build an actionable summary when the Playwright output cannot be used.
+ */
+function unavailableResultsSummary(message, affectedTests = []) {
+  const affectedTestsMarkdown = affectedTests.length === 0
+    ? ''
+    : [
+      '### Affected Tests\n',
+      ...affectedTests.map((test) => {
+        const file = test.file ? ` in \`${test.file}\`` : '';
+        return `- \`${test.fullTitle}\`${file}`;
+      }),
+      '',
+    ].join('\n');
+
+  return {
+    failed: true,
+    markdown: [
+      '## ❌ Acceptance Test Results Unavailable\n',
+      `${message}\n`,
+      affectedTestsMarkdown,
+      'Inspect the workflow run and artifacts to determine why the acceptance results were not produced or cannot be trusted.\n',
+    ].join('\n'),
+  };
 }
 
 /**
@@ -438,30 +531,48 @@ function main() {
   const featureMapPaths = findFiles(args.featureMapsDir, 'feature-map.json');
   const resultsPaths = findFiles(args.resultsDir, 'results.json');
 
-  const emit = (markdown) => {
+  const emit = (summary) => {
     if (args.output) {
       mkdirSync(dirname(args.output), { recursive: true });
-      writeFileSync(args.output, markdown);
+      writeFileSync(args.output, summary.markdown);
       console.log(`Summary written to ${args.output}`);
     } else {
-      console.log(markdown);
+      console.log(summary.markdown);
     }
+    process.exitCode = summary.failed ? 1 : 0;
   };
 
   if (resultsPaths.length === 0) {
-    emit('## ⚠️ Acceptance Test Summary\n\nNo results found. Playwright may have crashed before producing output.\n');
-    process.exit(0);
+    emit(unavailableResultsSummary('No Playwright results files were found. A test harness may have crashed before producing output.'));
+    return;
   }
 
   if (featureMapPaths.length === 0) {
-    console.error(`Error: no feature-map.json fragments found under ${args.featureMapsDir}`);
-    process.exit(1);
+    emit(unavailableResultsSummary(`No feature-map.json fragments were found under ${args.featureMapsDir}.`));
+    return;
+  }
+
+  if (args.expectedResults !== null) {
+    if (!Number.isInteger(args.expectedResults) || args.expectedResults < 1) {
+      emit(unavailableResultsSummary('The expected Playwright results count is invalid.'));
+      return;
+    }
+    if (resultsPaths.length !== args.expectedResults) {
+      emit(unavailableResultsSummary(
+        `Expected ${args.expectedResults} Playwright results ${args.expectedResults === 1 ? 'file' : 'files'}, but found ${resultsPaths.length}.`,
+      ));
+      return;
+    }
   }
 
   const featureMap = mergeFeatureMaps(featureMapPaths);
   const results = combineResults(resultsPaths);
 
-  emit(generateMarkdown(results, featureMap));
+  emit(generateSummary(results, featureMap));
 }
 
-main();
+export { generateSummary };
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/internal/acceptance/scripts/generate-summary.test.mjs
+++ b/internal/acceptance/scripts/generate-summary.test.mjs
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { generateSummary } from './generate-summary.mjs';
+
+const summaryScript = fileURLToPath(new URL('./generate-summary.mjs', import.meta.url));
+
+const featureMap = {
+  categories: {
+    Authentication: {
+      description: 'Authentication coverage',
+      files: { 'authn/login.spec.ts': ['OIDC login'] },
+    },
+  },
+};
+
+function playwrightResults(status, {
+  errors = [],
+  attempts = [{ status: 'passed', duration: 1_200 }],
+} = {}) {
+  return {
+    errors,
+    stats: { duration: 1_200 },
+    suites: [{
+      file: 'authn/login.spec.ts',
+      specs: [{
+        title: 'signs in through OIDC',
+        tests: [{ status, results: attempts }],
+      }],
+    }],
+  };
+}
+
+test('accepts passing results', () => {
+  const summary = generateSummary(playwrightResults('expected'), featureMap);
+
+  assert.equal(summary.failed, false);
+  assert.match(summary.markdown, /## ✅ Acceptance Test Summary/);
+});
+
+test('reports failed tests', () => {
+  const summary = generateSummary(playwrightResults('unexpected', {
+    attempts: [{ status: 'failed', duration: 1_200 }],
+  }), featureMap);
+
+  assert.equal(summary.failed, true);
+  assert.match(summary.markdown, /## ❌ Acceptance Test Summary/);
+});
+
+test('accepts skipped results', () => {
+  const summary = generateSummary(playwrightResults('skipped', {
+    attempts: [{ status: 'skipped', duration: 0 }],
+  }), featureMap);
+
+  assert.equal(summary.failed, false);
+  assert.match(summary.markdown, /\| ⊘ Skipped \| 1 \|/);
+});
+
+for (const [name, results, message] of [
+  ['results without test outcomes', { errors: [], suites: [{ specs: [] }] }, /Results Unavailable/],
+  ['an invalid suite shape', { errors: [], suites: [null] }, /invalid structure/],
+  ['top-level Playwright errors', playwrightResults('expected', {
+    errors: [{ message: 'global setup failed' }],
+  }), /top-level error/],
+  ['interrupted final attempts', playwrightResults('skipped', {
+    attempts: [{ status: 'interrupted', duration: 1_200 }],
+  }), /interrupted final attempt/],
+  ['an unknown test outcome', playwrightResults('unknown'), /missing or unknown status/],
+  ['an attempt status used as a test outcome', playwrightResults('failed', {
+    attempts: [{ status: 'failed' }],
+  }), /missing or unknown status/],
+  ['an unknown final attempt', playwrightResults('expected', {
+    attempts: [{ status: 'unknown' }],
+  }), /missing or unknown status/],
+  ['a flaky result without a passing final attempt', playwrightResults('flaky', {
+    attempts: [{ status: 'failed', duration: 1_200 }],
+  }), /without a passing final attempt/],
+]) {
+  test(`rejects ${name}`, () => {
+    const summary = generateSummary(results, featureMap);
+
+    assert.equal(summary.failed, true);
+    assert.match(summary.markdown, message);
+  });
+}
+
+test('keeps a completed flaky retry as a warning', () => {
+  const summary = generateSummary(playwrightResults('flaky', {
+    attempts: [
+      { status: 'failed', duration: 800 },
+      { status: 'passed', duration: 400 },
+    ],
+  }), featureMap);
+
+  assert.equal(summary.failed, false);
+  assert.match(summary.markdown, /## ⚠️ Acceptance Test Summary/);
+});
+
+test('writes an unavailable summary before exiting nonzero', (t) => {
+  const directory = realpathSync(mkdtempSync(join(tmpdir(), 'pomerium-acceptance-summary-')));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+
+  const resultsDirectory = join(directory, 'results');
+  const featureMapsDirectory = join(directory, 'feature-maps');
+  const output = join(directory, 'summary.md');
+  mkdirSync(resultsDirectory);
+  mkdirSync(featureMapsDirectory);
+  writeFileSync(join(resultsDirectory, 'results.json'), 'null');
+  writeFileSync(join(featureMapsDirectory, 'feature-map.json'), JSON.stringify(featureMap));
+
+  const result = spawnSync(process.execPath, [
+    summaryScript,
+    '--results-dir', resultsDirectory,
+    '--feature-maps-dir', featureMapsDirectory,
+    '--output', output,
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(readFileSync(output, 'utf8'), /Acceptance Test Results Unavailable/);
+});
+
+test('rejects a missing harness results file', (t) => {
+  const directory = realpathSync(mkdtempSync(join(tmpdir(), 'pomerium-acceptance-summary-')));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+
+  const resultsDirectory = join(directory, 'results');
+  const featureMapsDirectory = join(directory, 'feature-maps');
+  const output = join(directory, 'summary.md');
+  mkdirSync(resultsDirectory);
+  mkdirSync(featureMapsDirectory);
+  writeFileSync(join(resultsDirectory, 'results.json'), JSON.stringify(playwrightResults('expected')));
+  writeFileSync(join(featureMapsDirectory, 'feature-map.json'), JSON.stringify(featureMap));
+
+  const result = spawnSync(process.execPath, [
+    summaryScript,
+    '--results-dir', resultsDirectory,
+    '--feature-maps-dir', featureMapsDirectory,
+    '--expected-results', '2',
+    '--output', output,
+  ]);
+
+  assert.equal(result.status, 1);
+  assert.match(readFileSync(output, 'utf8'), /Expected 2 Playwright results files, but found 1/);
+});


### PR DESCRIPTION
## Summary

Coveralls reports repository-wide coverage movement that is not actionable for an individual PR, while passing Acceptance runs add a full sticky report to every PR. Replace that noise with a quiet Test-job summary for material coverage changes in changed Go files, and a single sticky comment only when Acceptance fails.

The Test job compares the PR profile with the latest successful `main` profile for the PR base SHA. It emits nothing for non-Go changes, sub-1.0pp deltas, or unavailable base data. The trusted reporter links failed Acceptance jobs without executing PR code or artifacts, then hides its comment after the current rerun succeeds.

## Related issues

- [ENG-4244](https://linear.app/pomerium/issue/ENG-4244/harden-acceptance-failure-summaries)

## User Explanation

No user-facing change.

## Testing

- `go test ./scripts`
- `node --test internal/acceptance/scripts/generate-summary.test.mjs`
- `actionlint .github/workflows/test.yaml .github/workflows/acceptance.yaml .github/workflows/ci-report.yaml`
- `go mod tidy`
- `git diff --check`
- `make build`
- `make test`
- `make lint`

## AI disclosure

GPT-5 Codex drafted the implementation and PR description; the author supplied the requirements and review direction.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`ci`)
- [x] disclosed AI usage per AI_POLICY.md
- [x] ready for review
