### PR TITLE
test(config): add an integration test for the use proxy protocol option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"google.golang.org/protobuf/types/known/durationpb"
 
 	"github.com/pomerium/pomerium/internal/fileutil"
@@ -238,7 +240,7 @@ func (cfg *Config) GetCertificatePool() (*x509.CertPool, error) {
 
 // GetAuthenticateKeyFetcher returns a key fetcher for the authenticate service
 func (cfg *Config) GetAuthenticateKeyFetcher() (hpke.KeyFetcher, error) {
-	authenticateURL, transport, err := cfg.resolveAuthenticateURL()
+	authenticateURL, transport, err := cfg.resolveAuthenticateURL(otel.GetTracerProvider())
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +250,7 @@ func (cfg *Config) GetAuthenticateKeyFetcher() (hpke.KeyFetcher, error) {
 	return hpke.NewKeyFetcher(hpkeURL, transport), nil
 }
 
-func (cfg *Config) resolveAuthenticateURL() (*url.URL, http.RoundTripper, error) {
+func (cfg *Config) resolveAuthenticateURL(tracerProvider oteltrace.TracerProvider) (*url.URL, http.RoundTripper, error) {
 	authenticateURL, err := cfg.Options.GetInternalAuthenticateURL()
 	if err != nil {
 		return nil, nil, fmt.Errorf("invalid authenticate service url: %w", err)
@@ -269,7 +271,7 @@ func (cfg *Config) resolveAuthenticateURL() (*url.URL, http.RoundTripper, error)
 	if cfg.Options.UseProxyProtocol {
 		transport = httputil.NewLocalProxyProtocolTransport(transport)
 	}
-	return authenticateURL, otelhttp.NewTransport(transport), nil
+	return authenticateURL, otelhttp.NewTransport(transport, otelhttp.WithTracerProvider(tracerProvider)), nil
 }
 
 func getOneOf[OneOfContainer, OneOf, Value any](container OneOfContainer, _ OneOf, value Value) *Value {

--- a/config/session.go
+++ b/config/session.go
@@ -207,7 +207,7 @@ func (c *incomingIDPTokenSessionCreator) createSessionForAccessToken(
 			return nil, err
 		}
 
-		authenticateURL, transport, err := cfg.resolveAuthenticateURL()
+		authenticateURL, transport, err := cfg.resolveAuthenticateURL(c.telemetry.GetTracerProvider())
 		if err != nil {
 			return nil, fmt.Errorf("error resolving authenticate url to verify access token: %w", err)
 		}
@@ -279,7 +279,7 @@ func (c *incomingIDPTokenSessionCreator) createSessionForIdentityToken(
 			return nil, err
 		}
 
-		authenticateURL, transport, err := cfg.resolveAuthenticateURL()
+		authenticateURL, transport, err := cfg.resolveAuthenticateURL(c.telemetry.GetTracerProvider())
 		if err != nil {
 			return nil, fmt.Errorf("error resolving authenticate url to verify identity token: %w", err)
 		}

--- a/config/session_int_test.go
+++ b/config/session_int_test.go
@@ -1,0 +1,68 @@
+package config_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/scenarios"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	"github.com/pomerium/pomerium/pkg/nullable"
+)
+
+func TestBearerTokenFormat(t *testing.T) {
+	run := func(t *testing.T, useProxyProtocol bool) {
+		t.Helper()
+
+		env := testenv.New(t)
+
+		env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
+			cfg.Options.BearerTokenFormat = nullable.From(configpb.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_ACCESS_TOKEN)
+			cfg.Options.UseProxyProtocol = useProxyProtocol
+		}))
+
+		env.Add(scenarios.NewIDP([]*scenarios.User{{Email: "test@example.com"}}))
+
+		up := upstreams.HTTP(nil)
+		up.Handle("/", func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte(r.Header.Get("Access-Token")))
+		})
+		route := up.Route().
+			From(env.SubdomainURL("http")).
+			Policy(func(p *config.Policy) {
+				p.AllowAnyAuthenticatedUser = true
+				p.SetRequestHeaders = map[string]string{"access-token": "$pomerium.access_token"}
+			})
+		env.AddUpstream(up)
+
+		env.Start()
+
+		// first request is a normal login
+		r1, err := up.Get(route,
+			upstreams.AuthenticateAs("test@example.com"))
+		require.NoError(t, err)
+		defer r1.Body.Close()
+		accessToken, err := io.ReadAll(r1.Body)
+		require.NoError(t, err)
+
+		// second request is via the authorization header
+		r2, err := up.Get(route,
+			upstreams.Headers(map[string]string{
+				"Authorization": "Bearer " + string(accessToken),
+			}))
+		require.NoError(t, err)
+		defer r2.Body.Close()
+		data, err := io.ReadAll(r2.Body)
+		require.NoError(t, err)
+		assert.Equal(t, string(accessToken), string(data))
+	}
+	t.Run("without proxy protocol", func(t *testing.T) { run(t, false) })
+	t.Run("with proxy protocol", func(t *testing.T) { run(t, true) })
+}

--- a/internal/testenv/upstreams/http.go
+++ b/internal/testenv/upstreams/http.go
@@ -13,11 +13,13 @@ import (
 	"net/http/httptrace"
 	"net/url"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/websocket"
+	"github.com/pires/go-proxyproto"
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -392,6 +394,30 @@ func (h *httpUpstream) newClient(options *RequestOptions) *http.Client {
 		Certificates: options.clientCerts,
 	}
 	transport.DialTLSContext = nil
+	if h.Env().Config().Options.UseProxyProtocol {
+		transport.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
+			var zeroDialer net.Dialer
+			conn, err := zeroDialer.DialContext(ctx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+
+			// if this is a proxy connection, use the haproxy proxy protocol
+			if _, p, _ := net.SplitHostPort(addr); p == strconv.Itoa(h.Env().Ports().ProxyHTTP.Value()) {
+				header := &proxyproto.Header{
+					Version: 2,
+					Command: proxyproto.LOCAL,
+				}
+				_, err = header.WriteTo(conn)
+				if err != nil {
+					_ = conn.Close()
+					return nil, err
+				}
+			}
+
+			return conn, nil
+		}
+	}
 	c := http.Client{
 		Transport: &Transport{
 			Transport: otelhttp.NewTransport(transport,


### PR DESCRIPTION
## Summary
Add an integration test for #6516 

## Related issues
- [ENG-4226](https://linear.app/pomerium/issue/ENG-4226/idp-access-token-bearer-auth-fails-under-use-proxy-protocol-true-all)


## AI disclosure
No AI was used for this PR.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
