### PR TITLE
feat: enable mcp runtime flag by default

### DIFF
--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -31,7 +31,7 @@ var (
 	RuntimeFlagMatchAnyIncomingPort = runtimeFlag("match_any_incoming_port", true)
 
 	// RuntimeFlagMCP enables the MCP services for the authorize service
-	RuntimeFlagMCP = runtimeFlag("mcp", false)
+	RuntimeFlagMCP = runtimeFlag("mcp", true)
 
 	// RuntimeFlagMCPDynamicClientRegistration enables Dynamic Client Registration as an authorization
 	// method for upstream MCP servers

--- a/proxy/handlers_portal.go
+++ b/proxy/handlers_portal.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"sync"
 
 	"github.com/pomerium/pomerium/config"
@@ -97,6 +98,12 @@ func (p *Proxy) fillMCPPortalRoutes(ctx context.Context, u handlers.UserInfoData
 	mcpSrv := p.mcp.Load()
 	if mcpSrv == nil {
 		log.Ctx(ctx).Debug().Msg("portal: MCP handler not loaded, skipping MCP route info")
+		return ""
+	}
+
+	if !slices.ContainsFunc(portalRoutes, func(r portal.Route) bool {
+		return r.Type == portal.RouteTypeMCP
+	}) {
 		return ""
 	}
 


### PR DESCRIPTION
## Summary

Enables MCP related features by default.

## Related issues

[ENG-4168](https://linear.app/pomerium/issue/ENG-4168/mcp-split-a-narrow-dcr-feature-flag-enable-the-mcp-runtime-flag-by)

## User Explanation

MCP aware features are enabled by default. Dynamic Client Registration is disabled by default and behind the `mcp_dynamic_client_registration` flag.

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
