### PR TITLE
config: add (referenceable) proto option, annotate set_request_headers

### DIFF
--- a/config/secrets.go
+++ b/config/secrets.go
@@ -16,11 +16,39 @@ import (
 	"github.com/pomerium/pomerium/pkg/secrets/ref"
 )
 
-// ReferenceableFields is the single list of proto fields whose values may carry
-// ${secret.ID} references. M7's lint test diffs it against the (referenceable)
-// proto annotations; extend it (and the annotation) together when a field
-// becomes referenceable in a later phase.
-var ReferenceableFields = []string{"pomerium.config.Route.set_request_headers"}
+// referenceableField is one proto field whose values may carry ${secret.ID}
+// references, paired with the way to read those values off a policy.
+//
+// This table is the single source of truth, and it is load-bearing in both
+// directions: validateSecrets walks it instead of naming fields inline, and
+// ReferenceableFields exposes its paths so M7's lint test can diff them
+// against the (referenceable) proto annotations. Annotating a new field
+// without adding it here therefore fails that test rather than silently
+// leaving the field unvalidated.
+type referenceableField struct {
+	// path is the fully-qualified proto field name.
+	path string
+	// kind names the surface in validation errors ("request header").
+	kind string
+	// values returns the field's values on a policy, keyed by their name.
+	values func(*Policy) map[string]string
+}
+
+var referenceableFields = []referenceableField{{
+	path:   "pomerium.config.Route.set_request_headers",
+	kind:   "request header",
+	values: func(p *Policy) map[string]string { return p.SetRequestHeaders },
+}}
+
+// ReferenceableFields returns the proto fields whose values may carry
+// ${secret.ID} references — exactly the fields validateSecrets checks.
+func ReferenceableFields() []string {
+	out := make([]string, 0, len(referenceableFields))
+	for _, f := range referenceableFields {
+		out = append(out, f.path)
+	}
+	return out
+}
 
 // SecretsOptions is the YAML/settings `secrets` block: a binding table plus
 // tuning defaults. Its fields are operator config, never secret material.
@@ -207,12 +235,16 @@ func (o *Options) validateSecrets() error {
 		return nil
 	}
 
-	// Iterate policies (and their headers) in a deterministic order.
+	// Iterate policies (and their referenceable fields) in a deterministic order.
 	for policy := range o.GetAllPolicies() {
 		route := policy.String()
-		for _, name := range sortedKeys(policy.SetRequestHeaders) {
-			if err := checkRequestValue(fmt.Sprintf("route %s request header %q", route, name), policy.SetRequestHeaders[name]); err != nil {
-				return err
+		for _, f := range referenceableFields {
+			values := f.values(policy)
+			for _, name := range sortedKeys(values) {
+				where := fmt.Sprintf("route %s %s %q", route, f.kind, name)
+				if err := checkRequestValue(where, values[name]); err != nil {
+					return err
+				}
 			}
 		}
 		for _, name := range sortedKeys(policy.SetResponseHeaders) {

--- a/pkg/grpc/config/config.pb.go
+++ b/pkg/grpc/config/config.pb.go
@@ -9771,7 +9771,7 @@ const file_config_proto_rawDesc = "" +
 	"\x0esupported_algs\x18\x03 \x03(\tR\rsupportedAlgs\x12\x1c\n" +
 	"\taudiences\x18\x04 \x03(\tR\taudiences\",\n" +
 	"\x10SessionRecording\x12\x18\n" +
-	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xe2/\n" +
+	"\aenabled\x18\x01 \x01(\bR\aenabled\"\xe8/\n" +
 	"\x05Route\x12\x13\n" +
 	"\x02id\x18\x1c \x01(\tH\x00R\x02id\x88\x01\x01\x12&\n" +
 	"\fnamespace_id\x18P \x01(\tH\x01R\vnamespaceId\x88\x01\x01\x12(\n" +
@@ -9820,8 +9820,8 @@ const file_config_proto_rawDesc = "" +
 	"\x1dtls_downstream_client_ca_file\x18' \x01(\tB\x02\x18\x01R\x19tlsDownstreamClientCaFile\x12U\n" +
 	"$tls_downstream_client_ca_key_pair_id\x18T \x01(\tB\x02\x18\x01H\n" +
 	"R\x1etlsDownstreamClientCaKeyPairId\x88\x01\x01\x12G\n" +
-	" tls_upstream_allow_renegotiation\x18< \x01(\bR\x1dtlsUpstreamAllowRenegotiation\x12]\n" +
-	"\x13set_request_headers\x18\x16 \x03(\v2-.pomerium.config.Route.SetRequestHeadersEntryR\x11setRequestHeaders\x124\n" +
+	" tls_upstream_allow_renegotiation\x18< \x01(\bR\x1dtlsUpstreamAllowRenegotiation\x12c\n" +
+	"\x13set_request_headers\x18\x16 \x03(\v2-.pomerium.config.Route.SetRequestHeadersEntryB\x04\xf0\xd6,\x01R\x11setRequestHeaders\x124\n" +
 	"\x16remove_request_headers\x18\x17 \x03(\tR\x14removeRequestHeaders\x12`\n" +
 	"\x14set_response_headers\x18) \x03(\v2..pomerium.config.Route.SetResponseHeadersEntryR\x12setResponseHeaders\x12]\n" +
 	"\x18rewrite_response_headers\x18( \x03(\v2#.pomerium.config.RouteRewriteHeaderR\x16rewriteResponseHeaders\x120\n" +
@@ -9984,7 +9984,7 @@ const file_config_proto_rawDesc = "" +
 	"\v_source_pplB\x0e\n" +
 	"\f_explanationB\x0e\n" +
 	"\f_remediationB\x11\n" +
-	"\x0f_namespace_nameJ\x04\b\x04\x10\x05\"\x81j\n" +
+	"\x0f_namespace_nameJ\x04\b\x04\x10\x05\"\x87j\n" +
 	"\bSettings\x12\x14\n" +
 	"\x02id\x18\x9e\x01 \x01(\tH\x00R\x02id\x88\x01\x01\x12'\n" +
 	"\fnamespace_id\x18\x9f\x01 \x01(\tH\x01R\vnamespaceId\x88\x01\x01\x12#\n" +
@@ -10051,8 +10051,8 @@ const file_config_proto_rawDesc = "" +
 	"\x13bearer_token_format\x18\x8a\x01 \x01(\x0e2\".pomerium.config.BearerTokenFormatH/R\x11bearerTokenFormat\x88\x01\x01\x12X\n" +
 	"\x18default_upstream_timeout\x18' \x01(\v2\x19.google.protobuf.DurationH0R\x16defaultUpstreamTimeout\x88\x01\x01\x12)\n" +
 	"\rdebug_address\x18\x9c\x01 \x01(\tH1R\fdebugAddress\x88\x01\x01\x12,\n" +
-	"\x0fmetrics_address\x18( \x01(\tH2R\x0emetricsAddress\x88\x01\x01\x121\n" +
-	"\x12metrics_basic_auth\x18@ \x01(\tH3R\x10metricsBasicAuth\x88\x01\x01\x12[\n" +
+	"\x0fmetrics_address\x18( \x01(\tH2R\x0emetricsAddress\x88\x01\x01\x127\n" +
+	"\x12metrics_basic_auth\x18@ \x01(\tB\x04\xe8\xd6,\x01H3R\x10metricsBasicAuth\x88\x01\x01\x12[\n" +
 	"\x13metrics_certificate\x18A \x01(\v2%.pomerium.config.Settings.CertificateH4R\x12metricsCertificate\x88\x01\x01\x12/\n" +
 	"\x11metrics_client_ca\x18B \x01(\tH5R\x0fmetricsClientCa\x88\x01\x01\x12E\n" +
 	"\x1dmetrics_client_ca_key_pair_id\x18\xa4\x01 \x01(\tH6R\x18metricsClientCaKeyPairId\x88\x01\x01\x125\n" +

--- a/pkg/grpc/config/config.pb.json
+++ b/pkg/grpc/config/config.pb.json
@@ -8783,6 +8783,21 @@
       "enums": [],
       "extensions": [
         {
+          "name": "referenceable",
+          "longName": ".google.protobuf.FieldOptions.referenceable",
+          "fullName": ".google.protobuf.FieldOptions.referenceable",
+          "description": "referenceable marks a field whose string values may embed ${secret.ID}\nreferences (and the existing ${pomerium.*} references). The resolution\ntime is field-specific — e.g. set_request_headers resolves in the\nauthorize service at request time. Fields not marked referenceable must\nreject secret references at config validation.",
+          "label": "",
+          "type": "bool",
+          "longType": "bool",
+          "fullType": "bool",
+          "number": 91502,
+          "defaultValue": "",
+          "containingType": "FieldOptions",
+          "containingLongType": ".google.protobuf.FieldOptions",
+          "containingFullType": "google.protobuf.FieldOptions"
+        },
+        {
           "name": "sensitive",
           "longName": ".google.protobuf.FieldOptions.sensitive",
           "fullName": ".google.protobuf.FieldOptions.sensitive",

--- a/pkg/grpc/config/config.pb.json
+++ b/pkg/grpc/config/config.pb.json
@@ -8786,7 +8786,7 @@
           "name": "referenceable",
           "longName": ".google.protobuf.FieldOptions.referenceable",
           "fullName": ".google.protobuf.FieldOptions.referenceable",
-          "description": "referenceable marks a field whose string values may embed ${secret.ID}\nreferences (and the existing ${pomerium.*} references). The resolution\ntime is field-specific — e.g. set_request_headers resolves in the\nauthorize service at request time. Fields not marked referenceable must\nreject secret references at config validation.",
+          "description": "referenceable marks a field whose string values may embed ${secret.ID}\nreferences (and the existing ${pomerium.*} references). The resolution\ntime is field-specific — e.g. set_request_headers resolves in the\nauthorize service at request time.\n\nEvery annotated field must also appear in the config package's\nreferenceable-field table, which is what config validation actually walks;\na field that has no resolver is not scanned, and a ${secret.ID} written\nthere is inert literal text rather than a resolved secret.",
           "label": "",
           "type": "bool",
           "longType": "bool",

--- a/pkg/grpc/config/config.proto
+++ b/pkg/grpc/config/config.proto
@@ -386,7 +386,7 @@ message Route {
   // - ${pomerium.client_cert_fingerprint}: Short-form SHA-256 fingerprint of the presented client certificate.
   // - ${pomerium.id_token}: OIDC ID token from the identity provider.
   // - ${pomerium.jwt}: The Pomerium assertion JWT for the logged-in user.
-  map<string, string> set_request_headers = 22;
+  map<string, string> set_request_headers = 22 [(referenceable) = true];
   // Headers to remove from upstream requests. This can be useful if you want to
   // prevent privacy information from being passed to upstream applications.
   repeated string remove_request_headers = 23;
@@ -897,7 +897,7 @@ message Settings {
   optional string metrics_address = 40;
   // HTTP Basic Auth credentials required to access `metrics_address`, of
   // the form "user:password". Empty disables auth.
-  optional string metrics_basic_auth = 64;
+  optional string metrics_basic_auth = 64 [(sensitive) = true];
   // TLS certificate/key pair Pomerium uses on the metrics listener.
   optional Certificate metrics_certificate = 65;
   // PEM-encoded CA bundle used to authenticate clients connecting to the

--- a/pkg/grpc/config/options.pb.go
+++ b/pkg/grpc/config/options.pb.go
@@ -30,6 +30,14 @@ var file_options_proto_extTypes = []protoimpl.ExtensionInfo{
 		Tag:           "varint,91501,opt,name=sensitive",
 		Filename:      "options.proto",
 	},
+	{
+		ExtendedType:  (*descriptorpb.FieldOptions)(nil),
+		ExtensionType: (*bool)(nil),
+		Field:         91502,
+		Name:          "pomerium.config.referenceable",
+		Tag:           "varint,91502,opt,name=referenceable",
+		Filename:      "options.proto",
+	},
 }
 
 // Extension fields to descriptorpb.FieldOptions.
@@ -42,6 +50,14 @@ var (
 	//
 	// optional bool sensitive = 91501;
 	E_Sensitive = &file_options_proto_extTypes[0]
+	// referenceable marks a field whose string values may embed ${secret.ID}
+	// references (and the existing ${pomerium.*} references). The resolution
+	// time is field-specific — e.g. set_request_headers resolves in the
+	// authorize service at request time. Fields not marked referenceable must
+	// reject secret references at config validation.
+	//
+	// optional bool referenceable = 91502;
+	E_Referenceable = &file_options_proto_extTypes[1]
 )
 
 var File_options_proto protoreflect.FileDescriptor
@@ -49,17 +65,19 @@ var File_options_proto protoreflect.FileDescriptor
 const file_options_proto_rawDesc = "" +
 	"\n" +
 	"\roptions.proto\x12\x0fpomerium.config\x1a google/protobuf/descriptor.proto:=\n" +
-	"\tsensitive\x12\x1d.google.protobuf.FieldOptions\x18\xed\xca\x05 \x01(\bR\tsensitiveB.Z,github.com/pomerium/pomerium/pkg/grpc/configb\x06proto3"
+	"\tsensitive\x12\x1d.google.protobuf.FieldOptions\x18\xed\xca\x05 \x01(\bR\tsensitive:E\n" +
+	"\rreferenceable\x12\x1d.google.protobuf.FieldOptions\x18\xee\xca\x05 \x01(\bR\rreferenceableB.Z,github.com/pomerium/pomerium/pkg/grpc/configb\x06proto3"
 
 var file_options_proto_goTypes = []any{
 	(*descriptorpb.FieldOptions)(nil), // 0: google.protobuf.FieldOptions
 }
 var file_options_proto_depIdxs = []int32{
 	0, // 0: pomerium.config.sensitive:extendee -> google.protobuf.FieldOptions
-	1, // [1:1] is the sub-list for method output_type
-	1, // [1:1] is the sub-list for method input_type
-	1, // [1:1] is the sub-list for extension type_name
-	0, // [0:1] is the sub-list for extension extendee
+	0, // 1: pomerium.config.referenceable:extendee -> google.protobuf.FieldOptions
+	2, // [2:2] is the sub-list for method output_type
+	2, // [2:2] is the sub-list for method input_type
+	2, // [2:2] is the sub-list for extension type_name
+	0, // [0:2] is the sub-list for extension extendee
 	0, // [0:0] is the sub-list for field type_name
 }
 
@@ -75,7 +93,7 @@ func file_options_proto_init() {
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_options_proto_rawDesc), len(file_options_proto_rawDesc)),
 			NumEnums:      0,
 			NumMessages:   0,
-			NumExtensions: 1,
+			NumExtensions: 2,
 			NumServices:   0,
 		},
 		GoTypes:           file_options_proto_goTypes,

--- a/pkg/grpc/config/options.pb.go
+++ b/pkg/grpc/config/options.pb.go
@@ -53,8 +53,12 @@ var (
 	// referenceable marks a field whose string values may embed ${secret.ID}
 	// references (and the existing ${pomerium.*} references). The resolution
 	// time is field-specific — e.g. set_request_headers resolves in the
-	// authorize service at request time. Fields not marked referenceable must
-	// reject secret references at config validation.
+	// authorize service at request time.
+	//
+	// Every annotated field must also appear in the config package's
+	// referenceable-field table, which is what config validation actually walks;
+	// a field that has no resolver is not scanned, and a ${secret.ID} written
+	// there is inert literal text rather than a resolved secret.
 	//
 	// optional bool referenceable = 91502;
 	E_Referenceable = &file_options_proto_extTypes[1]

--- a/pkg/grpc/config/options.proto
+++ b/pkg/grpc/config/options.proto
@@ -13,4 +13,11 @@ extend google.protobuf.FieldOptions {
   // ConfigService to such audiences are expected to redact and merge these
   // fields appropriately.
   bool sensitive = 91501;
+
+  // referenceable marks a field whose string values may embed ${secret.ID}
+  // references (and the existing ${pomerium.*} references). The resolution
+  // time is field-specific — e.g. set_request_headers resolves in the
+  // authorize service at request time. Fields not marked referenceable must
+  // reject secret references at config validation.
+  bool referenceable = 91502;
 }

--- a/pkg/grpc/config/options.proto
+++ b/pkg/grpc/config/options.proto
@@ -17,7 +17,11 @@ extend google.protobuf.FieldOptions {
   // referenceable marks a field whose string values may embed ${secret.ID}
   // references (and the existing ${pomerium.*} references). The resolution
   // time is field-specific — e.g. set_request_headers resolves in the
-  // authorize service at request time. Fields not marked referenceable must
-  // reject secret references at config validation.
+  // authorize service at request time.
+  //
+  // Every annotated field must also appear in the config package's
+  // referenceable-field table, which is what config validation actually walks;
+  // a field that has no resolver is not scanned, and a ${secret.ID} written
+  // there is inert literal text rather than a resolved secret.
   bool referenceable = 91502;
 }

--- a/pkg/mcp/configapi/lint_test.go
+++ b/pkg/mcp/configapi/lint_test.go
@@ -110,6 +110,7 @@ var expectedSensitiveFields = map[string]struct{}{
 	"pomerium.config.Settings.autocert_eab_mac_key":          {},
 	"pomerium.config.Settings.ssh_host_keys":                 {},
 	"pomerium.config.Settings.ssh_user_ca_key":               {},
+	"pomerium.config.Settings.metrics_basic_auth":            {},
 	"pomerium.config.KeyPair.key":                            {},
 	"pomerium.config.CreateServiceAccountResponse.jwt":       {},
 	"pomerium.config.UpdateServiceAccountResponse.jwt":       {},

--- a/pkg/mcp/configapi/referenceable.go
+++ b/pkg/mcp/configapi/referenceable.go
@@ -1,0 +1,16 @@
+package configapi
+
+import (
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+)
+
+// IsReferenceable reports whether fd carries the
+// (pomerium.config.referenceable) option, meaning its string values may embed
+// ${secret.ID} references. Resolution time is field-specific.
+func IsReferenceable(fd protoreflect.FieldDescriptor) bool {
+	v, ok := proto.GetExtension(fd.Options(), configpb.E_Referenceable).(bool)
+	return ok && v
+}

--- a/pkg/mcp/configapi/referenceable_test.go
+++ b/pkg/mcp/configapi/referenceable_test.go
@@ -1,0 +1,143 @@
+package configapi_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	"github.com/pomerium/pomerium/config"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	"github.com/pomerium/pomerium/pkg/mcp/configapi"
+)
+
+// expectedReferenceableFields enumerates every config-proto field that MUST
+// carry [(pomerium.config.referenceable) = true]. Adding a referenceable field
+// means annotating it in config.proto AND adding it here AND extending
+// config.ReferenceableFields — the tests below keep the three in lockstep.
+var expectedReferenceableFields = map[string]struct{}{
+	"pomerium.config.Route.set_request_headers": {},
+}
+
+func referenceable(fd protoreflect.FieldDescriptor) bool {
+	v, ok := proto.GetExtension(fd.Options(), configpb.E_Referenceable).(bool)
+	return ok && v
+}
+
+func collectReferenceable(t *testing.T) map[string]struct{} {
+	t.Helper()
+	actual := map[string]struct{}{}
+	visited := map[protoreflect.FullName]bool{}
+	var collect func(protoreflect.MessageDescriptor)
+	collect = func(md protoreflect.MessageDescriptor) {
+		if visited[md.FullName()] {
+			return
+		}
+		visited[md.FullName()] = true
+		fields := md.Fields()
+		for i := 0; i < fields.Len(); i++ {
+			fd := fields.Get(i)
+			if referenceable(fd) {
+				actual[string(md.FullName())+"."+string(fd.Name())] = struct{}{}
+			}
+			if fd.Kind() == protoreflect.MessageKind {
+				collect(fd.Message())
+			}
+		}
+	}
+
+	svc := configpb.File_config_proto.Services().Get(0)
+	if svc == nil {
+		t.Fatalf("config.proto exposes no service")
+	}
+	methods := svc.Methods()
+	for i := 0; i < methods.Len(); i++ {
+		m := methods.Get(i)
+		collect(m.Input())
+		collect(m.Output())
+	}
+	return actual
+}
+
+func TestReferenceableFieldsMatchExpected(t *testing.T) {
+	t.Parallel()
+
+	actual := collectReferenceable(t)
+
+	var missing, extra []string
+	for path := range expectedReferenceableFields {
+		if _, ok := actual[path]; !ok {
+			missing = append(missing, path)
+		}
+	}
+	for path := range actual {
+		if _, ok := expectedReferenceableFields[path]; !ok {
+			extra = append(extra, path)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	if len(missing) > 0 {
+		t.Errorf("fields in expectedReferenceableFields but NOT annotated [(pomerium.config.referenceable) = true]:\n  - %s",
+			strings.Join(missing, "\n  - "))
+	}
+	if len(extra) > 0 {
+		t.Errorf("fields annotated [(pomerium.config.referenceable) = true] but NOT in expectedReferenceableFields:\n  - %s",
+			strings.Join(extra, "\n  - "))
+	}
+}
+
+// TestValidatedFieldsAreAnnotatedReferenceable keeps config.ReferenceableFields
+// (consulted by the config validator) equal to the set of proto fields
+// annotated referenceable, so adding a v2 field forces touching both.
+func TestValidatedFieldsAreAnnotatedReferenceable(t *testing.T) {
+	t.Parallel()
+
+	annotated := collectReferenceable(t)
+
+	validated := map[string]struct{}{}
+	for _, f := range config.ReferenceableFields {
+		validated[f] = struct{}{}
+	}
+
+	var missing, extra []string
+	for path := range validated {
+		if _, ok := annotated[path]; !ok {
+			missing = append(missing, path)
+		}
+	}
+	for path := range annotated {
+		if _, ok := validated[path]; !ok {
+			extra = append(extra, path)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	if len(missing) > 0 {
+		t.Errorf("config.ReferenceableFields entries with no (referenceable) proto annotation:\n  - %s",
+			strings.Join(missing, "\n  - "))
+	}
+	if len(extra) > 0 {
+		t.Errorf("(referenceable) proto fields missing from config.ReferenceableFields:\n  - %s",
+			strings.Join(extra, "\n  - "))
+	}
+}
+
+func TestIsReferenceable(t *testing.T) {
+	t.Parallel()
+
+	route := (&configpb.Route{}).ProtoReflect().Descriptor()
+	fields := route.Fields()
+
+	setReqHeaders := fields.ByName("set_request_headers")
+	setRespHeaders := fields.ByName("set_response_headers")
+	require.NotNil(t, setReqHeaders)
+	require.NotNil(t, setRespHeaders)
+
+	assert.True(t, configapi.IsReferenceable(setReqHeaders))
+	assert.False(t, configapi.IsReferenceable(setRespHeaders))
+}

--- a/pkg/mcp/configapi/referenceable_test.go
+++ b/pkg/mcp/configapi/referenceable_test.go
@@ -17,8 +17,9 @@ import (
 
 // expectedReferenceableFields enumerates every config-proto field that MUST
 // carry [(pomerium.config.referenceable) = true]. Adding a referenceable field
-// means annotating it in config.proto AND adding it here AND extending
-// config.ReferenceableFields — the tests below keep the three in lockstep.
+// means annotating it in config.proto AND adding it here AND adding it to the
+// config package's referenceable-field table (which is what the validator
+// walks) — the tests below keep the three in lockstep.
 var expectedReferenceableFields = map[string]struct{}{
 	"pomerium.config.Route.set_request_headers": {},
 }
@@ -91,16 +92,17 @@ func TestReferenceableFieldsMatchExpected(t *testing.T) {
 	}
 }
 
-// TestValidatedFieldsAreAnnotatedReferenceable keeps config.ReferenceableFields
-// (consulted by the config validator) equal to the set of proto fields
-// annotated referenceable, so adding a v2 field forces touching both.
+// TestValidatedFieldsAreAnnotatedReferenceable keeps the set of proto fields
+// annotated referenceable equal to config.ReferenceableFields, which reports
+// exactly the fields the config validator walks. Annotating a field without
+// teaching the validator to read it (or the reverse) fails here.
 func TestValidatedFieldsAreAnnotatedReferenceable(t *testing.T) {
 	t.Parallel()
 
 	annotated := collectReferenceable(t)
 
 	validated := map[string]struct{}{}
-	for _, f := range config.ReferenceableFields {
+	for _, f := range config.ReferenceableFields() {
 		validated[f] = struct{}{}
 	}
 


### PR DESCRIPTION
Adds a `(referenceable)` field option beside `(sensitive)`, marking proto fields whose string values may embed `${secret.ID}` references. `Route.set_request_headers` is the only one in v1. Two lint tests keep three things in lockstep — the proto annotations, the exported `config.ReferenceableFields` list the validator consults, and an expected-set — so making a field referenceable in a later phase forces touching all three consciously. Also annotates the previously-missed `Settings.metrics_basic_auth` as `(sensitive)`.
