### PR TITLE
secrets: resolver with refresh-ahead cache and stale-while-error

### DIFF
--- a/pkg/secrets/bindings/bindings.go
+++ b/pkg/secrets/bindings/bindings.go
@@ -132,3 +132,21 @@ func (s *Scope) Resolve(id string) (Binding, bool) {
 	}
 	return Binding{}, false
 }
+
+// Effective returns the flattened, leaf-wins set of bindings visible from this
+// scope: one binding per distinct ID, the child's winning over any parent's.
+// The order is unspecified.
+func (s *Scope) Effective() []Binding {
+	seen := make(map[string]struct{})
+	var out []Binding
+	for cur := s; cur != nil; cur = cur.parent {
+		for id, b := range cur.byID {
+			if _, ok := seen[id]; ok {
+				continue
+			}
+			seen[id] = struct{}{}
+			out = append(out, b)
+		}
+	}
+	return out
+}

--- a/pkg/secrets/bindings/effective_test.go
+++ b/pkg/secrets/bindings/effective_test.go
@@ -1,0 +1,47 @@
+package bindings_test
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/secrets/bindings"
+)
+
+func TestScopeEffective(t *testing.T) {
+	t.Parallel()
+
+	reg := testRegistry(t)
+
+	parent, err := bindings.NewScope(nil, []bindings.Binding{
+		{ID: "shared", Ref: mustRef(t, "file:///parent")},
+		{ID: "only-parent", Ref: mustRef(t, "file:///p")},
+	}, stdDefaults(), reg)
+	require.NoError(t, err)
+
+	child, err := bindings.NewScope(parent, []bindings.Binding{
+		{ID: "shared", Ref: mustRef(t, "file:///child")},
+		{ID: "only-child", Ref: mustRef(t, "file:///c")},
+	}, stdDefaults(), reg)
+	require.NoError(t, err)
+
+	eff := child.Effective()
+
+	byID := make(map[string]string, len(eff))
+	for _, b := range eff {
+		byID[b.ID] = b.Ref.Key()
+	}
+
+	ids := make([]string, 0, len(byID))
+	for id := range byID {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+
+	assert.Equal(t, []string{"only-child", "only-parent", "shared"}, ids)
+	assert.Equal(t, "file:///child", byID["shared"], "leaf wins")
+	assert.Equal(t, "file:///p", byID["only-parent"])
+	assert.Equal(t, "file:///c", byID["only-child"])
+}

--- a/pkg/secrets/resolver/bench_test.go
+++ b/pkg/secrets/resolver/bench_test.go
@@ -1,0 +1,39 @@
+package resolver
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkLookup guards the hot-path allocation target (§1.8): one atomic load
+// plus two map reads. Run with -benchmem; expect 0 allocs/op.
+//
+// The snapshot is built directly (bypassing the fetch loops) so the benchmark
+// measures only the read path.
+func BenchmarkLookup(b *testing.B) {
+	const bindingsN = 1000
+	snap := &snapshot{
+		bindings: make(map[string]bindingInfo, bindingsN),
+		values:   make(map[string]valueEntry, bindingsN/2),
+	}
+	ids := make([]string, 0, bindingsN)
+	for i := range bindingsN {
+		vk := fmt.Sprintf("file:///s%d", i/2) // 500 distinct value keys
+		snap.values[vk] = valueEntry{value: secretString(fmt.Sprintf("value-%d", i)), state: StateFresh}
+		id := fmt.Sprintf("id%d", i)
+		snap.bindings[id] = bindingInfo{valueKey: vk, metricLabel: id, scheme: "file"}
+		ids = append(ids, id)
+	}
+
+	var r Resolver
+	r.snap.Store(snap)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	var sink LookupResult
+	for i := range b.N {
+		sink = r.Lookup(ids[i%len(ids)])
+	}
+	_ = sink
+}

--- a/pkg/secrets/resolver/entry.go
+++ b/pkg/secrets/resolver/entry.go
@@ -135,6 +135,7 @@ type fetchState struct {
 	lastVersion    string
 	haveVersion    bool
 	lastRawPayload secretBytes
+	lastRawAt      time.Time // when lastRawPayload was fetched
 	haveRawGood    bool
 
 	cancel    func()

--- a/pkg/secrets/resolver/entry.go
+++ b/pkg/secrets/resolver/entry.go
@@ -1,0 +1,180 @@
+package resolver
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/pomerium/pomerium/pkg/secrets/provider"
+	"github.com/pomerium/pomerium/pkg/secrets/ref"
+)
+
+// State is the externally-visible cache state of a resolved value.
+type State int
+
+const (
+	// StateFailed is the zero value: no successful fetch has ever completed.
+	StateFailed State = iota
+	// StateFresh means the last fetch succeeded within the refresh window.
+	StateFresh
+	// StateStale means refresh is failing but the last-good value is still
+	// within its stale grace window.
+	StateStale
+	// StateExpired means the grace window elapsed without success; the value
+	// has been dropped.
+	StateExpired
+)
+
+// String returns a stable, value-free label for metrics and logs.
+func (s State) String() string {
+	switch s {
+	case StateFresh:
+		return "fresh"
+	case StateStale:
+		return "stale"
+	case StateExpired:
+		return "expired"
+	default:
+		return "failed"
+	}
+}
+
+// LookupResult is what a View returns for a binding ID.
+type LookupResult struct {
+	Value string
+	State State
+	Found bool // binding ID known to the current snapshot
+}
+
+// secretBytes and secretString wrap secret material so that %v/%+v/%#v never
+// print it. The real value is recovered only via explicit conversion (string()
+// / []byte()) on the read path.
+type secretBytes []byte
+
+func (secretBytes) String() string   { return "[REDACTED]" }
+func (secretBytes) GoString() string { return "[REDACTED]" }
+
+type secretString string
+
+func (secretString) String() string   { return "[REDACTED]" }
+func (secretString) GoString() string { return "[REDACTED]" }
+
+// snapshot is the immutable, atomically-published read model. Readers touch
+// only this via one atomic pointer load plus two map reads.
+type snapshot struct {
+	bindings map[string]bindingInfo // binding ID -> value identity + metadata
+	values   map[string]valueEntry  // valueKey (ref.Key()) -> value + state
+}
+
+type bindingInfo struct {
+	valueKey    string
+	metricLabel string
+	scheme      string
+}
+
+type valueEntry struct {
+	value secretString
+	state State
+}
+
+// String/GoString redact valueEntry so a whole-struct %+v/%#v never prints the
+// value. (fmt cannot invoke a Stringer on an unexported field, so redaction
+// must live on the container types, not only on secretString.)
+func (v valueEntry) String() string   { return fmt.Sprintf("valueEntry{state:%s}", v.state) }
+func (v valueEntry) GoString() string { return v.String() }
+
+// Lookup implements View.
+func (s *snapshot) Lookup(id string) LookupResult {
+	bi, ok := s.bindings[id]
+	if !ok {
+		return LookupResult{}
+	}
+	ve, ok := s.values[bi.valueKey]
+	if !ok {
+		return LookupResult{Found: true, State: StateFailed}
+	}
+	return LookupResult{Found: true, Value: string(ve.value), State: ve.state}
+}
+
+// valueState is the writer-side authoritative state for one valueKey. It is
+// guarded by Resolver.mu.
+type valueState struct {
+	ref         ref.Ref
+	valueKey    string
+	staleGrace  time.Duration
+	metricLabel string
+
+	value           secretBytes
+	state           State
+	lastGood        time.Time
+	loggedFirst     bool
+	loggedFirstFail bool
+	lastErrClass    string
+}
+
+// String/GoString redact valueState (it holds the post-selector value).
+func (vs *valueState) String() string {
+	return fmt.Sprintf("valueState{label:%q key:%q state:%s}", vs.metricLabel, vs.valueKey, vs.state)
+}
+func (vs *valueState) GoString() string { return vs.String() }
+
+// fetchState is the writer-side per-FetchKey bookkeeping. It is guarded by
+// Resolver.mu except for the runtime channels/cancel which are set once.
+type fetchState struct {
+	fetchKey    string
+	fetchRef    ref.Ref // representative ref (URL to fetch)
+	provider    provider.Provider
+	schemeLabel string
+
+	refresh     time.Duration // min across bindings sharing this FetchKey
+	negativeTTL time.Duration // min across bindings sharing this FetchKey
+
+	values map[string]*valueState // valueKey -> state
+
+	negativeUntil  time.Time
+	negLoggedAt    time.Time
+	lastVersion    string
+	haveVersion    bool
+	lastRawPayload secretBytes
+	haveRawGood    bool
+
+	cancel    func()
+	watchStop func()
+	notifyCh  chan struct{}
+}
+
+// String/GoString redact fetchState (it holds the last raw payload).
+func (fs *fetchState) String() string {
+	return fmt.Sprintf("fetchState{fetchKey:%q values:%d haveRawGood:%t}", fs.fetchKey, len(fs.values), fs.haveRawGood)
+}
+func (fs *fetchState) GoString() string { return fs.String() }
+
+// backoffState is a loop-local exponential backoff, floored at minInterval and
+// capped at maxBackoff.
+type backoffState struct {
+	cur time.Duration
+}
+
+const maxBackoff = 30 * time.Second
+
+func (b *backoffState) reset() { b.cur = 0 }
+
+func (b *backoffState) next() time.Duration {
+	if b.cur == 0 {
+		b.cur = minInterval
+	} else {
+		b.cur *= 2
+	}
+	b.cur = min(b.cur, maxBackoff)
+	return b.cur
+}
+
+func errClass(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case provider.IsNotFound(err):
+		return "not_found"
+	default:
+		return "transient"
+	}
+}

--- a/pkg/secrets/resolver/lifecycle_test.go
+++ b/pkg/secrets/resolver/lifecycle_test.go
@@ -1,0 +1,67 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLookupDuringInitialFetch(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+		fake.Block(fk) // first fetch blocks
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait() // loop is blocked inside the first provider.Fetch
+
+		// The resolver never gates callers on fetch completion: the binding is
+		// known but not yet resolved.
+		got := r.Lookup("tok")
+		assert.True(t, got.Found)
+		assert.Equal(t, StateFailed, got.State)
+		assert.Equal(t, "", got.Value)
+
+		fake.Release(fk)
+		synctest.Wait()
+
+		got = r.Lookup("tok")
+		assert.Equal(t, StateFresh, got.State)
+		assert.Equal(t, "v1", got.Value)
+	})
+}
+
+func TestCloseStops(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		r := newTestResolver(t, reg)
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait()
+		require.Equal(t, "v1", r.Lookup("tok").Value)
+
+		r.Close()
+		r.Close() // idempotent
+		synctest.Wait()
+
+		// No further fetches after Close.
+		before := fake.FetchCount(fk)
+		advance(10 * time.Minute)
+		assert.Equal(t, before, fake.FetchCount(fk))
+
+		// Reads still serve the last snapshot.
+		assert.Equal(t, "v1", r.Lookup("tok").Value)
+	})
+}

--- a/pkg/secrets/resolver/metrics.go
+++ b/pkg/secrets/resolver/metrics.go
@@ -32,7 +32,7 @@ func newResolverMetrics(meter metric.Meter, r *Resolver) *resolverMetrics {
 		fetchDuration: mustInt64Histogram(meter, "secrets.fetch.duration", metric.WithUnit("ms"),
 			metric.WithDescription("Duration of secret backend fetch attempts in milliseconds, by provider scheme and outcome.")),
 		servingStale: mustInt64Counter(meter, "secrets.serving_stale",
-			metric.WithDescription("Reads served from a stale last-good secret value while refresh is failing, by ref.")),
+			metric.WithDescription("Failed refreshes that left a ref serving its stale last-good value, one per ref per attempt.")),
 		negativeCacheHits: mustInt64Counter(meter, "secrets.negative_cache_hits",
 			metric.WithDescription("Fetches suppressed by the negative cache after a not-found result, by ref.")),
 		singleflightCollapsed: mustInt64Counter(meter, "secrets.singleflight_collapsed",

--- a/pkg/secrets/resolver/metrics.go
+++ b/pkg/secrets/resolver/metrics.go
@@ -1,0 +1,136 @@
+package resolver
+
+import (
+	"context"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/pomerium/pomerium/pkg/secrets/provider"
+)
+
+// resolverMetrics holds the OTel instruments from §1.7. No instrument ever
+// receives a secret value: attributes are provider scheme, binding metric
+// label, outcome, and state only.
+type resolverMetrics struct {
+	fetches               metric.Int64Counter
+	fetchDuration         metric.Int64Histogram
+	servingStale          metric.Int64Counter
+	negativeCacheHits     metric.Int64Counter
+	singleflightCollapsed metric.Int64Counter
+
+	// observable gauges, kept referenced so the callbacks stay registered
+	refsRegistered metric.Int64ObservableGauge
+	cacheState     metric.Int64ObservableGauge
+}
+
+func newResolverMetrics(meter metric.Meter, r *Resolver) *resolverMetrics {
+	m := &resolverMetrics{
+		fetches: mustInt64Counter(meter, "secrets.fetches",
+			metric.WithDescription("Total secret backend fetch attempts, by provider scheme and outcome.")),
+		fetchDuration: mustInt64Histogram(meter, "secrets.fetch.duration", metric.WithUnit("ms"),
+			metric.WithDescription("Duration of secret backend fetch attempts in milliseconds, by provider scheme and outcome.")),
+		servingStale: mustInt64Counter(meter, "secrets.serving_stale",
+			metric.WithDescription("Reads served from a stale last-good secret value while refresh is failing, by ref.")),
+		negativeCacheHits: mustInt64Counter(meter, "secrets.negative_cache_hits",
+			metric.WithDescription("Fetches suppressed by the negative cache after a not-found result, by ref.")),
+		singleflightCollapsed: mustInt64Counter(meter, "secrets.singleflight_collapsed",
+			metric.WithDescription("Concurrent fetches collapsed into a single in-flight backend call, by provider scheme.")),
+	}
+
+	var err error
+	m.refsRegistered, err = meter.Int64ObservableGauge("secrets.refs_registered",
+		metric.WithDescription("Number of registered secret references, by provider scheme."),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			counts := map[string]int64{}
+			for _, bi := range r.snap.Load().bindings {
+				counts[bi.scheme]++
+			}
+			for scheme, n := range counts {
+				o.Observe(n, metric.WithAttributes(attribute.String("provider", scheme)))
+			}
+			return nil
+		}))
+	if err != nil {
+		panic(err)
+	}
+
+	m.cacheState, err = meter.Int64ObservableGauge("secrets.cache_state",
+		metric.WithDescription("Current cache state of each secret reference (one series per ref_label and state)."),
+		metric.WithInt64Callback(func(_ context.Context, o metric.Int64Observer) error {
+			snap := r.snap.Load()
+			for _, bi := range snap.bindings {
+				state := StateFailed
+				if ve, ok := snap.values[bi.valueKey]; ok {
+					state = ve.state
+				}
+				o.Observe(1, metric.WithAttributes(
+					attribute.String("ref_label", bi.metricLabel),
+					attribute.String("state", state.String()),
+				))
+			}
+			return nil
+		}))
+	if err != nil {
+		panic(err)
+	}
+
+	return m
+}
+
+func (r *Resolver) recordFetchMetrics(fs *fetchState, err error, dur time.Duration) {
+	outcome := "success"
+	switch {
+	case err == nil:
+	case provider.IsNotFound(err):
+		outcome = "not_found"
+	default:
+		outcome = "error"
+	}
+	attrs := metric.WithAttributes(
+		attribute.String("provider", fs.schemeLabel),
+		attribute.String("outcome", outcome),
+	)
+	r.metrics.fetches.Add(context.Background(), 1, attrs)
+	r.metrics.fetchDuration.Record(context.Background(), dur.Milliseconds(), attrs)
+}
+
+func (r *Resolver) recordServingStale(vs *valueState) {
+	r.metrics.servingStale.Add(context.Background(), 1,
+		metric.WithAttributes(attribute.String("ref_label", vs.metricLabel)))
+}
+
+func (r *Resolver) recordSingleflightCollapsed(fs *fetchState) {
+	r.metrics.singleflightCollapsed.Add(context.Background(), 1,
+		metric.WithAttributes(attribute.String("provider", fs.schemeLabel)))
+}
+
+func (r *Resolver) recordNegativeCacheHit(fs *fetchState) {
+	r.mu.Lock()
+	labels := make([]string, 0, len(fs.values))
+	for _, vs := range fs.values {
+		labels = append(labels, vs.metricLabel)
+	}
+	r.mu.Unlock()
+	for _, label := range labels {
+		r.metrics.negativeCacheHits.Add(context.Background(), 1,
+			metric.WithAttributes(attribute.String("ref_label", label)))
+	}
+}
+
+func mustInt64Counter(meter metric.Meter, name string, opts ...metric.Int64CounterOption) metric.Int64Counter {
+	c, err := meter.Int64Counter(name, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func mustInt64Histogram(meter metric.Meter, name string, opts ...metric.Int64HistogramOption) metric.Int64Histogram {
+	h, err := meter.Int64Histogram(name, opts...)
+	if err != nil {
+		panic(err)
+	}
+	return h
+}

--- a/pkg/secrets/resolver/metrics_test.go
+++ b/pkg/secrets/resolver/metrics_test.go
@@ -1,0 +1,252 @@
+package resolver
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/pomerium/pomerium/pkg/secrets/provider"
+)
+
+func sprintfPlus(v any) string { return fmt.Sprintf("%+v", v) }
+
+// counterSum collects the reader and returns the summed value of an int64 sum
+// instrument by name (0 if absent).
+func counterSum(t *testing.T, reader *sdkmetric.ManualReader, name string) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != name {
+				continue
+			}
+			if d, ok := m.Data.(metricdata.Sum[int64]); ok {
+				var sum int64
+				for _, dp := range d.DataPoints {
+					sum += dp.Value
+				}
+				return sum
+			}
+		}
+	}
+	return 0
+}
+
+func metricNames(t *testing.T, reader *sdkmetric.ManualReader) map[string]bool {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	names := map[string]bool{}
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			names[m.Name] = true
+		}
+	}
+	return names
+}
+
+func TestMetrics(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		r, reader := newTestResolverReader(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait()
+
+		// A manual reader only reports instruments that recorded data, so this
+		// success scenario covers the always-firing instruments; the stale,
+		// negative-cache, and singleflight instruments are covered by the
+		// scenarios that exercise them below and in TestSingleflightCollapse.
+		names := metricNames(t, reader)
+		for _, want := range []string{
+			"secrets.fetches",
+			"secrets.fetch.duration",
+			"secrets.refs_registered",
+			"secrets.cache_state",
+		} {
+			assert.True(t, names[want], "instrument %q must be registered", want)
+		}
+		assert.GreaterOrEqual(t, counterSum(t, reader, "secrets.fetches"), int64(1))
+	})
+}
+
+func TestMetricsNegativeCacheHits(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetError(fk, provider.ErrNotFound)
+
+		r, reader := newTestResolverReader(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait() // initial not-found sets the negative window
+
+		fake.TriggerWatch(fk) // a trigger inside the window is suppressed
+		synctest.Wait()
+
+		assert.GreaterOrEqual(t, counterSum(t, reader, "secrets.negative_cache_hits"), int64(1))
+	})
+}
+
+func TestMetricsStaleAndNegative(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		r, reader := newTestResolverReader(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bindTuned(t, "tok", "file:///a", 10*time.Second, time.Hour)))
+		synctest.Wait()
+
+		fake.SetError(fk, errors.New("io error"))
+		advance(11 * time.Second)
+		require.Equal(t, StateStale, r.Lookup("tok").State)
+		assert.GreaterOrEqual(t, counterSum(t, reader, "secrets.serving_stale"), int64(1))
+	})
+}
+
+func TestLogTransitions(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		var buf syncBuffer
+		logger := zerolog.New(&buf)
+
+		r := newTestResolver(t, reg, WithLogger(logger))
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bindTuned(t, "tok", "file:///a", 10*time.Second, 60*time.Second)))
+		synctest.Wait()
+
+		fake.SetError(fk, errors.New("io error"))
+		advance(11 * time.Second) // -> Stale (WARN)
+		advance(90 * time.Second) // -> Expired (ERROR)
+
+		fake.SetValue(fk, "v2")
+		advance(31 * time.Second) // -> Fresh recovery (INFO)
+
+		out := buf.String()
+		assert.Equal(t, 1, strings.Count(out, "secret resolved"), "INFO once on first success")
+		assert.Contains(t, out, "secret serving stale")
+		assert.Contains(t, out, "secret expired")
+		assert.Contains(t, out, "secret recovered")
+	})
+}
+
+func TestLogFirstFailure(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetError(fk, errors.New("io error")) // broken from the first fetch
+
+		var buf syncBuffer
+		logger := zerolog.New(&buf)
+
+		r := newTestResolver(t, reg, WithLogger(logger))
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bindTuned(t, "tok", "file:///a", 10*time.Second, 60*time.Second)))
+		synctest.Wait() // first fetch fails; value never leaves StateFailed
+
+		require.Equal(t, StateFailed, r.Lookup("tok").State)
+		out := buf.String()
+		assert.Equal(t, 1, strings.Count(out, "secret unavailable"), "ERROR once on first failure")
+		assert.Contains(t, out, `"level":"error"`)
+
+		advance(90 * time.Second) // further failed fetches must not re-log
+		assert.Equal(t, 1, strings.Count(buf.String(), "secret unavailable"), "first-failure ERROR is one-time")
+	})
+}
+
+func TestNoValueInLogs(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		const sentinel = "SENTINEL-s3cr3t"
+
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, sentinel)
+
+		var buf syncBuffer
+		logger := zerolog.New(&buf)
+
+		r := newTestResolver(t, reg, WithLogger(logger))
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bindTuned(t, "tok", "file:///a", 10*time.Second, 60*time.Second)))
+		synctest.Wait()
+		require.Equal(t, sentinel, r.Lookup("tok").Value)
+
+		fake.SetError(fk, errors.New("io error"))
+		advance(11 * time.Second) // stale
+		advance(90 * time.Second) // expired
+		fake.SetValue(fk, sentinel)
+		advance(31 * time.Second) // recovery
+
+		assert.NotContains(t, buf.String(), sentinel, "secret value must never appear in logs")
+
+		// Struct dumps must not leak the value either.
+		assert.NotContains(t, dumpResolver(r), sentinel)
+	})
+}
+
+// dumpResolver renders the resolver's internal state with %+v so the redaction
+// wrappers are exercised.
+func dumpResolver(r *Resolver) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var b strings.Builder
+	for _, fs := range r.fetches {
+		b.WriteString(sprintfPlus(fs))
+		for _, vs := range fs.values {
+			b.WriteString(sprintfPlus(vs))
+		}
+	}
+	return b.String()
+}
+
+// syncBuffer is a goroutine-safe bytes.Buffer for capturing log output from
+// background loops.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuffer) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuffer) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}

--- a/pkg/secrets/resolver/resolver.go
+++ b/pkg/secrets/resolver/resolver.go
@@ -1,0 +1,520 @@
+// Package resolver is the secret cache engine. It owns background fetch loops
+// (one per distinct backend URL), a refresh-ahead schedule with jitter,
+// singleflight de-duplication, stale-while-error and negative caching, and it
+// publishes an immutable snapshot behind one atomic pointer so the request hot
+// path is a single atomic load plus two map reads.
+//
+// Fetch loops start on Apply (there is no Run and no readiness gating); the
+// service serves from boot and any binding whose first fetch has not yet
+// succeeded reads as StateFailed, so requests referencing it fail closed.
+package resolver
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/metric"
+	"golang.org/x/sync/singleflight"
+
+	"github.com/pomerium/pomerium/internal/log"
+	pommetrics "github.com/pomerium/pomerium/internal/telemetry/metrics"
+	"github.com/pomerium/pomerium/pkg/secrets/bindings"
+	"github.com/pomerium/pomerium/pkg/secrets/provider"
+	"github.com/pomerium/pomerium/pkg/secrets/ref"
+)
+
+// View is a point-in-time consistent read model. A single evaluation captures
+// exactly one View and reads all of its refs from it.
+type View interface {
+	Lookup(id string) LookupResult
+}
+
+// errSuppressed marks a fetch attempt skipped because of the negative cache.
+var errSuppressed = errors.New("fetch suppressed by negative cache")
+
+// Resolver is the secret cache engine.
+type Resolver struct {
+	reg     *provider.Registry
+	now     func() time.Time
+	rand    func() float64
+	logger  zerolog.Logger
+	meter   metric.Meter
+	metrics *resolverMetrics
+
+	baseCtx    context.Context
+	baseCancel context.CancelFunc
+
+	sf singleflight.Group
+
+	mu       sync.Mutex
+	closed   bool
+	bindings map[string]bindingReg  // binding ID -> reg
+	fetches  map[string]*fetchState // fetchKey -> state
+	snap     atomic.Pointer[snapshot]
+}
+
+type bindingReg struct {
+	valueKey    string
+	metricLabel string
+	scheme      string
+}
+
+// Option configures a Resolver.
+type Option func(*Resolver)
+
+// WithClock overrides the time source (default time.Now).
+func WithClock(now func() time.Time) Option { return func(r *Resolver) { r.now = now } }
+
+// WithRand overrides the jitter source, returning values in [0,1) (default
+// math/rand/v2).
+func WithRand(rnd func() float64) Option { return func(r *Resolver) { r.rand = rnd } }
+
+// WithLogger overrides the logger.
+func WithLogger(l zerolog.Logger) Option { return func(r *Resolver) { r.logger = l } }
+
+// WithMeter overrides the OTel meter (default the global pomerium meter).
+func WithMeter(m metric.Meter) Option { return func(r *Resolver) { r.meter = m } }
+
+// New constructs a Resolver. Fetch loops do not start until Apply.
+func New(reg *provider.Registry, opts ...Option) *Resolver {
+	r := &Resolver{
+		reg:      reg,
+		now:      time.Now,
+		rand:     rand.Float64,
+		logger:   *log.Logger(),
+		meter:    pommetrics.Meter,
+		bindings: make(map[string]bindingReg),
+		fetches:  make(map[string]*fetchState),
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	r.metrics = newResolverMetrics(r.meter, r)
+	r.baseCtx, r.baseCancel = context.WithCancel(context.Background())
+	r.snap.Store(&snapshot{
+		bindings: map[string]bindingInfo{},
+		values:   map[string]valueEntry{},
+	})
+	return r
+}
+
+// View returns a point-in-time consistent view via one atomic load.
+func (r *Resolver) View() View { return r.snap.Load() }
+
+// Lookup is a convenience for View().Lookup(id).
+func (r *Resolver) Lookup(id string) LookupResult { return r.snap.Load().Lookup(id) }
+
+// Close stops every fetch loop and watch. It is idempotent. Reads keep serving
+// the last snapshot afterwards.
+func (r *Resolver) Close() {
+	r.mu.Lock()
+	if r.closed {
+		r.mu.Unlock()
+		return
+	}
+	r.closed = true
+	stops := make([]func(), 0, len(r.fetches))
+	for _, fs := range r.fetches {
+		if fs.watchStop != nil {
+			stops = append(stops, fs.watchStop)
+		}
+	}
+	r.mu.Unlock()
+
+	r.baseCancel()
+	for _, stop := range stops {
+		stop()
+	}
+}
+
+// valAgg / fetchAgg are the desired-state aggregations built during Apply.
+type valAgg struct {
+	ref         ref.Ref
+	staleGrace  time.Duration
+	metricLabel string
+}
+
+type fetchAgg struct {
+	ref         ref.Ref
+	refresh     time.Duration
+	negativeTTL time.Duration
+	values      map[string]*valAgg // valueKey -> agg
+}
+
+// Apply diffs the desired bindings against the running set: it registers new
+// fetch keys (starting their loops), unregisters removed ones (stopping loops),
+// and updates tuning/value sets on surviving ones without re-fetching a warm
+// entry. In-flight requests hold previously-loaded snapshots, so removals are
+// safe without a linger delay (immutable snapshots).
+func (r *Resolver) Apply(_ context.Context, root *bindings.Scope) {
+	var desired []bindings.Binding
+	if root != nil {
+		desired = root.Effective()
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closed {
+		return
+	}
+
+	newBindings := make(map[string]bindingReg, len(desired))
+	fetchAggs := make(map[string]*fetchAgg)
+
+	for _, b := range desired {
+		fk := b.Ref.FetchKey()
+		vk := b.Ref.Key()
+		newBindings[b.ID] = bindingReg{valueKey: vk, metricLabel: b.MetricLabel, scheme: b.Ref.Scheme()}
+
+		fa := fetchAggs[fk]
+		if fa == nil {
+			fa = &fetchAgg{ref: b.Ref, refresh: b.Refresh, negativeTTL: b.NegativeTTL, values: map[string]*valAgg{}}
+			fetchAggs[fk] = fa
+		} else {
+			fa.refresh = min(fa.refresh, b.Refresh)
+			fa.negativeTTL = min(fa.negativeTTL, b.NegativeTTL)
+		}
+		if va := fa.values[vk]; va == nil {
+			fa.values[vk] = &valAgg{ref: b.Ref, staleGrace: b.StaleGrace, metricLabel: b.MetricLabel}
+		} else {
+			va.staleGrace = min(va.staleGrace, b.StaleGrace)
+		}
+	}
+
+	r.bindings = newBindings
+
+	// Remove fetch keys no longer desired.
+	for fk, fs := range r.fetches {
+		if _, ok := fetchAggs[fk]; !ok {
+			fs.cancel()
+			if fs.watchStop != nil {
+				fs.watchStop()
+			}
+			delete(r.fetches, fk)
+		}
+	}
+
+	// Add or update desired fetch keys.
+	for fk, fa := range fetchAggs {
+		if fs, ok := r.fetches[fk]; ok {
+			r.updateFetchLocked(fs, fa)
+		} else {
+			r.startFetchLocked(fk, fa)
+		}
+	}
+
+	r.rebuildSnapshotLocked()
+}
+
+// updateFetchLocked reconciles an existing fetch state against desired state.
+// A warm value whose valueKey survives is kept and not re-fetched.
+func (r *Resolver) updateFetchLocked(fs *fetchState, fa *fetchAgg) {
+	fs.refresh = fa.refresh
+	fs.negativeTTL = fa.negativeTTL
+
+	for vk, va := range fa.values {
+		if vs, ok := fs.values[vk]; ok {
+			vs.staleGrace = va.staleGrace
+			vs.metricLabel = va.metricLabel
+			continue
+		}
+		vs := &valueState{ref: va.ref, valueKey: vk, staleGrace: va.staleGrace, metricLabel: va.metricLabel, state: StateFailed}
+		fs.values[vk] = vs
+		r.applyLastPayloadLocked(fs, vs)
+	}
+	for vk := range fs.values {
+		if _, ok := fa.values[vk]; !ok {
+			delete(fs.values, vk)
+		}
+	}
+}
+
+// startFetchLocked creates a new fetch state and starts its loop (and watch).
+func (r *Resolver) startFetchLocked(fk string, fa *fetchAgg) {
+	p, _ := r.reg.Get(fa.ref.Scheme())
+	fs := &fetchState{
+		fetchKey:    fk,
+		fetchRef:    fa.ref,
+		provider:    p,
+		schemeLabel: fa.ref.Scheme(),
+		refresh:     fa.refresh,
+		negativeTTL: fa.negativeTTL,
+		values:      make(map[string]*valueState, len(fa.values)),
+		notifyCh:    make(chan struct{}, 1),
+	}
+	for vk, va := range fa.values {
+		fs.values[vk] = &valueState{ref: va.ref, valueKey: vk, staleGrace: va.staleGrace, metricLabel: va.metricLabel, state: StateFailed}
+	}
+
+	ctx, cancel := context.WithCancel(r.baseCtx)
+	fs.cancel = cancel
+	r.fetches[fk] = fs
+
+	if p == nil {
+		// Unknown scheme (should be prevented by config validation): leave all
+		// values StateFailed and do not start a loop.
+		return
+	}
+
+	if w, ok := p.(provider.Watcher); ok {
+		notify := func() {
+			select {
+			case fs.notifyCh <- struct{}{}:
+			default:
+			}
+		}
+		if stop, err := w.Watch(ctx, fs.fetchRef, notify); err == nil {
+			fs.watchStop = stop
+			go r.watchPump(ctx, fs)
+		}
+	}
+
+	go r.scheduleLoop(ctx, fs)
+}
+
+// scheduleLoop performs the initial fetch and then refresh-ahead fetches.
+func (r *Resolver) scheduleLoop(ctx context.Context, fs *fetchState) {
+	var bo backoffState
+	for {
+		res, err := r.doFetch(ctx, fs)
+		if ctx.Err() != nil {
+			return
+		}
+		wait := r.computeWait(fs, &bo, res, err)
+		timer := time.NewTimer(wait)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return
+		case <-timer.C:
+		}
+	}
+}
+
+// watchPump turns change hints into immediate (singleflight-collapsed) fetches.
+func (r *Resolver) watchPump(ctx context.Context, fs *fetchState) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-fs.notifyCh:
+			_, _ = r.doFetch(ctx, fs)
+		}
+	}
+}
+
+// doFetch performs one fetch through singleflight, keyed by FetchKey, so at
+// most one provider call per backend URL is in flight regardless of trigger.
+// The result is returned to every caller, so the schedule loop can compute the
+// next refresh even when its call was collapsed into another's.
+func (r *Resolver) doFetch(ctx context.Context, fs *fetchState) (provider.Result, error) {
+	leader := false
+	v, err, shared := r.sf.Do(fs.fetchKey, func() (any, error) {
+		leader = true
+
+		r.mu.Lock()
+		negUntil := fs.negativeUntil
+		r.mu.Unlock()
+
+		if r.now().Before(negUntil) {
+			r.recordNegativeCacheHit(fs)
+			return provider.Result{}, errSuppressed
+		}
+
+		start := r.now()
+		res, ferr := fs.provider.Fetch(ctx, fs.fetchRef)
+		dur := r.now().Sub(start)
+		r.commitFetch(fs, res, ferr)
+		r.recordFetchMetrics(fs, ferr, dur)
+		return res, ferr
+	})
+	if shared && !leader {
+		r.recordSingleflightCollapsed(fs)
+	}
+	res, _ := v.(provider.Result)
+	return res, err
+}
+
+// computeWait returns how long the schedule loop should sleep before its next
+// fetch, given the last outcome.
+func (r *Resolver) computeWait(fs *fetchState, bo *backoffState, res provider.Result, err error) time.Duration {
+	now := r.now()
+	if err != nil {
+		if errors.Is(err, errSuppressed) || provider.IsNotFound(err) {
+			bo.reset()
+			r.mu.Lock()
+			nu := fs.negativeUntil
+			r.mu.Unlock()
+			return max(nu.Sub(now), minInterval)
+		}
+		return bo.next()
+	}
+	bo.reset()
+	r.mu.Lock()
+	refresh := fs.refresh
+	r.mu.Unlock()
+	return max(nextRefresh(now, res.TTL, refresh, false, r.rand).Sub(now), minInterval)
+}
+
+// commitFetch applies a fetch outcome to every value under the FetchKey and
+// publishes a new snapshot.
+func (r *Resolver) commitFetch(fs *fetchState, res provider.Result, err error) {
+	now := r.now()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err != nil {
+		if provider.IsNotFound(err) {
+			fs.negativeUntil = now.Add(fs.negativeTTL)
+			r.logNegativeCacheLocked(fs, now)
+		}
+		for _, vs := range fs.values {
+			r.applyErrorLocked(fs, vs, now, err)
+		}
+		r.rebuildSnapshotLocked()
+		return
+	}
+
+	fs.negativeUntil = time.Time{}
+	fs.lastVersion = res.Version
+	fs.haveVersion = true
+	fs.lastRawPayload = append(fs.lastRawPayload[:0], res.Value...)
+	fs.haveRawGood = true
+
+	for _, vs := range fs.values {
+		selected, serr := ref.ApplySelector(res.Value, vs.ref.Selector())
+		if serr != nil {
+			// A selector failure is an error for this value only; siblings on
+			// the same FetchKey are unaffected.
+			r.applyErrorLocked(fs, vs, now, serr)
+			continue
+		}
+		prev := vs.state
+		vs.value = selected
+		vs.lastGood = now
+		vs.state = StateFresh
+		vs.lastErrClass = ""
+		r.logTransitionLocked(fs, vs, prev, StateFresh)
+	}
+	r.rebuildSnapshotLocked()
+}
+
+// applyErrorLocked transitions one value on a failed fetch/selector.
+func (r *Resolver) applyErrorLocked(fs *fetchState, vs *valueState, now time.Time, err error) {
+	prev := vs.state
+	vs.lastErrClass = errClass(err)
+
+	switch vs.state {
+	case StateFresh, StateStale:
+		if now.Sub(vs.lastGood) > vs.staleGrace {
+			vs.state = StateExpired
+			vs.value = nil
+		} else {
+			vs.state = StateStale
+		}
+	default: // StateFailed, StateExpired: no servable value, remain
+		vs.value = nil
+	}
+
+	if vs.state == StateStale {
+		r.recordServingStale(vs)
+	}
+	r.logTransitionLocked(fs, vs, prev, vs.state)
+
+	// A value that has never resolved produces no state transition on failure
+	// (StateFailed -> StateFailed), so transition-driven logging would stay
+	// silent for a binding that is broken from the start (unreadable backend,
+	// never-matching selector). Emit a one-time ERROR on that first failure so
+	// the break is visible in logs without scraping the cache_state gauge.
+	if vs.state == StateFailed && !vs.loggedFirstFail {
+		vs.loggedFirstFail = true
+		r.logEvent(zerolog.ErrorLevel, fs, vs, "secret unavailable")
+	}
+}
+
+// applyLastPayloadLocked populates a newly-added value from the cached raw
+// payload, so a config change that adds a selector on an already-fetched URL
+// resolves immediately rather than waiting for the next refresh.
+func (r *Resolver) applyLastPayloadLocked(fs *fetchState, vs *valueState) {
+	if !fs.haveRawGood {
+		return
+	}
+	now := r.now()
+	selected, err := ref.ApplySelector(fs.lastRawPayload, vs.ref.Selector())
+	if err != nil {
+		r.applyErrorLocked(fs, vs, now, err)
+		return
+	}
+	prev := vs.state
+	vs.value = selected
+	vs.lastGood = now
+	vs.state = StateFresh
+	r.logTransitionLocked(fs, vs, prev, StateFresh)
+}
+
+// rebuildSnapshotLocked publishes a fresh immutable snapshot (copy-on-write).
+func (r *Resolver) rebuildSnapshotLocked() {
+	snap := &snapshot{
+		bindings: make(map[string]bindingInfo, len(r.bindings)),
+		values:   make(map[string]valueEntry),
+	}
+	for id, br := range r.bindings {
+		snap.bindings[id] = bindingInfo(br)
+	}
+	for _, fs := range r.fetches {
+		for vk, vs := range fs.values {
+			snap.values[vk] = valueEntry{value: secretString(vs.value), state: vs.state}
+		}
+	}
+	r.snap.Store(snap)
+}
+
+// logTransitionLocked emits a state-transition log line. It routes through the
+// value-free logEvent chokepoint.
+func (r *Resolver) logTransitionLocked(fs *fetchState, vs *valueState, prev, cur State) {
+	if prev == cur {
+		return
+	}
+	switch cur {
+	case StateFresh:
+		if !vs.loggedFirst {
+			vs.loggedFirst = true
+			r.logEvent(zerolog.InfoLevel, fs, vs, "secret resolved")
+		} else {
+			r.logEvent(zerolog.InfoLevel, fs, vs, "secret recovered")
+		}
+	case StateStale:
+		r.logEvent(zerolog.WarnLevel, fs, vs, "secret serving stale")
+	case StateExpired:
+		r.logEvent(zerolog.ErrorLevel, fs, vs, "secret expired")
+	}
+}
+
+func (r *Resolver) logNegativeCacheLocked(fs *fetchState, now time.Time) {
+	if !fs.negLoggedAt.IsZero() && now.Sub(fs.negLoggedAt) < fs.negativeTTL {
+		return
+	}
+	fs.negLoggedAt = now
+	r.logger.Warn().
+		Str("ref", fs.fetchRef.String()).
+		Str("error_class", "not_found").
+		Msg("secret not found; negative-caching")
+}
+
+// logEvent is the single logging chokepoint. It structurally cannot receive a
+// secret value: it takes only the fetch/value metadata.
+func (r *Resolver) logEvent(level zerolog.Level, fs *fetchState, vs *valueState, msg string) {
+	e := r.logger.WithLevel(level).
+		Str("ref", fs.fetchRef.String()).
+		Str("label", vs.metricLabel).
+		Str("state", vs.state.String())
+	if vs.lastErrClass != "" {
+		e = e.Str("error_class", vs.lastErrClass)
+	}
+	e.Msg(msg)
+}

--- a/pkg/secrets/resolver/resolver.go
+++ b/pkg/secrets/resolver/resolver.go
@@ -346,7 +346,14 @@ func (r *Resolver) computeWait(fs *fetchState, bo *backoffState, res provider.Re
 	now := r.now()
 	if err != nil {
 		if errors.Is(err, errSuppressed) || provider.IsNotFound(err) {
-			bo.reset()
+			// Neither path is governed by backoff: the wait is the remaining
+			// negative window, floored at minInterval. Only a real fetch that
+			// answered not-found is evidence the backend is reachable, so only
+			// that one drops accumulated transient backoff; a suppressed
+			// attempt made no call and says nothing about the backend.
+			if !errors.Is(err, errSuppressed) {
+				bo.reset()
+			}
 			r.mu.Lock()
 			nu := fs.negativeUntil
 			r.mu.Unlock()

--- a/pkg/secrets/resolver/resolver.go
+++ b/pkg/secrets/resolver/resolver.go
@@ -368,6 +368,15 @@ func (r *Resolver) commitFetch(fs *fetchState, res provider.Result, err error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
+	// Apply cancels and drops a fetch state as soon as its bindings leave the
+	// config, but a provider.Fetch already in flight keeps running and lands
+	// here afterwards (usually with context.Canceled). The snapshot ignores it
+	// either way, so committing would only produce stale/expired log lines and
+	// serving_stale counts for a binding that no longer exists.
+	if cur, ok := r.fetches[fs.fetchKey]; !ok || cur != fs {
+		return
+	}
+
 	if err != nil {
 		if provider.IsNotFound(err) {
 			fs.negativeUntil = now.Add(fs.negativeTTL)

--- a/pkg/secrets/resolver/resolver.go
+++ b/pkg/secrets/resolver/resolver.go
@@ -400,6 +400,7 @@ func (r *Resolver) commitFetch(fs *fetchState, res provider.Result, err error) {
 	fs.lastVersion = res.Version
 	fs.haveVersion = true
 	fs.lastRawPayload = append(fs.lastRawPayload[:0], res.Value...)
+	fs.lastRawAt = now
 	fs.haveRawGood = true
 
 	for _, vs := range fs.values {
@@ -455,7 +456,10 @@ func (r *Resolver) applyErrorLocked(fs *fetchState, vs *valueState, now time.Tim
 
 // applyLastPayloadLocked populates a newly-added value from the cached raw
 // payload, so a config change that adds a selector on an already-fetched URL
-// resolves immediately rather than waiting for the next refresh.
+// resolves immediately rather than waiting for the next refresh. The value
+// inherits the epoch of the fetch that produced the payload, not the time of
+// the config change: it is exactly as old as its siblings on this FetchKey, so
+// its stale grace must run out at the same moment theirs does.
 func (r *Resolver) applyLastPayloadLocked(fs *fetchState, vs *valueState) {
 	if !fs.haveRawGood {
 		return
@@ -467,10 +471,17 @@ func (r *Resolver) applyLastPayloadLocked(fs *fetchState, vs *valueState) {
 		return
 	}
 	prev := vs.state
-	vs.value = selected
-	vs.lastGood = now
-	vs.state = StateFresh
-	r.logTransitionLocked(fs, vs, prev, StateFresh)
+	vs.lastGood = fs.lastRawAt
+	if now.Sub(vs.lastGood) > vs.staleGrace {
+		// The cached payload is already past this binding's grace, so a config
+		// change must not resurrect it: wait for the next successful fetch.
+		vs.value = nil
+		vs.state = StateExpired
+	} else {
+		vs.value = selected
+		vs.state = StateFresh
+	}
+	r.logTransitionLocked(fs, vs, prev, vs.state)
 }
 
 // rebuildSnapshotLocked publishes a fresh immutable snapshot (copy-on-write).

--- a/pkg/secrets/resolver/resolver.go
+++ b/pkg/secrets/resolver/resolver.go
@@ -376,10 +376,14 @@ func (r *Resolver) commitFetch(fs *fetchState, res provider.Result, err error) {
 	defer r.mu.Unlock()
 
 	// Apply cancels and drops a fetch state as soon as its bindings leave the
-	// config, but a provider.Fetch already in flight keeps running and lands
-	// here afterwards (usually with context.Canceled). The snapshot ignores it
-	// either way, so committing would only produce stale/expired log lines and
-	// serving_stale counts for a binding that no longer exists.
+	// config, and Close cancels every one of them, but a provider.Fetch already
+	// in flight keeps running and lands here afterwards (usually with
+	// context.Canceled). The snapshot ignores it either way, so committing would
+	// only downgrade state and produce stale/expired log lines and serving_stale
+	// counts for a binding that no longer exists, or for a resolver that is gone.
+	if r.closed {
+		return
+	}
 	if cur, ok := r.fetches[fs.fetchKey]; !ok || cur != fs {
 		return
 	}

--- a/pkg/secrets/resolver/resolver_test.go
+++ b/pkg/secrets/resolver/resolver_test.go
@@ -1,0 +1,443 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+
+	"github.com/pomerium/pomerium/pkg/secrets/bindings"
+	"github.com/pomerium/pomerium/pkg/secrets/provider"
+	"github.com/pomerium/pomerium/pkg/secrets/provider/providertest"
+	"github.com/pomerium/pomerium/pkg/secrets/ref"
+)
+
+var testDefaults = bindings.Defaults{
+	Refresh:     5 * time.Minute,
+	StaleGrace:  30 * time.Minute,
+	NegativeTTL: 30 * time.Second,
+}
+
+func testFakeRegistry(t *testing.T) (*provider.Registry, *providertest.Fake) {
+	t.Helper()
+	fake := providertest.New("file")
+	reg := provider.NewRegistry()
+	require.NoError(t, reg.Register(fake))
+	return reg, fake
+}
+
+func newTestResolver(t *testing.T, reg *provider.Registry, opts ...Option) *Resolver {
+	t.Helper()
+	r, _ := newTestResolverReader(t, reg, opts...)
+	return r
+}
+
+func newTestResolverReader(t *testing.T, reg *provider.Registry, opts ...Option) (*Resolver, *sdkmetric.ManualReader) {
+	t.Helper()
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	base := []Option{WithRand(constRand(0.5)), WithMeter(mp.Meter("test")), WithLogger(zerolog.Nop())}
+	return New(reg, append(base, opts...)...), reader
+}
+
+func mustRefParse(t *testing.T, raw string) ref.Ref {
+	t.Helper()
+	r, err := ref.Parse(raw)
+	require.NoError(t, err)
+	return r
+}
+
+func fkOf(t *testing.T, raw string) string {
+	t.Helper()
+	return mustRefParse(t, raw).FetchKey()
+}
+
+func bind(t *testing.T, id, raw string) bindings.Binding {
+	t.Helper()
+	return bindings.Binding{ID: id, Ref: mustRefParse(t, raw)}
+}
+
+func bindTuned(t *testing.T, id, raw string, refresh, staleGrace time.Duration) bindings.Binding {
+	t.Helper()
+	return bindings.Binding{ID: id, Ref: mustRefParse(t, raw), Refresh: refresh, StaleGrace: staleGrace}
+}
+
+func buildScope(t *testing.T, reg *provider.Registry, bs ...bindings.Binding) *bindings.Scope {
+	t.Helper()
+	s, err := bindings.NewScope(nil, bs, testDefaults, reg)
+	require.NoError(t, err)
+	return s
+}
+
+// advance moves the fake clock forward and lets background loops settle.
+func advance(d time.Duration) {
+	time.Sleep(d)
+	synctest.Wait()
+}
+
+func TestApplyRegistersAndFetches(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fake.SetValue(fkOf(t, "file:///a"), "v1")
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait()
+
+		got := r.Lookup("tok")
+		assert.True(t, got.Found)
+		assert.Equal(t, StateFresh, got.State)
+		assert.Equal(t, "v1", got.Value)
+		assert.Equal(t, 1, fake.FetchCount(fkOf(t, "file:///a")))
+	})
+}
+
+func TestLookupUnknownID(t *testing.T) {
+	t.Parallel()
+	reg, _ := testFakeRegistry(t)
+	r := newTestResolver(t, reg)
+	defer r.Close()
+	got := r.Lookup("nope")
+	assert.False(t, got.Found)
+}
+
+func TestDedupeByFetchKey(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fake.SetValue(fkOf(t, "file:///a"), "shared")
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg,
+			bind(t, "a", "file:///a"),
+			bind(t, "b", "file:///a"),
+		))
+		synctest.Wait()
+
+		assert.Equal(t, "shared", r.Lookup("a").Value)
+		assert.Equal(t, "shared", r.Lookup("b").Value)
+		assert.Equal(t, 1, fake.FetchCount(fkOf(t, "file:///a")))
+	})
+}
+
+func TestSharedFetchDistinctSelectors(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fake.SetValue(fkOf(t, "file:///data"), `{"a":"AAA","b":"BBB"}`)
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg,
+			bind(t, "ta", "file:///data#a"),
+			bind(t, "tb", "file:///data#b"),
+		))
+		synctest.Wait()
+
+		assert.Equal(t, "AAA", r.Lookup("ta").Value)
+		assert.Equal(t, "BBB", r.Lookup("tb").Value)
+		assert.Equal(t, 1, fake.FetchCount(fkOf(t, "file:///data")), "one underlying fetch for both selectors")
+	})
+}
+
+func TestApplyDiff(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fake.SetValue(fkOf(t, "file:///a"), "va")
+		fake.SetValue(fkOf(t, "file:///b"), "vb")
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "a", "file:///a")))
+		synctest.Wait()
+		require.Equal(t, StateFresh, r.Lookup("a").State)
+		countA := fake.FetchCount(fkOf(t, "file:///a"))
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "b", "file:///b")))
+		synctest.Wait()
+		assert.Equal(t, "vb", r.Lookup("b").Value)
+		assert.False(t, r.Lookup("a").Found)
+
+		// A's loop stopped: no further fetches after a full refresh interval.
+		advance(6 * time.Minute)
+		assert.Equal(t, countA, fake.FetchCount(fkOf(t, "file:///a")))
+	})
+}
+
+func TestApplyRebindsURL(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fake.SetValue(fkOf(t, "file:///x"), "vx")
+		fake.SetValue(fkOf(t, "file:///y"), "vy")
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///x")))
+		synctest.Wait()
+		require.Equal(t, "vx", r.Lookup("tok").Value)
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///y")))
+		synctest.Wait()
+		assert.Equal(t, "vy", r.Lookup("tok").Value)
+	})
+}
+
+func TestRefreshSwapsValue(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait()
+		require.Equal(t, "v1", r.Lookup("tok").Value)
+
+		fake.SetValue(fk, "v2")
+		advance(5 * time.Minute)
+		assert.Equal(t, "v2", r.Lookup("tok").Value)
+		assert.Equal(t, StateFresh, r.Lookup("tok").State)
+	})
+}
+
+func TestSelectorAppliedOnCommit(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fake.SetValue(fkOf(t, "file:///data"), `{"data":{"token":"s3cr3t"}}`)
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///data#data.token")))
+		synctest.Wait()
+		assert.Equal(t, "s3cr3t", r.Lookup("tok").Value)
+	})
+}
+
+func TestSelectorFailure(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		// Not JSON: the fragment-bearing binding fails its selector, but the
+		// sibling with no fragment gets the raw value fresh.
+		fake.SetValue(fkOf(t, "file:///data"), `not-json`)
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg,
+			bind(t, "sel", "file:///data#data.token"),
+			bind(t, "raw", "file:///data"),
+		))
+		synctest.Wait()
+
+		assert.Equal(t, StateFailed, r.Lookup("sel").State, "selector error fails only that value")
+		assert.Equal(t, StateFresh, r.Lookup("raw").State)
+		assert.Equal(t, "not-json", r.Lookup("raw").Value)
+	})
+}
+
+func TestStaleWithinGrace(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bindTuned(t, "tok", "file:///a", 10*time.Second, 60*time.Second)))
+		synctest.Wait()
+		require.Equal(t, StateFresh, r.Lookup("tok").State)
+
+		fake.SetError(fk, errors.New("transient io error"))
+		advance(11 * time.Second)
+
+		got := r.Lookup("tok")
+		assert.Equal(t, StateStale, got.State)
+		assert.Equal(t, "v1", got.Value, "last-good still served")
+
+		before := fake.FetchCount(fk)
+		advance(30 * time.Second)
+		assert.Greater(t, fake.FetchCount(fk), before, "keeps retrying with backoff")
+	})
+}
+
+func TestExpiredAfterGrace(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bindTuned(t, "tok", "file:///a", 10*time.Second, 60*time.Second)))
+		synctest.Wait()
+		require.Equal(t, StateFresh, r.Lookup("tok").State)
+
+		fake.SetError(fk, errors.New("io error"))
+		advance(90 * time.Second)
+
+		got := r.Lookup("tok")
+		assert.Equal(t, StateExpired, got.State)
+		assert.Equal(t, "", got.Value, "expired value dropped from snapshot")
+	})
+}
+
+func TestRecoveryFromExpired(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bindTuned(t, "tok", "file:///a", 10*time.Second, 60*time.Second)))
+		synctest.Wait()
+
+		fake.SetError(fk, errors.New("io error"))
+		advance(90 * time.Second)
+		require.Equal(t, StateExpired, r.Lookup("tok").State)
+
+		fake.SetValue(fk, "v2")
+		advance(31 * time.Second) // past the backoff cap
+		got := r.Lookup("tok")
+		assert.Equal(t, StateFresh, got.State)
+		assert.Equal(t, "v2", got.Value)
+	})
+}
+
+func TestFailedNeverFetched(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fake.SetError(fkOf(t, "file:///a"), errors.New("io error"))
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait()
+
+		got := r.Lookup("tok")
+		assert.Equal(t, StateFailed, got.State)
+		assert.Equal(t, "", got.Value)
+	})
+}
+
+func TestNotFoundNegativeCache(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetError(fk, provider.ErrNotFound)
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait()
+		require.Equal(t, StateFailed, r.Lookup("tok").State)
+
+		c := fake.FetchCount(fk)
+		advance(20 * time.Second) // within negative_ttl (30s)
+		assert.Equal(t, c, fake.FetchCount(fk), "no provider calls inside the negative window")
+
+		advance(15 * time.Second) // past 30s
+		assert.Greater(t, fake.FetchCount(fk), c, "retried after negative_ttl")
+	})
+}
+
+func TestAuthErrorNotNegativeCached(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetError(fk, errors.New("permission denied"))
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait()
+
+		c := fake.FetchCount(fk)
+		advance(2 * time.Second) // backoff retries, no 30s freeze
+		assert.Greater(t, fake.FetchCount(fk), c)
+	})
+}
+
+func TestWatchTriggersImmediateRefresh(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait()
+		require.Equal(t, "v1", r.Lookup("tok").Value)
+
+		fake.SetValue(fk, "v2")
+		fake.TriggerWatch(fk) // well before the 5m scheduled refresh
+		synctest.Wait()
+
+		assert.Equal(t, "v2", r.Lookup("tok").Value)
+	})
+}
+
+func TestSingleflightCollapse(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+		fake.Block(fk)
+
+		r, reader := newTestResolverReader(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bind(t, "tok", "file:///a")))
+		synctest.Wait()
+		require.Equal(t, 1, fake.StartedCount(fk), "leader entered provider.Fetch")
+
+		// A watch notify while the leader is blocked collapses into it.
+		fake.TriggerWatch(fk)
+		synctest.Wait()
+		assert.Equal(t, 1, fake.StartedCount(fk), "collapsed: still only one provider call in flight")
+
+		fake.Release(fk)
+		synctest.Wait()
+
+		assert.Equal(t, "v1", r.Lookup("tok").Value)
+		assert.GreaterOrEqual(t, counterSum(t, reader, "secrets.singleflight_collapsed"), int64(1))
+	})
+}

--- a/pkg/secrets/resolver/resolver_test.go
+++ b/pkg/secrets/resolver/resolver_test.go
@@ -514,6 +514,39 @@ func TestNoStaleEventsAfterBindingRemoval(t *testing.T) {
 	})
 }
 
+func TestNoStaleEventsAfterClose(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		var buf syncBuffer
+		r, reader := newTestResolverReader(t, reg, WithLogger(zerolog.New(&buf)))
+
+		r.Apply(context.Background(), buildScope(t, reg,
+			bindTuned(t, "tok", "file:///a", 10*time.Second, time.Hour)))
+		synctest.Wait()
+		require.Equal(t, StateFresh, r.Lookup("tok").State)
+		buf.buf.Reset()
+		staleBefore := counterSum(t, reader, "secrets.serving_stale")
+
+		// Let the refresh timer fire into a fetch that blocks, then close the
+		// resolver while that fetch is still in flight.
+		fake.Block(fk)
+		fake.SetError(fk, provider.ErrNotFound)
+		time.Sleep(11 * time.Second)
+		synctest.Wait()
+
+		r.Close()
+		fake.Release(fk)
+		synctest.Wait()
+
+		assert.Empty(t, buf.String(), "a closed resolver must emit no further events")
+		assert.Equal(t, staleBefore, counterSum(t, reader, "secrets.serving_stale"))
+	})
+}
+
 func TestBackfilledSelectorAgesFromFetch(t *testing.T) {
 	t.Parallel()
 	synctest.Test(t, func(t *testing.T) {

--- a/pkg/secrets/resolver/resolver_test.go
+++ b/pkg/secrets/resolver/resolver_test.go
@@ -441,3 +441,75 @@ func TestSingleflightCollapse(t *testing.T) {
 		assert.GreaterOrEqual(t, counterSum(t, reader, "secrets.singleflight_collapsed"), int64(1))
 	})
 }
+
+// The stale-grace window is enforced even when the failure is a not-found,
+// where the negative cache suppresses intermediate fetch attempts: the
+// schedule loop wakes exactly when the negative window closes, and that fetch
+// re-evaluates the grace boundary.
+func TestExpiredAfterGraceDuringNegativeCache(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		// refresh 10s, staleGrace 30s; negativeTTL comes from testDefaults (30s).
+		r.Apply(context.Background(), buildScope(t, reg,
+			bindTuned(t, "tok", "file:///a", 10*time.Second, 30*time.Second)))
+		synctest.Wait()
+		require.Equal(t, StateFresh, r.Lookup("tok").State)
+
+		// t=10s: the scheduled refresh returns not-found, opening a 30s
+		// negative window; the value is still within grace, so it serves stale.
+		fake.SetError(fk, provider.ErrNotFound)
+		advance(11 * time.Second)
+		require.Equal(t, StateStale, r.Lookup("tok").State)
+		require.Equal(t, 2, fake.FetchCount(fk), "intermediate attempts are suppressed")
+
+		// t=40s: the negative window closes, the loop fetches again, and the
+		// grace boundary (t=30s) is now behind us.
+		advance(30 * time.Second)
+		got := r.Lookup("tok")
+		assert.Equal(t, StateExpired, got.State)
+		assert.Empty(t, got.Value, "an expired value must not be served")
+		assert.Equal(t, 3, fake.FetchCount(fk))
+	})
+}
+
+// A binding removed by Apply must not keep emitting cache-state events when
+// its already-in-flight fetch finally returns.
+func TestNoStaleEventsAfterBindingRemoval(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, "v1")
+
+		var buf syncBuffer
+		r := newTestResolver(t, reg, WithLogger(zerolog.New(&buf)))
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg,
+			bindTuned(t, "tok", "file:///a", 10*time.Second, time.Hour)))
+		synctest.Wait()
+		require.Equal(t, StateFresh, r.Lookup("tok").State)
+		buf.buf.Reset()
+
+		// Let the refresh timer fire into a fetch that blocks, then drop the
+		// binding while that fetch is still in flight.
+		fake.Block(fk)
+		fake.SetError(fk, provider.ErrNotFound)
+		time.Sleep(11 * time.Second)
+		synctest.Wait()
+
+		r.Apply(context.Background(), nil)
+		fake.Release(fk)
+		synctest.Wait()
+
+		assert.Empty(t, buf.String(), "a removed binding must emit no further events")
+		assert.False(t, r.Lookup("tok").Found)
+	})
+}

--- a/pkg/secrets/resolver/resolver_test.go
+++ b/pkg/secrets/resolver/resolver_test.go
@@ -513,3 +513,75 @@ func TestNoStaleEventsAfterBindingRemoval(t *testing.T) {
 		assert.False(t, r.Lookup("tok").Found)
 	})
 }
+
+func TestBackfilledSelectorAgesFromFetch(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, `{"a":"1","b":"2"}`)
+
+		refresh, grace := 10*time.Minute, 60*time.Second
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bindTuned(t, "a", "file:///a#a", refresh, grace)))
+		synctest.Wait()
+		require.Equal(t, StateFresh, r.Lookup("a").State)
+
+		// The payload ages, still within grace, with no refresh due yet.
+		advance(45 * time.Second)
+
+		// A config change adds a selector served from that cached payload.
+		r.Apply(context.Background(), buildScope(t, reg,
+			bindTuned(t, "a", "file:///a#a", refresh, grace),
+			bindTuned(t, "b", "file:///a#b", refresh, grace)))
+		synctest.Wait()
+		require.Equal(t, StateFresh, r.Lookup("b").State)
+		require.Equal(t, "2", r.Lookup("b").Value)
+
+		// A failed refresh once the payload is 65s old: past the 60s grace for
+		// both selectors, because the backfilled one kept the fetch's epoch
+		// rather than restarting the clock at the config change.
+		fake.SetError(fk, errors.New("io error"))
+		advance(20 * time.Second)
+		fake.TriggerWatch(fk)
+		synctest.Wait()
+
+		assert.Equal(t, StateExpired, r.Lookup("a").State)
+		assert.Equal(t, StateExpired, r.Lookup("b").State)
+	})
+}
+
+func TestBackfillRejectsPayloadPastGrace(t *testing.T) {
+	t.Parallel()
+	synctest.Test(t, func(t *testing.T) {
+		reg, fake := testFakeRegistry(t)
+		fk := fkOf(t, "file:///a")
+		fake.SetValue(fk, `{"a":"1","b":"2"}`)
+
+		refresh, grace := 10*time.Second, 30*time.Second
+		r := newTestResolver(t, reg)
+		defer r.Close()
+
+		r.Apply(context.Background(), buildScope(t, reg, bindTuned(t, "a", "file:///a#a", refresh, grace)))
+		synctest.Wait()
+		require.Equal(t, StateFresh, r.Lookup("a").State)
+
+		// The backend breaks and the bound value ages out of its grace.
+		fake.SetError(fk, errors.New("io error"))
+		advance(60 * time.Second)
+		require.Equal(t, StateExpired, r.Lookup("a").State)
+
+		// A config change now adds a selector whose only available bytes are the
+		// expired payload. It must not be served.
+		r.Apply(context.Background(), buildScope(t, reg,
+			bindTuned(t, "a", "file:///a#a", refresh, grace),
+			bindTuned(t, "b", "file:///a#b", refresh, grace)))
+		synctest.Wait()
+
+		got := r.Lookup("b")
+		assert.Equal(t, StateExpired, got.State, "a payload past grace must not be resurrected")
+		assert.Empty(t, got.Value)
+	})
+}

--- a/pkg/secrets/resolver/schedule.go
+++ b/pkg/secrets/resolver/schedule.go
@@ -1,0 +1,42 @@
+package resolver
+
+import "time"
+
+// Refresh-ahead fractions and jitter, per §1.4 of the plan.
+const (
+	// renewableRefreshFraction is used for renewable leases (future Vault). The
+	// constant exists now; no v1 provider reports renewable leases.
+	renewableRefreshFraction = 0.66
+	// nonRenewableRefreshFraction is used when the provider reports a TTL.
+	nonRenewableRefreshFraction = 0.90
+	// jitterFraction is the ±fraction of uniform jitter applied to every interval.
+	jitterFraction = 0.10
+	// minInterval is the hard floor: never refresh more often than this.
+	minInterval = time.Second
+)
+
+// nextRefresh returns the absolute time of the next refresh attempt.
+//
+//	base = refreshInterval           if ttl <= 0 (flat poll, e.g. file://)
+//	     = renewableFraction × ttl   if renewable lease
+//	     = nonRenewableFraction × ttl otherwise
+//
+// The base is then jittered by ±jitterFraction (rnd returns [0,1); 0.5 => no
+// jitter) and floored at minInterval.
+func nextRefresh(now time.Time, ttl, refreshInterval time.Duration, renewable bool, rnd func() float64) time.Time {
+	var base time.Duration
+	switch {
+	case ttl <= 0:
+		base = refreshInterval
+	case renewable:
+		base = time.Duration(renewableRefreshFraction * float64(ttl))
+	default:
+		base = time.Duration(nonRenewableRefreshFraction * float64(ttl))
+	}
+
+	// rnd() in [0,1) maps to a jitter multiplier in [-jitterFraction, +jitterFraction);
+	// 0.5 => no jitter.
+	jitter := (rnd()*2 - 1) * jitterFraction
+	d := max(time.Duration(float64(base)*(1+jitter)), minInterval)
+	return now.Add(d)
+}

--- a/pkg/secrets/resolver/schedule_test.go
+++ b/pkg/secrets/resolver/schedule_test.go
@@ -1,0 +1,72 @@
+package resolver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var scheduleNow = time.Unix(1_000_000, 0)
+
+func constRand(v float64) func() float64 { return func() float64 { return v } }
+
+func TestNextRefresh(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		ttl        time.Duration
+		refresh    time.Duration
+		renewable  bool
+		rnd        float64
+		wantOffset time.Duration
+	}{
+		{name: "flat poll, no jitter", ttl: 0, refresh: 5 * time.Minute, rnd: 0.5, wantOffset: 5 * time.Minute},
+		{name: "non-renewable ttl", ttl: 100 * time.Second, refresh: 5 * time.Minute, rnd: 0.5, wantOffset: 90 * time.Second},
+		{name: "renewable ttl", ttl: 100 * time.Second, refresh: 5 * time.Minute, renewable: true, rnd: 0.5, wantOffset: 66 * time.Second},
+		{name: "jitter low", ttl: 0, refresh: 100 * time.Second, rnd: 0, wantOffset: 90 * time.Second},
+		{name: "jitter high", ttl: 0, refresh: 100 * time.Second, rnd: 0.999999, wantOffset: 110 * time.Second},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := nextRefresh(scheduleNow, tt.ttl, tt.refresh, tt.renewable, constRand(tt.rnd))
+			gotOffset := got.Sub(scheduleNow)
+			// Allow a small rounding tolerance on the jittered cases.
+			assert.InDelta(t, tt.wantOffset, gotOffset, float64(time.Second))
+		})
+	}
+}
+
+func TestNextRefreshJitterBounds(t *testing.T) {
+	t.Parallel()
+
+	base := 5 * time.Minute
+	for _, rnd := range []float64{0, 0.1, 0.25, 0.5, 0.75, 0.9, 0.999999} {
+		got := nextRefresh(scheduleNow, 0, base, false, constRand(rnd)).Sub(scheduleNow)
+		assert.Greater(t, got, time.Duration(0), "never <= 0")
+		assert.LessOrEqual(t, got, 2*base, "never > 2x base")
+		assert.GreaterOrEqual(t, got, time.Duration(float64(base)*0.9)-time.Second)
+		assert.LessOrEqual(t, got, time.Duration(float64(base)*1.1)+time.Second)
+	}
+}
+
+func TestScheduleFloor(t *testing.T) {
+	t.Parallel()
+
+	// A sub-second interval is floored at minInterval regardless of jitter.
+	for _, rnd := range []float64{0, 0.5, 0.999999} {
+		got := nextRefresh(scheduleNow, 0, 100*time.Millisecond, false, constRand(rnd)).Sub(scheduleNow)
+		assert.GreaterOrEqual(t, got, minInterval)
+	}
+}
+
+func TestNextRefreshDeterministic(t *testing.T) {
+	t.Parallel()
+
+	a := nextRefresh(scheduleNow, 100*time.Second, 5*time.Minute, false, constRand(0.3))
+	b := nextRefresh(scheduleNow, 100*time.Second, 5*time.Minute, false, constRand(0.3))
+	assert.Equal(t, a, b)
+}

--- a/pkg/secrets/resolver/schedule_test.go
+++ b/pkg/secrets/resolver/schedule_test.go
@@ -1,10 +1,14 @@
 package resolver
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/secrets/provider"
 )
 
 var scheduleNow = time.Unix(1_000_000, 0)
@@ -69,4 +73,40 @@ func TestNextRefreshDeterministic(t *testing.T) {
 	a := nextRefresh(scheduleNow, 100*time.Second, 5*time.Minute, false, constRand(0.3))
 	b := nextRefresh(scheduleNow, 100*time.Second, 5*time.Minute, false, constRand(0.3))
 	assert.Equal(t, a, b)
+}
+
+// A suppressed attempt makes no provider call, so it is no evidence about the
+// backend and must not clear backoff accumulated from real transient errors.
+// A real fetch that answers not-found is such evidence, and does clear it.
+func TestComputeWaitBackoffOnSuppression(t *testing.T) {
+	t.Parallel()
+
+	reg, _ := testFakeRegistry(t)
+	r := newTestResolver(t, reg)
+	defer r.Close()
+	fs := &fetchState{fetchKey: "file:///a", refresh: time.Hour}
+
+	t.Run("suppression preserves backoff", func(t *testing.T) {
+		var bo backoffState
+		transient := errors.New("boom")
+		r.computeWait(fs, &bo, provider.Result{}, transient)
+		r.computeWait(fs, &bo, provider.Result{}, transient)
+		accumulated := bo.cur
+		require.Positive(t, accumulated)
+
+		r.computeWait(fs, &bo, provider.Result{}, errSuppressed)
+		assert.Equal(t, accumulated, bo.cur, "a suppressed attempt must not reset backoff")
+
+		assert.Equal(t, accumulated*2, r.computeWait(fs, &bo, provider.Result{}, transient),
+			"the next transient error continues from the accumulated backoff")
+	})
+
+	t.Run("not-found resets backoff", func(t *testing.T) {
+		var bo backoffState
+		r.computeWait(fs, &bo, provider.Result{}, errors.New("boom"))
+		require.Positive(t, bo.cur)
+
+		r.computeWait(fs, &bo, provider.Result{}, provider.ErrNotFound)
+		assert.Zero(t, bo.cur, "a real fetch answering not-found clears transient backoff")
+	})
 }


### PR DESCRIPTION
The cache engine. Background fetch loops — one per distinct backend URL — start on `Apply` (there is no `Run` and no readiness gating). Every fetch dedupes through singleflight and publishes to an immutable snapshot behind one atomic pointer, so the request hot path is a single atomic load plus two map reads (0 allocs/op). Refresh-ahead scheduling with jitter, stale-while-error, negative caching for not-found, and file-watch-driven immediate refresh. Secret values never reach a log line, error, or metric label.

```mermaid
stateDiagram-v2
    [*] --> Fetching: Apply
    Fetching --> Fresh: success
    Fetching --> Failed: error
    Fresh --> Fresh: refresh ok
    Fresh --> Stale: refresh fails, within grace
    Stale --> Fresh: success
    Stale --> Expired: grace exhausted
    Expired --> Fresh: success
    Failed --> Fresh: success
```
