### PR TITLE
fix tag name

### DIFF
--- a/pkg/grpc/protoc.bash
+++ b/pkg/grpc/protoc.bash
@@ -71,5 +71,5 @@ for _d in "${_connect_dirs[@]}"; do
 		--connect-openapi_out="./$_d/" \
 		--connect-openapi_opt="content-types=json,trim-unused-types,features=connectrpc;gnostic;protovalidate" \
 		"./$_d"/*.proto
-	replace-in-file "^info:" "info:\n  version: $(git describe --tags --abbrev=0)" "$_d/config.openapi.yaml"
+	replace-in-file "^info:" "info:\n  version: $(git describe --tags --abbrev=0 --match=v*)" "$_d/config.openapi.yaml"
 done


### PR DESCRIPTION
## Summary
The `git describe --tags --abbrev=0` command sometimes returns tags with `/` in them, so use `--match` to exclude those tags.

## Related issues


## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure
None

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
