### PR TITLE
secrets: binding model and scoped resolution

### DIFF
--- a/pkg/secrets/bindings/bindings.go
+++ b/pkg/secrets/bindings/bindings.go
@@ -1,0 +1,111 @@
+// Package bindings models the secret binding table: the pairing of a stable ID
+// with a backend Ref and per-secret tuning, organized into hierarchical scopes
+// with leaf-wins shadowing.
+//
+// OSS uses only the implicit root scope, but the hierarchical walk is built and
+// tested now because Enterprise namespaces sit on top of it unchanged.
+package bindings
+
+import (
+	"fmt"
+	"regexp"
+	"time"
+
+	"github.com/pomerium/pomerium/pkg/secrets/provider"
+	"github.com/pomerium/pomerium/pkg/secrets/ref"
+)
+
+// Canonical tuning defaults and the refresh floor.
+const (
+	DefaultRefresh     = 5 * time.Minute
+	DefaultStaleGrace  = 30 * time.Minute
+	DefaultNegativeTTL = 30 * time.Second
+	MinRefresh         = time.Second
+)
+
+// IDPattern is the binding-ID charset. It must stay renderable as ${secret.ID}:
+// no dots (ambiguous in ${secret.a.b}) and a leading char that is not '-'. The
+// header-template grammar is laxer than this, so this is the only real gate.
+var IDPattern = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]*$`)
+
+// Binding pairs a stable ID with a backend Ref and per-secret tuning.
+type Binding struct {
+	ID          string
+	Ref         ref.Ref
+	Refresh     time.Duration
+	StaleGrace  time.Duration
+	NegativeTTL time.Duration
+	MetricLabel string
+}
+
+// Defaults are the tuning values applied to bindings that leave a field unset.
+type Defaults struct {
+	Refresh     time.Duration
+	StaleGrace  time.Duration
+	NegativeTTL time.Duration
+}
+
+// Scope is one level of the binding table, optionally shadowing a parent.
+type Scope struct {
+	parent *Scope
+	byID   map[string]Binding
+}
+
+// NewScope validates bs, applies d to unset fields, and returns a scope
+// shadowing parent. Validation covers: ID charset, duplicate IDs within this
+// level, non-negative tuning, the refresh floor (after defaults), and
+// registry acceptance of each ref. Error messages name the offending binding
+// ID (config, never secret material).
+func NewScope(parent *Scope, bs []Binding, d Defaults, reg *provider.Registry) (*Scope, error) {
+	byID := make(map[string]Binding, len(bs))
+	for _, b := range bs {
+		if !IDPattern.MatchString(b.ID) {
+			return nil, fmt.Errorf("secret binding %q: invalid ID, must match %s", b.ID, IDPattern.String())
+		}
+		if _, dup := byID[b.ID]; dup {
+			return nil, fmt.Errorf("secret binding %q: duplicate ID within scope", b.ID)
+		}
+		if b.Refresh < 0 {
+			return nil, fmt.Errorf("secret binding %q: refresh must not be negative", b.ID)
+		}
+		if b.StaleGrace < 0 {
+			return nil, fmt.Errorf("secret binding %q: stale_grace must not be negative", b.ID)
+		}
+		if b.NegativeTTL < 0 {
+			return nil, fmt.Errorf("secret binding %q: negative_ttl must not be negative", b.ID)
+		}
+
+		if b.Refresh == 0 {
+			b.Refresh = d.Refresh
+		}
+		if b.StaleGrace == 0 {
+			b.StaleGrace = d.StaleGrace
+		}
+		if b.NegativeTTL == 0 {
+			b.NegativeTTL = d.NegativeTTL
+		}
+		if b.MetricLabel == "" {
+			b.MetricLabel = b.ID
+		}
+
+		if b.Refresh < MinRefresh {
+			return nil, fmt.Errorf("secret binding %q: refresh %s below minimum %s", b.ID, b.Refresh, MinRefresh)
+		}
+		if err := reg.Validate(b.Ref); err != nil {
+			return nil, fmt.Errorf("secret binding %q: %w", b.ID, err)
+		}
+
+		byID[b.ID] = b
+	}
+	return &Scope{parent: parent, byID: byID}, nil
+}
+
+// Resolve looks up id, walking from this scope up through parents (leaf wins).
+func (s *Scope) Resolve(id string) (Binding, bool) {
+	for cur := s; cur != nil; cur = cur.parent {
+		if b, ok := cur.byID[id]; ok {
+			return b, true
+		}
+	}
+	return Binding{}, false
+}

--- a/pkg/secrets/bindings/bindings.go
+++ b/pkg/secrets/bindings/bindings.go
@@ -45,6 +45,22 @@ type Defaults struct {
 	NegativeTTL time.Duration
 }
 
+// validate checks the tuning defaults themselves, so a bad default is reported
+// against "secret defaults" rather than against whichever binding happened to
+// inherit it. The same floor and non-negative rules apply as for a binding.
+func (d Defaults) validate() error {
+	if d.StaleGrace < 0 {
+		return fmt.Errorf("secret defaults: stale_grace must not be negative")
+	}
+	if d.NegativeTTL < 0 {
+		return fmt.Errorf("secret defaults: negative_ttl must not be negative")
+	}
+	if d.Refresh < MinRefresh {
+		return fmt.Errorf("secret defaults: refresh %s below minimum %s", d.Refresh, MinRefresh)
+	}
+	return nil
+}
+
 // Scope is one level of the binding table, optionally shadowing a parent.
 type Scope struct {
 	parent *Scope
@@ -57,6 +73,13 @@ type Scope struct {
 // registry acceptance of each ref. Error messages name the offending binding
 // ID (config, never secret material).
 func NewScope(parent *Scope, bs []Binding, d Defaults, reg *provider.Registry) (*Scope, error) {
+	// Validate the defaults first. A binding that leaves a field unset inherits
+	// them, so without this a bad default surfaces as an error naming some
+	// arbitrary binding ID and the operator goes looking in the wrong place.
+	if err := d.validate(); err != nil {
+		return nil, err
+	}
+
 	byID := make(map[string]Binding, len(bs))
 	for _, b := range bs {
 		if !IDPattern.MatchString(b.ID) {

--- a/pkg/secrets/bindings/bindings_test.go
+++ b/pkg/secrets/bindings/bindings_test.go
@@ -1,0 +1,177 @@
+package bindings_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/secrets/bindings"
+	"github.com/pomerium/pomerium/pkg/secrets/provider"
+	"github.com/pomerium/pomerium/pkg/secrets/provider/providertest"
+	"github.com/pomerium/pomerium/pkg/secrets/ref"
+)
+
+func testRegistry(t *testing.T) *provider.Registry {
+	t.Helper()
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(providertest.New("file")))
+	return reg
+}
+
+func mustRef(t *testing.T, raw string) ref.Ref {
+	t.Helper()
+	r, err := ref.Parse(raw)
+	require.NoError(t, err)
+	return r
+}
+
+func stdDefaults() bindings.Defaults {
+	return bindings.Defaults{
+		Refresh:     bindings.DefaultRefresh,
+		StaleGrace:  bindings.DefaultStaleGrace,
+		NegativeTTL: bindings.DefaultNegativeTTL,
+	}
+}
+
+func TestBindingIDCharset(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"upstream-api-token", "a", "_x9", "A_b-9"}
+	invalid := []string{"", "-x", "a.b", "a b", "a:b", "ünıcode"}
+
+	reg := testRegistry(t)
+
+	for _, id := range valid {
+		t.Run("valid/"+id, func(t *testing.T) {
+			t.Parallel()
+			_, err := bindings.NewScope(nil, []bindings.Binding{{ID: id, Ref: mustRef(t, "file:///etc/x")}}, stdDefaults(), reg)
+			assert.NoError(t, err)
+		})
+	}
+	for _, id := range invalid {
+		t.Run("invalid/"+id, func(t *testing.T) {
+			t.Parallel()
+			_, err := bindings.NewScope(nil, []bindings.Binding{{ID: id, Ref: mustRef(t, "file:///etc/x")}}, stdDefaults(), reg)
+			require.Error(t, err)
+			if id != "" {
+				assert.Contains(t, err.Error(), id, "error should name the offending ID")
+			}
+		})
+	}
+}
+
+func TestBindingValidate(t *testing.T) {
+	t.Parallel()
+
+	reg := testRegistry(t)
+
+	t.Run("valid binding", func(t *testing.T) {
+		t.Parallel()
+		_, err := bindings.NewScope(nil, []bindings.Binding{{ID: "tok", Ref: mustRef(t, "file:///etc/x")}}, stdDefaults(), reg)
+		assert.NoError(t, err)
+	})
+
+	t.Run("unknown scheme rejected by registry", func(t *testing.T) {
+		t.Parallel()
+		_, err := bindings.NewScope(nil, []bindings.Binding{{ID: "tok", Ref: mustRef(t, "vault:///secret/data/x")}}, stdDefaults(), reg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tok")
+	})
+
+	t.Run("refresh below floor", func(t *testing.T) {
+		t.Parallel()
+		_, err := bindings.NewScope(nil, []bindings.Binding{{ID: "tok", Ref: mustRef(t, "file:///etc/x"), Refresh: 500 * time.Millisecond}}, stdDefaults(), reg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tok")
+	})
+
+	t.Run("negative stale_grace", func(t *testing.T) {
+		t.Parallel()
+		_, err := bindings.NewScope(nil, []bindings.Binding{{ID: "tok", Ref: mustRef(t, "file:///etc/x"), StaleGrace: -time.Second}}, stdDefaults(), reg)
+		require.Error(t, err)
+	})
+
+	t.Run("interpolation in URL never forms a binding", func(t *testing.T) {
+		t.Parallel()
+		_, err := ref.Parse("file:///etc/x${y}")
+		assert.Error(t, err, "a ${...} URL is rejected at parse, so it can never reach NewScope")
+	})
+}
+
+func TestScopeResolve(t *testing.T) {
+	t.Parallel()
+
+	reg := testRegistry(t)
+
+	t.Run("root exact match", func(t *testing.T) {
+		t.Parallel()
+		s, err := bindings.NewScope(nil, []bindings.Binding{{ID: "a", Ref: mustRef(t, "file:///a")}}, stdDefaults(), reg)
+		require.NoError(t, err)
+
+		got, ok := s.Resolve("a")
+		require.True(t, ok)
+		assert.Equal(t, "file:///a", got.Ref.Key())
+
+		_, ok = s.Resolve("missing")
+		assert.False(t, ok)
+	})
+
+	t.Run("child shadows parent, leaf wins", func(t *testing.T) {
+		t.Parallel()
+		parent, err := bindings.NewScope(nil, []bindings.Binding{
+			{ID: "shared", Ref: mustRef(t, "file:///parent")},
+			{ID: "only-parent", Ref: mustRef(t, "file:///p")},
+		}, stdDefaults(), reg)
+		require.NoError(t, err)
+
+		child, err := bindings.NewScope(parent, []bindings.Binding{
+			{ID: "shared", Ref: mustRef(t, "file:///child")},
+			{ID: "only-child", Ref: mustRef(t, "file:///c")},
+		}, stdDefaults(), reg)
+		require.NoError(t, err)
+
+		shared, ok := child.Resolve("shared")
+		require.True(t, ok)
+		assert.Equal(t, "file:///child", shared.Ref.Key(), "leaf wins")
+
+		parentOnly, ok := child.Resolve("only-parent")
+		require.True(t, ok)
+		assert.Equal(t, "file:///p", parentOnly.Ref.Key(), "resolves from parent")
+
+		childOnly, ok := child.Resolve("only-child")
+		require.True(t, ok)
+		assert.Equal(t, "file:///c", childOnly.Ref.Key())
+
+		_, ok = child.Resolve("nowhere")
+		assert.False(t, ok)
+	})
+}
+
+func TestScopeDuplicateWithinLevel(t *testing.T) {
+	t.Parallel()
+
+	reg := testRegistry(t)
+	_, err := bindings.NewScope(nil, []bindings.Binding{
+		{ID: "dup", Ref: mustRef(t, "file:///a")},
+		{ID: "dup", Ref: mustRef(t, "file:///b")},
+	}, stdDefaults(), reg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "dup")
+}
+
+func TestDefaultsApplied(t *testing.T) {
+	t.Parallel()
+
+	reg := testRegistry(t)
+	s, err := bindings.NewScope(nil, []bindings.Binding{{ID: "tok", Ref: mustRef(t, "file:///a")}}, stdDefaults(), reg)
+	require.NoError(t, err)
+
+	b, ok := s.Resolve("tok")
+	require.True(t, ok)
+	assert.Equal(t, bindings.DefaultRefresh, b.Refresh)
+	assert.Equal(t, bindings.DefaultStaleGrace, b.StaleGrace)
+	assert.Equal(t, bindings.DefaultNegativeTTL, b.NegativeTTL)
+	assert.Equal(t, "tok", b.MetricLabel, "metric label defaults to ID")
+}

--- a/pkg/secrets/bindings/bindings_test.go
+++ b/pkg/secrets/bindings/bindings_test.go
@@ -93,6 +93,20 @@ func TestBindingValidate(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("negative refresh", func(t *testing.T) {
+		t.Parallel()
+		_, err := bindings.NewScope(nil, []bindings.Binding{{ID: "tok", Ref: mustRef(t, "file:///etc/x"), Refresh: -time.Second}}, stdDefaults(), reg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tok")
+	})
+
+	t.Run("negative negative_ttl", func(t *testing.T) {
+		t.Parallel()
+		_, err := bindings.NewScope(nil, []bindings.Binding{{ID: "tok", Ref: mustRef(t, "file:///etc/x"), NegativeTTL: -time.Second}}, stdDefaults(), reg)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "tok")
+	})
+
 	t.Run("interpolation in URL never forms a binding", func(t *testing.T) {
 		t.Parallel()
 		_, err := ref.Parse("file:///etc/x${y}")
@@ -174,4 +188,31 @@ func TestDefaultsApplied(t *testing.T) {
 	assert.Equal(t, bindings.DefaultStaleGrace, b.StaleGrace)
 	assert.Equal(t, bindings.DefaultNegativeTTL, b.NegativeTTL)
 	assert.Equal(t, "tok", b.MetricLabel, "metric label defaults to ID")
+}
+
+// A bad tuning default must be reported against the defaults, not against
+// whichever binding happened to inherit it.
+func TestDefaultsValidated(t *testing.T) {
+	t.Parallel()
+
+	reg := testRegistry(t)
+
+	cases := []struct {
+		name string
+		d    bindings.Defaults
+	}{
+		{"refresh below floor", bindings.Defaults{Refresh: 500 * time.Millisecond, StaleGrace: bindings.DefaultStaleGrace, NegativeTTL: bindings.DefaultNegativeTTL}},
+		{"refresh unset", bindings.Defaults{StaleGrace: bindings.DefaultStaleGrace, NegativeTTL: bindings.DefaultNegativeTTL}},
+		{"negative stale_grace", bindings.Defaults{Refresh: bindings.DefaultRefresh, StaleGrace: -time.Second, NegativeTTL: bindings.DefaultNegativeTTL}},
+		{"negative negative_ttl", bindings.Defaults{Refresh: bindings.DefaultRefresh, StaleGrace: bindings.DefaultStaleGrace, NegativeTTL: -time.Second}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			_, err := bindings.NewScope(nil, []bindings.Binding{{ID: "tok", Ref: mustRef(t, "file:///etc/x")}}, tc.d, reg)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "secret defaults")
+			assert.NotContains(t, err.Error(), `"tok"`, "a bad default must not be blamed on a binding")
+		})
+	}
 }


### PR DESCRIPTION
Layer three. A `Binding` pairs a stable ID with a parsed `Ref` and per-secret tuning (refresh interval, stale grace, negative TTL). `Scope` is one level of the binding table with hierarchical, leaf-wins resolution: OSS uses only the implicit root, but the walk is built and tested now because Enterprise namespaces sit on top of it unchanged. `NewScope` validates the ID charset (which must stay renderable as `${secret.ID}`), rejects duplicates and sub-second refresh intervals, and confirms each ref is accepted by the provider registry.
