### PR TITLE
ssh: fix some issues causing test timeouts; add new testenv logs to help debug timeouts

### DIFF
--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -377,7 +377,9 @@ func (srv *Server) Run(ctx context.Context) error {
 
 	// start the gRPC server
 	eg.Go(func() error {
-		log.Ctx(ctx).Debug().Str("addr", srv.GRPCListener.Addr().String()).Msg("starting control-plane gRPC server")
+		lg := log.Ctx(ctx).With().Str("addr", srv.GRPCListener.Addr().String()).Logger()
+		lg.Debug().Msg("starting control-plane gRPC server")
+		defer lg.Debug().Msg("stopped control-plane gRPC server")
 		return grpcutil.ServeWithGracefulStop(ctx, srv.GRPCServer, srv.GRPCListener, time.Second*5)
 	})
 
@@ -396,9 +398,9 @@ func (srv *Server) Run(ctx context.Context) error {
 	} {
 		// start the HTTP server
 		eg.Go(func() error {
-			log.Ctx(ctx).Debug().
-				Str("addr", entry.Listener.Addr().String()).
-				Msgf("starting control-plane %s server", entry.Name)
+			lg := log.Ctx(ctx).With().Str("addr", entry.Listener.Addr().String()).Logger()
+			lg.Debug().Msgf("starting control-plane %s server", entry.Name)
+			defer lg.Debug().Msgf("stopped control-plane %s server", entry.Name)
 			return httputil.ServeWithGracefulStop(ctx, entry.Handler, entry.Listener, time.Second*5)
 		})
 	}

--- a/internal/testenv/environment.go
+++ b/internal/testenv/environment.go
@@ -243,6 +243,11 @@ func (e EnvironmentState) String() string {
 	}
 }
 
+type stateChangeListenerCallback struct {
+	fn     func()
+	source string
+}
+
 type environment struct {
 	EnvironmentOptions
 	t               testing.TB
@@ -270,7 +275,7 @@ type environment struct {
 
 	stateMu              sync.Mutex
 	state                EnvironmentState
-	stateChangeListeners map[EnvironmentState][]func()
+	stateChangeListeners map[EnvironmentState][]stateChangeListenerCallback
 	stateChangeBlockers  sync.WaitGroup
 
 	src *configSource
@@ -485,7 +490,7 @@ func New(t testing.TB, opts ...EnvironmentOption) Environment {
 		tracer:               tracer,
 		logWriter:            writer,
 		taskErrGroup:         taskErrGroup,
-		stateChangeListeners: make(map[EnvironmentState][]func()),
+		stateChangeListeners: make(map[EnvironmentState][]stateChangeListenerCallback),
 		rootSpan:             span,
 		provider:             chP,
 	}
@@ -758,13 +763,16 @@ func (e *environment) Start() {
 		opts = append(opts, e.extraOpts...)
 		pom := pomerium.New(opts...)
 		startDone := make(chan error, 1)
+		waitDone := make(chan error, 1)
 		e.OnStateChanged(Stopping, func() {
+			defer close(waitDone)
 			startErr := <-startDone
 			if startErr != nil {
 				return // Start() failed, so there is nothing to shut down
 			}
 			if err := pom.Shutdown(ctx); err != nil {
 				log.Ctx(ctx).Err(err).Msg("error shutting down pomerium server")
+				waitDone <- err
 			} else {
 				e.debugf("pomerium server shut down without error")
 			}
@@ -772,7 +780,7 @@ func (e *environment) Start() {
 		err := pom.Start(ctx, e.tracerProvider, e.src)
 		startDone <- err
 		require.NoError(e.t, err)
-		return pom.Wait()
+		return (<-waitDone)
 	}))
 
 	for i, task := range e.tasks {
@@ -1071,20 +1079,42 @@ func (e *environment) advanceState(newState EnvironmentState) {
 	e.debugf("state %s -> %s", e.state.String(), newState.String())
 	e.state = newState
 	if len(e.stateChangeListeners[newState]) > 0 {
+		start := time.Now()
 		e.debugf("notifying %d listeners of state change", len(e.stateChangeListeners[newState]))
 		var wg sync.WaitGroup
 		for _, listener := range e.stateChangeListeners[newState] {
-			wg.Add(1)
+			warnTimer := time.NewTicker(2 * time.Second)
+			done := make(chan struct{})
 			go func() {
+				defer warnTimer.Stop()
+				for {
+					select {
+					case <-warnTimer.C:
+						e.debugf("warning: currently blocked waiting for state change listener (elapsed: %s; source: %s)",
+							time.Since(start).Round(time.Second), listener.source)
+					case <-done:
+						if time.Since(start) >= 2*time.Second {
+							e.debugf("warning: slow state change listener took %s (source: %s)",
+								time.Since(start), listener.source)
+						} else {
+							e.debugf("state change listener done after %s (source: %s)",
+								time.Since(start), listener.source)
+						}
+						return
+					}
+				}
+			}()
+			wg.Go(func() {
+				defer close(done)
 				_, span := e.tracer.Start(e.Context(), "State Change Callback")
 				span.SetAttributes(attribute.String("state", newState.String()))
+				span.SetAttributes(attribute.String("source", listener.source))
 				defer span.End()
-				defer wg.Done()
-				listener()
-			}()
+				listener.fn()
+			})
 		}
 		wg.Wait()
-		e.debugf("done notifying state change listeners")
+		e.debugf("done notifying state change listeners (took %s)", time.Since(start))
 	}
 }
 
@@ -1114,11 +1144,14 @@ func (e *environment) OnStateChanged(state EnvironmentState, callback func()) (c
 		return func() bool { return false }
 	default:
 		canceled := &atomic.Bool{}
-		e.stateChangeListeners[state] = append(e.stateChangeListeners[state], func() {
-			if canceled.CompareAndSwap(false, true) {
-				e.debugf("invoking state change callback (caller: %s:%d)", file, line)
-				callback()
-			}
+		e.stateChangeListeners[state] = append(e.stateChangeListeners[state], stateChangeListenerCallback{
+			fn: func() {
+				if canceled.CompareAndSwap(false, true) {
+					e.debugf("invoking state change callback (caller: %s:%d)", file, line)
+					callback()
+				}
+			},
+			source: getCaller(),
 		})
 		return func() bool {
 			e.debugf("stopped state change callback (state: %s, caller: %s:%d)", state.String(), file, line)

--- a/internal/testenv/upstreams/ssh.go
+++ b/internal/testenv/upstreams/ssh.go
@@ -184,7 +184,11 @@ func (h *sshUpstream) Run(ctx context.Context) error {
 
 func (h *sshUpstream) handleConnection(ctx context.Context, conn net.Conn) {
 	serverConn, ncc, rc, err := ssh.NewServerConn(conn, &h.serverConfig)
-	h.Env().Require().NoError(err, "ssh connection handshake failed")
+	if err != nil {
+		conn.Close()
+		h.Env().Assert().Fail("ssh connection handshake failed")
+		return
+	}
 	go func() {
 		<-ctx.Done()
 		conn.Close()

--- a/pkg/ssh/stream.go
+++ b/pkg/ssh/stream.go
@@ -165,6 +165,7 @@ type StreamHandler struct {
 	writeC                  chan *extensions_ssh.ServerMessage
 	readC                   chan *extensions_ssh.ClientMessage
 	reauthC                 chan struct{}
+	reauthStoppedC          chan struct{}
 	terminateC              chan error
 	internalChannelRequestC chan InternalChannelRequest
 	handoffRequestC         chan HandoffRequest
@@ -214,6 +215,7 @@ func NewStreamHandler(
 		writeC:                  writeC,
 		readC:                   make(chan *extensions_ssh.ClientMessage, 32),
 		reauthC:                 make(chan struct{}),
+		reauthStoppedC:          make(chan struct{}),
 		terminateC:              make(chan error, 1),
 		internalChannelRequestC: make(chan InternalChannelRequest, 1),
 		handoffRequestC:         make(chan HandoffRequest, 1),
@@ -271,7 +273,10 @@ func (sh *StreamHandler) WriteC() <-chan *extensions_ssh.ServerMessage {
 
 // Reauth blocks until authorization policy is reevaluated.
 func (sh *StreamHandler) Reauth() {
-	sh.reauthC <- struct{}{}
+	select {
+	case sh.reauthC <- struct{}{}:
+	case <-sh.reauthStoppedC:
+	}
 }
 
 func (sh *StreamHandler) periodicReauth() (cancel func()) {
@@ -281,7 +286,10 @@ func (sh *StreamHandler) periodicReauth() (cancel func()) {
 			sh.Reauth()
 		}
 	}()
-	return t.Stop
+	return func() {
+		close(sh.reauthStoppedC)
+		t.Stop()
+	}
 }
 
 // Prompt implements KeyboardInteractiveQuerier.

--- a/pkg/ssh/stream_test.go
+++ b/pkg/ssh/stream_test.go
@@ -205,12 +205,13 @@ func (s *StreamHandlerSuite) expectError(fn func(), msg string) {
 
 func (s *StreamHandlerSuite) startStreamHandler(streamID uint64) *ssh.StreamHandler {
 	sh := s.mgr.NewStreamHandler(&extensions_ssh.DownstreamConnectEvent{StreamId: streamID})
-	s.errC = make(chan error, 1)
+	errC := make(chan error, 1)
+	s.errC = errC
 	ctx, ca := context.WithCancel(s.T().Context())
 	s.streamCtx = ctx
 	go func() {
-		defer close(s.errC)
-		s.errC <- sh.Run(ctx)
+		defer close(errC)
+		errC <- sh.Run(ctx)
 	}()
 	s.cleanup = append(s.cleanup, func() {
 		start := time.Now()
@@ -223,7 +224,7 @@ func (s *StreamHandlerSuite) startStreamHandler(streamID uint64) *ssh.StreamHand
 		ca()
 		var err error
 		select {
-		case err = <-s.errC:
+		case err = <-errC:
 		case <-time.After(DefaultTimeout):
 			s.Fail("timed out waiting for stream handler to close")
 		}


### PR DESCRIPTION
## Summary

This fixes a couple of test timeout failures and adds some new debug log messages to the test environment that can help to figure out what might be delaying shutdown.


## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

None

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
