### PR TITLE
ssh: require streams to have a valid session before indexing

### DIFF
--- a/authorize/ssh_grpc.go
+++ b/authorize/ssh_grpc.go
@@ -112,7 +112,10 @@ func (a *Authorize) EvaluateSSH(ctx context.Context, streamID uint64, req ssh.Au
 
 	allowed := res.Allow.Value && !res.Deny.Value
 
-	if allowed && !initialAuthComplete {
+	// Note: the stream is not considered authenticated until it passes evaluation
+	// with a valid session ID and session binding ID.
+	if allowed && !initialAuthComplete &&
+		req.SessionBindingID != "" && req.SessionID != "" {
 		if err := a.ssh.OnStreamAuthenticated(ctx, streamID, req); err != nil {
 			log.Ctx(ctx).Error().Err(err).Msg("failed to set session id for stream")
 			return nil, err

--- a/pkg/ssh/manager.go
+++ b/pkg/ssh/manager.go
@@ -313,6 +313,11 @@ func (sm *StreamManager) OnStreamAuthenticated(ctx context.Context, streamID uin
 		return status.Errorf(codes.Internal, "stream %d already has an associated session", streamID)
 	}
 
+	// sanity check: this should only be called with valid session IDs
+	if req.SessionBindingID == "" || req.SessionID == "" {
+		panic("bug: call to OnStreamAuthenticated with missing SessionBindingID or SessionID")
+	}
+
 	if sm.sessionStreams[req.SessionID] == nil {
 		sm.sessionStreams[req.SessionID] = map[uint64]struct{}{}
 	}


### PR DESCRIPTION
## Summary

This change has no effect on the current auth logic, since the stream will always have a session at this point. To support future changes to the auth flow which may perform partial evaluations using only the public key info, this makes sure the streams are not indexed as authenticated until they are evaluated with a valid session in the request input.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

None

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
