### PR TITLE
config: add IdentityProviderResolver for external JWT verification

### DIFF
--- a/config/identity_provider.go
+++ b/config/identity_provider.go
@@ -1,14 +1,23 @@
 package config
 
 import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"maps"
 	"net"
+	"net/http"
 	"net/url"
 	"slices"
 	"strings"
 
+	"github.com/pomerium/pomerium/internal/hashutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/extjwt"
 )
 
 // IdentityProvider declares an additional identity provider. Today it is
@@ -255,4 +264,256 @@ func setIdentityProviders(dst *map[string]IdentityProvider, src map[string]*conf
 		}
 	}
 	*dst = out
+}
+
+// ErrNoMatchingIdentityProvider is returned by IdentityProviderResolver.Verify
+// when the token's `iss` claim does not match any configured identity provider.
+var ErrNoMatchingIdentityProvider = errors.New("config/identity_provider: no identity provider matches the token's iss claim")
+
+// IdentityProviderVerifyResult is the successful outcome of
+// IdentityProviderResolver.Verify.
+type IdentityProviderVerifyResult struct {
+	// ProviderName is the name (Options.IdentityProviders map key) of the
+	// provider that verified the token. It is the workload's identity-provider
+	// identity, used for the session's idp_id, user-id prefix, and cache keys.
+	ProviderName string
+	// Claims is the verified JWT payload.
+	Claims map[string]any
+}
+
+// resolvedIdentityProvider is the per-issuer verification context: the provider
+// name (for identity), the provider's audiences (for audience binding), and the
+// verifier.
+type resolvedIdentityProvider struct {
+	Name      string
+	Audiences []string
+	Provider  *extjwt.Provider
+}
+
+// IdentityProviderResolver owns one *extjwt.Provider per configured identity
+// provider and verifies incoming bearer tokens against whichever provider's
+// issuer matches the token's `iss` claim.
+//
+// Construct once per Options snapshot; the provider instances are immutable
+// after creation.
+type IdentityProviderResolver struct {
+	byIssuer map[string]resolvedIdentityProvider // key: issuer
+	// cacheKey identifies the configuration this resolver was built from, so a
+	// later configuration generation can tell whether it may reuse it. Set by
+	// NewIdentityProviderResolverFromConfig. Zero means "unknown" — a
+	// directly-constructed resolver, or a key that could not be computed — and is
+	// never reused.
+	cacheKey uint64
+}
+
+// NewIdentityProviderResolver builds a resolver from the given providers, keyed
+// by name. httpClient (if non-nil) is used for all JWKS/discovery fetches — e.g.
+// a CA-aware client for issuers behind a private CA. Returns an error if any
+// provider is invalid or two share the same issuer.
+func NewIdentityProviderResolver(providers map[string]IdentityProvider, httpClient *http.Client) (*IdentityProviderResolver, error) {
+	r := &IdentityProviderResolver{
+		byIssuer: make(map[string]resolvedIdentityProvider, len(providers)),
+	}
+	// Sorted-name order keeps errors (e.g. duplicate-issuer) deterministic.
+	for _, name := range slices.Sorted(maps.Keys(providers)) {
+		ip := providers[name]
+		if err := validateProviderName(name); err != nil {
+			return nil, err
+		}
+		if err := ip.Validate(); err != nil {
+			return nil, fmt.Errorf("identity_providers[%s]: %w", name, err)
+		}
+		issuer, jwksURL, client := ip.Issuer, ip.JWKSURL, httpClient
+		// Dedup by issuer: it is the byIssuer dispatch key.
+		if existing, dup := r.byIssuer[issuer]; dup {
+			return nil, fmt.Errorf("identity_providers: issuer %q used by both %q and %q",
+				issuer, existing.Name, name)
+		}
+		p, err := extjwt.New(extjwt.Config{
+			Issuer:        issuer,
+			JWKSURL:       jwksURL,
+			SupportedAlgs: ip.EffectiveSupportedAlgs(),
+			HTTPClient:    client,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("identity_providers[%s]: %w", name, err)
+		}
+		r.byIssuer[issuer] = resolvedIdentityProvider{
+			Name:      name,
+			Audiences: slices.Clone(ip.Audiences),
+			Provider:  p,
+		}
+	}
+	return r, nil
+}
+
+// resolveUnverified returns the verification context of the provider whose
+// issuer matches the token's UNVERIFIED `iss` claim, without performing any
+// signature/audience checks. It is used to enforce a route's provider allowlist
+// before the (expensive) verification runs. Returns
+// ErrNoMatchingIdentityProvider if no provider matches.
+func (r *IdentityProviderResolver) resolveUnverified(rawJWT string) (resolvedIdentityProvider, error) {
+	iss, err := unverifiedIssuer(rawJWT)
+	if err != nil {
+		return resolvedIdentityProvider{}, fmt.Errorf("config/identity_provider: parse iss: %w", err)
+	}
+	rp, ok := r.byIssuer[iss]
+	if !ok {
+		return resolvedIdentityProvider{}, ErrNoMatchingIdentityProvider
+	}
+	return rp, nil
+}
+
+// Verify verifies the raw JWT against the provider whose issuer matches the
+// token's `iss` claim, enforcing that provider's audiences (fail-closed).
+//
+// Dispatch:
+//  1. Parse the token's `iss` claim (no signature check yet).
+//  2. Look up the provider with that issuer.
+//  3. Verify signature/exp/nbf via that provider's verifier, with `aud`
+//     checked against the provider's configured audiences.
+//
+// Unverified-`iss` dispatch is safe: the matched verifier re-checks `iss`,
+// signature, and exp/nbf. Returns ErrNoMatchingIdentityProvider if no provider
+// matches.
+func (r *IdentityProviderResolver) Verify(ctx context.Context, rawJWT string) (*IdentityProviderVerifyResult, error) {
+	rp, err := r.resolveUnverified(rawJWT)
+	if err != nil {
+		return nil, err
+	}
+	claims, err := rp.Provider.Verify(ctx, rawJWT, rp.Audiences)
+	if err != nil {
+		return nil, err
+	}
+	return &IdentityProviderVerifyResult{
+		ProviderName: rp.Name,
+		Claims:       claims,
+	}, nil
+}
+
+// NewIdentityProviderResolverFromConfig builds the resolver for cfg, reusing
+// previous when everything the resolver is built from is unchanged. Callers own
+// one resolver per configuration generation (see newAuthorizeStateFromConfig
+// and newProxyStateFromConfig) and pass the previous generation's resolver here,
+// so a go-oidc JWKS cache — and any kubernetes:/// discovery result — survives
+// configuration changes that do not concern identity providers.
+//
+// Returns (nil, nil) when no identity providers are configured.
+//
+// A failed build returns a nil resolver, which is never reused, so the next
+// configuration generation retries. Callers should treat the error as fatal to
+// JWT bearer verification only, not to their whole state: the in-cluster
+// discovery call can fail transiently.
+func NewIdentityProviderResolverFromConfig(
+	cfg *Config,
+	previous *IdentityProviderResolver,
+) (*IdentityProviderResolver, error) {
+	if cfg == nil || cfg.Options == nil || len(cfg.Options.IdentityProviders) == 0 {
+		return nil, nil
+	}
+	key, err := cfg.identityProviderResolverCacheKey()
+	if err != nil {
+		return nil, err
+	}
+	if previous != nil && previous.cacheKey != 0 && previous.cacheKey == key {
+		return previous, nil
+	}
+	client, err := cfg.identityProviderHTTPClient()
+	if err != nil {
+		return nil, err
+	}
+	r, err := NewIdentityProviderResolver(cfg.Options.IdentityProviders, client)
+	if err != nil {
+		return nil, err
+	}
+	r.cacheKey = key
+	return r, nil
+}
+
+// identityProviderResolverCacheKey hashes everything a resolver is built from:
+// the provider definitions and the CA material backing its JWKS/discovery
+// fetches.
+//
+// The CA is hashed by CONTENT rather than by the (CA, CAFile) option values,
+// because certificate_authority_file is watched (see getAllConfigFilePaths): a
+// rotated file at an unchanged path triggers a reload whose Options are
+// byte-identical, and a key over option values alone would keep reusing a
+// resolver pinned to the old CA pool. AllCertificateAuthoritiesPEM is a
+// superset of what identityProviderHTTPClient actually trusts, which can only
+// cost a spurious rebuild, never staleness.
+//
+// Reading the CA here and again when the pool is built is a benign race: a
+// rotation in between yields a resolver whose key does not describe its pool,
+// and the next reload rebuilds it.
+func (cfg *Config) identityProviderResolverCacheKey() (uint64, error) {
+	caPEM, err := cfg.AllCertificateAuthoritiesPEM()
+	if err != nil {
+		return 0, fmt.Errorf("config: identity_providers: error reading certificate authorities: %w", err)
+	}
+	// The providers map goes through MustHash (reflection, but a handful of small
+	// strings) so that fields added to IdentityProvider are covered
+	// automatically. The CA bundle is written to the digest directly: routing
+	// kilobytes of PEM through hashstructure costs milliseconds and tens of
+	// thousands of allocations, and this runs on every configuration generation.
+	d := hashutil.NewDigest()
+	d.WriteUint64(hashutil.MustHash(cfg.Options.IdentityProviders))
+	d.WriteWithLen(caPEM)
+	return d.Sum64(), nil
+}
+
+// identityProviderHTTPClient builds the HTTP client used for JWKS/discovery
+// fetches. When a global certificate_authority / certificate_authority_file is
+// configured (e.g. Kubernetes' cluster CA), it returns a CA-aware client;
+// when neither is set it returns nil so go-oidc uses its default client with
+// system roots.
+//
+// A CA that is explicitly configured but fails to load is a hard error, not a
+// silent fallback: falling back to system roots would make the intended
+// private-CA issuer's JWKS/discovery fetch fail with "unknown authority" and
+// silently reject every token, with only a single startup log line. The
+// misconfiguration must surface to the caller instead.
+func (cfg *Config) identityProviderHTTPClient() (*http.Client, error) {
+	o := cfg.Options
+	if o.CA == "" && o.CAFile == "" {
+		return nil, nil
+	}
+	rootCAs, err := cryptutil.GetCertPool(o.CA, o.CAFile)
+	if err != nil {
+		return nil, fmt.Errorf("config: identity_providers: error building CA cert pool: %w", err)
+	}
+	transport := http.DefaultTransport.(interface{ Clone() *http.Transport }).Clone()
+	// http.DefaultTransport may be config.NewHTTPTransport's transport (see
+	// pkg/cmd/pomerium), whose DialTLSContext is pinned to the global CA pool
+	// and takes precedence over TLSClientConfig.
+	transport.DialTLSContext = nil
+	transport.TLSClientConfig = &tls.Config{
+		RootCAs:    rootCAs,
+		MinVersion: tls.VersionTLS12,
+	}
+	return &http.Client{Transport: transport}, nil
+}
+
+// unverifiedIssuer extracts the `iss` claim from the JWT payload WITHOUT
+// verifying the signature. Used only to dispatch to the correct verifier; the
+// matched verifier then performs full verification including signature and
+// `iss` re-check.
+func unverifiedIssuer(rawJWT string) (string, error) {
+	parts := strings.SplitN(rawJWT, ".", 3)
+	if len(parts) != 3 {
+		return "", fmt.Errorf("malformed JWT (expected 3 parts)")
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return "", fmt.Errorf("decode payload: %w", err)
+	}
+	var c struct {
+		Iss string `json:"iss"`
+	}
+	if err := json.Unmarshal(payload, &c); err != nil {
+		return "", fmt.Errorf("unmarshal payload: %w", err)
+	}
+	if c.Iss == "" {
+		return "", fmt.Errorf("missing iss claim")
+	}
+	return c.Iss, nil
 }

--- a/config/identity_provider_resolver_test.go
+++ b/config/identity_provider_resolver_test.go
@@ -1,0 +1,397 @@
+package config
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"hegel.dev/go/hegel"
+
+	"github.com/pomerium/pomerium/internal/testutil/mockidp"
+	"github.com/pomerium/pomerium/pkg/derivecert"
+	"github.com/pomerium/pomerium/pkg/identity/oidc/extjwt"
+)
+
+func TestUnverifiedIssuer(t *testing.T) {
+	t.Parallel()
+
+	// No idp.Start: unverifiedIssuer only parses payload bytes, no network.
+	idp := mockidp.New(mockidp.Config{})
+
+	tok := idp.SignJWT(map[string]any{"iss": "https://example.com", "exp": time.Now().Add(time.Hour).Unix()})
+	iss, err := unverifiedIssuer(tok)
+	require.NoError(t, err)
+	assert.Equal(t, "https://example.com", iss)
+
+	_, err = unverifiedIssuer("not-a-jwt")
+	assert.Error(t, err)
+}
+
+// encodeUnsignedJWT builds a syntactically-valid (header.payload.sig) JWT with
+// the given claims. The signature is a placeholder — unverifiedIssuer only
+// parses the payload, it does not verify.
+func encodeUnsignedJWT(t testing.TB, claims map[string]any) string {
+	t.Helper()
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+	payloadBytes, err := json.Marshal(claims)
+	require.NoError(t, err)
+	payload := base64.RawURLEncoding.EncodeToString(payloadBytes)
+	return header + "." + payload + ".c2ln"
+}
+
+// TestUnverifiedIssuer_RoundTrip is the core property of the issuer-dispatch
+// parser: for any non-empty iss claim, unverifiedIssuer must recover exactly
+// the iss that was encoded. If the byte-for-byte iss the dispatcher reads ever
+// diverges from what was in the token, the wrong provider (and thus the wrong
+// signing keys / verifier) could be selected.
+func TestUnverifiedIssuer_RoundTrip(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		iss := hegel.Draw(ht, hegel.Text().MinSize(1))
+		ht.Assume(iss != "") // empty iss is a documented error, not a roundtrip case
+
+		tok := encodeUnsignedJWT(ht.T, map[string]any{
+			"iss": iss,
+			"sub": "whatever",
+		})
+		got, err := unverifiedIssuer(tok)
+		if err != nil {
+			ht.Fatalf("unverifiedIssuer returned error for iss=%q: %v", iss, err)
+		}
+		if got != iss {
+			ht.Fatalf("iss roundtrip mismatch: encoded %q, parsed %q", iss, got)
+		}
+	})
+}
+
+// TestUnverifiedIssuer_NoCrash is a robustness property: unverifiedIssuer
+// processes the raw, attacker-controlled bearer token BEFORE any verification,
+// so it must never panic on arbitrary input — it must only ever return a value
+// or an error.
+func TestUnverifiedIssuer_NoCrash(t *testing.T) {
+	t.Parallel()
+	hegel.Test(t, func(ht *hegel.T) {
+		raw := hegel.Draw(ht, hegel.Text())
+		_, _ = unverifiedIssuer(raw) // must not panic
+	})
+}
+
+func TestNewIdentityProviderResolver_DuplicateIssuer(t *testing.T) {
+	t.Parallel()
+	_, err := NewIdentityProviderResolver(map[string]IdentityProvider{
+		"a": {Issuer: "https://dup", Audiences: []string{"x"}, SupportedAlgs: []string{"RS256"}},
+		"b": {Issuer: "https://dup", Audiences: []string{"y"}, SupportedAlgs: []string{"RS256"}},
+	}, nil)
+	require.Error(t, err)
+}
+
+func TestNewIdentityProviderResolver_InvalidProviderName(t *testing.T) {
+	t.Parallel()
+	// A name containing '/' would break the "<provider>/<sub>" user-id split.
+	_, err := NewIdentityProviderResolver(map[string]IdentityProvider{
+		"k8s/prod": {Issuer: "https://a", Audiences: []string{"x"}, SupportedAlgs: []string{"RS256"}},
+	}, nil)
+	require.Error(t, err)
+}
+
+func TestIdentityProviderResolver_Verify(t *testing.T) {
+	t.Parallel()
+
+	idp := mockidp.New(mockidp.Config{})
+	issuer := idp.Start(t)
+
+	resolver, err := NewIdentityProviderResolver(map[string]IdentityProvider{
+		"k8s": {Issuer: issuer, Audiences: []string{"pomerium.example.com"}, SupportedAlgs: []string{"ES256"}},
+	}, nil)
+	require.NoError(t, err)
+
+	now := time.Now()
+	tok := idp.SignJWT(map[string]any{
+		"iss": issuer,
+		"sub": "system:serviceaccount:ns:sa",
+		"aud": []string{"pomerium.example.com"},
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+	})
+
+	t.Run("happy path returns provider name", func(t *testing.T) {
+		res, err := resolver.Verify(t.Context(), tok)
+		require.NoError(t, err)
+		assert.Equal(t, "k8s", res.ProviderName)
+		assert.Equal(t, "system:serviceaccount:ns:sa", res.Claims["sub"])
+	})
+
+	t.Run("untrusted issuer", func(t *testing.T) {
+		other := mockidp.New(mockidp.Config{})
+		otherIssuer := other.Start(t)
+		otherTok := other.SignJWT(map[string]any{
+			"iss": otherIssuer,
+			"aud": []string{"pomerium.example.com"},
+			"exp": now.Add(time.Hour).Unix(),
+		})
+		_, err := resolver.Verify(t.Context(), otherTok)
+		assert.ErrorIs(t, err, ErrNoMatchingIdentityProvider)
+	})
+
+	t.Run("wrong audience for provider", func(t *testing.T) {
+		wrongAud := idp.SignJWT(map[string]any{
+			"iss": issuer,
+			"sub": "x",
+			"aud": []string{"someone-else"},
+			"exp": now.Add(time.Hour).Unix(),
+			"iat": now.Unix(),
+			"nbf": now.Unix(),
+		})
+		_, err := resolver.Verify(t.Context(), wrongAud)
+		require.ErrorIs(t, err, extjwt.ErrAudienceMismatch)
+		require.NotErrorIs(t, err, ErrNoMatchingIdentityProvider)
+	})
+
+	t.Run("garbage token", func(t *testing.T) {
+		_, err := resolver.Verify(t.Context(), "not.a.jwt")
+		require.Error(t, err)
+	})
+}
+
+// TestIdentityProviderResolver_ResolveUnverified pins the unverified dispatch:
+// it maps a token's iss to a provider without any signature/audience check.
+func TestIdentityProviderResolver_ResolveUnverified(t *testing.T) {
+	t.Parallel()
+
+	provider := IdentityProvider{Issuer: "https://k8s.example.com", Audiences: []string{"pomerium"}, SupportedAlgs: []string{"RS256"}}
+	resolver, err := NewIdentityProviderResolver(map[string]IdentityProvider{
+		"k8s": provider,
+	}, nil)
+	require.NoError(t, err)
+
+	// A syntactically-valid but unsigned token is enough — the dispatch never
+	// verifies the signature.
+	known := encodeUnsignedJWT(t, map[string]any{"iss": "https://k8s.example.com", "sub": "x"})
+	rp, err := resolver.resolveUnverified(known)
+	require.NoError(t, err)
+	assert.Equal(t, "k8s", rp.Name)
+
+	unknown := encodeUnsignedJWT(t, map[string]any{"iss": "https://other.example.com"})
+	_, err = resolver.resolveUnverified(unknown)
+	assert.ErrorIs(t, err, ErrNoMatchingIdentityProvider)
+
+	_, err = resolver.resolveUnverified("not-a-jwt")
+	require.Error(t, err)
+}
+
+// derivedCAPEM returns a self-signed CA certificate PEM derived from psk.
+func derivedCAPEM(t testing.TB, psk string) []byte {
+	t.Helper()
+	ca, err := derivecert.NewCA([]byte(psk))
+	require.NoError(t, err)
+	p, err := ca.PEM()
+	require.NoError(t, err)
+	return p.Cert
+}
+
+// TestNewIdentityProviderResolverFromConfig pins the reuse gate: a resolver (and
+// with it the JWKS cache behind it) survives configuration changes that do not
+// concern identity providers, and is rebuilt when any input to it changes.
+func TestNewIdentityProviderResolverFromConfig(t *testing.T) {
+	t.Parallel()
+
+	providers := func() map[string]IdentityProvider {
+		return map[string]IdentityProvider{
+			"k8s": {Issuer: "https://k8s.example.com", Audiences: []string{"pomerium"}, SupportedAlgs: []string{"RS256"}},
+		}
+	}
+
+	t.Run("no providers configured", func(t *testing.T) {
+		r, err := NewIdentityProviderResolverFromConfig(New(&Options{}), nil)
+		require.NoError(t, err)
+		assert.Nil(t, r, "no providers configured -> nil resolver")
+	})
+
+	t.Run("reused when unchanged", func(t *testing.T) {
+		cfg := New(&Options{IdentityProviders: providers()})
+		r1, err := NewIdentityProviderResolverFromConfig(cfg, nil)
+		require.NoError(t, err)
+		require.NotNil(t, r1)
+
+		r2, err := NewIdentityProviderResolverFromConfig(cfg, r1)
+		require.NoError(t, err)
+		assert.Same(t, r1, r2)
+	})
+
+	t.Run("reused across an unrelated configuration change", func(t *testing.T) {
+		r1, err := NewIdentityProviderResolverFromConfig(
+			New(&Options{IdentityProviders: providers()}), nil)
+		require.NoError(t, err)
+
+		// A new generation that changes something the resolver does not depend on
+		// must not discard it: rebuilding would drop the JWKS cache and repeat any
+		// in-cluster discovery.
+		next := New(&Options{IdentityProviders: providers(), CookieExpire: time.Hour})
+		r2, err := NewIdentityProviderResolverFromConfig(next, r1)
+		require.NoError(t, err)
+		assert.Same(t, r1, r2)
+	})
+
+	t.Run("rebuilt when the provider set changes", func(t *testing.T) {
+		r1, err := NewIdentityProviderResolverFromConfig(
+			New(&Options{IdentityProviders: providers()}), nil)
+		require.NoError(t, err)
+		require.NotNil(t, r1)
+
+		for _, tc := range []struct {
+			name   string
+			mutate func(map[string]IdentityProvider)
+		}{
+			{"provider added", func(m map[string]IdentityProvider) {
+				m["other"] = IdentityProvider{Issuer: "https://other.example.com", Audiences: []string{"pomerium"}}
+			}},
+			{"provider removed", func(m map[string]IdentityProvider) {
+				delete(m, "k8s")
+			}},
+			{"issuer changed", func(m map[string]IdentityProvider) {
+				p := m["k8s"]
+				p.Issuer = "https://k8s2.example.com"
+				m["k8s"] = p
+			}},
+			{"audiences narrowed", func(m map[string]IdentityProvider) {
+				p := m["k8s"]
+				p.Audiences = []string{"other"}
+				m["k8s"] = p
+			}},
+			{"supported algs changed", func(m map[string]IdentityProvider) {
+				p := m["k8s"]
+				p.SupportedAlgs = []string{"ES256"}
+				m["k8s"] = p
+			}},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				next := providers()
+				tc.mutate(next)
+				r2, err := NewIdentityProviderResolverFromConfig(
+					New(&Options{IdentityProviders: next}), r1)
+				require.NoError(t, err)
+				assert.NotSame(t, r1, r2)
+			})
+		}
+	})
+
+	// certificate_authority_file is watched, so rotating it in place produces a
+	// reload whose Options are byte-identical. The resolver must still be rebuilt
+	// or it would keep trusting the old CA for JWKS/discovery fetches.
+	t.Run("rebuilt when the CA file contents change", func(t *testing.T) {
+		// Distinct PSKs derive distinct CAs; httptest's TLS servers all share one
+		// hardcoded certificate, so they cannot stand in here.
+		caFile := filepath.Join(t.TempDir(), "ca.pem")
+		writeCA := func(psk string) {
+			require.NoError(t, os.WriteFile(caFile, derivedCAPEM(t, psk), 0o600))
+		}
+
+		writeCA("psk-1")
+		cfg := New(&Options{IdentityProviders: providers(), CAFile: caFile})
+		r1, err := NewIdentityProviderResolverFromConfig(cfg, nil)
+		require.NoError(t, err)
+		require.NotNil(t, r1)
+
+		writeCA("psk-2") // same path, different CA
+		r2, err := NewIdentityProviderResolverFromConfig(cfg, r1)
+		require.NoError(t, err)
+		assert.NotSame(t, r1, r2)
+	})
+
+	// A failed build yields no resolver to reuse, so the next generation retries.
+	t.Run("failed build is retried", func(t *testing.T) {
+		bad := New(&Options{IdentityProviders: providers(), CA: "@@@not-valid-base64-or-pem@@@"})
+		r1, err := NewIdentityProviderResolverFromConfig(bad, nil)
+		require.Error(t, err)
+		require.Nil(t, r1)
+
+		good := New(&Options{IdentityProviders: providers()})
+		r2, err := NewIdentityProviderResolverFromConfig(good, r1)
+		require.NoError(t, err)
+		assert.NotNil(t, r2)
+	})
+
+	// A zero key would make every resolver look reusable.
+	t.Run("cache key is non-zero", func(t *testing.T) {
+		key, err := New(&Options{IdentityProviders: providers()}).identityProviderResolverCacheKey()
+		require.NoError(t, err)
+		assert.NotZero(t, key)
+	})
+}
+
+// TestIdentityProviderResolver_CustomCA verifies that the resolver built for a
+// Config wires the global certificate_authority into the JWKS/discovery HTTP
+// client: a self-signed issuer verifies only when its CA is trusted.
+func TestIdentityProviderResolver_CustomCA(t *testing.T) {
+	t.Parallel()
+
+	idp := mockidp.New(mockidp.Config{})
+	router := mux.NewRouter()
+	idp.Register(router)
+	srv := httptest.NewTLSServer(router)
+	t.Cleanup(srv.Close)
+
+	issuer := srv.URL
+	now := time.Now()
+	tok := idp.SignJWT(map[string]any{
+		"iss": issuer,
+		"sub": "sa",
+		"aud": []string{"pomerium"},
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+	})
+
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srv.Certificate().Raw})
+	caB64 := base64.StdEncoding.EncodeToString(caPEM)
+
+	providers := map[string]IdentityProvider{
+		"k8s": {Issuer: issuer, Audiences: []string{"pomerium"}, SupportedAlgs: []string{"ES256"}},
+	}
+
+	t.Run("with CA verifies", func(t *testing.T) {
+		cfg := New(&Options{CA: caB64, IdentityProviders: providers})
+		resolver, err := NewIdentityProviderResolverFromConfig(cfg, nil)
+		require.NoError(t, err)
+		require.NotNil(t, resolver)
+		res, err := resolver.Verify(t.Context(), tok)
+		require.NoError(t, err)
+		assert.Equal(t, "k8s", res.ProviderName)
+	})
+
+	t.Run("without CA fails on TLS", func(t *testing.T) {
+		cfg := New(&Options{IdentityProviders: providers})
+		resolver, err := NewIdentityProviderResolverFromConfig(cfg, nil)
+		require.NoError(t, err)
+		require.NotNil(t, resolver)
+		_, err = resolver.Verify(t.Context(), tok)
+		require.Error(t, err)
+	})
+}
+
+// TestIdentityProviderResolver_BadCASurfacesError verifies that an explicitly
+// configured certificate_authority that fails to load is a hard error, not a
+// silent fallback to system roots. Falling back would make the intended
+// private-CA issuer's JWKS/discovery fetch fail with "unknown authority" and
+// silently reject every token, with only a single startup log line.
+func TestIdentityProviderResolver_BadCASurfacesError(t *testing.T) {
+	t.Parallel()
+
+	providers := map[string]IdentityProvider{
+		"k8s": {Issuer: "https://issuer.example.com", Audiences: []string{"aud"}, SupportedAlgs: []string{"ES256"}},
+	}
+	// certificate_authority is set but malformed (not valid base64-encoded PEM).
+	cfg := New(&Options{CA: "@@@not-valid-base64-or-pem@@@", IdentityProviders: providers})
+
+	_, err := NewIdentityProviderResolverFromConfig(cfg, nil)
+	require.Error(t, err)
+}


### PR DESCRIPTION
## Summary

Wires the `extjwt` verifier into config as `IdentityProviderResolver`:

- Builds one verifier per configured `identity_providers` entry; rejects duplicate issuers.
- Dispatches an incoming token by its (unverified) `iss` claim; the matched verifier then re-checks `iss`, signature, `exp`/`nbf`, and enforces that provider's `audiences` fail-closed. The same issuer lookup is available without verifying, for route-allowlist checks ahead of the expensive path.
- A resolver is built for one configuration generation. Construction accepts the previous generation's resolver and keeps it when the provider set and the CA material behind JWKS/discovery are unchanged, so cached signing keys and any issuer discovery survive configuration changes that do not concern identity providers. The CA is compared by content, so rotating `certificate_authority_file` in place still rebuilds.
- The global `certificate_authority`/`certificate_authority_file` is wired into the JWKS/discovery HTTP client for private-CA issuers; a configured-but-unloadable CA is a hard error, not a silent fallback to system roots. The client clears `DialTLSContext` when cloning `http.DefaultTransport`, which otherwise pins TLS to the process-global config CA pool and silently overrides the per-resolver root CAs.

Nothing consumes the resolver yet.

Stack 3/6, based on #6588. Split from #6501.

## Related issues

- #6501

## User Explanation

No user-facing changes.

## AI disclosure

Claude Code: carved this stack from the PoC branch (#6501) and adapted it to current `main`; the feature itself was developed on that branch (also AI-assisted).

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review

