### PR TITLE
wip: handle token refresh by identity manager

### DIFF
--- a/internal/mcp/handler_token.go
+++ b/internal/mcp/handler_token.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -20,6 +21,11 @@ import (
 	rfc7591v1 "github.com/pomerium/pomerium/internal/rfc7591"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/identity/manager"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+var (
+	ErrTokenNoInitiatingSession = errors.New("mcp upstream refresh token does not have an initiating session")
 )
 
 const (
@@ -218,6 +224,7 @@ func (srv *Handler) handleAuthorizationCodeToken(w http.ResponseWriter, r *http.
 		IssuedAt:             timestamppb.Now(),
 		ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
 		Scopes:               authReq.GetScopes(),
+		InitiatingSessionId:  session.GetId(),
 	}
 
 	log.Ctx(ctx).Debug().
@@ -453,6 +460,8 @@ func (srv *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 		IssuedAt:             timestamppb.Now(),
 		ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
 		Scopes:               refreshTokenRecord.Scopes,
+		// keep the initating session
+		InitiatingSessionId: newSession.GetId(),
 	}
 
 	log.Ctx(ctx).Debug().
@@ -517,13 +526,42 @@ func (srv *Handler) getOrRecreateSession(
 	log.Ctx(ctx).Debug().
 		Str("user-id", refreshTokenRecord.UserId).
 		Str("idp-id", refreshTokenRecord.IdpId).
+		Str("initating-session-id", refreshTokenRecord.InitiatingSessionId).
 		Bool("has-upstream-refresh-token", refreshTokenRecord.UpstreamRefreshToken != "").
-		Msg("mcp/session: recreating session from refresh token")
+		Msg("mcp/session: getting session for refresh token")
 
-	// For now, we need to create a new session since we don't track the original session ID
-	// The session will be created using the upstream refresh token
+	upstreamRefreshToken := refreshTokenRecord.UpstreamRefreshToken
+	initiatingSession, existingRecordVersion, err := srv.getRecordSession(ctx, refreshTokenRecord)
+	if storage.IsNotFound(err) || errors.Is(err, ErrTokenNoInitiatingSession) {
+		// TODO : this needs to have the latest refresh token from the previously delete session
+		return srv.recreateSession(ctx, refreshTokenRecord, refreshTokenRecord.UpstreamRefreshToken)
+	} else if err != nil {
+		return nil, 0, err
+	}
 
-	if refreshTokenRecord.UpstreamRefreshToken == "" {
+	if sessionUsable(initiatingSession) {
+		log.Ctx(ctx).Debug().
+			Str("session-id", initiatingSession.Id).
+			Time("expires-at", initiatingSession.ExpiresAt.AsTime()).
+			Msg("mcp/session: reusing existing session, skipping upstream token exchange")
+		return initiatingSession, existingRecordVersion, nil
+	}
+	// Prefer the refresh token stored on the session: the identity manager may have rotated it
+	// after this record was written, in which case the record's copy is no longer valid upstream.
+
+	// The session stil exists, but is no longer usable. In what scenarios could this happen?
+	if t := initiatingSession.GetOauthToken().GetRefreshToken(); t != "" {
+		upstreamRefreshToken = t
+	}
+	return srv.recreateSession(ctx, refreshTokenRecord, upstreamRefreshToken)
+}
+
+func (srv *Handler) recreateSession(
+	ctx context.Context,
+	refreshTokenRecord *oauth21proto.MCPRefreshToken,
+	curUpstreamRefreshToken string,
+) (*session.Session, uint64, error) {
+	if curUpstreamRefreshToken == "" {
 		log.Ctx(ctx).Error().Msg("mcp/session: no upstream refresh token available")
 		return nil, 0, fmt.Errorf("no upstream refresh token available")
 	}
@@ -531,7 +569,6 @@ func (srv *Handler) getOrRecreateSession(
 	// Create a new session first so we can populate it with claims from the upstream IdP
 	newSessionID := uuid.NewString()
 	newSession := session.Create(refreshTokenRecord.IdpId, newSessionID, refreshTokenRecord.UserId, time.Now(), srv.sessionExpiry)
-
 	log.Ctx(ctx).Debug().
 		Str("session-id", newSession.Id).
 		Str("user-id", newSession.UserId).
@@ -569,7 +606,7 @@ func (srv *Handler) getOrRecreateSession(
 
 	log.Ctx(ctx).Debug().Msg("mcp/session: refreshing upstream OAuth token")
 	oldToken := &oauth2.Token{
-		RefreshToken: refreshTokenRecord.UpstreamRefreshToken,
+		RefreshToken: curUpstreamRefreshToken,
 	}
 	// Use NewSessionUnmarshaler to capture ID token claims from the upstream IdP.
 	// This ensures the recreated session has the same claims as a fresh session.
@@ -612,6 +649,30 @@ func (srv *Handler) getOrRecreateSession(
 		Msg("mcp/session: session stored successfully")
 
 	return newSession, sessionRecordVersion, nil
+}
+
+func (srv *Handler) getRecordSession(
+	ctx context.Context,
+	refreshTokenRecord *oauth21proto.MCPRefreshToken,
+) (*session.Session, uint64, error) {
+	if refreshTokenRecord.GetInitiatingSessionId() == "" {
+		return nil, 0, ErrTokenNoInitiatingSession
+	}
+
+	s, recordVersion, err := srv.storage.GetSession(ctx, refreshTokenRecord.GetInitiatingSessionId())
+	if err != nil {
+		return nil, 0, err
+	}
+	return s, recordVersion, nil
+}
+
+// sessionUsable reports whether a session can be handed back to the client as-is, without
+// exchanging the upstream refresh token.
+func sessionUsable(s *session.Session) bool {
+	if s.GetOauthToken().GetAccessToken() == "" {
+		return false
+	}
+	return s.Validate() == nil
 }
 
 // createTokenResponse generates access and refresh tokens for a session.

--- a/internal/oauth21/gen/mcp_refresh_token.pb.go
+++ b/internal/oauth21/gen/mcp_refresh_token.pb.go
@@ -44,9 +44,12 @@ type MCPRefreshToken struct {
 	// Scopes granted with this refresh token
 	Scopes []string `protobuf:"bytes,8,rep,name=scopes,proto3" json:"scopes,omitempty"`
 	// Whether this refresh token has been revoked
-	Revoked       bool `protobuf:"varint,9,opt,name=revoked,proto3" json:"revoked,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Revoked bool `protobuf:"varint,9,opt,name=revoked,proto3" json:"revoked,omitempty"`
+	// Reference to the user's session that initated the original
+	// mcp refresh token
+	InitiatingSessionId string `protobuf:"bytes,10,opt,name=initiating_session_id,json=initiatingSessionId,proto3" json:"initiating_session_id,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *MCPRefreshToken) Reset() {
@@ -142,11 +145,18 @@ func (x *MCPRefreshToken) GetRevoked() bool {
 	return false
 }
 
+func (x *MCPRefreshToken) GetInitiatingSessionId() string {
+	if x != nil {
+		return x.InitiatingSessionId
+	}
+	return ""
+}
+
 var File_mcp_refresh_token_proto protoreflect.FileDescriptor
 
 const file_mcp_refresh_token_proto_rawDesc = "" +
 	"\n" +
-	"\x17mcp_refresh_token.proto\x12\aoauth21\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xee\x02\n" +
+	"\x17mcp_refresh_token.proto\x12\aoauth21\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa2\x03\n" +
 	"\x0fMCPRefreshToken\x12\x1a\n" +
 	"\x02id\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x02id\x12#\n" +
@@ -160,7 +170,9 @@ const file_mcp_refresh_token_proto_rawDesc = "" +
 	"\n" +
 	"expires_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12\x16\n" +
 	"\x06scopes\x18\b \x03(\tR\x06scopes\x12\x18\n" +
-	"\arevoked\x18\t \x01(\bR\arevokedB\x92\x01\n" +
+	"\arevoked\x18\t \x01(\bR\arevoked\x122\n" +
+	"\x15initiating_session_id\x18\n" +
+	" \x01(\tR\x13initiatingSessionIdB\x92\x01\n" +
 	"\vcom.oauth21B\x14McpRefreshTokenProtoP\x01Z1github.com/pomerium/pomerium/internal/oauth21/gen\xa2\x02\x03OXX\xaa\x02\aOauth21\xca\x02\aOauth21\xe2\x02\x13Oauth21\\GPBMetadata\xea\x02\aOauth21b\x06proto3"
 
 var (

--- a/internal/oauth21/proto/mcp_refresh_token.proto
+++ b/internal/oauth21/proto/mcp_refresh_token.proto
@@ -45,4 +45,8 @@ message MCPRefreshToken {
 
   // Whether this refresh token has been revoked
   bool revoked = 9;
+
+  // Reference to the user's session that initated the original
+  // mcp refresh token
+  string initiating_session_id = 10;
 }


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

## Related issues

<!-- For example...
- #159
-->

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

<!-- If this PR was assisted by AI (Claude, Copilot, Cursor, Amp, etc.),
state which tool and roughly how much of the work was AI-assisted (e.g.
"Cursor autocomplete only", "Claude Code drafted scaffolding, I rewrote
the auth path"). If no AI was used, write "none". See AI_POLICY.md. -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
