### PR TITLE
ssh: allow configuring code TTL in issuer

### DIFF
--- a/pkg/ssh/auth.go
+++ b/pkg/ssh/auth.go
@@ -358,7 +358,7 @@ func (a *Auth) handleLogin(
 		Protocol:  session.ProtocolSSH,
 		State:     session.SessionBindingRequestState_InFlight,
 		CreatedAt: now,
-		ExpiresAt: timestamppb.New(now.AsTime().Add(code.DefaultCodeTTL)),
+		ExpiresAt: timestamppb.New(now.AsTime().Add(a.codeIssuer.CodeTTL())),
 		Details: map[string]string{
 			session.DetailSourceAddr: sourceAddr,
 		},

--- a/pkg/ssh/auth_test.go
+++ b/pkg/ssh/auth_test.go
@@ -771,12 +771,20 @@ func (q *noopQuerier) Prompt(
 
 type fakeIssuer struct {
 	state *code.Status
+	ttl   time.Duration
 }
 
 var _ code.Issuer = (*fakeIssuer)(nil)
 
 func (f *fakeIssuer) IssueCode() code.CodeID {
 	return ""
+}
+
+func (f *fakeIssuer) CodeTTL() time.Duration {
+	if f.ttl == 0 {
+		return 1 * time.Minute
+	}
+	return f.ttl
 }
 
 func (f *fakeIssuer) AssociateCode(context.Context, code.CodeID, *session.SessionBindingRequest) (code.CodeID, error) {

--- a/pkg/ssh/code/api.go
+++ b/pkg/ssh/code/api.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	DefaultCodeTTL = time.Minute * 15
+	defaultIssuerCodeTTL = time.Minute * 15
 
 	queryLimit = 100000
 )
@@ -32,6 +32,7 @@ type Issuer interface {
 	IssueCode() CodeID
 	AssociateCode(context.Context, CodeID, *session.SessionBindingRequest) (CodeID, error)
 	OnCodeDecision(context.Context, CodeID) <-chan Status
+	CodeTTL() time.Duration
 	Done() chan struct{}
 }
 

--- a/pkg/ssh/code/code_manager.go
+++ b/pkg/ssh/code/code_manager.go
@@ -27,6 +27,7 @@ type codeManager struct {
 	clientB          databroker.ClientGetter
 	accessMu         *sync.RWMutex
 	codeByExpiration *btree.BTreeG[Status]
+	codeTTL          time.Duration
 }
 
 var _ databrokerutil.SyncerHandler = (*codeManager)(nil)
@@ -43,6 +44,7 @@ func (c *codeManager) GetDataBrokerServiceClient() databroker.DataBrokerServiceC
 
 func newCodeManager(
 	client databroker.ClientGetter,
+	codeTTL time.Duration,
 ) *codeManager {
 	return &codeManager{
 		clientB:  client,
@@ -54,6 +56,7 @@ func newCodeManager(
 				cmp.Compare(a.BindingKey, b.BindingKey),
 			) < 0
 		}),
+		codeTTL: codeTTL,
 	}
 }
 
@@ -86,7 +89,7 @@ func (c *codeManager) GetByCodeID(codeID string) (Status, bool) {
 func (c *codeManager) clearExpiredLocked() {
 	toRemove := []Status{}
 	c.codeByExpiration.AscendLessThan(Status{
-		ExpiresAt: time.Now().Add(-DefaultCodeTTL),
+		ExpiresAt: time.Now().Add(-c.codeTTL),
 	}, func(item Status) bool {
 		toRemove = append(toRemove, item)
 		return true

--- a/pkg/ssh/code/code_manager_test.go
+++ b/pkg/ssh/code/code_manager_test.go
@@ -22,7 +22,7 @@ func newSbr(id string, sbr *session.SessionBindingRequest) *databroker.Record {
 }
 
 func TestCodeManager(t *testing.T) {
-	c := newCodeManager(nil)
+	c := newCodeManager(nil, defaultIssuerCodeTTL)
 
 	all := []*databroker.Record{
 		newSbr("c1", &session.SessionBindingRequest{

--- a/pkg/ssh/code/issuer.go
+++ b/pkg/ssh/code/issuer.go
@@ -37,7 +37,7 @@ func NewIssuer(ctx context.Context, client databroker.ClientGetter) Issuer {
 	i := &issuer{
 		clientB: client,
 		done:    doneC,
-		mgr:     newCodeManager(client),
+		mgr:     newCodeManager(client, defaultIssuerCodeTTL),
 		Reader:  NewReader(client),
 		Revoker: NewRevoker(client),
 	}
@@ -67,6 +67,10 @@ func (i *issuer) IssueCode() CodeID {
 	_, _ = rand.Read(code[:])
 	codeStr := base64.RawURLEncoding.EncodeToString(code[:])
 	return CodeID(codeStr)
+}
+
+func (i *issuer) CodeTTL() time.Duration {
+	return defaultIssuerCodeTTL
 }
 
 func (i *issuer) OnCodeDecision(ctx context.Context, code CodeID) <-chan Status {

--- a/pkg/ssh/code/metrics.go
+++ b/pkg/ssh/code/metrics.go
@@ -72,7 +72,7 @@ func NewMetrics(meter metric.Meter) (*Metrics, error) {
 		"ssh.auth.code.user.decision",
 		metric.WithDescription("measures the duration from the time the code is issued to when it is accepted or denied"),
 		metric.WithExplicitBucketBoundaries(
-			linearBuckets(10, DefaultCodeTTL.Seconds())...,
+			linearBuckets(10, defaultIssuerCodeTTL.Seconds())...,
 		),
 	)
 	if err != nil {


### PR DESCRIPTION
## Summary

Allow configuring the default ssh code TTL in the issuer. This is only for fake implementations of the code issuer in tests, to test timeouts without having to wait the full duration. The tests that use this are added in https://github.com/pomerium/pomerium/pull/6543.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

None

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review