### PR TITLE
ci: fix ssh tests

### DIFF
--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -2,5 +2,5 @@
   "config": "v0.37.0",
   "hosted-authenticate-oidc": "v0.1.0",
   "mcp": "v0.32.0",
-  "ssh": "v0.19.0"
+  "ssh": "v0.20.0"
 }

--- a/pkg/ssh/ssh_int_test.go
+++ b/pkg/ssh/ssh_int_test.go
@@ -222,7 +222,9 @@ func (s *SSHTestSuite) TestReevaluatePolicyOnConfigChange() {
 	}))
 
 	sess.Wait()
-	s.ErrorContains(client.Wait(), "ssh: disconnect, reason 2: Permission Denied: access denied{via_upstream}")
+	err = client.Wait()
+	s.ErrorContains(err, "ssh: disconnect, reason 2")
+	s.ErrorContains(err, "Permission Denied: access denied{via_upstream}")
 }
 
 func (s *SSHTestSuite) TestRevokeSession() {
@@ -264,7 +266,9 @@ func (s *SSHTestSuite) TestRevokeSession() {
 	})
 	s.Require().NoError(err)
 	sess.Wait()
-	s.ErrorContains(client.Wait(), "ssh: disconnect, reason 2: Permission Denied: no longer authorized{via_upstream}")
+	err = client.Wait()
+	s.ErrorContains(err, "ssh: disconnect, reason 2")
+	s.ErrorContains(err, "Permission Denied: no longer authorized{via_upstream}")
 }
 
 func (s *SSHTestSuite) TestDirectTcpipSession() {


### PR DESCRIPTION
## Summary
It looks like double quotes were added to error messages, resulting in test failures. This PR updates the tests to tolerate either.

## Related issues
- [ENG-4250](https://linear.app/pomerium/issue/ENG-4250/core-ssh-test-failures)


## AI disclosure
No AI was used for this PR.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
