### PR TITLE
test(mcp): drop explicit mcp runtime flag, force-pull mutable image tags

### DIFF
--- a/internal/acceptance/mcp/pomerium/config.yaml
+++ b/internal/acceptance/mcp/pomerium/config.yaml
@@ -34,9 +34,9 @@ shared_secret: 0CdEkgO02jgxmgSC2AdkqIbFELAN4CGw0v0RY85xNr4=
 
 log_level: debug
 
-# Enable the MCP service surface (authorize service feature flag).
+# The MCP service surface is enabled by default as of #6521; no `mcp: true`
+# runtime flag is needed.
 runtime_flags:
-  mcp: true
   # Advertise the DCR `registration_endpoint` in the authorization-server
   # metadata. As of #6483 (ENG-4184) the official image gates inbound Dynamic
   # Client Registration behind this flag (default off); without it the SDK and

--- a/internal/acceptance/mcp/setup/containers.ts
+++ b/internal/acceptance/mcp/setup/containers.ts
@@ -14,6 +14,7 @@ import * as path from "node:path";
 import {
   GenericContainer,
   Network,
+  PullPolicy,
   Wait,
   type StartedTestContainer,
   type StartedNetwork,
@@ -31,6 +32,14 @@ const UPSTREAM_DIR = path.join(MCP_DIR, "upstream");
 const KEYCLOAK_IMAGE = "quay.io/keycloak/keycloak:26.5.2";
 const NODE_IMAGE = "node:22-alpine";
 const POMERIUM_IMAGE = process.env.POMERIUM_IMAGE || "pomerium/pomerium:main";
+
+// testcontainers reuses an already-present local image and never re-pulls a
+// mutable tag on its own. That silently pins the suite to a stale `:main` (a
+// two-month-old cached image once left `mcp` defaulting off and 404'd every
+// route), so force a fresh pull whenever the image is a moving tag. A pinned
+// version/digest override is immutable, so leave it on the default policy and
+// skip the needless network round-trip.
+const POMERIUM_MUTABLE_TAG = /:(main|latest)$/.test(POMERIUM_IMAGE) || !POMERIUM_IMAGE.includes(":");
 
 const STARTUP_TIMEOUT_MS = 240_000;
 const LOGS = !!process.env.MCP_E2E_LOGS;
@@ -107,8 +116,12 @@ export async function startStack(): Promise<Stack> {
     launched.push(upstream);
 
     // --- Pomerium (official image, all-in-one) -----------------------------
+    const pomeriumImage = new GenericContainer(POMERIUM_IMAGE);
+    if (POMERIUM_MUTABLE_TAG) {
+      pomeriumImage.withPullPolicy(PullPolicy.alwaysPull());
+    }
     const pomerium = await withLogs(
-      new GenericContainer(POMERIUM_IMAGE)
+      pomeriumImage
         .withNetwork(network)
         .withNetworkAliases(
           "authenticate.localhost.pomerium.io",

--- a/internal/acceptance/mcp/setup/containers.ts
+++ b/internal/acceptance/mcp/setup/containers.ts
@@ -39,7 +39,22 @@ const POMERIUM_IMAGE = process.env.POMERIUM_IMAGE || "pomerium/pomerium:main";
 // route), so force a fresh pull whenever the image is a moving tag. A pinned
 // version/digest override is immutable, so leave it on the default policy and
 // skip the needless network round-trip.
-const POMERIUM_MUTABLE_TAG = /:(main|latest)$/.test(POMERIUM_IMAGE) || !POMERIUM_IMAGE.includes(":");
+//
+// The tag only ever lives in the final path component, so isolate it before
+// inspecting: a registry host can carry a port (registry:5000/pomerium/pomerium)
+// whose `:` would otherwise be mistaken for a tag separator.
+function isMutableTag(image: string): boolean {
+  // A digest pin (@sha256:...) is immutable regardless of any tag.
+  if (image.includes("@")) return false;
+  const lastComponent = image.slice(image.lastIndexOf("/") + 1);
+  const colon = lastComponent.indexOf(":");
+  // No tag → Docker defaults to the mutable `:latest`.
+  if (colon === -1) return true;
+  const tag = lastComponent.slice(colon + 1);
+  return tag === "main" || tag === "latest";
+}
+
+const POMERIUM_MUTABLE_TAG = isMutableTag(POMERIUM_IMAGE);
 
 const STARTUP_TIMEOUT_MS = 240_000;
 const LOGS = !!process.env.MCP_E2E_LOGS;


### PR DESCRIPTION
## Summary

The `mcp` runtime flag defaults to `true` as of #6521, so the MCP acceptance suite no longer needs to set `mcp: true` explicitly in its Pomerium config. This removes it.

Removing the flag surfaced a latent trap in the suite's container setup. testcontainers reuses an already-present local image and never re-pulls a mutable tag on its own, so a stale cached `pomerium/pomerium:main` (from before #6521) kept `mcp` defaulting off and 404'd every route — the suite was silently pinned to whatever `:main` happened to be cached. This only bites locally; CI runs on a clean runner and always pulls fresh.

To close that gap, the Pomerium container now uses an `alwaysPull` policy when `POMERIUM_IMAGE` is a moving tag (`:main`/`:latest`). A pinned version or digest override is immutable, so it stays on the default policy and skips the extra registry round-trip.

## Related issues

- #6521

## User Explanation

No user-facing changes; test-suite only.

## AI disclosure

Claude Code — investigated the failing suite, identified the stale-image cause, and drafted both changes; I reviewed and verified locally.

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
