### PR TITLE
fix: root spans when mcp runtime flag is on

### DIFF
--- a/authorize/state.go
+++ b/authorize/state.go
@@ -60,21 +60,6 @@ func newAuthorizeStateFromConfig(
 		previousEvaluator = previousState.evaluator
 	}
 
-	var evaluatorOptions []evaluator.Option
-	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
-		mcp, err := mcp.New(ctx, mcp.DefaultPrefix, cfg, outboundGrpcConn)
-		if err != nil {
-			return nil, fmt.Errorf("authorize: failed to create mcp handler: %w", err)
-		}
-		state.mcp = mcp
-		evaluatorOptions = append(evaluatorOptions, evaluator.WithMCPAccessTokenProvider(mcp))
-	}
-
-	state.evaluator, err = newPolicyEvaluator(ctx, cfg.Options, store, previousEvaluator, evaluatorOptions...)
-	if err != nil {
-		return nil, fmt.Errorf("authorize: failed to update policy with options: %w", err)
-	}
-
 	state.sharedKey, err = cfg.Options.GetSharedKey()
 	if err != nil {
 		return nil, err
@@ -102,6 +87,21 @@ func newAuthorizeStateFromConfig(
 	}
 	state.dataBrokerClientConnection = cc
 	state.dataBrokerClient = databroker.NewDataBrokerServiceClient(cc)
+
+	var evaluatorOptions []evaluator.Option
+	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
+		mcp, err := mcp.New(ctx, mcp.DefaultPrefix, cfg, outboundGrpcConn)
+		if err != nil {
+			return nil, fmt.Errorf("authorize: failed to create mcp handler: %w", err)
+		}
+		state.mcp = mcp
+		evaluatorOptions = append(evaluatorOptions, evaluator.WithMCPAccessTokenProvider(mcp))
+	}
+
+	state.evaluator, err = newPolicyEvaluator(ctx, cfg.Options, store, previousEvaluator, evaluatorOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("authorize: failed to update policy with options: %w", err)
+	}
 
 	state.sessionStore, err = config.NewSessionStore(cfg.Options)
 	if err != nil {

--- a/internal/testenv/selftests/tracing_test.go
+++ b/internal/testenv/selftests/tracing_test.go
@@ -365,10 +365,10 @@ func TestSampling(t *testing.T) {
 func TestExternalSpans(t *testing.T) {
 	type testcase struct {
 		name          string
-		envAndResults func() (env testenv.Environment, external *otlptrace.Exporter, externalTracerProvider *sdktrace.TracerProvider, getResults func() *TraceResults)
+		envAndResults func(t *testing.T) (env testenv.Environment, external *otlptrace.Exporter, externalTracerProvider *sdktrace.TracerProvider, getResults func() *TraceResults)
 	}
-	scenarioSetup := func(mcpEnabled bool) func() (testenv.Environment, *otlptrace.Exporter, *sdktrace.TracerProvider, func() *TraceResults) {
-		return func() (testenv.Environment, *otlptrace.Exporter, *sdktrace.TracerProvider, func() *TraceResults) {
+	scenarioSetup := func(mcpEnabled bool) func(t *testing.T) (testenv.Environment, *otlptrace.Exporter, *sdktrace.TracerProvider, func() *TraceResults) {
+		return func(t *testing.T) (testenv.Environment, *otlptrace.Exporter, *sdktrace.TracerProvider, func() *TraceResults) {
 			srv := scenarios.NewOTLPTraceReceiver()
 
 			// set up external tracer
@@ -409,7 +409,7 @@ func TestExternalSpans(t *testing.T) {
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
-			env, external, externalTracerProvider, getResults := tc.envAndResults()
+			env, external, externalTracerProvider, getResults := tc.envAndResults(t)
 
 			up := upstreams.HTTP(nil, upstreams.WithNoClientTracing())
 			up.Handle("/foo", func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/testenv/selftests/tracing_test.go
+++ b/internal/testenv/selftests/tracing_test.go
@@ -43,82 +43,114 @@ var allServices = []string{
 }
 
 func TestOTLPTracing(t *testing.T) {
-	srv := scenarios.NewOTLPTraceReceiver()
-	env := testenv.New(t, testenv.WithTraceDebugFlags(testenv.StandardTraceDebugFlags), testenv.WithTraceClient(srv.NewGRPCClient()))
-	env.Add(srv)
-
-	up := upstreams.HTTP(nil, upstreams.WithDisplayName("Upstream"))
-	up.Handle("/foo", func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte("OK"))
-	})
-	env.Add(scenarios.NewIDP([]*scenarios.User{
+	type testcase struct {
+		name          string
+		envAndResults func(t *testing.T) (env testenv.Environment, getResults func() *TraceResults)
+	}
+	scenarioSetup := func(mcpEnabled bool) func(t *testing.T) (testenv.Environment, func() *TraceResults) {
+		return func(t *testing.T) (e testenv.Environment, f func() *TraceResults) {
+			srv := scenarios.NewOTLPTraceReceiver()
+			env := testenv.New(t, testenv.WithTraceDebugFlags(testenv.StandardTraceDebugFlags), testenv.WithTraceClient(srv.NewGRPCClient()))
+			env.Add(srv)
+			env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
+				if cfg.Options.RuntimeFlags == nil {
+					cfg.Options.RuntimeFlags = make(config.RuntimeFlags)
+				}
+				cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = mcpEnabled
+			}))
+			return env, func() *TraceResults {
+				results := NewTraceResults(srv.FlushResourceSpans())
+				return results
+			}
+		}
+	}
+	tcs := []testcase{
 		{
-			Email:     "foo@example.com",
-			FirstName: "Firstname",
-			LastName:  "Lastname",
+			name:          "mcp on",
+			envAndResults: scenarioSetup(true),
 		},
-	}))
-
-	route := up.Route().
-		From(env.SubdomainURL("foo")).
-		PPL(`{"allow":{"and":["email":{"is":"foo@example.com"}]}}`)
-
-	env.AddUpstream(up)
-	env.Start()
-	snippets.WaitStartupComplete(env)
-
-	ctx, span := env.Tracer().Start(env.Context(), "Authenticate", oteltrace.WithNewRoot())
-	resp, err := up.Get(route, upstreams.AuthenticateAs("foo@example.com"), upstreams.Path("/foo"), upstreams.Context(ctx))
-	span.End()
-	require.NoError(t, err)
-	body, err := io.ReadAll(resp.Body)
-	assert.NoError(t, err)
-	assert.NoError(t, resp.Body.Close())
-	assert.Equal(t, resp.StatusCode, 200)
-	assert.Equal(t, "OK", string(body))
-
-	env.Stop()
-
-	results := NewTraceResults(srv.FlushResourceSpans())
-	var (
-		testEnvironmentLocalTest                  = fmt.Sprintf("Test Environment: %s", t.Name())
-		testEnvironmentAuthenticate               = "Test Environment: Authenticate"
-		authenticateOAuth2Client                  = "Authenticate: OAuth2 Client: GET /.well-known/jwks.json"
-		authorizeDatabrokerSync                   = "Authorize: databroker.DataBrokerService/Sync"
-		authorizeDatabrokerSyncLatest             = "Authorize: databroker.DataBrokerService/SyncLatest"
-		idpServerGetUserinfo                      = "IDP: Server: GET /oidc/userinfo"
-		idpServerPostToken                        = "IDP: Server: POST /oidc/token"
-		controlPlaneEnvoyAccessLogs               = "Control Plane: envoy.service.accesslog.v3.AccessLogService/StreamAccessLogs"
-		controlPlaneEnvoyDiscovery                = "Control Plane: envoy.service.discovery.v3.AggregatedDiscoveryService/DeltaAggregatedResources"
-		controlPlaneExport                        = "Control Plane: opentelemetry.proto.collector.trace.v1.TraceService/Export"
-		dataBrokerClusteredServerUpdateLeader     = "Data Broker: databroker-clustered-server.UpdateLeader"
-		dataBrokerClusteredServerUpdateServer     = "Data Broker: databroker-clustered-server.UpdateServer"
-		dataBrokerClientManagerUpdateOptions      = "Data Broker: grpc-client-manager.UpdateOptions"
-		dataBrokerGRPCClientManagerOnConfigChange = "Data Broker: databroker-grpc-client-manager.OnConfigChange"
-		dataBrokerRaftStreamLayerOnConfigChange   = "Data Broker: raft-stream-layer.OnConfigChange"
-	)
-
-	results.MatchTraces(t,
-		MatchOptions{
-			Exact:              true,
-			CheckDetachedSpans: true,
+		{
+			name:          "mcp off",
+			envAndResults: scenarioSetup(false),
 		},
-		Match{Name: testEnvironmentLocalTest, TraceCount: 1, Services: []string{"Authenticate", "Authorize", "Test Environment", "Control Plane", "Data Broker", "IDP"}},
-		Match{Name: testEnvironmentAuthenticate, TraceCount: 1, Services: allServices},
-		Match{Name: authenticateOAuth2Client, TraceCount: Greater(0)},
-		Match{Name: dataBrokerClusteredServerUpdateLeader, TraceCount: Greater(0)},
-		Match{Name: dataBrokerClusteredServerUpdateServer, TraceCount: Greater(0)},
-		Match{Name: dataBrokerGRPCClientManagerOnConfigChange, TraceCount: Greater(0)},
-		Match{Name: dataBrokerClientManagerUpdateOptions, TraceCount: Greater(0)},
-		Match{Name: dataBrokerRaftStreamLayerOnConfigChange, TraceCount: Greater(0)},
-		Match{Name: idpServerGetUserinfo, TraceCount: EqualToMatch(authenticateOAuth2Client)},
-		Match{Name: idpServerPostToken, TraceCount: EqualToMatch(authenticateOAuth2Client)},
-		Match{Name: authorizeDatabrokerSync, TraceCount: Greater(0)},
-		Match{Name: authorizeDatabrokerSyncLatest, TraceCount: Greater(0)},
-		Match{Name: controlPlaneEnvoyDiscovery, TraceCount: 1},
-		Match{Name: controlPlaneExport, TraceCount: Greater(0)},
-		Match{Name: controlPlaneEnvoyAccessLogs, TraceCount: Any{}},
-	)
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			env, getResults := tc.envAndResults(t)
+			up := upstreams.HTTP(nil, upstreams.WithDisplayName("Upstream"))
+			up.Handle("/foo", func(w http.ResponseWriter, _ *http.Request) {
+				w.Write([]byte("OK"))
+			})
+			env.Add(scenarios.NewIDP([]*scenarios.User{
+				{
+					Email:     "foo@example.com",
+					FirstName: "Firstname",
+					LastName:  "Lastname",
+				},
+			}))
+
+			route := up.Route().
+				From(env.SubdomainURL("foo")).
+				PPL(`{"allow":{"and":["email":{"is":"foo@example.com"}]}}`)
+
+			env.AddUpstream(up)
+			env.Start()
+			snippets.WaitStartupComplete(env)
+
+			ctx, span := env.Tracer().Start(env.Context(), "Authenticate", oteltrace.WithNewRoot())
+			resp, err := up.Get(route, upstreams.AuthenticateAs("foo@example.com"), upstreams.Path("/foo"), upstreams.Context(ctx))
+			span.End()
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.NoError(t, resp.Body.Close())
+			assert.Equal(t, resp.StatusCode, 200)
+			assert.Equal(t, "OK", string(body))
+
+			env.Stop()
+
+			results := getResults()
+			var (
+				testEnvironmentLocalTest                  = fmt.Sprintf("Test Environment: %s", t.Name())
+				testEnvironmentAuthenticate               = "Test Environment: Authenticate"
+				authenticateOAuth2Client                  = "Authenticate: OAuth2 Client: GET /.well-known/jwks.json"
+				authorizeDatabrokerSync                   = "Authorize: databroker.DataBrokerService/Sync"
+				authorizeDatabrokerSyncLatest             = "Authorize: databroker.DataBrokerService/SyncLatest"
+				idpServerGetUserinfo                      = "IDP: Server: GET /oidc/userinfo"
+				idpServerPostToken                        = "IDP: Server: POST /oidc/token"
+				controlPlaneEnvoyAccessLogs               = "Control Plane: envoy.service.accesslog.v3.AccessLogService/StreamAccessLogs"
+				controlPlaneEnvoyDiscovery                = "Control Plane: envoy.service.discovery.v3.AggregatedDiscoveryService/DeltaAggregatedResources"
+				controlPlaneExport                        = "Control Plane: opentelemetry.proto.collector.trace.v1.TraceService/Export"
+				dataBrokerClusteredServerUpdateLeader     = "Data Broker: databroker-clustered-server.UpdateLeader"
+				dataBrokerClusteredServerUpdateServer     = "Data Broker: databroker-clustered-server.UpdateServer"
+				dataBrokerClientManagerUpdateOptions      = "Data Broker: grpc-client-manager.UpdateOptions"
+				dataBrokerGRPCClientManagerOnConfigChange = "Data Broker: databroker-grpc-client-manager.OnConfigChange"
+				dataBrokerRaftStreamLayerOnConfigChange   = "Data Broker: raft-stream-layer.OnConfigChange"
+			)
+
+			results.MatchTraces(t,
+				MatchOptions{
+					Exact:              true,
+					CheckDetachedSpans: true,
+				},
+				Match{Name: testEnvironmentLocalTest, TraceCount: 1, Services: []string{"Authenticate", "Authorize", "Test Environment", "Control Plane", "Data Broker", "IDP"}},
+				Match{Name: testEnvironmentAuthenticate, TraceCount: 1, Services: allServices},
+				Match{Name: authenticateOAuth2Client, TraceCount: Greater(0)},
+				Match{Name: dataBrokerClusteredServerUpdateLeader, TraceCount: Greater(0)},
+				Match{Name: dataBrokerClusteredServerUpdateServer, TraceCount: Greater(0)},
+				Match{Name: dataBrokerGRPCClientManagerOnConfigChange, TraceCount: Greater(0)},
+				Match{Name: dataBrokerClientManagerUpdateOptions, TraceCount: Greater(0)},
+				Match{Name: dataBrokerRaftStreamLayerOnConfigChange, TraceCount: Greater(0)},
+				Match{Name: idpServerGetUserinfo, TraceCount: EqualToMatch(authenticateOAuth2Client)},
+				Match{Name: idpServerPostToken, TraceCount: EqualToMatch(authenticateOAuth2Client)},
+				Match{Name: authorizeDatabrokerSync, TraceCount: Greater(0)},
+				Match{Name: authorizeDatabrokerSyncLatest, TraceCount: Greater(0)},
+				Match{Name: controlPlaneEnvoyDiscovery, TraceCount: 1},
+				Match{Name: controlPlaneExport, TraceCount: Greater(0)},
+				Match{Name: controlPlaneEnvoyAccessLogs, TraceCount: Any{}},
+			)
+		})
+	}
 }
 
 func TestOTLPTracing_TraceCorrelation(t *testing.T) {
@@ -163,10 +195,11 @@ func TestOTLPTracing_TraceCorrelation(t *testing.T) {
 
 type SamplingTestSuite struct {
 	suite.Suite
-	env      testenv.Environment
-	receiver *scenarios.OTLPTraceReceiver
-	route    testenv.Route
-	upstream upstreams.HTTPUpstream
+	mcpEnabled bool
+	env        testenv.Environment
+	receiver   *scenarios.OTLPTraceReceiver
+	route      testenv.Route
+	upstream   upstreams.HTTPUpstream
 
 	sampled    atomic.Int32
 	notSampled atomic.Int32
@@ -186,6 +219,10 @@ func (s *SamplingTestSuite) SetupTest() {
 	s.env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
 		half := 0.5
 		cfg.Options.Tracing.OtelTracesSamplerArg = &half
+		if cfg.Options.RuntimeFlags == nil {
+			cfg.Options.RuntimeFlags = make(config.RuntimeFlags)
+		}
+		cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = s.mcpEnabled
 	}))
 	s.env.Add(scenarios.NewIDP([]*scenarios.User{
 		{
@@ -317,77 +354,114 @@ func (s *SamplingTestSuite) TestExternalTraceparentNeverSample() {
 }
 
 func TestSampling(t *testing.T) {
-	suite.Run(t, &SamplingTestSuite{})
+	t.Run("mcp on", func(t *testing.T) {
+		suite.Run(t, &SamplingTestSuite{mcpEnabled: true})
+	})
+	t.Run("mcp off", func(t *testing.T) {
+		suite.Run(t, &SamplingTestSuite{mcpEnabled: false})
+	})
 }
 
 func TestExternalSpans(t *testing.T) {
-	srv := scenarios.NewOTLPTraceReceiver()
+	type testcase struct {
+		name          string
+		envAndResults func() (env testenv.Environment, external *otlptrace.Exporter, externalTracerProvider *sdktrace.TracerProvider, getResults func() *TraceResults)
+	}
+	scenarioSetup := func(mcpEnabled bool) func() (testenv.Environment, *otlptrace.Exporter, *sdktrace.TracerProvider, func() *TraceResults) {
+		return func() (testenv.Environment, *otlptrace.Exporter, *sdktrace.TracerProvider, func() *TraceResults) {
+			srv := scenarios.NewOTLPTraceReceiver()
 
-	// set up external tracer
-	external := otlptrace.NewUnstarted(srv.NewGRPCClient())
-	r, err := resource.Merge(
-		resource.Empty(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName("External"),
-		),
-	)
-	require.NoError(t, err)
+			// set up external tracer
+			external := otlptrace.NewUnstarted(srv.NewGRPCClient())
+			r, err := resource.Merge(
+				resource.Empty(),
+				resource.NewWithAttributes(
+					semconv.SchemaURL,
+					semconv.ServiceName("External"),
+				),
+			)
+			require.NoError(t, err)
 
-	externalTracerProvider := sdktrace.NewTracerProvider(sdktrace.WithBatcher(external), sdktrace.WithResource(r))
+			externalTracerProvider := sdktrace.NewTracerProvider(sdktrace.WithBatcher(external), sdktrace.WithResource(r))
 
-	env := testenv.New(t, testenv.WithTraceDebugFlags(testenv.StandardTraceDebugFlags|trace.EnvoyFlushEverySpan), testenv.WithTraceClient(srv.NewGRPCClient()))
-	env.Add(srv)
-
-	up := upstreams.HTTP(nil, upstreams.WithNoClientTracing())
-	up.Handle("/foo", func(w http.ResponseWriter, _ *http.Request) {
-		w.Write([]byte("OK"))
-	})
-	env.Add(scenarios.NewIDP([]*scenarios.User{
+			env := testenv.New(t, testenv.WithTraceDebugFlags(testenv.StandardTraceDebugFlags|trace.EnvoyFlushEverySpan), testenv.WithTraceClient(srv.NewGRPCClient()))
+			env.Add(srv)
+			env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
+				if cfg.Options.RuntimeFlags == nil {
+					cfg.Options.RuntimeFlags = make(config.RuntimeFlags)
+				}
+				cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = mcpEnabled
+			}))
+			return env, external, externalTracerProvider, func() *TraceResults {
+				return NewTraceResults(srv.FlushResourceSpans())
+			}
+		}
+	}
+	tcs := []testcase{
 		{
-			Email:     "foo@example.com",
-			FirstName: "Firstname",
-			LastName:  "Lastname",
+			name:          "mcp on",
+			envAndResults: scenarioSetup(true),
 		},
-	}))
+		{
+			name:          "mcp off",
+			envAndResults: scenarioSetup(false),
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			env, external, externalTracerProvider, getResults := tc.envAndResults()
 
-	route := up.Route().
-		From(env.SubdomainURL("foo")).
-		PPL(`{"allow":{"and":["email":{"is":"foo@example.com"}]}}`)
+			up := upstreams.HTTP(nil, upstreams.WithNoClientTracing())
+			up.Handle("/foo", func(w http.ResponseWriter, _ *http.Request) {
+				w.Write([]byte("OK"))
+			})
+			env.Add(scenarios.NewIDP([]*scenarios.User{
+				{
+					Email:     "foo@example.com",
+					FirstName: "Firstname",
+					LastName:  "Lastname",
+				},
+			}))
 
-	env.AddUpstream(up)
-	env.Start()
-	require.NoError(t, external.Start(env.Context()))
-	snippets.WaitStartupComplete(env)
+			route := up.Route().
+				From(env.SubdomainURL("foo")).
+				PPL(`{"allow":{"and":["email":{"is":"foo@example.com"}]}}`)
 
-	ctx, span := externalTracerProvider.Tracer("external").Start(t.Context(), "External Root", oteltrace.WithNewRoot())
-	t.Logf("external span id: %s", span.SpanContext().SpanID().String())
-	resp, err := up.Get(route, upstreams.AuthenticateAs("foo@example.com"), upstreams.Path("/foo"), upstreams.Context(ctx))
-	span.End()
-	require.NoError(t, err)
-	body, err := io.ReadAll(resp.Body)
-	assert.NoError(t, err)
-	assert.NoError(t, resp.Body.Close())
-	assert.Equal(t, resp.StatusCode, 200)
-	assert.Equal(t, "OK", string(body))
+			env.AddUpstream(up)
+			env.Start()
+			require.NoError(t, external.Start(env.Context()))
+			snippets.WaitStartupComplete(env)
 
-	assert.NoError(t, externalTracerProvider.ForceFlush(t.Context()))
-	assert.NoError(t, externalTracerProvider.Shutdown(t.Context()))
-	assert.NoError(t, external.Shutdown(ctx))
-	env.Stop()
+			ctx, span := externalTracerProvider.Tracer("external").Start(t.Context(), "External Root", oteltrace.WithNewRoot())
+			t.Logf("external span id: %s", span.SpanContext().SpanID().String())
+			resp, err := up.Get(route, upstreams.AuthenticateAs("foo@example.com"), upstreams.Path("/foo"), upstreams.Context(ctx))
+			span.End()
+			require.NoError(t, err)
+			body, err := io.ReadAll(resp.Body)
+			assert.NoError(t, err)
+			assert.NoError(t, resp.Body.Close())
+			assert.Equal(t, resp.StatusCode, 200)
+			assert.Equal(t, "OK", string(body))
 
-	results := NewTraceResults(srv.FlushResourceSpans())
-	results.MatchTraces(t, MatchOptions{CheckDetachedSpans: true},
-		Match{Name: "External: External Root", TraceCount: 1, Services: []string{
-			"Authorize",
-			"Authenticate",
-			"Control Plane",
-			"Data Broker",
-			"Proxy",
-			"IDP",
-			"Envoy",
-			"External",
-			"HTTP Upstream",
-		}},
-	)
+			assert.NoError(t, externalTracerProvider.ForceFlush(t.Context()))
+			assert.NoError(t, externalTracerProvider.Shutdown(t.Context()))
+			assert.NoError(t, external.Shutdown(ctx))
+			env.Stop()
+
+			results := getResults()
+			results.MatchTraces(t, MatchOptions{CheckDetachedSpans: true},
+				Match{Name: "External: External Root", TraceCount: 1, Services: []string{
+					"Authorize",
+					"Authenticate",
+					"Control Plane",
+					"Data Broker",
+					"Proxy",
+					"IDP",
+					"Envoy",
+					"External",
+					"HTTP Upstream",
+				}},
+			)
+		})
+	}
 }


### PR DESCRIPTION
## Summary

The creation order of the tracer provider matters. Previously the MCP tracer provider was being created before the Databroker tracer provider for a given outbound client connection in `authorize/state.go`.



When `mcp=true`, this meant that traces sourced from the Authorize service appeared as the MCP service.

## Related issues

[ENG-4254](https://linear.app/pomerium/issue/ENG-4254/bug-mcp-databroker-authorize-spans-start-with-a-root-span-in-the-mcp)

## User Explanation

Root spans in the authorize service now have the correct root spans when mcp is enabled.

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
