### PR TITLE
ssh: small fixes to session formatting; fix session format test flakes

### DIFF
--- a/pkg/grpc/session/session.go
+++ b/pkg/grpc/session/session.go
@@ -176,45 +176,47 @@ func (x *Session) Format() []byte {
 	fmt.Fprintf(&b, "User ID:    %s\n", x.UserId)
 	fmt.Fprintf(&b, "Session ID: %s\n", x.Id)
 	fmt.Fprintf(&b, "Expires at: %s (in %s)\n",
-		x.ExpiresAt.AsTime().String(),
+		x.ExpiresAt.AsTime().Round(time.Second).String(),
 		time.Until(x.ExpiresAt.AsTime()).Round(time.Second))
-	fmt.Fprintf(&b, "Claims:\n")
-	keys := make([]string, 0, len(x.Claims))
-	for key := range x.Claims {
-		keys = append(keys, key)
-	}
-	stdslices.Sort(keys)
-	for _, key := range keys {
-		fmt.Fprintf(&b, "  %s: ", key)
-		vs := x.Claims[key].AsSlice()
-		if len(vs) != 1 {
-			b.WriteRune('[')
+	if len(x.Claims) > 0 {
+		fmt.Fprintf(&b, "Claims:\n")
+		keys := make([]string, 0, len(x.Claims))
+		for key := range x.Claims {
+			keys = append(keys, key)
 		}
-		if len(vs) == 1 {
-			switch key {
-			case "iat":
-				d, _ := vs[0].(float64)
-				t := time.Unix(int64(d), 0)
-				fmt.Fprintf(&b, "%s (%s ago)", t, time.Since(t).Round(time.Second))
-			case "exp":
-				d, _ := vs[0].(float64)
-				t := time.Unix(int64(d), 0)
-				fmt.Fprintf(&b, "%s (in %s)", t, time.Until(t).Round(time.Second))
-			default:
-				fmt.Fprintf(&b, "%#v", vs[0])
+		stdslices.Sort(keys)
+		for _, key := range keys {
+			fmt.Fprintf(&b, "  %s: ", key)
+			vs := x.Claims[key].AsSlice()
+			if len(vs) != 1 {
+				b.WriteRune('[')
 			}
-		} else if len(vs) > 1 {
-			for i, v := range vs {
-				fmt.Fprintf(&b, "%#v", v)
-				if i < len(vs)-1 {
-					b.WriteString(", ")
+			if len(vs) == 1 {
+				switch key {
+				case "iat":
+					d, _ := vs[0].(float64)
+					t := time.Unix(int64(d), 0)
+					fmt.Fprintf(&b, "%s (%s ago)", t, time.Since(t).Round(time.Second))
+				case "exp":
+					d, _ := vs[0].(float64)
+					t := time.Unix(int64(d), 0)
+					fmt.Fprintf(&b, "%s (in %s)", t, time.Until(t).Round(time.Second))
+				default:
+					fmt.Fprintf(&b, "%#v", vs[0])
+				}
+			} else if len(vs) > 1 {
+				for i, v := range vs {
+					fmt.Fprintf(&b, "%#v", v)
+					if i < len(vs)-1 {
+						b.WriteString(", ")
+					}
 				}
 			}
+			if len(vs) != 1 {
+				b.WriteRune(']')
+			}
+			b.WriteRune('\n')
 		}
-		if len(vs) != 1 {
-			b.WriteRune(']')
-		}
-		b.WriteRune('\n')
 	}
 	return b.Bytes()
 }

--- a/pkg/ssh/stream_test.go
+++ b/pkg/ssh/stream_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"iter"
 	"os"
+	"regexp"
 	"runtime"
 	"slices"
 	"strings"
@@ -32,6 +33,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/structpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
@@ -1933,10 +1936,24 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_Whoami() {
 	resp := recvChannelMsg[ssh.ChannelOpenConfirmMsg](s, stream)
 	peerID := resp.MyID
 
+	iat := time.Now().Add(-1 * time.Hour)
+	exp := iat.Add(10 * time.Hour)
+
 	session := &session.Session{
-		Id:     "test",
-		UserId: "a",
-		IdpId:  "b",
+		Id:        "test",
+		UserId:    "a",
+		IdpId:     "b",
+		IssuedAt:  timestamppb.New(iat),
+		ExpiresAt: timestamppb.New(exp),
+		Claims: map[string]*structpb.ListValue{
+			"iat": {Values: []*structpb.Value{structpb.NewNumberValue(float64(iat.Unix()))}},
+			"exp": {Values: []*structpb.Value{structpb.NewNumberValue(float64(exp.Unix()))}},
+			"foo": {Values: []*structpb.Value{structpb.NewStringValue("bar")}},
+			"list": {Values: []*structpb.Value{
+				structpb.NewStringValue("item1"),
+				structpb.NewStringValue("item2"),
+			}},
+		},
 	}
 	s.mockAuth.EXPECT().
 		GetSession(Any(), Any()).
@@ -1952,8 +1969,25 @@ func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_Whoami() {
 	}))
 	recvChannelMsg[ssh.ChannelRequestSuccessMsg](s, stream)
 
+	// The formatted session includes information about session expiry (e.g.,
+	// "expires in 5h20m1s") and since we are checking to see if the format
+	// matches by running it locally, this test can flake if it is timed precisely
+	// such that the calls to Format() on the server vs the client contain
+	// durations rounded to different seconds.
+
+	// Matches "(in <duration>)" or "(<duration> ago)"
+	// See [time.ParseDuration] for the duration regex
+	durationRegex, err := regexp.Compile(`\((in )?[-+]?([0-9]*(\.[0-9]*)?[a-z]+)+( ago)?\)`)
+	require.NoError(s.T(), err)
+	sanitizeDurations := func(in string) string {
+		return durationRegex.ReplaceAllString(in, "(-snip-)")
+	}
 	channelData := s.channelDataLoop(peerID, stream, 0)
-	s.Equal(string(session.Format()), channelData.String())
+	expected := string(session.Format())
+	expectedSanitized := sanitizeDurations(expected)
+	actual := channelData.String()
+	actualSanitized := sanitizeDurations(actual)
+	s.Equal(expectedSanitized, actualSanitized)
 }
 
 func (s *StreamHandlerSuite) TestServeChannel_Session_Exec_WhoamiError() {


### PR DESCRIPTION
## Summary

Couple of small fixes to session string formatting:
- If there are no claims, it won't show the "Claims:" header with nothing under it
- Round 'Expires at' timestamp to the nearest second like the other durations

Also improved the session formatting test to fix a test flake and populate more fields in the example session

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

none

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
