### PR TITLE
authorize/config: unify bearer-token retrieval; reject cookie+bearer on jwt routes

### DIFF
--- a/authorize/cookie_bearer_test.go
+++ b/authorize/cookie_bearer_test.go
@@ -1,0 +1,201 @@
+package authorize_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/scenarios"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	"github.com/pomerium/pomerium/internal/testenv/values"
+	"github.com/pomerium/pomerium/internal/testutil/mockidp"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	"github.com/pomerium/pomerium/pkg/nullable"
+)
+
+// TestCookieAndBearer_NonJWTRoutePassthrough asserts that on a route that does
+// not itself consume the bearer token (bearer_token_format not set), a
+// cookie-authenticated browser request may also carry an Authorization: Bearer
+// header meant for the upstream. Pomerium must authenticate via the session
+// cookie and forward the header untouched — a common pattern for a browser app
+// behind Pomerium SSO that also calls an API wanting its own bearer token.
+//
+// The cookie+bearer mutual-exclusion guard (see
+// TestExternalJWTBearer_CookieAndBearerCollision below) only applies to routes
+// where Pomerium consumes the bearer itself.
+//
+// The test logs in normally (populating the route client's cookie jar), then
+// issues a second request on the same route that additionally carries an
+// Authorization: Bearer header, and asserts it succeeds (200) with the header
+// forwarded to the upstream.
+func TestCookieAndBearer_NonJWTRoutePassthrough(t *testing.T) {
+	env := testenv.New(t)
+	env.Add(scenarios.NewIDP([]*mockidp.User{
+		{Email: "foo@example.com", FirstName: "Foo", LastName: "Bar"},
+	}))
+
+	up := upstreams.HTTP(nil, upstreams.WithDisplayName("Echo"))
+	up.Handle("/echo", func(w http.ResponseWriter, r *http.Request) {
+		// Report whether the upstream received the Authorization header, so a
+		// green run also proves the header is forwarded (not consumed).
+		fmt.Fprintf(w, "upstream-auth=%q", r.Header.Get("Authorization"))
+	})
+
+	route := up.Route().
+		From(env.SubdomainURL("echo")).
+		To(values.Bind(up.Addr(), func(addr string) string {
+			return fmt.Sprintf("http://%s", addr)
+		})).
+		Policy(func(p *config.Policy) {
+			// bearer_token_format intentionally NOT set → normal cookie-SSO route.
+			p.AllowAnyAuthenticatedUser = true
+		})
+
+	env.AddUpstream(up)
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	// 1) Log in normally. up.Get caches one *http.Client per route; the login
+	//    flow populates that client's cookie jar with a valid _pomerium session.
+	resp, err := up.Get(route, upstreams.AuthenticateAs("foo@example.com"), upstreams.Path("/echo"))
+	require.NoError(t, err)
+	_, _ = io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "initial cookie login should succeed")
+
+	// 2) Same route → same cached client → the request carries the session
+	//    cookie from the jar, and we ALSO attach an Authorization: Bearer
+	//    header destined for the upstream service.
+	resp2, err := up.Get(route,
+		upstreams.Path("/echo"),
+		upstreams.Headers(map[string]string{"Authorization": "Bearer upstream-app-token"}),
+	)
+	require.NoError(t, err)
+	body, _ := io.ReadAll(resp2.Body)
+	_ = resp2.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp2.StatusCode,
+		"a cookie-authenticated request on a non-JWT route must not be rejected "+
+			"for also carrying an Authorization header (got %d, body=%q)",
+		resp2.StatusCode, string(body))
+}
+
+// jwtBearerAudience is the audience the mock identity providers accept and the
+// tests mint tokens for.
+const jwtBearerAudience = "pomerium.example.com"
+
+// configureJWTIdp wires a mock OIDC issuer into Pomerium's identity_providers
+// map under the given name (audiences are per-provider) and returns the IDP
+// plus its URL.
+func configureJWTIdp(t *testing.T, env testenv.Environment, idpName string) (*mockidp.IDP, values.Value[string]) {
+	t.Helper()
+
+	idp := mockidp.New(mockidp.Config{})
+	idpUp := upstreams.HTTP(nil, upstreams.WithDisplayName("JWT Issuer"))
+	idp.Register(idpUp.Router())
+	env.AddUpstream(idpUp)
+
+	idpURL := values.Bind(idpUp.Addr(), func(addr string) string {
+		return fmt.Sprintf("http://%s", addr)
+	})
+
+	env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
+		if cfg.Options.IdentityProviders == nil {
+			cfg.Options.IdentityProviders = map[string]config.IdentityProvider{}
+		}
+		cfg.Options.IdentityProviders[idpName] = config.IdentityProvider{
+			Issuer:        idpURL.Value(),
+			Audiences:     []string{jwtBearerAudience},
+			SupportedAlgs: []string{"ES256"}, // mockidp signs with ES256
+		}
+	}))
+
+	return idp, idpURL
+}
+
+// useJWTBearer configures a route to verify JWT bearer tokens. The optional
+// providerNames set the route's identity-provider allowlist; when none are
+// given the route accepts tokens from any configured provider.
+func useJWTBearer(p *config.Policy, providerNames ...string) {
+	p.BearerTokenFormat = nullable.From(configpb.BearerTokenFormat_BEARER_TOKEN_FORMAT_JWT)
+	p.IdentityProviders = providerNames
+}
+
+// stdSAClaims returns a minimal Kubernetes-shaped SA token claims map.
+func stdSAClaims(issuer, sub, aud string, now time.Time) map[string]any {
+	return map[string]any{
+		"iss": issuer,
+		"sub": sub,
+		"aud": []string{aud},
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+		"kubernetes.io": map[string]any{
+			"namespace": "default",
+			"serviceaccount": map[string]any{
+				"name": "my-sa",
+				"uid":  "00000000-0000-0000-0000-000000000001",
+			},
+		},
+	}
+}
+
+// TestExternalJWTBearer_CookieAndBearerCollision asserts that a request
+// carrying both a Pomerium session cookie AND an Authorization: Bearer
+// header is rejected with 400.
+func TestExternalJWTBearer_CookieAndBearerCollision(t *testing.T) {
+	env := testenv.New(t)
+	idp, idpURL := configureJWTIdp(t, env, "demo-idp")
+
+	up := upstreams.HTTP(nil, upstreams.WithDisplayName("Echo"))
+	up.Handle("/echo", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+
+	route := up.Route().
+		From(env.SubdomainURL("api")).
+		To(values.Bind(up.Addr(), func(addr string) string {
+			return fmt.Sprintf("http://%s", addr)
+		})).
+		Policy(func(p *config.Policy) {
+			useJWTBearer(p)
+			var ppl config.PPLPolicy
+			require.NoError(t, ppl.UnmarshalJSON([]byte(`{
+				"allow": {"and": [{"claim/sub": "system:serviceaccount:default:my-sa"}]}
+			}`)))
+			p.Policy = &ppl
+		})
+
+	env.AddUpstream(up)
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	tok := idp.SignJWT(stdSAClaims(idpURL.Value(), "system:serviceaccount:default:my-sa", "pomerium.example.com", time.Now()))
+
+	resp, err := up.Get(route,
+		upstreams.Path("/echo"),
+		upstreams.Headers(map[string]string{
+			"Authorization": "Bearer " + tok,
+			"Cookie":        "_pomerium=fake-session-value",
+		}),
+		upstreams.ClientHook(func(_ *http.Client) *http.Client {
+			return &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			}}
+		}),
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode,
+		"cookie + bearer must be rejected as 400")
+}

--- a/authorize/grpc.go
+++ b/authorize/grpc.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pomerium/pomerium/internal/mcp"
 	"github.com/pomerium/pomerium/internal/sessions"
 	"github.com/pomerium/pomerium/pkg/contextutil"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
 	"github.com/pomerium/pomerium/pkg/storage"
@@ -64,6 +65,24 @@ func (a *Authorize) Check(ctx context.Context, in *envoy_service_auth_v3.CheckRe
 		headers := make(http.Header)
 		mcp.SetCORSHeaders(headers)
 		return mkDeniedCheckResponse(http.StatusNoContent, headers, ""), nil
+	}
+
+	// Cookie + Authorization: Bearer are mutually exclusive trust contexts,
+	// but only on bearer_token_format: jwt routes: cookies come from a
+	// browser, an external JWT comes from an M2M client, so a request
+	// carrying both is a misconfigured client or a confusion attempt —
+	// reject with 400. The IdP access/identity token formats predate this
+	// check and allow both credentials together (a logged-in browser may
+	// send its IdP token via Authorization; see TestBearerTokenFormat), and
+	// on pass-through routes the Authorization header belongs to the
+	// upstream, so neither may be rejected here.
+	cfg := a.currentConfig.Load()
+	if cfg.GetBearerTokenFormatForPolicy(req.Policy) == configpb.BearerTokenFormat_BEARER_TOKEN_FORMAT_JWT &&
+		hasCookieAndBearer(hreq, cfg.Options.CookieName) {
+		log.Ctx(ctx).Info().
+			Str("request-id", requestID).
+			Msg("request carried both a session cookie and an Authorization: Bearer header on a bearer_token_format:jwt route; rejecting as 400")
+		return a.deniedResponse(ctx, in, int32(http.StatusBadRequest), http.StatusText(http.StatusBadRequest), nil)
 	}
 
 	// load the session
@@ -299,4 +318,23 @@ func updateSpanWithMCPInfo(span oteltrace.Span, mcp evaluator.RequestMCP) {
 	if tc := mcp.ToolCall; tc != nil {
 		span.SetAttributes(attribute.String("mcp.tool", tc.Name))
 	}
+}
+
+// hasCookieAndBearer reports whether the request carries BOTH a Pomerium
+// session cookie AND an Authorization: Bearer header. The two are mutually
+// exclusive trust contexts (browser vs M2M).
+func hasCookieAndBearer(r *http.Request, cookieName string) bool {
+	if cookieName == "" {
+		return false
+	}
+	// Check the (cheap) Authorization header before parsing cookies: the
+	// common authenticated browser case carries a cookie but no bearer, so
+	// short-circuiting here skips cookie parsing on the hot path.
+	const prefix = "Bearer "
+	auth := r.Header.Get(httputil.HeaderAuthorization)
+	if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return false
+	}
+	_, err := r.Cookie(cookieName)
+	return err == nil
 }

--- a/config/session.go
+++ b/config/session.go
@@ -170,15 +170,19 @@ func (c *incomingIDPTokenSessionCreator) CreateSession(
 	ctx, op := c.telemetry.Start(ctx, "CreateSession")
 	defer op.Complete()
 
-	if rawAccessToken, ok := cfg.GetIncomingIDPAccessTokenForPolicy(policy, r); ok {
-		return c.createSessionForAccessToken(ctx, cfg, policy, rawAccessToken)
+	rawToken, format, ok := cfg.getIncomingBearerToken(policy, r)
+	if !ok {
+		return nil, sessions.ErrNoSessionFound
 	}
 
-	if rawIdentityToken, ok := cfg.GetIncomingIDPIdentityTokenForPolicy(policy, r); ok {
-		return c.createSessionForIdentityToken(ctx, cfg, policy, rawIdentityToken)
+	switch format {
+	case config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_ACCESS_TOKEN:
+		return c.createSessionForAccessToken(ctx, cfg, policy, rawToken)
+	case config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_IDENTITY_TOKEN:
+		return c.createSessionForIdentityToken(ctx, cfg, policy, rawToken)
+	default:
+		return nil, sessions.ErrNoSessionFound
 	}
-
-	return nil, sessions.ErrNoSessionFound
 }
 
 func (c *incomingIDPTokenSessionCreator) createSessionForAccessToken(
@@ -253,6 +257,8 @@ func (c *incomingIDPTokenSessionCreator) createSessionForAccessToken(
 	return res.(*session.Session), nil
 }
 
+// createSessionForIdentityToken verifies an IdP-issued identity token against
+// the route's (browser/SSO) identity provider via the authenticate service.
 func (c *incomingIDPTokenSessionCreator) createSessionForIdentityToken(
 	ctx context.Context,
 	cfg *Config,
@@ -444,46 +450,39 @@ func (c *incomingIDPTokenSessionCreator) putSessionAndUser(ctx context.Context, 
 	return nil
 }
 
-// GetIncomingIDPAccessTokenForPolicy returns the raw idp access token from a request if there is one.
-func (cfg *Config) GetIncomingIDPAccessTokenForPolicy(policy *Policy, r *http.Request) (rawAccessToken string, ok bool) {
-	bearerTokenFormat := config.BearerTokenFormat_BEARER_TOKEN_FORMAT_UNKNOWN
+// GetBearerTokenFormatForPolicy resolves the effective bearer_token_format for
+// the policy: per-route override, else the global default, else UNKNOWN.
+func (cfg *Config) GetBearerTokenFormatForPolicy(policy *Policy) config.BearerTokenFormat {
+	format := config.BearerTokenFormat_BEARER_TOKEN_FORMAT_UNKNOWN
 	if cfg.Options != nil && cfg.Options.BearerTokenFormat.IsSet {
-		bearerTokenFormat = cfg.Options.BearerTokenFormat.Value
+		format = cfg.Options.BearerTokenFormat.Value
 	}
 	if policy != nil && policy.BearerTokenFormat.IsSet {
-		bearerTokenFormat = policy.BearerTokenFormat.Value
+		format = policy.BearerTokenFormat.Value
 	}
-
-	if auth := r.Header.Get(httputil.HeaderAuthorization); auth != "" {
-		prefix := "Bearer "
-		if strings.HasPrefix(strings.ToLower(auth), strings.ToLower(prefix)) &&
-			bearerTokenFormat == config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_ACCESS_TOKEN {
-			return auth[len(prefix):], true
-		}
-	}
-
-	return "", false
+	return format
 }
 
-// GetIncomingIDPAccessTokenForPolicy returns the raw idp identity token from a request if there is one.
-func (cfg *Config) GetIncomingIDPIdentityTokenForPolicy(policy *Policy, r *http.Request) (rawIdentityToken string, ok bool) {
-	bearerTokenFormat := config.BearerTokenFormat_BEARER_TOKEN_FORMAT_UNKNOWN
-	if cfg.Options != nil && cfg.Options.BearerTokenFormat.IsSet {
-		bearerTokenFormat = cfg.Options.BearerTokenFormat.Value
-	}
-	if policy != nil && policy.BearerTokenFormat.IsSet {
-		bearerTokenFormat = policy.BearerTokenFormat.Value
-	}
-
-	if auth := r.Header.Get(httputil.HeaderAuthorization); auth != "" {
-		prefix := "Bearer "
-		if strings.HasPrefix(strings.ToLower(auth), strings.ToLower(prefix)) &&
-			bearerTokenFormat == config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_IDENTITY_TOKEN {
-			return auth[len(prefix):], true
-		}
+// getIncomingBearerToken resolves the effective bearer_token_format for the
+// policy and, when it calls for interpreting the token (access/identity/jwt),
+// returns the raw Bearer token from the Authorization header. For DEFAULT or
+// UNKNOWN (passthrough), or when no Bearer header is present, ok is false.
+func (cfg *Config) getIncomingBearerToken(policy *Policy, r *http.Request) (rawToken string, format config.BearerTokenFormat, ok bool) {
+	format = cfg.GetBearerTokenFormatForPolicy(policy)
+	switch format {
+	case config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_ACCESS_TOKEN,
+		config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_IDENTITY_TOKEN,
+		config.BearerTokenFormat_BEARER_TOKEN_FORMAT_JWT:
+	default:
+		return "", format, false
 	}
 
-	return "", false
+	auth := r.Header.Get(httputil.HeaderAuthorization)
+	const prefix = "Bearer "
+	if len(auth) < len(prefix) || !strings.EqualFold(auth[:len(prefix)], prefix) {
+		return "", format, false
+	}
+	return auth[len(prefix):], format, true
 }
 
 var accessTokenUUIDNamespace = uuid.MustParse("0194f6f8-e760-76a0-8917-e28ac927a34d")

--- a/config/session_test.go
+++ b/config/session_test.go
@@ -195,54 +195,90 @@ func Test_getTokenSessionID(t *testing.T) {
 	assert.Equal(t, "0fe0e289-40bb-5ffe-b328-e290e043a652", getIdentityTokenSessionID(&identitypb.Provider{Id: "IDP1"}, "TOKEN"))
 }
 
-func TestGetIncomingIDPAccessTokenForPolicy(t *testing.T) {
+func TestGetIncomingBearerToken(t *testing.T) {
 	t.Parallel()
 
-	bearerTokenFormatIDPAccessToken := config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_ACCESS_TOKEN
+	fmtDefault := config.BearerTokenFormat_BEARER_TOKEN_FORMAT_DEFAULT
+	fmtAccess := config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_ACCESS_TOKEN
+	fmtIdentity := config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_IDENTITY_TOKEN
+	fmtJWT := config.BearerTokenFormat_BEARER_TOKEN_FORMAT_JWT
 
 	for _, tc := range []struct {
-		name                    string
-		globalBearerTokenFormat *config.BearerTokenFormat
-		routeBearerTokenFormat  *config.BearerTokenFormat
-		headers                 http.Header
-		expectedOK              bool
-		expectedToken           string
+		name           string
+		globalFormat   *config.BearerTokenFormat
+		routeFormat    *config.BearerTokenFormat
+		headers        http.Header
+		expectedOK     bool
+		expectedToken  string
+		expectedFormat config.BearerTokenFormat
 	}{
 		{
-			name:       "empty headers",
+			name:       "empty headers, passthrough",
 			expectedOK: false,
 		},
 		{
-			name:       "bearer disabled",
-			headers:    http.Header{"Authorization": {"Bearer access token via bearer"}},
+			name:       "unset format ignores bearer (passthrough)",
+			headers:    http.Header{"Authorization": {"Bearer tok"}},
 			expectedOK: false,
 		},
 		{
-			name:                    "bearer enabled via options",
-			globalBearerTokenFormat: &bearerTokenFormatIDPAccessToken,
-			headers:                 http.Header{"Authorization": {"Bearer access token via bearer"}},
-			expectedOK:              true,
-			expectedToken:           "access token via bearer",
+			name:           "default format ignores bearer",
+			globalFormat:   &fmtDefault,
+			headers:        http.Header{"Authorization": {"Bearer tok"}},
+			expectedOK:     false,
+			expectedFormat: fmtDefault,
 		},
 		{
-			name:                   "bearer enabled via route",
-			routeBearerTokenFormat: &bearerTokenFormatIDPAccessToken,
-			headers:                http.Header{"Authorization": {"Bearer access token via bearer"}},
-			expectedOK:             true,
-			expectedToken:          "access token via bearer",
+			name:           "access token via options",
+			globalFormat:   &fmtAccess,
+			headers:        http.Header{"Authorization": {"Bearer tok"}},
+			expectedOK:     true,
+			expectedToken:  "tok",
+			expectedFormat: fmtAccess,
+		},
+		{
+			name:           "access token via route override",
+			routeFormat:    &fmtAccess,
+			headers:        http.Header{"Authorization": {"Bearer tok"}},
+			expectedOK:     true,
+			expectedToken:  "tok",
+			expectedFormat: fmtAccess,
+		},
+		{
+			name:           "identity token",
+			globalFormat:   &fmtIdentity,
+			headers:        http.Header{"Authorization": {"Bearer id-tok"}},
+			expectedOK:     true,
+			expectedToken:  "id-tok",
+			expectedFormat: fmtIdentity,
+		},
+		{
+			name:           "jwt",
+			routeFormat:    &fmtJWT,
+			headers:        http.Header{"Authorization": {"Bearer jwt-tok"}},
+			expectedOK:     true,
+			expectedToken:  "jwt-tok",
+			expectedFormat: fmtJWT,
+		},
+		{
+			name:           "jwt but non-Bearer auth header",
+			routeFormat:    &fmtJWT,
+			headers:        http.Header{"Authorization": {"Basic dXNlcjpwYXNz"}},
+			expectedOK:     false,
+			expectedFormat: fmtJWT,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			cfg := New(NewDefaultOptions())
-			cfg.Options.BearerTokenFormat = nullable.FromPtr(tc.globalBearerTokenFormat)
+			cfg.Options.BearerTokenFormat = nullable.FromPtr(tc.globalFormat)
 
 			var route *Policy
-			if tc.routeBearerTokenFormat != nil {
+			if tc.routeFormat != nil {
 				route = &Policy{
 					RouteOptions: RouteOptions{
-						BearerTokenFormat: nullable.FromPtr(tc.routeBearerTokenFormat),
+						BearerTokenFormat: nullable.FromPtr(tc.routeFormat),
 					},
 				}
 			}
@@ -253,74 +289,10 @@ func TestGetIncomingIDPAccessTokenForPolicy(t *testing.T) {
 				r.Header = tc.headers
 			}
 
-			actualToken, actualOK := cfg.GetIncomingIDPAccessTokenForPolicy(route, r)
+			actualToken, actualFormat, actualOK := cfg.getIncomingBearerToken(route, r)
 			assert.Equal(t, tc.expectedOK, actualOK)
 			assert.Equal(t, tc.expectedToken, actualToken)
-		})
-	}
-}
-
-func TestGetIncomingIDPIdentityTokenForPolicy(t *testing.T) {
-	t.Parallel()
-
-	bearerTokenFormatIDPIdentityToken := config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_IDENTITY_TOKEN
-
-	for _, tc := range []struct {
-		name                    string
-		globalBearerTokenFormat *config.BearerTokenFormat
-		routeBearerTokenFormat  *config.BearerTokenFormat
-		headers                 http.Header
-		expectedOK              bool
-		expectedToken           string
-	}{
-		{
-			name:       "empty headers",
-			expectedOK: false,
-		},
-		{
-			name:       "bearer disabled",
-			headers:    http.Header{"Authorization": {"Bearer identity token via bearer"}},
-			expectedOK: false,
-		},
-		{
-			name:                    "bearer enabled via options",
-			globalBearerTokenFormat: &bearerTokenFormatIDPIdentityToken,
-			headers:                 http.Header{"Authorization": {"Bearer identity token via bearer"}},
-			expectedOK:              true,
-			expectedToken:           "identity token via bearer",
-		},
-		{
-			name:                   "bearer enabled via route",
-			routeBearerTokenFormat: &bearerTokenFormatIDPIdentityToken,
-			headers:                http.Header{"Authorization": {"Bearer identity token via bearer"}},
-			expectedOK:             true,
-			expectedToken:          "identity token via bearer",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
-			cfg := New(NewDefaultOptions())
-			cfg.Options.BearerTokenFormat = nullable.FromPtr(tc.globalBearerTokenFormat)
-
-			var route *Policy
-			if tc.routeBearerTokenFormat != nil {
-				route = &Policy{
-					RouteOptions: RouteOptions{
-						BearerTokenFormat: nullable.FromPtr(tc.routeBearerTokenFormat),
-					},
-				}
-			}
-
-			r, err := http.NewRequest(http.MethodGet, "https://example.com", nil)
-			require.NoError(t, err)
-			if tc.headers != nil {
-				r.Header = tc.headers
-			}
-
-			actualToken, actualOK := cfg.GetIncomingIDPIdentityTokenForPolicy(route, r)
-			assert.Equal(t, tc.expectedOK, actualOK)
-			assert.Equal(t, tc.expectedToken, actualToken)
+			assert.Equal(t, tc.expectedFormat, actualFormat)
 		})
 	}
 }
@@ -591,3 +563,8 @@ func TestIncomingIDPTokenSessionCreator_CreateSession(t *testing.T) {
 		assert.True(t, s.GetRefreshDisabled())
 	})
 }
+
+// TestJWTSingleflightKey checks the de-dup key is keyed on (provider name, raw
+// token): the same token under different providers must not collapse, and
+// different tokens must not collapse. Audiences are per-provider now, so they
+// are no longer part of the key — the provider name already scopes them.


### PR DESCRIPTION
## Summary

- Replaces the two per-format bearer getters (`GetIncomingIDPAccessTokenForPolicy`, `GetIncomingIDPIdentityTokenForPolicy`) with one `GetBearerTokenFormatForPolicy` + `getIncomingBearerToken` pair; `CreateSession` dispatches on the resolved format. Behavior for the existing access/identity formats is unchanged; `jwt` still creates no session in this PR.
- On routes whose `bearer_token_format` resolves to `jwt`, a request carrying both a Pomerium session cookie and an `Authorization: Bearer` header is rejected with 400 before session load: on those routes the two are mutually exclusive trust contexts (browser vs M2M), and rejecting beats silently picking one. IdP access/identity-token routes keep accepting both (a logged-in browser may send its IdP token — covered by `TestBearerTokenFormat` on main), and pass-through routes keep forwarding the header to the upstream untouched.

Integration tests cover both directions: cookie+bearer passes through on a non-jwt route; 400 on a jwt route.

Stack 4/6, based on #6589. Split from #6501.

## Related issues

- #6501

## User Explanation

On routes with `bearer_token_format: jwt` (new, not yet functional), requests must present either a session cookie or a bearer token, never both. No change for existing routes.

## AI disclosure

Claude Code: carved this stack from the PoC branch (#6501) and adapted it to current `main`; the feature itself was developed on that branch (also AI-assisted).

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
