### PR TITLE
[0.33] identity: prevent IdP request param overrides

### DIFF
--- a/pkg/identity/providers.go
+++ b/pkg/identity/providers.go
@@ -5,6 +5,7 @@ package identity
 import (
 	"context"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 
@@ -78,6 +79,23 @@ func init() {
 func NewAuthenticator(ctx context.Context, tracerProvider oteltrace.TracerProvider, o oauth.Options) (a Authenticator, err error) {
 	if o.ProviderName == "" {
 		return nil, fmt.Errorf("identity: provider is not defined")
+	}
+
+	hadAuthCodeOptions := len(o.AuthCodeOptions) > 0
+	o.AuthCodeOptions = maps.Clone(o.AuthCodeOptions)
+	for _, key := range []string{
+		"client_id",
+		"response_type",
+		"redirect_uri",
+		"scope",
+		"state",
+		"code_challenge",
+		"code_challenge_method",
+	} {
+		delete(o.AuthCodeOptions, key)
+	}
+	if hadAuthCodeOptions && len(o.AuthCodeOptions) == 0 {
+		o.AuthCodeOptions = nil
 	}
 
 	ctx = context.WithValue(ctx, oauth2.HTTPClient, &http.Client{

--- a/pkg/identity/providers.go
+++ b/pkg/identity/providers.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -83,16 +84,11 @@ func NewAuthenticator(ctx context.Context, tracerProvider oteltrace.TracerProvid
 
 	hadAuthCodeOptions := len(o.AuthCodeOptions) > 0
 	o.AuthCodeOptions = maps.Clone(o.AuthCodeOptions)
-	for _, key := range []string{
-		"client_id",
-		"response_type",
-		"redirect_uri",
-		"scope",
-		"state",
-		"code_challenge",
-		"code_challenge_method",
-	} {
-		delete(o.AuthCodeOptions, key)
+	for key := range o.AuthCodeOptions {
+		switch strings.ToLower(key) {
+		case "client_id", "response_type", "redirect_uri", "scope", "state", "code_challenge", "code_challenge_method":
+			delete(o.AuthCodeOptions, key)
+		}
 	}
 	if hadAuthCodeOptions && len(o.AuthCodeOptions) == 0 {
 		o.AuthCodeOptions = nil

--- a/pkg/identity/providers_test.go
+++ b/pkg/identity/providers_test.go
@@ -1,0 +1,55 @@
+package identity
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/pomerium/pomerium/pkg/identity/oauth"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/google"
+)
+
+func TestNewAuthenticatorRemovesReservedAuthCodeOptions(t *testing.T) {
+	const providerName = "test-reserved-auth-code-options"
+
+	var got map[string]string
+	RegisterAuthenticator(providerName, func(_ context.Context, o *oauth.Options) (Authenticator, error) {
+		got = o.AuthCodeOptions
+		return nil, nil
+	})
+	t.Cleanup(func() { delete(registry, providerName) })
+
+	requestParams := map[string]string{
+		"client_id":             "client_id",
+		"response_type":         "response_type",
+		"redirect_uri":          "https://example.com/callback",
+		"scope":                 "openid",
+		"state":                 "state",
+		"code_challenge":        "challenge",
+		"code_challenge_method": "plain",
+		"prompt":                "login",
+	}
+
+	_, err := NewAuthenticator(t.Context(), noop.NewTracerProvider(), oauth.Options{
+		ProviderName:    providerName,
+		AuthCodeOptions: requestParams,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{"prompt": "login"}, got)
+	assert.Contains(t, requestParams, "client_id")
+
+	a, err := NewAuthenticator(t.Context(), noop.NewTracerProvider(), oauth.Options{
+		ProviderName: google.Name,
+		AuthCodeOptions: map[string]string{
+			"client_id": "client_id",
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, map[string]string{
+		"access_type": "offline",
+		"prompt":      "select_account consent",
+	}, a.(*google.Provider).AuthCodeOptions)
+}

--- a/pkg/identity/providers_test.go
+++ b/pkg/identity/providers_test.go
@@ -24,6 +24,7 @@ func TestNewAuthenticatorRemovesReservedAuthCodeOptions(t *testing.T) {
 
 	requestParams := map[string]string{
 		"client_id":             "client_id",
+		"Client_ID":             "client_id",
 		"response_type":         "response_type",
 		"redirect_uri":          "https://example.com/callback",
 		"scope":                 "openid",


### PR DESCRIPTION
## Summary

Console 0.33 can persist literal Identity Provider Request Params such as `client_id=client_id`. Core 0.33 then applies those values after constructing the authorization URL, replacing the real OAuth handshake parameters and locking users out of the Console login flow.

Backport #6522 to `0-33-0`. The release branch now filters Pomerium-owned authorization parameters case-insensitively at the shared `identity.NewAuthenticator` boundary, preserves custom parameters without mutating the caller's map, and restores provider defaults when filtering removes every supplied value.

The implementation and regression test are identical to the main-branch fix. This backport does not rewrite persisted settings or add Console-side validation.

## Related issues

- Backport of #6522
- Documentation: pomerium/documentation#2312
- [ENG-4222](https://linear.app/pomerium/issue/ENG-4222/identity-provider-request-params-saved-with-placeholder-values-client)

## User Explanation

Identity Provider Request Params can no longer override OAuth values generated by Pomerium. Existing invalid values such as `client_id=client_id` are ignored during sign-in, while provider-specific custom parameters continue to work.

## Testing

- `go test ./pkg/identity`
- `make build`
- `make test`
- `GOLANGCI_LINT_CACHE=/tmp/eng-4222-lint-0-33 make lint`

## AI disclosure

GPT-5 Codex applied and validated the maintainer-directed backport; Codex and Greptile feedback about preserving provider defaults and mixed-case keys was incorporated before the main and release-branch suites were rerun.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
