### PR TITLE
ssh: move portforward.RouteInfo to new package pkg/ssh/common

### DIFF
--- a/pkg/ssh/common/route_info.go
+++ b/pkg/ssh/common/route_info.go
@@ -1,0 +1,11 @@
+package common
+
+import "github.com/pomerium/pomerium/config"
+
+type RouteInfo struct {
+	From      string
+	To        config.WeightedURLs
+	Hostname  string // not including port
+	Port      uint32
+	ClusterID string
+}

--- a/pkg/ssh/mock/mock_policy_index.go
+++ b/pkg/ssh/mock/mock_policy_index.go
@@ -12,7 +12,7 @@ package mock_ssh
 import (
 	reflect "reflect"
 
-	portforward "github.com/pomerium/pomerium/pkg/ssh/portforward"
+	common "github.com/pomerium/pomerium/pkg/ssh/common"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -41,7 +41,7 @@ func (m *MockPolicyIndexSubscriber) EXPECT() *MockPolicyIndexSubscriberMockRecor
 }
 
 // UpdateAuthorizedRoutes mocks base method.
-func (m *MockPolicyIndexSubscriber) UpdateAuthorizedRoutes(routes []portforward.RouteInfo) {
+func (m *MockPolicyIndexSubscriber) UpdateAuthorizedRoutes(routes []common.RouteInfo) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "UpdateAuthorizedRoutes", routes)
 }
@@ -65,13 +65,13 @@ func (c *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall) Return() *MockPoli
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall) Do(f func([]portforward.RouteInfo)) *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall {
+func (c *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall) Do(f func([]common.RouteInfo)) *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall) DoAndReturn(f func([]portforward.RouteInfo)) *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall {
+func (c *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall) DoAndReturn(f func([]common.RouteInfo)) *MockPolicyIndexSubscriberUpdateAuthorizedRoutesCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/pkg/ssh/models/routes.go
+++ b/pkg/ssh/models/routes.go
@@ -8,6 +8,7 @@ import (
 	datav3 "github.com/envoyproxy/go-control-plane/envoy/data/core/v3"
 
 	extensions_ssh "github.com/pomerium/envoy-custom/api/extensions/filters/network/ssh"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 )
 
@@ -25,7 +26,7 @@ const (
 )
 
 type Route struct {
-	portforward.RouteInfo
+	common.RouteInfo
 	Status string
 	Health string
 }
@@ -85,7 +86,7 @@ func (m *RouteModel) HandleClusterEndpointsUpdate(added map[string]portforward.R
 	}
 }
 
-func (m *RouteModel) HandleRoutesUpdate(routes []portforward.RouteInfo) {
+func (m *RouteModel) HandleRoutesUpdate(routes []common.RouteInfo) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	items := make([]Route, len(routes))

--- a/pkg/ssh/policy_index.go
+++ b/pkg/ssh/policy_index.go
@@ -5,14 +5,19 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
-	"github.com/pomerium/pomerium/pkg/ssh/portforward"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 )
 
 //go:generate go tool go.uber.org/mock/mockgen -typed -destination ./mock/mock_policy_index.go . PolicyIndexSubscriber
 
-type PolicyIndexSubscriber interface {
+// Upstream tunnel callbacks
+type PolicyIndexTunnelSubscriber interface {
 	UpdateEnabledStaticPorts(allowedStaticPorts []uint)
-	UpdateAuthorizedRoutes(routes []portforward.RouteInfo)
+	UpdateAuthorizedRoutes(routes []common.RouteInfo)
+}
+
+type PolicyIndexSubscriber interface {
+	PolicyIndexTunnelSubscriber
 }
 
 type PolicyIndexer interface {

--- a/pkg/ssh/policy_index_inmemory.go
+++ b/pkg/ssh/policy_index_inmemory.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
-	"github.com/pomerium/pomerium/pkg/ssh/portforward"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	"github.com/pomerium/protoutil/messages"
 )
 
@@ -105,7 +105,7 @@ func (kr *knownAuthRequest) RemoveActiveStream(streamID uint64) {
 // this is a separate struct so it can be updated in-place in the lru without
 // affecting recentness
 type authorizedRoutesList struct {
-	Entries []portforward.RouteInfo
+	Entries []common.RouteInfo
 }
 
 type authorizedRoutesCache struct {
@@ -165,7 +165,7 @@ func (c *authorizedRoutesCache) Keys() iter.Seq[*knownAuthRequest] {
 // Returns cached route entries for an auth request. The auth request must be
 // active (have at least one active stream), otherwise it will be reported as
 // not found.
-func (c *authorizedRoutesCache) Get(knownReq *knownAuthRequest) ([]portforward.RouteInfo, bool) {
+func (c *authorizedRoutesCache) Get(knownReq *knownAuthRequest) ([]common.RouteInfo, bool) {
 	if active, ok := c.active[knownReq]; ok {
 		return active.Entries, true
 	}
@@ -194,7 +194,7 @@ func (c *authorizedRoutesCache) StreamCount() int {
 	return len(c.byStreamID)
 }
 
-func (c *authorizedRoutesCache) Update(k *knownAuthRequest, v []portforward.RouteInfo) {
+func (c *authorizedRoutesCache) Update(k *knownAuthRequest, v []common.RouteInfo) {
 	if l, ok := c.active[k]; ok {
 		l.Entries = v
 	} else if l, ok := c.standby.Peek(k); ok {
@@ -210,7 +210,7 @@ func (c *authorizedRoutesCache) Update(k *knownAuthRequest, v []portforward.Rout
 	}
 }
 
-func (c *authorizedRoutesCache) Peek(k *knownAuthRequest) ([]portforward.RouteInfo, bool) {
+func (c *authorizedRoutesCache) Peek(k *knownAuthRequest) ([]common.RouteInfo, bool) {
 	if active, ok := c.active[k]; ok {
 		return active.Entries, true
 	} else if inactive, ok := c.standby.Peek(k); ok {
@@ -246,7 +246,7 @@ type knownSession struct {
 }
 
 type knownRoute struct {
-	Info  portforward.RouteInfo
+	Info  common.RouteInfo
 	Route *config.Policy
 }
 
@@ -297,7 +297,7 @@ func (i *InMemoryPolicyIndexer) recomputeSessionAuthorizedRoutes(ctx context.Con
 			}
 		}
 	} else {
-		routeInfos := make([]portforward.RouteInfo, len(updatedAuthorizedRoutes))
+		routeInfos := make([]common.RouteInfo, len(updatedAuthorizedRoutes))
 		for i, ar := range updatedAuthorizedRoutes {
 			routeInfos[i] = ar.Info
 		}
@@ -546,7 +546,7 @@ func (i *InMemoryPolicyIndexer) Run(ctx context.Context) error {
 					if route.UpstreamTunnel == nil {
 						continue
 					}
-					info := portforward.RouteInfo{
+					info := common.RouteInfo{
 						From:      route.From,
 						To:        route.To,
 						ClusterID: envoyconfig.GetClusterID(route),

--- a/pkg/ssh/portforward/manager.go
+++ b/pkg/ssh/portforward/manager.go
@@ -11,6 +11,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 )
 
 //go:generate go tool go.uber.org/mock/mockgen -typed -destination ./mock/mock_port_forward.go . RouteEvaluator,UpdateListener
@@ -19,16 +20,8 @@ import (
 // forward requests) that can be active at a time.
 const MaxPermissionEntries = 128
 
-type RouteInfo struct {
-	From      string
-	To        config.WeightedURLs
-	Hostname  string // not including port
-	Port      uint32
-	ClusterID string
-}
-
 type RoutePortForwardInfo struct {
-	RouteInfo
+	common.RouteInfo
 	Permission Permission
 }
 
@@ -42,7 +35,7 @@ type RouteEvaluator interface {
 }
 
 type UpdateListener interface {
-	OnRoutesUpdated(routes []RouteInfo)
+	OnRoutesUpdated(routes []common.RouteInfo)
 	OnPermissionsUpdated(permissions []Permission)
 	OnClusterEndpointsUpdated(added map[string]RoutePortForwardInfo, removed map[string]struct{})
 }
@@ -156,7 +149,7 @@ type Manager struct {
 
 	// Cached list of all routes the current session would be authorized to
 	// port-forward.
-	cachedAuthorizedRoutes []RouteInfo
+	cachedAuthorizedRoutes []common.RouteInfo
 	// Contains the most recently built set of endpoints, keyed by cluster ID.
 	// Updated automatically by rebuildEndpoints().
 	cachedEndpoints map[string]RoutePortForwardInfo
@@ -321,7 +314,7 @@ func (pfm *Manager) UpdateEnabledStaticPorts(enabledStaticPorts []uint) {
 	pfm.rebuildEndpoints()
 }
 
-func (pfm *Manager) UpdateAuthorizedRoutes(routes []RouteInfo) {
+func (pfm *Manager) UpdateAuthorizedRoutes(routes []common.RouteInfo) {
 	pfm.mu.Lock()
 	defer pfm.mu.Unlock()
 	pfm.cachedAuthorizedRoutes = routes

--- a/pkg/ssh/portforward/manager_test.go
+++ b/pkg/ssh/portforward/manager_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/config/envoyconfig"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 	mock_portforward "github.com/pomerium/pomerium/pkg/ssh/portforward/mock"
 )
@@ -66,19 +67,19 @@ func TestPortForwardManager(t *testing.T) {
 
 		route1, route2, route3 := &cfg.Options.Routes[0], &cfg.Options.Routes[1], &cfg.Options.Routes[4]
 
-		expectedInfo1 := portforward.RouteInfo{
+		expectedInfo1 := common.RouteInfo{
 			Hostname:  "route-1",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route1),
 		}
 
-		expectedInfo2 := portforward.RouteInfo{
+		expectedInfo2 := common.RouteInfo{
 			Hostname:  "route-2",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route2),
 		}
 
-		expectedInfo3 := portforward.RouteInfo{
+		expectedInfo3 := common.RouteInfo{
 			Hostname:  "route-3",
 			Port:      22,
 			ClusterID: envoyconfig.GetClusterID(route3),
@@ -89,7 +90,7 @@ func TestPortForwardManager(t *testing.T) {
 
 		mgr := portforward.NewManager()
 		mgr.UpdateEnabledStaticPorts([]uint{443, 22})
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
 
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))
 		listener.EXPECT().OnClusterEndpointsUpdated(gomock.Len(0), gomock.Len(0))
@@ -149,19 +150,19 @@ func TestPortForwardManager(t *testing.T) {
 		cfg.Options.Routes = routes
 		cfg.Options.SSHAddr = "localhost:22"
 		route1, route2, route3 := &cfg.Options.Routes[0], &cfg.Options.Routes[1], &cfg.Options.Routes[4]
-		expectedInfo1 := portforward.RouteInfo{
+		expectedInfo1 := common.RouteInfo{
 			Hostname:  "route-1",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route1),
 		}
 
-		expectedInfo2 := portforward.RouteInfo{
+		expectedInfo2 := common.RouteInfo{
 			Hostname:  "route-2",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route2),
 		}
 
-		expectedInfo3 := portforward.RouteInfo{
+		expectedInfo3 := common.RouteInfo{
 			Hostname:  "route-3",
 			Port:      22,
 			ClusterID: envoyconfig.GetClusterID(route3),
@@ -171,7 +172,7 @@ func TestPortForwardManager(t *testing.T) {
 
 		mgr := portforward.NewManager()
 		mgr.UpdateEnabledStaticPorts([]uint{443, 22})
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(3))
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))
@@ -235,13 +236,13 @@ func TestPortForwardManager(t *testing.T) {
 		cfg.Options.SSHAddr = "localhost:22"
 		route1, route2 := &cfg.Options.Routes[0], &cfg.Options.Routes[1]
 
-		expectedInfo1 := portforward.RouteInfo{
+		expectedInfo1 := common.RouteInfo{
 			Hostname:  "route-1",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route1),
 		}
 
-		expectedInfo2 := portforward.RouteInfo{
+		expectedInfo2 := common.RouteInfo{
 			Hostname:  "route-2",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route2),
@@ -251,7 +252,7 @@ func TestPortForwardManager(t *testing.T) {
 
 		mgr := portforward.NewManager()
 		mgr.UpdateEnabledStaticPorts([]uint{443, 22})
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{expectedInfo1, expectedInfo2})
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{expectedInfo1, expectedInfo2})
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(2))
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))
@@ -315,7 +316,7 @@ func TestPortForwardManager(t *testing.T) {
 		mgr.AddUpdateListener(listener)
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(2))
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{
 			{
 				Hostname:  "route-1",
 				Port:      443,
@@ -380,7 +381,7 @@ func TestPortForwardManager(t *testing.T) {
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(1))
 		mgr.UpdateEnabledStaticPorts([]uint{443, 22})
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{
 			{
 				Hostname:  "route-1",
 				Port:      443,
@@ -396,19 +397,19 @@ func TestPortForwardManager(t *testing.T) {
 		cfg.Options.SSHAddr = "localhost:2200"
 		cfg.Options.Routes = routes
 		route1, route2, route3 := &cfg.Options.Routes[0], &cfg.Options.Routes[1], &cfg.Options.Routes[4]
-		expectedInfo1 := portforward.RouteInfo{
+		expectedInfo1 := common.RouteInfo{
 			Hostname:  "route-1",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route1),
 		}
 
-		expectedInfo2 := portforward.RouteInfo{
+		expectedInfo2 := common.RouteInfo{
 			Hostname:  "route-2",
 			Port:      443,
 			ClusterID: envoyconfig.GetClusterID(route2),
 		}
 
-		expectedInfo3 := portforward.RouteInfo{
+		expectedInfo3 := common.RouteInfo{
 			Hostname:  "route-3",
 			Port:      22,
 			ClusterID: envoyconfig.GetClusterID(route3),
@@ -417,7 +418,7 @@ func TestPortForwardManager(t *testing.T) {
 		listener := mock_portforward.NewMockUpdateListener(ctrl)
 		mgr := portforward.NewManager()
 		mgr.UpdateEnabledStaticPorts([]uint{443, 22})
-		mgr.UpdateAuthorizedRoutes([]portforward.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
+		mgr.UpdateAuthorizedRoutes([]common.RouteInfo{expectedInfo1, expectedInfo2, expectedInfo3})
 
 		listener.EXPECT().OnRoutesUpdated(gomock.Len(3))
 		listener.EXPECT().OnPermissionsUpdated(gomock.Len(0))

--- a/pkg/ssh/portforward/mock/mock_port_forward.go
+++ b/pkg/ssh/portforward/mock/mock_port_forward.go
@@ -14,6 +14,7 @@ import (
 	reflect "reflect"
 
 	config "github.com/pomerium/pomerium/config"
+	common "github.com/pomerium/pomerium/pkg/ssh/common"
 	portforward "github.com/pomerium/pomerium/pkg/ssh/portforward"
 	gomock "go.uber.org/mock/gomock"
 )
@@ -177,7 +178,7 @@ func (c *MockUpdateListenerOnPermissionsUpdatedCall) DoAndReturn(f func([]portfo
 }
 
 // OnRoutesUpdated mocks base method.
-func (m *MockUpdateListener) OnRoutesUpdated(routes []portforward.RouteInfo) {
+func (m *MockUpdateListener) OnRoutesUpdated(routes []common.RouteInfo) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnRoutesUpdated", routes)
 }
@@ -201,13 +202,13 @@ func (c *MockUpdateListenerOnRoutesUpdatedCall) Return() *MockUpdateListenerOnRo
 }
 
 // Do rewrite *gomock.Call.Do
-func (c *MockUpdateListenerOnRoutesUpdatedCall) Do(f func([]portforward.RouteInfo)) *MockUpdateListenerOnRoutesUpdatedCall {
+func (c *MockUpdateListenerOnRoutesUpdatedCall) Do(f func([]common.RouteInfo)) *MockUpdateListenerOnRoutesUpdatedCall {
 	c.Call = c.Call.Do(f)
 	return c
 }
 
 // DoAndReturn rewrite *gomock.Call.DoAndReturn
-func (c *MockUpdateListenerOnRoutesUpdatedCall) DoAndReturn(f func([]portforward.RouteInfo)) *MockUpdateListenerOnRoutesUpdatedCall {
+func (c *MockUpdateListenerOnRoutesUpdatedCall) DoAndReturn(f func([]common.RouteInfo)) *MockUpdateListenerOnRoutesUpdatedCall {
 	c.Call = c.Call.DoAndReturn(f)
 	return c
 }

--- a/pkg/ssh/stream.go
+++ b/pkg/ssh/stream.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/slices"
 	"github.com/pomerium/pomerium/pkg/ssh/api"
 	"github.com/pomerium/pomerium/pkg/ssh/cli"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	"github.com/pomerium/pomerium/pkg/ssh/models"
 	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 )
@@ -243,7 +244,7 @@ func (sh *StreamHandler) OnPermissionsUpdated(permissions []portforward.Permissi
 }
 
 // OnRoutesUpdated implements portforward.UpdateListener.
-func (sh *StreamHandler) OnRoutesUpdated(routes []portforward.RouteInfo) {
+func (sh *StreamHandler) OnRoutesUpdated(routes []common.RouteInfo) {
 	sh.routeModel.HandleRoutesUpdate(routes)
 }
 

--- a/pkg/ssh/test/policy_index_suite.go
+++ b/pkg/ssh/test/policy_index_suite.go
@@ -14,8 +14,8 @@ import (
 	"github.com/pomerium/pomerium/config/envoyconfig"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/ssh"
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	mock_ssh "github.com/pomerium/pomerium/pkg/ssh/mock"
-	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 )
 
 type OpOrder int
@@ -258,8 +258,8 @@ var orders = [][]OpOrder{
 	23: {ProcessConfigUpdate, OnSessionCreated, OnStreamAuthenticated, AddStream},
 }
 
-func makeRouteInfoFromPolicy(p *config.Policy) portforward.RouteInfo {
-	return portforward.RouteInfo{
+func makeRouteInfoFromPolicy(p *config.Policy) common.RouteInfo {
+	return common.RouteInfo{
 		From:      p.From,
 		To:        p.To,
 		Hostname:  strings.TrimPrefix(p.From, "https://"),
@@ -375,7 +375,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestAllowAll() {
 			onSessionCreatedArgs{session: &session.Session{Id: "session1"}},
 			processConfigUpdateArgs{config: cfg},
 			func() {
-				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -417,7 +417,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestAllowSome() {
 			onSessionCreatedArgs{session: &session.Session{Id: "session1"}},
 			processConfigUpdateArgs{config: cfg},
 			func() {
-				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				}))
@@ -500,7 +500,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUpdateEvalResult() {
 			onSessionCreatedArgs{session: &session.Session{Id: "session1"}},
 			processConfigUpdateArgs{config: cfg2},
 			func() {
-				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[2]),
@@ -548,7 +548,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUpdatePoliciesDenyThenAllow() {
 			onSessionCreatedArgs{session: &session.Session{Id: "session1"}},
 			processConfigUpdateArgs{config: cfg2},
 			func() {
-				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[2]),
@@ -590,7 +590,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUpdatePoliciesAllowThenDeny() {
 
 		s.index.ProcessConfigUpdate(cfg)
 		expectInitialAuthRoutes := func() {
-			sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+			sub1.EXPECT().UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -659,14 +659,14 @@ func (s *PolicyIndexConformanceSuite[T]) TestUpdatePoliciesAllowThenAllow() {
 		s.index.ProcessConfigUpdate(cfg)
 		if slices.Index(s.order, ProcessConfigUpdate) == 3 {
 			call1 := sub1.EXPECT().
-				UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
 				})).
 				Times(1)
 			sub1.EXPECT().
-				UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[2]),
@@ -674,7 +674,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUpdatePoliciesAllowThenAllow() {
 				After(call1)
 		} else {
 			sub1.EXPECT().
-				UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+				UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[0]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[1]),
 					makeRouteInfoFromPolicy(&cfg2.Options.Policies[2]),
@@ -714,7 +714,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestMultipleStreamsWithSameSession() {
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -726,7 +726,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestMultipleStreamsWithSameSession() {
 
 	s.index.AddStream(2, sub2)
 	sub2.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -758,7 +758,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestStreamReconnectSameSession() {
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -772,7 +772,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestStreamReconnectSameSession() {
 	sub1.EXPECT().UpdateEnabledStaticPorts(gomock.Eq([]uint{443, 22}))
 	s.index.AddStream(2, sub1)
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -808,7 +808,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestMultipleAuthRequestsForSession() {
 
 		s.index.AddStream(i, sub)
 		sub.EXPECT().
-			UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+			UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -841,7 +841,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestMultipleAuthRequestsForSession() {
 		s.index.AddStream(NumAuthRequests+i, sub)
 
 		sub.EXPECT().
-			UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+			UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -880,7 +880,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUnusedAuthRequestsShouldNotGrowUnbo
 
 		s.index.AddStream(i, sub)
 		sub.EXPECT().
-			UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+			UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -923,7 +923,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestUnusedAuthRequestsShouldNotGrowUnbo
 		s.index.AddStream(NumAuthRequests+i, sub)
 
 		sub.EXPECT().
-			UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+			UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 				makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -969,7 +969,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestPolicyChangeBeforeReconnect() {
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1023,7 +1023,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestPolicyChangeBeforeReconnectWithOthe
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1035,7 +1035,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestPolicyChangeBeforeReconnectWithOthe
 
 	s.index.AddStream(2, sub2)
 	sub2.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1081,7 +1081,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestSessionDeletedWhileConnected() {
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1116,7 +1116,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestSessionDeletedThenStreamsRemoved() 
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1127,7 +1127,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestSessionDeletedThenStreamsRemoved() 
 	sub2.EXPECT().UpdateEnabledStaticPorts(gomock.Eq([]uint{443, 22}))
 	s.index.AddStream(2, sub2)
 	sub2.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),
@@ -1197,7 +1197,7 @@ func (s *PolicyIndexConformanceSuite[T]) TestSessionDeletedWhileDisconnected() {
 	s.index.OnStreamAuthenticated(1, sessionAuthReq1)
 
 	sub1.EXPECT().
-		UpdateAuthorizedRoutes(gomock.Eq([]portforward.RouteInfo{
+		UpdateAuthorizedRoutes(gomock.Eq([]common.RouteInfo{
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[0]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[1]),
 			makeRouteInfoFromPolicy(&cfg.Options.Policies[2]),

--- a/pkg/ssh/tui/tunnel/program.go
+++ b/pkg/ssh/tui/tunnel/program.go
@@ -6,6 +6,7 @@ import (
 
 	tea "charm.land/bubbletea/v2"
 
+	"github.com/pomerium/pomerium/pkg/ssh/common"
 	"github.com/pomerium/pomerium/pkg/ssh/portforward"
 )
 
@@ -39,6 +40,6 @@ func (ts *Program) OnPermissionsUpdated(permissions []portforward.Permission) {
 }
 
 // OnRoutesUpdated implements portforward.UpdateListener.
-func (ts *Program) OnRoutesUpdated(routes []portforward.RouteInfo) {
+func (ts *Program) OnRoutesUpdated(routes []common.RouteInfo) {
 	go ts.Send(routes)
 }


### PR DESCRIPTION
## Summary

Moves `portforward.RouteInfo` to a new `pkg/ssh/common` package so it can be used in other places without depending on portforward. This is to support upcoming refactors to the policy indexer to support two-person auth.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

None

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review