### PR TITLE
config: add WaitStartupComplete() in testenv test

### DIFF
--- a/config/session_int_test.go
+++ b/config/session_int_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/testenv"
 	"github.com/pomerium/pomerium/internal/testenv/scenarios"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
 	"github.com/pomerium/pomerium/internal/testenv/upstreams"
 	configpb "github.com/pomerium/pomerium/pkg/grpc/config"
 	"github.com/pomerium/pomerium/pkg/nullable"
@@ -43,6 +44,7 @@ func TestBearerTokenFormat(t *testing.T) {
 		env.AddUpstream(up)
 
 		env.Start()
+		snippets.WaitStartupComplete(env)
 
 		// first request is a normal login
 		r1, err := up.Get(route,


### PR DESCRIPTION
## Summary

TestBearerTokenFormat sometimes fails with a data race warning on the `Options.UseProxyProtocol` field. I think if we add a `WaitStartupComplete()` call this should avoid the race.

## Related issues

https://linear.app/pomerium/issue/ENG-4269/core-data-race-in-testbearertokenformat-testenv-initialization

## User Explanation

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
