### PR TITLE
identity: add extjwt external-JWT verification package

### DIFF
--- a/internal/jwtutil/jwtutil_test.go
+++ b/internal/jwtutil/jwtutil_test.go
@@ -1,0 +1,155 @@
+package jwtutil
+
+import (
+	"encoding/json"
+	"slices"
+	"strconv"
+	"testing"
+
+	"hegel.dev/go/hegel"
+)
+
+// These property tests cover the `aud`-claim normalization that underpins JWT
+// bearer audience matching: a JWT `aud` may be a single string OR an array of
+// strings, and toStringSlice (via the exported GetStringSlice/GetAudience)
+// must handle both — plus arbitrary, attacker-controlled claim values — without
+// panicking. See pkg/identity/oidc/extjwt for the matching step that consumes
+// these normalized audiences.
+
+// TestGetAudience_SingleStringIsSingleton asserts the single-string `aud` form
+// normalizes to a one-element slice (the form used by many OIDC issuers).
+func TestGetAudience_SingleStringIsSingleton(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		s := hegel.Draw(ht, hegel.Text())
+
+		got, ok := Claims{"aud": s}.GetAudience()
+		if !ok {
+			ht.Fatalf("GetAudience ok=false for present aud=%q", s)
+		}
+		if !slices.Equal(got, []string{s}) {
+			ht.Fatalf("single-string aud=%q normalized to %q, want [%q]", s, got, s)
+		}
+	})
+}
+
+// TestGetStringSlice_StringSliceIdentity asserts that an array-of-strings claim
+// round-trips element-for-element with no loss or reordering.
+func TestGetStringSlice_StringSliceIdentity(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		xs := hegel.Draw(ht, hegel.Lists(hegel.Text()))
+
+		got, ok := Claims{"k": xs}.GetStringSlice("k")
+		if !ok {
+			ht.Fatalf("GetStringSlice ok=false for present key")
+		}
+		if !slices.Equal(got, xs) {
+			ht.Fatalf("[]string identity broken: in=%q out=%q", xs, got)
+		}
+	})
+}
+
+// TestToStringSlice_LengthContract asserts the output-length contract:
+// a slice input preserves its length, a non-slice input yields exactly one
+// element.
+func TestToStringSlice_LengthContract(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		// Slice case: mixed element types, length must be preserved.
+		n := hegel.Draw(ht, hegel.Integers(0, 20))
+		input := make([]any, 0, n)
+		for range n {
+			switch hegel.Draw(ht, hegel.Integers(0, 2)) {
+			case 0:
+				input = append(input, hegel.Draw(ht, hegel.Text()))
+			case 1:
+				input = append(input, hegel.Draw(ht, hegel.Integers(-1000, 1000)))
+			default:
+				input = append(input, hegel.Draw(ht, hegel.Booleans()))
+			}
+		}
+		if got := toStringSlice(input); len(got) != len(input) {
+			ht.Fatalf("slice length not preserved: in len=%d out len=%d (%q)", len(input), len(got), got)
+		}
+
+		// Non-slice case: a scalar must produce a single-element slice.
+		scalar := hegel.Draw(ht, hegel.Integers(-1000, 1000))
+		if got := toStringSlice(scalar); len(got) != 1 {
+			ht.Fatalf("non-slice scalar %d produced %d elements: %q", scalar, len(got), got)
+		}
+	})
+}
+
+// drawClaimValue builds an arbitrary JSON-shaped claim value: strings,
+// json.Number (the form UnmarshalJSON produces for numbers), plain ints,
+// booleans, nil, and nested []any up to the given depth.
+func drawClaimValue(ht *hegel.T, depth int) any {
+	maxKind := 4
+	if depth > 0 {
+		maxKind = 5 // allow a nested slice only while depth remains
+	}
+	switch hegel.Draw(ht, hegel.Integers(0, maxKind)) {
+	case 0:
+		return hegel.Draw(ht, hegel.Text())
+	case 1:
+		return json.Number(strconv.Itoa(hegel.Draw(ht, hegel.Integers(-100000, 100000))))
+	case 2:
+		return hegel.Draw(ht, hegel.Booleans())
+	case 3:
+		return nil
+	case 4:
+		return hegel.Draw(ht, hegel.Integers(-100000, 100000))
+	default: // 5: nested slice
+		n := hegel.Draw(ht, hegel.Integers(0, 5))
+		xs := make([]any, 0, n)
+		for range n {
+			xs = append(xs, drawClaimValue(ht, depth-1))
+		}
+		return xs
+	}
+}
+
+// TestGetStringSlice_NoCrashArbitrary is the robustness property: claim values
+// are attacker-controlled, so normalization must never panic and must always
+// return a non-nil slice for a present key, whatever the value's shape.
+func TestGetStringSlice_NoCrashArbitrary(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		v := drawClaimValue(ht, 3)
+
+		got, ok := Claims{"x": v}.GetStringSlice("x")
+		if !ok {
+			ht.Fatalf("ok=false for present key (value=%#v)", v)
+		}
+		if got == nil {
+			ht.Fatalf("nil slice for present key (value=%#v)", v)
+		}
+	})
+}
+
+// TestGetAudience_MatchesGetStringSlice asserts the two related APIs agree:
+// GetAudience must be exactly GetStringSlice("aud"), and `ok` must reflect
+// whether the aud key is present.
+func TestGetAudience_MatchesGetStringSlice(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		present := hegel.Draw(ht, hegel.Booleans())
+		claims := Claims{}
+		if present {
+			claims["aud"] = drawClaimValue(ht, 2)
+		}
+
+		a, aok := claims.GetAudience()
+		b, bok := claims.GetStringSlice("aud")
+		if aok != bok {
+			ht.Fatalf("ok mismatch: GetAudience ok=%v, GetStringSlice ok=%v", aok, bok)
+		}
+		if !slices.Equal(a, b) {
+			ht.Fatalf("value mismatch: GetAudience=%q, GetStringSlice=%q", a, b)
+		}
+		if aok != present {
+			ht.Fatalf("ok=%v but key present=%v", aok, present)
+		}
+	})
+}

--- a/internal/testutil/mockidp/mockidp.go
+++ b/internal/testutil/mockidp/mockidp.go
@@ -556,6 +556,22 @@ func (token *idToken) Encode(signingKey jose.SigningKey) string {
 	return str
 }
 
+// SignJWT signs an arbitrary claims payload with the IDP's signing key.
+// Used by integration tests that need to mint JWTs outside of the OIDC flow
+// (e.g. Kubernetes ServiceAccount-style tokens presented in the Authorization
+// header).
+func (idp *IDP) SignJWT(claims any) string {
+	sig, err := jose.NewSigner(idp.signingKey, (&jose.SignerOptions{}).WithType("JWT"))
+	if err != nil {
+		panic(err)
+	}
+	str, err := jwt.Signed(sig).Claims(claims).CompactSerialize()
+	if err != nil {
+		panic(err)
+	}
+	return str
+}
+
 type User struct {
 	ID        string `json:"-"`
 	Email     string `json:"email"`

--- a/pkg/identity/oidc/extjwt/audience_internal_test.go
+++ b/pkg/identity/oidc/extjwt/audience_internal_test.go
@@ -1,0 +1,108 @@
+package extjwt
+
+import (
+	"testing"
+
+	"hegel.dev/go/hegel"
+)
+
+// audienceMatches is the heart of the per-route audience binding (Verify
+// rejects with ErrAudienceMismatch when it returns false). These property
+// tests exercise the matcher across many generated inputs — empty sets,
+// duplicates, unicode, arbitrary order — rather than the few hand-picked
+// examples in the external test package.
+
+// intersectsOracle is an independent reference for "do these two sets share an
+// element": it uses a map, NOT the implementation's nested loop, so it can
+// actually disagree with a buggy audienceMatches.
+func intersectsOracle(have, want []string) bool {
+	set := make(map[string]struct{}, len(have))
+	for _, h := range have {
+		set[h] = struct{}{}
+	}
+	for _, w := range want {
+		if _, ok := set[w]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// TestAudienceMatches_OracleEquivalence is the core property: audienceMatches
+// must agree with a map-based set-intersection oracle for any pair of slices.
+func TestAudienceMatches_OracleEquivalence(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		have := hegel.Draw(ht, hegel.Lists(hegel.Text()))
+		want := hegel.Draw(ht, hegel.Lists(hegel.Text()))
+
+		got := audienceMatches(have, want)
+		exp := intersectsOracle(have, want)
+		if got != exp {
+			ht.Fatalf("audienceMatches(%q, %q) = %v, oracle = %v", have, want, got, exp)
+		}
+	})
+}
+
+// TestAudienceMatches_Symmetric asserts intersection-non-emptiness is
+// order-independent across the two arguments. The implementation iterates the
+// first slice and scans the second, so an asymmetry would be a real bug.
+func TestAudienceMatches_Symmetric(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		a := hegel.Draw(ht, hegel.Lists(hegel.Text()))
+		b := hegel.Draw(ht, hegel.Lists(hegel.Text()))
+
+		if audienceMatches(a, b) != audienceMatches(b, a) {
+			ht.Fatalf("not symmetric: audienceMatches(%q,%q)=%v but audienceMatches(%q,%q)=%v",
+				a, b, audienceMatches(a, b), b, a, audienceMatches(b, a))
+		}
+	})
+}
+
+// TestAudienceMatches_EmptyIsFalse asserts the fail-closed behavior of the
+// matcher itself: an empty operand on either side can never match.
+func TestAudienceMatches_EmptyIsFalse(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		xs := hegel.Draw(ht, hegel.Lists(hegel.Text()))
+
+		if audienceMatches(nil, xs) {
+			ht.Fatalf("audienceMatches(nil, %q) must be false", xs)
+		}
+		if audienceMatches(xs, nil) {
+			ht.Fatalf("audienceMatches(%q, nil) must be false", xs)
+		}
+	})
+}
+
+// TestAudienceMatches_DuplicatesInert asserts that duplicate audiences don't
+// change the verdict: matching against the de-duplicated inputs must give the
+// same answer as matching against the originals.
+func TestAudienceMatches_DuplicatesInert(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		have := hegel.Draw(ht, hegel.Lists(hegel.Text()))
+		want := hegel.Draw(ht, hegel.Lists(hegel.Text()))
+
+		dedup := func(xs []string) []string {
+			seen := make(map[string]struct{}, len(xs))
+			out := make([]string, 0, len(xs))
+			for _, x := range xs {
+				if _, ok := seen[x]; ok {
+					continue
+				}
+				seen[x] = struct{}{}
+				out = append(out, x)
+			}
+			return out
+		}
+
+		full := audienceMatches(have, want)
+		deduped := audienceMatches(dedup(have), dedup(want))
+		if full != deduped {
+			ht.Fatalf("duplicates changed result: have=%q want=%q full=%v deduped=%v",
+				have, want, full, deduped)
+		}
+	})
+}

--- a/pkg/identity/oidc/extjwt/extjwt.go
+++ b/pkg/identity/oidc/extjwt/extjwt.go
@@ -1,0 +1,176 @@
+// Package extjwt verifies externally-issued JWT bearer tokens (Kubernetes
+// ServiceAccount tokens, GitHub Actions OIDC, SPIFFE JWT-SVIDs, etc.). It is
+// intentionally NOT an identity.Authenticator — there is no OAuth2 flow, no
+// SignIn, no Refresh, no UpdateUserInfo. Instances are owned by a per-route
+// JWT-IdP resolver (see config) rather than registered as a global IdP.
+//
+// Verification steps performed by Verify:
+//
+//  1. JWKS fetch (OIDC discovery if JWKSURL unset; direct fetch otherwise).
+//     Keys are cached and auto-refreshed via go-oidc's RemoteKeySet.
+//  2. Signature verification against the JWKS, restricted to the configured
+//     SupportedAlgs allowlist (defaults to RS256+ES256+EdDSA).
+//  3. `iss` matches the configured Issuer.
+//  4. `exp` and `nbf` checks (with go-oidc's default leeway).
+//  5. `aud` claim intersects the per-call allowedAudiences set (mandatory).
+//
+// No claim enrichment of any kind is performed — verified claims are
+// returned as-is so PPL can reference them directly via `claim/<path>`.
+package extjwt
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"slices"
+	"sync"
+
+	go_oidc "github.com/coreos/go-oidc/v3/oidc"
+
+	"github.com/pomerium/pomerium/internal/jwtutil"
+)
+
+var (
+	// ErrMissingIssuer is returned when Config.Issuer is empty.
+	ErrMissingIssuer = errors.New("identity/extjwt: issuer is required")
+	// ErrEmptyAudiences is returned when a Verify call passes no audiences.
+	// Audience binding is mandatory; an empty set is a configuration error,
+	// not "accept any."
+	ErrEmptyAudiences = errors.New("identity/extjwt: at least one allowed audience is required")
+	// ErrAudienceMismatch indicates the token's `aud` did not intersect the
+	// configured audiences.
+	ErrAudienceMismatch = errors.New("identity/extjwt: token audience does not match any allowed audience")
+)
+
+// Config configures a single verify-only JWT provider.
+type Config struct {
+	// Issuer is the expected JWT `iss` claim. Required.
+	Issuer string
+	// JWKSURL, when non-empty, skips OIDC discovery and fetches keys
+	// directly from this URL. The verifier still enforces `iss == Issuer`.
+	JWKSURL string
+	// SupportedAlgs is the signing-algorithm allowlist. Required to be
+	// non-empty; callers can fall back to a sensible default (e.g.
+	// {"RS256","ES256","EdDSA"}). go-oidc would otherwise default to
+	// RS256-only, silently rejecting ES256 / EdDSA tokens.
+	SupportedAlgs []string
+	// HTTPClient, when non-nil, is the HTTP client used to fetch the OIDC
+	// discovery document and JWKS. It is injected via oidc.ClientContext, so
+	// both the discovery and explicit-JWKS-URL paths honor it. Use it to
+	// supply a CA-aware client for issuers behind a private CA (e.g.
+	// Kubernetes' cluster CA). When nil, go-oidc's default client is used.
+	HTTPClient *http.Client
+}
+
+// Provider verifies JWTs against a single trusted issuer.
+type Provider struct {
+	cfg Config
+
+	mu       sync.Mutex
+	verifier *go_oidc.IDTokenVerifier
+}
+
+// New creates a Provider. Lazy: JWKS fetch happens on first Verify.
+func New(cfg Config) (*Provider, error) {
+	if cfg.Issuer == "" {
+		return nil, ErrMissingIssuer
+	}
+	if len(cfg.SupportedAlgs) == 0 {
+		return nil, fmt.Errorf("identity/extjwt: supported_algs must be non-empty")
+	}
+	return &Provider{cfg: cfg}, nil
+}
+
+// Issuer returns the configured issuer URL.
+func (p *Provider) Issuer() string { return p.cfg.Issuer }
+
+// Verify verifies the raw JWT against the configured issuer and the given
+// audience allowlist. Returns the verified claims map on success.
+//
+// allowedAudiences MUST be non-empty (an empty allowlist would silently
+// accept any audience, which is forbidden — fail closed instead).
+func (p *Provider) Verify(ctx context.Context, rawJWT string, allowedAudiences []string) (map[string]any, error) {
+	if len(allowedAudiences) == 0 {
+		return nil, ErrEmptyAudiences
+	}
+	v, err := p.getVerifier(ctx)
+	if err != nil {
+		return nil, err
+	}
+	tok, err := v.Verify(ctx, rawJWT)
+	if err != nil {
+		return nil, fmt.Errorf("identity/extjwt: token verification failed: %w", err)
+	}
+	if !audienceMatches(tok.Audience, allowedAudiences) {
+		return nil, ErrAudienceMismatch
+	}
+	claims := jwtutil.Claims(map[string]any{})
+	if err := tok.Claims(&claims); err != nil {
+		return nil, fmt.Errorf("identity/extjwt: unmarshal claims: %w", err)
+	}
+	return claims, nil
+}
+
+// getVerifier lazily constructs the verifier. Two paths:
+//
+//   - JWKSURL set: direct JWKS fetch via NewRemoteKeySet. The configured
+//     issuer is enforced as the JWT's expected `iss` even though there's
+//     no OIDC discovery doc to cross-check it against.
+//   - JWKSURL empty: standard OIDC discovery; go-oidc cross-checks the
+//     discovery doc's `issuer` against p.cfg.Issuer.
+//
+// The mutex protects against concurrent first-init. Once initialized the
+// verifier is reused for the lifetime of the Provider.
+func (p *Provider) getVerifier(ctx context.Context) (*go_oidc.IDTokenVerifier, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.verifier != nil {
+		return p.verifier, nil
+	}
+
+	// Inject the CA-aware HTTP client (if any) as a context value. go-oidc
+	// honors it on both the discovery (NewProvider) and explicit-JWKS
+	// (NewRemoteKeySet) paths.
+	//
+	// The verifier is memoized for the Provider's lifetime, so it outlives this
+	// (request-scoped) ctx. That is safe because go-oidc's RemoteKeySet stores
+	// the context as context.WithoutCancel(ctx) (oidc/jwks.go): it retains only
+	// the values (our HTTP client) for later JWKS key refreshes, NOT the cancel
+	// signal — so cancelling the first request cannot break future refreshes.
+	// This depends on go-oidc >= the version that adopted WithoutCancel; a
+	// downgrade would reintroduce a permanent fail-closed on key rotation
+	// (regression-tested by TestProvider_KeyRefreshAfterInitContextCancelled).
+	if p.cfg.HTTPClient != nil {
+		ctx = go_oidc.ClientContext(ctx, p.cfg.HTTPClient)
+	}
+
+	cfg := &go_oidc.Config{
+		SkipClientIDCheck:    true, // audience check is enforced in Verify against the route's allowlist
+		SupportedSigningAlgs: slices.Clone(p.cfg.SupportedAlgs),
+	}
+
+	if p.cfg.JWKSURL != "" {
+		keySet := go_oidc.NewRemoteKeySet(ctx, p.cfg.JWKSURL)
+		p.verifier = go_oidc.NewVerifier(p.cfg.Issuer, keySet, cfg)
+		return p.verifier, nil
+	}
+
+	pp, err := go_oidc.NewProvider(ctx, p.cfg.Issuer)
+	if err != nil {
+		return nil, fmt.Errorf("identity/extjwt: discovery failed for %s: %w", p.cfg.Issuer, err)
+	}
+	p.verifier = pp.Verifier(cfg)
+	return p.verifier, nil
+}
+
+// audienceMatches reports whether any element of `have` is also in `want`.
+func audienceMatches(have, want []string) bool {
+	for _, h := range have {
+		if slices.Contains(want, h) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/identity/oidc/extjwt/extjwt_test.go
+++ b/pkg/identity/oidc/extjwt/extjwt_test.go
@@ -1,0 +1,347 @@
+package extjwt_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/internal/testutil/mockidp"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/extjwt"
+)
+
+// rs256issuer is a mockidp-based test issuer (ES256 signing key, since
+// mockidp uses ES256). We use it for the RS256 vs ES256 alg-allowlist test.
+
+// newTestIssuer returns (issuer URL, mockidp instance).
+func newTestIssuer(t *testing.T) (string, *mockidp.IDP) {
+	t.Helper()
+	idp := mockidp.New(mockidp.Config{})
+	return idp.Start(t), idp
+}
+
+func newProvider(t *testing.T, issuer string, algs []string) *extjwt.Provider {
+	t.Helper()
+	if algs == nil {
+		algs = []string{"ES256"} // mockidp uses ES256
+	}
+	p, err := extjwt.New(extjwt.Config{
+		Issuer:        issuer,
+		SupportedAlgs: algs,
+	})
+	require.NoError(t, err)
+	return p
+}
+
+func stdClaims(issuer, sub, aud string, now time.Time) map[string]any {
+	return map[string]any{
+		"iss": issuer,
+		"sub": sub,
+		"aud": []string{aud},
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+	}
+}
+
+func TestVerify_HappyPath(t *testing.T) {
+	t.Parallel()
+	issuer, idp := newTestIssuer(t)
+	p := newProvider(t, issuer, nil)
+	tok := idp.SignJWT(stdClaims(issuer, "system:serviceaccount:ns:sa", "pomerium.example.com", time.Now()))
+	claims, err := p.Verify(t.Context(), tok, []string{"pomerium.example.com"})
+	require.NoError(t, err)
+	assert.Equal(t, "system:serviceaccount:ns:sa", claims["sub"])
+}
+
+func TestVerify_AudienceMismatch(t *testing.T) {
+	t.Parallel()
+	issuer, idp := newTestIssuer(t)
+	p := newProvider(t, issuer, nil)
+	tok := idp.SignJWT(stdClaims(issuer, "sub", "other.example.com", time.Now()))
+	_, err := p.Verify(t.Context(), tok, []string{"pomerium.example.com"})
+	assert.ErrorIs(t, err, extjwt.ErrAudienceMismatch)
+}
+
+func TestVerify_EmptyAudiencesIsConfigError(t *testing.T) {
+	t.Parallel()
+	// The plan forbids empty audience allowlists; the verifier must
+	// surface this as a config error rather than silently accept any aud.
+	issuer, idp := newTestIssuer(t)
+	p := newProvider(t, issuer, nil)
+	tok := idp.SignJWT(stdClaims(issuer, "sub", "aud", time.Now()))
+	_, err := p.Verify(t.Context(), tok, nil)
+	assert.ErrorIs(t, err, extjwt.ErrEmptyAudiences)
+	_, err = p.Verify(t.Context(), tok, []string{})
+	assert.ErrorIs(t, err, extjwt.ErrEmptyAudiences)
+}
+
+func TestVerify_Expired(t *testing.T) {
+	t.Parallel()
+	issuer, idp := newTestIssuer(t)
+	p := newProvider(t, issuer, nil)
+	tok := idp.SignJWT(map[string]any{
+		"iss": issuer,
+		"sub": "sub",
+		"aud": []string{"aud"},
+		"exp": time.Now().Add(-time.Hour).Unix(),
+		"iat": time.Now().Add(-2 * time.Hour).Unix(),
+		"nbf": time.Now().Add(-2 * time.Hour).Unix(),
+	})
+	_, err := p.Verify(t.Context(), tok, []string{"aud"})
+	require.Error(t, err)
+}
+
+func TestVerify_FutureNbf(t *testing.T) {
+	t.Parallel()
+	issuer, idp := newTestIssuer(t)
+	p := newProvider(t, issuer, nil)
+	tok := idp.SignJWT(map[string]any{
+		"iss": issuer,
+		"sub": "sub",
+		"aud": []string{"aud"},
+		"nbf": time.Now().Add(time.Hour).Unix(),
+		"iat": time.Now().Unix(),
+		"exp": time.Now().Add(2 * time.Hour).Unix(),
+	})
+	_, err := p.Verify(t.Context(), tok, []string{"aud"})
+	require.Error(t, err)
+}
+
+func TestVerify_IssuerMismatch(t *testing.T) {
+	t.Parallel()
+	issuer, idp := newTestIssuer(t)
+	p := newProvider(t, issuer, nil)
+	tok := idp.SignJWT(stdClaims("https://attacker.example.com", "sub", "aud", time.Now()))
+	_, err := p.Verify(t.Context(), tok, []string{"aud"})
+	require.Error(t, err)
+}
+
+func TestVerify_GarbageToken(t *testing.T) {
+	t.Parallel()
+	issuer, _ := newTestIssuer(t)
+	p := newProvider(t, issuer, nil)
+	_, err := p.Verify(t.Context(), "not-a-jwt", []string{"aud"})
+	require.Error(t, err)
+}
+
+func TestNew_MissingIssuer(t *testing.T) {
+	t.Parallel()
+	_, err := extjwt.New(extjwt.Config{SupportedAlgs: []string{"RS256"}})
+	assert.ErrorIs(t, err, extjwt.ErrMissingIssuer)
+}
+
+func TestNew_EmptyAlgs(t *testing.T) {
+	t.Parallel()
+	_, err := extjwt.New(extjwt.Config{Issuer: "https://example.com"})
+	require.Error(t, err)
+}
+
+// TestVerify_AlgAllowlist_ES256_OnJWKSPath verifies the review #5 fix:
+// when using the explicit JWKS-URL path, an ES256 token must be accepted if
+// "ES256" is in SupportedAlgs (go-oidc would otherwise default to RS256-only
+// and silently reject it).
+func TestVerify_AlgAllowlist_ES256_OnJWKSPath(t *testing.T) {
+	t.Parallel()
+
+	// Custom JWKS server hosting an ES256 key.
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{
+		Key:       &priv.PublicKey,
+		Algorithm: "ES256",
+		Use:       "sig",
+	}
+	thumb, _ := jwk.Thumbprint(crypto.SHA256)
+	jwk.KeyID = hex.EncodeToString(thumb)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(&jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}})
+	}))
+	t.Cleanup(srv.Close)
+
+	issuer := "https://my-issuer.example.com"
+
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES256, Key: priv}, (&jose.SignerOptions{}).WithType("JWT"))
+	require.NoError(t, err)
+	tok, err := jwt.Signed(signer).Claims(stdClaims(issuer, "sub", "aud", time.Now())).CompactSerialize()
+	require.NoError(t, err)
+
+	t.Run("default ES256 is accepted", func(t *testing.T) {
+		// SupportedAlgs is required, and our default explicitly includes ES256.
+		p, err := extjwt.New(extjwt.Config{
+			Issuer:        issuer,
+			JWKSURL:       srv.URL,
+			SupportedAlgs: []string{"RS256", "ES256", "EdDSA"},
+		})
+		require.NoError(t, err)
+		claims, err := p.Verify(t.Context(), tok, []string{"aud"})
+		require.NoError(t, err)
+		assert.Equal(t, "sub", claims["sub"])
+	})
+
+	t.Run("ES256 rejected when allowlist is RS256-only", func(t *testing.T) {
+		p, err := extjwt.New(extjwt.Config{
+			Issuer:        issuer,
+			JWKSURL:       srv.URL,
+			SupportedAlgs: []string{"RS256"},
+		})
+		require.NoError(t, err)
+		_, err = p.Verify(context.Background(), tok, []string{"aud"})
+		require.Error(t, err)
+	})
+}
+
+// TestVerify_BadSignature verifies that a structurally-valid token signed by a
+// key that is NOT in the JWKS is rejected. This is the core security property
+// of the verifier: a well-formed token with the right iss/aud/exp must still
+// fail if the signature can't be traced to a published key.
+func TestVerify_BadSignature(t *testing.T) {
+	t.Parallel()
+
+	// JWKS server publishes one ES256 key...
+	published, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	jwk := jose.JSONWebKey{
+		Key:       &published.PublicKey,
+		Algorithm: "ES256",
+		Use:       "sig",
+	}
+	thumb, _ := jwk.Thumbprint(crypto.SHA256)
+	jwk.KeyID = hex.EncodeToString(thumb)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(&jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}})
+	}))
+	t.Cleanup(srv.Close)
+
+	issuer := "https://my-issuer.example.com"
+
+	// ...but the token is signed by a different, unpublished key.
+	attacker, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.ES256, Key: attacker}, (&jose.SignerOptions{}).WithType("JWT"))
+	require.NoError(t, err)
+	tok, err := jwt.Signed(signer).Claims(stdClaims(issuer, "sub", "aud", time.Now())).CompactSerialize()
+	require.NoError(t, err)
+
+	p, err := extjwt.New(extjwt.Config{
+		Issuer:        issuer,
+		JWKSURL:       srv.URL,
+		SupportedAlgs: []string{"ES256"},
+	})
+	require.NoError(t, err)
+	_, err = p.Verify(t.Context(), tok, []string{"aud"})
+	require.Error(t, err)
+}
+
+// TestVerify_DiscoveryFailure verifies that when OIDC discovery is used (no
+// JWKSURL) and the issuer serves no discovery document, Verify surfaces the
+// failure rather than succeeding or panicking.
+func TestVerify_DiscoveryFailure(t *testing.T) {
+	t.Parallel()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+
+	p := newProvider(t, srv.URL, nil)
+	_, err := p.Verify(t.Context(), "irrelevant", []string{"aud"})
+	require.Error(t, err)
+}
+
+// tlsIssuer starts a mock OIDC issuer served over HTTPS with a self-signed
+// certificate. The returned client trusts that certificate; the default HTTP
+// client does not. This lets the custom-HTTP-client tests prove that key
+// fetching honors the injected client on both constructor paths.
+func tlsIssuer(t *testing.T) (issuer string, client *http.Client, idp *mockidp.IDP) {
+	t.Helper()
+	idp = mockidp.New(mockidp.Config{})
+	r := mux.NewRouter()
+	idp.Register(r)
+	srv := httptest.NewTLSServer(r)
+	t.Cleanup(srv.Close)
+	return srv.URL, srv.Client(), idp
+}
+
+// TestVerify_CustomHTTPClient_JWKSPath proves that on the explicit-JWKS-URL
+// path, JWKS fetching uses Config.HTTPClient: with the CA-trusting client the
+// self-signed JWKS server is reachable and verification succeeds; without it
+// the fetch fails on certificate validation.
+func TestVerify_CustomHTTPClient_JWKSPath(t *testing.T) {
+	t.Parallel()
+
+	issuer, client, idp := tlsIssuer(t)
+	jwksURL := issuer + "/.well-known/jwks.json"
+	tok := idp.SignJWT(stdClaims(issuer, "sub", "aud", time.Now()))
+
+	t.Run("with custom client succeeds", func(t *testing.T) {
+		p, err := extjwt.New(extjwt.Config{
+			Issuer:        issuer,
+			JWKSURL:       jwksURL,
+			SupportedAlgs: []string{"ES256"},
+			HTTPClient:    client,
+		})
+		require.NoError(t, err)
+		claims, err := p.Verify(t.Context(), tok, []string{"aud"})
+		require.NoError(t, err)
+		assert.Equal(t, "sub", claims["sub"])
+	})
+
+	t.Run("without custom client fails on TLS", func(t *testing.T) {
+		p, err := extjwt.New(extjwt.Config{
+			Issuer:        issuer,
+			JWKSURL:       jwksURL,
+			SupportedAlgs: []string{"ES256"},
+		})
+		require.NoError(t, err)
+		_, err = p.Verify(t.Context(), tok, []string{"aud"})
+		require.Error(t, err)
+	})
+}
+
+// TestVerify_CustomHTTPClient_DiscoveryPath proves the same for the OIDC
+// discovery path (no JWKSURL): both the discovery document fetch and the
+// subsequent JWKS fetch must use Config.HTTPClient.
+func TestVerify_CustomHTTPClient_DiscoveryPath(t *testing.T) {
+	t.Parallel()
+
+	issuer, client, idp := tlsIssuer(t)
+	tok := idp.SignJWT(stdClaims(issuer, "sub", "aud", time.Now()))
+
+	t.Run("with custom client succeeds", func(t *testing.T) {
+		p, err := extjwt.New(extjwt.Config{
+			Issuer:        issuer,
+			SupportedAlgs: []string{"ES256"},
+			HTTPClient:    client,
+		})
+		require.NoError(t, err)
+		claims, err := p.Verify(t.Context(), tok, []string{"aud"})
+		require.NoError(t, err)
+		assert.Equal(t, "sub", claims["sub"])
+	})
+
+	t.Run("without custom client fails on TLS", func(t *testing.T) {
+		p, err := extjwt.New(extjwt.Config{
+			Issuer:        issuer,
+			SupportedAlgs: []string{"ES256"},
+		})
+		require.NoError(t, err)
+		_, err = p.Verify(t.Context(), tok, []string{"aud"})
+		require.Error(t, err)
+	})
+}

--- a/pkg/identity/oidc/extjwt/keyrefresh_test.go
+++ b/pkg/identity/oidc/extjwt/keyrefresh_test.go
@@ -1,0 +1,126 @@
+package extjwt_test
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-jose/go-jose/v3"
+	"github.com/go-jose/go-jose/v3/jwt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/identity/oidc/extjwt"
+)
+
+// rotatableJWKS is a JWKS server whose published key can be swapped at will,
+// so a test can force go-oidc's RemoteKeySet into a key-cache miss (which is
+// the only path that triggers a background JWKS re-fetch).
+type rotatableJWKS struct {
+	mu     sync.RWMutex
+	priv   *ecdsa.PrivateKey
+	kid    string
+	server *httptest.Server
+}
+
+func newRotatableJWKS(t *testing.T) *rotatableJWKS {
+	t.Helper()
+	r := &rotatableJWKS{}
+	r.rotate(t, "keyA")
+	r.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		r.mu.RLock()
+		defer r.mu.RUnlock()
+		jwk := jose.JSONWebKey{Key: &r.priv.PublicKey, KeyID: r.kid, Algorithm: "ES256", Use: "sig"}
+		_ = json.NewEncoder(w).Encode(&jose.JSONWebKeySet{Keys: []jose.JSONWebKey{jwk}})
+	}))
+	t.Cleanup(r.server.Close)
+	return r
+}
+
+// rotate swaps in a brand-new signing key published under the given kid.
+func (r *rotatableJWKS) rotate(t *testing.T, kid string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	r.mu.Lock()
+	r.priv = priv
+	r.kid = kid
+	r.mu.Unlock()
+}
+
+// sign mints a token with the CURRENT key, embedding its kid in the JWS header
+// so RemoteKeySet knows which key to look for (and detects a cache miss).
+func (r *rotatableJWKS) sign(t *testing.T, issuer, sub, aud string) string {
+	t.Helper()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.ES256, Key: jose.JSONWebKey{Key: r.priv, KeyID: r.kid, Algorithm: "ES256"}},
+		(&jose.SignerOptions{}).WithType("JWT"),
+	)
+	require.NoError(t, err)
+	now := time.Now()
+	tok, err := jwt.Signed(signer).Claims(map[string]any{
+		"iss": issuer, "sub": sub, "aud": []string{aud},
+		"exp": now.Add(time.Hour).Unix(), "iat": now.Unix(), "nbf": now.Unix(),
+	}).CompactSerialize()
+	require.NoError(t, err)
+	return tok
+}
+
+// TestProvider_KeyRefreshAfterInitContextCancelled guards a subtle lifetime
+// property: getVerifier builds the RemoteKeySet with the FIRST inbound
+// request's context, and the verifier is then memoized for the Provider's
+// lifetime. Cancelling that first request's context must NOT break later JWKS
+// key refreshes — go-oidc stores the constructor context as
+// context.WithoutCancel(ctx) (oidc/jwks.go), retaining only its values (the
+// injected HTTP client), not its cancellation.
+//
+// The test drives that scenario end to end — verify, cancel the init context,
+// rotate the issuer's signing key (a new kid forces a real cache-miss JWKS
+// re-fetch), then verify a new token with a fresh context — and asserts the
+// second verify still succeeds. A go-oidc downgrade that dropped WithoutCancel
+// would reintroduce a permanent fail-closed on key rotation, which this catches.
+func TestProvider_KeyRefreshAfterInitContextCancelled(t *testing.T) {
+	t.Parallel()
+
+	jwks := newRotatableJWKS(t)
+	const issuer = "https://issuer.review.example.com"
+
+	p, err := extjwt.New(extjwt.Config{
+		Issuer:        issuer,
+		JWKSURL:       jwks.server.URL,
+		SupportedAlgs: []string{"ES256"},
+	})
+	require.NoError(t, err)
+
+	// First verify with a cancellable context — this is the request whose
+	// context getVerifier captures into the RemoteKeySet.
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	tok1 := jwks.sign(t, issuer, "sub1", "aud")
+	_, err = p.Verify(ctx1, tok1, []string{"aud"})
+	require.NoError(t, err, "first verify must succeed and populate the key cache")
+
+	// The request completes: its context is cancelled.
+	cancel1()
+
+	// Rotate the issuer's signing key. The next token carries a new kid that
+	// is NOT in the cache, forcing RemoteKeySet.updateKeys() to hit the network
+	// again — the exact path the review says uses the cancelled context.
+	jwks.rotate(t, "keyB")
+	tok2 := jwks.sign(t, issuer, "sub2", "aud")
+
+	// Second verify with a FRESH context. If the finding were correct, the
+	// background key-refresh would use the cancelled ctx1 and fail with
+	// "context canceled". WithoutCancel means it does not.
+	claims, err := p.Verify(context.Background(), tok2, []string{"aud"})
+	require.NoError(t, err, "key refresh after init-context cancellation must still succeed (finding #2 is a false positive)")
+	assert.Equal(t, "sub2", claims["sub"])
+}


### PR DESCRIPTION
## Summary

New self-contained package `pkg/identity/oidc/extjwt`: verifies a raw JWT against a single trusted issuer.

- Key discovery via OIDC discovery from the issuer, or directly from an explicit JWKS URL.
- Verifies signature, `iss`, `exp`/`nbf`; `aud` must intersect the caller-supplied audience set — an empty set rejects all tokens (fail-closed).
- Signing-algorithm allowlist is caller-supplied and asymmetric-only.
- Optional custom `*http.Client` for issuers behind a private CA.
- Verifier is built lazily and memoized; a regression test pins go-oidc's `context.WithoutCancel` semantics so a dependency downgrade that re-ties JWKS refreshes to the first request's context fails CI.

Also adds `mockidp.SignJWT` (mint arbitrary-claims tokens from the test IdP) and property-based tests for the `jwtutil.Claims` accessors the package relies on. No wiring into config/authorize yet.

Stack 2/6, based on #6587. Split from #6501.

## Related issues

- #6501

## User Explanation

No user-facing changes.

## AI disclosure

Claude Code: carved this stack from the PoC branch (#6501) and adapted it to current `main`; the feature itself was developed on that branch (also AI-assisted).

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
