### PR TITLE
ssh: refactor auth logic to use updated api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -85,8 +85,8 @@ require (
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pires/go-proxyproto v0.11.0
-	github.com/pomerium/datasource v0.18.2-0.20260716182004-1c5ab56d78c6
-	github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260618180819-16ede7a56f2f
+	github.com/pomerium/datasource v0.18.2-0.20260712023818-d0e40970f4c4
+	github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260716001632-70f126e0d09d
 	github.com/pomerium/pomerium/pkg/grpc/config v0.0.0-00010101000000-000000000000
 	github.com/pomerium/pomerium/pkg/grpc/databroker v0.0.0-00010101000000-000000000000
 	github.com/pomerium/protoutil v0.0.0-20260712023948-476583c4c434

--- a/go.sum
+++ b/go.sum
@@ -867,10 +867,10 @@ github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/pomerium/datasource v0.18.2-0.20260716182004-1c5ab56d78c6 h1:zZR6pfhZxLs091ebGg4lzBsMneBAzGidZ8hoN0gOQ7M=
-github.com/pomerium/datasource v0.18.2-0.20260716182004-1c5ab56d78c6/go.mod h1:GcLXvpHDGS1HVG51LKcjts3kO/fPH35qB9iv6hKlRB4=
-github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260618180819-16ede7a56f2f h1:LG3PfhAQrJzPoSNnpkGpqwojoJQzrmrynX484yCmn4Y=
-github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260618180819-16ede7a56f2f/go.mod h1:7Svo/CaRt9vfJ22sEC+T/q/y2WNi/cZTlugNYUS7xwI=
+github.com/pomerium/datasource v0.18.2-0.20260712023818-d0e40970f4c4 h1:TNoZswUWBzCpO99LZC4ke4CNJ7Yvc8lW58r4wKLe4VM=
+github.com/pomerium/datasource v0.18.2-0.20260712023818-d0e40970f4c4/go.mod h1:uM2aJ6QOkKZn+ugldQnQG4/ANRRk4WFVtsxNWnppzpg=
+github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260716001632-70f126e0d09d h1:i8enQq0JkKt2nT/TZ7QQoGpgtuSvG8/M1A1RP4ppLXg=
+github.com/pomerium/envoy-custom v1.37.0-rc3.0.20260716001632-70f126e0d09d/go.mod h1:7Svo/CaRt9vfJ22sEC+T/q/y2WNi/cZTlugNYUS7xwI=
 github.com/pomerium/protoutil v0.0.0-20260712023948-476583c4c434 h1:RIaEViw7WEO/xDqk/s2I3pyBQbrCjJwprKOKlLcCrjQ=
 github.com/pomerium/protoutil v0.0.0-20260712023948-476583c4c434/go.mod h1:xwCM2uuRDv4OWk/AeiEM7RYO3HQ7JaJD/Uk4mit19xc=
 github.com/pomerium/webauthn v0.0.0-20260712023900-f47fcf774920 h1:D3EjISouFV+o7sD7h5ILDmON6mCsNEBhdD5KrLIiDKs=

--- a/go.work.sum
+++ b/go.work.sum
@@ -329,6 +329,7 @@ golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/sys v0.44.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/telemetry v0.0.0-20260409153401-be6f6cb8b1fa/go.mod h1:kHjTxDEnAu6/Nl9lDkzjWpR+bmKfxeiRuSDlsMb70gE=
 golang.org/x/telemetry v0.0.0-20260508192327-42602be52be6/go.mod h1:Eqhaxk/wZsWEH8CRxLwj6xzEJbz7k1EFGqx7nyCoabE=
+golang.org/x/telemetry v0.0.0-20260625142307-59b4966ccb57/go.mod h1:3AWMyWHS+caVoiEXpiq6+tzKA40J4vQT3MYr80ZtQpc=
 golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
 golang.org/x/text v0.31.0/go.mod h1:tKRAlv61yKIjGGHX/4tP1LTbc13YSec1pxVEWXzfoeM=
 golang.org/x/text v0.32.0/go.mod h1:o/rUWzghvpD5TXrTIBuJU77MTaN0ljMWE47kxGJQ7jY=
@@ -343,6 +344,7 @@ google.golang.org/appengine v1.6.8/go.mod h1:1jJ3jBArFh5pcgW8gCtRJnepW8FzD1V44FJ
 google.golang.org/genproto/googleapis/api v0.0.0-20260226221140-a57be14db171/go.mod h1:M5krXqk4GhBKvB596udGL3UyjL4I1+cTbK0orROM9ng=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20260427160629-7cedc36a6bc4/go.mod h1:6TABGosqSqU2l1+fJ3jdvOYPPVryeKybxYF0cCZkTBE=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20260523011958-0a33c5d7ca68/go.mod h1:6TABGosqSqU2l1+fJ3jdvOYPPVryeKybxYF0cCZkTBE=
+google.golang.org/genproto/googleapis/bytestream v0.0.0-20260622175928-b703f567277d/go.mod h1:6TABGosqSqU2l1+fJ3jdvOYPPVryeKybxYF0cCZkTBE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260226221140-a57be14db171/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260511170946-3700d4141b60/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
 google.golang.org/grpc v1.79.3/go.mod h1:KmT0Kjez+0dde/v2j9vzwoAScgEPx/Bw1CYChhHLrHQ=

--- a/pkg/ssh/auth.go
+++ b/pkg/ssh/auth.go
@@ -49,7 +49,10 @@ const (
 
 //nolint:revive
 type SSHEvaluator interface {
+	// Evaluates whether a user can connect to this route
 	EvaluateSSH(ctx context.Context, streamID uint64, req AuthRequest, initialAuthComplete bool) (*evaluator.Result, error)
+
+	// Evaluates whether a user can attach an upstream tunnel to this route
 	EvaluateUpstreamTunnel(ctx context.Context, req AuthRequest, route *config.Policy) (*evaluator.Result, error)
 }
 
@@ -108,6 +111,7 @@ func NewAuth(
 	currentConfig *atomic.Pointer[config.Config],
 	tracerProvider oteltrace.TracerProvider,
 	codeIssuer code.Issuer,
+	_ any, // temporary placeholder
 	opts ...Option,
 ) *Auth {
 	options := Options{
@@ -137,18 +141,22 @@ func (a *Auth) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
 
 func (a *Auth) HandlePublicKeyMethodRequest(
 	ctx context.Context,
-	info StreamAuthInfo,
+	streamInfo StreamInfo,
+	authInfo StreamAuthInfo,
 	user api.UserRequest,
 	req *extensions_ssh.PublicKeyMethodRequest,
-) (PublicKeyAuthMethodResponse, error) {
+) (AuthMethodResponse, error) {
 	ctx, span := a.tracer.Start(ctx, "authorize.ssh.HandlePublicKeyMethodRequest")
 	defer span.End()
-	resp, err := a.handlePublicKeyMethodRequest(ctx, info, user, req)
+	resp, err := a.handlePublicKeyMethodRequest(ctx, streamInfo, authInfo, user, req)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("ssh publickey auth request error")
-		span.SetStatus(otelcode.Error, "internal error")
-		return resp, status.Error(codes.Internal, "internal error")
+		span.SetStatus(otelcode.Error, err.Error())
+		// TODO: handle ShowErrorDetails here
+		return resp, status.Error(codes.PermissionDenied, "permission denied")
 	}
+	resp.Validate()
+	span.SetStatus(otelcode.Ok, resp.String())
 	return resp, err
 }
 
@@ -159,135 +167,151 @@ func fingerprintAsStrAttribute(publicKeyFingerprintSha256 []byte) string {
 	return base64.RawStdEncoding.EncodeToString(publicKeyFingerprintSha256)
 }
 
-func (a *Auth) handlePublicKeyMethodRequest(
-	ctx context.Context,
-	info StreamAuthInfo,
-	user api.UserRequest,
-	req *extensions_ssh.PublicKeyMethodRequest,
-) (PublicKeyAuthMethodResponse, error) {
-	ctx, span := a.tracer.Start(ctx, "authorize.ssh.handlePublicKeyMethodRequest")
-	defer span.End()
-	sessionBindingID, err := sessionIDFromFingerprint(req.PublicKeyFingerprintSha256)
-	if err != nil {
-		return PublicKeyAuthMethodResponse{}, err
-	}
-	sessionBinding, err := a.resolveSession(ctx, sessionBindingID)
-	if err != nil {
-		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
-			span.SetStatus(otelcode.Ok, "must reauthenticated")
-			return PublicKeyAuthMethodResponse{
-				Allow:                    publicKeyAllowResponse(req.PublicKey),
-				RequireAdditionalMethods: []string{MethodKeyboardInteractive},
-			}, nil
-		}
-		return PublicKeyAuthMethodResponse{}, err
-	}
-	sshreq := AuthRequest{
-		Username:         user.Username(),
-		Hostname:         user.Hostname(),
-		PublicKey:        string(req.PublicKey),
-		SessionID:        sessionBinding.SessionId,
-		SessionBindingID: sessionBindingID,
-		SourceAddress:    info.SourceAddress,
-	}
-	log.Ctx(ctx).Debug().
-		Str("username", user.Username()).
-		Str("hostname", user.Hostname()).
-		Str("session-id", sessionBinding.SessionId).
-		Msg("ssh publickey auth request")
-
-	// Special case: internal command (e.g. routes portal).
-	if user.Hostname() == "" {
-		_, err := session.Get(ctx, a.evaluator.GetDataBrokerServiceClient(), sessionBinding.SessionId)
-		if status.Code(err) == codes.NotFound {
-			// Require IdP login.
-			return PublicKeyAuthMethodResponse{
-				Allow:                    publicKeyAllowResponse(req.PublicKey),
-				RequireAdditionalMethods: []string{MethodKeyboardInteractive},
-			}, nil
-		} else if err != nil {
-			return PublicKeyAuthMethodResponse{}, err
-		}
-	}
-
-	res, err := a.evaluator.EvaluateSSH(ctx, info.StreamID, sshreq, info.InitialAuthComplete)
-	if err != nil {
-		span.SetStatus(otelcode.Error, "internal error : evaluate")
-		return PublicKeyAuthMethodResponse{}, err
-	}
-
-	// Interpret the results of policy evaluation.
-	if res.HasReason(criteria.ReasonSSHPublickeyUnauthorized) {
-		// This public key is not allowed, but the client is free to try a different key.
-		span.SetStatus(otelcode.Ok, "public key not allowed")
-		return PublicKeyAuthMethodResponse{
-			RequireAdditionalMethods: []string{MethodPublicKey},
-		}, nil
-	} else if res.HasReason(criteria.ReasonUserUnauthenticated) {
-		// Mark public key as allowed, to initiate IdP login flow.
-		span.SetStatus(otelcode.Ok, "un-authenticated")
-		return PublicKeyAuthMethodResponse{
-			Allow:                    publicKeyAllowResponse(req.PublicKey),
-			RequireAdditionalMethods: []string{MethodKeyboardInteractive},
-		}, nil
-	} else if res.Allow.Value && !res.Deny.Value {
-		// Allowed, no login needed.
-		span.SetStatus(otelcode.Ok, "allowed")
-		return PublicKeyAuthMethodResponse{
-			Allow: publicKeyAllowResponse(req.PublicKey),
-		}, nil
-	}
-	// Denied, no login needed.
-	span.SetStatus(otelcode.Ok, "denied")
-	return PublicKeyAuthMethodResponse{}, nil
+func authInfoHasPublicKey(info StreamAuthInfo) bool {
+	return len(info.GetPublicKey()) > 0 &&
+		len(info.GetPublicKeyAlg()) > 0 &&
+		len(info.GetPublicKeyFingerprintSha256()) > 0
 }
 
-func publicKeyAllowResponse(publicKey []byte) *extensions_ssh.PublicKeyAllowResponse {
-	return &extensions_ssh.PublicKeyAllowResponse{
-		PublicKey: publicKey,
-		Permissions: &extensions_ssh.Permissions{
-			PermitPortForwarding:  true,
-			PermitAgentForwarding: true,
-			PermitX11Forwarding:   true,
-			PermitPty:             true,
-			PermitUserRc:          true,
-			ValidStartTime:        timestamppb.New(time.Now().Add(-1 * time.Minute)),
-			ValidEndTime:          timestamppb.New(time.Now().Add(1 * time.Hour)),
-		},
+func authInfoHasSession(info StreamAuthInfo) bool {
+	return len(info.GetSessionId()) > 0 &&
+		len(info.GetSessionBindingId()) > 0
+}
+
+func (a *Auth) handlePublicKeyMethodRequest(
+	ctx context.Context,
+	streamInfo StreamInfo,
+	authInfo StreamAuthInfo,
+	user api.UserRequest,
+	req *extensions_ssh.PublicKeyMethodRequest,
+) (AuthMethodResponse, error) {
+	pendingAuthContextUpdates := &extensions_ssh.AuthContext{}
+
+	// First, try authenticating with the public key only, to see if it is allowed
+	res, err := a.evaluator.EvaluateSSH(ctx, streamInfo.StreamID, AuthRequest{
+		Username:        user.Username(),
+		Hostname:        user.Hostname(),
+		PublicKey:       string(req.PublicKey),
+		SourceAddress:   streamInfo.SourceAddress,
+		LogOnlyIfDenied: true,
+	}, streamInfo.InitialAuthComplete)
+	if err != nil {
+		return AuthMethodResponse{}, err
 	}
+
+	// Check for non-retriable deny reasons
+	if res.HasReason(criteria.ReasonSourceIPUnauthorized) ||
+		res.HasReason(criteria.ReasonSSHUsernameUnauthorized) {
+		return AuthMethodResponse{}, nil
+	}
+
+	if res.HasReason(criteria.ReasonSSHPublickeyUnauthorized) {
+		// If the public key itself is not allowed, allow the client to retry
+		return AuthMethodResponse{
+			AllowMethod:            false,
+			NextRequiredAuthMethod: MethodPublicKey,
+		}, nil
+	} else {
+		// The public key is acceptable
+		pendingAuthContextUpdates.PublicKey = req.PublicKey
+		pendingAuthContextUpdates.PublicKeyAlg = req.PublicKeyAlg
+		pendingAuthContextUpdates.PublicKeyFingerprintSha256 = req.PublicKeyFingerprintSha256
+	}
+
+	isPomeriumInternalRoute := res.HasReason(criteria.ReasonPomeriumRoute)
+	if !res.HasReason(criteria.ReasonUserUnauthenticated) && !isPomeriumInternalRoute {
+		// sanity check
+		panic("bug: missing user-unauthenticated deny reason from evaluator result for non-pomerium route")
+	}
+
+	// First check if there is a session for this public key
+	sessionBindingID, err := sessionIDFromFingerprint(req.PublicKeyFingerprintSha256)
+	if err != nil {
+		return AuthMethodResponse{}, err
+	}
+	sessionBinding, _, err := a.resolveSession(ctx, sessionBindingID)
+	if err != nil {
+		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+			// No session, and one is required
+			return AuthMethodResponse{
+				AllowMethod:            true, // publickey
+				NextRequiredAuthMethod: MethodKeyboardInteractive,
+				ContextUpdates:         pendingAuthContextUpdates, // the public key is valid
+			}, nil
+		}
+		// No session, but there was an error checking the databroker or something
+		return AuthMethodResponse{}, err
+	}
+
+	// Evaluate again, this time with the session info populated.
+	res, err = a.evaluator.EvaluateSSH(ctx, streamInfo.StreamID, AuthRequest{
+		Username:      user.Username(),
+		Hostname:      user.Hostname(),
+		PublicKey:     string(req.PublicKey),
+		SourceAddress: streamInfo.SourceAddress,
+
+		SessionID:        sessionBinding.SessionId,
+		SessionBindingID: sessionBindingID,
+		// Keep AccessRequestState unset
+	}, streamInfo.InitialAuthComplete)
+	if err != nil {
+		return AuthMethodResponse{}, err
+	}
+
+	if res.HasReason(criteria.ReasonUserUnauthenticated) {
+		// The session is not valid
+		return AuthMethodResponse{
+			AllowMethod:            true, // publickey
+			NextRequiredAuthMethod: MethodKeyboardInteractive,
+			ContextUpdates:         pendingAuthContextUpdates, // the public key is valid
+		}, nil
+	}
+
+	return processSessionEvaluateResult(sessionIDs{
+		SessionBindingID: sessionBindingID,
+		SessionID:        sessionBinding.SessionId,
+		UserID:           sessionBinding.UserId,
+	}, res, pendingAuthContextUpdates)
 }
 
 func (a *Auth) HandleKeyboardInteractiveMethodRequest(
 	ctx context.Context,
-	info StreamAuthInfo,
+	streamInfo StreamInfo,
+	authInfo StreamAuthInfo,
 	user api.UserRequest,
 	_ *extensions_ssh.KeyboardInteractiveMethodRequest,
 	querier KeyboardInteractiveQuerier,
-) (KeyboardInteractiveAuthMethodResponse, error) {
-	resp, err := a.handleKeyboardInteractiveMethodRequest(ctx, info, user, querier)
+) (AuthMethodResponse, error) {
+	ctx, span := a.tracer.Start(ctx, "authorize.ssh.HandleKeyboardInteractiveMethodRequest")
+	defer span.End()
+	var policy *config.Policy
+	resp, err := a.handleKeyboardInteractiveMethodRequest(ctx, streamInfo, authInfo, user, querier, &policy)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("ssh keyboard-interactive auth request error")
-		if _, ok := status.FromError(err); !ok {
-			return resp, status.Error(codes.Internal, err.Error())
+		span.SetStatus(otelcode.Error, err.Error())
+		if policy != nil && policy.ShowErrorDetails {
+			return resp, err
 		}
-		return resp, err
+		return resp, status.Error(codes.PermissionDenied, "permission denied")
 	}
+	resp.Validate()
+	span.SetStatus(otelcode.Ok, resp.String())
 	return resp, err
 }
 
 func (a *Auth) handleKeyboardInteractiveMethodRequest(
 	ctx context.Context,
-	info StreamAuthInfo,
+	streamInfo StreamInfo,
+	authInfo StreamAuthInfo,
 	user api.UserRequest,
 	querier KeyboardInteractiveQuerier,
-) (KeyboardInteractiveAuthMethodResponse, error) {
-	fingerprintAttrVal := fingerprintAsStrAttribute(info.PublicKeyFingerprintSha256)
-	ctx, span := a.tracer.Start(ctx, "authorize.ssh.handleKeyboardInteractiveMethodRequest")
-	defer span.End()
-	if info.PublicKeyAllow.Value == nil {
-		// Sanity check: this method is only valid if we already accepted a public key.
-		return KeyboardInteractiveAuthMethodResponse{}, errPublicKeyAllowNil
-	}
+	outPolicy **config.Policy,
+) (AuthMethodResponse, error) {
+	cfg := a.currentConfig.Load()
+
+	fingerprintAttrVal := fingerprintAsStrAttribute(authInfo.GetPublicKeyFingerprintSha256())
+
+	pendingAuthContextUpdates := &extensions_ssh.AuthContext{}
 
 	log.Ctx(ctx).Debug().
 		Str("username", user.Username()).
@@ -295,38 +319,103 @@ func (a *Auth) handleKeyboardInteractiveMethodRequest(
 		Str(telemetryFingerprintAttribute, fingerprintAttrVal).
 		Msg("ssh keyboard-interactive auth request")
 
-	// Initiate the IdP login flow.
-	err := a.handleLogin(ctx, user.Hostname(), info.SourceAddress, info.PublicKeyFingerprintSha256, querier)
-	if err != nil {
-		span.SetStatus(otelcode.Error, "login failed")
-		return KeyboardInteractiveAuthMethodResponse{}, err
+	if !authInfoHasPublicKey(authInfo) {
+		// Sanity check: this method is only valid if we already accepted a public key.
+		panic("bug: public key info missing from auth context")
 	}
 
-	if err := a.EvaluateDelayed(ctx, info, user); err != nil {
-		// Denied.
-		span.SetStatus(otelcode.Ok, "denied")
-		return KeyboardInteractiveAuthMethodResponse{}, nil
+	policy := cfg.Options.GetRouteForSSHHostname(user.Hostname())
+	if outPolicy != nil {
+		*outPolicy = policy
 	}
-	// Allowed.
-	span.SetStatus(otelcode.Ok, "allowed")
-	return KeyboardInteractiveAuthMethodResponse{
-		Allow: &extensions_ssh.KeyboardInteractiveAllowResponse{},
-	}, nil
+
+	var sessionID, userID, sessionBindingID string
+
+	if !authInfoHasSession(authInfo) {
+		// No session (this is the most common case)
+
+		// Initiate the IdP login flow.
+		var err error
+		sessionBinding, sbID, err := a.handleLogin(ctx, cfg, policy, streamInfo.SourceAddress, authInfo.GetPublicKeyFingerprintSha256(), querier)
+		if err != nil {
+			return AuthMethodResponse{}, err
+		}
+		sessionID = sessionBinding.SessionId
+		userID = sessionBinding.UserId
+		sessionBindingID = sbID
+	} else {
+		// There is already a valid session, so keyboard-interactive is requested
+		// for a different reason
+		sessionID = authInfo.GetSessionId()
+		userID = authInfo.GetUserId()
+		sessionBindingID = authInfo.GetSessionBindingId()
+
+		// (not implemented yet)
+
+		panic("bug: keyboard-interactive auth request is not valid in this state")
+	}
+
+	res, err := a.evaluator.EvaluateSSH(ctx, streamInfo.StreamID, AuthRequest{
+		Username:         user.Username(),
+		Hostname:         user.Hostname(),
+		PublicKey:        string(authInfo.GetPublicKey()),
+		SourceAddress:    streamInfo.SourceAddress,
+		SessionID:        sessionID,
+		SessionBindingID: sessionBindingID,
+	}, streamInfo.InitialAuthComplete)
+	if err != nil {
+		return AuthMethodResponse{}, err
+	}
+	return processSessionEvaluateResult(sessionIDs{
+		SessionBindingID: sessionBindingID,
+		SessionID:        sessionID,
+		UserID:           userID,
+	}, res, pendingAuthContextUpdates)
+}
+
+type sessionIDs struct {
+	SessionBindingID string
+	SessionID        string
+	UserID           string
+}
+
+func processSessionEvaluateResult(
+	ids sessionIDs,
+	res *evaluator.Result,
+	pendingAuthContextUpdates *extensions_ssh.AuthContext,
+) (AuthMethodResponse, error) {
+	if res.Allow.Value {
+		if !res.Deny.Value {
+			// The session is valid and there are no deny reasons
+			pendingAuthContextUpdates.SessionBindingId = ids.SessionBindingID
+			pendingAuthContextUpdates.SessionId = ids.SessionID
+			pendingAuthContextUpdates.UserId = ids.UserID
+
+			return AuthMethodResponse{
+				AllowMethod:              true, // publickey
+				NoFurtherMethodsRequired: true,
+				ContextUpdates:           pendingAuthContextUpdates, // public key + session
+			}, nil
+		}
+	}
+
+	// Deny
+	return AuthMethodResponse{}, nil
 }
 
 func (a *Auth) handleLogin(
 	ctx context.Context,
-	hostname string,
+	cfg *config.Config,
+	policy *config.Policy,
 	sourceAddr string,
 	publicKeyFingerprint []byte,
 	querier KeyboardInteractiveQuerier,
-) (err error) {
+) (*session.SessionBinding, string /*sessionBindingID*/, error) {
 	ctx, span := a.tracer.Start(ctx, "authorize.ssh.handleLogin")
 	defer span.End()
 
-	cfg := a.currentConfig.Load()
 	if cfg.Options.UseStatelessAuthenticateFlow() {
-		return status.Error(codes.FailedPrecondition, "ssh login is not currently enabled")
+		return nil, "", status.Error(codes.FailedPrecondition, "ssh login is not currently enabled")
 	}
 
 	l := log.Ctx(ctx).With().
@@ -342,11 +431,11 @@ func (a *Auth) handleLogin(
 
 	bindingKey, err := sessionIDFromFingerprint(publicKeyFingerprint)
 	if err != nil {
-		return a.reportLoginCodeFailure(ctx, l, span, codes.Internal, err.Error())
+		return nil, "", a.reportLoginCodeFailure(ctx, l, span, codes.Internal, err.Error())
 	}
-	idp, authenticator, err := a.getAuthenticator(ctx, hostname)
+	idp, authenticator, err := a.getAuthenticator(ctx, cfg, policy)
 	if err != nil {
-		return a.reportLoginCodeFailure(ctx, l, span, codes.Internal, err.Error())
+		return nil, "", a.reportLoginCodeFailure(ctx, l, span, codes.Internal, err.Error())
 	}
 	authURL, _ := cfg.Options.GetAuthenticateURL()
 	generatedCode := a.codeIssuer.IssueCode()
@@ -371,7 +460,7 @@ func (a *Auth) handleLogin(
 	endCodeTime := time.Now()
 	a.codeMetrics.SSHIssueCodeDuration.Record(ctx, endCodeTime.Sub(startCodeTime).Seconds())
 	if err != nil {
-		return a.reportLoginCodeFailure(ctx, l, span, codes.Aborted, "failed to associate a code to this session")
+		return nil, "", a.reportLoginCodeFailure(ctx, l, span, codes.Aborted, "failed to associate a code to this session")
 	}
 	var prompt string
 
@@ -382,11 +471,14 @@ func (a *Auth) handleLogin(
 		RawQuery: query.Encode(),
 	})
 	prompt = promptURI.String()
-	_, _ = querier.Prompt(ctxT, &extensions_ssh.KeyboardInteractiveInfoPrompts{
+	_, err = querier.Prompt(ctxT, &extensions_ssh.KeyboardInteractiveInfoPrompts{
 		Name:        SignInPrompt(authenticator),
 		Instruction: prompt,
 		Prompts:     nil,
 	})
+	if err != nil {
+		return nil, "", err
+	}
 	startDecisionTime := time.Now()
 
 	defer func() {
@@ -397,43 +489,57 @@ func (a *Auth) handleLogin(
 	statusC := a.codeIssuer.OnCodeDecision(ctxT, associatedCode)
 	select {
 	case <-a.codeIssuer.Done():
-		return a.reportLoginCodeFailure(ctx, l, span, codes.Internal, "code issuer can no longer process this request")
+		return nil, "", a.reportLoginCodeFailure(ctx, l, span, codes.Internal, "code issuer can no longer process this request")
 	case <-ctxT.Done():
-		return a.reportLoginCodeFailure(ctx, l, span, codes.Canceled, "authentication request timeout")
+		return nil, "", a.reportLoginCodeFailure(ctx, l, span, codes.Canceled, "authentication request timeout")
 	case st, ok := <-statusC:
 		if !ok {
-			return a.reportLoginCodeFailure(ctx, l, span, codes.DeadlineExceeded, "authentication request cancelled by user or timeout exceeded")
+			return nil, "", a.reportLoginCodeFailure(ctx, l, span, codes.DeadlineExceeded, "authentication request cancelled by user or timeout exceeded")
 		}
-		if st.State == session.SessionBindingRequestState_Revoked {
-			return a.reportLoginCodeFailure(ctx, l, span, codes.PermissionDenied, "user has denied this code")
+		switch st.State {
+		case session.SessionBindingRequestState_Revoked:
+			return nil, "", a.reportLoginCodeFailure(ctx, l, span, codes.PermissionDenied, "user has denied this code")
+		case session.SessionBindingRequestState_Accepted:
+		default:
+			// the code issuer must not send a status reply here with state=InFlight
+			panic(fmt.Sprintf("bug: invalid session binding request state in code.Status: %v", st.State))
 		}
 		if st.BindingKey != bindingKey {
-			return a.reportLoginCodeFailure(ctx, l, span, codes.Internal, "mismatched binding keys")
+			return nil, "", a.reportLoginCodeFailure(ctx, l, span, codes.Internal, "mismatched binding keys")
 		}
-		ctxca, ca := context.WithTimeout(context.Background(), 30*time.Second)
+		// use ctxT as the parent here so that this will time out in 30s or if the
+		// request itself expires, whichever comes first
+		ctxca, ca := context.WithTimeout(ctxT, 30*time.Second)
 		defer ca()
 		b := backoff.WithContext(backoff.NewExponentialBackOff(), ctxca)
-		client := a.evaluator.GetDataBrokerServiceClient()
+		var sessionBinding *session.SessionBinding
+		var lastError error
 		err := backoff.Retry(func() error {
-			rec, err := client.Get(ctxca, &databroker.GetRequest{
+			sessionBinding, _, lastError = a.resolveSession(ctxca, bindingKey)
+			if lastError != nil {
+				if databroker.IsNotFound(lastError) {
+					return lastError
+				}
+				return backoff.Permanent(lastError)
+			}
+			a.evaluator.InvalidateCacheForRecords(ctxca, &databroker.Record{
 				Type: "type.googleapis.com/session.SessionBinding",
 				Id:   bindingKey,
 			})
-			if rec.Record.DeletedAt != nil {
-				return fmt.Errorf("stale record")
-			}
-			if err != nil {
-				return err
-			}
-			a.evaluator.InvalidateCacheForRecords(ctxca, rec.GetRecord())
 			return nil
 		}, b)
 		if err != nil {
-			return a.reportLoginCodeFailure(ctx, l, span, codes.Internal, fmt.Sprintf("failed to get matching session binding : %s", err.Error()))
+			// try to prevent "context canceled" from masking the underlying error
+			// if the backoff timed out
+			if errors.Is(err, lastError) {
+				return nil, "", a.reportLoginCodeFailure(ctx, l, span, codes.Internal, fmt.Sprintf("failed to get matching session binding: %s", err.Error()))
+			} else {
+				return nil, "", a.reportLoginCodeFailure(ctx, l, span, codes.Internal, fmt.Sprintf("failed to get matching session binding: %s (last error: %s)", err.Error(), lastError.Error()))
+			}
 		}
 		l.Info().Msg("successfully authenticated")
 		span.SetStatus(otelcode.Ok, "successfully authenticated")
-		return nil
+		return sessionBinding, bindingKey, nil
 	}
 }
 
@@ -479,12 +585,12 @@ func (a *Auth) reportLoginCodeFailure(
 
 var errAccessDenied = status.Error(codes.PermissionDenied, "access denied")
 
-func (a *Auth) EvaluateDelayed(ctx context.Context, info StreamAuthInfo, user api.UserRequest) error {
-	req, err := a.sshRequestFromStreamAuthInfo(ctx, info, user)
+func (a *Auth) EvaluateDelayed(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo, user api.UserRequest) error {
+	req, err := a.sshRequestFromStreamAuthInfo(ctx, streamInfo, authInfo, user)
 	if err != nil {
 		return err
 	}
-	res, err := a.evaluator.EvaluateSSH(ctx, info.StreamID, req, info.InitialAuthComplete)
+	res, err := a.evaluator.EvaluateSSH(ctx, streamInfo.StreamID, req, streamInfo.InitialAuthComplete)
 	if err != nil {
 		return err
 	}
@@ -496,7 +602,7 @@ func (a *Auth) EvaluateDelayed(ctx context.Context, info StreamAuthInfo, user ap
 }
 
 // BuildTargetChannelFilters implements [AuthInterface].
-func (a *Auth) BuildTargetChannelFilters(ctx context.Context, info StreamAuthInfo, user api.UserRequest) (*corev3.SocketAddress, []*corev3.TypedExtensionConfig, error) {
+func (a *Auth) BuildTargetChannelFilters(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo, user api.UserRequest) (*corev3.SocketAddress, []*corev3.TypedExtensionConfig, error) {
 	hostname := user.Hostname()
 	if hostname == "" {
 		return nil, nil, fmt.Errorf("no hostname")
@@ -511,7 +617,7 @@ func (a *Auth) BuildTargetChannelFilters(ctx context.Context, info StreamAuthInf
 	if !route.SessionRecording.IsSet || !route.SessionRecording.Value.Enabled.Or(false) {
 		return addr, []*corev3.TypedExtensionConfig{}, nil
 	}
-	sess, err := a.GetSession(ctx, info)
+	sess, err := a.GetSession(ctx, streamInfo, authInfo)
 	if err != nil {
 		return nil, nil, fmt.Errorf("no session")
 	}
@@ -557,47 +663,16 @@ func buildSSHRecordingConfig(recCfg *config.SessionRecording, sessionID, userID 
 	}
 }
 
-// EvaluatePortForward implements AuthInterface.
-func (a *Auth) EvaluatePortForward(ctx context.Context, info StreamAuthInfo, user api.UserRequest, route *config.Policy) error {
-	req, err := a.sshRequestFromStreamAuthInfo(ctx, info, user)
-	if err != nil {
-		return err
-	}
-	res, err := a.evaluator.EvaluateUpstreamTunnel(ctx, req, route)
-	if err != nil {
-		return err
-	}
-
-	if res.Allow.Value && !res.Deny.Value {
-		return nil
-	}
-	return errAccessDenied
-}
-
-func (a *Auth) GetSession(ctx context.Context, info StreamAuthInfo) (*session.Session, error) {
-	sessionBinding, err := a.resolveSessionFromFingerprint(ctx, info.PublicKeyFingerprintSha256)
+func (a *Auth) GetSession(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo) (*session.Session, error) {
+	_, session, err := a.resolveSession(ctx, authInfo.GetSessionBindingId())
 	if err != nil {
 		return nil, err
 	}
-	sessionResp, err := a.evaluator.GetDataBrokerServiceClient().Get(ctx, &databroker.GetRequest{
-		Type: "type.googleapis.com/session.Session",
-		Id:   sessionBinding.SessionId,
-	})
-	if err != nil {
-		return nil, err
-	}
-	if sessionResp.GetRecord().DeletedAt != nil {
-		return nil, status.Error(codes.NotFound, "session deleted")
-	}
-	var s session.Session
-	if err := sessionResp.Record.Data.UnmarshalTo(&s); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	return &s, nil
+	return session, nil
 }
 
-func (a *Auth) DeleteSession(ctx context.Context, info StreamAuthInfo) error {
-	binding, err := a.resolveSessionFromFingerprint(ctx, info.PublicKeyFingerprintSha256)
+func (a *Auth) DeleteSession(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo) error {
+	binding, _, err := a.resolveSession(ctx, authInfo.GetSessionBindingId())
 	if err != nil {
 		return err
 	}
@@ -622,21 +697,23 @@ func (a *Auth) DeleteSession(ctx context.Context, info StreamAuthInfo) error {
 	return errors.Join(sessionErr, bindingErr)
 }
 
-func (a *Auth) getAuthenticator(ctx context.Context, hostname string) (*identitypb.Provider, identity.Authenticator, error) {
-	opts := a.currentConfig.Load().Options
-
-	redirectURL, err := opts.GetAuthenticateRedirectURL()
+func (a *Auth) getAuthenticator(
+	ctx context.Context,
+	cfg *config.Config,
+	policy *config.Policy,
+) (*identitypb.Provider, identity.Authenticator, error) {
+	redirectURL, err := cfg.Options.GetAuthenticateRedirectURL()
 	if err != nil {
 		return nil, nil, err
 	}
 
-	idp, err := opts.GetIdentityProviderForPolicy(opts.GetRouteForSSHHostname(hostname))
+	idp, err := cfg.Options.GetIdentityProviderForPolicy(policy)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	authenticator, err := identity.GetIdentityProvider(ctx, a.tracerProvider, idp, redirectURL,
-		opts.RuntimeFlags[config.RuntimeFlagRefreshSessionAtIDTokenExpiration])
+		cfg.Options.RuntimeFlags[config.RuntimeFlagRefreshSessionAtIDTokenExpiration])
 	if err != nil {
 		return nil, nil, err
 	}
@@ -648,41 +725,46 @@ var _ AuthInterface = (*Auth)(nil)
 
 var errInvalidFingerprint = errors.New("invalid public key fingerprint")
 
-func (a *Auth) resolveSession(ctx context.Context, sessionBindingID string) (*session.SessionBinding, error) {
+func (a *Auth) resolveSession(ctx context.Context, sessionBindingID string) (*session.SessionBinding, *session.Session, error) {
 	resp, err := a.evaluator.GetDataBrokerServiceClient().Get(ctx, &databroker.GetRequest{
 		Type: "type.googleapis.com/session.SessionBinding",
 		Id:   sessionBindingID,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if resp.Record.DeletedAt != nil {
-		return nil, status.Error(codes.NotFound, "session binding deleted")
+		return nil, nil, status.Error(codes.NotFound, "session binding deleted")
 	}
 
 	var binding session.SessionBinding
 	if err := resp.Record.Data.UnmarshalTo(&binding); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
+		return nil, nil, status.Error(codes.Internal, err.Error())
 	}
 	now := time.Now()
 	if binding.ExpiresAt.AsTime().Before(now) {
-		return nil, status.Error(codes.NotFound, "session binding no longer valid")
+		return nil, nil, status.Error(codes.NotFound, "session binding no longer valid")
 	}
 	if binding.Protocol != session.ProtocolSSH {
-		return nil, status.Error(codes.Internal, "invalid protocol")
+		return nil, nil, status.Error(codes.Internal, "invalid protocol")
 	}
 	sessionResp, err := a.evaluator.GetDataBrokerServiceClient().Get(ctx, &databroker.GetRequest{
 		Type: "type.googleapis.com/session.Session",
 		Id:   binding.SessionId,
 	})
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if sessionResp.GetRecord().DeletedAt != nil {
-		return nil, status.Error(codes.NotFound, "session deleted")
+		return nil, nil, status.Error(codes.NotFound, "session deleted")
 	}
 
-	return &binding, nil
+	var session session.Session
+	if err := sessionResp.GetRecord().GetData().UnmarshalTo(&session); err != nil {
+		return nil, nil, err
+	}
+
+	return &binding, &session, nil
 }
 
 func sessionIDFromFingerprint(sha256fingerprint []byte) (string, error) {
@@ -692,37 +774,25 @@ func sessionIDFromFingerprint(sha256fingerprint []byte) (string, error) {
 	return "sshkey-SHA256:" + base64.RawStdEncoding.EncodeToString(sha256fingerprint), nil
 }
 
-func (a *Auth) resolveSessionFromFingerprint(ctx context.Context, sha256fingerprint []byte) (*session.SessionBinding, error) {
+func (a *Auth) resolveSessionFromFingerprint(ctx context.Context, sha256fingerprint []byte) (*session.SessionBinding, *session.Session, error) {
 	id, err := sessionIDFromFingerprint(sha256fingerprint)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	return a.resolveSession(ctx, id)
 }
 
-var errPublicKeyAllowNil = errors.New("expected PublicKeyAllow message not to be nil")
+var errMissingPublicKeyInfo = errors.New("public key info missing from auth context")
 
 // Converts from StreamAuthInfo to an SSHRequest, assuming the PublicKeyAllow field is not nil.
-func (a *Auth) sshRequestFromStreamAuthInfo(ctx context.Context, info StreamAuthInfo, user api.UserRequest) (AuthRequest, error) {
-	if info.PublicKeyAllow.Value == nil {
-		return AuthRequest{}, errPublicKeyAllowNil
-	}
-	sessionBindingID, err := sessionIDFromFingerprint(info.PublicKeyFingerprintSha256)
-	if err != nil {
-		return AuthRequest{}, err
-	}
-	sessionBinding, err := a.resolveSession(ctx, sessionBindingID)
-	if err != nil {
-		return AuthRequest{}, err
-	}
-
+func (a *Auth) sshRequestFromStreamAuthInfo(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo, user api.UserRequest) (AuthRequest, error) {
 	return AuthRequest{
 		Username:         user.Username(),
 		Hostname:         user.Hostname(),
-		PublicKey:        string(info.PublicKeyAllow.Value.PublicKey),
-		SessionID:        sessionBinding.SessionId,
-		SourceAddress:    info.SourceAddress,
-		SessionBindingID: sessionBindingID,
-		LogOnlyIfDenied:  info.InitialAuthComplete,
+		PublicKey:        string(authInfo.GetPublicKey()),
+		SessionID:        authInfo.GetSessionId(),
+		SourceAddress:    streamInfo.SourceAddress,
+		SessionBindingID: authInfo.GetSessionBindingId(),
+		LogOnlyIfDenied:  streamInfo.InitialAuthComplete,
 	}, nil
 }

--- a/pkg/ssh/auth_test.go
+++ b/pkg/ssh/auth_test.go
@@ -13,14 +13,17 @@ import (
 
 	corev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	nooptrace "go.opentelemetry.io/otel/trace/noop"
+	gossh "golang.org/x/crypto/ssh"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/testing/protocmp"
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
 	"github.com/pomerium/pomerium/authorize/evaluator"
@@ -28,7 +31,6 @@ import (
 	"github.com/pomerium/pomerium/internal/testutil/mockidp"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
-	"github.com/pomerium/pomerium/pkg/grpcutil"
 	"github.com/pomerium/pomerium/pkg/identity"
 	"github.com/pomerium/pomerium/pkg/identity/oauth"
 	"github.com/pomerium/pomerium/pkg/identity/oidc"
@@ -41,192 +43,383 @@ import (
 	"github.com/pomerium/pomerium/pkg/ssh/code"
 )
 
-func TestHandlePublicKeyMethodRequest(t *testing.T) {
-	t.Run("no public key fingerprint", func(t *testing.T) {
-		a := ssh.NewAuth(nil, nil, &nooptrace.TracerProvider{}, nil)
-		var req extensions_ssh.PublicKeyMethodRequest
-		_, err := a.UnexportedHandlePublicKeyMethodRequest(t.Context(), ssh.StreamAuthInfo{}, mustNewUserRequest(t, "username", "hostname"), &req)
-		assert.ErrorContains(t, err, "invalid public key fingerprint")
-	})
-	t.Run("evaluate error", func(t *testing.T) {
-		client := newValidGetClient()
-		user := mustNewUserRequest(t, "username", "hostname")
-		var req extensions_ssh.PublicKeyMethodRequest
-		req.PublicKeyFingerprintSha256 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
-		pe := func(context.Context, uint64, ssh.AuthRequest) (*evaluator.Result, error) {
-			return nil, errors.New("error evaluating policy")
+func sessionBindingIDFromPublicKey(key gossh.PublicKey) string {
+	fp, err := ssh.UnexportedSessionIDFromFingerprint(RawFingerprintSHA256(key))
+	if err != nil {
+		panic(err)
+	}
+	return fp
+}
+
+func newPkMethodRequest(key gossh.PublicKey) *extensions_ssh.PublicKeyMethodRequest {
+	return &extensions_ssh.PublicKeyMethodRequest{
+		PublicKey:                  key.Marshal(),
+		PublicKeyAlg:               key.Type(),
+		PublicKeyFingerprintSha256: RawFingerprintSHA256(key),
+	}
+}
+
+func newPkAuthContextUpdates(key gossh.PublicKey) *extensions_ssh.AuthContext {
+	return &extensions_ssh.AuthContext{
+		PublicKey:                  key.Marshal(),
+		PublicKeyAlg:               key.Type(),
+		PublicKeyFingerprintSha256: RawFingerprintSHA256(key),
+	}
+}
+
+func TestInitialPublicKeyRequestWithNoSession(t *testing.T) {
+	user := mustNewUserRequest(t, "username", "hostname")
+	sshKey1 := newPublicKey(t, newSSHKey(t).Public())
+	sshKey2 := newPublicKey(t, newSSHKey(t).Public())
+
+	databrokerClient := fakeDataBrokerServiceClient{
+		get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
+			return nil, status.Error(codes.NotFound, "not found")
+		},
+	}
+
+	t.Run("no session found", func(t *testing.T) {
+		evaluator := &fakePolicyEvaluator{
+			evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+				assert.Equal(t, ssh.AuthRequest{
+					Username:        "username",
+					Hostname:        "hostname",
+					PublicKey:       string(sshKey1.Marshal()),
+					LogOnlyIfDenied: true,
+				}, r)
+				return &evaluator.Result{
+					Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+					Deny:  evaluator.NewRuleResult(false),
+				}, nil
+			},
+			client: databrokerClient,
 		}
-		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe, client: client}, nil, nil, &fakeIssuer{})
-		_, err := a.UnexportedHandlePublicKeyMethodRequest(t.Context(), ssh.StreamAuthInfo{}, user, &req)
-		assert.ErrorContains(t, err, "error evaluating policy")
-	})
-	t.Run("allow", func(t *testing.T) {
-		client := newValidGetClient()
-		user := mustNewUserRequest(t, "username", "hostname")
-		var req extensions_ssh.PublicKeyMethodRequest
-		req.PublicKeyFingerprintSha256 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
-		fakePublicKey := []byte{1, 2, 3, 4, 5, 6, 7}
-		req.PublicKey = fakePublicKey
-		pe := func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
-			assert.Equal(t, r, ssh.AuthRequest{
-				Username:         "username",
-				Hostname:         "hostname",
-				PublicKey:        string(fakePublicKey),
-				SessionID:        "",
-				SessionBindingID: "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
-			})
-			return &evaluator.Result{
-				Allow: evaluator.NewRuleResult(true),
-				Deny:  evaluator.NewRuleResult(false),
-			}, nil
-		}
-		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe, client: client}, nil, &nooptrace.TracerProvider{}, &fakeIssuer{})
-		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamAuthInfo{}, user, &req)
+
+		a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey1))
 		assert.NoError(t, err)
-		assert.Empty(t, res.RequireAdditionalMethods)
-		require.NotNil(t, res.Allow)
-		assert.Equal(t, res.Allow.PublicKey, fakePublicKey)
-	})
-	t.Run("deny", func(t *testing.T) {
-		client := newValidGetClient()
-		user := mustNewUserRequest(t, "username", "hostname")
-		var req extensions_ssh.PublicKeyMethodRequest
-		req.PublicKeyFingerprintSha256 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
-		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
-			return &evaluator.Result{
-				Allow: evaluator.NewRuleResult(true),
-				Deny:  evaluator.NewRuleResult(true),
-			}, nil
-		}
-		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe, client: client}, nil, &nooptrace.TracerProvider{}, &fakeIssuer{})
-		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamAuthInfo{}, user, &req)
-		assert.NoError(t, err)
-		assert.Nil(t, res.Allow)
-		assert.Empty(t, res.RequireAdditionalMethods)
-	})
-	t.Run("public key unauthorized", func(t *testing.T) {
-		client := newValidGetClient()
-		user := mustNewUserRequest(t, "username", "hostname")
-		var req extensions_ssh.PublicKeyMethodRequest
-		req.PublicKeyFingerprintSha256 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
-		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
-			return &evaluator.Result{
-				Allow: evaluator.NewRuleResult(false, criteria.ReasonSSHPublickeyUnauthorized),
-				Deny:  evaluator.NewRuleResult(false),
-			}, nil
-		}
-		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe, client: client}, nil, &nooptrace.TracerProvider{}, &fakeIssuer{})
-		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamAuthInfo{}, user, &req)
-		assert.NoError(t, err)
-		assert.Nil(t, res.Allow)
-		assert.Equal(t, res.RequireAdditionalMethods, []string{ssh.MethodPublicKey})
+		assert.Equal(t, ssh.AuthMethodResponse{
+			AllowMethod:            true,
+			NextRequiredAuthMethod: ssh.MethodKeyboardInteractive,
+			ContextUpdates:         newPkAuthContextUpdates(sshKey1),
+		}, res)
 	})
 
-	t.Run("needs login", func(t *testing.T) {
-		client := newValidGetClient()
-		user := mustNewUserRequest(t, "username", "hostname")
-		var req extensions_ssh.PublicKeyMethodRequest
-		req.PublicKeyFingerprintSha256 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
-		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
-			return &evaluator.Result{
-				Allow: evaluator.NewRuleResult(false),
-				Deny:  evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
-			}, nil
-		}
-		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe, client: client}, nil, &nooptrace.TracerProvider{}, &fakeIssuer{})
-		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamAuthInfo{}, user, &req)
-		assert.NoError(t, err)
-		assert.NotNil(t, res.Allow)
-		assert.Equal(t, res.RequireAdditionalMethods, []string{ssh.MethodKeyboardInteractive})
-	})
-	t.Run("internal command no session", func(t *testing.T) {
-		client := fakeDataBrokerServiceClient{
-			get: func(
-				_ context.Context, _ *databroker.GetRequest, _ ...grpc.CallOption,
-			) (*databroker.GetResponse, error) {
-				return nil, status.Error(codes.NotFound, "not found")
+	t.Run("error during evaluation", func(t *testing.T) {
+		evaluator := &fakePolicyEvaluator{
+			evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+				return nil, errors.New("test error")
 			},
+			client: databrokerClient,
 		}
-		user := mustNewUserRequest(t, "username", "")
-		var req extensions_ssh.PublicKeyMethodRequest
-		req.PublicKeyFingerprintSha256 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
-		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
-			return &evaluator.Result{
-				Allow: evaluator.NewRuleResult(false),
-				Deny:  evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
-			}, nil
-		}
-		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe, client: client}, nil, &nooptrace.TracerProvider{}, &fakeIssuer{})
-		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamAuthInfo{}, user, &req)
-		assert.NoError(t, err)
-		assert.NotNil(t, res.Allow)
-		assert.Equal(t, res.RequireAdditionalMethods, []string{ssh.MethodKeyboardInteractive})
+
+		a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		// Use the unexported version, since by default most errors are converted to
+		// a generic "internal error"
+		res, err := a.UnexportedHandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey1))
+		assert.ErrorContains(t, err, "test error")
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
 	})
-	t.Run("internal command with session", func(t *testing.T) {
-		client := fakeDataBrokerServiceClient{
-			get: func(
-				_ context.Context, r *databroker.GetRequest, _ ...grpc.CallOption,
-			) (*databroker.GetResponse, error) {
-				switch r.Type {
-				case "type.googleapis.com/session.Session":
-					return &databroker.GetResponse{
-						Record: &databroker.Record{
-							Type: "type.googleapis.com/session.Session",
-							Id:   "abc",
-							Data: protoutil.NewAny(&session.Session{
-								Id:     "abc",
-								UserId: "USER-ID",
-							}),
-						},
+
+	t.Run("public key unauthorized", func(t *testing.T) {
+		evaluator := &fakePolicyEvaluator{
+			evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+				assert.True(t, r.LogOnlyIfDenied)
+				assert.Equal(t, "username", r.Username)
+				assert.Equal(t, "hostname", r.Hostname)
+				if r.PublicKey != string(sshKey2.Marshal()) {
+					return &evaluator.Result{
+						Allow: evaluator.NewRuleResult(false, criteria.ReasonSSHPublickeyUnauthorized),
+						Deny:  evaluator.NewRuleResult(true),
 					}, nil
-				case "type.googleapis.com/session.SessionBinding":
-					return &databroker.GetResponse{
-						Record: &databroker.Record{
-							Type: "type.googleapis.com/session.SessionBinding",
-							Id:   "abc",
-							Data: protoutil.NewAny(&session.SessionBinding{
-								SessionId: "abc",
-								UserId:    "USER-ID",
-								ExpiresAt: timestamppb.New(time.Now().Add(time.Hour * 10000)),
-								Protocol:  session.ProtocolSSH,
-							}),
-						},
+				} else {
+					return &evaluator.Result{
+						Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+						Deny:  evaluator.NewRuleResult(true),
 					}, nil
-				default:
-					return nil, fmt.Errorf("unsupported type")
 				}
 			},
+			client: databrokerClient,
 		}
-		user := mustNewUserRequest(t, "username", "")
-		var req extensions_ssh.PublicKeyMethodRequest
-		req.PublicKeyFingerprintSha256 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
-		a := ssh.NewAuth(staticFakePolicyEvaluator(true, client), nil, &nooptrace.TracerProvider{}, &fakeIssuer{})
-		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamAuthInfo{}, user, &req)
+
+		a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		res, err := a.UnexportedHandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey1))
 		assert.NoError(t, err)
-		assert.NotNil(t, res.Allow)
-		assert.Empty(t, res.RequireAdditionalMethods)
-	})
-	t.Run("internal command databroker error", func(t *testing.T) {
-		client := fakeDataBrokerServiceClient{
-			get: func(
-				_ context.Context, _ *databroker.GetRequest, _ ...grpc.CallOption,
-			) (*databroker.GetResponse, error) {
-				return nil, status.Error(codes.Unknown, "unknown")
-			},
-		}
-		user := mustNewUserRequest(t, "username", "")
-		var req extensions_ssh.PublicKeyMethodRequest
-		req.PublicKeyFingerprintSha256 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
-		a := ssh.NewAuth(staticFakePolicyEvaluator(true, client), nil, &nooptrace.TracerProvider{}, &fakeIssuer{})
-		_, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamAuthInfo{}, user, &req)
-		assert.ErrorContains(t, err, "internal error")
+		assert.Equal(t, ssh.AuthMethodResponse{
+			AllowMethod:            false,
+			NextRequiredAuthMethod: ssh.MethodPublicKey,
+		}, res)
+
+		res, err = a.UnexportedHandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey2))
+		assert.NoError(t, err)
+		assert.Equal(t, ssh.AuthMethodResponse{
+			AllowMethod:            true,
+			NextRequiredAuthMethod: ssh.MethodKeyboardInteractive,
+			ContextUpdates:         newPkAuthContextUpdates(sshKey2),
+		}, res)
 	})
 
-	t.Run("unauthenticated", func(t *testing.T) {
+	t.Run("source IP denied", func(t *testing.T) {
+		evaluator := &fakePolicyEvaluator{
+			evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+				return &evaluator.Result{
+					Allow: evaluator.NewRuleResult(false, criteria.ReasonSourceIPUnauthorized),
+					Deny:  evaluator.NewRuleResult(false),
+				}, nil
+			},
+			client: databrokerClient,
+		}
+
+		a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey1))
+		assert.NoError(t, err)
+		// non-retriable
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
+	})
+
+	t.Run("ssh username denied", func(t *testing.T) {
+		evaluator := &fakePolicyEvaluator{
+			evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+				return &evaluator.Result{
+					Allow: evaluator.NewRuleResult(false, criteria.ReasonSSHUsernameUnauthorized),
+					Deny:  evaluator.NewRuleResult(false),
+				}, nil
+			},
+			client: databrokerClient,
+		}
+
+		a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey1))
+		assert.NoError(t, err)
+		// non-retriable
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
+	})
+
+	t.Run("bad evaluator response", func(t *testing.T) {
+		evaluator := &fakePolicyEvaluator{
+			evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+				// the evaluator should only allow requests that are missing session IDs
+				// if the hostname is empty
+				require.NotEmpty(t, r.Hostname)
+				require.Empty(t, r.SessionBindingID)
+				require.Empty(t, r.SessionID)
+				return &evaluator.Result{
+					Allow: evaluator.NewRuleResult(true),
+					Deny:  evaluator.NewRuleResult(false),
+				}, nil
+			},
+			client: databrokerClient,
+		}
+
+		a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		assert.Panics(t, func() {
+			_, _ = a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey1))
+		})
+	})
+
+	t.Run("invalid fingerprint in request", func(t *testing.T) {
+		evaluator := &fakePolicyEvaluator{
+			evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+				return &evaluator.Result{
+					Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+					Deny:  evaluator.NewRuleResult(false),
+				}, nil
+			},
+			client: databrokerClient,
+		}
+
+		a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		for _, fp := range [][]byte{{}, []byte("invalid")} {
+			res, err := a.UnexportedHandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, &extensions_ssh.PublicKeyMethodRequest{
+				PublicKey:                  sshKey1.Marshal(),
+				PublicKeyAlg:               sshKey1.Type(),
+				PublicKeyFingerprintSha256: fp,
+			})
+			assert.ErrorContains(t, err, "invalid public key fingerprint")
+			assert.Equal(t, ssh.AuthMethodResponse{}, res)
+		}
+	})
+}
+
+func TestInitialPublicKeyRequestWithExistingValidSession(t *testing.T) {
+	user := mustNewUserRequest(t, "username", "hostname")
+	sshKey1 := newPublicKey(t, newSSHKey(t).Public())
+	sessionId := uuid.NewString()
+	userId := "user"
+
+	sessionBindingID := sessionBindingIDFromPublicKey(sshKey1)
+	databrokerClient := fakeDataBrokerServiceClient{
+		get: func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
+			switch in.Type {
+			case "type.googleapis.com/session.SessionBinding":
+				assert.Equal(t, sessionBindingID, in.Id)
+				return &databroker.GetResponse{
+					Record: &databroker.Record{
+						Type: "type.googleapis.com/session.SessionBinding",
+						Data: protoutil.NewAny(&session.SessionBinding{
+							Protocol:  session.ProtocolSSH,
+							IssuedAt:  timestamppb.New(time.Now().Add(-1 * time.Minute)),
+							ExpiresAt: timestamppb.New(time.Now().Add(time.Hour * 1000)),
+							SessionId: sessionId,
+							UserId:    userId,
+						}),
+					},
+				}, nil
+			case "type.googleapis.com/session.Session":
+				assert.Equal(t, sessionId, in.Id)
+				return &databroker.GetResponse{
+					Record: &databroker.Record{
+						Type: "type.googleapis.com/session.Session",
+						Data: protoutil.NewAny(&session.Session{
+							Id:     sessionId,
+							UserId: userId,
+						}),
+					},
+				}, nil
+			}
+			panic("unreachable")
+		},
+	}
+
+	t.Run("session is valid", func(t *testing.T) {
+		evaluator := &fakePolicyEvaluator{
+			evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+				assert.Equal(t, "username", r.Username)
+				assert.Equal(t, "hostname", r.Hostname)
+				assert.Equal(t, string(sshKey1.Marshal()), r.PublicKey)
+				if r.SessionBindingID == "" || r.SessionID == "" {
+					assert.True(t, r.LogOnlyIfDenied)
+					return &evaluator.Result{
+						Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+						Deny:  evaluator.NewRuleResult(false),
+					}, nil
+				} else {
+					assert.Equal(t, sessionBindingID, r.SessionBindingID)
+					assert.Equal(t, sessionId, r.SessionID)
+					return &evaluator.Result{
+						Allow: evaluator.NewRuleResult(true, criteria.ReasonUserOK),
+						Deny:  evaluator.NewRuleResult(false),
+					}, nil
+				}
+			},
+			client: databrokerClient,
+		}
+		a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey1))
+		require.NoError(t, err)
+		assert.Equal(t, ssh.AuthMethodResponse{
+			AllowMethod:              true,
+			NoFurtherMethodsRequired: true,
+			ContextUpdates: &extensions_ssh.AuthContext{
+				PublicKey:                  sshKey1.Marshal(),
+				PublicKeyAlg:               sshKey1.Type(),
+				PublicKeyFingerprintSha256: RawFingerprintSHA256(sshKey1),
+				SessionId:                  sessionId,
+				UserId:                     userId,
+				SessionBindingId:           sessionBindingID,
+			},
+		}, res)
+	})
+
+	t.Run("session exists but is invalid", func(t *testing.T) {
+		evaluator := &fakePolicyEvaluator{
+			evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+				assert.Equal(t, "username", r.Username)
+				assert.Equal(t, "hostname", r.Hostname)
+				assert.Equal(t, string(sshKey1.Marshal()), r.PublicKey)
+				if r.SessionBindingID == "" || r.SessionID == "" {
+					assert.True(t, r.LogOnlyIfDenied)
+					return &evaluator.Result{
+						Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+						Deny:  evaluator.NewRuleResult(false),
+					}, nil
+				} else {
+					assert.Equal(t, sessionBindingID, r.SessionBindingID)
+					assert.Equal(t, sessionId, r.SessionID)
+					return &evaluator.Result{
+						// ReasonUserUnauthenticated triggers the login flow
+						Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+						Deny:  evaluator.NewRuleResult(false),
+					}, nil
+				}
+			},
+			client: databrokerClient,
+		}
+		a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		res, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey1))
+		require.NoError(t, err)
+		assert.Equal(t, ssh.AuthMethodResponse{
+			AllowMethod:            true,
+			NextRequiredAuthMethod: ssh.MethodKeyboardInteractive,
+			ContextUpdates: &extensions_ssh.AuthContext{
+				PublicKey:                  sshKey1.Marshal(),
+				PublicKeyAlg:               sshKey1.Type(),
+				PublicKeyFingerprintSha256: RawFingerprintSHA256(sshKey1),
+			},
+		}, res)
+	})
+
+	t.Run("session exists but evaluation fails", func(t *testing.T) {
+		evaluator := &fakePolicyEvaluator{
+			evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+				if r.SessionBindingID == "" || r.SessionID == "" {
+					return &evaluator.Result{
+						Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+						Deny:  evaluator.NewRuleResult(false),
+					}, nil
+				} else {
+					return nil, errors.New("test error")
+				}
+			},
+			client: databrokerClient,
+		}
+		a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		res, err := a.UnexportedHandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey1))
+		require.ErrorContains(t, err, "test error")
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
+	})
+
+	t.Run("session is valid but user is unauthorized", func(t *testing.T) {
+		// there are several ways this can occur
+		results := []*evaluator.Result{
+			{ // allow is false
+				Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthorized),
+				Deny:  evaluator.NewRuleResult(false),
+			},
+			{ // deny is true and reason isn't ReasonSSHAccessRequestRequired
+				Allow: evaluator.NewRuleResult(true, criteria.ReasonUserOK),
+				Deny:  evaluator.NewRuleResult(true, criteria.ReasonClaimUnauthorized),
+			},
+		}
+
+		for i, result := range results {
+			t.Run(fmt.Sprintf("result %d", i), func(t *testing.T) {
+				evaluator := &fakePolicyEvaluator{
+					evaluateSSH: func(_ context.Context, _ uint64, r ssh.AuthRequest) (*evaluator.Result, error) {
+						if r.SessionBindingID == "" || r.SessionID == "" {
+							return &evaluator.Result{
+								Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+								Deny:  evaluator.NewRuleResult(false),
+							}, nil
+						} else {
+							return result, nil
+						}
+					},
+					client: databrokerClient,
+				}
+				a := ssh.NewAuth(evaluator, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+				res, err := a.UnexportedHandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, newPkMethodRequest(sshKey1))
+				require.NoError(t, err)
+				assert.Equal(t, ssh.AuthMethodResponse{}, res)
+			})
+		}
+	})
+
+	t.Run("session or session binding records missing or invalid", func(t *testing.T) {
 		type testcase struct {
-			retSessionBinding *session.SessionBinding
-			retSession        *session.Session
-			expectedResp      ssh.PublicKeyAuthMethodResponse
+			retSessionBinding     *databroker.Record
+			retSession            *databroker.Record
+			expectedErrorContains string
 		}
 
 		tcs := []testcase{
@@ -234,30 +427,108 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 			{
 				retSessionBinding: nil,
 				retSession:        nil,
-				expectedResp: ssh.PublicKeyAuthMethodResponse{
-					RequireAdditionalMethods: []string{ssh.MethodKeyboardInteractive},
-				},
 			},
 			// binding expired
 			{
-				retSessionBinding: &session.SessionBinding{
-					ExpiresAt: timestamppb.New(time.Now().Add(-time.Minute)),
+				retSessionBinding: &databroker.Record{
+					Type: "type.googleapis.com/session.SessionBinding",
+					Data: protoutil.NewAny(&session.SessionBinding{
+						ExpiresAt: timestamppb.New(time.Now().Add(-time.Minute)),
+					}),
 				},
 				retSession: nil,
-				expectedResp: ssh.PublicKeyAuthMethodResponse{
-					RequireAdditionalMethods: []string{ssh.MethodKeyboardInteractive},
-				},
 			},
 			// binding valid, but no such session
 			{
-				retSessionBinding: &session.SessionBinding{
-					Protocol:  session.ProtocolSSH,
-					ExpiresAt: timestamppb.New(time.Now().Add(time.Hour * 10000)),
+				retSessionBinding: &databroker.Record{
+					Type: "type.googleapis.com/session.SessionBinding",
+					Data: protoutil.NewAny(&session.SessionBinding{
+						Protocol:  session.ProtocolSSH,
+						ExpiresAt: timestamppb.New(time.Now().Add(time.Hour)),
+					}),
 				},
 				retSession: nil,
-				expectedResp: ssh.PublicKeyAuthMethodResponse{
-					RequireAdditionalMethods: []string{ssh.MethodKeyboardInteractive},
+			},
+			// binding valid, but wrong protocol
+			{
+				retSessionBinding: &databroker.Record{
+					Type: "type.googleapis.com/session.SessionBinding",
+					Data: protoutil.NewAny(&session.SessionBinding{
+						Protocol:  "not-ssh",
+						ExpiresAt: timestamppb.New(time.Now().Add(time.Hour)),
+					}),
 				},
+				retSession:            nil,
+				expectedErrorContains: "invalid protocol",
+			},
+			// binding deleted
+			{
+				retSessionBinding: &databroker.Record{
+					Type: "type.googleapis.com/session.SessionBinding",
+					Data: protoutil.NewAny(&session.SessionBinding{
+						Protocol:  session.ProtocolSSH,
+						ExpiresAt: timestamppb.New(time.Now().Add(time.Hour)),
+					}),
+					DeletedAt: timestamppb.Now(),
+				},
+				retSession: nil,
+			},
+			// binding valid, but session deleted
+			{
+				retSessionBinding: &databroker.Record{
+					Type: "type.googleapis.com/session.SessionBinding",
+					Data: protoutil.NewAny(&session.SessionBinding{
+						Protocol:  session.ProtocolSSH,
+						ExpiresAt: timestamppb.New(time.Now().Add(time.Hour)),
+					}),
+				},
+				retSession: &databroker.Record{
+					Type: "type.googleapis.com/session.Session",
+					Data: protoutil.NewAny(&session.Session{
+						ExpiresAt: timestamppb.New(time.Now().Add(time.Hour)),
+					}),
+					DeletedAt: timestamppb.Now(),
+				},
+			},
+			// binding valid, but session expired
+			{
+				retSessionBinding: &databroker.Record{
+					Type: "type.googleapis.com/session.SessionBinding",
+					Data: protoutil.NewAny(&session.SessionBinding{
+						Protocol:  session.ProtocolSSH,
+						ExpiresAt: timestamppb.New(time.Now().Add(time.Hour)),
+					}),
+				},
+				retSession: &databroker.Record{
+					Type: "type.googleapis.com/session.Session",
+					Data: protoutil.NewAny(&session.Session{
+						ExpiresAt: timestamppb.New(time.Now().Add(-time.Hour)),
+					}),
+				},
+			},
+			// binding has wrong data type
+			{
+				retSessionBinding: &databroker.Record{
+					Type: "type.googleapis.com/session.SessionBinding",
+					Data: protoutil.NewAny(&wrapperspb.StringValue{Value: "not a session binding"}),
+				},
+				retSession:            nil,
+				expectedErrorContains: "mismatched message type",
+			},
+			// binding valid, but session has wrong data type
+			{
+				retSessionBinding: &databroker.Record{
+					Type: "type.googleapis.com/session.SessionBinding",
+					Data: protoutil.NewAny(&session.SessionBinding{
+						Protocol:  session.ProtocolSSH,
+						ExpiresAt: timestamppb.New(time.Now().Add(time.Hour)),
+					}),
+				},
+				retSession: &databroker.Record{
+					Type: "type.googleapis.com/session.Session",
+					Data: protoutil.NewAny(&wrapperspb.StringValue{Value: "not a session"}),
+				},
+				expectedErrorContains: "mismatched message type",
 			},
 		}
 
@@ -270,20 +541,14 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 							return nil, status.Error(codes.NotFound, "not found")
 						}
 						return &databroker.GetResponse{
-							Record: &databroker.Record{
-								Type: grpcutil.GetTypeURL(tc.retSessionBinding),
-								Data: protoutil.NewAny(tc.retSessionBinding),
-							},
+							Record: tc.retSessionBinding,
 						}, nil
 					case "type.googleapis.com/session.Session":
 						if tc.retSession == nil {
 							return nil, status.Error(codes.NotFound, "not found")
 						}
 						return &databroker.GetResponse{
-							Record: &databroker.Record{
-								Type: grpcutil.GetTypeURL(tc.retSession),
-								Data: protoutil.NewAny(tc.retSession),
-							},
+							Record: tc.retSession,
 						}, nil
 					}
 					return nil, fmt.Errorf("not implemented")
@@ -292,40 +557,74 @@ func TestHandlePublicKeyMethodRequest(t *testing.T) {
 
 			user := mustNewUserRequest(t, "username", "")
 
-			var req extensions_ssh.PublicKeyMethodRequest
-			req.PublicKeyFingerprintSha256 = []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456")
-			a := ssh.NewAuth(staticFakePolicyEvaluator(true, client), nil, &nooptrace.TracerProvider{}, &fakeIssuer{})
-			resp, err := a.HandlePublicKeyMethodRequest(t.Context(), ssh.StreamAuthInfo{}, user, &req)
-			assert.NoError(t, err, fmt.Sprintf("testcase %d failed", idx))
-			assert.Equal(t, tc.expectedResp.RequireAdditionalMethods, resp.RequireAdditionalMethods, fmt.Sprintf("testcase %d failed", idx))
+			req := newPkMethodRequest(sshKey1)
+			a := ssh.NewAuth(&fakePolicyEvaluator{
+				evaluateSSH: func(ctx context.Context, u uint64, ar ssh.AuthRequest) (*evaluator.Result, error) {
+					if ar.SessionBindingID == "" || ar.SessionID == "" {
+						return &evaluator.Result{
+							Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthenticated),
+							Deny:  evaluator.NewRuleResult(false),
+						}, nil
+					}
+					return &evaluator.Result{
+						Allow: evaluator.NewRuleResult(true),
+						Deny:  evaluator.NewRuleResult(false),
+					}, nil
+				},
+				client: client,
+			}, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+			resp, err := a.UnexportedHandlePublicKeyMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, req)
+			if tc.expectedErrorContains != "" {
+				require.ErrorContains(t, err, tc.expectedErrorContains, fmt.Sprintf("testcase %d failed", idx))
+				assert.Equal(t, ssh.AuthMethodResponse{}, resp)
+			} else {
+				require.NoError(t, err, fmt.Sprintf("testcase %d failed", idx))
+				// the response should always be the same for each case, if there is no error
+				assert.Equal(t, ssh.AuthMethodResponse{
+					AllowMethod:            true,
+					NextRequiredAuthMethod: ssh.MethodKeyboardInteractive,
+					ContextUpdates:         newPkAuthContextUpdates(sshKey1),
+				}, resp)
+			}
 		}
 	})
 }
 
-func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
-	t.Run("no public key", func(t *testing.T) {
-		a := ssh.NewAuth(nil, nil, nil, nil)
-		_, err := a.UnexportedHandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamAuthInfo{}, mustNewUserRequest(t, "username", "hostname"), nil)
-		assert.ErrorContains(t, err, "expected PublicKeyAllow message not to be nil")
-	})
-
-	exampleAuthInfo := ssh.StreamAuthInfo{
-		PublicKeyAllow: ssh.AuthMethodValue[*extensions_ssh.PublicKeyAllowResponse]{
-			Value: &extensions_ssh.PublicKeyAllowResponse{
-				PublicKey: []byte("fake-public-key"),
-			},
-		},
-		PublicKeyFingerprintSha256: []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+func TestKeyboardInteractiveLoginRequest(t *testing.T) {
+	user := mustNewUserRequest(t, "username", "hostname")
+	route := config.Policy{
+		From:             "ssh://hostname",
+		To:               mustParseWeightedURLs(t, "ssh://dest"),
+		ShowErrorDetails: true,
 	}
-	exampleUser := mustNewUserRequest(t, "username", "hostname")
+	sshKey1 := newPublicKey(t, newSSHKey(t).Public())
+	sessionBindingId := sessionBindingIDFromPublicKey(sshKey1)
+	initialAuthContext := func() *extensions_ssh.AuthContext {
+		return &extensions_ssh.AuthContext{
+			PublicKey:                  sshKey1.Marshal(),
+			PublicKeyAlg:               sshKey1.Type(),
+			PublicKeyFingerprintSha256: RawFingerprintSHA256(sshKey1),
+		}
+	}
 
-	t.Run("stateless authenticate", func(t *testing.T) {
+	t.Run("public key info missing", func(t *testing.T) {
 		cfg := config.New(config.NewDefaultOptions())
 		var p atomic.Pointer[config.Config]
 		p.Store(cfg)
 
-		a := ssh.NewAuth(nil, &p, &nooptrace.TracerProvider{}, nil)
-		_, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), exampleAuthInfo, exampleUser, nil, &noopQuerier{})
+		a := ssh.NewAuth(nil, &p, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		assert.Panics(t, func() {
+			_, _ = a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{}, user, nil, &noopQuerier{})
+		})
+	})
+	t.Run("stateless authenticate", func(t *testing.T) {
+		cfg := config.New(config.NewDefaultOptions())
+		cfg.Options.Policies = append(cfg.Options.Policies, route)
+		var p atomic.Pointer[config.Config]
+		p.Store(cfg)
+
+		a := ssh.NewAuth(nil, &p, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		_, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
 
 		assert.ErrorContains(t, err, "ssh login is not currently enabled")
 		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
@@ -341,25 +640,57 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 		cfg.Options.ProviderURL = idpURL
 		cfg.Options.ClientID = "client-id"
 		cfg.Options.ClientSecret = "client-secret"
+		cfg.Options.Policies = append(cfg.Options.Policies, route)
+
 		var p atomic.Pointer[config.Config]
 		p.Store(cfg)
 		return &p
 	}
 
-	t.Run("ok", func(t *testing.T) {
-		bindingKey := "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY"
-		sessionID := "some-opaque-id-set-by-idp"
-		// var putRecords []*databroker.Record
-		client := fakeDataBrokerServiceClient{
+	t.Run("invalid fingerprint", func(t *testing.T) {
+		a := ssh.NewAuth(staticFakePolicyEvaluator(evalResultAlwaysAllow, nil), minimalConfig("https://unused"), &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		_, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{
+			PublicKey:                  sshKey1.Marshal(),
+			PublicKeyAlg:               sshKey1.Type(),
+			PublicKeyFingerprintSha256: []byte("bad fingerprint"),
+		}, user, nil, &noopQuerier{})
+
+		assert.ErrorContains(t, err, "invalid public key fingerprint")
+	})
+
+	t.Run("ShowErrorDetails disabled", func(t *testing.T) {
+		cfg := minimalConfig("https://unused")
+		cfg.Load().Options.Policies[0].ShowErrorDetails = false
+		a := ssh.NewAuth(staticFakePolicyEvaluator(evalResultAlwaysAllow, nil), cfg, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		_, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{
+			PublicKey:                  sshKey1.Marshal(),
+			PublicKeyAlg:               sshKey1.Type(),
+			PublicKeyFingerprintSha256: []byte("bad fingerprint"),
+		}, user, nil, &noopQuerier{})
+
+		assert.Equal(t, status.Error(codes.PermissionDenied, "permission denied").Error(), err.Error())
+	})
+
+	t.Run("invalid authentiate config", func(t *testing.T) {
+		p := minimalConfig("https://unused")
+		p.Load().Options.AuthenticateURLString = "invalid url"
+		a := ssh.NewAuth(staticFakePolicyEvaluator(evalResultAlwaysAllow, nil), p, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		_, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
+
+		assert.ErrorContains(t, err, "url does not contain a valid scheme")
+	})
+
+	validRecordsClient := func(sessionID string) fakeDataBrokerServiceClient {
+		return fakeDataBrokerServiceClient{
 			get: func(
 				_ context.Context, r *databroker.GetRequest, _ ...grpc.CallOption,
 			) (*databroker.GetResponse, error) {
 				switch r.Type {
 				case "type.googleapis.com/session.SessionBinding":
-					if r.Id == bindingKey {
+					if r.Id == sessionBindingId {
 						return &databroker.GetResponse{
 								Record: &databroker.Record{
-									Id:   "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
+									Id:   sessionBindingId,
 									Type: "type.googleapis.com/session.SessionBinding",
 									Data: protoutil.NewAny(&session.SessionBinding{
 										Protocol:  session.ProtocolSSH,
@@ -376,12 +707,11 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 					if r.Id == sessionID {
 						return &databroker.GetResponse{
 							Record: &databroker.Record{
-								Id:   "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
-								Type: "type.googleapis.com/session.SessionBinding",
-								Data: protoutil.NewAny(&session.SessionBinding{
-									Protocol:  session.ProtocolSSH,
+								Id:   sessionID,
+								Type: "type.googleapis.com/session.Session",
+								Data: protoutil.NewAny(&session.Session{
 									UserId:    "fake.user@example.com",
-									SessionId: "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
+									ExpiresAt: timestamppb.New(time.Now().Add(time.Hour * 100000)),
 								}),
 							},
 						}, nil
@@ -395,24 +725,69 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 				return nil, fmt.Errorf("not implemented")
 			},
 		}
+	}
+	t.Run("ok", func(t *testing.T) {
+		sessionID := "some-opaque-id-set-by-idp"
 		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
 		idpURL := mockIDP.Start(t)
-		a := ssh.NewAuth(staticFakePolicyEvaluator(true, client), minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
-			state: &code.Status{
-				BindingKey: "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
-				State:      session.SessionBindingRequestState_Accepted,
-				ExpiresAt:  time.Now().Add(time.Hour * 1000),
+		a := ssh.NewAuth(staticFakePolicyEvaluator(evalResultAlwaysAllow, validRecordsClient(sessionID)), minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			onCodeDecision: func(_ context.Context, id code.CodeID, c chan code.Status) {
+				c <- code.Status{
+					Code:       string(id),
+					BindingKey: sessionBindingId,
+					State:      session.SessionBindingRequestState_Accepted,
+					ExpiresAt:  time.Now().Add(time.Hour * 1000),
+				}
 			},
-		})
+		}, nil)
 		querier := &noopQuerier{}
-		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), exampleAuthInfo, exampleUser, nil, querier)
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, querier)
 		require.NoError(t, err)
 		if assert.Len(t, querier.prompts, 1, "expected to receive a sign-in prompt") {
 			assert.Equal(t, "https://pomerium.example.com/.pomerium/sign_in?user_code=associated-code",
 				querier.prompts[0].Instruction)
 		}
-		assert.NotNil(t, res.Allow)
-		assert.Empty(t, res.RequireAdditionalMethods)
+
+		assert.Equal(t, ssh.AuthMethodResponse{
+			AllowMethod:              true,
+			NoFurtherMethodsRequired: true,
+			ContextUpdates: &extensions_ssh.AuthContext{
+				SessionBindingId: sessionBindingId,
+				SessionId:        sessionID,
+				UserId:           "fake.user@example.com",
+			},
+		}, res)
+	})
+
+	t.Run("error evaluating session after login", func(t *testing.T) {
+		sessionID := "some-opaque-id-set-by-idp"
+		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
+		idpURL := mockIDP.Start(t)
+		a := ssh.NewAuth(&fakePolicyEvaluator{
+			evaluateSSH: func(ctx context.Context, u uint64, ar ssh.AuthRequest) (*evaluator.Result, error) {
+				if ar.SessionID == "" || ar.SessionBindingID == "" {
+					return &evaluator.Result{
+						Allow: evaluator.NewRuleResult(true),
+						Deny:  evaluator.NewRuleResult(false),
+					}, nil
+				}
+				return nil, fmt.Errorf("error evaluating session")
+			},
+			client: validRecordsClient(sessionID),
+		}, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			onCodeDecision: func(_ context.Context, id code.CodeID, c chan code.Status) {
+				c <- code.Status{
+					Code:       string(id),
+					BindingKey: sessionBindingId,
+					State:      session.SessionBindingRequestState_Accepted,
+					ExpiresAt:  time.Now().Add(time.Hour * 1000),
+				}
+			},
+		}, nil)
+		querier := &noopQuerier{}
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, querier)
+		assert.ErrorContains(t, err, "error evaluating session")
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
 	})
 
 	t.Run("denied : code revoked", func(t *testing.T) {
@@ -424,22 +799,163 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 		}
 		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
 		idpURL := mockIDP.Start(t)
-		a := ssh.NewAuth(fakePolicyEvaluator{evaluateSSH: pe}, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
-			state: &code.Status{
-				Code:       "",
-				BindingKey: "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
-				State:      session.SessionBindingRequestState_Revoked,
+		a := ssh.NewAuth(&fakePolicyEvaluator{evaluateSSH: pe}, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			onCodeDecision: func(_ context.Context, id code.CodeID, c chan code.Status) {
+				c <- code.Status{
+					Code:       string(id),
+					BindingKey: sessionBindingId,
+					State:      session.SessionBindingRequestState_Revoked,
+				}
 			},
-		})
-		_, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), exampleAuthInfo, exampleUser, nil, &noopQuerier{})
+		}, nil)
+		resp, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
 		require.Error(t, err)
 		st, ok := status.FromError(err)
 		assert.True(t, ok)
 		assert.Equal(t, st.Code().String(), codes.PermissionDenied.String())
+		assert.Equal(t, ssh.AuthMethodResponse{}, resp)
 	})
 
-	t.Run("denied : no parent session", func(t *testing.T) {
-		bindingKey := "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY"
+	t.Run("denied : code issuer canceled", func(t *testing.T) {
+		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
+			return &evaluator.Result{
+				Allow: evaluator.NewRuleResult(true),
+				Deny:  evaluator.NewRuleResult(false),
+			}, nil
+		}
+		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
+		idpURL := mockIDP.Start(t)
+		done := make(chan struct{})
+		a := ssh.NewAuth(&fakePolicyEvaluator{evaluateSSH: pe}, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			done: done,
+			onCodeDecision: func(_ context.Context, _ code.CodeID, _ chan code.Status) {
+				close(done)
+			},
+		}, nil)
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
+		require.ErrorContains(t, err, "code issuer can no longer process this request")
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
+	})
+
+	t.Run("denied : request canceled by user", func(t *testing.T) {
+		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
+			return &evaluator.Result{
+				Allow: evaluator.NewRuleResult(true),
+				Deny:  evaluator.NewRuleResult(false),
+			}, nil
+		}
+		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
+		idpURL := mockIDP.Start(t)
+		a := ssh.NewAuth(&fakePolicyEvaluator{evaluateSSH: pe}, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			onCodeDecision: func(_ context.Context, _ code.CodeID, c chan code.Status) {
+				close(c)
+			},
+		}, nil)
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
+		require.ErrorContains(t, err, "authentication request cancelled by user")
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
+	})
+
+	t.Run("denied : session binding expires", func(t *testing.T) {
+		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
+			return &evaluator.Result{
+				Allow: evaluator.NewRuleResult(true),
+				Deny:  evaluator.NewRuleResult(false),
+			}, nil
+		}
+		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
+		idpURL := mockIDP.Start(t)
+		a := ssh.NewAuth(&fakePolicyEvaluator{evaluateSSH: pe}, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			ttl: 1 * time.Millisecond,
+		}, nil)
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
+		require.ErrorContains(t, err, "authentication request timeout")
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
+	})
+
+	t.Run("denied : code status does not match request binding key", func(t *testing.T) {
+		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
+			return &evaluator.Result{
+				Allow: evaluator.NewRuleResult(true),
+				Deny:  evaluator.NewRuleResult(false),
+			}, nil
+		}
+		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
+		idpURL := mockIDP.Start(t)
+		a := ssh.NewAuth(&fakePolicyEvaluator{evaluateSSH: pe}, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			onCodeDecision: func(_ context.Context, id code.CodeID, c chan code.Status) {
+				c <- code.Status{
+					BindingKey: "not the same binding key",
+					State:      session.SessionBindingRequestState_Accepted,
+				}
+			},
+		}, nil)
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
+		require.ErrorContains(t, err, "mismatched binding keys")
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
+	})
+
+	t.Run("code issuer sends invalid status", func(t *testing.T) {
+		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
+			return &evaluator.Result{
+				Allow: evaluator.NewRuleResult(true),
+				Deny:  evaluator.NewRuleResult(false),
+			}, nil
+		}
+		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
+		idpURL := mockIDP.Start(t)
+		a := ssh.NewAuth(&fakePolicyEvaluator{evaluateSSH: pe}, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			onCodeDecision: func(_ context.Context, id code.CodeID, c chan code.Status) {
+				c <- code.Status{
+					BindingKey: sessionBindingId,
+					State:      session.SessionBindingRequestState_InFlight, // invalid
+				}
+			},
+		}, nil)
+		assert.Panics(t, func() {
+			_, _ = a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
+		})
+	})
+
+	t.Run("error while prompting user", func(t *testing.T) {
+		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
+			return &evaluator.Result{
+				Allow: evaluator.NewRuleResult(true),
+				Deny:  evaluator.NewRuleResult(false),
+			}, nil
+		}
+		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
+		idpURL := mockIDP.Start(t)
+		a := ssh.NewAuth(&fakePolicyEvaluator{evaluateSSH: pe}, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &fakeQuerier{
+			prompt: func(ctx context.Context, p *extensions_ssh.KeyboardInteractiveInfoPrompts) (*extensions_ssh.KeyboardInteractiveInfoPromptResponses, error) {
+				return nil, fmt.Errorf("test prompt error")
+			},
+		})
+		require.ErrorContains(t, err, "test prompt error")
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
+	})
+
+	t.Run("error associating code", func(t *testing.T) {
+		pe := func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
+			return &evaluator.Result{
+				Allow: evaluator.NewRuleResult(true),
+				Deny:  evaluator.NewRuleResult(false),
+			}, nil
+		}
+		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
+		idpURL := mockIDP.Start(t)
+		a := ssh.NewAuth(&fakePolicyEvaluator{evaluateSSH: pe}, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			associateCode: func(ctx context.Context, ci code.CodeID, sbr *session.SessionBindingRequest) (code.CodeID, error) {
+				return "", fmt.Errorf("test associate code error")
+			},
+		}, nil)
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
+		require.ErrorContains(t, err, "failed to associate a code to this session")
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
+	})
+
+	t.Run("denied : error retrieving parent session", func(t *testing.T) {
 		sessionID := "some-opaque-id-set-by-idp"
 		// var putRecords []*databroker.Record
 		client := fakeDataBrokerServiceClient{
@@ -448,10 +964,10 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 			) (*databroker.GetResponse, error) {
 				switch r.Type {
 				case "type.googleapis.com/session.SessionBinding":
-					if r.Id == bindingKey {
+					if r.Id == sessionBindingId {
 						return &databroker.GetResponse{
 								Record: &databroker.Record{
-									Id:   "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
+									Id:   sessionBindingId,
 									Type: "type.googleapis.com/session.SessionBinding",
 									Data: protoutil.NewAny(&session.SessionBinding{
 										Protocol:  session.ProtocolSSH,
@@ -465,7 +981,9 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 					}
 					return nil, fmt.Errorf("not found")
 				case "type.googleapis.com/session.Session":
-					return nil, fmt.Errorf("no matching session")
+					// if the code is not NotFound it will prevent any retries looking up
+					// the session
+					return nil, fmt.Errorf("test error")
 				default:
 					return nil, fmt.Errorf("type unsupported")
 				}
@@ -476,34 +994,107 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 		}
 		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
 		idpURL := mockIDP.Start(t)
-		a := ssh.NewAuth(staticFakePolicyEvaluator(true, client), minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
-			state: &code.Status{
-				BindingKey: "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
-				State:      session.SessionBindingRequestState_Accepted,
-				ExpiresAt:  time.Now().Add(time.Hour * 1000),
+		a := ssh.NewAuth(staticFakePolicyEvaluator(evalResultAlwaysAllow, client), minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			onCodeDecision: func(_ context.Context, id code.CodeID, c chan code.Status) {
+				c <- code.Status{
+					BindingKey: sessionBindingId,
+					State:      session.SessionBindingRequestState_Accepted,
+					ExpiresAt:  time.Now().Add(time.Hour * 1000),
+				}
 			},
-		})
-		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), exampleAuthInfo, exampleUser, nil, &noopQuerier{})
-		require.NoError(t, err)
-		assert.Nil(t, res.Allow)
-		assert.Empty(t, res.RequireAdditionalMethods)
+		}, nil)
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
+		require.ErrorContains(t, err, "test error")
+		require.Equal(t, codes.Internal, status.Code(err))
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
+	})
+
+	t.Run("denied : session record lookup timeout", func(t *testing.T) {
+		sessionID := "some-opaque-id-set-by-idp"
+		client := fakeDataBrokerServiceClient{
+			get: func(
+				_ context.Context, r *databroker.GetRequest, _ ...grpc.CallOption,
+			) (*databroker.GetResponse, error) {
+				switch r.Type {
+				case "type.googleapis.com/session.SessionBinding":
+					if r.Id == sessionBindingId {
+						return &databroker.GetResponse{
+								Record: &databroker.Record{
+									Id:   sessionBindingId,
+									Type: "type.googleapis.com/session.SessionBinding",
+									Data: protoutil.NewAny(&session.SessionBinding{
+										Protocol:  session.ProtocolSSH,
+										UserId:    "fake.user@example.com",
+										SessionId: sessionID,
+										ExpiresAt: timestamppb.New(time.Now().Add(time.Hour * 1000)),
+									}),
+								},
+							},
+							nil
+					}
+					return nil, fmt.Errorf("not found")
+				case "type.googleapis.com/session.Session":
+					return nil, status.Errorf(codes.NotFound, "not found")
+				default:
+					return nil, fmt.Errorf("type unsupported")
+				}
+			},
+			put: func(_ context.Context, _ *databroker.PutRequest, _ ...grpc.CallOption) (*databroker.PutResponse, error) {
+				return nil, fmt.Errorf("not implemented")
+			},
+		}
+		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
+		idpURL := mockIDP.Start(t)
+		a := ssh.NewAuth(staticFakePolicyEvaluator(evalResultAlwaysAllow, client), minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			onCodeDecision: func(_ context.Context, id code.CodeID, c chan code.Status) {
+				c <- code.Status{
+					Code:       string(id),
+					BindingKey: sessionBindingId,
+					State:      session.SessionBindingRequestState_Accepted,
+					ExpiresAt:  time.Now().Add(time.Hour * 1000),
+				}
+			},
+			ttl: 1 * time.Second, // short ttl since this tests a backoff timeout
+		}, nil)
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
+		require.ErrorContains(t, err, "failed to get matching session binding: context deadline exceeded")
+		require.Equal(t, codes.Internal, status.Code(err))
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
 	})
 
 	t.Run("denied : not authorized", func(t *testing.T) {
 		client := fakeDataBrokerServiceClient{
 			get: func(
-				_ context.Context, _ *databroker.GetRequest, _ ...grpc.CallOption,
+				_ context.Context, r *databroker.GetRequest, _ ...grpc.CallOption,
 			) (*databroker.GetResponse, error) {
-				return &databroker.GetResponse{
-					Record: &databroker.Record{
-						Type: "type.googleapis.com/session.SessionBinding",
-						Id:   "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
-						Data: protoutil.NewAny(&session.SessionBinding{
-							Protocol:  session.ProtocolSSH,
-							ExpiresAt: timestamppb.New(time.Now().Add(time.Hour * 1000)),
-						}),
-					},
-				}, nil
+				switch r.Type {
+				case "type.googleapis.com/session.SessionBinding":
+					return &databroker.GetResponse{
+						Record: &databroker.Record{
+							Type: "type.googleapis.com/session.SessionBinding",
+							Id:   sessionBindingId,
+							Data: protoutil.NewAny(&session.SessionBinding{
+								Protocol:  session.ProtocolSSH,
+								ExpiresAt: timestamppb.New(time.Now().Add(time.Hour * 1000)),
+								SessionId: "fake-session-id",
+								UserId:    "fake-user-id",
+							}),
+						},
+					}, nil
+				case "type.googleapis.com/session.Session":
+					return &databroker.GetResponse{
+						Record: &databroker.Record{
+							Id:   "fake-session-id",
+							Type: "type.googleapis.com/session.Session",
+							Data: protoutil.NewAny(&session.Session{
+								UserId:    "fake.user@example.com",
+								ExpiresAt: timestamppb.New(time.Now().Add(time.Hour * 1000)),
+							}),
+						},
+					}, nil
+				default:
+					return nil, fmt.Errorf("type unsupported")
+				}
 			},
 			put: func(
 				_ context.Context, in *databroker.PutRequest, _ ...grpc.CallOption,
@@ -515,45 +1106,25 @@ func TestHandleKeyboardInteractiveMethodRequest(t *testing.T) {
 		}
 		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
 		idpURL := mockIDP.Start(t)
-		a := ssh.NewAuth(staticFakePolicyEvaluator(false, client), minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
-			state: &code.Status{
-				Code:       "",
-				BindingKey: "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY",
-				State:      session.SessionBindingRequestState_Accepted,
+		a := ssh.NewAuth(staticFakePolicyEvaluator(evaluator.Result{
+			Allow: evaluator.NewRuleResult(false, criteria.ReasonUserUnauthorized),
+			Deny:  evaluator.NewRuleResult(false),
+		}, client), minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{
+			onCodeDecision: func(_ context.Context, id code.CodeID, c chan code.Status) {
+				c <- code.Status{
+					Code:       "",
+					BindingKey: sessionBindingId,
+					State:      session.SessionBindingRequestState_Accepted,
+				}
 			},
-		})
-		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), exampleAuthInfo, exampleUser, nil, &noopQuerier{})
+		}, nil)
+		res, err := a.HandleKeyboardInteractiveMethodRequest(t.Context(), ssh.StreamInfo{}, initialAuthContext(), user, nil, &noopQuerier{})
 		require.NoError(t, err)
-		assert.Nil(t, res.Allow)
-		assert.Empty(t, res.RequireAdditionalMethods)
-	})
-
-	t.Run("invalid fingerprint", func(t *testing.T) {
-		mockIDP := mockidp.New(mockidp.Config{EnableDeviceAuth: false})
-		idpURL := mockIDP.Start(t)
-		a := ssh.NewAuth(nil, minimalConfig(idpURL), &nooptrace.TracerProvider{}, &fakeIssuer{})
-		info := ssh.StreamAuthInfo{
-			PublicKeyAllow: ssh.AuthMethodValue[*extensions_ssh.PublicKeyAllowResponse]{
-				Value: &extensions_ssh.PublicKeyAllowResponse{
-					PublicKey: []byte("fake-public-key"),
-				},
-			},
-		}
-		user := mustNewUserRequest(t, "username", "hostname")
-		_, err := a.UnexportedHandleKeyboardInteractiveMethodRequest(t.Context(), info, user, &noopQuerier{})
-		assert.ErrorContains(t, err, "invalid public key fingerprint")
+		assert.Equal(t, ssh.AuthMethodResponse{}, res)
 	})
 }
 
 func TestFormatSession(t *testing.T) {
-	t.Run("invalid fingerprint", func(t *testing.T) {
-		var a ssh.Auth
-		info := ssh.StreamAuthInfo{
-			PublicKeyFingerprintSha256: []byte("wrong-length"),
-		}
-		_, err := a.GetSession(t.Context(), info)
-		assert.ErrorContains(t, err, "invalid public key fingerprint")
-	})
 	t.Run("ok", func(t *testing.T) {
 		// TODO : this also has to lookup session binding -> session
 		exp := time.Now().Add(1 * time.Minute)
@@ -563,7 +1134,7 @@ func TestFormatSession(t *testing.T) {
 			"foo":  []any{"bar", "baz"},
 			"quux": []any{42},
 		}
-		const expectedID = "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY"
+		const bindingID = "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY"
 		client := fakeDataBrokerServiceClient{
 			get: func(_ context.Context, r *databroker.GetRequest, _ ...grpc.CallOption) (*databroker.GetResponse, error) {
 				switch r.Type {
@@ -582,10 +1153,10 @@ func TestFormatSession(t *testing.T) {
 						},
 					}, nil
 				case "type.googleapis.com/session.SessionBinding":
-					assert.Equal(t, expectedID, r.Id)
+					assert.Equal(t, bindingID, r.Id)
 					return &databroker.GetResponse{
 						Record: &databroker.Record{
-							Id:   expectedID,
+							Id:   bindingID,
 							Type: "type.googleapis.com/session.SessionBinding",
 							Data: protoutil.NewAny(&session.SessionBinding{
 								Protocol:  session.ProtocolSSH,
@@ -599,11 +1170,11 @@ func TestFormatSession(t *testing.T) {
 				}
 			},
 		}
-		a := ssh.NewAuth(fakePolicyEvaluator{client: client}, nil, &nooptrace.TracerProvider{}, &fakeIssuer{})
-		info := ssh.StreamAuthInfo{
-			PublicKeyFingerprintSha256: []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
-		}
-		b, err := a.GetSession(t.Context(), info)
+		a := ssh.NewAuth(&fakePolicyEvaluator{client: client}, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		b, err := a.GetSession(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{
+			SessionBindingId: bindingID,
+			SessionId:        sessionID,
+		})
 		assert.NoError(t, err)
 		assert.Regexp(t, fmt.Sprintf(`
 User ID:    %s
@@ -617,15 +1188,6 @@ Claims:
 }
 
 func TestDeleteSession(t *testing.T) {
-	t.Run("invalid fingerprint", func(t *testing.T) {
-		var a ssh.Auth
-		info := ssh.StreamAuthInfo{
-			PublicKeyFingerprintSha256: []byte("wrong-length"),
-		}
-		err := a.DeleteSession(t.Context(), info)
-		assert.ErrorContains(t, err, "invalid public key fingerprint")
-	})
-
 	t.Run("ok", func(t *testing.T) {
 		putError := errors.New("sentinel")
 		const bindingID = "sshkey-SHA256:QUJDREVGR0hJSktMTU5PUFFSU1RVVldYWVoxMjM0NTY"
@@ -671,11 +1233,15 @@ func TestDeleteSession(t *testing.T) {
 				return nil, putError
 			},
 		}
-		a := ssh.NewAuth(fakePolicyEvaluator{client: client}, nil, &nooptrace.TracerProvider{}, &fakeIssuer{})
-		info := ssh.StreamAuthInfo{
-			PublicKeyFingerprintSha256: []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
-		}
-		err := a.DeleteSession(t.Context(), info)
+		a := ssh.NewAuth(&fakePolicyEvaluator{client: client}, nil, &nooptrace.TracerProvider{}, &fakeIssuer{}, nil)
+		err := a.DeleteSession(t.Context(), ssh.StreamInfo{}, &extensions_ssh.AuthContext{
+			// Note: this used to work using only the fingerprint in the auth context,
+			// but now the session binding ID is always available directly if there is
+			// a valid session.
+			// PublicKeyFingerprintSha256: []byte("ABCDEFGHIJKLMNOPQRSTUVWXYZ123456"),
+			SessionBindingId: bindingID,
+			SessionId:        sessionID,
+		})
 		assert.ErrorIs(t, err, putError)
 	})
 }
@@ -702,123 +1268,6 @@ func TestSignInPrompt(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "Please sign in with google to continue", ssh.SignInPrompt(authenticator))
 	})
-}
-
-type fakePolicyEvaluator struct {
-	evaluateSSH            func(context.Context, uint64, ssh.AuthRequest) (*evaluator.Result, error)
-	evaluateUpstreamTunnel func(context.Context, ssh.AuthRequest, *config.Policy) (*evaluator.Result, error)
-	client                 databroker.DataBrokerServiceClient
-}
-
-// EvaluateUpstreamTunnel implements ssh.Evaluator.
-func (f fakePolicyEvaluator) EvaluateUpstreamTunnel(ctx context.Context, req ssh.AuthRequest, policy *config.Policy) (*evaluator.Result, error) {
-	return f.evaluateUpstreamTunnel(ctx, req, policy)
-}
-
-func (f fakePolicyEvaluator) EvaluateSSH(ctx context.Context, streamID uint64, req ssh.AuthRequest, _ bool) (*evaluator.Result, error) {
-	return f.evaluateSSH(ctx, streamID, req)
-}
-
-func (f fakePolicyEvaluator) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
-	return f.client
-}
-
-func (f fakePolicyEvaluator) InvalidateCacheForRecords(_ context.Context, _ ...*databroker.Record) {}
-
-func staticFakePolicyEvaluator(allow bool, client databroker.DataBrokerServiceClient) fakePolicyEvaluator {
-	return fakePolicyEvaluator{
-		evaluateSSH: func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
-			return &evaluator.Result{
-				Allow: evaluator.NewRuleResult(allow),
-				Deny:  evaluator.NewRuleResult(!allow),
-			}, nil
-		},
-		evaluateUpstreamTunnel: func(_ context.Context, _ ssh.AuthRequest, _ *config.Policy) (*evaluator.Result, error) {
-			return &evaluator.Result{
-				Allow: evaluator.NewRuleResult(allow),
-				Deny:  evaluator.NewRuleResult(!allow),
-			}, nil
-		},
-		client: client,
-	}
-}
-
-type fakeDataBrokerServiceClient struct {
-	databroker.DataBrokerServiceClient
-
-	get func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error)
-	put func(ctx context.Context, in *databroker.PutRequest, opts ...grpc.CallOption) (*databroker.PutResponse, error)
-}
-
-func (f fakeDataBrokerServiceClient) Get(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
-	return f.get(ctx, in, opts...)
-}
-
-func (f fakeDataBrokerServiceClient) Put(ctx context.Context, in *databroker.PutRequest, opts ...grpc.CallOption) (*databroker.PutResponse, error) {
-	return f.put(ctx, in, opts...)
-}
-
-type noopQuerier struct {
-	prompts []*extensions_ssh.KeyboardInteractiveInfoPrompts
-}
-
-func (q *noopQuerier) Prompt(
-	_ context.Context, p *extensions_ssh.KeyboardInteractiveInfoPrompts,
-) (*extensions_ssh.KeyboardInteractiveInfoPromptResponses, error) {
-	q.prompts = append(q.prompts, p)
-	return nil, nil
-}
-
-type fakeIssuer struct {
-	state *code.Status
-}
-
-var _ code.Issuer = (*fakeIssuer)(nil)
-
-func (f *fakeIssuer) IssueCode() code.CodeID {
-	return ""
-}
-
-func (f *fakeIssuer) AssociateCode(context.Context, code.CodeID, *session.SessionBindingRequest) (code.CodeID, error) {
-	return "associated-code", nil
-}
-
-func (f *fakeIssuer) OnCodeDecision(context.Context, code.CodeID) <-chan code.Status {
-	ret := make(chan code.Status, 1)
-	if f.state != nil {
-		go func() {
-			ret <- *f.state
-		}()
-	}
-	return ret
-}
-
-func (f *fakeIssuer) Done() chan struct{} {
-	return nil
-}
-
-func (f *fakeIssuer) GetBindingRequest(context.Context, code.CodeID) (*session.SessionBindingRequest, bool) {
-	return nil, false
-}
-
-func (f *fakeIssuer) GetSessionBindingsByUserID(context.Context, string) (map[string]*code.IdentitySessionPair, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (f *fakeIssuer) RevokeCode(context.Context, code.CodeID) error {
-	return fmt.Errorf("not implemented")
-}
-
-func (f *fakeIssuer) RevokeSessionBinding(context.Context, code.BindingID) error {
-	return fmt.Errorf("not implemented")
-}
-
-func (f *fakeIssuer) RevokeSessionBindingBySession(context.Context, string) ([]*databroker.Record, error) {
-	return nil, fmt.Errorf("not implemented")
-}
-
-func (f *fakeIssuer) RevokeIdentityBinding(context.Context, code.BindingID) error {
-	return fmt.Errorf("not implemented")
 }
 
 func newValidGetClient() databroker.DataBrokerServiceClient {

--- a/pkg/ssh/helpers_test.go
+++ b/pkg/ssh/helpers_test.go
@@ -2,13 +2,25 @@ package ssh_test
 
 import (
 	"bytes"
+	"context"
 	"crypto/ed25519"
+	"crypto/sha256"
+	"fmt"
 	"strings"
 	"testing"
+	"time"
 
+	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
+	"github.com/pomerium/pomerium/authorize/evaluator"
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/ssh"
+	"github.com/pomerium/pomerium/pkg/ssh/code"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gossh "golang.org/x/crypto/ssh"
+	"google.golang.org/grpc"
 )
 
 type SSHKeys struct {
@@ -89,4 +101,154 @@ func VerifyWorkingShell(t *testing.T, client *gossh.Client) {
 	require.NoError(t, sess.Wait())
 
 	assert.Equal(t, "> hello world\r\nhello world\r\n> ", b.String())
+}
+
+func RawFingerprintSHA256(pk gossh.PublicKey) []byte {
+	return (*new(sha256.Sum256(pk.Marshal())))[:]
+}
+
+type fakePolicyEvaluator struct {
+	evaluateSSH                      func(context.Context, uint64, ssh.AuthRequest) (*evaluator.Result, error)
+	evaluateUpstreamTunnel           func(context.Context, ssh.AuthRequest, *config.Policy) (*evaluator.Result, error)
+	evaluateAccessRequestArbitration func(context.Context, ssh.AuthRequest, *config.Policy) (*evaluator.Result, error)
+	client                           databroker.DataBrokerServiceClient
+}
+
+// EvaluateUpstreamTunnel implements ssh.Evaluator.
+func (f *fakePolicyEvaluator) EvaluateUpstreamTunnel(ctx context.Context, req ssh.AuthRequest, policy *config.Policy) (*evaluator.Result, error) {
+	return f.evaluateUpstreamTunnel(ctx, req, policy)
+}
+
+// EvaluateUpstreamTunnel implements ssh.Evaluator.
+func (f *fakePolicyEvaluator) EvaluateAccessRequestArbitration(ctx context.Context, req ssh.AuthRequest, policy *config.Policy) (*evaluator.Result, error) {
+	return f.evaluateAccessRequestArbitration(ctx, req, policy)
+}
+
+func (f *fakePolicyEvaluator) EvaluateSSH(ctx context.Context, streamID uint64, req ssh.AuthRequest, _ bool) (*evaluator.Result, error) {
+	return f.evaluateSSH(ctx, streamID, req)
+}
+
+func (f *fakePolicyEvaluator) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	return f.client
+}
+
+func (f *fakePolicyEvaluator) InvalidateCacheForRecords(_ context.Context, _ ...*databroker.Record) {}
+
+func staticFakePolicyEvaluator(result evaluator.Result, client databroker.DataBrokerServiceClient) *fakePolicyEvaluator {
+	return &fakePolicyEvaluator{
+		evaluateSSH: func(_ context.Context, _ uint64, _ ssh.AuthRequest) (*evaluator.Result, error) {
+			return &result, nil
+		},
+		evaluateUpstreamTunnel: func(_ context.Context, _ ssh.AuthRequest, _ *config.Policy) (*evaluator.Result, error) {
+			return &result, nil
+		},
+		evaluateAccessRequestArbitration: func(ctx context.Context, ar ssh.AuthRequest, p *config.Policy) (*evaluator.Result, error) {
+			return &result, nil
+		},
+		client: client,
+	}
+}
+
+var evalResultAlwaysAllow = evaluator.Result{
+	Allow: evaluator.NewRuleResult(true),
+	Deny:  evaluator.NewRuleResult(false),
+}
+
+type fakeDataBrokerServiceClient struct {
+	databroker.DataBrokerServiceClient
+
+	get func(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error)
+	put func(ctx context.Context, in *databroker.PutRequest, opts ...grpc.CallOption) (*databroker.PutResponse, error)
+}
+
+func (f fakeDataBrokerServiceClient) Get(ctx context.Context, in *databroker.GetRequest, opts ...grpc.CallOption) (*databroker.GetResponse, error) {
+	return f.get(ctx, in, opts...)
+}
+
+func (f fakeDataBrokerServiceClient) Put(ctx context.Context, in *databroker.PutRequest, opts ...grpc.CallOption) (*databroker.PutResponse, error) {
+	return f.put(ctx, in, opts...)
+}
+
+type noopQuerier struct {
+	prompts []*extensions_ssh.KeyboardInteractiveInfoPrompts
+}
+
+func (q *noopQuerier) Prompt(
+	_ context.Context, p *extensions_ssh.KeyboardInteractiveInfoPrompts,
+) (*extensions_ssh.KeyboardInteractiveInfoPromptResponses, error) {
+	q.prompts = append(q.prompts, p)
+	return nil, nil
+}
+
+type fakeQuerier struct {
+	prompt func(ctx context.Context, p *extensions_ssh.KeyboardInteractiveInfoPrompts) (*extensions_ssh.KeyboardInteractiveInfoPromptResponses, error)
+}
+
+func (q *fakeQuerier) Prompt(
+	ctx context.Context, p *extensions_ssh.KeyboardInteractiveInfoPrompts,
+) (*extensions_ssh.KeyboardInteractiveInfoPromptResponses, error) {
+	return q.prompt(ctx, p)
+}
+
+type fakeIssuer struct {
+	onCodeDecision func(ctx context.Context, id code.CodeID, c chan code.Status)
+	associateCode  func(context.Context, code.CodeID, *session.SessionBindingRequest) (code.CodeID, error)
+	ttl            time.Duration
+	done           chan struct{} // can be nil to never cancel, or non-nil to allow canceling via close() out of band
+}
+
+var _ code.Issuer = (*fakeIssuer)(nil)
+
+func (f *fakeIssuer) IssueCode() code.CodeID {
+	return ""
+}
+
+func (f *fakeIssuer) CodeTTL() time.Duration {
+	if f.ttl == 0 {
+		return 1 * time.Minute
+	}
+	return f.ttl
+}
+
+func (f *fakeIssuer) AssociateCode(ctx context.Context, id code.CodeID, sbr *session.SessionBindingRequest) (code.CodeID, error) {
+	if f.associateCode != nil {
+		return f.associateCode(ctx, id, sbr)
+	}
+	return "associated-code", nil
+}
+
+func (f *fakeIssuer) OnCodeDecision(ctx context.Context, id code.CodeID) <-chan code.Status {
+	ret := make(chan code.Status, 1)
+	if f.onCodeDecision != nil {
+		go f.onCodeDecision(ctx, id, ret)
+	}
+	return ret
+}
+
+func (f *fakeIssuer) Done() chan struct{} {
+	return f.done
+}
+
+func (f *fakeIssuer) GetBindingRequest(context.Context, code.CodeID) (*session.SessionBindingRequest, bool) {
+	return nil, false
+}
+
+func (f *fakeIssuer) GetSessionBindingsByUserID(context.Context, string) (map[string]*code.IdentitySessionPair, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeIssuer) RevokeCode(context.Context, code.CodeID) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (f *fakeIssuer) RevokeSessionBinding(context.Context, code.BindingID) error {
+	return fmt.Errorf("not implemented")
+}
+
+func (f *fakeIssuer) RevokeSessionBindingBySession(context.Context, string) ([]*databroker.Record, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func (f *fakeIssuer) RevokeIdentityBinding(context.Context, code.BindingID) error {
+	return fmt.Errorf("not implemented")
 }

--- a/pkg/ssh/manager_test.go
+++ b/pkg/ssh/manager_test.go
@@ -52,7 +52,7 @@ func TestStreamManager(t *testing.T) {
 	m := ssh.NewStreamManager(
 		t.Context(),
 		auth,
-		ssh.NewInMemoryPolicyIndexer(staticFakePolicyEvaluator(true, databrokerClient)),
+		ssh.NewInMemoryPolicyIndexer(staticFakePolicyEvaluator(evalResultAlwaysAllow, databrokerClient)),
 		ssh.NewDefaultCLIController(cfg, style.NewTheme(style.Ansi16Colors)),
 		cfg,
 	)
@@ -240,24 +240,28 @@ func TestReverseTunnelEDS(t *testing.T) {
 				MethodRequest: marshalAny(&extensions_ssh.PublicKeyMethodRequest{
 					PublicKey:                  key,
 					PublicKeyAlg:               "ssh-ed25519",
-					PublicKeyFingerprintSha256: []byte(gossh.FingerprintSHA256(sshKey)),
+					PublicKeyFingerprintSha256: RawFingerprintSHA256(sshKey),
 				}),
 			},
 		},
 	}
 	auth.EXPECT().
-		HandlePublicKeyMethodRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(context.Context, ssh.StreamAuthInfo, api.UserRequest, *extensions_ssh.PublicKeyMethodRequest) (ssh.PublicKeyAuthMethodResponse, error) {
-			return ssh.PublicKeyAuthMethodResponse{
-				Allow: &extensions_ssh.PublicKeyAllowResponse{
-					PublicKey: []byte(gossh.FingerprintSHA256(sshKey)),
+		HandlePublicKeyMethodRequest(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, ssh.StreamInfo, ssh.StreamAuthInfo, api.UserRequest, *extensions_ssh.PublicKeyMethodRequest) (ssh.AuthMethodResponse, error) {
+			return ssh.AuthMethodResponse{
+				AllowMethod:              true,
+				NoFurtherMethodsRequired: true,
+				ContextUpdates: &extensions_ssh.AuthContext{
+					PublicKey:                  sshKey.Marshal(),
+					PublicKeyAlg:               sshKey.Type(),
+					PublicKeyFingerprintSha256: RawFingerprintSHA256(sshKey),
 				},
 			}, nil
 		}).
 		AnyTimes()
 	auth.EXPECT().
-		EvaluateDelayed(gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(context.Context, ssh.StreamAuthInfo, api.UserRequest) error {
+		EvaluateDelayed(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(context.Context, ssh.StreamInfo, ssh.StreamAuthInfo, api.UserRequest) error {
 			return nil
 		}).
 		AnyTimes()
@@ -327,7 +331,7 @@ func TestReverseTunnelEDS(t *testing.T) {
 		databrokerClient := databrokerpb.NewDataBrokerServiceClient(cc)
 		auth.EXPECT().GetDataBrokerServiceClient().Return(databrokerClient).AnyTimes()
 
-		indexer := ssh.NewInMemoryPolicyIndexer(staticFakePolicyEvaluator(true, databrokerClient))
+		indexer := ssh.NewInMemoryPolicyIndexer(staticFakePolicyEvaluator(evalResultAlwaysAllow, databrokerClient))
 		m := ssh.NewStreamManager(t.Context(), auth, indexer, ssh.NewDefaultCLIController(cfg, style.NewTheme(style.Ansi16Colors)), cfg)
 
 		go indexer.Run(t.Context())
@@ -487,7 +491,7 @@ func TestReverseTunnelEDS(t *testing.T) {
 		databrokerClient := databrokerpb.NewDataBrokerServiceClient(cc)
 		auth.EXPECT().GetDataBrokerServiceClient().Return(databrokerClient).AnyTimes()
 
-		indexer := ssh.NewInMemoryPolicyIndexer(staticFakePolicyEvaluator(true, databrokerClient))
+		indexer := ssh.NewInMemoryPolicyIndexer(staticFakePolicyEvaluator(evalResultAlwaysAllow, databrokerClient))
 		m := ssh.NewStreamManager(t.Context(), auth, indexer, ssh.NewDefaultCLIController(cfg, style.NewTheme(style.Ansi16Colors)), cfg)
 
 		go indexer.Run(t.Context())

--- a/pkg/ssh/mock/mock_auth_interface.go
+++ b/pkg/ssh/mock/mock_auth_interface.go
@@ -47,9 +47,9 @@ func (m *MockAuthInterface) EXPECT() *MockAuthInterfaceMockRecorder {
 }
 
 // BuildTargetChannelFilters mocks base method.
-func (m *MockAuthInterface) BuildTargetChannelFilters(ctx context.Context, info ssh0.StreamAuthInfo, user api.UserRequest) (*corev3.SocketAddress, []*corev3.TypedExtensionConfig, error) {
+func (m *MockAuthInterface) BuildTargetChannelFilters(ctx context.Context, streamInfo ssh0.StreamInfo, authInfo ssh0.StreamAuthInfo, user api.UserRequest) (*corev3.SocketAddress, []*corev3.TypedExtensionConfig, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "BuildTargetChannelFilters", ctx, info, user)
+	ret := m.ctrl.Call(m, "BuildTargetChannelFilters", ctx, streamInfo, authInfo, user)
 	ret0, _ := ret[0].(*corev3.SocketAddress)
 	ret1, _ := ret[1].([]*corev3.TypedExtensionConfig)
 	ret2, _ := ret[2].(error)
@@ -57,9 +57,9 @@ func (m *MockAuthInterface) BuildTargetChannelFilters(ctx context.Context, info 
 }
 
 // BuildTargetChannelFilters indicates an expected call of BuildTargetChannelFilters.
-func (mr *MockAuthInterfaceMockRecorder) BuildTargetChannelFilters(ctx, info, user any) *MockAuthInterfaceBuildTargetChannelFiltersCall {
+func (mr *MockAuthInterfaceMockRecorder) BuildTargetChannelFilters(ctx, streamInfo, authInfo, user any) *MockAuthInterfaceBuildTargetChannelFiltersCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildTargetChannelFilters", reflect.TypeOf((*MockAuthInterface)(nil).BuildTargetChannelFilters), ctx, info, user)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BuildTargetChannelFilters", reflect.TypeOf((*MockAuthInterface)(nil).BuildTargetChannelFilters), ctx, streamInfo, authInfo, user)
 	return &MockAuthInterfaceBuildTargetChannelFiltersCall{Call: call}
 }
 
@@ -75,29 +75,29 @@ func (c *MockAuthInterfaceBuildTargetChannelFiltersCall) Return(arg0 *corev3.Soc
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthInterfaceBuildTargetChannelFiltersCall) Do(f func(context.Context, ssh0.StreamAuthInfo, api.UserRequest) (*corev3.SocketAddress, []*corev3.TypedExtensionConfig, error)) *MockAuthInterfaceBuildTargetChannelFiltersCall {
+func (c *MockAuthInterfaceBuildTargetChannelFiltersCall) Do(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo, api.UserRequest) (*corev3.SocketAddress, []*corev3.TypedExtensionConfig, error)) *MockAuthInterfaceBuildTargetChannelFiltersCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthInterfaceBuildTargetChannelFiltersCall) DoAndReturn(f func(context.Context, ssh0.StreamAuthInfo, api.UserRequest) (*corev3.SocketAddress, []*corev3.TypedExtensionConfig, error)) *MockAuthInterfaceBuildTargetChannelFiltersCall {
+func (c *MockAuthInterfaceBuildTargetChannelFiltersCall) DoAndReturn(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo, api.UserRequest) (*corev3.SocketAddress, []*corev3.TypedExtensionConfig, error)) *MockAuthInterfaceBuildTargetChannelFiltersCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // DeleteSession mocks base method.
-func (m *MockAuthInterface) DeleteSession(ctx context.Context, info ssh0.StreamAuthInfo) error {
+func (m *MockAuthInterface) DeleteSession(ctx context.Context, streamInfo ssh0.StreamInfo, authInfo ssh0.StreamAuthInfo) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteSession", ctx, info)
+	ret := m.ctrl.Call(m, "DeleteSession", ctx, streamInfo, authInfo)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteSession indicates an expected call of DeleteSession.
-func (mr *MockAuthInterfaceMockRecorder) DeleteSession(ctx, info any) *MockAuthInterfaceDeleteSessionCall {
+func (mr *MockAuthInterfaceMockRecorder) DeleteSession(ctx, streamInfo, authInfo any) *MockAuthInterfaceDeleteSessionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSession", reflect.TypeOf((*MockAuthInterface)(nil).DeleteSession), ctx, info)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSession", reflect.TypeOf((*MockAuthInterface)(nil).DeleteSession), ctx, streamInfo, authInfo)
 	return &MockAuthInterfaceDeleteSessionCall{Call: call}
 }
 
@@ -113,29 +113,29 @@ func (c *MockAuthInterfaceDeleteSessionCall) Return(arg0 error) *MockAuthInterfa
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthInterfaceDeleteSessionCall) Do(f func(context.Context, ssh0.StreamAuthInfo) error) *MockAuthInterfaceDeleteSessionCall {
+func (c *MockAuthInterfaceDeleteSessionCall) Do(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo) error) *MockAuthInterfaceDeleteSessionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthInterfaceDeleteSessionCall) DoAndReturn(f func(context.Context, ssh0.StreamAuthInfo) error) *MockAuthInterfaceDeleteSessionCall {
+func (c *MockAuthInterfaceDeleteSessionCall) DoAndReturn(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo) error) *MockAuthInterfaceDeleteSessionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // EvaluateDelayed mocks base method.
-func (m *MockAuthInterface) EvaluateDelayed(ctx context.Context, info ssh0.StreamAuthInfo, user api.UserRequest) error {
+func (m *MockAuthInterface) EvaluateDelayed(ctx context.Context, streamInfo ssh0.StreamInfo, authInfo ssh0.StreamAuthInfo, user api.UserRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EvaluateDelayed", ctx, info, user)
+	ret := m.ctrl.Call(m, "EvaluateDelayed", ctx, streamInfo, authInfo, user)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EvaluateDelayed indicates an expected call of EvaluateDelayed.
-func (mr *MockAuthInterfaceMockRecorder) EvaluateDelayed(ctx, info, user any) *MockAuthInterfaceEvaluateDelayedCall {
+func (mr *MockAuthInterfaceMockRecorder) EvaluateDelayed(ctx, streamInfo, authInfo, user any) *MockAuthInterfaceEvaluateDelayedCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateDelayed", reflect.TypeOf((*MockAuthInterface)(nil).EvaluateDelayed), ctx, info, user)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvaluateDelayed", reflect.TypeOf((*MockAuthInterface)(nil).EvaluateDelayed), ctx, streamInfo, authInfo, user)
 	return &MockAuthInterfaceEvaluateDelayedCall{Call: call}
 }
 
@@ -151,13 +151,13 @@ func (c *MockAuthInterfaceEvaluateDelayedCall) Return(arg0 error) *MockAuthInter
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthInterfaceEvaluateDelayedCall) Do(f func(context.Context, ssh0.StreamAuthInfo, api.UserRequest) error) *MockAuthInterfaceEvaluateDelayedCall {
+func (c *MockAuthInterfaceEvaluateDelayedCall) Do(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo, api.UserRequest) error) *MockAuthInterfaceEvaluateDelayedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthInterfaceEvaluateDelayedCall) DoAndReturn(f func(context.Context, ssh0.StreamAuthInfo, api.UserRequest) error) *MockAuthInterfaceEvaluateDelayedCall {
+func (c *MockAuthInterfaceEvaluateDelayedCall) DoAndReturn(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo, api.UserRequest) error) *MockAuthInterfaceEvaluateDelayedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
@@ -201,18 +201,18 @@ func (c *MockAuthInterfaceGetDataBrokerServiceClientCall) DoAndReturn(f func() d
 }
 
 // GetSession mocks base method.
-func (m *MockAuthInterface) GetSession(ctx context.Context, info ssh0.StreamAuthInfo) (*session.Session, error) {
+func (m *MockAuthInterface) GetSession(ctx context.Context, streamInfo ssh0.StreamInfo, authInfo ssh0.StreamAuthInfo) (*session.Session, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSession", ctx, info)
+	ret := m.ctrl.Call(m, "GetSession", ctx, streamInfo, authInfo)
 	ret0, _ := ret[0].(*session.Session)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetSession indicates an expected call of GetSession.
-func (mr *MockAuthInterfaceMockRecorder) GetSession(ctx, info any) *MockAuthInterfaceGetSessionCall {
+func (mr *MockAuthInterfaceMockRecorder) GetSession(ctx, streamInfo, authInfo any) *MockAuthInterfaceGetSessionCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSession", reflect.TypeOf((*MockAuthInterface)(nil).GetSession), ctx, info)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSession", reflect.TypeOf((*MockAuthInterface)(nil).GetSession), ctx, streamInfo, authInfo)
 	return &MockAuthInterfaceGetSessionCall{Call: call}
 }
 
@@ -228,30 +228,30 @@ func (c *MockAuthInterfaceGetSessionCall) Return(arg0 *session.Session, arg1 err
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthInterfaceGetSessionCall) Do(f func(context.Context, ssh0.StreamAuthInfo) (*session.Session, error)) *MockAuthInterfaceGetSessionCall {
+func (c *MockAuthInterfaceGetSessionCall) Do(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo) (*session.Session, error)) *MockAuthInterfaceGetSessionCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthInterfaceGetSessionCall) DoAndReturn(f func(context.Context, ssh0.StreamAuthInfo) (*session.Session, error)) *MockAuthInterfaceGetSessionCall {
+func (c *MockAuthInterfaceGetSessionCall) DoAndReturn(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo) (*session.Session, error)) *MockAuthInterfaceGetSessionCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HandleKeyboardInteractiveMethodRequest mocks base method.
-func (m *MockAuthInterface) HandleKeyboardInteractiveMethodRequest(ctx context.Context, info ssh0.StreamAuthInfo, user api.UserRequest, req *ssh.KeyboardInteractiveMethodRequest, querier ssh0.KeyboardInteractiveQuerier) (ssh0.KeyboardInteractiveAuthMethodResponse, error) {
+func (m *MockAuthInterface) HandleKeyboardInteractiveMethodRequest(ctx context.Context, streamInfo ssh0.StreamInfo, authInfo ssh0.StreamAuthInfo, user api.UserRequest, req *ssh.KeyboardInteractiveMethodRequest, querier ssh0.KeyboardInteractiveQuerier) (ssh0.AuthMethodResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandleKeyboardInteractiveMethodRequest", ctx, info, user, req, querier)
-	ret0, _ := ret[0].(ssh0.KeyboardInteractiveAuthMethodResponse)
+	ret := m.ctrl.Call(m, "HandleKeyboardInteractiveMethodRequest", ctx, streamInfo, authInfo, user, req, querier)
+	ret0, _ := ret[0].(ssh0.AuthMethodResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HandleKeyboardInteractiveMethodRequest indicates an expected call of HandleKeyboardInteractiveMethodRequest.
-func (mr *MockAuthInterfaceMockRecorder) HandleKeyboardInteractiveMethodRequest(ctx, info, user, req, querier any) *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall {
+func (mr *MockAuthInterfaceMockRecorder) HandleKeyboardInteractiveMethodRequest(ctx, streamInfo, authInfo, user, req, querier any) *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleKeyboardInteractiveMethodRequest", reflect.TypeOf((*MockAuthInterface)(nil).HandleKeyboardInteractiveMethodRequest), ctx, info, user, req, querier)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandleKeyboardInteractiveMethodRequest", reflect.TypeOf((*MockAuthInterface)(nil).HandleKeyboardInteractiveMethodRequest), ctx, streamInfo, authInfo, user, req, querier)
 	return &MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall{Call: call}
 }
 
@@ -261,36 +261,36 @@ type MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall) Return(arg0 ssh0.KeyboardInteractiveAuthMethodResponse, arg1 error) *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall {
+func (c *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall) Return(arg0 ssh0.AuthMethodResponse, arg1 error) *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall) Do(f func(context.Context, ssh0.StreamAuthInfo, api.UserRequest, *ssh.KeyboardInteractiveMethodRequest, ssh0.KeyboardInteractiveQuerier) (ssh0.KeyboardInteractiveAuthMethodResponse, error)) *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall {
+func (c *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall) Do(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo, api.UserRequest, *ssh.KeyboardInteractiveMethodRequest, ssh0.KeyboardInteractiveQuerier) (ssh0.AuthMethodResponse, error)) *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall) DoAndReturn(f func(context.Context, ssh0.StreamAuthInfo, api.UserRequest, *ssh.KeyboardInteractiveMethodRequest, ssh0.KeyboardInteractiveQuerier) (ssh0.KeyboardInteractiveAuthMethodResponse, error)) *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall {
+func (c *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall) DoAndReturn(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo, api.UserRequest, *ssh.KeyboardInteractiveMethodRequest, ssh0.KeyboardInteractiveQuerier) (ssh0.AuthMethodResponse, error)) *MockAuthInterfaceHandleKeyboardInteractiveMethodRequestCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }
 
 // HandlePublicKeyMethodRequest mocks base method.
-func (m *MockAuthInterface) HandlePublicKeyMethodRequest(ctx context.Context, info ssh0.StreamAuthInfo, user api.UserRequest, req *ssh.PublicKeyMethodRequest) (ssh0.PublicKeyAuthMethodResponse, error) {
+func (m *MockAuthInterface) HandlePublicKeyMethodRequest(ctx context.Context, streamInfo ssh0.StreamInfo, authInfo ssh0.StreamAuthInfo, user api.UserRequest, req *ssh.PublicKeyMethodRequest) (ssh0.AuthMethodResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HandlePublicKeyMethodRequest", ctx, info, user, req)
-	ret0, _ := ret[0].(ssh0.PublicKeyAuthMethodResponse)
+	ret := m.ctrl.Call(m, "HandlePublicKeyMethodRequest", ctx, streamInfo, authInfo, user, req)
+	ret0, _ := ret[0].(ssh0.AuthMethodResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // HandlePublicKeyMethodRequest indicates an expected call of HandlePublicKeyMethodRequest.
-func (mr *MockAuthInterfaceMockRecorder) HandlePublicKeyMethodRequest(ctx, info, user, req any) *MockAuthInterfaceHandlePublicKeyMethodRequestCall {
+func (mr *MockAuthInterfaceMockRecorder) HandlePublicKeyMethodRequest(ctx, streamInfo, authInfo, user, req any) *MockAuthInterfaceHandlePublicKeyMethodRequestCall {
 	mr.mock.ctrl.T.Helper()
-	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandlePublicKeyMethodRequest", reflect.TypeOf((*MockAuthInterface)(nil).HandlePublicKeyMethodRequest), ctx, info, user, req)
+	call := mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HandlePublicKeyMethodRequest", reflect.TypeOf((*MockAuthInterface)(nil).HandlePublicKeyMethodRequest), ctx, streamInfo, authInfo, user, req)
 	return &MockAuthInterfaceHandlePublicKeyMethodRequestCall{Call: call}
 }
 
@@ -300,19 +300,19 @@ type MockAuthInterfaceHandlePublicKeyMethodRequestCall struct {
 }
 
 // Return rewrite *gomock.Call.Return
-func (c *MockAuthInterfaceHandlePublicKeyMethodRequestCall) Return(arg0 ssh0.PublicKeyAuthMethodResponse, arg1 error) *MockAuthInterfaceHandlePublicKeyMethodRequestCall {
+func (c *MockAuthInterfaceHandlePublicKeyMethodRequestCall) Return(arg0 ssh0.AuthMethodResponse, arg1 error) *MockAuthInterfaceHandlePublicKeyMethodRequestCall {
 	c.Call = c.Call.Return(arg0, arg1)
 	return c
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockAuthInterfaceHandlePublicKeyMethodRequestCall) Do(f func(context.Context, ssh0.StreamAuthInfo, api.UserRequest, *ssh.PublicKeyMethodRequest) (ssh0.PublicKeyAuthMethodResponse, error)) *MockAuthInterfaceHandlePublicKeyMethodRequestCall {
+func (c *MockAuthInterfaceHandlePublicKeyMethodRequestCall) Do(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo, api.UserRequest, *ssh.PublicKeyMethodRequest) (ssh0.AuthMethodResponse, error)) *MockAuthInterfaceHandlePublicKeyMethodRequestCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockAuthInterfaceHandlePublicKeyMethodRequestCall) DoAndReturn(f func(context.Context, ssh0.StreamAuthInfo, api.UserRequest, *ssh.PublicKeyMethodRequest) (ssh0.PublicKeyAuthMethodResponse, error)) *MockAuthInterfaceHandlePublicKeyMethodRequestCall {
+func (c *MockAuthInterfaceHandlePublicKeyMethodRequestCall) DoAndReturn(f func(context.Context, ssh0.StreamInfo, ssh0.StreamAuthInfo, api.UserRequest, *ssh.PublicKeyMethodRequest) (ssh0.AuthMethodResponse, error)) *MockAuthInterfaceHandlePublicKeyMethodRequestCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/pkg/ssh/ssh_export_test.go
+++ b/pkg/ssh/ssh_export_test.go
@@ -11,20 +11,12 @@ import (
 
 func (a *Auth) UnexportedHandlePublicKeyMethodRequest(
 	ctx context.Context,
-	info StreamAuthInfo,
+	streamInfo StreamInfo,
+	authInfo StreamAuthInfo,
 	user api.UserRequest,
 	req *extensions_ssh.PublicKeyMethodRequest,
-) (PublicKeyAuthMethodResponse, error) {
-	return a.handlePublicKeyMethodRequest(ctx, info, user, req)
-}
-
-func (a *Auth) UnexportedHandleKeyboardInteractiveMethodRequest(
-	ctx context.Context,
-	info StreamAuthInfo,
-	user api.UserRequest,
-	querier KeyboardInteractiveQuerier,
-) (KeyboardInteractiveAuthMethodResponse, error) {
-	return a.handleKeyboardInteractiveMethodRequest(ctx, info, user, querier)
+) (AuthMethodResponse, error) {
+	return a.handlePublicKeyMethodRequest(ctx, streamInfo, authInfo, user, req)
 }
 
 func (sm *StreamManager) UnexportedEdsCache() *cache.LinearCache {
@@ -39,6 +31,4 @@ func (i *InMemoryPolicyIndexer) UnexportedState() *inMemoryIndexerState { //revi
 	return &i.state
 }
 
-func (i *StreamAuthInfo) UnexportedAllMethodsValid() bool {
-	return i.allMethodsValid()
-}
+var UnexportedSessionIDFromFingerprint = sessionIDFromFingerprint

--- a/pkg/ssh/stream.go
+++ b/pkg/ssh/stream.go
@@ -2,8 +2,8 @@ package ssh
 
 import (
 	"context"
+	"fmt"
 	"iter"
-	"reflect"
 	"sync/atomic"
 	"time"
 
@@ -15,6 +15,7 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
 	"github.com/pomerium/pomerium/config"
@@ -22,7 +23,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/protoutil"
-	"github.com/pomerium/pomerium/pkg/slices"
 	"github.com/pomerium/pomerium/pkg/ssh/api"
 	"github.com/pomerium/pomerium/pkg/ssh/cli"
 	"github.com/pomerium/pomerium/pkg/ssh/common"
@@ -45,25 +45,66 @@ type KeyboardInteractiveQuerier interface {
 	Prompt(ctx context.Context, prompts *extensions_ssh.KeyboardInteractiveInfoPrompts) (*extensions_ssh.KeyboardInteractiveInfoPromptResponses, error)
 }
 
-type AuthMethodResponse[T any] struct {
-	Allow                    *T
-	RequireAdditionalMethods []string
+type AuthMethodResponse struct {
+	AllowMethod              bool
+	NextRequiredAuthMethod   string
+	NoFurtherMethodsRequired bool
+	ContextUpdates           *extensions_ssh.AuthContext
 }
 
-type (
-	PublicKeyAuthMethodResponse           = AuthMethodResponse[extensions_ssh.PublicKeyAllowResponse]
-	KeyboardInteractiveAuthMethodResponse = AuthMethodResponse[extensions_ssh.KeyboardInteractiveAllowResponse]
-)
+func (r *AuthMethodResponse) Validate() {
+	if r.AllowMethod {
+		if r.NextRequiredAuthMethod == "" && !r.NoFurtherMethodsRequired {
+			panic("invalid AuthMethodResponse: either NextRequiredAuthMethod or NoFurtherMethodsRequired must be set if AllowMethod is true")
+		}
+		if r.NextRequiredAuthMethod == MethodPublicKey {
+			// There is currently no situation where we need to restart a successful publickey request, but it is not invalid.
+			// If we ever need to do so, remove this check
+			panic("invalid AuthMethodResponse: unexpected NextRequiredAuthMethod publickey when AllowMethod is true")
+		}
+	} else {
+		if r.ContextUpdates != nil {
+			panic("invalid AuthMethodResponse: ContextUpdates can only be set if AllowMethod is true")
+		}
+		if r.NoFurtherMethodsRequired {
+			panic("invalid AuthMethodResponse: NoFurtherMethodsRequired can only be set if AllowMethod is true")
+		}
+	}
+	if r.NextRequiredAuthMethod != "" {
+		if r.NoFurtherMethodsRequired {
+			panic("invalid AuthMethodResponse: NextRequiredAuthMethod and NoFurtherMethodsRequired are mutually exclusive")
+		}
+		switch r.NextRequiredAuthMethod {
+		case MethodPublicKey:
+		case MethodKeyboardInteractive:
+		default:
+			panic("invalid AuthMethodResponse: unknown auth method name: " + r.NextRequiredAuthMethod)
+		}
+	}
+}
+
+func (r *AuthMethodResponse) String() string {
+	if !r.AllowMethod {
+		if r.NextRequiredAuthMethod != "" {
+			return fmt.Sprintf("unauthorized (retry: %s)", r.NextRequiredAuthMethod)
+		}
+		return "unauthorized"
+	}
+	if !r.NoFurtherMethodsRequired {
+		return fmt.Sprintf("partially authorized (next: %s)", r.NextRequiredAuthMethod)
+	}
+	return fmt.Sprintf("authorized")
+}
 
 //go:generate go tool go.uber.org/mock/mockgen -typed -destination ./mock/mock_auth_interface.go . AuthInterface
 
 type AuthInterface interface {
-	HandlePublicKeyMethodRequest(ctx context.Context, info StreamAuthInfo, user api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (PublicKeyAuthMethodResponse, error)
-	HandleKeyboardInteractiveMethodRequest(ctx context.Context, info StreamAuthInfo, user api.UserRequest, req *extensions_ssh.KeyboardInteractiveMethodRequest, querier KeyboardInteractiveQuerier) (KeyboardInteractiveAuthMethodResponse, error)
-	EvaluateDelayed(ctx context.Context, info StreamAuthInfo, user api.UserRequest) error
-	BuildTargetChannelFilters(ctx context.Context, info StreamAuthInfo, user api.UserRequest) (*corev3.SocketAddress, []*corev3.TypedExtensionConfig, error)
-	GetSession(ctx context.Context, info StreamAuthInfo) (*session.Session, error)
-	DeleteSession(ctx context.Context, info StreamAuthInfo) error
+	HandlePublicKeyMethodRequest(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo, user api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (AuthMethodResponse, error)
+	HandleKeyboardInteractiveMethodRequest(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo, user api.UserRequest, req *extensions_ssh.KeyboardInteractiveMethodRequest, querier KeyboardInteractiveQuerier) (AuthMethodResponse, error)
+	EvaluateDelayed(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo, user api.UserRequest) error
+	BuildTargetChannelFilters(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo, user api.UserRequest) (*corev3.SocketAddress, []*corev3.TypedExtensionConfig, error)
+	GetSession(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo) (*session.Session, error)
+	DeleteSession(ctx context.Context, streamInfo StreamInfo, authInfo StreamAuthInfo) error
 	GetDataBrokerServiceClient() databroker.DataBrokerServiceClient
 }
 
@@ -76,66 +117,31 @@ type EndpointDiscoveryInterface interface {
 	UpdateClusterEndpoints(added map[string]portforward.RoutePortForwardInfo, removed map[string]struct{})
 }
 
-type AuthMethodValue[T interface {
-	comparable
-	proto.Message
-}] struct {
-	attempted bool
-	Value     T
+type StreamInfo struct {
+	StreamID            uint64
+	SourceAddress       string
+	ChannelType         string
+	InitialAuthComplete bool
 }
 
-func (v *AuthMethodValue[T]) Update(value T) {
-	v.attempted = true
-	v.Value = value
-}
+type StreamAuthInfo interface {
+	// Public key info
+	GetPublicKey() []byte
+	GetPublicKeyAlg() string
+	GetPublicKeyFingerprintSha256() []byte // No formatting
 
-func (v *AuthMethodValue[T]) IsValid() bool {
-	if v.attempted {
-		// method was attempted - valid iff there is a value
-		return !reflect.ValueOf(v.Value).IsNil()
-	}
-	return true // method was not attempted - valid
-}
-
-func (v *AuthMethodValue[T]) Clone() AuthMethodValue[T] {
-	return AuthMethodValue[T]{
-		attempted: v.attempted,
-		Value:     proto.CloneOf(v.Value),
-	}
-}
-
-type StreamAuthInfo struct {
-	StreamID                   uint64
-	SourceAddress              string
-	ChannelType                string
-	PublicKeyFingerprintSha256 []byte
-	PublicKeyAllow             AuthMethodValue[*extensions_ssh.PublicKeyAllowResponse]
-	KeyboardInteractiveAllow   AuthMethodValue[*extensions_ssh.KeyboardInteractiveAllowResponse]
-	InitialAuthComplete        bool
-}
-
-func (i *StreamAuthInfo) Clone() StreamAuthInfo {
-	clone := StreamAuthInfo{
-		StreamID:                   i.StreamID,
-		SourceAddress:              i.SourceAddress,
-		ChannelType:                i.ChannelType,
-		PublicKeyFingerprintSha256: i.PublicKeyFingerprintSha256,
-		PublicKeyAllow:             i.PublicKeyAllow.Clone(),
-		KeyboardInteractiveAllow:   i.KeyboardInteractiveAllow.Clone(),
-		InitialAuthComplete:        i.InitialAuthComplete,
-	}
-	return clone
-}
-
-func (i *StreamAuthInfo) allMethodsValid() bool {
-	return i.PublicKeyAllow.IsValid() && i.KeyboardInteractiveAllow.IsValid()
+	// Session and user IDs
+	GetSessionId() string
+	GetUserId() string
+	GetSessionBindingId() string
 }
 
 type StreamState struct {
-	StreamAuthInfo
-	CurrentUser                     api.UserRequest
-	RemainingUnauthenticatedMethods []string
-	DownstreamChannelInfo           *extensions_ssh.SSHDownstreamChannelInfo
+	StreamInfo
+	AuthContext            *extensions_ssh.AuthContext
+	CurrentUser            api.UserRequest
+	NextRequiredAuthMethod string
+	DownstreamChannelInfo  *extensions_ssh.SSHDownstreamChannelInfo
 }
 
 type InternalChannelRequest struct {
@@ -145,7 +151,8 @@ type InternalChannelRequest struct {
 }
 
 type InternalChannelReply struct {
-	StreamAuthInfo
+	StreamInfo  StreamInfo
+	AuthInfo    StreamAuthInfo
 	CurrentUser api.UserRequest
 }
 
@@ -170,9 +177,11 @@ type StreamHandler struct {
 	terminateC              chan error
 	internalChannelRequestC chan InternalChannelRequest
 	handoffRequestC         chan HandoffRequest
+	terminateFunc           context.CancelCauseFunc
 
-	close   func()
-	runOnce bool
+	close        func()
+	runOnce      bool
+	terminateErr error
 
 	expectingInternalChannel atomic.Bool
 	internalSession          atomic.Pointer[ChannelHandler]
@@ -253,7 +262,10 @@ func (sh *StreamHandler) OnClusterHealthUpdate(_ context.Context, event *datav3.
 }
 
 func (sh *StreamHandler) Terminate(err error) {
-	sh.terminateC <- err
+	sh.terminateErr = err
+	if sh.terminateFunc != nil {
+		sh.terminateFunc(err)
+	}
 }
 
 func (sh *StreamHandler) Close() {
@@ -298,9 +310,9 @@ func (sh *StreamHandler) Prompt(ctx context.Context, prompts *extensions_ssh.Key
 	sh.sendInfoPrompts(prompts)
 	select {
 	case <-ctx.Done():
+		// Important: ctx is expected to be canceled on terminate
+		// TODO sanity check this
 		return nil, context.Cause(ctx)
-	case err := <-sh.terminateC:
-		return nil, err
 	case req := <-sh.readC:
 		switch msg := req.Message.(type) {
 		case *extensions_ssh.ClientMessage_InfoResponse:
@@ -324,9 +336,14 @@ func (sh *StreamHandler) Run(ctx context.Context) error {
 		panic("Run called twice")
 	}
 	sh.runOnce = true
+	if sh.terminateErr != nil {
+		return sh.terminateErr
+	}
+	ctx, sh.terminateFunc = context.WithCancelCause(ctx)
+
 	state := &StreamState{
-		RemainingUnauthenticatedMethods: []string{MethodPublicKey},
-		StreamAuthInfo: StreamAuthInfo{
+		NextRequiredAuthMethod: MethodPublicKey,
+		StreamInfo: StreamInfo{
 			StreamID:      sh.downstream.StreamId,
 			SourceAddress: sh.downstream.SourceAddress.GetSocketAddress().GetAddress(),
 		},
@@ -341,8 +358,6 @@ func (sh *StreamHandler) Run(ctx context.Context) error {
 			if err := sh.reauth(ctx, state); err != nil {
 				return err
 			}
-		case err := <-sh.terminateC:
-			return err
 		case req := <-sh.readC:
 			switch req := req.Message.(type) {
 			case *extensions_ssh.ClientMessage_Event:
@@ -408,7 +423,7 @@ func (sh *StreamHandler) handleHandoffRequest(ctx context.Context, state *Stream
 		req.Err <- status.Error(codes.InvalidArgument, err.Error())
 		return
 	}
-	err := sh.auth.EvaluateDelayed(ctx, state.StreamAuthInfo, pendingUser)
+	err := sh.auth.EvaluateDelayed(ctx, state.StreamInfo, state.AuthContext, pendingUser)
 	if err != nil {
 		lg.Debug().Err(err).Msg("ssh: handoff request denied")
 		req.Err <- status.Error(codes.PermissionDenied, err.Error())
@@ -417,7 +432,7 @@ func (sh *StreamHandler) handleHandoffRequest(ctx context.Context, state *Stream
 	state.CurrentUser = pendingUser
 	lg.Debug().Msg("ssh: user updated successfully; initiating handoff to upstream")
 
-	addr, filters, err := sh.auth.BuildTargetChannelFilters(ctx, state.StreamAuthInfo, state.CurrentUser)
+	addr, filters, err := sh.auth.BuildTargetChannelFilters(ctx, state.StreamInfo, state.AuthContext, state.CurrentUser)
 	if err != nil {
 		log.Ctx(ctx).Err(err).Msg("failed to build extensions for filters")
 		filters = []*corev3.TypedExtensionConfig{}
@@ -432,8 +447,9 @@ func (sh *StreamHandler) handleInternalChannelRequest(state *StreamState, c Inte
 	state.DownstreamChannelInfo = c.DownstreamChannelInfo
 	state.ChannelType = c.ChannelType
 	c.Reply <- InternalChannelReply{
-		StreamAuthInfo: state.StreamAuthInfo.Clone(),
-		CurrentUser:    state.CurrentUser,
+		StreamInfo:  state.StreamInfo,
+		AuthInfo:    proto.CloneOf(state.AuthContext),
+		CurrentUser: state.CurrentUser,
 	}
 }
 
@@ -549,13 +565,13 @@ func (sh *StreamHandler) ServeChannel(
 	}
 	select {
 	case reply := <-infoC:
-		reply.ChannelType = msg.ChanType
+		reply.StreamInfo.ChannelType = msg.ChanType
 		if reply.CurrentUser.Hostname() != "" {
 			panic("bug: current hostname is not empty")
 		}
 		currentUsername := reply.CurrentUser.Username()
 		channel := NewChannelImpl(
-			newStreamHandlerInterfaceImpl(sh, currentUsername, downstreamInfo.DownstreamChannelId, reply.StreamAuthInfo),
+			newStreamHandlerInterfaceImpl(sh, currentUsername, downstreamInfo.DownstreamChannelId, reply.StreamInfo, reply.AuthInfo),
 			stream, downstreamInfo)
 		switch msg.ChanType {
 		case ChannelTypeSession:
@@ -607,7 +623,7 @@ func (sh *StreamHandler) handleAuthRequest(ctx context.Context, state *StreamSta
 	if req.Service != ServiceConnection {
 		return status.Errorf(codes.InvalidArgument, "invalid service: %s", req.Service)
 	}
-	if !slices.Contains(state.RemainingUnauthenticatedMethods, req.AuthMethod) {
+	if req.AuthMethod != state.NextRequiredAuthMethod {
 		return status.Errorf(codes.InvalidArgument, "unexpected auth method: %s", req.AuthMethod)
 	}
 
@@ -615,17 +631,13 @@ func (sh *StreamHandler) handleAuthRequest(ctx context.Context, state *StreamSta
 		return status.Error(codes.InvalidArgument, err.Error())
 	}
 
-	updateMethods := func(add []string) {
-		state.RemainingUnauthenticatedMethods = slices.Remove(state.RemainingUnauthenticatedMethods, req.AuthMethod)
-		state.RemainingUnauthenticatedMethods = append(state.RemainingUnauthenticatedMethods, add...)
-	}
 	log.Ctx(ctx).Debug().
 		Str("method", req.AuthMethod).
 		Str("username", state.CurrentUser.Username()).
 		Str("hostname", state.CurrentUser.Hostname()).
 		Msg("ssh: handling auth request")
 
-	var partial bool
+	var response AuthMethodResponse
 	switch req.AuthMethod {
 	case MethodPublicKey:
 		methodReq, _ := req.MethodRequest.UnmarshalNew()
@@ -633,46 +645,49 @@ func (sh *StreamHandler) handleAuthRequest(ctx context.Context, state *StreamSta
 		if !ok {
 			return status.Errorf(codes.InvalidArgument, "invalid public key method request type")
 		}
-		response, err := sh.auth.HandlePublicKeyMethodRequest(ctx, state.StreamAuthInfo, state.CurrentUser, pubkeyReq)
+
+		var err error
+		response, err = sh.auth.HandlePublicKeyMethodRequest(ctx, state.StreamInfo, state.AuthContext, state.CurrentUser, pubkeyReq)
 		if err != nil {
 			return err
-		} else if response.Allow != nil {
-			partial = true
-			state.PublicKeyFingerprintSha256 = pubkeyReq.PublicKeyFingerprintSha256
 		}
-		state.PublicKeyAllow.Update(response.Allow)
-		updateMethods(response.RequireAdditionalMethods)
 	case MethodKeyboardInteractive:
 		methodReq, _ := req.MethodRequest.UnmarshalNew()
 		kbiReq, ok := methodReq.(*extensions_ssh.KeyboardInteractiveMethodRequest)
 		if !ok {
 			return status.Errorf(codes.InvalidArgument, "invalid keyboard-interactive method request type")
 		}
-		response, err := sh.auth.HandleKeyboardInteractiveMethodRequest(ctx, state.StreamAuthInfo, state.CurrentUser, kbiReq, sh)
+		var err error
+		response, err = sh.auth.HandleKeyboardInteractiveMethodRequest(ctx, state.StreamInfo, state.AuthContext, state.CurrentUser, kbiReq, sh)
 		if err != nil {
 			return err
 		}
-		partial = response.Allow != nil
-		state.KeyboardInteractiveAllow.Update(response.Allow)
-		updateMethods(response.RequireAdditionalMethods)
 	default:
 		return status.Errorf(codes.Internal, "bug: server requested an unsupported auth method %q", req.AuthMethod)
 	}
+	if response.ContextUpdates != nil {
+		if state.AuthContext == nil {
+			state.AuthContext = &extensions_ssh.AuthContext{}
+		}
+		proto.Merge(state.AuthContext, response.ContextUpdates)
+	}
+	state.NextRequiredAuthMethod = response.NextRequiredAuthMethod
+
 	log.Ctx(ctx).Debug().
 		Str("method", req.AuthMethod).
-		Bool("partial", partial).
-		Strs("methods-remaining", state.RemainingUnauthenticatedMethods).
+		Bool("method-allowed", response.AllowMethod).
+		Str("methods-remaining", state.NextRequiredAuthMethod).
 		Msg("ssh: auth request complete")
 
-	if len(state.RemainingUnauthenticatedMethods) == 0 && state.allMethodsValid() {
-		// If there are no methods remaining, the user is allowed if all attempted
-		// methods have a valid response in the state
+	if response.AllowMethod && state.NextRequiredAuthMethod == "" {
+		// If this method was allowed and there are no methods remaining, auth is
+		// successful
 		state.InitialAuthComplete = true
 		log.Ctx(ctx).Debug().Msg("ssh: all methods valid, sending allow response")
 		sh.sendAllowResponse(ctx, state)
 	} else {
 		log.Ctx(ctx).Debug().Msg("ssh: unauthenticated methods remain, sending deny response")
-		sh.sendDenyResponseWithRemainingMethods(partial, state)
+		sh.sendDenyResponseWithRemainingMethods(response.AllowMethod, state)
 	}
 	return nil
 }
@@ -681,7 +696,7 @@ func (sh *StreamHandler) reauth(ctx context.Context, state *StreamState) error {
 	if !state.InitialAuthComplete {
 		return nil
 	}
-	err := sh.auth.EvaluateDelayed(ctx, state.StreamAuthInfo, state.CurrentUser)
+	err := sh.auth.EvaluateDelayed(ctx, state.StreamInfo, state.AuthContext, state.CurrentUser)
 	if err != nil {
 		return err
 	}
@@ -689,7 +704,7 @@ func (sh *StreamHandler) reauth(ctx context.Context, state *StreamState) error {
 }
 
 func buildHandoffAction(state *StreamState, ptyInfo api.SSHPtyInfo, addr *corev3.SocketAddress, filters []*corev3.TypedExtensionConfig) *extensions_ssh.SSHChannelControlAction {
-	upstreamAllow := buildUpstreamAllowResponse(state.StreamAuthInfo, state.CurrentUser, addr, filters)
+	upstreamAllow := buildUpstreamAllowResponse(state, addr, filters)
 	var downstreamPtyInfo *extensions_ssh.SSHDownstreamPTYInfo
 	if ptyInfo != nil {
 		downstreamPtyInfo = &extensions_ssh.SSHDownstreamPTYInfo{
@@ -756,13 +771,18 @@ func (sh *StreamHandler) PortForwardManager() *portforward.Manager {
 }
 
 func (sh *StreamHandler) sendDenyResponseWithRemainingMethods(partial bool, state *StreamState) {
+	var methods []string
+	// empty string is not a valid method, it signals lack of next method
+	if state.NextRequiredAuthMethod != "" {
+		methods = append(methods, state.NextRequiredAuthMethod)
+	}
 	sh.writeC <- &extensions_ssh.ServerMessage{
 		Message: &extensions_ssh.ServerMessage_AuthResponse{
 			AuthResponse: &extensions_ssh.AuthenticationResponse{
 				Response: &extensions_ssh.AuthenticationResponse_Deny{
 					Deny: &extensions_ssh.DenyResponse{
 						Partial: partial,
-						Methods: state.RemainingUnauthenticatedMethods,
+						Methods: methods,
 					},
 				},
 			},
@@ -777,14 +797,14 @@ func (sh *StreamHandler) sendAllowResponse(ctx context.Context, state *StreamSta
 	}
 	if state.CurrentUser.Hostname() == "" {
 		sh.expectingInternalChannel.Store(true)
-		allow = buildInternalAllowResponse(state.StreamAuthInfo, state.CurrentUser)
+		allow = buildInternalAllowResponse(state)
 	} else {
-		addr, filters, err := sh.auth.BuildTargetChannelFilters(ctx, state.StreamAuthInfo, state.CurrentUser)
+		addr, filters, err := sh.auth.BuildTargetChannelFilters(ctx, state.StreamInfo, state.AuthContext, state.CurrentUser)
 		if err != nil {
 			log.Ctx(ctx).Err(err).Msg("failed to build channel filters")
 			filters = []*corev3.TypedExtensionConfig{}
 		}
-		allow = buildUpstreamAllowResponse(state.StreamAuthInfo, state.CurrentUser, addr, filters)
+		allow = buildUpstreamAllowResponse(state, addr, filters)
 	}
 
 	sh.writeC <- &extensions_ssh.ServerMessage{
@@ -814,48 +834,51 @@ func (sh *StreamHandler) sendInfoPrompts(prompts *extensions_ssh.KeyboardInterac
 }
 
 func buildUpstreamAllowResponse(
-	info StreamAuthInfo,
-	user api.UserRequest,
+	state *StreamState,
 	address *corev3.SocketAddress,
 	filters []*corev3.TypedExtensionConfig,
 ) *extensions_ssh.AllowResponse {
-	var allowedMethods []*extensions_ssh.AllowedMethod
-	if value := info.PublicKeyAllow.Value; value != nil {
-		allowedMethods = append(allowedMethods, &extensions_ssh.AllowedMethod{
-			Method:     MethodPublicKey,
-			MethodData: protoutil.NewAny(value),
-		})
+	authContext := proto.CloneOf(state.AuthContext)
+	now := time.Now()
+	certOptions := &extensions_ssh.CertificateOptions{
+		PermitPortForwarding:  true,
+		PermitAgentForwarding: true,
+		PermitX11Forwarding:   true,
+		PermitPty:             true,
+		PermitUserRc:          true,
+		// These timestamps are just for the temporary certificate and are only
+		// checked by the upstream at the time of login. The durations aren't
+		// particularly important and don't correspond to pomerium session
+		// validity. The temporary certificates are only used for this connection
+		// and are never shared with the downstream.
+		ValidStartTime: timestamppb.New(now.Add(-1 * time.Minute)),
+		ValidEndTime:   timestamppb.New(now.Add(1 * time.Hour)),
 	}
-	if value := info.KeyboardInteractiveAllow.Value; value != nil {
-		allowedMethods = append(allowedMethods, &extensions_ssh.AllowedMethod{
-			Method:     MethodKeyboardInteractive,
-			MethodData: protoutil.NewAny(value),
-		})
-	}
-
 	return &extensions_ssh.AllowResponse{
-		Username: user.Username(),
+		LoginName:   state.CurrentUser.Username(),
+		AuthContext: authContext,
 		Target: &extensions_ssh.AllowResponse_Upstream{
 			Upstream: &extensions_ssh.UpstreamTarget{
-				Hostname:       user.Hostname(),
-				Address:        address,
-				DirectTcpip:    info.ChannelType == ChannelTypeDirectTcpip,
-				AllowedMethods: allowedMethods,
-				ChannelFilters: filters,
+				Hostname:           state.CurrentUser.Hostname(),
+				Address:            address,
+				DirectTcpip:        state.ChannelType == ChannelTypeDirectTcpip,
+				ChannelFilters:     filters,
+				CertificateOptions: certOptions,
 			},
 		},
 	}
 }
 
-func buildInternalAllowResponse(info StreamAuthInfo, user api.UserRequest) *extensions_ssh.AllowResponse {
+func buildInternalAllowResponse(state *StreamState) *extensions_ssh.AllowResponse {
 	return &extensions_ssh.AllowResponse{
-		Username: user.Username(),
+		LoginName:   state.CurrentUser.Username(),
+		AuthContext: state.AuthContext,
 		Target: &extensions_ssh.AllowResponse_Internal{
 			Internal: &extensions_ssh.InternalTarget{
 				SetMetadata: &corev3.Metadata{
 					TypedFilterMetadata: map[string]*anypb.Any{
 						"com.pomerium.ssh": protoutil.NewAny(&extensions_ssh.FilterMetadata{
-							StreamId: info.StreamID,
+							StreamId: state.StreamID,
 						}),
 					},
 				},
@@ -868,6 +891,7 @@ type streamHandlerInterfaceImpl struct {
 	*StreamHandler
 	username            string
 	downstreamChannelID uint32
+	streamInfo          StreamInfo
 	authInfo            StreamAuthInfo
 }
 
@@ -875,11 +899,12 @@ type streamHandlerInterfaceImpl struct {
 // fields contained in the StreamState which are needed to implement this
 // interface. The StreamState is not stored in the StreamHandler, so it cannot
 // implement this interface itself.
-func newStreamHandlerInterfaceImpl(sh *StreamHandler, username string, downstreamChannelID uint32, authInfo StreamAuthInfo) api.StreamHandlerInterface {
+func newStreamHandlerInterfaceImpl(sh *StreamHandler, username string, downstreamChannelID uint32, streamInfo StreamInfo, authInfo StreamAuthInfo) api.StreamHandlerInterface {
 	return &streamHandlerInterfaceImpl{
 		StreamHandler:       sh,
 		username:            username,
 		downstreamChannelID: downstreamChannelID,
+		streamInfo:          streamInfo,
 		authInfo:            authInfo,
 	}
 }
@@ -891,12 +916,12 @@ func (si *streamHandlerInterfaceImpl) DownstreamChannelID() uint32 {
 
 // DownstreamSourceAddress implements StreamHandlerInterface.
 func (si *streamHandlerInterfaceImpl) DownstreamSourceAddress() string {
-	return si.authInfo.SourceAddress
+	return si.streamInfo.SourceAddress
 }
 
 // DownstreamPublicKeyFingerprint implements StreamHandlerInterface.
 func (si *streamHandlerInterfaceImpl) DownstreamPublicKeyFingerprint() []byte {
-	return si.authInfo.PublicKeyFingerprintSha256
+	return si.authInfo.GetPublicKeyFingerprintSha256()
 }
 
 // Username implements StreamHandlerInterface.
@@ -906,10 +931,10 @@ func (si *streamHandlerInterfaceImpl) Username() string {
 
 // GetSession implements StreamHandlerInterface
 func (si *streamHandlerInterfaceImpl) GetSession(ctx context.Context) (*session.Session, error) {
-	return si.auth.GetSession(ctx, si.authInfo)
+	return si.auth.GetSession(ctx, si.streamInfo, si.authInfo)
 }
 
 // DeleteSession implements StreamHandlerInterface
 func (si *streamHandlerInterfaceImpl) DeleteSession(ctx context.Context) error {
-	return si.auth.DeleteSession(ctx, si.authInfo)
+	return si.auth.DeleteSession(ctx, si.streamInfo, si.authInfo)
 }

--- a/pkg/ssh/stream_test.go
+++ b/pkg/ssh/stream_test.go
@@ -131,7 +131,7 @@ type StreamHandlerSuite struct {
 func (s *StreamHandlerSuite) SetupTest() {
 	s.ctrl = NewController(s.T())
 	s.mockAuth = mock_ssh.NewMockAuthInterface(s.ctrl)
-	s.mockAuth.EXPECT().BuildTargetChannelFilters(Any(), Any(), Any()).AnyTimes()
+	s.mockAuth.EXPECT().BuildTargetChannelFilters(Any(), Any(), Any(), Any()).AnyTimes()
 	s.cleanup = []func(){}
 	s.errC = make(chan error, 1)
 
@@ -158,7 +158,7 @@ func (s *StreamHandlerSuite) SetupTest() {
 	s.mgr = ssh.NewStreamManager(
 		s.T().Context(),
 		s.mockAuth,
-		ssh.NewInMemoryPolicyIndexer(staticFakePolicyEvaluator(true, nil)),
+		ssh.NewInMemoryPolicyIndexer(staticFakePolicyEvaluator(evalResultAlwaysAllow, nil)),
 		ssh.NewDefaultCLIController(s.cfg, style.NewTheme(style.Ansi16Colors)),
 		s.cfg,
 	)
@@ -360,12 +360,42 @@ func (s *StreamHandlerSuite) validPublicKeyMethodRequest() *anypb.Any {
 	return marshalAny(&extensions_ssh.PublicKeyMethodRequest{
 		PublicKey:                  s.ed25519SshPublicKey.Marshal(),
 		PublicKeyAlg:               s.ed25519SshPublicKey.Type(),
-		PublicKeyFingerprintSha256: []byte(gossh.FingerprintSHA256(s.ed25519SshPublicKey)),
+		PublicKeyFingerprintSha256: RawFingerprintSHA256(s.ed25519SshPublicKey),
 	})
 }
 
 func (s *StreamHandlerSuite) newMockChannelStream() *mockChannelStream {
 	return newMockChannelStream(s.streamCtx, s.T())
+}
+
+func (s *StreamHandlerSuite) newPublicKeyFromRequest(req *extensions_ssh.PublicKeyMethodRequest) gossh.PublicKey {
+	key, err := gossh.ParsePublicKey(req.PublicKey)
+	require.NoError(s.T(), err)
+	return key
+}
+
+func (s *StreamHandlerSuite) authMethodResponsePublicKeyAllow(publicKey gossh.PublicKey) ssh.AuthMethodResponse {
+	return ssh.AuthMethodResponse{
+		AllowMethod:              true,
+		NoFurtherMethodsRequired: true,
+		ContextUpdates: &extensions_ssh.AuthContext{
+			PublicKey:                  publicKey.Marshal(),
+			PublicKeyAlg:               publicKey.Type(),
+			PublicKeyFingerprintSha256: RawFingerprintSHA256(publicKey),
+		},
+	}
+}
+
+func (s *StreamHandlerSuite) authMethodResponsePublicKeyAllowKbdIntNext(publicKey gossh.PublicKey) ssh.AuthMethodResponse {
+	return ssh.AuthMethodResponse{
+		AllowMethod:            true,
+		NextRequiredAuthMethod: ssh.MethodKeyboardInteractive,
+		ContextUpdates: &extensions_ssh.AuthContext{
+			PublicKey:                  publicKey.Marshal(),
+			PublicKeyAlg:               publicKey.Type(),
+			PublicKeyFingerprintSha256: RawFingerprintSHA256(publicKey),
+		},
+	}
 }
 
 //
@@ -474,11 +504,8 @@ func (s *StreamHandlerSuite) TestHandleAuthRequest_EmptyHostname() {
 
 	// empty hostname is allowed initially
 	s.mockAuth.EXPECT().
-		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
-		Return(ssh.PublicKeyAuthMethodResponse{Allow: &extensions_ssh.PublicKeyAllowResponse{
-			PublicKey:   s.ed25519SshPublicKey.Marshal(),
-			Permissions: &extensions_ssh.Permissions{},
-		}}, nil)
+		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
+		Return(s.authMethodResponsePublicKeyAllow(s.ed25519SshPublicKey), nil)
 
 	sh.ReadC() <- &extensions_ssh.ClientMessage{
 		Message: &extensions_ssh.ClientMessage_AuthRequest{
@@ -519,11 +546,8 @@ func (s *StreamHandlerSuite) TestHandleAuthRequest_ValidPublicKeyMethodRequest()
 	sh := s.startStreamHandler(1)
 
 	s.mockAuth.EXPECT().
-		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
-		Return(ssh.PublicKeyAuthMethodResponse{Allow: &extensions_ssh.PublicKeyAllowResponse{
-			PublicKey:   s.ed25519SshPublicKey.Marshal(),
-			Permissions: &extensions_ssh.Permissions{},
-		}}, nil)
+		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
+		Return(s.authMethodResponsePublicKeyAllow(s.ed25519SshPublicKey), nil)
 
 	sh.ReadC() <- &extensions_ssh.ClientMessage{
 		Message: &extensions_ssh.ClientMessage_AuthRequest{
@@ -545,8 +569,8 @@ func (s *StreamHandlerSuite) TestHandleAuthRequest_ValidPublicKeyMethodRequestEr
 	sh := s.startStreamHandler(1)
 
 	s.mockAuth.EXPECT().
-		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
-		Return(ssh.PublicKeyAuthMethodResponse{}, errors.New("test error"))
+		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
+		Return(ssh.AuthMethodResponse{}, errors.New("test error"))
 
 	s.expectError(func() {
 		sh.ReadC() <- &extensions_ssh.ClientMessage{
@@ -569,20 +593,17 @@ func (s *StreamHandlerSuite) TestHandleAuthRequest_PublicKeyRetry() {
 
 	i := -1
 	s.mockAuth.EXPECT().
-		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
+		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
 		MaxTimes(4).
-		DoAndReturn(func(_ context.Context, _ ssh.StreamAuthInfo, _ api.UserRequest, _ *extensions_ssh.PublicKeyMethodRequest) (ssh.PublicKeyAuthMethodResponse, error) {
+		DoAndReturn(func(_ context.Context, _ ssh.StreamInfo, _ ssh.StreamAuthInfo, _ api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (ssh.AuthMethodResponse, error) {
 			i++
 			switch i {
 			case 0, 1, 2:
-				return ssh.PublicKeyAuthMethodResponse{
-					RequireAdditionalMethods: []string{"publickey"},
+				return ssh.AuthMethodResponse{
+					NextRequiredAuthMethod: "publickey",
 				}, nil
 			case 3:
-				return ssh.PublicKeyAuthMethodResponse{Allow: &extensions_ssh.PublicKeyAllowResponse{
-					PublicKey:   s.ed25519SshPublicKey.Marshal(),
-					Permissions: &extensions_ssh.Permissions{},
-				}}, nil
+				return s.authMethodResponsePublicKeyAllow(s.newPublicKeyFromRequest(req)), nil
 			default:
 				panic("unreachable")
 			}
@@ -613,11 +634,11 @@ func (s *StreamHandlerSuite) TestHandleAuthRequest_InconsistentUsername() {
 	sh := s.startStreamHandler(1)
 
 	s.mockAuth.EXPECT().
-		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
+		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
 		Times(1).
-		DoAndReturn(func(_ context.Context, _ ssh.StreamAuthInfo, _ api.UserRequest, _ *extensions_ssh.PublicKeyMethodRequest) (ssh.PublicKeyAuthMethodResponse, error) {
-			return ssh.PublicKeyAuthMethodResponse{
-				RequireAdditionalMethods: []string{"publickey"},
+		DoAndReturn(func(_ context.Context, _ ssh.StreamInfo, _ ssh.StreamAuthInfo, _ api.UserRequest, _ *extensions_ssh.PublicKeyMethodRequest) (ssh.AuthMethodResponse, error) {
+			return ssh.AuthMethodResponse{
+				NextRequiredAuthMethod: "publickey",
 			}, nil
 		})
 	sh.ReadC() <- &extensions_ssh.ClientMessage{
@@ -655,11 +676,11 @@ func (s *StreamHandlerSuite) TestHandleAuthRequest_InconsistentHostname() {
 	sh := s.startStreamHandler(1)
 
 	s.mockAuth.EXPECT().
-		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
+		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
 		Times(1).
-		DoAndReturn(func(_ context.Context, _ ssh.StreamAuthInfo, _ api.UserRequest, _ *extensions_ssh.PublicKeyMethodRequest) (ssh.PublicKeyAuthMethodResponse, error) {
-			return ssh.PublicKeyAuthMethodResponse{
-				RequireAdditionalMethods: []string{"publickey"},
+		DoAndReturn(func(_ context.Context, _ ssh.StreamInfo, _ ssh.StreamAuthInfo, _ api.UserRequest, _ *extensions_ssh.PublicKeyMethodRequest) (ssh.AuthMethodResponse, error) {
+			return ssh.AuthMethodResponse{
+				NextRequiredAuthMethod: "publickey",
 			}, nil
 		})
 	sh.ReadC() <- &extensions_ssh.ClientMessage{
@@ -695,16 +716,10 @@ func (s *StreamHandlerSuite) TestHandleAuthRequest_InconsistentEmptyHostname() {
 	sh := s.startStreamHandler(1)
 
 	s.mockAuth.EXPECT().
-		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
+		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
 		Times(1).
-		DoAndReturn(func(_ context.Context, _ ssh.StreamAuthInfo, _ api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (ssh.PublicKeyAuthMethodResponse, error) {
-			return ssh.PublicKeyAuthMethodResponse{
-				Allow: &extensions_ssh.PublicKeyAllowResponse{
-					PublicKey:   req.PublicKey,
-					Permissions: &extensions_ssh.Permissions{},
-				},
-				RequireAdditionalMethods: []string{"keyboard-interactive"},
-			}, nil
+		DoAndReturn(func(_ context.Context, _ ssh.StreamInfo, _ ssh.StreamAuthInfo, _ api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (ssh.AuthMethodResponse, error) {
+			return s.authMethodResponsePublicKeyAllowKbdIntNext(s.newPublicKeyFromRequest(req)), nil
 		})
 	sh.ReadC() <- &extensions_ssh.ClientMessage{
 		Message: &extensions_ssh.ClientMessage_AuthRequest{
@@ -755,11 +770,11 @@ func (s *StreamHandlerSuite) TestHandleAuthRequest_UnknownAuthMethod() {
 func (s *StreamHandlerSuite) TestHandleAuthRequest_UnimplementedAuthMethod() {
 	sh := s.startStreamHandler(1)
 	s.mockAuth.EXPECT().
-		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
+		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
 		Times(1).
-		DoAndReturn(func(_ context.Context, _ ssh.StreamAuthInfo, _ api.UserRequest, _ *extensions_ssh.PublicKeyMethodRequest) (ssh.PublicKeyAuthMethodResponse, error) {
-			return ssh.PublicKeyAuthMethodResponse{
-				RequireAdditionalMethods: []string{"password"},
+		DoAndReturn(func(_ context.Context, _ ssh.StreamInfo, _ ssh.StreamAuthInfo, _ api.UserRequest, _ *extensions_ssh.PublicKeyMethodRequest) (ssh.AuthMethodResponse, error) {
+			return ssh.AuthMethodResponse{
+				NextRequiredAuthMethod: "password",
 			}, nil
 		})
 	sh.ReadC() <- &extensions_ssh.ClientMessage{
@@ -793,16 +808,10 @@ func (s *StreamHandlerSuite) TestHandleAuthRequest_UnimplementedAuthMethod() {
 func (s *StreamHandlerSuite) TestHandleAuthRequest_WrongClientMessage() {
 	sh := s.startStreamHandler(1)
 	s.mockAuth.EXPECT().
-		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
+		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
 		Times(1).
-		DoAndReturn(func(_ context.Context, _ ssh.StreamAuthInfo, _ api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (ssh.PublicKeyAuthMethodResponse, error) {
-			return ssh.PublicKeyAuthMethodResponse{
-				Allow: &extensions_ssh.PublicKeyAllowResponse{
-					PublicKey:   req.PublicKey,
-					Permissions: &extensions_ssh.Permissions{},
-				},
-				RequireAdditionalMethods: []string{"keyboard-interactive"},
-			}, nil
+		DoAndReturn(func(_ context.Context, _ ssh.StreamInfo, _ ssh.StreamAuthInfo, _ api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (ssh.AuthMethodResponse, error) {
+			return s.authMethodResponsePublicKeyAllowKbdIntNext(s.newPublicKeyFromRequest(req)), nil
 		})
 	newMsg := func() *extensions_ssh.ClientMessage_AuthRequest {
 		return &extensions_ssh.ClientMessage_AuthRequest{
@@ -831,16 +840,10 @@ func (s *StreamHandlerSuite) TestHandleAuthRequest_KeyboardInteractive_WrongMeth
 	sh := s.startStreamHandler(1)
 
 	s.mockAuth.EXPECT().
-		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
+		HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
 		Times(1).
-		DoAndReturn(func(_ context.Context, _ ssh.StreamAuthInfo, _ api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (ssh.PublicKeyAuthMethodResponse, error) {
-			return ssh.PublicKeyAuthMethodResponse{
-				Allow: &extensions_ssh.PublicKeyAllowResponse{
-					PublicKey:   req.PublicKey,
-					Permissions: &extensions_ssh.Permissions{},
-				},
-				RequireAdditionalMethods: []string{"keyboard-interactive"},
-			}, nil
+		DoAndReturn(func(_ context.Context, _ ssh.StreamInfo, _ ssh.StreamAuthInfo, _ api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (ssh.AuthMethodResponse, error) {
+			return s.authMethodResponsePublicKeyAllowKbdIntNext(s.newPublicKeyFromRequest(req)), nil
 		})
 	sh.ReadC() <- &extensions_ssh.ClientMessage{
 		Message: &extensions_ssh.ClientMessage_AuthRequest{
@@ -878,39 +881,34 @@ func init() {
 
 		i := -1
 		s.mockAuth.EXPECT().
-			HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
+			HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
 			Times(2).
-			DoAndReturn(func(_ context.Context, _ ssh.StreamAuthInfo, _ api.UserRequest, _ *extensions_ssh.PublicKeyMethodRequest) (ssh.PublicKeyAuthMethodResponse, error) {
+			DoAndReturn(func(_ context.Context, _ ssh.StreamInfo, _ ssh.StreamAuthInfo, _ api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (ssh.AuthMethodResponse, error) {
 				i++
 				switch i {
 				case 0:
-					return ssh.PublicKeyAuthMethodResponse{
-						RequireAdditionalMethods: []string{"publickey"},
+					return ssh.AuthMethodResponse{
+						NextRequiredAuthMethod: "publickey",
 					}, nil
 				case 1:
-					return ssh.PublicKeyAuthMethodResponse{
-						Allow: &extensions_ssh.PublicKeyAllowResponse{
-							PublicKey:   s.ed25519SshPublicKey.Marshal(),
-							Permissions: &extensions_ssh.Permissions{},
-						},
-						RequireAdditionalMethods: []string{"keyboard-interactive"},
-					}, nil
+					return s.authMethodResponsePublicKeyAllowKbdIntNext(s.newPublicKeyFromRequest(req)), nil
 				default:
 					panic("unreachable")
 				}
 			})
 		s.mockAuth.EXPECT().
-			HandleKeyboardInteractiveMethodRequest(Any(), Any(), Any(), Any(), Any()).
+			HandleKeyboardInteractiveMethodRequest(Any(), Any(), Any(), Any(), Any(), Any()).
 			DoAndReturn(func(
 				ctx context.Context,
-				info ssh.StreamAuthInfo,
+				streamInfo ssh.StreamInfo,
+				authInfo ssh.StreamAuthInfo,
 				user api.UserRequest,
 				_ *extensions_ssh.KeyboardInteractiveMethodRequest,
 				querier ssh.KeyboardInteractiveQuerier,
-			) (ssh.KeyboardInteractiveAuthMethodResponse, error) {
+			) (ssh.AuthMethodResponse, error) {
 				s.Equal("test", user.Username())
 				s.Equal("host1", user.Hostname())
-				s.Equal(uint64(100), info.StreamID)
+				s.Equal(uint64(100), streamInfo.StreamID)
 				resp, err := querier.Prompt(ctx, &extensions_ssh.KeyboardInteractiveInfoPrompts{
 					Name:        "test-name",
 					Instruction: "test-instruction",
@@ -924,11 +922,17 @@ func init() {
 				s.Require().Equal(querierErr, err, "unexpected error from querier.Prompt")
 				if querierErr == nil {
 					s.Equal([]string{"test-prompt-response"}, resp.Responses)
-					return ssh.KeyboardInteractiveAuthMethodResponse{
-						Allow: &extensions_ssh.KeyboardInteractiveAllowResponse{},
+					return ssh.AuthMethodResponse{
+						AllowMethod:              true,
+						NoFurtherMethodsRequired: true,
+						ContextUpdates: &extensions_ssh.AuthContext{
+							SessionId:        "fake-session-id",
+							UserId:           "fake-user-id",
+							SessionBindingId: "fake-session-binding-id",
+						},
 					}, nil
 				}
-				return ssh.KeyboardInteractiveAuthMethodResponse{}, err
+				return ssh.AuthMethodResponse{}, err
 			})
 		for range 2 {
 			sh.ReadC() <- &extensions_ssh.ClientMessage{
@@ -1201,18 +1205,12 @@ func init() {
 		sh := s.startStreamHandler(1)
 
 		s.mockAuth.EXPECT().
-			HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any()).
+			HandlePublicKeyMethodRequest(Any(), Any(), Any(), Any(), Any()).
 			Times(1).
-			DoAndReturn(func(_ context.Context, _ ssh.StreamAuthInfo, user api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (ssh.PublicKeyAuthMethodResponse, error) {
+			DoAndReturn(func(_ context.Context, _ ssh.StreamInfo, _ ssh.StreamAuthInfo, user api.UserRequest, req *extensions_ssh.PublicKeyMethodRequest) (ssh.AuthMethodResponse, error) {
 				s.Equal("test", user.Username())
 				s.Equal("", user.Hostname())
-				return ssh.PublicKeyAuthMethodResponse{
-					Allow: &extensions_ssh.PublicKeyAllowResponse{
-						PublicKey:   req.PublicKey,
-						Permissions: &extensions_ssh.Permissions{},
-					},
-					RequireAdditionalMethods: []string{},
-				}, nil
+				return s.authMethodResponsePublicKeyAllow(s.newPublicKeyFromRequest(req)), nil
 			})
 		s.False(sh.IsExpectingInternalChannel())
 		sh.ReadC() <- &extensions_ssh.ClientMessage{
@@ -1549,7 +1547,7 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Interactive() {
 		IdpId:  "b",
 	}
 	s.mockAuth.EXPECT().
-		GetSession(Any(), Any()).
+		GetSession(Any(), Any(), Any()).
 		Return(session, nil)
 
 	recvChannelMsg[ssh.ChannelRequestSuccessMsg](s, stream)
@@ -1835,8 +1833,8 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_RoutesPortal_Select() {
 			})
 		case 2:
 			currentFrame++
-			s.mockAuth.EXPECT().EvaluateDelayed(Any(), Any(), Any()).
-				DoAndReturn(func(_ context.Context, _ ssh.StreamAuthInfo, user api.UserRequest) error {
+			s.mockAuth.EXPECT().EvaluateDelayed(Any(), Any(), Any(), Any()).
+				DoAndReturn(func(_ context.Context, _ ssh.StreamInfo, _ ssh.StreamAuthInfo, user api.UserRequest) error {
 					s.Equal("test", user.Username())
 					s.Equal("host2", user.Hostname())
 					return nil
@@ -1872,19 +1870,15 @@ LOOP:
 			handoff := sshAction.GetHandOff()
 			s.Require().NotNil(action, "expected handoff action")
 			s.Require().NotNil(handoff.GetUpstreamAuth().GetUpstream(), "expected upstream handoff action")
-			s.Equal("test", handoff.GetUpstreamAuth().Username)
+			s.Equal("test", handoff.GetUpstreamAuth().GetLoginName())
 			s.Equal("host2", handoff.GetUpstreamAuth().GetUpstream().Hostname)
 			s.Equal(uint32(32), handoff.GetDownstreamPtyInfo().GetWidthColumns())
 			s.Equal(uint32(10), handoff.GetDownstreamPtyInfo().GetHeightRows())
-			testutil.AssertProtoEqual(s.T(), []*extensions_ssh.AllowedMethod{
-				{
-					Method: "publickey",
-					MethodData: marshalAny(&extensions_ssh.PublicKeyAllowResponse{
-						PublicKey:   s.ed25519SshPublicKey.Marshal(),
-						Permissions: &extensions_ssh.Permissions{},
-					}),
-				},
-			}, handoff.GetUpstreamAuth().GetUpstream().AllowedMethods)
+
+			s.Equal(s.ed25519SshPublicKey.Marshal(), handoff.GetUpstreamAuth().GetAuthContext().GetPublicKey())
+			s.Equal(s.ed25519SshPublicKey.Type(), handoff.GetUpstreamAuth().GetAuthContext().GetPublicKeyAlg())
+			s.Equal(RawFingerprintSHA256(s.ed25519SshPublicKey), handoff.GetUpstreamAuth().GetAuthContext().GetPublicKeyFingerprintSha256())
+
 			handoffOk = true
 			break LOOP
 		}
@@ -1940,7 +1934,7 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_Whoami() {
 		IdpId:  "b",
 	}
 	s.mockAuth.EXPECT().
-		GetSession(Any(), Any()).
+		GetSession(Any(), Any(), Any()).
 		Return(session, nil)
 
 	// The formatted session includes information about session expiry (e.g.,
@@ -1985,7 +1979,7 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_WhoamiError() {
 	peerID := resp.MyID
 
 	s.mockAuth.EXPECT().
-		GetSession(Any(), Any()).
+		GetSession(Any(), Any(), Any()).
 		Return(nil, errors.New("test error"))
 
 	stream.SendClientToServer(channelMsg(ssh.ChannelRequestMsg{
@@ -2014,7 +2008,7 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_Logout() {
 	peerID := resp.MyID
 
 	s.mockAuth.EXPECT().
-		DeleteSession(Any(), Any()).
+		DeleteSession(Any(), Any(), Any()).
 		Return(nil)
 
 	stream.SendClientToServer(channelMsg(ssh.ChannelRequestMsg{
@@ -2043,7 +2037,7 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_LogoutError() {
 	peerID := resp.MyID
 
 	s.mockAuth.EXPECT().
-		DeleteSession(Any(), Any()).
+		DeleteSession(Any(), Any(), Any()).
 		Return(status.Errorf(codes.Aborted, "failed to delete session"))
 
 	stream.SendClientToServer(channelMsg(ssh.ChannelRequestMsg{
@@ -2093,7 +2087,7 @@ func (s *StreamHandlerSuite) TestServeChannel_DirectTcpip_BadHostname() {
 func (s *StreamHandlerSuite) TestServeChannel_DirectTcpip_AuthFailed() {
 	if s.directTcpipEnabled() {
 		s.mockAuth.EXPECT().
-			EvaluateDelayed(Any(), Any(), Any()).
+			EvaluateDelayed(Any(), Any(), Any(), Any()).
 			Times(1).
 			Return(errors.New("test error"))
 	}
@@ -2118,7 +2112,7 @@ func (s *StreamHandlerSuite) TestServeChannel_DirectTcpip() {
 
 	if s.directTcpipEnabled() {
 		s.mockAuth.EXPECT().
-			EvaluateDelayed(Any(), Any(), Any()).
+			EvaluateDelayed(Any(), Any(), Any(), Any()).
 			Times(1).
 			Return(nil)
 	}
@@ -2144,6 +2138,15 @@ func (s *StreamHandlerSuite) TestServeChannel_DirectTcpip() {
 	s.Require().NotNil(action, "received a message, but it was not a channel control action")
 	handoff := extensions_ssh.SSHChannelControlAction{}
 	s.Require().NoError(action.UnmarshalTo(&handoff))
+
+	actual := handoff.GetHandOff()
+	// Can't compare timestamppb.Timestamp, so check the timestamps directly and
+	// then clear the fields
+	certOptions := actual.UpstreamAuth.GetUpstream().CertificateOptions
+	s.Less(certOptions.ValidStartTime.AsTime(), certOptions.ValidEndTime.AsTime())
+	certOptions.ValidStartTime = nil
+	certOptions.ValidEndTime = nil
+
 	testutil.AssertProtoEqual(s.T(), extensions_ssh.SSHChannelControlAction_HandOffUpstream{
 		DownstreamChannelInfo: &extensions_ssh.SSHDownstreamChannelInfo{
 			ChannelType:               "direct-tcpip",
@@ -2154,24 +2157,28 @@ func (s *StreamHandlerSuite) TestServeChannel_DirectTcpip() {
 		},
 		DownstreamPtyInfo: nil,
 		UpstreamAuth: &extensions_ssh.AllowResponse{
-			Username: "test",
+			LoginName: "test",
+			AuthContext: &extensions_ssh.AuthContext{
+				PublicKey:                  s.ed25519SshPublicKey.Marshal(),
+				PublicKeyAlg:               s.ed25519SshPublicKey.Type(),
+				PublicKeyFingerprintSha256: RawFingerprintSHA256(s.ed25519SshPublicKey),
+			},
 			Target: &extensions_ssh.AllowResponse_Upstream{
 				Upstream: &extensions_ssh.UpstreamTarget{
 					Hostname:    "host1",
 					DirectTcpip: true,
-					AllowedMethods: []*extensions_ssh.AllowedMethod{
-						{
-							Method: "publickey",
-							MethodData: marshalAny(&extensions_ssh.PublicKeyAllowResponse{
-								PublicKey:   s.ed25519SshPublicKey.Marshal(),
-								Permissions: &extensions_ssh.Permissions{},
-							}),
-						},
+					CertificateOptions: &extensions_ssh.CertificateOptions{
+						PermitPortForwarding:  true,
+						PermitAgentForwarding: true,
+						PermitX11Forwarding:   true,
+						PermitPty:             true,
+						PermitUserRc:          true,
+						// omit start/end time fields
 					},
 				},
 			},
 		},
-	}, handoff.GetHandOff())
+	}, actual)
 }
 
 func (s *StreamHandlerSuite) directTcpipEnabled() bool {
@@ -2285,103 +2292,109 @@ func TestStreamHandlerSuiteWithRuntimeFlags(t *testing.T) {
 	})
 }
 
-func TestAuthMethodValue(t *testing.T) {
-	t.Run("Update to a non-nil value", func(t *testing.T) {
-		var amv ssh.AuthMethodValue[*extensions_ssh.PublicKeyAllowResponse]
-		assert.True(t, amv.IsValid())
-		amv.Update(&extensions_ssh.PublicKeyAllowResponse{})
-		assert.True(t, amv.IsValid())
-	})
-	t.Run("Update to a nil value", func(t *testing.T) {
+func TestValidateAuthMethodResponse(t *testing.T) {
+	validResponses := []ssh.AuthMethodResponse{
+		{},
 		{
-			var amv ssh.AuthMethodValue[*extensions_ssh.PublicKeyAllowResponse]
-			assert.True(t, amv.IsValid())
-			amv.Update(nil)
-			assert.False(t, amv.IsValid())
-		}
+			AllowMethod:            true,
+			NextRequiredAuthMethod: "keyboard-interactive",
+			ContextUpdates:         &extensions_ssh.AuthContext{},
+		},
 		{
-			var amv ssh.AuthMethodValue[*extensions_ssh.PublicKeyAllowResponse]
-			assert.True(t, amv.IsValid())
-			amv.Update(&extensions_ssh.PublicKeyAllowResponse{})
-			assert.True(t, amv.IsValid())
-			amv.Update(nil)
-			assert.False(t, amv.IsValid())
-		}
-	})
-	t.Run("Clone", func(t *testing.T) {
+			AllowMethod:              true,
+			NoFurtherMethodsRequired: true,
+			ContextUpdates:           &extensions_ssh.AuthContext{},
+		},
 		{
-			var amv ssh.AuthMethodValue[*extensions_ssh.PublicKeyAllowResponse]
-			clone := amv.Clone()
-			assert.Equal(t, amv, clone)
-		}
+			AllowMethod:            true,
+			NextRequiredAuthMethod: "keyboard-interactive",
+		},
 		{
-			var amv ssh.AuthMethodValue[*extensions_ssh.PublicKeyAllowResponse]
-			amv.Update(nil)
-			clone := amv.Clone()
-			assert.Equal(t, amv, clone)
-		}
+			AllowMethod:              true,
+			NoFurtherMethodsRequired: true,
+		},
 		{
-			var amv ssh.AuthMethodValue[*extensions_ssh.PublicKeyAllowResponse]
-			value := &extensions_ssh.PublicKeyAllowResponse{
-				PublicKey: []byte("testing"),
-				Permissions: &extensions_ssh.Permissions{
-					PermitPortForwarding: true,
-					PermitX11Forwarding:  true,
-				},
-			}
-			amv.Update(value)
-			clone := amv.Clone()
-			assert.Equal(t, amv.IsValid(), clone.IsValid())
-			assert.NotSame(t, amv.Value, clone.Value)
-			assert.NotSame(t, amv.Value.Permissions, clone.Value.Permissions)
-			testutil.AssertProtoEqual(t, amv.Value, clone.Value)
-		}
-	})
+			AllowMethod:            false,
+			NextRequiredAuthMethod: "publickey",
+		},
+	}
+	invalidResponses := []ssh.AuthMethodResponse{
+		{
+			AllowMethod:    false,
+			ContextUpdates: &extensions_ssh.AuthContext{},
+		},
+		{
+			AllowMethod:              false,
+			NoFurtherMethodsRequired: true,
+		},
+		{
+			AllowMethod:              true,
+			NextRequiredAuthMethod:   "",
+			NoFurtherMethodsRequired: false,
+		},
+		{
+			AllowMethod:              false,
+			NextRequiredAuthMethod:   "keyboard-interactive",
+			NoFurtherMethodsRequired: true,
+		},
+		{
+			AllowMethod:              true,
+			NextRequiredAuthMethod:   "keyboard-interactive",
+			NoFurtherMethodsRequired: true,
+		},
+		{ // See note in Validate()
+			AllowMethod:            true,
+			NextRequiredAuthMethod: "publickey",
+		},
+		{
+			NextRequiredAuthMethod: "nonexistent",
+		},
+		{
+			AllowMethod:            false,
+			NextRequiredAuthMethod: "publickey",
+			ContextUpdates:         &extensions_ssh.AuthContext{},
+		},
+	}
+
+	for _, valid := range validResponses {
+		assert.NotPanics(t, func() { valid.Validate() })
+	}
+	for _, valid := range invalidResponses {
+		assert.Panics(t, func() { valid.Validate() })
+	}
 }
 
-func TestStreamAuthInfo(t *testing.T) {
-	t.Run("AllMethodsValid", func(t *testing.T) {
+func TestAuthMethodResponseString(t *testing.T) {
+	for _, tc := range []struct {
+		resp     ssh.AuthMethodResponse
+		expected string
+	}{
 		{
-			var info ssh.StreamAuthInfo
-			// Note: methods not attempted are considered valid, but allMethodsValid()
-			// is only run when StreamState.RemainingUnauthenticatedMethods is 0, i.e.
-			// when all required methods have had a chance to call Update() (and pass
-			// either a nil or non-nil value)
-			assert.True(t, info.UnexportedAllMethodsValid())
-		}
+			ssh.AuthMethodResponse{},
+			"unauthorized",
+		},
 		{
-			var info ssh.StreamAuthInfo
-			info.KeyboardInteractiveAllow.Update(nil)
-			assert.False(t, info.UnexportedAllMethodsValid())
-		}
+			ssh.AuthMethodResponse{
+				AllowMethod:              true,
+				NoFurtherMethodsRequired: true,
+			},
+			"authorized",
+		},
 		{
-			var info ssh.StreamAuthInfo
-			info.PublicKeyAllow.Update(nil)
-			assert.False(t, info.UnexportedAllMethodsValid())
-		}
+			ssh.AuthMethodResponse{
+				AllowMethod:            true,
+				NextRequiredAuthMethod: "keyboard-interactive",
+			},
+			"partially authorized (next: keyboard-interactive)",
+		},
 		{
-			var info ssh.StreamAuthInfo
-			info.KeyboardInteractiveAllow.Update(nil)
-			info.PublicKeyAllow.Update(nil)
-			assert.False(t, info.UnexportedAllMethodsValid())
-		}
-		{
-			var info ssh.StreamAuthInfo
-			info.KeyboardInteractiveAllow.Update(&extensions_ssh.KeyboardInteractiveAllowResponse{})
-			info.PublicKeyAllow.Update(nil)
-			assert.False(t, info.UnexportedAllMethodsValid())
-		}
-		{
-			var info ssh.StreamAuthInfo
-			info.KeyboardInteractiveAllow.Update(nil)
-			info.PublicKeyAllow.Update(&extensions_ssh.PublicKeyAllowResponse{})
-			assert.False(t, info.UnexportedAllMethodsValid())
-		}
-		{
-			var info ssh.StreamAuthInfo
-			info.KeyboardInteractiveAllow.Update(&extensions_ssh.KeyboardInteractiveAllowResponse{})
-			info.PublicKeyAllow.Update(&extensions_ssh.PublicKeyAllowResponse{})
-			assert.True(t, info.UnexportedAllMethodsValid())
-		}
-	})
+			ssh.AuthMethodResponse{
+				AllowMethod:            false,
+				NextRequiredAuthMethod: "publickey",
+			},
+			"unauthorized (retry: publickey)",
+		},
+	} {
+		assert.Equal(t, tc.expected, tc.resp.String())
+	}
 }


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

<!-- If this PR was assisted by AI (Claude, Copilot, Cursor, Amp, etc.),
state which tool and roughly how much of the work was AI-assisted (e.g.
"Cursor autocomplete only", "Claude Code drafted scaffolding, I rewrote
the auth path"). If no AI was used, write "none". See AI_POLICY.md. -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>