### PR TITLE
ci: replace Coveralls with coverage deltas

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,5 +1,6 @@
 name: Test
 permissions:
+  actions: read
   contents: read
 on:
   push:
@@ -29,7 +30,7 @@ jobs:
           node-version-file: .tool-versions
 
       - name: set env vars
-        run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: build dev docker image
         run: |
@@ -54,6 +55,8 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 2
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16
         with:
@@ -80,20 +83,70 @@ jobs:
           max_attempts: 3
           command: make cover
 
-      - uses: jandelgado/gcov2lcov-action@e4612787670fc5b5f49026b8c29c5569921de1db
-        if: matrix.platform == 'ubuntu-latest'
-        name: convert coverage to lcov
+      - name: Upload base coverage
+        if: matrix.platform == 'ubuntu-latest' && github.ref == 'refs/heads/main'
+        continue-on-error: true
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          infile: coverage.txt
-          outfile: coverage.lcov
+          name: coverage-profile
+          path: coverage.txt
+          retention-days: 30
 
-      - name: upload to coveralls
-        uses: coverallsapp/github-action@5cbfd81b66ca5d10c19b062c04de0199c215fb6e
-        if: matrix.platform == 'ubuntu-latest'
+      - name: Check for Go changes
+        id: coverage-changes
+        if: matrix.platform == 'ubuntu-latest' && github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          if git diff --quiet HEAD^1 HEAD -- '*.go'; then
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+          else
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Find base coverage
+        id: coverage-base
+        if: matrix.platform == 'ubuntu-latest' && github.event_name == 'pull_request' && steps.coverage-changes.outputs.changed == 'true'
+        continue-on-error: true
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: coverage.lcov
-          fail-on-error: false
+          script: |
+            const { data } = await github.rest.actions.listWorkflowRuns({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'test.yaml',
+              event: 'push',
+              head_sha: process.env.BASE_SHA,
+              status: 'completed',
+              per_page: 10,
+            });
+            const run = data.workflow_runs.find((run) => run.conclusion === 'success');
+            if (run) core.setOutput('run-id', run.id);
+
+      - name: Download base coverage
+        id: coverage-download
+        if: matrix.platform == 'ubuntu-latest' && github.event_name == 'pull_request' && steps.coverage-changes.outputs.changed == 'true' && steps.coverage-base.outputs.run-id != ''
+        continue-on-error: true
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: coverage-profile
+          path: coverage-base
+          github-token: ${{ github.token }}
+          run-id: ${{ steps.coverage-base.outputs.run-id }}
+
+      - name: Summarize material Go coverage changes
+        if: matrix.platform == 'ubuntu-latest' && github.event_name == 'pull_request' && steps.coverage-changes.outputs.changed == 'true' && steps.coverage-download.outcome == 'success'
+        continue-on-error: true
+        run: |
+          go run ./scripts/coverage_delta.go \
+            --base coverage-base/coverage.txt \
+            --head coverage.txt \
+            --module "$(GOWORK=off go list -m -f '{{.Path}}')" \
+            --repository "$GITHUB_REPOSITORY" \
+            --sha "$GITHUB_SHA" \
+            --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            >> "$GITHUB_STEP_SUMMARY"
 
   build-docker:
     runs-on: ubuntu-22.04

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -117,17 +117,27 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
         with:
           script: |
+            const { owner, repo } = context.repo;
             const { data } = await github.rest.actions.listWorkflowRuns({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner,
+              repo,
               workflow_id: 'test.yaml',
               event: 'push',
               head_sha: process.env.BASE_SHA,
               status: 'completed',
               per_page: 10,
             });
-            const run = data.workflow_runs.find((run) => run.conclusion === 'success');
-            if (run) core.setOutput('run-id', run.id);
+            for (const run of data.workflow_runs.filter((run) => run.conclusion === 'success')) {
+              const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner,
+                repo,
+                run_id: run.id,
+              });
+              if (data.artifacts.some((artifact) => artifact.name === 'coverage-profile' && !artifact.expired)) {
+                core.setOutput('run-id', run.id);
+                break;
+              }
+            }
 
       - name: Download base coverage
         id: coverage-download

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,11 @@ on:
       - main
   pull_request:
 
+# Keep an older PR run from publishing after a newer commit.
+concurrency:
+  group: test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   integration:
     strategy:
@@ -144,7 +149,7 @@ jobs:
             --head coverage.txt \
             --module "$(GOWORK=off go list -m -f '{{.Path}}')" \
             --repository "$GITHUB_REPOSITORY" \
-            --sha "$GITHUB_SHA" \
+            --sha "${{ github.event.pull_request.head.sha }}" \
             --run-url "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
             >> "$GITHUB_STEP_SUMMARY"
 

--- a/go.mod
+++ b/go.mod
@@ -140,6 +140,7 @@ require (
 	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	golang.org/x/time v0.15.0
+	golang.org/x/tools v0.47.0
 	google.golang.org/api v0.283.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa
 	google.golang.org/grpc v1.82.0
@@ -419,7 +420,6 @@ require (
 	go.yaml.in/yaml/v4 v4.0.0-rc.4 // indirect
 	golang.org/x/image v0.42.0 // indirect
 	golang.org/x/text v0.40.0 // indirect
-	golang.org/x/tools v0.47.0 // indirect
 	golang.org/x/xerrors v0.0.0-20240903120638-7835f813f4da // indirect
 	google.golang.org/genproto v0.0.0-20260319201613-d00831a3d3e7 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/scripts/coverage_delta.go
+++ b/scripts/coverage_delta.go
@@ -1,0 +1,252 @@
+// coverage_delta writes a quiet, diff-scoped Go coverage summary.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"golang.org/x/tools/cover"
+)
+
+type coverage struct {
+	covered int
+	total   int
+}
+
+func (c coverage) percent() float64 {
+	if c.total == 0 {
+		return 0
+	}
+	return 100 * float64(c.covered) / float64(c.total)
+}
+
+type fileDelta struct {
+	file string
+	base coverage
+	head coverage
+}
+
+type fileChange struct {
+	file     string
+	baseFile string
+}
+
+func main() {
+	baseProfile := flag.String("base", "", "base Go coverage profile")
+	headProfile := flag.String("head", "coverage.txt", "PR Go coverage profile")
+	module := flag.String("module", "", "Go module path")
+	repository := flag.String("repository", "", "GitHub owner/repository")
+	sha := flag.String("sha", "", "GitHub commit SHA")
+	runURL := flag.String("run-url", "", "GitHub Actions run URL")
+	threshold := flag.Float64("threshold", 1, "minimum absolute percentage-point change to report")
+	flag.Parse()
+
+	if *baseProfile == "" {
+		failf("-base is required")
+	}
+	if *module == "" {
+		failf("-module is required")
+	}
+	if *threshold < 0 {
+		failf("-threshold must not be negative")
+	}
+
+	base, err := readProfile(*baseProfile)
+	if err != nil {
+		failf("read base profile: %v", err)
+	}
+	head, err := readProfile(*headProfile)
+	if err != nil {
+		failf("read PR profile: %v", err)
+	}
+	files, err := changedGoFiles()
+	if err != nil {
+		failf("find changed Go files: %v", err)
+	}
+
+	fmt.Print(summary(base, head, files, *module, *threshold, *repository, *sha, *runURL))
+}
+
+func failf(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "coverage delta: "+format+"\n", args...)
+	os.Exit(1)
+}
+
+func readProfile(path string) (map[string]coverage, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var mode string
+	var records []string
+	for line := range strings.SplitSeq(string(contents), "\n") {
+		if strings.HasPrefix(line, "mode: ") {
+			mode = line
+			continue
+		}
+		records = append(records, line)
+	}
+	if mode == "" {
+		return nil, fmt.Errorf("missing coverage mode")
+	}
+	profiles, err := cover.ParseProfilesFromReader(strings.NewReader(mode + "\n" + strings.Join(records, "\n")))
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(map[string]coverage, len(profiles))
+	for _, profile := range profiles {
+		file := filepath.ToSlash(profile.FileName)
+		stats := result[file]
+		for _, block := range profile.Blocks {
+			stats.total += block.NumStmt
+			if block.Count > 0 {
+				stats.covered += block.NumStmt
+			}
+		}
+		result[file] = stats
+	}
+	return result, nil
+}
+
+func changedGoFiles() ([]fileChange, error) {
+	output, err := exec.Command("git", "diff", "--name-status", "-z", "--find-renames", "--diff-filter=AMR", "HEAD^1", "HEAD").Output()
+	if err != nil {
+		return nil, err
+	}
+	return parseChangedGoFiles(string(output))
+}
+
+func parseChangedGoFiles(output string) ([]fileChange, error) {
+	fields := strings.Split(output, "\x00")
+	var files []fileChange
+	for len(fields) > 1 {
+		status, file := fields[0], fields[1]
+		fields = fields[2:]
+		if strings.HasPrefix(status, "R") {
+			if len(fields) == 0 {
+				return nil, fmt.Errorf("rename without destination")
+			}
+			baseFile := file
+			file, fields = fields[0], fields[1:]
+			if strings.HasSuffix(file, ".go") {
+				files = append(files, fileChange{file: filepath.ToSlash(file), baseFile: filepath.ToSlash(baseFile)})
+			}
+			continue
+		}
+		if strings.HasSuffix(file, ".go") {
+			file = filepath.ToSlash(file)
+			files = append(files, fileChange{file: file, baseFile: file})
+		}
+	}
+	return files, nil
+}
+
+func summary(base, head map[string]coverage, files []fileChange, module string, threshold float64, repository, sha, runURL string) string {
+	rows := deltas(base, head, files, module, threshold)
+	if len(rows) == 0 {
+		return ""
+	}
+
+	var baseTotal, headTotal coverage
+	for _, row := range rows {
+		if row.base.total == 0 || row.head.total == 0 {
+			continue
+		}
+		baseTotal.covered += row.base.covered
+		baseTotal.total += row.base.total
+		headTotal.covered += row.head.covered
+		headTotal.total += row.head.total
+	}
+
+	var b strings.Builder
+	fmt.Fprintln(&b, "## Go coverage")
+	fmt.Fprintln(&b)
+	if baseTotal.total > 0 && headTotal.total > 0 {
+		delta := headTotal.percent() - baseTotal.percent()
+		if delta >= threshold {
+			fmt.Fprintf(&b, "Improved **%+.1fpp** across reported files.\n", delta)
+		} else if delta <= -threshold {
+			fmt.Fprintf(&b, "Changed **%+.1fpp** across reported files.\n", delta)
+		} else {
+			fmt.Fprintln(&b, "Material coverage changes in modified files.")
+		}
+	} else {
+		fmt.Fprintln(&b, "Coverage for new Go files.")
+	}
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "| File | Base | PR | Change |")
+	fmt.Fprintln(&b, "| --- | ---: | ---: | ---: |")
+	for _, row := range rows {
+		file := "`" + row.file + "`"
+		if repository != "" && sha != "" {
+			file = fmt.Sprintf("[%s](https://github.com/%s/blob/%s/%s)", file, repository, sha, row.file)
+		}
+		fmt.Fprintf(&b, "| %s | %s | %s | %s |\n", file, formatCoverage(row.base), formatCoverage(row.head), formatDelta(row))
+	}
+	if runURL != "" {
+		fmt.Fprintf(&b, "\n[View Test run](%s)\n", runURL)
+	}
+	return b.String()
+}
+
+func deltas(base, head map[string]coverage, files []fileChange, module string, threshold float64) []fileDelta {
+	var result []fileDelta
+	for _, change := range files {
+		baseCoverage := profileFile(base, module, change.baseFile)
+		headCoverage := profileFile(head, module, change.file)
+		if headCoverage.total == 0 {
+			continue
+		}
+		if baseCoverage.total > 0 && headCoverage.total > 0 && abs(headCoverage.percent()-baseCoverage.percent()) < threshold {
+			continue
+		}
+		result = append(result, fileDelta{file: change.file, base: baseCoverage, head: headCoverage})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].file < result[j].file })
+	return result
+}
+
+func profileFile(profiles map[string]coverage, module, file string) coverage {
+	if stats, ok := profiles[module+"/"+file]; ok {
+		return stats
+	}
+	var match coverage
+	matches := 0
+	for profile, stats := range profiles {
+		if strings.HasSuffix(profile, "/"+file) {
+			match = stats
+			matches++
+		}
+	}
+	if matches == 1 {
+		return match
+	}
+	return coverage{}
+}
+
+func formatCoverage(value coverage) string {
+	if value.total == 0 {
+		return "new"
+	}
+	return fmt.Sprintf("%.1f%%", value.percent())
+}
+
+func formatDelta(value fileDelta) string {
+	if value.base.total == 0 || value.head.total == 0 {
+		return "new"
+	}
+	return fmt.Sprintf("%+.1fpp", value.head.percent()-value.base.percent())
+}
+
+func abs(value float64) float64 {
+	if value < 0 {
+		return -value
+	}
+	return value
+}

--- a/scripts/coverage_delta.go
+++ b/scripts/coverage_delta.go
@@ -4,6 +4,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"math"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,9 +20,6 @@ type coverage struct {
 }
 
 func (c coverage) percent() float64 {
-	if c.total == 0 {
-		return 0
-	}
 	return 100 * float64(c.covered) / float64(c.total)
 }
 
@@ -155,7 +153,7 @@ func summary(base, head map[string]coverage, files []fileChange, module string, 
 
 	var baseTotal, headTotal coverage
 	for _, row := range rows {
-		if row.base.total == 0 || row.head.total == 0 {
+		if row.base.total == 0 {
 			continue
 		}
 		baseTotal.covered += row.base.covered
@@ -167,7 +165,7 @@ func summary(base, head map[string]coverage, files []fileChange, module string, 
 	var b strings.Builder
 	fmt.Fprintln(&b, "## Go coverage")
 	fmt.Fprintln(&b)
-	if baseTotal.total > 0 && headTotal.total > 0 {
+	if baseTotal.total > 0 {
 		delta := headTotal.percent() - baseTotal.percent()
 		if delta >= threshold {
 			fmt.Fprintf(&b, "Improved **%+.1fpp** across reported files.\n", delta)
@@ -203,7 +201,7 @@ func deltas(base, head map[string]coverage, files []fileChange, module string, t
 		if headCoverage.total == 0 {
 			continue
 		}
-		if baseCoverage.total > 0 && headCoverage.total > 0 && abs(headCoverage.percent()-baseCoverage.percent()) < threshold {
+		if baseCoverage.total > 0 && math.Abs(headCoverage.percent()-baseCoverage.percent()) < threshold {
 			continue
 		}
 		result = append(result, fileDelta{file: change.file, base: baseCoverage, head: headCoverage})
@@ -238,15 +236,8 @@ func formatCoverage(value coverage) string {
 }
 
 func formatDelta(value fileDelta) string {
-	if value.base.total == 0 || value.head.total == 0 {
+	if value.base.total == 0 {
 		return "new"
 	}
 	return fmt.Sprintf("%+.1fpp", value.head.percent()-value.base.percent())
-}
-
-func abs(value float64) float64 {
-	if value < 0 {
-		return -value
-	}
-	return value
 }

--- a/scripts/coverage_delta_test.go
+++ b/scripts/coverage_delta_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+const module = "github.com/pomerium/pomerium"
+
+func TestSummaryShowsMaterialChanges(t *testing.T) {
+	base := map[string]coverage{
+		"github.com/pomerium/pomerium/pkg/a.go":      {covered: 8, total: 10},
+		"github.com/pomerium/pomerium/pkg/jitter.go": {covered: 8, total: 10},
+	}
+	head := map[string]coverage{
+		"github.com/pomerium/pomerium/pkg/a.go":      {covered: 10, total: 10},
+		"github.com/pomerium/pomerium/pkg/jitter.go": {covered: 8, total: 10},
+		"github.com/pomerium/pomerium/pkg/new.go":    {covered: 3, total: 4},
+	}
+
+	got := summary(base, head, []fileChange{
+		{file: "pkg/new.go", baseFile: "pkg/new.go"},
+		{file: "pkg/jitter.go", baseFile: "pkg/jitter.go"},
+		{file: "pkg/a.go", baseFile: "pkg/a.go"},
+	}, module, 1, "pomerium/pomerium", "abc", "https://github.com/pomerium/pomerium/actions/runs/1")
+	for _, want := range []string{
+		"Improved **+20.0pp** across reported files.",
+		"[View Test run](https://github.com/pomerium/pomerium/actions/runs/1)",
+		"[`pkg/a.go`](https://github.com/pomerium/pomerium/blob/abc/pkg/a.go) | 80.0% | 100.0% | +20.0pp",
+		"[`pkg/new.go`](https://github.com/pomerium/pomerium/blob/abc/pkg/new.go) | new | 75.0% | new",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("summary missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "jitter.go") {
+		t.Fatalf("summary includes unchanged coverage:\n%s", got)
+	}
+}
+
+func TestSummaryOmitsJitter(t *testing.T) {
+	base := map[string]coverage{"github.com/pomerium/pomerium/pkg/a.go": {covered: 800, total: 1000}}
+	head := map[string]coverage{"github.com/pomerium/pomerium/pkg/a.go": {covered: 799, total: 1000}}
+	if got := summary(base, head, []fileChange{{file: "pkg/a.go", baseFile: "pkg/a.go"}}, module, 1, "", "", ""); got != "" {
+		t.Fatalf("summary = %q, want empty", got)
+	}
+}
+
+func TestSummaryOmitsBaseOnlyCoverage(t *testing.T) {
+	base := map[string]coverage{"github.com/pomerium/pomerium/pkg/a.go": {covered: 8, total: 10}}
+	if got := summary(base, nil, []fileChange{{file: "pkg/a.go", baseFile: "pkg/a.go"}}, module, 1, "", "", ""); got != "" {
+		t.Fatalf("summary = %q, want empty", got)
+	}
+}
+
+func TestSummaryPreservesCoverageForRenamedFiles(t *testing.T) {
+	base := map[string]coverage{"github.com/pomerium/pomerium/pkg/old.go": {covered: 8, total: 10}}
+	head := map[string]coverage{"github.com/pomerium/pomerium/pkg/new.go": {covered: 9, total: 10}}
+
+	got := summary(base, head, []fileChange{{file: "pkg/new.go", baseFile: "pkg/old.go"}}, module, 1, "", "", "")
+	if !strings.Contains(got, "`pkg/new.go` | 80.0% | 90.0% | +10.0pp") {
+		t.Fatalf("summary did not compare renamed file coverage:\n%s", got)
+	}
+	if strings.Contains(got, "| new |") {
+		t.Fatalf("summary treated renamed file as new:\n%s", got)
+	}
+}
+
+func TestProfileFileUsesModulePathForSharedSuffix(t *testing.T) {
+	profiles := map[string]coverage{
+		module + "/config/config.go":          {covered: 8, total: 10},
+		module + "/pkg/grpc/config/config.go": {covered: 2, total: 10},
+	}
+
+	got := profileFile(profiles, module, "config/config.go")
+	if got != (coverage{covered: 8, total: 10}) {
+		t.Fatalf("profile = %#v, want config/config.go coverage", got)
+	}
+	if got := profileFile(profiles, "example.com/other", "config/config.go"); got != (coverage{}) {
+		t.Fatalf("ambiguous fallback = %#v, want no coverage", got)
+	}
+}
+
+func TestParseChangedGoFilesPreservesRenameSource(t *testing.T) {
+	got, err := parseChangedGoFiles("M\x00pkg/a.go\x00R100\x00pkg/old.go\x00pkg/new.go\x00A\x00docs/readme.md\x00")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []fileChange{
+		{file: "pkg/a.go", baseFile: "pkg/a.go"},
+		{file: "pkg/new.go", baseFile: "pkg/old.go"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("files = %#v, want %#v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("files = %#v, want %#v", got, want)
+		}
+	}
+}
+
+func TestReadProfile(t *testing.T) {
+	path := t.TempDir() + "/coverage.txt"
+	profile := "github.com/pomerium/pomerium/pkg/a.go:1.1,2.2 2 1\n" +
+		"mode: atomic\n" +
+		"github.com/pomerium/pomerium/pkg/a.go:3.1,3.2 1 0\n"
+	if err := os.WriteFile(path, []byte(profile), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := readProfile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got["github.com/pomerium/pomerium/pkg/a.go"] != (coverage{covered: 2, total: 3}) {
+		t.Fatalf("profile = %#v", got)
+	}
+}

--- a/scripts/coverage_delta_test.go
+++ b/scripts/coverage_delta_test.go
@@ -39,6 +39,50 @@ func TestSummaryShowsMaterialChanges(t *testing.T) {
 	}
 }
 
+func TestSummaryHeadlines(t *testing.T) {
+	tests := []struct {
+		name  string
+		base  map[string]coverage
+		head  map[string]coverage
+		files []fileChange
+		want  string
+	}{
+		{
+			name: "regression",
+			base: map[string]coverage{module + "/pkg/a.go": {covered: 8, total: 10}},
+			head: map[string]coverage{module + "/pkg/a.go": {covered: 7, total: 10}},
+			files: []fileChange{
+				{file: "pkg/a.go", baseFile: "pkg/a.go"},
+			},
+			want: "Changed **-10.0pp** across reported files.",
+		},
+		{
+			name: "offsetting changes",
+			base: map[string]coverage{
+				module + "/pkg/a.go": {covered: 5, total: 10},
+				module + "/pkg/b.go": {covered: 9, total: 10},
+			},
+			head: map[string]coverage{
+				module + "/pkg/a.go": {covered: 6, total: 10},
+				module + "/pkg/b.go": {covered: 8, total: 10},
+			},
+			files: []fileChange{
+				{file: "pkg/a.go", baseFile: "pkg/a.go"},
+				{file: "pkg/b.go", baseFile: "pkg/b.go"},
+			},
+			want: "Material coverage changes in modified files.",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := summary(test.base, test.head, test.files, module, 1, "", "", ""); !strings.Contains(got, test.want) {
+				t.Fatalf("summary missing %q:\n%s", test.want, got)
+			}
+		})
+	}
+}
+
 func TestSummaryOmitsJitter(t *testing.T) {
 	base := map[string]coverage{"github.com/pomerium/pomerium/pkg/a.go": {covered: 800, total: 1000}}
 	head := map[string]coverage{"github.com/pomerium/pomerium/pkg/a.go": {covered: 799, total: 1000}}


### PR DESCRIPTION
## Summary

Coveralls comments report repository-wide movement which was largely useless and annoying because it was non-dterministic and full of jitter. And the report  had unrelated coverage noise to individual pull requests. 

This PR removes the Coveralls upload in favor of a gha driven job summary which only drops an update when  coverage in a changed Go file moves by at least a percentage point.

example outputs:

```text
## Go coverage

Improved **+20.0pp** across reported files.

| File | Base | PR | Change |
| --- | ---: | ---: | ---: |
| `pkg/a.go` | 80.0% | 100.0% | +20.0pp |
```

Representative material regression:

```text
## Go coverage

Changed **-10.0pp** across reported files.

| File | Base | PR | Change |
| --- | ---: | ---: | ---: |
| `pkg/a.go` | 80.0% | 70.0% | -10.0pp |
```

Representative new Go file:

```text
## Go coverage

Coverage for new Go files.

| File | Base | PR | Change |
| --- | ---: | ---: | ---: |
| `pkg/new.go` | new | 75.0% | new |
```

No coverage section is written when:

- no Go files changed;
- every changed file moved less than 1.0 percentage point;
- the exact base profile is unavailable or expired;
- changed files contain no instrumented statements; or
- coverage artifact or reporting infrastructure fails.

## Related issues

- [ENG-4255](https://linear.app/pomerium/issue/ENG-4255/replace-coveralls-pr-noise-with-native-go-coverage-deltas)
- Follow-up to #6515

## User Explanation

No user-facing change.

## AI disclosure

Codex wrote the code. I reviewed it. And edited the PR body. The go code is a little weird in places but not worth the cycles to refactor which I'm happy to throw away if we are unhappy with the output. I'm happier for less noise in the PRs. 

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`ci`)
- [x] disclosed AI usage per AI_POLICY.md
- [x] ready for review
