### PR TITLE
bump Go to 1.25.12

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golangci-lint 2.8.0
-golang 1.25.11
+golang 1.25.12
 goreleaser 2.13.3
 nodejs 22.22.0
 protoc 33.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN make npm-install
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.25.6-bookworm@sha256:2f768d462dbffbb0f0b3a5171009f162945b086f326e0b2a8fd5d29c3219ff14 AS build
+FROM golang:1.25.12-bookworm@sha256:ea341baa9bd5ba6784f6d7161ace70544349a6242d54d34a0fbfd2c4d51c9d58 AS build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -13,7 +13,7 @@ RUN make npm-install
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.25.6-bookworm@sha256:2f768d462dbffbb0f0b3a5171009f162945b086f326e0b2a8fd5d29c3219ff14 AS build
+FROM golang:1.25.12-bookworm@sha256:ea341baa9bd5ba6784f6d7161ace70544349a6242d54d34a0fbfd2c4d51c9d58 AS build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \

--- a/examples/mutual-tls/Dockerfile
+++ b/examples/mutual-tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.6-bookworm@sha256:2f768d462dbffbb0f0b3a5171009f162945b086f326e0b2a8fd5d29c3219ff14 AS build-env
+FROM golang:1.25.12-bookworm@sha256:ea341baa9bd5ba6784f6d7161ace70544349a6242d54d34a0fbfd2c4d51c9d58 AS build-env
 
 WORKDIR /go/src/app
 ADD . /go/src/app

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pomerium/pomerium
 
-go 1.25.4
+go 1.25.12
 
 require (
 	buf.build/gen/go/bufbuild/protovalidate/protocolbuffers/go v1.36.11-20251209175733-2a1774d88802.1

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/pomerium/pomerium/internal/tools
 
-go 1.25.5
+go 1.25.12
 
 tool (
 	github.com/bufbuild/buf/cmd/buf


### PR DESCRIPTION
## Summary

Bump the Go toolchain to 1.25.12, the latest 1.25 patch release, on the v0.32 branch.

- `.tool-versions`: 1.25.11 → 1.25.12 (also drives CI via `go-version-file`)
- `go.mod`: 1.25.4 → 1.25.12
- `internal/tools/go.mod`: 1.25.5 → 1.25.12
- `Dockerfile`, `Dockerfile.debug`, `examples/mutual-tls/Dockerfile`: `golang:1.25.6-bookworm` → `golang:1.25.12-bookworm` (digest re-pinned)

Release binaries and container images pick up the upstream runtime and standard
library fixes released since 1.25.6. Raising the `go` directive to 1.25.12 makes
that the minimum toolchain for building the module.

## Related issues

n/a

## User Explanation

n/a

## AI disclosure

Claude Code, for locating the pinned versions and applying the edits.

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
