### PR TITLE
ssh: small refactor to evaluator request to allow for additional eval modes

### DIFF
--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -134,11 +134,18 @@ func getClientCertificateInfo(
 	return c
 }
 
+type SSHEvalMode int
+
+const (
+	EvalModeDefault SSHEvalMode = iota
+	EvalModeReverseTunnel
+)
+
 type RequestSSH struct {
 	Username  string `json:"username"`
 	PublicKey []byte `json:"publickey"`
 
-	ReverseTunnel bool `json:"-"`
+	EvalMode SSHEvalMode `json:"-"`
 }
 
 // RequestSession is the session field in the request.

--- a/authorize/evaluator/policy_evaluator.go
+++ b/authorize/evaluator/policy_evaluator.go
@@ -224,10 +224,14 @@ func NewPolicyEvaluator(
 
 // Evaluate evaluates the policy rego scripts.
 func (e *PolicyEvaluator) Evaluate(ctx context.Context, req *PolicyRequest) (*PolicyResponse, error) {
-	if req.SSH.ReverseTunnel {
+	switch req.SSH.EvalMode {
+	case EvalModeDefault:
+		return evaluateQueries(ctx, req, e.queries)
+	case EvalModeReverseTunnel:
 		return evaluateQueries(ctx, req, e.upstreamTunnelQuery)
+	default:
+		panic("invalid eval mode")
 	}
-	return evaluateQueries(ctx, req, e.queries)
 }
 
 func evaluateQueries(ctx context.Context, req *PolicyRequest, queries []policyQuery) (*PolicyResponse, error) {

--- a/authorize/evaluator/policy_evaluator_test.go
+++ b/authorize/evaluator/policy_evaluator_test.go
@@ -372,7 +372,7 @@ func TestPolicyEvaluator(t *testing.T) {
 			[]proto.Message{s1, u1, s2, u2},
 			&PolicyRequest{
 				SSH: RequestSSH{
-					ReverseTunnel: true,
+					EvalMode: EvalModeReverseTunnel,
 				},
 				Session: RequestSession{ID: "s1"},
 			})
@@ -388,7 +388,7 @@ func TestPolicyEvaluator(t *testing.T) {
 			[]proto.Message{s1, u1, s2, u2},
 			&PolicyRequest{
 				SSH: RequestSSH{
-					ReverseTunnel: true,
+					EvalMode: EvalModeReverseTunnel,
 				},
 				Session: RequestSession{ID: "s2"},
 			})

--- a/authorize/ssh_grpc.go
+++ b/authorize/ssh_grpc.go
@@ -132,7 +132,7 @@ func (a *Authorize) EvaluateUpstreamTunnel(ctx context.Context, req ssh.AuthRequ
 
 	evalreq := baseEvaluatorRequestFromSSHRequest(req)
 	evalreq.Policy = route
-	evalreq.SSH.ReverseTunnel = true
+	evalreq.SSH.EvalMode = evaluator.EvalModeReverseTunnel
 
 	res, err := a.state.Load().evaluator.Evaluate(ctx, evalreq)
 	if err != nil {


### PR DESCRIPTION
## Summary

This is a small change to the ssh evaluator input type to replace the ReverseTunnel bool field with an enum which will be easier to update in the future with additional eval modes.

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

None

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review