### PR TITLE
ssh: move portforward.RouteInfo to new package pkg/ssh/common

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -377,7 +377,9 @@ func (srv *Server) Run(ctx context.Context) error {
 
 	// start the gRPC server
 	eg.Go(func() error {
-		log.Ctx(ctx).Debug().Str("addr", srv.GRPCListener.Addr().String()).Msg("starting control-plane gRPC server")
+		lg := log.Ctx(ctx).With().Str("addr", srv.GRPCListener.Addr().String()).Logger()
+		lg.Debug().Msg("starting control-plane gRPC server")
+		defer lg.Debug().Msg("stopped control-plane gRPC server")
 		return grpcutil.ServeWithGracefulStop(ctx, srv.GRPCServer, srv.GRPCListener, time.Second*5)
 	})
 
@@ -396,9 +398,9 @@ func (srv *Server) Run(ctx context.Context) error {
 	} {
 		// start the HTTP server
 		eg.Go(func() error {
-			log.Ctx(ctx).Debug().
-				Str("addr", entry.Listener.Addr().String()).
-				Msgf("starting control-plane %s server", entry.Name)
+			lg := log.Ctx(ctx).With().Str("addr", entry.Listener.Addr().String()).Logger()
+			lg.Debug().Msgf("starting control-plane %s server", entry.Name)
+			defer lg.Debug().Msgf("stopped control-plane %s server", entry.Name)
 			return httputil.ServeWithGracefulStop(ctx, entry.Handler, entry.Listener, time.Second*5)
 		})
 	}

--- a/internal/testenv/environment.go
+++ b/internal/testenv/environment.go
@@ -243,6 +243,11 @@ func (e EnvironmentState) String() string {
 	}
 }
 
+type stateChangeListenerCallback struct {
+	fn     func()
+	source string
+}
+
 type environment struct {
 	EnvironmentOptions
 	t               testing.TB
@@ -270,7 +275,7 @@ type environment struct {
 
 	stateMu              sync.Mutex
 	state                EnvironmentState
-	stateChangeListeners map[EnvironmentState][]func()
+	stateChangeListeners map[EnvironmentState][]stateChangeListenerCallback
 	stateChangeBlockers  sync.WaitGroup
 
 	src *configSource
@@ -485,7 +490,7 @@ func New(t testing.TB, opts ...EnvironmentOption) Environment {
 		tracer:               tracer,
 		logWriter:            writer,
 		taskErrGroup:         taskErrGroup,
-		stateChangeListeners: make(map[EnvironmentState][]func()),
+		stateChangeListeners: make(map[EnvironmentState][]stateChangeListenerCallback),
 		rootSpan:             span,
 		provider:             chP,
 	}
@@ -758,13 +763,16 @@ func (e *environment) Start() {
 		opts = append(opts, e.extraOpts...)
 		pom := pomerium.New(opts...)
 		startDone := make(chan error, 1)
+		waitDone := make(chan error, 1)
 		e.OnStateChanged(Stopping, func() {
+			defer close(waitDone)
 			startErr := <-startDone
 			if startErr != nil {
 				return // Start() failed, so there is nothing to shut down
 			}
 			if err := pom.Shutdown(ctx); err != nil {
 				log.Ctx(ctx).Err(err).Msg("error shutting down pomerium server")
+				waitDone <- err
 			} else {
 				e.debugf("pomerium server shut down without error")
 			}
@@ -772,7 +780,7 @@ func (e *environment) Start() {
 		err := pom.Start(ctx, e.tracerProvider, e.src)
 		startDone <- err
 		require.NoError(e.t, err)
-		return pom.Wait()
+		return (<-waitDone)
 	}))
 
 	for i, task := range e.tasks {
@@ -1071,20 +1079,42 @@ func (e *environment) advanceState(newState EnvironmentState) {
 	e.debugf("state %s -> %s", e.state.String(), newState.String())
 	e.state = newState
 	if len(e.stateChangeListeners[newState]) > 0 {
+		start := time.Now()
 		e.debugf("notifying %d listeners of state change", len(e.stateChangeListeners[newState]))
 		var wg sync.WaitGroup
 		for _, listener := range e.stateChangeListeners[newState] {
-			wg.Add(1)
+			warnTimer := time.NewTicker(2 * time.Second)
+			done := make(chan struct{})
 			go func() {
+				defer warnTimer.Stop()
+				for {
+					select {
+					case <-warnTimer.C:
+						e.debugf("warning: currently blocked waiting for state change listener (elapsed: %s; source: %s)",
+							time.Since(start).Round(time.Second), listener.source)
+					case <-done:
+						if time.Since(start) >= 2*time.Second {
+							e.debugf("warning: slow state change listener took %s (source: %s)",
+								time.Since(start), listener.source)
+						} else {
+							e.debugf("state change listener done after %s (source: %s)",
+								time.Since(start), listener.source)
+						}
+						return
+					}
+				}
+			}()
+			wg.Go(func() {
+				defer close(done)
 				_, span := e.tracer.Start(e.Context(), "State Change Callback")
 				span.SetAttributes(attribute.String("state", newState.String()))
+				span.SetAttributes(attribute.String("source", listener.source))
 				defer span.End()
-				defer wg.Done()
-				listener()
-			}()
+				listener.fn()
+			})
 		}
 		wg.Wait()
-		e.debugf("done notifying state change listeners")
+		e.debugf("done notifying state change listeners (took %s)", time.Since(start))
 	}
 }
 
@@ -1114,11 +1144,14 @@ func (e *environment) OnStateChanged(state EnvironmentState, callback func()) (c
 		return func() bool { return false }
 	default:
 		canceled := &atomic.Bool{}
-		e.stateChangeListeners[state] = append(e.stateChangeListeners[state], func() {
-			if canceled.CompareAndSwap(false, true) {
-				e.debugf("invoking state change callback (caller: %s:%d)", file, line)
-				callback()
-			}
+		e.stateChangeListeners[state] = append(e.stateChangeListeners[state], stateChangeListenerCallback{
+			fn: func() {
+				if canceled.CompareAndSwap(false, true) {
+					e.debugf("invoking state change callback (caller: %s:%d)", file, line)
+					callback()
+				}
+			},
+			source: getCaller(),
 		})
 		return func() bool {
 			e.debugf("stopped state change callback (state: %s, caller: %s:%d)", state.String(), file, line)

--- a/internal/testenv/upstreams/ssh.go
+++ b/internal/testenv/upstreams/ssh.go
@@ -184,7 +184,11 @@ func (h *sshUpstream) Run(ctx context.Context) error {
 
 func (h *sshUpstream) handleConnection(ctx context.Context, conn net.Conn) {
 	serverConn, ncc, rc, err := ssh.NewServerConn(conn, &h.serverConfig)
-	h.Env().Require().NoError(err, "ssh connection handshake failed")
+	if err != nil {
+		conn.Close()
+		h.Env().Assert().Fail("ssh connection handshake failed")
+		return
+	}
 	go func() {
 		<-ctx.Done()
 		conn.Close()

--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -177,7 +177,7 @@ func (x *Session) Format() []byte {
 	fmt.Fprintf(&b, "Session ID: %s\n", x.Id)
 	fmt.Fprintf(&b, "Expires at: %s (in %s)\n",
 		x.ExpiresAt.AsTime().String(),
-		time.Until(x.ExpiresAt.AsTime()).Round(time.Second))
+		time.Until(x.ExpiresAt.AsTime()).Round(time.Minute))
 	fmt.Fprintf(&b, "Claims:\n")
 	keys := make([]string, 0, len(x.Claims))
 	for key := range x.Claims {
@@ -195,11 +195,11 @@ func (x *Session) Format() []byte {
 			case "iat":
 				d, _ := vs[0].(float64)
 				t := time.Unix(int64(d), 0)
-				fmt.Fprintf(&b, "%s (%s ago)", t, time.Since(t).Round(time.Second))
+				fmt.Fprintf(&b, "%s (%s ago)", t, time.Since(t).Round(time.Minute))
 			case "exp":
 				d, _ := vs[0].(float64)
 				t := time.Unix(int64(d), 0)
-				fmt.Fprintf(&b, "%s (in %s)", t, time.Until(t).Round(time.Second))
+				fmt.Fprintf(&b, "%s (in %s)", t, time.Until(t).Round(time.Minute))
 			default:
 				fmt.Fprintf(&b, "%#v", vs[0])
 			}

--- a/pkg/ssh/common/route_info.go
+++ b/pkg/ssh/common/route_info.go
@@ -1,0 +1,11 @@
+package common
+
+import "github.com/pomerium/pomerium/config"
+
+type RouteInfo struct {
+	From      string
+	To        config.WeightedURLs
+	Hostname  string // not including port
+	Port      uint32
+	ClusterID string
+}

--- a/pkg/ssh/mock/mock_policy_index.go
+++ b/pkg/ssh/mock/mock_policy_index.go
@@ -12,7 +12,7 @@ package mock_ssh
 import (
 	reflect "reflect"
 
-	portforward "github.com/pomerium/pomerium/pkg/ssh/portforward"
+	common "github.com/pomerium/pomerium/pkg/ssh/common"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,7 +41,7 @@ func (m *MockPolicyIndexSubscriber) EXPECT() *MockPolicyIndexSubscriberMockRecor
 }
 
 // UpdateAuthorizedRoutes mocks base method.
-func (m *MockPolicyIndexSubscriber) UpdateAuthorizedRoutes(routes []portforward.RouteInfo) {
+func (m *MockPolicyIndexSubscriber) UpdateAuthorizedRoutes(routes []common.RouteInfo) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateAuthorizedRoutes", routes)
 }
@@ -65,13 +65,13 @@ func (c *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall) Return() *MockPoli
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall) Do(f func([]portforward.RouteInfo)) *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall {
+func (c *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall) Do(f func([]common.RouteInfo)) *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall) DoAndReturn(f func([]portforward.RouteInfo)) *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall {
+func (c *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall) DoAndReturn(f func([]common.RouteInfo)) *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/pkg/ssh/models/routes.go
+++ b/pkg/ssh/models/routes.go
@@ -8,6 +8,7 @@ import (
 	datav3 "github.com/envoyproxy/go-control-plane/envoy/data/core/v3"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 )
 
@@ -25,7 +26,7 @@ const (
 )
 
 type Route struct {
-	portforward.RouteInfo
+	common.RouteInfo
 	Status string
 	Health string
 }
@@ -85,7 +86,7 @@ func (m *RouteModel) HandleClusterEndpointsUpdate(added map[string]portforward.R
 	}
 }
 
-func (m *RouteModel) HandleRoutesUpdate(routes []portforward.RouteInfo) {
+func (m *RouteModel) HandleRoutesUpdate(routes []common.RouteInfo) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	items := make([]Route, len(routes))

--- a/pkg/ssh/policy_index.go
+++ b/pkg/ssh/policy_index.go
@@ -5,14 +5,19 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
-	"github.com/pomerium/pomerium/pkg/ssh/portforward"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 )
 
 //go:generate go tool go.uber.org/mock/mockgen -typed -destination ./mock/mock_policy_index.go . PolicyIndexSubscriber
 
-type PolicyIndexSubscriber interface {
+// Upstream tunnel callbacks
+type PolicyIndexTunnelSubscriber interface {
 	UpdateEnabledStaticPorts(allowedStaticPorts []uint)
-	UpdateAuthorizedRoutes(routes []portforward.RouteInfo)
+	UpdateAuthorizedRoutes(routes []common.RouteInfo)
+}
+
+type PolicyIndexSubscriber interface {
+	PolicyIndexTunnelSubscriber
 }
 
 type PolicyIndexer interface {

--- a/pkg/ssh/policy_index_inmemory.go
+++ b/pkg/ssh/policy_index_inmemory.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
-	"github.com/pomerium/pomerium/pkg/ssh/portforward"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	"github.com/pomerium/protoutil/messages"
 )
 
@@ -105,7 +105,7 @@ func (kr *knownAuthRequest) RemoveActiveStream(streamID uint64) {
 // this is a separate struct so it can be updated in-place in the lru without
 // affecting recentness
 type authorizedRoutesList struct {
-	Entries []portforward.RouteInfo
+	Entries []common.RouteInfo
 }
 
 type authorizedRoutesCache struct {
@@ -165,7 +165,7 @@ func (c *authorizedRoutesCache) Keys() iter.Seq[*knownAuthRequest] {
 // Returns cached route entries for an auth request. The auth request must be
 // active (have at least one active stream), otherwise it will be reported as
 // not found.
-func (c *authorizedRoutesCache) Get(knownReq *knownAuthRequest) ([]portforward.RouteInfo, bool) {
+func (c *authorizedRoutesCache) Get(knownReq *knownAuthRequest) ([]common.RouteInfo, bool) {
 	if active, ok := c.active[knownReq]; ok {
 		return active.Entries, true
 	}
@@ -194,7 +194,7 @@ func (c *authorizedRoutesCache) StreamCount() int {
 	return len(c.byStreamID)
 }
 
-func (c *authorizedRoutesCache) Update(k *knownAuthRequest, v []portforward.RouteInfo) {
+func (c *authorizedRoutesCache) Update(k *knownAuthRequest, v []common.RouteInfo) {
 	if l, ok := c.active[k]; ok {
 		l.Entries = v
 	} else if l, ok := c.standby.Peek(k); ok {
@@ -210,7 +210,7 @@ func (c *authorizedRoutesCache) Update(k *knownAuthRequest, v []portforward.Rout
 	}
 }
 
-func (c *authorizedRoutesCache) Peek(k *knownAuthRequest) ([]portforward.RouteInfo, bool) {
+func (c *authorizedRoutesCache) Peek(k *knownAuthRequest) ([]common.RouteInfo, bool) {
 	if active, ok := c.active[k]; ok {
 		return active.Entries, true
 	} else if inactive, ok := c.standby.Peek(k); ok {
@@ -246,7 +246,7 @@ type knownSession struct {
 }
 
 type knownRoute struct {
-	Info  portforward.RouteInfo
+	Info  common.RouteInfo
 	Route *config.Policy
 }
 
@@ -297,7 +297,7 @@ func (i *InMemoryPolicyIndexer) recomputeSessionAuthorizedRoutes(ctx context.Con
 			}
 		}
 	} else {
-		routeInfos := make([]portforward.RouteInfo, len(updatedAuthorizedRoutes))
+		routeInfos := make([]common.RouteInfo, len(updatedAuthorizedRoutes))
 		for i, ar := range updatedAuthorizedRoutes {
 			routeInfos[i] = ar.Info
 		}
@@ -546,7 +546,7 @@ func (i *InMemoryPolicyIndexer) Run(ctx context.Context) error {
 					if route.UpstreamTunnel == nil {
 						continue
 					}
-					info := portforward.RouteInfo{
+					info := common.RouteInfo{
 						From:      route.From,
 						To:        route.To,
 						ClusterID: envoyconfig.GetClusterID(route),

--- a/pkg/ssh/portforward/manager.go
+++ b/pkg/ssh/portforward/manager.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 )
 
 //go:generate go tool go.uber.org/mock/mockgen -typed -destination ./mock/mock_port_forward.go . RouteEvaluator,UpdateListener
@@ -19,16 +20,8 @@ import (
 // forward requests) that can be active at a time.
 const MaxPermissionEntries = 128
 
-type RouteInfo struct {
-	From      string
-	To        config.WeightedURLs
-	Hostname  string // not including port
-	Port      uint32
-	ClusterID string
-}
-
 type RoutePortForwardInfo struct {
-	RouteInfo
+	common.RouteInfo
 	Permission Permission
 }
 
@@ -42,7 +35,7 @@ type RouteEvaluator interface {
 }
 
 type UpdateListener interface {
-	OnRoutesUpdated(routes []RouteInfo)
+	OnRoutesUpdated(routes []common.RouteInfo)
 	OnPermissionsUpdated(permissions []Permission)
 	OnClusterEndpointsUpdated(added map[string]RoutePortForwardInfo, removed map[string]struct{})
 }
@@ -156,7 +149,7 @@ type Manager struct {
 
 	// Cached list of all routes the current session would be authorized to
 	// port-forward.
-	cachedAuthorizedRoutes []RouteInfo
+	cachedAuthorizedRoutes []common.RouteInfo
 	// Contains the most recently built set of endpoints, keyed by cluster ID.
 	// Updated automatically by rebuildEndpoints().
 	cachedEndpoints map[string]RoutePortForwardInfo
@@ -321,7 +314,7 @@ func (pfm *Manager) UpdateEnabledStaticPorts(enabledStaticPorts []uint) {
 	pfm.rebuildEndpoints()
 }
 
-func (pfm *Manager) UpdateAuthorizedRoutes(routes []RouteInfo) {
+func (pfm *Manager) UpdateAuthorizedRoutes(routes []common.RouteInfo) {
 	pfm.mu.Lock()
 	defer pfm.mu.Unlock()
 	pfm.cachedAuthorizedRoutes = routes

--- a/pkg/ssh/portforward/manager_test.go
+++ b/pkg/ssh/portforward/manager_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/envoyconfig"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 	mock_portforward "github.com/pomerium/pomerium/pkg/ssh/portforward/mock"
 )
@@ -66,19 +67,19 @@ func TestPortForwardManager(t *testing.T) {
 
 		route1, route2, route3 := &cfg.Options.Routes[0], &cfg.Options.Routes[1], &cfg.Options.Routes[4]
 
-		expectedInfo1 := portforward.RouteInfo{
+		expectedInfo1 := common.RouteInfo{
 			Hostname:  "route-1",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route1),
 		}
 
-		expectedInfo2 := portforward.RouteInfo{
+		expectedInfo2 := common.RouteInfo{
 			Hostname:  "route-2",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route2),
 		}
 
-		expectedInfo3 := portforward.RouteInfo{
+		expectedInfo3 := common.RouteInfo{
 			Hostname:  "route-3",
 			Port:      22,
 			ClusterID: envoyconfig.GetClusterID(route3),
@@ -89,7 +90,7 @@ func TestPortForwardManager(t *testing.T) {
 
 		mgr := portforward.NewManager()
 		mgr.UpdateEnabledStaticPorts([]uint{443, 22})
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
 
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))
 		listener.EXPECT().OnClusterEndpointsUpdated(gomock.Len(0), gomock.Len(0))
@@ -149,19 +150,19 @@ func TestPortForwardManager(t *testing.T) {
 		cfg.Options.Routes = routes
 		cfg.Options.SSHAddr = "localhost:22"
 		route1, route2, route3 := &cfg.Options.Routes[0], &cfg.Options.Routes[1], &cfg.Options.Routes[4]
-		expectedInfo1 := portforward.RouteInfo{
+		expectedInfo1 := common.RouteInfo{
 			Hostname:  "route-1",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route1),
 		}
 
-		expectedInfo2 := portforward.RouteInfo{
+		expectedInfo2 := common.RouteInfo{
 			Hostname:  "route-2",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route2),
 		}
 
-		expectedInfo3 := portforward.RouteInfo{
+		expectedInfo3 := common.RouteInfo{
 			Hostname:  "route-3",
 			Port:      22,
 			ClusterID: envoyconfig.GetClusterID(route3),
@@ -171,7 +172,7 @@ func TestPortForwardManager(t *testing.T) {
 
 		mgr := portforward.NewManager()
 		mgr.UpdateEnabledStaticPorts([]uint{443, 22})
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(3))
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))
@@ -235,13 +236,13 @@ func TestPortForwardManager(t *testing.T) {
 		cfg.Options.SSHAddr = "localhost:22"
 		route1, route2 := &cfg.Options.Routes[0], &cfg.Options.Routes[1]
 
-		expectedInfo1 := portforward.RouteInfo{
+		expectedInfo1 := common.RouteInfo{
 			Hostname:  "route-1",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route1),
 		}
 
-		expectedInfo2 := portforward.RouteInfo{
+		expectedInfo2 := common.RouteInfo{
 			Hostname:  "route-2",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route2),
@@ -251,7 +252,7 @@ func TestPortForwardManager(t *testing.T) {
 
 		mgr := portforward.NewManager()
 		mgr.UpdateEnabledStaticPorts([]uint{443, 22})
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{expectedInfo1, expectedInfo2})
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{expectedInfo1, expectedInfo2})
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(2))
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))
@@ -315,7 +316,7 @@ func TestPortForwardManager(t *testing.T) {
 		mgr.AddUpdateListener(listener)
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(2))
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{
 			{
 				Hostname:  "route-1",
 				Port:      443,
@@ -380,7 +381,7 @@ func TestPortForwardManager(t *testing.T) {
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(1))
 		mgr.UpdateEnabledStaticPorts([]uint{443, 22})
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{
 			{
 				Hostname:  "route-1",
 				Port:      443,
@@ -396,19 +397,19 @@ func TestPortForwardManager(t *testing.T) {
 		cfg.Options.SSHAddr = "localhost:2200"
 		cfg.Options.Routes = routes
 		route1, route2, route3 := &cfg.Options.Routes[0], &cfg.Options.Routes[1], &cfg.Options.Routes[4]
-		expectedInfo1 := portforward.RouteInfo{
+		expectedInfo1 := common.RouteInfo{
 			Hostname:  "route-1",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route1),
 		}
 
-		expectedInfo2 := portforward.RouteInfo{
+		expectedInfo2 := common.RouteInfo{
 			Hostname:  "route-2",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route2),
 		}
 
-		expectedInfo3 := portforward.RouteInfo{
+		expectedInfo3 := common.RouteInfo{
 			Hostname:  "route-3",
 			Port:      22,
 			ClusterID: envoyconfig.GetClusterID(route3),
@@ -417,7 +418,7 @@ func TestPortForwardManager(t *testing.T) {
 		listener := mock_portforward.NewMockUpdateListener(ctrl)
 		mgr := portforward.NewManager()
 		mgr.UpdateEnabledStaticPorts([]uint{443, 22})
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(3))
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))

--- a/pkg/ssh/portforward/mock/mock_port_forward.go
+++ b/pkg/ssh/portforward/mock/mock_port_forward.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	config "github.com/pomerium/pomerium/config"
+	common "github.com/pomerium/pomerium/pkg/ssh/common"
 	portforward "github.com/pomerium/pomerium/pkg/ssh/portforward"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -177,7 +178,7 @@ func (c *MockUpdateListenerOnPermissionsUpdatedCall) DoAndReturn(f func([]portfo
 }
 
 // OnRoutesUpdated mocks base method.
-func (m *MockUpdateListener) OnRoutesUpdated(routes []portforward.RouteInfo) {
+func (m *MockUpdateListener) OnRoutesUpdated(routes []common.RouteInfo) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnRoutesUpdated", routes)
 }
@@ -201,13 +202,13 @@ func (c *MockUpdateListenerOnRoutesUpdatedCall) Return() *MockUpdateListenerOnRo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUpdateListenerOnRoutesUpdatedCall) Do(f func([]portforward.RouteInfo)) *MockUpdateListenerOnRoutesUpdatedCall {
+func (c *MockUpdateListenerOnRoutesUpdatedCall) Do(f func([]common.RouteInfo)) *MockUpdateListenerOnRoutesUpdatedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUpdateListenerOnRoutesUpdatedCall) DoAndReturn(f func([]portforward.RouteInfo)) *MockUpdateListenerOnRoutesUpdatedCall {
+func (c *MockUpdateListenerOnRoutesUpdatedCall) DoAndReturn(f func([]common.RouteInfo)) *MockUpdateListenerOnRoutesUpdatedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/pkg/ssh/stream.go
+++ b/pkg/ssh/stream.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/slices"
 	"github.com/pomerium/pomerium/pkg/ssh/api"
 	"github.com/pomerium/pomerium/pkg/ssh/cli"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	"github.com/pomerium/pomerium/pkg/ssh/models"
 	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 )
@@ -243,7 +244,7 @@ func (sh *StreamHandler) OnPermissionsUpdated(permissions []portforward.Permissi
 }
 
 // OnRoutesUpdated implements portforward.UpdateListener.
-func (sh *StreamHandler) OnRoutesUpdated(routes []portforward.RouteInfo) {
+func (sh *StreamHandler) OnRoutesUpdated(routes []common.RouteInfo) {
 	sh.routeModel.HandleRoutesUpdate(routes)
 }
 

--- a/pkg/ssh/stream.go
+++ b/pkg/ssh/stream.go
@@ -165,6 +165,7 @@ type StreamHandler struct {
 	writeC                  chan *extensions_ssh.ServerMessage
 	readC                   chan *extensions_ssh.ClientMessage
 	reauthC                 chan struct{}
+	reauthStoppedC          chan struct{}
 	terminateC              chan error
 	internalChannelRequestC chan InternalChannelRequest
 	handoffRequestC         chan HandoffRequest
@@ -214,6 +215,7 @@ func NewStreamHandler(
 		writeC:                  writeC,
 		readC:                   make(chan *extensions_ssh.ClientMessage, 32),
 		reauthC:                 make(chan struct{}),
+		reauthStoppedC:          make(chan struct{}),
 		terminateC:              make(chan error, 1),
 		internalChannelRequestC: make(chan InternalChannelRequest, 1),
 		handoffRequestC:         make(chan HandoffRequest, 1),
@@ -271,7 +273,10 @@ func (sh *StreamHandler) WriteC() <-chan *extensions_ssh.ServerMessage {
 
 // Reauth blocks until authorization policy is reevaluated.
 func (sh *StreamHandler) Reauth() {
-	sh.reauthC <- struct{}{}
+	select {
+	case sh.reauthC <- struct{}{}:
+	case <-sh.reauthStoppedC:
+	}
 }
 
 func (sh *StreamHandler) periodicReauth() (cancel func()) {
@@ -281,7 +286,10 @@ func (sh *StreamHandler) periodicReauth() (cancel func()) {
 			sh.Reauth()
 		}
 	}()
-	return t.Stop
+	return func() {
+		close(sh.reauthStoppedC)
+		t.Stop()
+	}
 }
 
 // Prompt implements KeyboardInteractiveQuerier.

--- a/pkg/ssh/stream_test.go
+++ b/pkg/ssh/stream_test.go
@@ -205,12 +205,13 @@ func (s *StreamHandlerSuite) expectError(fn func(), msg string) {
 
 func (s *StreamHandlerSuite) startStreamHandler(streamID uint64) *ssh.StreamHandler {
 	sh := s.mgr.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: streamID})
-	s.errC = make(chan error, 1)
+	errC := make(chan error, 1)
+	s.errC = errC
 	ctx, ca := context.WithCancel(s.T().Context())
 	s.streamCtx = ctx
 	go func() {
-		defer close(s.errC)
-		s.errC <- sh.Run(ctx)
+		defer close(errC)
+		errC <- sh.Run(ctx)
 	}()
 	s.cleanup = append(s.cleanup, func() {
 		start := time.Now()
@@ -223,7 +224,7 @@ func (s *StreamHandlerSuite) startStreamHandler(streamID uint64) *ssh.StreamHand
 		ca()
 		var err error
 		select {
-		case err = <-s.errC:
+		case err = <-errC:
 		case <-time.After(DefaultTimeout):
 			s.Fail("timed out waiting for stream handler to close")
 		}
@@ -1942,6 +1943,19 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_Whoami() {
 		GetSession(Any(), Any()).
 		Return(session, nil)
 
+	// The formatted session includes information about session expiry (e.g.,
+	// "expires in 5h20m") and since we are checking to see if the format matches
+	// by running it locally, this test can flake if it is timed precisely such
+	// that Format() runs on the server when the wall clock is at minute N and
+	// the local Format() runs at minute N+1.
+	if now := time.Now(); now.Second() == 59 && now.Nanosecond() >= 900*int(time.Millisecond) {
+		// Wait until the next minute. The routine below takes about 1ms with race
+		// detector enabled, so a window of +/- 100ms should be plenty to account
+		// for CI slowdown
+		s.T().Log("delaying test 200ms")
+		time.Sleep(200 * time.Second)
+	}
+	now := time.Now()
 	stream.SendClientToServer(channelMsg(ssh.ChannelRequestMsg{
 		PeersID:   peerID,
 		Request:   "exec",
@@ -1953,7 +1967,10 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_Whoami() {
 	recvChannelMsg[ssh.ChannelRequestSuccessMsg](s, stream)
 
 	channelData := s.channelDataLoop(peerID, stream, 0)
-	s.Equal(string(session.Format()), channelData.String())
+	expected := string(session.Format())
+	s.T().Logf("duration: %s", time.Since(now))
+	actual := channelData.String()
+	s.Equal(expected, actual)
 }
 
 func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_WhoamiError() {

--- a/pkg/ssh/test/policy_index_suite.go
+++ b/pkg/ssh/test/policy_index_suite.go
@@ -14,8 +14,8 @@ import (
 	"github.com/pomerium/pomerium/config/envoyconfig"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/ssh"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	mock_ssh "github.com/pomerium/pomerium/pkg/ssh/mock"
-	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 )
 
 type OpOrder int
@@ -258,8 +258,8 @@ var orders = [][]OpOrder{
 	23: {ProcessConfigUpdate, OnSessionCreated, OnStreamAuthenticated, AddStream},
 }
 
-func makeRouteInfoFromPolicy(p *config.Policy) portforward.RouteInfo {
-	return portforward.RouteInfo{
+func makeRouteInfoFromPolicy(p *config.Policy) common.RouteInfo {
+	return common.RouteInfo{
 		From:      p.From,
 		To:        p.To,
 		Hostname:  strings.TrimPrefix(p.From, "https://"),
@@ -375,7 +375,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestAllowAll() {
 			onSessionCreatedArgs{session: &session.Session{Id: "session1"}},
 			processConfigUpdateArgs{config: cfg},
 			func() {
-				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -417,7 +417,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestAllowSome() {
 			onSessionCreatedArgs{session: &session.Session{Id: "session1"}},
 			processConfigUpdateArgs{config: cfg},
 			func() {
-				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				}))
@@ -500,7 +500,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUpdateEvalResult() {
 			onSessionCreatedArgs{session: &session.Session{Id: "session1"}},
 			processConfigUpdateArgs{config: cfg2},
 			func() {
-				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[2]),
@@ -548,7 +548,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUpdatePoliciesDenyThenAllow() {
 			onSessionCreatedArgs{session: &session.Session{Id: "session1"}},
 			processConfigUpdateArgs{config: cfg2},
 			func() {
-				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[2]),
@@ -590,7 +590,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUpdatePoliciesAllowThenDeny() {
 
 		s.index.ProcessConfigUpdate(cfg)
 		expectInitialAuthRoutes := func() {
-			sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+			sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -659,14 +659,14 @@ func (s *PolicyIndexConformanceSuite[T]) TestUpdatePoliciesAllowThenAllow() {
 		s.index.ProcessConfigUpdate(cfg)
 		if slices.Index(s.order, ProcessConfigUpdate) == 3 {
 			call1 := sub1.EXPECT().
-				UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
 				})).
 				Times(1)
 			sub1.EXPECT().
-				UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[2]),
@@ -674,7 +674,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUpdatePoliciesAllowThenAllow() {
 				After(call1)
 		} else {
 			sub1.EXPECT().
-				UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[2]),
@@ -714,7 +714,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestMultipleStreamsWithSameSession() {
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -726,7 +726,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestMultipleStreamsWithSameSession() {
 
 	s.index.AddStream(2, sub2)
 	sub2.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -758,7 +758,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestStreamReconnectSameSession() {
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -772,7 +772,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestStreamReconnectSameSession() {
 	sub1.EXPECT().UpdateEnabledStaticPorts(gomock.Eq([]uint{443, 22}))
 	s.index.AddStream(2, sub1)
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -808,7 +808,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestMultipleAuthRequestsForSession() {
 
 		s.index.AddStream(i, sub)
 		sub.EXPECT().
-			UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+			UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -841,7 +841,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestMultipleAuthRequestsForSession() {
 		s.index.AddStream(NumAuthRequests+i, sub)
 
 		sub.EXPECT().
-			UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+			UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -880,7 +880,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUnusedAuthRequestsShouldNotGrowUnbo
 
 		s.index.AddStream(i, sub)
 		sub.EXPECT().
-			UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+			UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -923,7 +923,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUnusedAuthRequestsShouldNotGrowUnbo
 		s.index.AddStream(NumAuthRequests+i, sub)
 
 		sub.EXPECT().
-			UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+			UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -969,7 +969,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestPolicyChangeBeforeReconnect() {
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1023,7 +1023,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestPolicyChangeBeforeReconnectWithOthe
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1035,7 +1035,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestPolicyChangeBeforeReconnectWithOthe
 
 	s.index.AddStream(2, sub2)
 	sub2.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1081,7 +1081,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestSessionDeletedWhileConnected() {
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1116,7 +1116,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestSessionDeletedThenStreamsRemoved() 
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1127,7 +1127,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestSessionDeletedThenStreamsRemoved() 
 	sub2.EXPECT().UpdateEnabledStaticPorts(gomock.Eq([]uint{443, 22}))
 	s.index.AddStream(2, sub2)
 	sub2.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1197,7 +1197,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestSessionDeletedWhileDisconnected() {
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),

--- a/pkg/ssh/tui/tunnel/program.go
+++ b/pkg/ssh/tui/tunnel/program.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 )
 
@@ -39,6 +40,6 @@ func (ts *Program) OnPermissionsUpdated(permissions []portforward.Permission) {
 }
 
 // OnRoutesUpdated implements portforward.UpdateListener.
-func (ts *Program) OnRoutesUpdated(routes []portforward.RouteInfo) {
+func (ts *Program) OnRoutesUpdated(routes []common.RouteInfo) {
 	go ts.Send(routes)
 }


### PR DESCRIPTION
## Summary

Moves `portforward.RouteInfo` to a new `pkg/ssh/common` package so it can be used in other places without depending on portforward. This is to support upcoming refactors to the policy indexer to support two-person auth.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

none

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review