### PR TITLE
fix(config): use proxy protocol for internal communication

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -257,17 +257,19 @@ func (cfg *Config) resolveAuthenticateURL() (*url.URL, http.RoundTripper, error)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error determining if authenticate service will have a certificate name: %w", err)
 	}
-	if !ok {
-		return authenticateURL, httputil.GetInsecureTransport(), nil
+	var transport *http.Transport
+	if ok {
+		transport, err = GetTLSClientTransport(cfg)
+		if err != nil {
+			return nil, nil, fmt.Errorf("get tls client config: %w", err)
+		}
+	} else {
+		transport = httputil.GetInsecureTransport()
 	}
-
-	transport, err := GetTLSClientTransport(cfg)
-	if err != nil {
-		return nil, nil, fmt.Errorf("get tls client config: %w", err)
+	if cfg.Options.UseProxyProtocol {
+		transport = httputil.NewLocalProxyProtocolTransport(transport)
 	}
-
-	transport = otelhttp.NewTransport(transport)
-	return authenticateURL, transport, nil
+	return authenticateURL, otelhttp.NewTransport(transport), nil
 }
 
 func getOneOf[OneOfContainer, OneOf, Value any](container OneOfContainer, _ OneOf, value Value) *Value {

--- a/config/http.go
+++ b/config/http.go
@@ -119,7 +119,7 @@ func NewPolicyHTTPTransport(options *Options, policy *Policy, disableHTTP2 bool)
 }
 
 // GetTLSClientTransport returns http transport accounting for custom CAs from config
-func GetTLSClientTransport(cfg *Config) (http.RoundTripper, error) {
+func GetTLSClientTransport(cfg *Config) (*http.Transport, error) {
 	tlsConfig, err := cfg.GetTLSClientConfig()
 	if err != nil {
 		return nil, err

--- a/config/session_test.go
+++ b/config/session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,6 +12,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pires/go-proxyproto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
@@ -508,6 +510,62 @@ func TestIncomingIDPTokenSessionCreator_CreateSession(t *testing.T) {
 		cfg.Options.ClientSecret = "CLIENT_SECRET_1"
 		cfg.Options.ClientID = "CLIENT_ID_1"
 		cfg.Options.BearerTokenFormat = nullable.From(*config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_IDENTITY_TOKEN.Enum())
+		route := &Policy{}
+		route.IDPClientSecret = "CLIENT_SECRET_2"
+		route.IDPClientID = "CLIENT_ID_2"
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer IDENTITY_TOKEN")
+		c := NewIncomingIDPTokenSessionCreator(
+			noop.NewTracerProvider(),
+			func(_ context.Context, _, _ string) (*databroker.Record, error) {
+				return nil, storage.ErrNotFound
+			},
+			func(_ context.Context, records []*databroker.Record) error {
+				if assert.Len(t, records, 2, "should put session and user") {
+					assert.Equal(t, "type.googleapis.com/session.Session", records[0].Type)
+					assert.Equal(t, "type.googleapis.com/user.User", records[1].Type)
+				}
+				return nil
+			},
+		)
+		s, err := c.CreateSession(ctx, cfg, route, req)
+		assert.NoError(t, err)
+		assert.Equal(t, "U1", s.GetUserId())
+		assert.True(t, s.GetRefreshDisabled())
+	})
+	t.Run("proxy_protocol", func(t *testing.T) {
+		t.Parallel()
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/.pomerium/verify-identity-token", func(w http.ResponseWriter, _ *http.Request) {
+			json.NewEncoder(w).Encode(&authenticateapi.VerifyTokenResponse{
+				Valid:  true,
+				Claims: jwtutil.Claims{"sub": "U1"},
+			})
+		})
+		li, err := net.Listen("tcp", ":0")
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = li.Close() })
+		li = &proxyproto.Listener{
+			Listener: li,
+			ConnPolicy: func(_ proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+				return proxyproto.REQUIRE, nil
+			},
+		}
+		srv := &httptest.Server{
+			Listener: li,
+			Config:   &http.Server{Handler: mux},
+		}
+		srv.Start()
+
+		ctx := testutil.GetContext(t, time.Minute)
+		cfg := New(NewDefaultOptions())
+		cfg.Options.AuthenticateURLString = srv.URL
+		cfg.Options.ClientSecret = "CLIENT_SECRET_1"
+		cfg.Options.ClientID = "CLIENT_ID_1"
+		cfg.Options.BearerTokenFormat = nullable.From(*config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_IDENTITY_TOKEN.Enum())
+		cfg.Options.UseProxyProtocol = true
 		route := &Policy{}
 		route.IDPClientSecret = "CLIENT_SECRET_2"
 		route.IDPClientID = "CLIENT_ID_2"

--- a/internal/httputil/transport.go
+++ b/internal/httputil/transport.go
@@ -1,8 +1,12 @@
 package httputil
 
 import (
+	"context"
 	"crypto/tls"
+	"net"
 	"net/http"
+
+	"github.com/pires/go-proxyproto"
 )
 
 // GetInsecureTransport gets an insecure HTTP transport.
@@ -11,5 +15,43 @@ func GetInsecureTransport() *http.Transport {
 	transport.DialTLS = nil
 	transport.DialTLSContext = nil
 	transport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	return transport
+}
+
+// NewLocalProxyProtocolTransport creates a new http transport that uses the proxy
+// protocol with the LOCAL command. The base protocol is cloned and a new transport
+// is returned.
+func NewLocalProxyProtocolTransport(base *http.Transport) *http.Transport {
+	if base == nil {
+		base = http.DefaultTransport.(*http.Transport)
+	}
+	transport := base.Clone()
+	originalDial := transport.Dial
+	originalDialContext := transport.DialContext
+	baseDial := func(ctx context.Context, network, addr string) (net.Conn, error) {
+		if originalDialContext != nil {
+			return originalDialContext(ctx, network, addr)
+		}
+		if originalDial != nil {
+			return originalDial(network, addr)
+		}
+		var zeroDialer net.Dialer
+		return zeroDialer.DialContext(ctx, network, addr)
+	}
+	transport.Dial = nil
+	transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+		conn, err := baseDial(ctx, network, addr)
+		if err == nil {
+			header := &proxyproto.Header{
+				Version: 2,
+				Command: proxyproto.LOCAL,
+			}
+			_, err = header.WriteTo(conn)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return conn, err
+	}
 	return transport
 }

--- a/internal/httputil/transport.go
+++ b/internal/httputil/transport.go
@@ -48,6 +48,7 @@ func NewLocalProxyProtocolTransport(base *http.Transport) *http.Transport {
 			}
 			_, err = header.WriteTo(conn)
 			if err != nil {
+				_ = conn.Close()
 				return nil, err
 			}
 		}

--- a/internal/httputil/transport_test.go
+++ b/internal/httputil/transport_test.go
@@ -1,0 +1,58 @@
+package httputil_test
+
+import (
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/pires/go-proxyproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/internal/httputil"
+)
+
+func TestNewLocalProxyProtocolTransport(t *testing.T) {
+	t.Parallel()
+
+	li, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = li.Close() })
+
+	li = &proxyproto.Listener{
+		Listener: li,
+		ConnPolicy: func(_ proxyproto.ConnPolicyOptions) (proxyproto.Policy, error) {
+			return proxyproto.REQUIRE, nil
+		},
+	}
+
+	srv := &httptest.Server{
+		Listener: li,
+		Config: &http.Server{
+			Handler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "text/plain")
+				w.Write([]byte("HELLO WORLD"))
+			}),
+		},
+	}
+	srv.Start()
+
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+
+	t1 := &http.Transport{}
+	t2 := httputil.NewLocalProxyProtocolTransport(t1)
+
+	_, err = (&http.Client{Transport: t1}).Do(req)
+	assert.ErrorIs(t, err, io.EOF, "should close connections not using the proxy protocol")
+
+	r2, err := (&http.Client{Transport: t2}).Do(req)
+	assert.NoError(t, err)
+	defer r2.Body.Close()
+
+	bs, err := io.ReadAll(r2.Body)
+	assert.NoError(t, err)
+	assert.Equal(t, "HELLO WORLD", string(bs))
+}


### PR DESCRIPTION
## Summary

The `identity` and `access` token options for the bearer token format use an HTTP endpoint on the authenticate service to verify the validity of tokens. When `use_proxy_protocol` is enabled that endpoint expects requests to use the protocol. Unfortunately the internal HTTP client we were using to make those requests wasn't making them with the proxy protocol so they were being rejected.

This PR updates the code to wrap the HTTP transport making the requests so that they are framed with the proxy protocol when the option is enabled.

Two tests are added for this, but we should also add an acceptance test, which will be done in a subsequent PR.

## Related issues

* pomerium/pomerium#6503
* pomerium/pomerium#6503

## AI disclosure

No AI was used for this PR.

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review