### PR TITLE
secrets: add ref parsing, canonical keys, payload selector

### DIFF
--- a/pkg/secrets/ref/ref.go
+++ b/pkg/secrets/ref/ref.go
@@ -1,0 +1,126 @@
+// Package ref parses and canonicalizes secret backend references.
+//
+// A Ref is the parsed form of a binding URL such as
+// "file:///etc/pomerium/secrets/token#data.token". It exposes two derived
+// keys used by the resolver:
+//
+//   - FetchKey() dedupes fetches/watches/singleflight on the canonical URL
+//     WITHOUT the fragment, so N bindings selecting different fields of one
+//     backend payload share a single fetch loop.
+//   - Key() is the full value identity: the canonical URL WITH the fragment,
+//     so each distinct selector yields a distinct cached value.
+//
+// A Ref carries only configuration (scheme, path, query, selector); it never
+// holds secret material and is safe to log via String().
+package ref
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// Ref is a parsed, canonicalizable secret backend reference.
+type Ref struct {
+	scheme   string
+	url      *url.URL
+	selector string
+}
+
+// Parse parses raw into a Ref, applying shape-only validation. Scheme
+// registration and provider-specific parameter validation are the provider's
+// responsibility (see pkg/secrets/provider).
+func Parse(raw string) (Ref, error) {
+	if raw == "" {
+		return Ref{}, errors.New("secret ref: empty URL")
+	}
+	// No ${...} interpolation is permitted anywhere in a binding URL: URLs are
+	// static config, never derived from request data.
+	if strings.Contains(raw, "${") {
+		return Ref{}, errors.New(`secret ref: URL must not contain "${...}" interpolation`)
+	}
+
+	u, err := url.Parse(raw)
+	if err != nil {
+		return Ref{}, fmt.Errorf("secret ref: invalid URL: %w", err)
+	}
+
+	scheme := strings.ToLower(u.Scheme)
+	if scheme == "" {
+		return Ref{}, errors.New("secret ref: URL must have a scheme")
+	}
+	u.Scheme = scheme
+
+	// file:// URLs must be host-less absolute paths (stdlib/RFC 8089 semantics);
+	// "file://relative/path" parses relative as an authority, which is invalid.
+	if scheme == "file" {
+		if u.Host != "" {
+			return Ref{}, fmt.Errorf("secret ref: file URL must not have a host component (got %q)", u.Host)
+		}
+		if !strings.HasPrefix(u.Path, "/") {
+			return Ref{}, errors.New("secret ref: file URL path must be absolute")
+		}
+	}
+
+	// The fragment is the payload selector. A leading '/' is reserved for a
+	// future RFC 6901 JSON-pointer form, so reject it now (D2).
+	if strings.HasPrefix(u.Fragment, "/") {
+		return Ref{}, errors.New(`secret ref: fragment selectors beginning with "/" are reserved`)
+	}
+
+	return Ref{scheme: scheme, url: u, selector: u.Fragment}, nil
+}
+
+// Scheme returns the lowercased URL scheme.
+func (r Ref) Scheme() string { return r.scheme }
+
+// URL returns a defensive copy of the parsed URL.
+func (r Ref) URL() *url.URL {
+	if r.url == nil {
+		return nil
+	}
+	u := *r.url
+	if r.url.User != nil {
+		user := *r.url.User
+		u.User = &user
+	}
+	return &u
+}
+
+// Selector returns the payload selector (the URL fragment), or "" if none.
+func (r Ref) Selector() string { return r.selector }
+
+// Key returns the full value identity: the canonical URL including fragment.
+// Distinct selectors over the same backend produce distinct keys.
+func (r Ref) Key() string { return r.canonical(true) }
+
+// FetchKey returns the fetch/singleflight/watch dedupe key: the canonical URL
+// excluding fragment. Refs differing only by selector share a FetchKey.
+func (r Ref) FetchKey() string { return r.canonical(false) }
+
+// String returns a display form safe to log; it never contains secret material
+// because a Ref only ever holds configuration.
+func (r Ref) String() string { return r.Key() }
+
+// canonical renders a deterministic, canonicalized URL string. Query
+// parameters are re-encoded via url.Values.Encode (sorted by key), the scheme
+// is lowercased, and the fragment is canonically re-escaped or dropped.
+func (r Ref) canonical(withFragment bool) string {
+	if r.url == nil {
+		return ""
+	}
+	u := *r.url
+	u.Scheme = r.scheme
+	if u.RawQuery != "" {
+		u.RawQuery = u.Query().Encode()
+	}
+	if withFragment {
+		u.Fragment = r.selector
+		u.RawFragment = ""
+	} else {
+		u.Fragment = ""
+		u.RawFragment = ""
+	}
+	return u.String()
+}

--- a/pkg/secrets/ref/ref.go
+++ b/pkg/secrets/ref/ref.go
@@ -52,6 +52,17 @@ func Parse(raw string) (Ref, error) {
 	}
 	u.Scheme = scheme
 
+	// url.Parse keeps RawQuery verbatim without validating its percent-encoding,
+	// and url.Values.Encode (used by canonical) silently drops every pair it
+	// cannot decode. Left alone, "?v=%GG" and "?v=%HH" would both canonicalize
+	// to a bare path and so share a Key and a fetch loop. Reject the malformed
+	// query up front instead.
+	if u.RawQuery != "" {
+		if _, err := url.ParseQuery(u.RawQuery); err != nil {
+			return Ref{}, fmt.Errorf("secret ref: invalid query string: %w", err)
+		}
+	}
+
 	// file:// URLs must be host-less absolute paths (stdlib/RFC 8089 semantics);
 	// "file://relative/path" parses relative as an authority, which is invalid.
 	if scheme == "file" {
@@ -105,7 +116,8 @@ func (r Ref) String() string { return r.Key() }
 
 // canonical renders a deterministic, canonicalized URL string. Query
 // parameters are re-encoded via url.Values.Encode (sorted by key), the scheme
-// is lowercased, and the fragment is canonically re-escaped or dropped.
+// is lowercased, an empty query is dropped, and the fragment is canonically
+// re-escaped or dropped.
 func (r Ref) canonical(withFragment bool) string {
 	if r.url == nil {
 		return ""
@@ -115,6 +127,9 @@ func (r Ref) canonical(withFragment bool) string {
 	if u.RawQuery != "" {
 		u.RawQuery = u.Query().Encode()
 	}
+	// A trailing "?" carries no parameters, so it must not distinguish keys:
+	// "file:///x?" and "file:///x" name the same backend value.
+	u.ForceQuery = false
 	if withFragment {
 		u.Fragment = r.selector
 		u.RawFragment = ""

--- a/pkg/secrets/ref/ref.go
+++ b/pkg/secrets/ref/ref.go
@@ -52,6 +52,14 @@ func Parse(raw string) (Ref, error) {
 	}
 	u.Scheme = scheme
 
+	// String() and Key() render the whole URL and are documented safe to log,
+	// which userinfo would break: url.URL.String writes the password out in
+	// full. Keep credentials out of a Ref entirely rather than redacting them,
+	// since redaction would also collapse two refs onto one key.
+	if u.User != nil {
+		return Ref{}, errors.New("secret ref: URL must not contain credentials")
+	}
+
 	// url.Parse keeps RawQuery verbatim without validating its percent-encoding,
 	// and url.Values.Encode (used by canonical) silently drops every pair it
 	// cannot decode. Left alone, "?v=%GG" and "?v=%HH" would both canonicalize

--- a/pkg/secrets/ref/ref_test.go
+++ b/pkg/secrets/ref/ref_test.go
@@ -1,0 +1,157 @@
+package ref
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		raw          string
+		wantErr      bool
+		wantScheme   string
+		wantSelector string
+		wantPath     string
+		wantQuery    map[string]string
+	}{
+		{name: "file absolute", raw: "file:///etc/pomerium/secret", wantScheme: "file", wantPath: "/etc/pomerium/secret"},
+		{name: "scheme lowercased", raw: "FILE:///etc/x", wantScheme: "file", wantPath: "/etc/x"},
+		{name: "file with host", raw: "file://relative/path", wantErr: true},
+		{name: "empty url", raw: "", wantErr: true},
+		{name: "no scheme absolute", raw: "/etc/pomerium/secret", wantErr: true},
+		{name: "no scheme relative", raw: "relative/path", wantErr: true},
+		{name: "interpolation brace", raw: "file:///${pomerium.user.id}", wantErr: true},
+		{name: "interpolation embedded", raw: "file:///etc/x${y}", wantErr: true},
+		{name: "fragment captured", raw: "file:///etc/x#data.token", wantScheme: "file", wantPath: "/etc/x", wantSelector: "data.token"},
+		{name: "query captured", raw: "file:///etc/x?a=1&b=2", wantScheme: "file", wantPath: "/etc/x", wantQuery: map[string]string{"a": "1", "b": "2"}},
+		{name: "rfc6901 fragment reserved", raw: "file:///etc/x#/data/token", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r, err := Parse(tt.raw)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantScheme, r.Scheme())
+			assert.Equal(t, tt.wantSelector, r.Selector())
+			assert.Equal(t, tt.wantPath, r.URL().Path)
+			for k, v := range tt.wantQuery {
+				assert.Equal(t, v, r.URL().Query().Get(k), "query %q", k)
+			}
+		})
+	}
+}
+
+func TestParseErrorHasNoInterpolationLeak(t *testing.T) {
+	t.Parallel()
+
+	// The error for an interpolated URL should not blindly echo an arbitrary
+	// backend URL; it is config, so echoing is safe, but the message must be
+	// actionable. Just assert it errors and mentions interpolation.
+	_, err := Parse("file:///${pomerium.user.id}")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "${")
+}
+
+func TestKey(t *testing.T) {
+	t.Parallel()
+
+	mustParse := func(raw string) Ref {
+		r, err := Parse(raw)
+		require.NoError(t, err)
+		return r
+	}
+
+	t.Run("scheme case insensitive", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, mustParse("FILE:///x").Key(), mustParse("file:///x").Key())
+	})
+
+	t.Run("query order independent", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, mustParse("file:///x?a=1&b=2").Key(), mustParse("file:///x?b=2&a=1").Key())
+	})
+
+	t.Run("fragment distinguishes", func(t *testing.T) {
+		t.Parallel()
+		assert.NotEqual(t, mustParse("file:///x#f1").Key(), mustParse("file:///x#f2").Key())
+		assert.NotEqual(t, mustParse("file:///x").Key(), mustParse("file:///x#f1").Key())
+	})
+
+	t.Run("different path distinguishes", func(t *testing.T) {
+		t.Parallel()
+		assert.NotEqual(t, mustParse("file:///x").Key(), mustParse("file:///y").Key())
+	})
+}
+
+func TestFetchKey(t *testing.T) {
+	t.Parallel()
+
+	mustParse := func(raw string) Ref {
+		r, err := Parse(raw)
+		require.NoError(t, err)
+		return r
+	}
+
+	t.Run("fragment ignored", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, mustParse("file:///x#f1").FetchKey(), mustParse("file:///x#f2").FetchKey())
+		assert.Equal(t, mustParse("file:///x").FetchKey(), mustParse("file:///x#f1").FetchKey())
+	})
+
+	t.Run("scheme case insensitive", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, mustParse("FILE:///x").FetchKey(), mustParse("file:///x").FetchKey())
+	})
+
+	t.Run("query order independent", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, mustParse("file:///x?a=1&b=2").FetchKey(), mustParse("file:///x?b=2&a=1").FetchKey())
+	})
+
+	t.Run("path and query distinguish", func(t *testing.T) {
+		t.Parallel()
+		assert.NotEqual(t, mustParse("file:///x").FetchKey(), mustParse("file:///y").FetchKey())
+		assert.NotEqual(t, mustParse("file:///x?a=1").FetchKey(), mustParse("file:///x?a=2").FetchKey())
+	})
+}
+
+func TestString(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"file:///etc/pomerium/secret",
+		"file:///etc/x#data.token",
+		"file:///etc/x?a=1&b=2",
+	} {
+		r, err := Parse(raw)
+		require.NoError(t, err)
+
+		// String round-trips: reparsing yields an identical identity.
+		r2, err := Parse(r.String())
+		require.NoError(t, err, "reparse %q", r.String())
+		assert.Equal(t, r.Key(), r2.Key())
+	}
+}
+
+func TestURLDefensiveCopy(t *testing.T) {
+	t.Parallel()
+
+	r, err := Parse("file:///etc/x")
+	require.NoError(t, err)
+
+	u := r.URL()
+	u.Path = "/tampered"
+
+	assert.Equal(t, "/etc/x", r.URL().Path, "mutating the returned URL must not affect the Ref")
+}

--- a/pkg/secrets/ref/ref_test.go
+++ b/pkg/secrets/ref/ref_test.go
@@ -30,6 +30,10 @@ func TestParse(t *testing.T) {
 		{name: "fragment captured", raw: "file:///etc/x#data.token", wantScheme: "file", wantPath: "/etc/x", wantSelector: "data.token"},
 		{name: "query captured", raw: "file:///etc/x?a=1&b=2", wantScheme: "file", wantPath: "/etc/x", wantQuery: map[string]string{"a": "1", "b": "2"}},
 		{name: "rfc6901 fragment reserved", raw: "file:///etc/x#/data/token", wantErr: true},
+		{name: "malformed query escape", raw: "file:///etc/x?version=%GG", wantErr: true},
+		{name: "malformed query escape in key", raw: "file:///etc/x?%GG=1", wantErr: true},
+		{name: "semicolon query separator", raw: "file:///etc/x?a=1;b=2", wantErr: true},
+		{name: "empty query", raw: "file:///etc/x?", wantScheme: "file", wantPath: "/etc/x"},
 	}
 
 	for _, tt := range tests {
@@ -92,6 +96,11 @@ func TestKey(t *testing.T) {
 		t.Parallel()
 		assert.NotEqual(t, mustParse("file:///x").Key(), mustParse("file:///y").Key())
 	})
+
+	t.Run("empty query canonicalizes away", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, mustParse("file:///x").Key(), mustParse("file:///x?").Key())
+	})
 }
 
 func TestFetchKey(t *testing.T) {
@@ -123,6 +132,11 @@ func TestFetchKey(t *testing.T) {
 		t.Parallel()
 		assert.NotEqual(t, mustParse("file:///x").FetchKey(), mustParse("file:///y").FetchKey())
 		assert.NotEqual(t, mustParse("file:///x?a=1").FetchKey(), mustParse("file:///x?a=2").FetchKey())
+	})
+
+	t.Run("empty query canonicalizes away", func(t *testing.T) {
+		t.Parallel()
+		assert.Equal(t, mustParse("file:///x").FetchKey(), mustParse("file:///x?").FetchKey())
 	})
 }
 

--- a/pkg/secrets/ref/ref_test.go
+++ b/pkg/secrets/ref/ref_test.go
@@ -34,6 +34,8 @@ func TestParse(t *testing.T) {
 		{name: "malformed query escape in key", raw: "file:///etc/x?%GG=1", wantErr: true},
 		{name: "semicolon query separator", raw: "file:///etc/x?a=1;b=2", wantErr: true},
 		{name: "empty query", raw: "file:///etc/x?", wantScheme: "file", wantPath: "/etc/x"},
+		{name: "userinfo rejected", raw: "file://user:pass@/etc/x", wantErr: true},
+		{name: "username only rejected", raw: "file://user@/etc/x", wantErr: true},
 	}
 
 	for _, tt := range tests {
@@ -65,6 +67,15 @@ func TestParseErrorHasNoInterpolationLeak(t *testing.T) {
 	_, err := Parse("file:///${pomerium.user.id}")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "${")
+}
+
+func TestParseErrorHasNoCredentialLeak(t *testing.T) {
+	t.Parallel()
+
+	// The rejection message must not echo the credential it rejected.
+	_, err := Parse("file://user:sekret@/etc/x")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "sekret")
 }
 
 func TestKey(t *testing.T) {

--- a/pkg/secrets/ref/selector.go
+++ b/pkg/secrets/ref/selector.go
@@ -1,0 +1,72 @@
+package ref
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// ErrSelectorNotFound indicates the selector did not resolve to a value in the
+// payload (a missing key, or a non-object encountered mid-path).
+var ErrSelectorNotFound = errors.New("secret selector: value not found")
+
+// ApplySelector applies a dotted-path selector to a JSON payload and returns
+// the selected scalar as raw bytes.
+//
+//   - An empty selector returns payload unchanged (including non-UTF8 content).
+//   - A string value is returned unquoted (its raw bytes).
+//   - A number/bool value is returned as its canonical JSON text.
+//   - Object, array, and null values are errors: headers carry scalars only.
+//   - A non-JSON payload is an error.
+//
+// Error messages never include payload bytes, so a secret value can never leak
+// through a selector failure.
+func ApplySelector(payload []byte, selector string) ([]byte, error) {
+	if selector == "" {
+		return payload, nil
+	}
+	// Leading '/' is reserved for a future RFC 6901 pointer form (D2); Parse
+	// already rejects it, but guard here too for direct callers.
+	if strings.HasPrefix(selector, "/") {
+		return nil, errors.New(`secret selector: "/"-prefixed (RFC 6901) selectors are reserved`)
+	}
+
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.UseNumber()
+	var doc any
+	if err := dec.Decode(&doc); err != nil {
+		// Do not wrap the decoder error: it can echo payload bytes.
+		return nil, errors.New("secret selector: payload is not valid JSON")
+	}
+
+	cur := doc
+	for part := range strings.SplitSeq(selector, ".") {
+		obj, ok := cur.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("%w: %q", ErrSelectorNotFound, selector)
+		}
+		v, ok := obj[part]
+		if !ok {
+			return nil, fmt.Errorf("%w: %q", ErrSelectorNotFound, selector)
+		}
+		cur = v
+	}
+
+	switch v := cur.(type) {
+	case string:
+		return []byte(v), nil
+	case json.Number:
+		return []byte(v.String()), nil
+	case bool:
+		if v {
+			return []byte("true"), nil
+		}
+		return []byte("false"), nil
+	default:
+		// Object, array, or null: not a usable header value. The %T verb
+		// reports only the Go type, never the payload contents.
+		return nil, fmt.Errorf("secret selector: value at %q is not a scalar (%T)", selector, cur)
+	}
+}

--- a/pkg/secrets/ref/selector.go
+++ b/pkg/secrets/ref/selector.go
@@ -40,6 +40,12 @@ func ApplySelector(payload []byte, selector string) ([]byte, error) {
 		// Do not wrap the decoder error: it can echo payload bytes.
 		return nil, errors.New("secret selector: payload is not valid JSON")
 	}
+	// Decode stops after one JSON value, so a truncated or concatenated backend
+	// response would otherwise be accepted silently. Trailing whitespace
+	// (including the newline the file provider strips) is not "more".
+	if dec.More() {
+		return nil, errors.New("secret selector: payload has trailing data after the JSON value")
+	}
 
 	cur := doc
 	for part := range strings.SplitSeq(selector, ".") {

--- a/pkg/secrets/ref/selector_test.go
+++ b/pkg/secrets/ref/selector_test.go
@@ -1,0 +1,75 @@
+package ref
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApplySelector(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		payload   string
+		selector  string
+		want      string
+		wantErr   bool
+		wantErrIs error
+	}{
+		{name: "empty selector returns raw", payload: "s3cr3t\x00\xff", selector: "", want: "s3cr3t\x00\xff"},
+		{name: "nested string", payload: `{"data":{"token":"s3cr3t"}}`, selector: "data.token", want: "s3cr3t"},
+		{name: "top-level string", payload: `{"token":"s3cr3t"}`, selector: "token", want: "s3cr3t"},
+		{name: "number canonical", payload: `{"n":42}`, selector: "n", want: "42"},
+		{name: "float canonical", payload: `{"n":42.5}`, selector: "n", want: "42.5"},
+		{name: "bool true", payload: `{"b":true}`, selector: "b", want: "true"},
+		{name: "bool false", payload: `{"b":false}`, selector: "b", want: "false"},
+		{name: "non-json payload", payload: "not json", selector: "data", wantErr: true},
+		{name: "missing key", payload: `{"data":{}}`, selector: "data.token", wantErr: true, wantErrIs: ErrSelectorNotFound},
+		{name: "missing top key", payload: `{"other":1}`, selector: "token", wantErr: true, wantErrIs: ErrSelectorNotFound},
+		{name: "descend into scalar", payload: `{"data":"x"}`, selector: "data.token", wantErr: true, wantErrIs: ErrSelectorNotFound},
+		{name: "object value", payload: `{"data":{"token":"x"}}`, selector: "data", wantErr: true},
+		{name: "array value", payload: `{"data":[1,2]}`, selector: "data", wantErr: true},
+		{name: "null value", payload: `{"data":null}`, selector: "data", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ApplySelector([]byte(tt.payload), tt.selector)
+			if tt.wantErr {
+				require.Error(t, err)
+				if tt.wantErrIs != nil {
+					assert.True(t, errors.Is(err, tt.wantErrIs), "want errors.Is(%v, %v)", err, tt.wantErrIs)
+				}
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(got))
+		})
+	}
+}
+
+func TestApplySelectorNoValueInError(t *testing.T) {
+	t.Parallel()
+
+	const sentinel = "s3cr3t"
+
+	// Missing-key error over a payload that contains the sentinel value.
+	_, err := ApplySelector([]byte(`{"data":{"other":"`+sentinel+`"}}`), "data.token")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), sentinel)
+
+	// Non-scalar (object) error over a payload containing the sentinel.
+	_, err = ApplySelector([]byte(`{"data":{"token":"`+sentinel+`"}}`), "data")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), sentinel)
+
+	// Non-JSON payload that is itself the sentinel.
+	_, err = ApplySelector([]byte(sentinel), "data")
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), sentinel)
+}

--- a/pkg/secrets/ref/selector_test.go
+++ b/pkg/secrets/ref/selector_test.go
@@ -33,6 +33,9 @@ func TestApplySelector(t *testing.T) {
 		{name: "object value", payload: `{"data":{"token":"x"}}`, selector: "data", wantErr: true},
 		{name: "array value", payload: `{"data":[1,2]}`, selector: "data", wantErr: true},
 		{name: "null value", payload: `{"data":null}`, selector: "data", wantErr: true},
+		{name: "trailing garbage", payload: `{"token":"s3cr3t"} GARBAGE`, selector: "token", wantErr: true},
+		{name: "concatenated documents", payload: `{"token":"a"}{"token":"b"}`, selector: "token", wantErr: true},
+		{name: "trailing whitespace ok", payload: "{\"token\":\"s3cr3t\"}\n\t ", selector: "token", want: "s3cr3t"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Bottom of the secret-injection stack. `pkg/secrets/ref` parses a binding URL into a `Ref` and derives the two keys the resolver dedupes on: `FetchKey()` — the canonical URL without the fragment, so bindings sharing a backend share one fetch loop — and `Key()`, which includes the fragment so each selector yields a distinct cached value. A `Ref` carries only configuration and is safe to log. `ApplySelector` extracts a single scalar from a JSON payload via a dotted-path fragment. Providers, caching, and config wiring layer on top in later PRs.
