### PR TITLE
config: create sessions from externally-issued JWT bearer tokens

### DIFF
--- a/authorize/jwt_bearer_int_test.go
+++ b/authorize/jwt_bearer_int_test.go
@@ -1,0 +1,319 @@
+package authorize_test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/upstreams"
+	"github.com/pomerium/pomerium/internal/testenv/values"
+	"github.com/pomerium/pomerium/internal/testutil/mockidp"
+)
+
+// TestExternalJWTBearer_HappyPath asserts a JWT-bearer authenticated request
+// reaches the upstream when the route's bearer_token_format is jwt and the
+// token's issuer/audience are trusted.
+func TestExternalJWTBearer_HappyPath(t *testing.T) {
+	env := testenv.New(t)
+	idp, idpURL := configureJWTIdp(t, env, "demo-idp")
+
+	const audience = "pomerium.example.com"
+
+	up := upstreams.HTTP(nil, upstreams.WithDisplayName("Echo"))
+	up.Handle("/echo", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+
+	route := up.Route().
+		From(env.SubdomainURL("api")).
+		To(values.Bind(up.Addr(), func(addr string) string {
+			return fmt.Sprintf("http://%s", addr)
+		})).
+		Policy(func(p *config.Policy) {
+			useJWTBearer(p)
+			var ppl config.PPLPolicy
+			require.NoError(t, ppl.UnmarshalJSON([]byte(`{
+				"allow": {
+					"and": [{
+						"claim/sub": "system:serviceaccount:default:my-sa"
+					}]
+				}
+			}`)))
+			p.Policy = &ppl
+		})
+
+	env.AddUpstream(up)
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	tok := idp.SignJWT(stdSAClaims(idpURL.Value(), "system:serviceaccount:default:my-sa", audience, time.Now()))
+
+	resp, err := up.Get(route,
+		upstreams.Path("/echo"),
+		upstreams.Headers(map[string]string{"Authorization": "Bearer " + tok}),
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusOK, resp.StatusCode, "expected 200; got %d body=%q", resp.StatusCode, string(body))
+	assert.Contains(t, string(body), "ok")
+}
+
+// TestExternalJWTBearer_KubernetesNamespacePolicy asserts that a policy
+// referencing `claim/kubernetes.io.namespace` (NO enrichment, no synthesized
+// groups) matches correctly against the structured claim path.
+func TestExternalJWTBearer_KubernetesNamespacePolicy(t *testing.T) {
+	env := testenv.New(t)
+	idp, idpURL := configureJWTIdp(t, env, "demo-idp")
+
+	const audience = "pomerium.example.com"
+
+	up := upstreams.HTTP(nil, upstreams.WithDisplayName("Echo"))
+	up.Handle("/echo", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+
+	route := up.Route().
+		From(env.SubdomainURL("api")).
+		To(values.Bind(up.Addr(), func(addr string) string {
+			return fmt.Sprintf("http://%s", addr)
+		})).
+		Policy(func(p *config.Policy) {
+			useJWTBearer(p)
+			var ppl config.PPLPolicy
+			require.NoError(t, ppl.UnmarshalJSON([]byte(`{
+				"allow": {
+					"and": [{
+						"claim/kubernetes.io.namespace": "platform"
+					}]
+				}
+			}`)))
+			p.Policy = &ppl
+		})
+
+	env.AddUpstream(up)
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	now := time.Now()
+
+	// Allowed: namespace=platform.
+	allowed := idp.SignJWT(map[string]any{
+		"iss": idpURL.Value(),
+		"sub": "system:serviceaccount:platform:any-sa",
+		"aud": []string{audience},
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+		"kubernetes.io": map[string]any{
+			"namespace":      "platform",
+			"serviceaccount": map[string]any{"name": "any-sa"},
+		},
+	})
+
+	resp, err := up.Get(route,
+		upstreams.Path("/echo"),
+		upstreams.Headers(map[string]string{"Authorization": "Bearer " + allowed}),
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+	assert.Equal(t, http.StatusOK, resp.StatusCode,
+		"namespace=platform token should be allowed by claim/kubernetes.io.namespace")
+
+	// Denied: namespace=other.
+	denied := idp.SignJWT(map[string]any{
+		"iss": idpURL.Value(),
+		"sub": "system:serviceaccount:other:any-sa",
+		"aud": []string{audience},
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+		"kubernetes.io": map[string]any{
+			"namespace":      "other",
+			"serviceaccount": map[string]any{"name": "any-sa"},
+		},
+	})
+
+	resp2, err := up.Get(route,
+		upstreams.Path("/echo"),
+		upstreams.Headers(map[string]string{"Authorization": "Bearer " + denied}),
+	)
+	require.NoError(t, err)
+	defer resp2.Body.Close()
+	io.ReadAll(resp2.Body)
+	assert.NotEqual(t, http.StatusOK, resp2.StatusCode, "namespace=other should be denied")
+}
+
+// TestExternalJWTBearer_WrongAudience asserts a token minted for a different
+// audience is rejected.
+func TestExternalJWTBearer_WrongAudience(t *testing.T) {
+	env := testenv.New(t)
+	idp, idpURL := configureJWTIdp(t, env, "demo-idp")
+
+	up := upstreams.HTTP(nil, upstreams.WithDisplayName("Echo"))
+	up.Handle("/echo", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+
+	route := up.Route().
+		From(env.SubdomainURL("api")).
+		To(values.Bind(up.Addr(), func(addr string) string {
+			return fmt.Sprintf("http://%s", addr)
+		})).
+		Policy(func(p *config.Policy) {
+			useJWTBearer(p)
+			var ppl config.PPLPolicy
+			require.NoError(t, ppl.UnmarshalJSON([]byte(`{
+				"allow": {"and": [{"claim/sub": "system:serviceaccount:default:my-sa"}]}
+			}`)))
+			p.Policy = &ppl
+		})
+
+	env.AddUpstream(up)
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	tok := idp.SignJWT(stdSAClaims(idpURL.Value(), "system:serviceaccount:default:my-sa", "someone-else", time.Now()))
+
+	resp, err := up.Get(route,
+		upstreams.Path("/echo"),
+		upstreams.Headers(map[string]string{"Authorization": "Bearer " + tok}),
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+	assert.NotEqual(t, http.StatusOK, resp.StatusCode)
+}
+
+// TestExternalJWTBearer_NoBearerNoFallthrough asserts a JWT-only route with
+// no Authorization header returns 401 (or non-200) — does NOT redirect to
+// browser SSO.
+func TestExternalJWTBearer_NoBearerNoFallthrough(t *testing.T) {
+	env := testenv.New(t)
+	configureJWTIdp(t, env, "demo-idp")
+
+	up := upstreams.HTTP(nil, upstreams.WithDisplayName("Echo"))
+	up.Handle("/echo", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+
+	route := up.Route().
+		From(env.SubdomainURL("api")).
+		To(values.Bind(up.Addr(), func(addr string) string {
+			return fmt.Sprintf("http://%s", addr)
+		})).
+		Policy(func(p *config.Policy) {
+			useJWTBearer(p)
+			var ppl config.PPLPolicy
+			require.NoError(t, ppl.UnmarshalJSON([]byte(`{
+				"allow": {"and": [{"claim/sub": "system:serviceaccount:default:my-sa"}]}
+			}`)))
+			p.Policy = &ppl
+		})
+
+	env.AddUpstream(up)
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	// No Authorization header — request should be denied, NOT redirected
+	// into an interactive sign-in.
+	resp, err := up.Get(route,
+		upstreams.Path("/echo"),
+		upstreams.ClientHook(func(_ *http.Client) *http.Client {
+			return &http.Client{CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			}}
+		}),
+	)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	io.ReadAll(resp.Body)
+	assert.NotEqual(t, http.StatusOK, resp.StatusCode,
+		"a JWT-only route should not allow access without a bearer token")
+}
+
+// TestExternalJWTBearer_RouteProviderScoping asserts a route's
+// identity_providers allowlist scopes which providers it accepts: a route
+// allowing only idp-a rejects an idp-b token, while a route with no allowlist
+// accepts tokens from either configured provider. (The session's IdpId ==
+// provider name is asserted at the unit level in config's
+// TestVerifyJWTAndCreateSession / TestCreateSessionForJWT_RouteProviderScoping.)
+func TestExternalJWTBearer_RouteProviderScoping(t *testing.T) {
+	env := testenv.New(t)
+	idpA, idpAURL := configureJWTIdp(t, env, "idp-a")
+	idpB, idpBURL := configureJWTIdp(t, env, "idp-b")
+
+	up := upstreams.HTTP(nil, upstreams.WithDisplayName("Echo"))
+	up.Handle("/echo", func(w http.ResponseWriter, _ *http.Request) {
+		fmt.Fprintln(w, "ok")
+	})
+
+	newPPL := func() *config.PPLPolicy {
+		var ppl config.PPLPolicy
+		require.NoError(t, ppl.UnmarshalJSON([]byte(`{"allow":{"and":[{"claim/sub":"svc"}]}}`)))
+		return &ppl
+	}
+	toAddr := values.Bind(up.Addr(), func(addr string) string {
+		return fmt.Sprintf("http://%s", addr)
+	})
+
+	// Route A: only idp-a is allowed.
+	routeA := up.Route().
+		From(env.SubdomainURL("api-a")).
+		To(toAddr).
+		Policy(func(p *config.Policy) {
+			useJWTBearer(p, "idp-a")
+			p.Policy = newPPL()
+		})
+	// Route B: no allowlist -> any configured provider is accepted.
+	routeB := up.Route().
+		From(env.SubdomainURL("api-b")).
+		To(toAddr).
+		Policy(func(p *config.Policy) {
+			useJWTBearer(p)
+			p.Policy = newPPL()
+		})
+
+	env.AddUpstream(up)
+	env.Start()
+	snippets.WaitStartupComplete(env)
+
+	now := time.Now()
+	mkTok := func(idp *mockidp.IDP, iss string) string {
+		return idp.SignJWT(map[string]any{
+			"iss": iss,
+			"sub": "svc",
+			"aud": []string{jwtBearerAudience},
+			"exp": now.Add(time.Hour).Unix(),
+			"iat": now.Unix(),
+			"nbf": now.Unix(),
+		})
+	}
+	tokA := mkTok(idpA, idpAURL.Value())
+	tokB := mkTok(idpB, idpBURL.Value())
+
+	status := func(route testenv.Route, tok string) int {
+		resp, err := up.Get(route,
+			upstreams.Path("/echo"),
+			upstreams.Headers(map[string]string{"Authorization": "Bearer " + tok}),
+		)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		io.ReadAll(resp.Body)
+		return resp.StatusCode
+	}
+
+	assert.Equal(t, http.StatusOK, status(routeA, tokA), "route allowing idp-a must accept idp-a token")
+	assert.NotEqual(t, http.StatusOK, status(routeA, tokB), "route allowing only idp-a must reject idp-b token")
+	assert.Equal(t, http.StatusOK, status(routeB, tokA), "route with no allowlist must accept idp-a token")
+	assert.Equal(t, http.StatusOK, status(routeB, tokB), "route with no allowlist must accept idp-b token")
+}

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -35,6 +35,7 @@ type authorizeState struct {
 	dataBrokerClient           databroker.DataBrokerServiceClient
 	sessionStore               *config.SessionStore
 	idpTokenSessionCreator     config.IncomingIDPTokenSessionCreator
+	idpResolver                *config.IdentityProviderResolver
 	authenticateFlow           authenticateFlow
 	syncQueriers               map[string]storage.Querier
 	mcp                        *mcp.Handler
@@ -56,8 +57,10 @@ func newAuthorizeStateFromConfig(
 
 	var err error
 	var previousEvaluator *evaluator.Evaluator
+	var previousIDPResolver *config.IdentityProviderResolver
 	if previousState != nil {
 		previousEvaluator = previousState.evaluator
+		previousIDPResolver = previousState.idpResolver
 	}
 
 	state.sharedKey, err = cfg.Options.GetSharedKey()
@@ -107,6 +110,18 @@ func newAuthorizeStateFromConfig(
 	if err != nil {
 		return nil, fmt.Errorf("authorize: invalid session store: %w", err)
 	}
+	// Built here, off the request path, reusing the previous generation's resolver
+	// when nothing it is built from changed. A failure is deliberately not fatal:
+	// OnConfigChange only logs a state-build error and keeps the previous state, so
+	// failing here would silently discard every unrelated route and policy change
+	// in this generation.
+	idpResolver, idpResolverErr := config.NewIdentityProviderResolverFromConfig(cfg, previousIDPResolver)
+	if idpResolverErr != nil {
+		log.Ctx(ctx).Error().Err(idpResolverErr).
+			Msg("authorize: error building identity provider resolver; routes using bearer_token_format=jwt will reject requests until the next configuration change")
+	}
+	state.idpResolver = idpResolver
+
 	state.idpTokenSessionCreator = config.NewIncomingIDPTokenSessionCreator(
 		tracerProvider,
 		func(ctx context.Context, recordType, recordID string) (*databroker.Record, error) {
@@ -122,6 +137,7 @@ func newAuthorizeStateFromConfig(
 			storage.InvalidateCacheForDataBrokerRecords(ctx, res.Records...)
 			return nil
 		},
+		config.WithIdentityProviderResolver(idpResolver, idpResolverErr),
 	)
 
 	if cfg.Options.UseStatelessAuthenticateFlow() {

--- a/authorize/state_test.go
+++ b/authorize/state_test.go
@@ -1,0 +1,51 @@
+package authorize
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/pomerium/pomerium/authorize/internal/store"
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/grpc"
+)
+
+// TestNewAuthorizeStateFromConfig_IdentityProviderResolverReuse pins that the
+// state builder hands the previous generation's resolver to the next one, so the
+// JWKS cache behind it (and any in-cluster discovery) survives a configuration
+// change that does not concern identity providers. The reuse gate itself is
+// covered by config.TestNewIdentityProviderResolverFromConfig.
+func TestNewAuthorizeStateFromConfig_IdentityProviderResolverReuse(t *testing.T) {
+	t.Parallel()
+
+	newOptions := func(providers map[string]config.IdentityProvider) *config.Options {
+		return &config.Options{
+			AuthenticateURLString: "https://authN.example.com",
+			DataBroker:            config.DataBrokerOptions{ServiceURL: "https://databroker.example.com"},
+			CookieSecret:          "15WXae6fvK9Hal0RGZ600JlCaflYHtNy9bAyOLTlvmc=",
+			SharedKey:             "2p/Wi2Q6bYDfzmoSEbKqYKtg+DUoLWTEHHs7vOhvL7w=",
+			Policies:              testPolicies(t),
+			IdentityProviders:     providers,
+		}
+	}
+	providers := map[string]config.IdentityProvider{
+		"k8s": {Issuer: "https://k8s.example.com", Audiences: []string{"pomerium"}, SupportedAlgs: []string{"RS256"}},
+	}
+	newState := func(t *testing.T, previous *authorizeState, opts *config.Options) *authorizeState {
+		t.Helper()
+		state, err := newAuthorizeStateFromConfig(t.Context(), previous, noop.NewTracerProvider(),
+			config.New(opts), store.New(), new(grpc.CachedOutboundGRPClientConn))
+		require.NoError(t, err)
+		return state
+	}
+
+	first := newState(t, nil, newOptions(providers))
+	require.NotNil(t, first.idpResolver)
+
+	opts := newOptions(providers)
+	opts.CookieExpire = time.Hour
+	assert.Same(t, first.idpResolver, newState(t, first, opts).idpResolver)
+}

--- a/config/session.go
+++ b/config/session.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -116,21 +117,45 @@ type incomingIDPTokenSessionCreator struct {
 	identityTokenSessionsCreatedCount  metric.Int64Counter
 	identityTokenSessionsCachedCount   metric.Int64Counter
 	identityTokenCreateSessionDuration metric.Int64Histogram
+	jwtBearerSessionsCreatedCount      metric.Int64Counter
+	jwtBearerSessionsCachedCount       metric.Int64Counter
+	jwtBearerCreateSessionDuration     metric.Int64Histogram
 
 	timeNow      func() time.Time
 	getRecord    func(ctx context.Context, recordType, recordID string) (*databroker.Record, error)
 	putRecords   func(ctx context.Context, records []*databroker.Record) error
 	singleflight singleflight.Group
 
+	// idpResolver verifies external JWT bearer tokens; idpResolverErr is why it is
+	// missing, if it could not be built. Both unset means no external JWT
+	// verification is configured, and those requests are rejected.
+	idpResolver    *IdentityProviderResolver
+	idpResolverErr error
+
 	telemetry telemetry.Component
+}
+
+// IncomingIDPTokenSessionCreatorOption customizes an
+// IncomingIDPTokenSessionCreator.
+type IncomingIDPTokenSessionCreatorOption func(*incomingIDPTokenSessionCreator)
+
+// WithIdentityProviderResolver supplies the resolver used to verify external JWT
+// bearer tokens, as built for the caller's configuration generation, together
+// with the error from building it — so that a build failure is surfaced on the
+// requests it affects instead of failing the caller's whole state.
+func WithIdentityProviderResolver(resolver *IdentityProviderResolver, buildErr error) IncomingIDPTokenSessionCreatorOption {
+	return func(c *incomingIDPTokenSessionCreator) {
+		c.idpResolver, c.idpResolverErr = resolver, buildErr
+	}
 }
 
 func NewIncomingIDPTokenSessionCreator(
 	tracerProvider oteltrace.TracerProvider,
 	getRecord func(ctx context.Context, recordType, recordID string) (*databroker.Record, error),
 	putRecords func(ctx context.Context, records []*databroker.Record) error,
+	opts ...IncomingIDPTokenSessionCreatorOption,
 ) IncomingIDPTokenSessionCreator {
-	return &incomingIDPTokenSessionCreator{
+	c := &incomingIDPTokenSessionCreator{
 		accessTokenSessionsCreatedCount: metrics.Int64Counter("config.idp_token_session_creator.access_token.sessions_created",
 			metric.WithDescription("Number of sessions created from IDP access tokens."),
 			metric.WithUnit("{session}")),
@@ -149,6 +174,15 @@ func NewIncomingIDPTokenSessionCreator(
 		identityTokenCreateSessionDuration: metrics.Int64Histogram("config.idp_token_session_creator.identity_token.create_session.duration",
 			metric.WithDescription("Duration of create session from IDP identity tokens."),
 			metric.WithUnit("ms")),
+		jwtBearerSessionsCreatedCount: metrics.Int64Counter("config.idp_token_session_creator.jwt_bearer.sessions_created",
+			metric.WithDescription("Number of sessions created from external JWT bearer tokens."),
+			metric.WithUnit("{session}")),
+		jwtBearerSessionsCachedCount: metrics.Int64Counter("config.idp_token_session_creator.jwt_bearer.sessions_cached",
+			metric.WithDescription("Number of sessions cached from external JWT bearer tokens."),
+			metric.WithUnit("{session}")),
+		jwtBearerCreateSessionDuration: metrics.Int64Histogram("config.idp_token_session_creator.jwt_bearer.create_session.duration",
+			metric.WithDescription("Duration of create session from external JWT bearer tokens."),
+			metric.WithUnit("ms")),
 
 		timeNow:    time.Now,
 		getRecord:  getRecord,
@@ -156,6 +190,10 @@ func NewIncomingIDPTokenSessionCreator(
 
 		telemetry: *telemetry.NewComponent(tracerProvider, zerolog.InfoLevel, "idp-token-session-creator"),
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 // CreateSession attempts to create a session for incoming idp access and
@@ -180,6 +218,8 @@ func (c *incomingIDPTokenSessionCreator) CreateSession(
 		return c.createSessionForAccessToken(ctx, cfg, policy, rawToken)
 	case config.BearerTokenFormat_BEARER_TOKEN_FORMAT_IDP_IDENTITY_TOKEN:
 		return c.createSessionForIdentityToken(ctx, cfg, policy, rawToken)
+	case config.BearerTokenFormat_BEARER_TOKEN_FORMAT_JWT:
+		return c.createSessionForJWT(ctx, cfg, policy, rawToken)
 	default:
 		return nil, sessions.ErrNoSessionFound
 	}
@@ -325,6 +365,161 @@ func (c *incomingIDPTokenSessionCreator) createSessionForIdentityToken(
 
 	c.identityTokenCreateSessionDuration.Record(ctx, time.Since(start).Milliseconds())
 	return res.(*session.Session), nil
+}
+
+// createSessionForJWT verifies an externally-issued JWT bearer token against
+// the configured identity_providers. The provider is selected by the token's
+// `iss`; audience binding is enforced per-provider (fail-closed). Authorization
+// on the verified claims is left to PPL.
+//
+// Verification follows the resolver, not cfg: a provider deleted from the
+// configuration, or one whose audiences were narrowed, keeps being accepted
+// until the state carrying the new resolver replaces this one — the same
+// revocation latency every other configuration-driven decision has.
+func (c *incomingIDPTokenSessionCreator) createSessionForJWT(
+	ctx context.Context,
+	cfg *Config,
+	policy *Policy,
+	rawJWT string,
+) (*session.Session, error) {
+	ctx, op := c.telemetry.Start(ctx, "createSessionForJWT")
+	defer op.Complete()
+
+	start := time.Now()
+
+	if c.idpResolverErr != nil {
+		return nil, op.Failure(fmt.Errorf("error building identity provider resolver: %w", c.idpResolverErr))
+	}
+	resolver := c.idpResolver
+	if resolver == nil {
+		return nil, op.Failure(fmt.Errorf("%w: no identity_providers configured", sessions.ErrInvalidSession))
+	}
+
+	// Resolve the provider from the token's unverified `iss` and enforce the
+	// route's provider allowlist BEFORE verification/singleflight. Dispatch on
+	// the unverified issuer is safe: the matched verifier re-checks iss,
+	// signature, exp/nbf, and audience.
+	rp, err := resolver.resolveUnverified(rawJWT)
+	if err != nil {
+		return nil, op.Failure(fmt.Errorf("%w: %w", sessions.ErrInvalidSession, err))
+	}
+
+	if policy != nil && len(policy.IdentityProviders) > 0 &&
+		!slices.Contains(policy.IdentityProviders, rp.Name) {
+		return nil, op.Failure(fmt.Errorf("%w: identity provider %q is not allowed on this route",
+			sessions.ErrInvalidSession, rp.Name))
+	}
+
+	res, err, _ := c.singleflight.Do(jwtSingleflightKey(rp.Name, rawJWT), func() (any, error) {
+		return c.verifyJWTAndCreateSession(ctx, cfg, resolver, rawJWT)
+	})
+	if err != nil {
+		return nil, op.Failure(err)
+	}
+
+	c.jwtBearerCreateSessionDuration.Record(ctx, time.Since(start).Milliseconds())
+	return res.(*session.Session), nil
+}
+
+// verifyJWTAndCreateSession verifies rawJWT against the resolver (selecting the
+// provider by issuer and enforcing that provider's audiences, fail-closed) and
+// returns the cached-or-newly-created session. It is the body executed under
+// singleflight in createSessionForJWT, split out for unit testing.
+//
+// The session's identity is namespaced by provider: user id is
+// "<provider-name>/<sub>" (preventing cross-provider and workload↔SSO user
+// collisions). A missing `sub` is rejected. The session TTL is capped at
+// min(token exp, now+CookieExpire), and the raw JWT is deliberately NOT
+// persisted (no SetRawIDToken) for these workload sessions — so
+// $pomerium.id_token substitution and the id-token log field are empty here.
+func (c *incomingIDPTokenSessionCreator) verifyJWTAndCreateSession(
+	ctx context.Context,
+	cfg *Config,
+	resolver *IdentityProviderResolver,
+	rawJWT string,
+) (*session.Session, error) {
+	vres, verr := resolver.Verify(ctx, rawJWT)
+	if verr != nil {
+		return nil, fmt.Errorf("%w: %w", sessions.ErrInvalidSession, verr)
+	}
+
+	claims := jwtutil.Claims(vres.Claims)
+	sub, ok := claims.GetSubject()
+	if !ok || sub == "" {
+		return nil, fmt.Errorf("%w: token is missing the sub claim", sessions.ErrInvalidSession)
+	}
+	userID := vres.ProviderName + "/" + sub
+
+	sessionID := jwtProviderSessionID(vres.ProviderName, rawJWT)
+
+	s, err := c.getSession(ctx, sessionID)
+	switch {
+	case err == nil && s.GetExpiresAt().AsTime().After(c.timeNow()):
+		c.jwtBearerSessionsCachedCount.Add(ctx, 1)
+		return s, nil
+	case err == nil:
+		// A cached session exists but has already hit its capped TTL. The
+		// bearer token may still be valid and longer-lived than CookieExpire,
+		// so re-mint (with a fresh cap) rather than return an expired session
+		// that authorize would reject.
+	case !storage.IsNotFound(err):
+		return nil, err
+	}
+
+	s = c.newSessionFromIDPClaims(cfg, vres.ProviderName, sessionID, claims)
+	// Namespace the identity by provider and cap the TTL. Do NOT persist the
+	// raw JWT for workload sessions.
+	s.UserId = userID
+	capSessionExpiry(s, c.timeNow().Add(cfg.Options.CookieExpire))
+
+	u, err := c.getUser(ctx, userID)
+	if errors.Is(err, storage.ErrNotFound) {
+		u = &user.User{Id: userID}
+	} else if err != nil {
+		return nil, fmt.Errorf("error retrieving existing user: %w", err)
+	}
+	c.fillUserFromIDPClaims(u, claims)
+	u.Id = userID // override the claims-derived id with the provider-prefixed id
+
+	err = c.putSessionAndUser(ctx, s, u)
+	if err != nil {
+		return nil, fmt.Errorf("error saving session and user: %w", err)
+	}
+
+	c.jwtBearerSessionsCreatedCount.Add(ctx, 1)
+	return s, nil
+}
+
+// capSessionExpiry clamps the session's ExpiresAt to no later than latest.
+func capSessionExpiry(s *session.Session, latest time.Time) {
+	if s.GetExpiresAt() == nil || s.GetExpiresAt().AsTime().After(latest) {
+		s.ExpiresAt = timestamppb.New(latest)
+	}
+}
+
+// jwtSingleflightNamespace seeds jwtSingleflightKey. Distinct from
+// jwtProviderSessionNamespace so the de-dup key and the stored session id never
+// coincide.
+var jwtSingleflightNamespace = uuid.MustParse("0195a000-a000-7000-8000-00000000a01b")
+
+// jwtSingleflightKey derives the singleflight de-dup key for a JWT bearer
+// verification, keyed on (provider name, raw token). Audiences are per-provider
+// now, so they need not be folded in — the provider name already scopes the
+// audience check. Chained as nested SHA-1 namespaces (collision-safe, no
+// separator), avoiding the cost of URL-escaping the (large) raw token.
+func jwtSingleflightKey(providerName, rawJWT string) string {
+	ns := uuid.NewSHA1(jwtSingleflightNamespace, []byte(providerName))
+	return uuid.NewSHA1(ns, []byte(rawJWT)).String()
+}
+
+// jwtProviderSessionID derives a stable session id from (provider name,
+// raw_token). Same token → same session; a different provider gets a fresh
+// session id naturally.
+var jwtProviderSessionNamespace = uuid.MustParse("0195a000-a000-7000-8000-00000000a01a")
+
+func jwtProviderSessionID(providerName, rawToken string) string {
+	ns := uuid.NewSHA1(jwtProviderSessionNamespace, []byte(providerName))
+	return uuid.NewSHA1(ns, []byte(rawToken)).String()
 }
 
 func (c *incomingIDPTokenSessionCreator) newSessionFromIDPClaims(

--- a/config/session_test.go
+++ b/config/session_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -18,6 +19,7 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/testing/protocmp"
+	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/internal/encoding/jws"
@@ -25,6 +27,7 @@ import (
 	"github.com/pomerium/pomerium/internal/jwtutil"
 	"github.com/pomerium/pomerium/internal/sessions"
 	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/internal/testutil/mockidp"
 	"github.com/pomerium/pomerium/internal/urlutil"
 	"github.com/pomerium/pomerium/pkg/authenticateapi"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
@@ -193,6 +196,7 @@ func Test_getTokenSessionID(t *testing.T) {
 	assert.Equal(t, "e0b8096c-54dd-5623-8098-5488f9c302db", getIdentityTokenSessionID(nil, "TOKEN"))
 	assert.Equal(t, "9c99d1d0-805e-51cb-b808-772ab654268b", getAccessTokenSessionID(&identitypb.Provider{Id: "IDP1"}, "TOKEN"))
 	assert.Equal(t, "0fe0e289-40bb-5ffe-b328-e290e043a652", getIdentityTokenSessionID(&identitypb.Provider{Id: "IDP1"}, "TOKEN"))
+	assert.Equal(t, "9175ce67-7b36-5d30-a901-26314c546a5a", jwtProviderSessionID("k8s-prod", "TOKEN"))
 }
 
 func TestGetIncomingBearerToken(t *testing.T) {
@@ -506,6 +510,65 @@ func TestIncomingIDPTokenSessionCreator_CreateSession(t *testing.T) {
 		assert.Equal(t, "U1", s.GetUserId())
 		assert.True(t, s.GetRefreshDisabled())
 	})
+	t.Run("jwt", func(t *testing.T) {
+		t.Parallel()
+
+		// Set up a mock JWT issuer (publishes OIDC discovery + JWKS).
+		idp := mockidp.New(mockidp.Config{})
+		issuer := idp.Start(t)
+
+		ctx := testutil.GetContext(t, time.Minute)
+		cfg := New(NewDefaultOptions())
+		cfg.Options.IdentityProviders = map[string]IdentityProvider{
+			"prod": {
+				Issuer:        issuer,
+				Audiences:     []string{"pomerium.example.com"},
+				SupportedAlgs: []string{"ES256"},
+			},
+		}
+
+		route := &Policy{
+			RouteOptions: RouteOptions{
+				BearerTokenFormat: nullable.From(config.BearerTokenFormat_BEARER_TOKEN_FORMAT_JWT),
+			},
+			IdentityProviders: []string{"prod"},
+		}
+
+		now := time.Now()
+		tok := idp.SignJWT(map[string]any{
+			"iss": issuer,
+			"sub": "U1",
+			"aud": []string{"pomerium.example.com"},
+			"exp": now.Add(time.Hour).Unix(),
+			"iat": now.Unix(),
+			"nbf": now.Unix(),
+		})
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+tok)
+		resolver, err := NewIdentityProviderResolverFromConfig(cfg, nil)
+		require.NoError(t, err)
+		c := NewIncomingIDPTokenSessionCreator(
+			noop.NewTracerProvider(),
+			func(_ context.Context, _, _ string) (*databroker.Record, error) {
+				return nil, storage.ErrNotFound
+			},
+			func(_ context.Context, records []*databroker.Record) error {
+				if assert.Len(t, records, 2, "should put session and user") {
+					assert.Equal(t, "type.googleapis.com/session.Session", records[0].Type)
+					assert.Equal(t, "type.googleapis.com/user.User", records[1].Type)
+				}
+				return nil
+			},
+			WithIdentityProviderResolver(resolver, nil),
+		)
+		s, err := c.CreateSession(ctx, cfg, route, req)
+		assert.NoError(t, err)
+		assert.Equal(t, "prod/U1", s.GetUserId())
+		assert.Equal(t, "prod", s.GetIdpId())
+		assert.True(t, s.GetRefreshDisabled())
+	})
 	t.Run("proxy_protocol", func(t *testing.T) {
 		t.Parallel()
 
@@ -568,3 +631,245 @@ func TestIncomingIDPTokenSessionCreator_CreateSession(t *testing.T) {
 // token): the same token under different providers must not collapse, and
 // different tokens must not collapse. Audiences are per-provider now, so they
 // are no longer part of the key — the provider name already scopes them.
+func TestJWTSingleflightKey(t *testing.T) {
+	t.Parallel()
+
+	const tok = "header.payload.sig"
+
+	assert.NotEqual(t,
+		jwtSingleflightKey("prod", tok),
+		jwtSingleflightKey("staging", tok),
+		"same token under different providers must not share a key")
+
+	assert.NotEqual(t,
+		jwtSingleflightKey("prod", tok),
+		jwtSingleflightKey("prod", "other.token.sig"),
+		"different tokens must not share a key")
+
+	assert.Equal(t,
+		jwtSingleflightKey("prod", tok),
+		jwtSingleflightKey("prod", tok),
+		"same (provider, token) must be stable")
+}
+
+// TestVerifyJWTAndCreateSession exercises the verify-and-create body factored
+// out of the singleflight wrapper: provider-namespaced identity, mandatory
+// `sub`, per-provider audience binding, the TTL cap, and non-persistence of the
+// raw JWT.
+func TestVerifyJWTAndCreateSession(t *testing.T) {
+	t.Parallel()
+
+	idp := mockidp.New(mockidp.Config{})
+	issuer := idp.Start(t)
+
+	ctx := testutil.GetContext(t, time.Minute)
+	cfg := New(NewDefaultOptions())
+	cfg.Options.CookieExpire = time.Hour // makes the TTL cap observable
+	cfg.Options.IdentityProviders = map[string]IdentityProvider{
+		"prod": {Issuer: issuer, Audiences: []string{"api-a"}, SupportedAlgs: []string{"ES256"}},
+	}
+	resolver, err := NewIdentityProviderResolverFromConfig(cfg, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resolver)
+
+	now := time.Now()
+	mkToken := func(sub string, aud []string, exp time.Time) string {
+		claims := map[string]any{
+			"iss": issuer,
+			"aud": aud,
+			"exp": exp.Unix(),
+			"iat": now.Unix(),
+			"nbf": now.Unix(),
+		}
+		if sub != "" {
+			claims["sub"] = sub
+		}
+		return idp.SignJWT(claims)
+	}
+	newCreator := func() *incomingIDPTokenSessionCreator {
+		return NewIncomingIDPTokenSessionCreator(
+			noop.NewTracerProvider(),
+			func(_ context.Context, _, _ string) (*databroker.Record, error) {
+				return nil, storage.ErrNotFound
+			},
+			func(_ context.Context, _ []*databroker.Record) error { return nil },
+		).(*incomingIDPTokenSessionCreator)
+	}
+
+	t.Run("happy path sets provider-namespaced identity", func(t *testing.T) {
+		c := newCreator()
+		c.timeNow = func() time.Time { return now }
+		tok := mkToken("U1", []string{"api-a"}, now.Add(time.Hour))
+		s, err := c.verifyJWTAndCreateSession(ctx, cfg, resolver, tok)
+		require.NoError(t, err)
+		assert.Equal(t, "prod", s.GetIdpId())
+		assert.Equal(t, "prod/U1", s.GetUserId())
+		assert.Equal(t, jwtProviderSessionID("prod", tok), s.GetId())
+		assert.True(t, s.GetRefreshDisabled())
+		assert.Empty(t, s.GetIdToken().GetRaw(), "raw JWT must not be persisted")
+	})
+
+	t.Run("missing sub rejected", func(t *testing.T) {
+		c := newCreator()
+		tok := mkToken("", []string{"api-a"}, now.Add(time.Hour))
+		_, err := c.verifyJWTAndCreateSession(ctx, cfg, resolver, tok)
+		assert.ErrorIs(t, err, sessions.ErrInvalidSession)
+	})
+
+	t.Run("wrong audience for provider rejected", func(t *testing.T) {
+		c := newCreator()
+		tok := mkToken("U1", []string{"api-b"}, now.Add(time.Hour))
+		_, err := c.verifyJWTAndCreateSession(ctx, cfg, resolver, tok)
+		assert.ErrorIs(t, err, sessions.ErrInvalidSession)
+	})
+
+	t.Run("ttl capped at now+CookieExpire", func(t *testing.T) {
+		c := newCreator()
+		c.timeNow = func() time.Time { return now }
+		tok := mkToken("U1", []string{"api-a"}, now.Add(100*time.Hour)) // far beyond CookieExpire
+		s, err := c.verifyJWTAndCreateSession(ctx, cfg, resolver, tok)
+		require.NoError(t, err)
+		assert.WithinDuration(t, now.Add(time.Hour), s.GetExpiresAt().AsTime(), time.Second)
+	})
+
+	t.Run("ttl uses token exp when earlier than cap", func(t *testing.T) {
+		c := newCreator()
+		c.timeNow = func() time.Time { return now }
+		exp := now.Add(5 * time.Minute)
+		tok := mkToken("U1", []string{"api-a"}, exp)
+		s, err := c.verifyJWTAndCreateSession(ctx, cfg, resolver, tok)
+		require.NoError(t, err)
+		assert.WithinDuration(t, exp, s.GetExpiresAt().AsTime(), time.Second)
+	})
+
+	// A cached session whose capped TTL has lapsed must NOT be returned stale
+	// (authorize would reject it as expired) — it is re-minted, so a still-valid
+	// token longer-lived than CookieExpire keeps working.
+	t.Run("expired cached session is re-minted", func(t *testing.T) {
+		tok := mkToken("U1", []string{"api-a"}, now.Add(100*time.Hour))
+		sessionID := jwtProviderSessionID("prod", tok)
+
+		stale := session.New("prod", sessionID)
+		stale.UserId = "prod/STALE"
+		stale.ExpiresAt = timestamppb.New(now.Add(-time.Hour)) // already lapsed
+		anyStale, err := anypb.New(stale)
+		require.NoError(t, err)
+
+		c := NewIncomingIDPTokenSessionCreator(
+			noop.NewTracerProvider(),
+			func(_ context.Context, _, id string) (*databroker.Record, error) {
+				if id == sessionID {
+					return &databroker.Record{Id: id, Data: anyStale}, nil
+				}
+				return nil, storage.ErrNotFound
+			},
+			func(_ context.Context, _ []*databroker.Record) error { return nil },
+		).(*incomingIDPTokenSessionCreator)
+		c.timeNow = func() time.Time { return now }
+
+		s, err := c.verifyJWTAndCreateSession(ctx, cfg, resolver, tok)
+		require.NoError(t, err)
+		assert.True(t, s.GetExpiresAt().AsTime().After(now), "re-minted session must have a future expiry")
+		assert.Equal(t, "prod/U1", s.GetUserId(), "must re-mint, not return the stale cached session")
+	})
+}
+
+// TestCreateSessionForJWT_RouteProviderScoping verifies the route's
+// identity_providers allowlist is enforced (on the unverified issuer, before
+// verification): a route allowing only idp-a rejects an idp-b token, while a
+// route with an empty allowlist accepts any configured provider.
+func TestCreateSessionForJWT_RouteProviderScoping(t *testing.T) {
+	t.Parallel()
+
+	idpA := mockidp.New(mockidp.Config{})
+	issuerA := idpA.Start(t)
+	idpB := mockidp.New(mockidp.Config{})
+	issuerB := idpB.Start(t)
+
+	ctx := testutil.GetContext(t, time.Minute)
+	cfg := New(NewDefaultOptions())
+	cfg.Options.IdentityProviders = map[string]IdentityProvider{
+		"idp-a": {Issuer: issuerA, Audiences: []string{"api"}, SupportedAlgs: []string{"ES256"}},
+		"idp-b": {Issuer: issuerB, Audiences: []string{"api"}, SupportedAlgs: []string{"ES256"}},
+	}
+
+	now := time.Now()
+	tokB := idpB.SignJWT(map[string]any{
+		"iss": issuerB,
+		"sub": "svc",
+		"aud": []string{"api"},
+		"exp": now.Add(time.Hour).Unix(),
+		"iat": now.Unix(),
+		"nbf": now.Unix(),
+	})
+
+	resolver, err := NewIdentityProviderResolverFromConfig(cfg, nil)
+	require.NoError(t, err)
+	// Defaults to the resolver built above; subtests override it to cover an
+	// unset and a failed resolver.
+	newCreator := func(opts ...IncomingIDPTokenSessionCreatorOption) *incomingIDPTokenSessionCreator {
+		opts = append([]IncomingIDPTokenSessionCreatorOption{
+			WithIdentityProviderResolver(resolver, nil),
+		}, opts...)
+		return NewIncomingIDPTokenSessionCreator(
+			noop.NewTracerProvider(),
+			func(_ context.Context, _, _ string) (*databroker.Record, error) {
+				return nil, storage.ErrNotFound
+			},
+			func(_ context.Context, _ []*databroker.Record) error { return nil },
+			opts...,
+		).(*incomingIDPTokenSessionCreator)
+	}
+	mkReq := func() *http.Request {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://www.example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer "+tokB)
+		return req
+	}
+	jwtRoute := func(providers ...string) *Policy {
+		return &Policy{
+			RouteOptions:      RouteOptions{BearerTokenFormat: nullable.From(config.BearerTokenFormat_BEARER_TOKEN_FORMAT_JWT)},
+			IdentityProviders: providers,
+		}
+	}
+
+	t.Run("route allowing only idp-a rejects idp-b token", func(t *testing.T) {
+		_, err := newCreator().CreateSession(ctx, cfg, jwtRoute("idp-a"), mkReq())
+		assert.ErrorIs(t, err, sessions.ErrInvalidSession)
+	})
+
+	t.Run("route with empty allowlist accepts idp-b token", func(t *testing.T) {
+		s, err := newCreator().CreateSession(ctx, cfg, jwtRoute(), mkReq())
+		require.NoError(t, err)
+		assert.Equal(t, "idp-b/svc", s.GetUserId())
+		assert.Equal(t, "idp-b", s.GetIdpId())
+	})
+
+	// cfg is not consulted for provider definitions: a provider absent from the
+	// configuration a request is evaluated against still verifies, because the
+	// resolver — owned by the caller's state generation, which can lag cfg — is
+	// the authority.
+	t.Run("verification follows the resolver, not cfg", func(t *testing.T) {
+		next := New(NewDefaultOptions()) // no identity_providers at all
+		s, err := newCreator().CreateSession(ctx, next, jwtRoute(), mkReq())
+		require.NoError(t, err)
+		assert.Equal(t, "idp-b/svc", s.GetUserId())
+	})
+
+	// Without a resolver there is nothing to verify against, so JWT bearer routes
+	// must reject rather than fall through to any other session source.
+	t.Run("no resolver supplied", func(t *testing.T) {
+		c := newCreator(WithIdentityProviderResolver(nil, nil))
+		_, err := c.CreateSession(ctx, cfg, jwtRoute(), mkReq())
+		assert.ErrorIs(t, err, sessions.ErrInvalidSession)
+	})
+
+	// A resolver that failed to build surfaces its error on the requests it
+	// affects; the caller's state build is not failed by it.
+	t.Run("resolver build error surfaces", func(t *testing.T) {
+		buildErr := errors.New("discovery failed")
+		c := newCreator(WithIdentityProviderResolver(nil, buildErr))
+		_, err := c.CreateSession(ctx, cfg, jwtRoute(), mkReq())
+		assert.ErrorIs(t, err, buildErr)
+	})
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -68,7 +68,7 @@ type Proxy struct {
 func New(ctx context.Context, cfg *config.Config) (*Proxy, error) {
 	tracerProvider := trace.NewTracerProvider(ctx, "Proxy")
 	outboundGrpcConn := &grpc.CachedOutboundGRPClientConn{}
-	state, err := newProxyStateFromConfig(ctx, tracerProvider, cfg, outboundGrpcConn)
+	state, err := newProxyStateFromConfig(ctx, nil, tracerProvider, cfg, outboundGrpcConn)
 	if err != nil {
 		return nil, err
 	}
@@ -130,7 +130,7 @@ func (p *Proxy) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	if err := p.setHandlers(ctx, cfg.Options); err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("proxy: failed to update proxy handlers from configuration settings")
 	}
-	if state, err := newProxyStateFromConfig(ctx, p.tracerProvider, cfg, p.outboundGrpcConn); err != nil {
+	if state, err := newProxyStateFromConfig(ctx, p.state.Load(), p.tracerProvider, cfg, p.outboundGrpcConn); err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("proxy: failed to update proxy state from configuration settings")
 	} else {
 		p.state.Store(state)

--- a/proxy/state.go
+++ b/proxy/state.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/authenticateflow"
+	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/pkg/endpoints"
 	"github.com/pomerium/pomerium/pkg/grpc"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
@@ -37,9 +38,10 @@ type proxyState struct {
 	programmaticRedirectDomainWhitelist []string
 	authenticateFlow                    authenticateFlow
 	incomingIDPTokenSessionCreator      config.IncomingIDPTokenSessionCreator
+	idpResolver                         *config.IdentityProviderResolver
 }
 
-func newProxyStateFromConfig(ctx context.Context, tracerProvider oteltrace.TracerProvider, cfg *config.Config, outboundGrpcConn *grpc.CachedOutboundGRPClientConn) (*proxyState, error) {
+func newProxyStateFromConfig(ctx context.Context, previousState *proxyState, tracerProvider oteltrace.TracerProvider, cfg *config.Config, outboundGrpcConn *grpc.CachedOutboundGRPClientConn) (*proxyState, error) {
 	err := ValidateOptions(cfg.Options)
 	if err != nil {
 		return nil, err
@@ -93,6 +95,21 @@ func newProxyStateFromConfig(ctx context.Context, tracerProvider oteltrace.Trace
 		return nil, err
 	}
 
+	// Built here, off the request path, reusing the previous generation's resolver
+	// when nothing it is built from changed. A failure is not fatal to the state:
+	// it is returned to the JWT bearer requests it affects (see
+	// newAuthorizeStateFromConfig for the reasoning).
+	var previousIDPResolver *config.IdentityProviderResolver
+	if previousState != nil {
+		previousIDPResolver = previousState.idpResolver
+	}
+	idpResolver, idpResolverErr := config.NewIdentityProviderResolverFromConfig(cfg, previousIDPResolver)
+	if idpResolverErr != nil {
+		log.Ctx(ctx).Error().Err(idpResolverErr).
+			Msg("proxy: error building identity provider resolver; routes using bearer_token_format=jwt will reject requests until the next configuration change")
+	}
+	state.idpResolver = idpResolver
+
 	state.incomingIDPTokenSessionCreator = config.NewIncomingIDPTokenSessionCreator(
 		tracerProvider,
 		func(ctx context.Context, recordType, recordID string) (*databroker.Record, error) {
@@ -108,6 +125,7 @@ func newProxyStateFromConfig(ctx context.Context, tracerProvider oteltrace.Trace
 			storage.InvalidateCacheForDataBrokerRecords(ctx, records...)
 			return err
 		},
+		config.WithIdentityProviderResolver(idpResolver, idpResolverErr),
 	)
 
 	return state, nil

--- a/proxy/state_test.go
+++ b/proxy/state_test.go
@@ -1,0 +1,69 @@
+package proxy
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/pkg/grpc"
+	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
+	"github.com/pomerium/pomerium/pkg/nullable"
+)
+
+// TestNewProxyStateFromConfig_IdentityProviderResolver covers the resolver the
+// proxy owns for the user-info page's bearer-token path: it must be wired into
+// the session creator, and it must survive configuration changes that do not
+// concern identity providers.
+func TestNewProxyStateFromConfig_IdentityProviderResolver(t *testing.T) {
+	t.Parallel()
+
+	providers := map[string]config.IdentityProvider{
+		"k8s": {Issuer: "https://k8s.example.com", Audiences: []string{"pomerium"}, SupportedAlgs: []string{"RS256"}},
+	}
+	newOptions := func(t *testing.T, ps map[string]config.IdentityProvider) *config.Options {
+		t.Helper()
+		opts := testOptions(t)
+		opts.BearerTokenFormat = nullable.From(configpb.BearerTokenFormat_BEARER_TOKEN_FORMAT_JWT)
+		opts.IdentityProviders = ps
+		return opts
+	}
+	newState := func(t *testing.T, previous *proxyState, opts *config.Options) *proxyState {
+		t.Helper()
+		state, err := newProxyStateFromConfig(t.Context(), previous, noop.NewTracerProvider(),
+			config.New(opts), new(grpc.CachedOutboundGRPClientConn))
+		require.NoError(t, err)
+		return state
+	}
+
+	first := newState(t, nil, newOptions(t, providers))
+	require.NotNil(t, first.idpResolver)
+
+	// getUserInfoData discards the error from CreateSession, so an unwired
+	// resolver would silently leave the dashboard without a session. Assert the
+	// resolver was consulted: the failure must come from the token, not from a
+	// missing provider configuration.
+	t.Run("wired into the session creator", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://www.example.com", nil)
+		require.NoError(t, err)
+		req.Header.Set("Authorization", "Bearer not.a.jwt")
+
+		_, err = first.incomingIDPTokenSessionCreator.CreateSession(
+			t.Context(), config.New(newOptions(t, providers)), nil, req)
+		require.Error(t, err)
+		// The resolver was consulted: the token failed issuer dispatch, rather than
+		// the request being rejected for having no resolver at all.
+		assert.Contains(t, err.Error(), "parse iss")
+		assert.NotContains(t, err.Error(), "no identity_providers configured")
+	})
+
+	t.Run("reused across an unrelated change", func(t *testing.T) {
+		opts := newOptions(t, providers)
+		opts.CookieExpire = time.Hour
+		assert.Same(t, first.idpResolver, newState(t, first, opts).idpResolver)
+	})
+}


### PR DESCRIPTION
## Summary

Makes `bearer_token_format: jwt` functional end-to-end:

- The bearer token is verified via the `IdentityProviderResolver` (issuer-dispatched, per-provider audiences fail-closed). The route's `identity_providers` allowlist is enforced on the resolved provider name before verification.
- Authorize and proxy each own the resolver for their current configuration generation, built when the configuration loads rather than on the first request, and carried over when nothing it depends on changed. In all-in-one mode that means one resolver per service rather than one per process, so each keeps its own signing-key cache.
- A resolver that cannot be built — an unloadable private CA, an unreachable issuer — fails only the JWT bearer requests that need it. The rest of the configuration update still takes effect, and the next configuration change retries.
- Every request is verified against the provider definition, so deleting a provider or narrowing its `audiences` takes effect when the configuration is applied rather than when tokens expire.
- Concurrent requests with the same token de-duplicate through singleflight keyed on (provider, token).
- The minted session: user id `<provider-name>/<sub>` (prevents cross-provider and workload/SSO collisions; missing `sub` is rejected), `idp_id` = provider name, TTL capped at min(token `exp`, now+`cookie_expire`), refresh disabled. The raw JWT is deliberately not persisted, so `$pomerium.id_token` substitution and the id-token log field stay empty for workload sessions. Same token maps to a stable session id; an expired cached session is re-minted with a fresh cap while the token remains valid.
- Authorization on the verified claims is PPL as usual (`claim/...`).

Covered by integration tests through envoy/authorize/PPL: happy path, wrong audience, no-fallthrough to other formats, cookie+bearer 400, route-level provider scoping, and PPL policy on Kubernetes-shaped claims.

Stack 5/6, based on #6590. Split from #6501.

## Related issues

- #6501

## User Explanation

Routes with `bearer_token_format: jwt` now accept externally-issued JWTs (Kubernetes ServiceAccount tokens, GitHub Actions OIDC, SPIFFE JWT-SVIDs) from the providers declared in `identity_providers`, subject to the route's provider allowlist and PPL policy over the verified claims.

## AI disclosure

Claude Code: carved this stack from the PoC branch (#6501) and adapted it to current `main`; the feature itself was developed on that branch (also AI-assisted).

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review


