### PR TITLE
identity: prevent IdP request params from overriding OAuth flow

### DIFF
--- a/pkg/identity/providers.go
+++ b/pkg/identity/providers.go
@@ -5,6 +5,7 @@ package identity
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 
@@ -78,6 +79,23 @@ func init() {
 func NewAuthenticator(ctx context.Context, tracerProvider oteltrace.TracerProvider, o oauth.Options) (a Authenticator, err error) {
 	if o.ProviderName == "" {
 		return nil, fmt.Errorf("identity: provider is not defined")
+	}
+
+	hadAuthCodeOptions := len(o.AuthCodeOptions) > 0
+	o.AuthCodeOptions = maps.Clone(o.AuthCodeOptions)
+	for _, key := range []string{
+		"client_id",
+		"response_type",
+		"redirect_uri",
+		"scope",
+		"state",
+		"code_challenge",
+		"code_challenge_method",
+	} {
+		delete(o.AuthCodeOptions, key)
+	}
+	if hadAuthCodeOptions && len(o.AuthCodeOptions) == 0 {
+		o.AuthCodeOptions = nil
 	}
 
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{

--- a/pkg/identity/providers.go
+++ b/pkg/identity/providers.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -83,16 +84,11 @@ func NewAuthenticator(ctx context.Context, tracerProvider oteltrace.TracerProvid
 
 	hadAuthCodeOptions := len(o.AuthCodeOptions) > 0
 	o.AuthCodeOptions = maps.Clone(o.AuthCodeOptions)
-	for _, key := range []string{
-		"client_id",
-		"response_type",
-		"redirect_uri",
-		"scope",
-		"state",
-		"code_challenge",
-		"code_challenge_method",
-	} {
-		delete(o.AuthCodeOptions, key)
+	for key := range o.AuthCodeOptions {
+		switch strings.ToLower(key) {
+		case "client_id", "response_type", "redirect_uri", "scope", "state", "code_challenge", "code_challenge_method":
+			delete(o.AuthCodeOptions, key)
+		}
 	}
 	if hadAuthCodeOptions && len(o.AuthCodeOptions) == 0 {
 		o.AuthCodeOptions = nil

--- a/pkg/identity/providers_test.go
+++ b/pkg/identity/providers_test.go
@@ -1,0 +1,55 @@
+package identity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/google"
+)
+
+func TestNewAuthenticatorRemovesReservedAuthCodeOptions(t *testing.T) {
+	const providerName = "test-reserved-auth-code-options"
+
+	var got map[string]string
+	RegisterAuthenticator(providerName, func(_ context.Context, o *oauth.Options) (Authenticator, error) {
+		got = o.AuthCodeOptions
+		return nil, nil
+	})
+	t.Cleanup(func() { delete(registry, providerName) })
+
+	requestParams := map[string]string{
+		"client_id":             "client_id",
+		"response_type":         "response_type",
+		"redirect_uri":          "https://example.com/callback",
+		"scope":                 "openid",
+		"state":                 "state",
+		"code_challenge":        "challenge",
+		"code_challenge_method": "plain",
+		"prompt":                "login",
+	}
+
+	_, err := NewAuthenticator(t.Context(), noop.NewTracerProvider(), oauth.Options{
+		ProviderName:    providerName,
+		AuthCodeOptions: requestParams,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"prompt": "login"}, got)
+	assert.Contains(t, requestParams, "client_id")
+
+	a, err := NewAuthenticator(t.Context(), noop.NewTracerProvider(), oauth.Options{
+		ProviderName: google.Name,
+		AuthCodeOptions: map[string]string{
+			"client_id": "client_id",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"access_type": "offline",
+		"prompt":      "select_account consent",
+	}, a.(*google.Provider).AuthCodeOptions)
+}

--- a/pkg/identity/providers_test.go
+++ b/pkg/identity/providers_test.go
@@ -24,6 +24,7 @@ func TestNewAuthenticatorRemovesReservedAuthCodeOptions(t *testing.T) {
 
 	requestParams := map[string]string{
 		"client_id":             "client_id",
+		"Client_ID":             "client_id",
 		"response_type":         "response_type",
 		"redirect_uri":          "https://example.com/callback",
 		"scope":                 "openid",


### PR DESCRIPTION
## Summary

Identity provider request parameters are applied after the OAuth client builds the authorization URL, so a configured `client_id`, `response_type`, `redirect_uri`, `scope`, `state`, or PKCE value can replace the value Pomerium generated. A literal placeholder such as `client_id=client_id` makes the identity provider reject the authorize request. Because that same flow gates the Console, the bad setting locks administrators out and previously required direct databroker recovery.

Filter Pomerium-owned authorization parameters case-insensitively at `identity.NewAuthenticator`, the shared provider-construction boundary. Custom request parameters still reach the provider, and the caller's map is cloned rather than mutated. If filtering removes every supplied parameter, pass `nil` so providers such as Google and Azure retain their built-in authorization defaults.

This contains already-persisted bad values as soon as Core is upgraded and protects every production authenticator caller. It intentionally does not rewrite stored settings or add Console-side validation; the documentation change removes the unsafe example separately.

The 0.33 release branch was validated with the identical patch in #6523. That PR was closed after review so the repository's normal post-merge backport automation can preserve main-before-release merge order.

## Related issues

- [ENG-4222](https://linear.app/pomerium/issue/ENG-4222/identity-provider-request-params-saved-with-placeholder-values-client)
- 0.33 validation PR (closed in favor of post-merge backport automation): #6523
- Documentation: pomerium/documentation#2312

## User Explanation

Identity Provider Request Params can no longer override OAuth values generated by Pomerium. Existing invalid values such as `client_id=client_id` are ignored during sign-in, while provider-specific custom parameters continue to work.

## Testing

- `go test ./pkg/identity`
- `make build`
- `make test`
- `GOLANGCI_LINT_CACHE=/tmp/eng-4222-lint-main make lint`

## AI disclosure

GPT-5 Codex implemented the patch and tests from the maintainer-supplied reproduction, scope, and reserved-parameter list; independent Codex and Greptile reviews identified the provider-default and mixed-case edges, which were incorporated before final validation.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
