### PR TITLE
ci: bump go-toml to v2.4.3

### DIFF
--- a/config/options_test.go
+++ b/config/options_test.go
@@ -501,6 +501,26 @@ func TestOptionsFromViper(t *testing.T) {
 	}
 }
 
+func TestOptionsFromViperTOML(t *testing.T) {
+	cfg := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(cfg, []byte(`
+autocert_dir = ""
+insecure_server = true
+
+[[policy]]
+from = "https://from.example"
+to = "https://to.example"
+set_response_headers = { "X-Test" = "value" }
+`), 0o644))
+
+	options, err := optionsFromViper(cfg)
+	require.NoError(t, err)
+	require.Len(t, options.Policies, 1)
+	assert.Equal(t, "https://from.example", options.Policies[0].From)
+	assert.Equal(t, mustParseWeightedURLs(t, "https://to.example"), options.Policies[0].To)
+	assert.Equal(t, map[string]string{"x-test": "value"}, options.Policies[0].SetResponseHeaders)
+}
+
 func Test_NewOptionsFromConfigEnvVar(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/go.mod
+++ b/go.mod
@@ -339,7 +339,7 @@ require (
 	github.com/pb33f/jsonpath v0.8.1 // indirect
 	github.com/pb33f/libopenapi v0.33.11 // indirect
 	github.com/pb33f/ordered-map/v2 v2.3.0 // indirect
-	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
+	github.com/pelletier/go-toml/v2 v2.4.3 // indirect
 	github.com/petermattis/goid v0.0.0-20260330135022-df67b199bc81 // indirect
 	github.com/philhofer/fwd v1.2.0 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -832,8 +832,8 @@ github.com/pb33f/libopenapi-validator v0.11.4 h1:TJjTKRfDA7VG4yKNZ2vWx/Q7Xaadqga
 github.com/pb33f/libopenapi-validator v0.11.4/go.mod h1:XqprWQl6jRur5n8qn3G2t+6/6lZh/YpZdB/KckT6hu4=
 github.com/pb33f/ordered-map/v2 v2.3.0 h1:k2OhVEQkhTCQMhAicQ3Z6iInzoZNQ7L9MVomwKBZ5WQ=
 github.com/pb33f/ordered-map/v2 v2.3.0/go.mod h1:oe5ue+6ZNhy7QN9cPZvPA23Hx0vMHnNVeMg4fGdCANw=
-github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
-github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=
 github.com/peterbourgon/ff/v3 v3.4.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
 github.com/petermattis/goid v0.0.0-20260330135022-df67b199bc81 h1:WDsQxOJDy0N1VRAjXLpi8sCEZRSGarLWQevDxpTBRrM=


### PR DESCRIPTION
## Summary

Customer vulnerability scans flag `github.com/pelletier/go-toml/v2` v2.2.4 for unbounded parser recursion that can overflow a goroutine stack. Pomerium reaches this package through Viper's TOML configuration codec, so bump it to v2.4.3, which bounds array and inline-table nesting depth.

The decoder is reached only through operator-supplied TOML configuration; no network-controlled bytes reach it. The regression test exercises a TOML policy with an array of tables and an inline response-header map through Pomerium's real Viper path.

## Related issues

- [ENG-4292](https://linear.app/pomerium/issue/ENG-4292/bump-go-toml-to-v243)

## User Explanation

Operators using TOML configuration get a parser that rejects pathologically nested input instead of overflowing the process stack. Normal configuration behavior is unchanged.

## Testing

- `make build`
- `make lint`
- `make test`
- `make govulncheck`
- `go mod tidy -diff`
- `go mod verify`

The build reports three pre-existing High npm audit findings in build-time UI dependencies; this change does not touch them.

## AI disclosure

Codex drafted the dependency bump and regression test; Claude Code verified reachability and the validation evidence.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`dependencies`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
