### PR TITLE
authorize: resolve ${secret.ID} refs in set_request_headers

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -30,6 +30,8 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/secrets"
+	"github.com/pomerium/pomerium/pkg/secrets/resolver"
 	"github.com/pomerium/pomerium/pkg/ssh"
 	ssh_cli "github.com/pomerium/pomerium/pkg/ssh/cli"
 	"github.com/pomerium/pomerium/pkg/ssh/code"
@@ -55,12 +57,18 @@ type Authorize struct {
 	outboundGrpcConn grpc.CachedOutboundGRPClientConn
 	*ratelimit.RateLimiter
 	recordingServer atomic.Pointer[recording.Server]
+
+	// secretsResolver is long-lived (like store): created once in New, its
+	// fetch loops start on Apply, and it is Closed on shutdown. It is not part
+	// of authorizeState (which is rebuilt per config change).
+	secretsResolver *resolver.Resolver
 }
 
 type options struct {
 	policyIndexerCtor func(ssh.SSHEvaluator) ssh.PolicyIndexer
 	cliController     ssh_cli.InternalCLIController
 	rls               envoy_service_ratelimit_v3.RateLimitServiceServer
+	secretsResolver   *resolver.Resolver
 }
 
 // Option configures the Authorize service.
@@ -83,6 +91,14 @@ func WithInternalCLIController(cliCtrl ssh_cli.InternalCLIController) Option {
 func WithRateLimitServer(rls envoy_service_ratelimit_v3.RateLimitServiceServer) Option {
 	return func(o *options) {
 		o.rls = rls
+	}
+}
+
+// withSecretsResolver injects a pre-built secrets resolver (test seam for
+// observing fetch behavior); production always lets New build its own.
+func withSecretsResolver(r *resolver.Resolver) Option {
+	return func(o *options) {
+		o.secretsResolver = r
 	}
 }
 
@@ -115,7 +131,18 @@ func New(ctx context.Context, cfg *config.Config, opts ...Option) (*Authorize, e
 		recordingServer: atomic.Pointer[recording.Server]{},
 	}
 	a.currentConfig.Store(cfg)
-	state, err := newAuthorizeStateFromConfig(ctx, nil, tracerProvider, cfg, a.store, &a.outboundGrpcConn)
+
+	// Create the resolver and start its fetch loops from the initial config
+	// before building the evaluator state, so the evaluator never references
+	// bindings the resolver has not been told about. There is no readiness
+	// gating: requests that arrive before the first successful fetch fail closed.
+	a.secretsResolver = o.secretsResolver
+	if a.secretsResolver == nil {
+		a.secretsResolver = resolver.New(secrets.DefaultRegistry())
+	}
+	a.applySecrets(ctx, cfg)
+
+	state, err := newAuthorizeStateFromConfig(ctx, nil, tracerProvider, cfg, a.store, a.secretsResolver, &a.outboundGrpcConn)
 	if err != nil {
 		return nil, err
 	}
@@ -153,8 +180,25 @@ func (a *Authorize) GetDataBrokerServiceClient() databroker.DataBrokerServiceCli
 	return a.state.Load().dataBrokerClient
 }
 
+// applySecrets diffs the config's secret bindings into the resolver, starting
+// or stopping fetch loops as needed. Binding validity is guaranteed by config
+// validation, so a scope error here is logged, not fatal.
+func (a *Authorize) applySecrets(ctx context.Context, cfg *config.Config) {
+	scope, _, err := cfg.Options.Secrets.ToScope(secrets.DefaultRegistry())
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("authorize: invalid secrets configuration")
+		return
+	}
+	a.secretsResolver.Apply(ctx, scope)
+}
+
 // Run runs the authorize service.
 func (a *Authorize) Run(ctx context.Context) error {
+	// The resolver's fetch loops start in New (on Apply); stop them on shutdown.
+	if a.secretsResolver != nil {
+		context.AfterFunc(ctx, a.secretsResolver.Close)
+	}
+
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		return a.ssh.Run(ctx)
@@ -248,7 +292,12 @@ func newPolicyEvaluator(
 func (a *Authorize) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	currentState := a.state.Load()
 	a.currentConfig.Store(cfg)
-	if newState, err := newAuthorizeStateFromConfig(ctx, currentState, a.tracerProvider, cfg, a.store, &a.outboundGrpcConn); err != nil {
+	// Apply the new bindings to the resolver before rebuilding the state, so the
+	// evaluator snapshot new requests see never references bindings the resolver
+	// has not been told about (the reverse order would open a window of spurious
+	// fail-closed 503s).
+	a.applySecrets(ctx, cfg)
+	if newState, err := newAuthorizeStateFromConfig(ctx, currentState, a.tracerProvider, cfg, a.store, a.secretsResolver, &a.outboundGrpcConn); err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("authorize: error updating state")
 	} else {
 		a.state.Store(newState)

--- a/authorize/check_response.go
+++ b/authorize/check_response.go
@@ -67,6 +67,19 @@ func (a *Authorize) handleResult(
 
 	// if there's an allow, the result is allowed.
 	if result.Allow.Value {
+		// A required secret could not be resolved: fail closed with a 503. A
+		// policy deny (handled above) always takes precedence, so authz reasons
+		// are never masked by secret trouble.
+		if result.SecretsUnavailable != nil {
+			evt := log.Ctx(ctx).Warn().
+				Str("binding", result.SecretsUnavailable.BindingID).
+				Str("header", result.SecretsUnavailable.HeaderName)
+			if request != nil && request.Policy != nil {
+				evt = evt.Str("route", request.Policy.String())
+			}
+			evt.Msg("authorize: secret unavailable, denying request")
+			return a.deniedResponse(ctx, in, http.StatusServiceUnavailable, "secret unavailable", nil)
+		}
 		return a.handleResultAllowed(ctx, in, request, result)
 	}
 

--- a/authorize/evaluator/config.go
+++ b/authorize/evaluator/config.go
@@ -21,6 +21,7 @@ type evaluatorConfig struct {
 	JWTGroupsFilter                                   config.JWTGroupsFilter
 	DefaultJWTIssuerFormat                            nullable.Value[configpb.IssuerFormat]
 	MCPAccessTokenProvider                            store.MCPAccessTokenProvider `hash:"-"`
+	SecretsLookup                                     store.SecretsLookup          `hash:"-"`
 }
 
 // cacheKey() returns a hash over the configuration, except for the policies.
@@ -122,5 +123,13 @@ func WithDefaultJWTIssuerFormat(format nullable.Value[configpb.IssuerFormat]) Op
 func WithMCPAccessTokenProvider(fn store.MCPAccessTokenProvider) Option {
 	return func(cfg *evaluatorConfig) {
 		cfg.MCPAccessTokenProvider = fn
+	}
+}
+
+// WithSecretsLookup sets the secrets lookup used to resolve ${secret.ID}
+// references in set_request_headers.
+func WithSecretsLookup(l store.SecretsLookup) Option {
+	return func(cfg *evaluatorConfig) {
+		cfg.SecretsLookup = l
 	}
 }

--- a/authorize/evaluator/evaluator.go
+++ b/authorize/evaluator/evaluator.go
@@ -162,6 +162,10 @@ type Result struct {
 	HeadersToRemove     []string
 	Traces              []contextutil.PolicyEvaluationTrace
 	AdditionalLogFields map[logfields.AuthorizeLogField]any
+	// SecretsUnavailable is set when a required ${secret.ID} reference could not
+	// be resolved for a set_request_headers value; the request must fail closed
+	// with a 503. It never carries a secret value.
+	SecretsUnavailable *SecretsUnavailableError
 }
 
 func (r *Result) HasReason(reason criteria.Reason) bool {
@@ -338,6 +342,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, req *Request) (*Result, error)
 		HeadersToRemove:     headersOutput.HeadersToRemove,
 		Traces:              policyOutput.Traces,
 		AdditionalLogFields: headersOutput.AdditionalLogFields,
+		SecretsUnavailable:  headersOutput.SecretsUnavailable,
 	}
 	return res, nil
 }
@@ -445,6 +450,7 @@ func updateStore(store *store.Store, cfg *evaluatorConfig) error {
 	store.UpdateRoutePolicies(cfg.Policies)
 	store.UpdateSigningKey(jwk)
 	store.UpdateMCPAccessTokenProvider(cfg.MCPAccessTokenProvider)
+	store.UpdateSecretsLookup(cfg.SecretsLookup)
 
 	return nil
 }

--- a/authorize/evaluator/headers_evaluator.go
+++ b/authorize/evaluator/headers_evaluator.go
@@ -14,17 +14,29 @@ import (
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
 
+// SecretsUnavailableError identifies a set_request_headers value whose
+// ${secret.ID} reference could not be resolved. It carries only the binding ID
+// and header name — never a secret value.
+type SecretsUnavailableError struct {
+	BindingID  string
+	HeaderName string
+}
+
 // HeadersResponse is the output from the headers.rego script.
 type HeadersResponse struct {
 	Headers             http.Header
 	HeadersToRemove     []string
 	AdditionalLogFields map[logfields.AuthorizeLogField]any
+	// SecretsUnavailable, when non-nil, means a required secret reference could
+	// not be resolved and the request must fail closed (503).
+	SecretsUnavailable *SecretsUnavailableError
 }
 
 // A HeadersEvaluator evaluates the headers.rego script.
 type HeadersEvaluator struct {
 	evaluationCount    metric.Int64Counter
 	evaluationDuration metric.Int64Histogram
+	headerInjectCount  metric.Int64Counter
 
 	store *store.Store
 }
@@ -38,6 +50,8 @@ func NewHeadersEvaluator(store *store.Store) *HeadersEvaluator {
 		evaluationDuration: metrics.Int64Histogram("authorize.header_evaluator.evaluation.duration",
 			metric.WithDescription("Duration of header evaluation."),
 			metric.WithUnit("ms")),
+		headerInjectCount: metrics.Int64Counter("secrets.header_inject",
+			metric.WithDescription("Number of secret header injection outcomes.")),
 
 		store: store,
 	}

--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -17,6 +17,8 @@ import (
 	"github.com/go-jose/go-jose/v3"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pomerium/datasource/pkg/directory"
@@ -29,6 +31,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/logfields"
+	"github.com/pomerium/pomerium/pkg/secrets/resolver"
 	"github.com/pomerium/pomerium/pkg/telemetry/requestid"
 )
 
@@ -175,35 +178,164 @@ func (e *headersEvaluatorEvaluation) fillRoutingKeyHeaders() {
 	}
 }
 
+// secretFailure records a per-header secret resolution failure. It never
+// carries the secret value.
+type secretFailure struct {
+	bindingID string
+	class     string // "unavailable" | "invalid_value"
+}
+
+const (
+	headerInjectInjected = "injected"
+	headerInjectRejected = "rejected"
+)
+
 func (e *headersEvaluatorEvaluation) fillSetRequestHeaders(ctx context.Context) {
 	if e.request.Policy == nil {
 		return
 	}
 
-	for k, v := range e.request.Policy.SetRequestHeaders {
-		e.response.Headers.Add(k, headertemplate.Render(v, func(ref []string) string {
-			switch {
-			case slices.Equal(ref, []string{"pomerium", "access_token"}):
-				s, _ := e.getSessionOrServiceAccount(ctx)
-				return s.GetOauthToken().GetAccessToken()
-			case slices.Equal(ref, []string{"pomerium", "client_cert_san_dns"}):
-				return e.getClientCertDNSNames()
-			case slices.Equal(ref, []string{"pomerium", "client_cert_san_email"}):
-				return e.getClientCertEmailAddresses()
-			case slices.Equal(ref, []string{"pomerium", "client_cert_fingerprint"}):
-				return e.getClientCertFingerprint()
-			case slices.Equal(ref, []string{"pomerium", "id_token"}):
-				s, _ := e.getSessionOrServiceAccount(ctx)
-				return s.GetIdToken().GetRaw()
-			case slices.Equal(ref, []string{"pomerium", "jwt"}):
-				return e.getSignedJWT(ctx)
-			case len(ref) > 3 && ref[0] == "pomerium" && ref[1] == "request" && ref[2] == "headers":
-				return e.request.HTTP.Headers[httputil.CanonicalHeaderKey(ref[3])]
+	// Capture exactly one point-in-time view per evaluation, lazily on the first
+	// secret ref, so every secret ref reads a consistent snapshot (§1.3) and
+	// routes with no secret refs never touch the lookup at all (hot-path guard).
+	var (
+		view         resolver.View
+		viewCaptured bool
+	)
+	captureView := func() resolver.View {
+		if !viewCaptured {
+			viewCaptured = true
+			if lookup := e.evaluator.store.GetSecretsLookup(); lookup != nil {
+				view = lookup.View()
 			}
-
-			return ""
-		}))
+		}
+		return view
 	}
+
+	// Iterate header names in sorted order so that, when multiple headers fail,
+	// the reported (binding, header) pair is deterministic (lexicographically
+	// smallest header name) despite Go's randomized map iteration (D3).
+	names := make([]string, 0, len(e.request.Policy.SetRequestHeaders))
+	for name := range e.request.Policy.SetRequestHeaders {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+
+	for _, name := range names {
+		value := e.request.Policy.SetRequestHeaders[name]
+		var sawSecret bool
+		var failure *secretFailure
+		rendered := headertemplate.Render(value, func(ref []string) string {
+			if len(ref) > 0 && ref[0] == "secret" {
+				sawSecret = true
+				return e.resolveSecretRef(captureView(), ref, &failure)
+			}
+			return e.renderPomeriumRef(ctx, ref)
+		})
+
+		if !sawSecret {
+			e.response.Headers.Add(name, rendered)
+			continue
+		}
+
+		if failure != nil {
+			e.recordHeaderInject(headerInjectRejected, failure.class)
+			// Fail closed: no partially-built header for this name, and record
+			// the first (smallest-name) failure as the request's deny marker.
+			if e.response.SecretsUnavailable == nil {
+				e.response.SecretsUnavailable = &SecretsUnavailableError{
+					BindingID:  failure.bindingID,
+					HeaderName: name,
+				}
+			}
+			continue
+		}
+
+		e.recordHeaderInject(headerInjectInjected, "")
+		e.response.Headers.Add(name, rendered)
+	}
+}
+
+// resolveSecretRef resolves a ${secret.ID} reference against the captured view.
+// On any failure it records the first failure into *failure and returns "" so
+// no partial value is built.
+func (e *headersEvaluatorEvaluation) resolveSecretRef(view resolver.View, ref []string, failure **secretFailure) string {
+	// The ref argument is static and config-validated to two segments; be
+	// defensive and fail closed on anything else.
+	if len(ref) != 2 {
+		setSecretFailure(failure, &secretFailure{bindingID: strings.Join(ref, "."), class: "unavailable"})
+		return ""
+	}
+	id := ref[1]
+
+	if view == nil {
+		setSecretFailure(failure, &secretFailure{bindingID: id, class: "unavailable"})
+		return ""
+	}
+
+	res := view.Lookup(id)
+	if !res.Found || (res.State != resolver.StateFresh && res.State != resolver.StateStale) {
+		setSecretFailure(failure, &secretFailure{bindingID: id, class: "unavailable"})
+		return ""
+	}
+	if !validSecretHeaderValue(res.Value) {
+		// A malformed secret fails closed; it never reaches http.Header.Add.
+		setSecretFailure(failure, &secretFailure{bindingID: id, class: "invalid_value"})
+		return ""
+	}
+	return res.Value
+}
+
+func setSecretFailure(dst **secretFailure, f *secretFailure) {
+	if *dst == nil {
+		*dst = f
+	}
+}
+
+// validSecretHeaderValue rejects values containing CR, LF, or NUL, which cannot
+// safely appear in an HTTP header value.
+func validSecretHeaderValue(v string) bool {
+	return !strings.ContainsAny(v, "\r\n\x00")
+}
+
+func (e *headersEvaluatorEvaluation) recordHeaderInject(outcome, errorClass string) {
+	routeID := ""
+	if e.request != nil && e.request.Policy != nil {
+		routeID, _ = e.request.Policy.RouteID()
+	}
+	e.evaluator.headerInjectCount.Add(context.Background(), 1, metric.WithAttributes(
+		attribute.String("route_id", routeID),
+		attribute.String("outcome", outcome),
+	))
+	if outcome == headerInjectRejected {
+		log.Ctx(context.Background()).Warn().
+			Str("route_id", routeID).
+			Str("error_class", errorClass).
+			Msg("authorize/header-evaluator: secret unavailable, rejecting request")
+	}
+}
+
+func (e *headersEvaluatorEvaluation) renderPomeriumRef(ctx context.Context, ref []string) string {
+	switch {
+	case slices.Equal(ref, []string{"pomerium", "access_token"}):
+		s, _ := e.getSessionOrServiceAccount(ctx)
+		return s.GetOauthToken().GetAccessToken()
+	case slices.Equal(ref, []string{"pomerium", "client_cert_san_dns"}):
+		return e.getClientCertDNSNames()
+	case slices.Equal(ref, []string{"pomerium", "client_cert_san_email"}):
+		return e.getClientCertEmailAddresses()
+	case slices.Equal(ref, []string{"pomerium", "client_cert_fingerprint"}):
+		return e.getClientCertFingerprint()
+	case slices.Equal(ref, []string{"pomerium", "id_token"}):
+		s, _ := e.getSessionOrServiceAccount(ctx)
+		return s.GetIdToken().GetRaw()
+	case slices.Equal(ref, []string{"pomerium", "jwt"}):
+		return e.getSignedJWT(ctx)
+	case len(ref) > 3 && ref[0] == "pomerium" && ref[1] == "request" && ref[2] == "headers":
+		return e.request.HTTP.Headers[httputil.CanonicalHeaderKey(ref[3])]
+	}
+
+	return ""
 }
 
 func (e *headersEvaluatorEvaluation) fillHeaders(ctx context.Context) error {

--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -239,7 +239,7 @@ func (e *headersEvaluatorEvaluation) fillSetRequestHeaders(ctx context.Context) 
 		}
 
 		if failure != nil {
-			e.recordHeaderInject(headerInjectRejected, failure.class)
+			e.recordHeaderInject(ctx, headerInjectRejected, failure.class)
 			// Fail closed: no partially-built header for this name, and record
 			// the first (smallest-name) failure as the request's deny marker.
 			if e.response.SecretsUnavailable == nil {
@@ -251,7 +251,7 @@ func (e *headersEvaluatorEvaluation) fillSetRequestHeaders(ctx context.Context) 
 			continue
 		}
 
-		e.recordHeaderInject(headerInjectInjected, "")
+		e.recordHeaderInject(ctx, headerInjectInjected, "")
 		e.response.Headers.Add(name, rendered)
 	}
 }
@@ -298,17 +298,17 @@ func validSecretHeaderValue(v string) bool {
 	return !strings.ContainsAny(v, "\r\n\x00")
 }
 
-func (e *headersEvaluatorEvaluation) recordHeaderInject(outcome, errorClass string) {
+func (e *headersEvaluatorEvaluation) recordHeaderInject(ctx context.Context, outcome, errorClass string) {
 	routeID := ""
 	if e.request != nil && e.request.Policy != nil {
 		routeID, _ = e.request.Policy.RouteID()
 	}
-	e.evaluator.headerInjectCount.Add(context.Background(), 1, metric.WithAttributes(
+	e.evaluator.headerInjectCount.Add(ctx, 1, metric.WithAttributes(
 		attribute.String("route_id", routeID),
 		attribute.String("outcome", outcome),
 	))
 	if outcome == headerInjectRejected {
-		log.Ctx(context.Background()).Warn().
+		log.Ctx(ctx).Warn().
 			Str("route_id", routeID).
 			Str("error_class", errorClass).
 			Msg("authorize/header-evaluator: secret unavailable, rejecting request")

--- a/authorize/evaluator/secrets_headers_test.go
+++ b/authorize/evaluator/secrets_headers_test.go
@@ -1,0 +1,177 @@
+package evaluator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/authorize/internal/store"
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/secrets/resolver"
+)
+
+// fakeView returns scripted lookup results and counts lookups.
+type fakeView struct {
+	results map[string]resolver.LookupResult
+	lookups int
+}
+
+func (v *fakeView) Lookup(id string) resolver.LookupResult {
+	v.lookups++
+	return v.results[id]
+}
+
+// fakeSecretsLookup hands out a (possibly changing) view and counts View calls.
+type fakeSecretsLookup struct {
+	views     []*fakeView
+	viewCalls int
+}
+
+func (f *fakeSecretsLookup) View() resolver.View {
+	v := f.views[min(f.viewCalls, len(f.views)-1)]
+	f.viewCalls++
+	return v
+}
+
+func fresh(v string) resolver.LookupResult {
+	return resolver.LookupResult{Value: v, State: resolver.StateFresh, Found: true}
+}
+
+func evalSecretHeaders(t *testing.T, lookup store.SecretsLookup, headers map[string]string) *HeadersResponse {
+	t.Helper()
+	s := store.New()
+	if lookup != nil {
+		s.UpdateSecretsLookup(lookup)
+	}
+	e := NewHeadersEvaluator(s)
+	res, err := e.Evaluate(t.Context(), &Request{
+		HTTP:    RequestHTTP{Hostname: "from.example.com"},
+		Policy:  &config.Policy{From: "https://from.example.com", SetRequestHeaders: headers},
+		Session: RequestSession{ID: "s1"},
+	}, rego.EvalTime(time.Unix(1686870680, 0)))
+	require.NoError(t, err)
+	return res
+}
+
+func TestFillSetRequestHeadersSecrets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("fresh value injected", func(t *testing.T) {
+		t.Parallel()
+		lookup := &fakeSecretsLookup{views: []*fakeView{{results: map[string]resolver.LookupResult{
+			"tok": fresh("s3cr3t"),
+		}}}}
+		res := evalSecretHeaders(t, lookup, map[string]string{"Authorization": "Bearer ${secret.tok}"})
+		assert.Equal(t, "Bearer s3cr3t", res.Headers.Get("Authorization"))
+		assert.Nil(t, res.SecretsUnavailable)
+	})
+
+	t.Run("repeated ref in one value", func(t *testing.T) {
+		t.Parallel()
+		lookup := &fakeSecretsLookup{views: []*fakeView{{results: map[string]resolver.LookupResult{
+			"tok": fresh("XYZ"),
+		}}}}
+		res := evalSecretHeaders(t, lookup, map[string]string{"X": "${secret.tok}-${secret.tok}"})
+		assert.Equal(t, "XYZ-XYZ", res.Headers.Get("X"))
+	})
+
+	t.Run("stale value still injected", func(t *testing.T) {
+		t.Parallel()
+		lookup := &fakeSecretsLookup{views: []*fakeView{{results: map[string]resolver.LookupResult{
+			"tok": {Value: "stale-val", State: resolver.StateStale, Found: true},
+		}}}}
+		res := evalSecretHeaders(t, lookup, map[string]string{"X": "${secret.tok}"})
+		assert.Equal(t, "stale-val", res.Headers.Get("X"))
+		assert.Nil(t, res.SecretsUnavailable)
+	})
+
+	t.Run("unavailable rejects with marker and no partial header", func(t *testing.T) {
+		t.Parallel()
+		lookup := &fakeSecretsLookup{views: []*fakeView{{results: map[string]resolver.LookupResult{
+			"tok": {State: resolver.StateExpired, Found: true},
+		}}}}
+		res := evalSecretHeaders(t, lookup, map[string]string{"Authorization": "Bearer ${secret.tok}"})
+		require.NotNil(t, res.SecretsUnavailable)
+		assert.Equal(t, "tok", res.SecretsUnavailable.BindingID)
+		assert.Equal(t, "Authorization", res.SecretsUnavailable.HeaderName)
+		assert.Empty(t, res.Headers.Get("Authorization"), "no partially-built header")
+	})
+
+	t.Run("failed state rejects", func(t *testing.T) {
+		t.Parallel()
+		lookup := &fakeSecretsLookup{views: []*fakeView{{results: map[string]resolver.LookupResult{
+			"tok": {State: resolver.StateFailed, Found: true},
+		}}}}
+		res := evalSecretHeaders(t, lookup, map[string]string{"X": "${secret.tok}"})
+		require.NotNil(t, res.SecretsUnavailable)
+	})
+
+	t.Run("unknown id rejects (config race)", func(t *testing.T) {
+		t.Parallel()
+		lookup := &fakeSecretsLookup{views: []*fakeView{{results: map[string]resolver.LookupResult{}}}}
+		res := evalSecretHeaders(t, lookup, map[string]string{"X": "${secret.gone}"})
+		require.NotNil(t, res.SecretsUnavailable)
+		assert.Equal(t, "gone", res.SecretsUnavailable.BindingID)
+	})
+
+	t.Run("nil lookup fails closed", func(t *testing.T) {
+		t.Parallel()
+		res := evalSecretHeaders(t, nil, map[string]string{"X": "${secret.tok}"})
+		require.NotNil(t, res.SecretsUnavailable)
+		assert.Empty(t, res.Headers.Get("X"))
+	})
+
+	t.Run("value with newline fails closed", func(t *testing.T) {
+		t.Parallel()
+		lookup := &fakeSecretsLookup{views: []*fakeView{{results: map[string]resolver.LookupResult{
+			"tok": fresh("bad\nvalue"),
+		}}}}
+		res := evalSecretHeaders(t, lookup, map[string]string{"X": "${secret.tok}"})
+		require.NotNil(t, res.SecretsUnavailable)
+		assert.Empty(t, res.Headers.Get("X"))
+	})
+
+	t.Run("deterministic smallest header name on multiple failures", func(t *testing.T) {
+		t.Parallel()
+		for range 20 {
+			lookup := &fakeSecretsLookup{views: []*fakeView{{results: map[string]resolver.LookupResult{
+				"tok": {State: resolver.StateExpired, Found: true},
+			}}}}
+			res := evalSecretHeaders(t, lookup, map[string]string{
+				"Z-Header": "${secret.tok}",
+				"A-Header": "${secret.tok}",
+				"M-Header": "${secret.tok}",
+			})
+			require.NotNil(t, res.SecretsUnavailable)
+			assert.Equal(t, "A-Header", res.SecretsUnavailable.HeaderName)
+		}
+	})
+
+	t.Run("no secret refs never touches lookup", func(t *testing.T) {
+		t.Parallel()
+		lookup := &fakeSecretsLookup{views: []*fakeView{{results: map[string]resolver.LookupResult{}}}}
+		res := evalSecretHeaders(t, lookup, map[string]string{"X": "static-value"})
+		assert.Equal(t, "static-value", res.Headers.Get("X"))
+		assert.Zero(t, lookup.viewCalls, "hot-path guard: no secret refs => no View()")
+	})
+
+	t.Run("one view per evaluation", func(t *testing.T) {
+		t.Parallel()
+		// Two different views; if the fill loop captured more than one, the two
+		// headers would disagree.
+		lookup := &fakeSecretsLookup{views: []*fakeView{
+			{results: map[string]resolver.LookupResult{"tok": fresh("first")}},
+			{results: map[string]resolver.LookupResult{"tok": fresh("second")}},
+		}}
+		res := evalSecretHeaders(t, lookup, map[string]string{
+			"A": "${secret.tok}",
+			"B": "${secret.tok}",
+		})
+		assert.Equal(t, "first", res.Headers.Get("A"))
+		assert.Equal(t, "first", res.Headers.Get("B"))
+		assert.Equal(t, 1, lookup.viewCalls, "View captured exactly once per evaluation")
+	})
+}

--- a/authorize/evaluator/secrets_headers_test.go
+++ b/authorize/evaluator/secrets_headers_test.go
@@ -1,10 +1,12 @@
 package evaluator
 
 import (
+	"bytes"
 	"testing"
 	"time"
 
 	"github.com/open-policy-agent/opa/rego"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -174,4 +176,30 @@ func TestFillSetRequestHeadersSecrets(t *testing.T) {
 		assert.Equal(t, "first", res.Headers.Get("B"))
 		assert.Equal(t, 1, lookup.viewCalls, "View captured exactly once per evaluation")
 	})
+}
+
+// The rejection warning and its metric must be emitted on the request context,
+// so operators can correlate the resulting 503 with the request that caused it.
+func TestSecretRejectionLoggedOnRequestContext(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	ctx := zerolog.New(&buf).With().Str("request-id", "req-42").Logger().WithContext(t.Context())
+
+	s := store.New()
+	s.UpdateSecretsLookup(&fakeSecretsLookup{views: []*fakeView{{results: map[string]resolver.LookupResult{
+		"tok": {State: resolver.StateExpired, Found: true},
+	}}}})
+
+	res, err := NewHeadersEvaluator(s).Evaluate(ctx, &Request{
+		HTTP:    RequestHTTP{Hostname: "from.example.com"},
+		Policy:  &config.Policy{From: "https://from.example.com", SetRequestHeaders: map[string]string{"Authorization": "Bearer ${secret.tok}"}},
+		Session: RequestSession{ID: "s1"},
+	}, rego.EvalTime(time.Unix(1686870680, 0)))
+	require.NoError(t, err)
+	require.NotNil(t, res.SecretsUnavailable)
+
+	assert.Contains(t, buf.String(), "secret unavailable, rejecting request")
+	assert.Contains(t, buf.String(), `"request-id":"req-42"`,
+		"the rejection must carry the request context's log fields")
 }

--- a/authorize/internal/store/secrets_test.go
+++ b/authorize/internal/store/secrets_test.go
@@ -1,0 +1,29 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/pkg/secrets/resolver"
+)
+
+type fakeLookup struct{}
+
+func (fakeLookup) View() resolver.View { return nil }
+
+func TestSecretsLookup(t *testing.T) {
+	t.Parallel()
+
+	s := New()
+	assert.Nil(t, s.GetSecretsLookup(), "nil-safe when never set")
+
+	l := fakeLookup{}
+	s.UpdateSecretsLookup(l)
+	assert.Equal(t, l, s.GetSecretsLookup())
+
+	// Mirrors the MCP provider: a nil update is a no-op, so the lookup can never
+	// be un-set.
+	s.UpdateSecretsLookup(nil)
+	assert.Equal(t, l, s.GetSecretsLookup())
+}

--- a/authorize/internal/store/store.go
+++ b/authorize/internal/store/store.go
@@ -24,6 +24,7 @@ import (
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/nullable"
+	"github.com/pomerium/pomerium/pkg/secrets/resolver"
 	"github.com/pomerium/pomerium/pkg/storage"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
@@ -38,12 +39,19 @@ type Store struct {
 	defaultJWTIssuerFormat                            atomic.Pointer[nullable.Value[configpb.IssuerFormat]]
 	signingKey                                        atomic.Pointer[jose.JSONWebKey]
 	mcpAccessTokenProvider                            atomic.Pointer[MCPAccessTokenProvider]
+	secretsLookup                                     atomic.Pointer[SecretsLookup]
 }
 
 type MCPAccessTokenProvider interface {
 	// GetAccessTokenForSession returns an access token for the given session ID and expiration time,
 	// that may be used by the MCP client to interact with the MCP servers fronted by Pomerium.
 	GetAccessTokenForSession(sessionID string, expiresAt time.Time) (string, error)
+}
+
+// SecretsLookup resolves ${secret.ID} references at request time. The header
+// fill loop captures exactly one View per evaluation for a consistent snapshot.
+type SecretsLookup interface {
+	View() resolver.View
 }
 
 // New creates a new Store.
@@ -136,6 +144,26 @@ func (s *Store) UpdateMCPAccessTokenProvider(mcpAccessTokenProvider MCPAccessTok
 	// This isn't used by the Rego code, so we don't need to write it to the opastorage.Store instance.
 	if mcpAccessTokenProvider != nil {
 		s.mcpAccessTokenProvider.Store(&mcpAccessTokenProvider)
+	}
+}
+
+// GetSecretsLookup returns the secrets lookup, or nil if never set.
+func (s *Store) GetSecretsLookup() SecretsLookup {
+	p := s.secretsLookup.Load()
+	if p == nil {
+		return nil
+	}
+	return *p
+}
+
+// UpdateSecretsLookup sets the secrets lookup. Like the MCP provider it no-ops
+// on nil, so the lookup can never be un-set: the authorize service wires the
+// long-lived resolver unconditionally, and "no bindings" is just an empty
+// snapshot, not a nil lookup.
+func (s *Store) UpdateSecretsLookup(secretsLookup SecretsLookup) {
+	// This isn't used by the Rego code, so we don't need to write it to the opastorage.Store instance.
+	if secretsLookup != nil {
+		s.secretsLookup.Store(&secretsLookup)
 	}
 }
 

--- a/authorize/secrets_check_response_test.go
+++ b/authorize/secrets_check_response_test.go
@@ -1,0 +1,75 @@
+package authorize
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/authorize/evaluator"
+	"github.com/pomerium/pomerium/config"
+	hpke_handlers "github.com/pomerium/pomerium/pkg/hpke/handlers"
+	"github.com/pomerium/pomerium/pkg/policy/criteria"
+)
+
+func newTestAuthorize(t *testing.T) *Authorize {
+	t.Helper()
+	opt := config.NewDefaultOptions()
+	opt.DataBroker.ServiceURL = "https://databroker.example.com"
+	opt.SharedKey = "E8wWIMnihUx+AUfRegAQDNs8eRb3UrB5G3zlJW9XJDM="
+
+	hpkePrivateKey, err := opt.GetHPKEPrivateKey()
+	require.NoError(t, err)
+	authnSrv := httptest.NewServer(hpke_handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
+	t.Cleanup(authnSrv.Close)
+	opt.AuthenticateURLString = authnSrv.URL
+
+	a, err := New(t.Context(), config.New(opt))
+	require.NoError(t, err)
+	return a
+}
+
+func TestHandleResultSecretUnavailable(t *testing.T) {
+	t.Parallel()
+	a := newTestAuthorize(t)
+
+	t.Run("allowed but secret unavailable => 503", func(t *testing.T) {
+		res, err := a.handleResult(t.Context(),
+			&envoy_service_auth_v3.CheckRequest{},
+			&evaluator.Request{Policy: &config.Policy{From: "https://app.example.com"}},
+			&evaluator.Result{
+				Allow:              evaluator.NewRuleResult(true, criteria.ReasonPomeriumRoute),
+				SecretsUnavailable: &evaluator.SecretsUnavailableError{BindingID: "tok", HeaderName: "Authorization"},
+			})
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusServiceUnavailable, int(res.GetDeniedResponse().GetStatus().GetCode()))
+	})
+
+	t.Run("policy deny takes precedence over secret unavailable", func(t *testing.T) {
+		res, err := a.handleResult(t.Context(),
+			&envoy_service_auth_v3.CheckRequest{},
+			&evaluator.Request{Policy: &config.Policy{From: "https://app.example.com"}},
+			&evaluator.Result{
+				Allow:              evaluator.NewRuleResult(false),
+				Deny:               evaluator.NewRuleResult(true, criteria.ReasonRouteNotFound),
+				SecretsUnavailable: &evaluator.SecretsUnavailableError{BindingID: "tok", HeaderName: "Authorization"},
+			})
+		require.NoError(t, err)
+		assert.NotEqual(t, http.StatusServiceUnavailable, int(res.GetDeniedResponse().GetStatus().GetCode()),
+			"policy deny must win, not the secret 503")
+	})
+
+	t.Run("allowed with no marker => ok", func(t *testing.T) {
+		res, err := a.handleResult(t.Context(),
+			&envoy_service_auth_v3.CheckRequest{},
+			&evaluator.Request{Policy: &config.Policy{From: "https://app.example.com"}},
+			&evaluator.Result{
+				Allow: evaluator.NewRuleResult(true, criteria.ReasonPomeriumRoute),
+			})
+		require.NoError(t, err)
+		assert.NotNil(t, res.GetOkResponse())
+	})
+}

--- a/authorize/secrets_lifecycle_test.go
+++ b/authorize/secrets_lifecycle_test.go
@@ -1,0 +1,194 @@
+package authorize
+
+import (
+	"context"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/open-policy-agent/opa/rego"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+
+	"github.com/pomerium/pomerium/authorize/evaluator"
+	"github.com/pomerium/pomerium/config"
+	hpke_handlers "github.com/pomerium/pomerium/pkg/hpke/handlers"
+	"github.com/pomerium/pomerium/pkg/secrets"
+	"github.com/pomerium/pomerium/pkg/secrets/resolver"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+func baseAuthorizeOptions(t *testing.T) *config.Options {
+	t.Helper()
+	opt := config.NewDefaultOptions()
+	opt.DataBroker.ServiceURL = "https://databroker.example.com"
+	opt.SharedKey = "E8wWIMnihUx+AUfRegAQDNs8eRb3UrB5G3zlJW9XJDM="
+
+	hpkePrivateKey, err := opt.GetHPKEPrivateKey()
+	require.NoError(t, err)
+	authnSrv := httptest.NewServer(hpke_handlers.HPKEPublicKeyHandler(hpkePrivateKey.PublicKey()))
+	t.Cleanup(authnSrv.Close)
+	opt.AuthenticateURLString = authnSrv.URL
+	return opt
+}
+
+func eventuallyResolves(t *testing.T, a *Authorize, id, want string) {
+	t.Helper()
+	assert.Eventually(t, func() bool {
+		r := a.secretsResolver.Lookup(id)
+		return r.Found && r.State == resolver.StateFresh && r.Value == want
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func secretsFetchCount(t *testing.T, reader *sdkmetric.ManualReader) int64 {
+	t.Helper()
+	var rm metricdata.ResourceMetrics
+	require.NoError(t, reader.Collect(context.Background(), &rm))
+	for _, sm := range rm.ScopeMetrics {
+		for _, m := range sm.Metrics {
+			if m.Name != "secrets.fetches" {
+				continue
+			}
+			if d, ok := m.Data.(metricdata.Sum[int64]); ok {
+				var sum int64
+				for _, dp := range d.DataPoints {
+					sum += dp.Value
+				}
+				return sum
+			}
+		}
+	}
+	return 0
+}
+
+func TestNewWithSecrets(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tok")
+	require.NoError(t, os.WriteFile(path, []byte("v1"), 0o600))
+
+	opt := baseAuthorizeOptions(t)
+	opt.Secrets = config.SecretsOptions{
+		Defaults: config.SecretsDefaultsOptions{Refresh: time.Second, StaleGrace: 2 * time.Second, NegativeTTL: time.Second},
+		Bindings: map[string]config.SecretsBindingOptions{"tok": {URL: "file://" + path}},
+	}
+
+	// New returns; Run is deliberately NOT called (boot-order regression).
+	a, err := New(t.Context(), config.New(opt))
+	require.NoError(t, err)
+
+	assert.NotNil(t, a.store.GetSecretsLookup(), "lookup wired into the store")
+
+	// Fetch loops started on Apply inside New, without Run.
+	eventuallyResolves(t, a, "tok", "v1")
+
+	// The header injects through a headers evaluator built over the same store
+	// New wired the lookup into — no Run required.
+	ctx := storage.WithQuerier(t.Context(), storage.NewStaticQuerier())
+	he := evaluator.NewHeadersEvaluator(a.store)
+	assert.Eventually(t, func() bool {
+		res, err := he.Evaluate(ctx, &evaluator.Request{
+			Policy: &config.Policy{
+				From:              "https://app.example.com",
+				SetRequestHeaders: map[string]string{"Authorization": "Bearer ${secret.tok}"},
+			},
+		}, rego.EvalTime(time.Unix(1686870680, 0)))
+		return err == nil && res.Headers.Get("Authorization") == "Bearer v1"
+	}, 5*time.Second, 50*time.Millisecond)
+}
+
+func TestOnConfigChangeRebindsSecrets(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	p1 := filepath.Join(dir, "tok1")
+	p2 := filepath.Join(dir, "tok2")
+	require.NoError(t, os.WriteFile(p1, []byte("v1"), 0o600))
+	require.NoError(t, os.WriteFile(p2, []byte("v2"), 0o600))
+
+	opt := baseAuthorizeOptions(t)
+	opt.Secrets = config.SecretsOptions{
+		Defaults: config.SecretsDefaultsOptions{Refresh: time.Second, StaleGrace: 2 * time.Second, NegativeTTL: time.Second},
+		Bindings: map[string]config.SecretsBindingOptions{"tok": {URL: "file://" + p1}},
+	}
+
+	a, err := New(t.Context(), config.New(opt))
+	require.NoError(t, err)
+	eventuallyResolves(t, a, "tok", "v1")
+
+	opt.Secrets.Bindings["tok"] = config.SecretsBindingOptions{URL: "file://" + p2}
+	a.OnConfigChange(t.Context(), config.New(opt))
+	eventuallyResolves(t, a, "tok", "v2")
+}
+
+func TestOnConfigChangeKeepsCacheWarm(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tok")
+	require.NoError(t, os.WriteFile(path, []byte("v1"), 0o600))
+
+	reader := sdkmetric.NewManualReader()
+	mp := sdkmetric.NewMeterProvider(sdkmetric.WithReader(reader))
+	res := resolver.New(secrets.DefaultRegistry(), resolver.WithMeter(mp.Meter("test")))
+
+	opt := baseAuthorizeOptions(t)
+	// Long refresh so no scheduled re-fetch pollutes the assertion.
+	opt.Secrets = config.SecretsOptions{
+		Bindings: map[string]config.SecretsBindingOptions{"tok": {URL: "file://" + path}},
+	}
+
+	a, err := New(t.Context(), config.New(opt), withSecretsResolver(res))
+	require.NoError(t, err)
+	eventuallyResolves(t, a, "tok", "v1")
+
+	before := secretsFetchCount(t, reader)
+	require.GreaterOrEqual(t, before, int64(1))
+
+	// A config change that does not touch the binding.
+	opt.LogLevel = "debug"
+	a.OnConfigChange(t.Context(), config.New(opt))
+	time.Sleep(500 * time.Millisecond)
+
+	assert.Equal(t, before, secretsFetchCount(t, reader), "warm binding must not be re-fetched on config change")
+}
+
+func TestNewDoesNotBlockOnUnresolvable(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "tok") // does not exist yet
+
+	opt := baseAuthorizeOptions(t)
+	opt.Secrets = config.SecretsOptions{
+		Defaults: config.SecretsDefaultsOptions{Refresh: time.Second, StaleGrace: 2 * time.Second, NegativeTTL: time.Second},
+		Bindings: map[string]config.SecretsBindingOptions{"tok": {URL: "file://" + path}},
+	}
+
+	// New returns promptly even though the secret is unresolvable.
+	done := make(chan *Authorize, 1)
+	go func() {
+		a, err := New(t.Context(), config.New(opt))
+		require.NoError(t, err)
+		done <- a
+	}()
+	var a *Authorize
+	select {
+	case a = <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("New blocked on an unresolvable secret")
+	}
+
+	// The unresolved binding reads as not-fresh (a referencing request 503s).
+	r := a.secretsResolver.Lookup("tok")
+	assert.True(t, r.State != resolver.StateFresh && r.State != resolver.StateStale, "unresolved => not servable")
+
+	// Once the file appears, it resolves without any config reload.
+	require.NoError(t, os.WriteFile(path, []byte("late"), 0o600))
+	eventuallyResolves(t, a, "tok", "late")
+}

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -47,6 +47,7 @@ func newAuthorizeStateFromConfig(
 	tracerProvider oteltrace.TracerProvider,
 	cfg *config.Config,
 	store *store.Store,
+	secretsLookup store.SecretsLookup,
 	outboundGrpcConn *grpc.CachedOutboundGRPClientConn,
 ) (*authorizeState, error) {
 	if err := validateOptions(cfg.Options); err != nil {
@@ -92,6 +93,12 @@ func newAuthorizeStateFromConfig(
 	state.dataBrokerClient = databroker.NewDataBrokerServiceClient(cc)
 
 	var evaluatorOptions []evaluator.Option
+	// Wire the secrets lookup unconditionally: with no bindings this is just an
+	// empty snapshot (a cheap no-op), and this is why the store's nil-reset
+	// semantics never matter.
+	if secretsLookup != nil {
+		evaluatorOptions = append(evaluatorOptions, evaluator.WithSecretsLookup(secretsLookup))
+	}
 	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
 		mcp, err := mcp.New(ctx, mcp.DefaultPrefix, cfg, outboundGrpcConn)
 		if err != nil {

--- a/authorize/state_test.go
+++ b/authorize/state_test.go
@@ -37,7 +37,7 @@ func TestNewAuthorizeStateFromConfig_IdentityProviderResolverReuse(t *testing.T)
 	newState := func(t *testing.T, previous *authorizeState, opts *config.Options) *authorizeState {
 		t.Helper()
 		state, err := newAuthorizeStateFromConfig(t.Context(), previous, noop.NewTracerProvider(),
-			config.New(opts), store.New(), new(grpc.CachedOutboundGRPClientConn))
+			config.New(opts), store.New(), nil, new(grpc.CachedOutboundGRPClientConn))
 		require.NoError(t, err)
 		return state
 	}


### PR DESCRIPTION
Where injection happens. The authorize service owns one long-lived resolver, created and `Apply`-ed in `New` before the evaluator state is built, so no request ever sees a binding the resolver has not been told about. The header-fill pass captures one resolver snapshot per evaluation and substitutes `${secret.ID}` alongside the existing `${pomerium.*}` references. Fail-closed throughout: an unavailable, unknown, or malformed (CR/LF/NUL) secret yields no header and a 503 — and a policy deny always takes precedence. Rotation becomes visible with no config reload.

```mermaid
flowchart TD
    A[request] --> B[render set_request_headers]
    B --> C{secret Fresh or Stale, value valid?}
    C -->|yes| D[header injected]
    C -->|no| E[mark SecretsUnavailable]
    D --> F{policy result}
    E --> F
    F -->|deny| G[deny reasons win]
    F -->|allow, marker set| H[503 fail closed]
    F -->|allow| I[ok response]
```
