### PR TITLE
ci: update dependencies for release branch

### DIFF
--- a/.github/workflows/update-branch-dependencies.yaml
+++ b/.github/workflows/update-branch-dependencies.yaml
@@ -28,7 +28,7 @@ jobs:
         run: ./scripts/update-dependencies docker
 
       - name: Update Pomerium Dependencies
-        if: ${{ inputs.branch == "main" }}
+        if: ${{ inputs.branch == 'main' }}
         run: ./scripts/update-dependencies pomerium
 
       - name: Proto

--- a/.github/workflows/update-branch-dependencies.yaml
+++ b/.github/workflows/update-branch-dependencies.yaml
@@ -17,6 +17,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           fetch-depth: 0
+          ref: ${{ inputs.branch }}
 
       - name: Setup ASDF
         uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47

--- a/.github/workflows/update-branch-dependencies.yaml
+++ b/.github/workflows/update-branch-dependencies.yaml
@@ -45,5 +45,5 @@ jobs:
           commit-message: "ci: update dependencies"
           delete-branch: true
           labels: ci
-          title: "ci: update dependencies"
+          title: "ci: update ${{ inputs.branch }} dependencies"
           token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}

--- a/.github/workflows/update-branch-dependencies.yaml
+++ b/.github/workflows/update-branch-dependencies.yaml
@@ -1,4 +1,5 @@
 name: Update Branch Dependencies
+run-name: Update ${{ inputs.branch }} Dependencies
 
 on:
   workflow_dispatch:

--- a/.github/workflows/update-branch-dependencies.yaml
+++ b/.github/workflows/update-branch-dependencies.yaml
@@ -1,0 +1,48 @@
+name: Update Branch Dependencies
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: The branch to run the script on
+        default: main
+        required: false
+        type: string
+
+jobs:
+  update-branch-depenencies:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+
+      - name: Setup ASDF
+        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
+
+      - name: Update Tools
+        run: ./scripts/update-dependencies tools
+
+      - name: Update Docker Dependencies
+        run: ./scripts/update-dependencies docker
+
+      - name: Update Pomerium Dependencies
+        if: ${{ inputs.branch == "main" }}
+        run: ./scripts/update-dependencies pomerium
+
+      - name: Proto
+        run: make proto
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
+        with:
+          author: GitHub Actions <apparitor@users.noreply.github.com>
+          base: ${{ inputs.branch }}
+          body: "This PR updates dependencies not managed by dependabot."
+          branch: ci/update-${{ inputs.branch }}
+          commit-message: "ci: update dependencies"
+          delete-branch: true
+          labels: ci
+          title: "ci: update dependencies"
+          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,7 +1,6 @@
 name: Update Dependencies
 
 on:
-  pull_request:
   schedule:
     - cron: "40 1 * * *"
   workflow_dispatch:

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -1,6 +1,7 @@
 name: Update Dependencies
 
 on:
+  pull_request:
   schedule:
     - cron: "40 1 * * *"
   workflow_dispatch:
@@ -9,35 +10,8 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - name: Trigger Update Main Dependencies
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
         with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Setup ASDF
-        uses: asdf-vm/actions/install@b7bcd026f18772e44fe1026d729e1611cc435d47
-
-      - name: Update Tools
-        run: ./scripts/update-dependencies tools
-
-      - name: Update Docker Dependencies
-        run: ./scripts/update-dependencies docker
-
-      - name: Update Pomerium Dependencies
-        run: ./scripts/update-dependencies pomerium
-
-      - name: Proto
-        run: make proto
-
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1
-        with:
-          author: GitHub Actions <apparitor@users.noreply.github.com>
-          body: "This PR updates dependencies not managed by dependabot."
-          branch: ci/update-core
-          commit-message: "ci: update dependencies"
-          delete-branch: true
-          labels: ci
-          title: "ci: update dependencies"
-          token: ${{ secrets.APPARITOR_GITHUB_TOKEN }}
+          workflow: update-branch-dependencies.yaml
+          inputs: '{"branch":"main"}'

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -10,14 +10,26 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Update Latest Release Dependencies
-        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
+      - name: Get Latest Release
+        uses: rez0n/actions-github-release@05fabbd6b2b3ce3383299555ea518faea69b736d
+        id: latest_release
         with:
-          workflow: update-branch-dependencies.yaml
-          inputs: '{"branch":"0-33-0"}'
+          repository: ${{ github.repository }}
+          type: "stable"
 
-      - name: Trigger Update Main Dependencies
-        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
-        with:
-          workflow: update-branch-dependencies.yaml
-          inputs: '{"branch":"main"}'
+      - name: Get Latest Release Branch
+        run: |
+          latest_release_branch="$(echo ${{ steps.latest_release.outputs.release }} | sed -E 's/^v?([0-9]+)[.]([0-9]+)[.].*$/\1-\2-0/')"
+          echo "latest_release_branch=$latest_release_branch" >> "$GITHUB_OUTPUT"
+
+      # - name: Trigger Update Latest Release Dependencies
+      #   uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
+      #   with:
+      #     workflow: update-branch-dependencies.yaml
+      #     inputs: '{"branch":"0-33-0"}'
+
+      # - name: Trigger Update Main Dependencies
+      #   uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
+      #   with:
+      #     workflow: update-branch-dependencies.yaml
+      #     inputs: '{"branch":"main"}'

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -18,9 +18,13 @@ jobs:
           type: "stable"
 
       - name: Get Latest Release Branch
+        id: latest_release_branch
         run: |
           latest_release_branch="$(echo ${{ steps.latest_release.outputs.release }} | sed -E 's/^v?([0-9]+)[.]([0-9]+)[.].*$/\1-\2-0/')"
-          echo "latest_release_branch=$latest_release_branch" >> "$GITHUB_OUTPUT"
+          echo "value=$latest_release_branch" >> "$GITHUB_OUTPUT"
+
+      - name: test
+        run: echo ${{ steps.latest_release_branch.outputs.value }}
 
       # - name: Trigger Update Latest Release Dependencies
       #   uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -23,17 +23,14 @@ jobs:
           latest_release_branch="$(echo ${{ steps.latest_release.outputs.release }} | sed -E 's/^v?([0-9]+)[.]([0-9]+)[.].*$/\1-\2-0/')"
           echo "value=$latest_release_branch" >> "$GITHUB_OUTPUT"
 
-      - name: test
-        run: echo ${{ steps.latest_release_branch.outputs.value }}
+      - name: Trigger Update Latest Release Dependencies
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
+        with:
+          workflow: update-branch-dependencies.yaml
+          inputs: '{"branch":"${{ steps.latest_release_branch.outputs.value }}"}'
 
-      # - name: Trigger Update Latest Release Dependencies
-      #   uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
-      #   with:
-      #     workflow: update-branch-dependencies.yaml
-      #     inputs: '{"branch":"0-33-0"}'
-
-      # - name: Trigger Update Main Dependencies
-      #   uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
-      #   with:
-      #     workflow: update-branch-dependencies.yaml
-      #     inputs: '{"branch":"main"}'
+      - name: Trigger Update Main Dependencies
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
+        with:
+          workflow: update-branch-dependencies.yaml
+          inputs: '{"branch":"main"}'

--- a/.github/workflows/update-dependencies.yaml
+++ b/.github/workflows/update-dependencies.yaml
@@ -10,6 +10,12 @@ jobs:
   update-dependencies:
     runs-on: ubuntu-latest
     steps:
+      - name: Trigger Update Latest Release Dependencies
+        uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
+        with:
+          workflow: update-branch-dependencies.yaml
+          inputs: '{"branch":"0-33-0"}'
+
       - name: Trigger Update Main Dependencies
         uses: benc-uk/workflow-dispatch@31e2b3319479a63f0ab15bf800eff9e913504e26
         with:


### PR DESCRIPTION
## Summary
Update the `Update Dependencies` workflow so that it now uses a reusable workflow and dispatches it for `main` as well as the latest release branch.

Tool dependencies (go, node, etc) are updated for all branches. Pomerium dependencies (datasource, webauthn, etc) are only updated on main.

Determining the latest release branch is done by taking the latest stable release on Github and running it through a regex to get the branch name.

## Related issues
- [ENG-4248](https://linear.app/pomerium/issue/ENG-4248/various-ci-update-tasks-should-also-update-release-branches)

## AI disclosure
No AI was used for this PR.

## Checklist
- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
