### PR TITLE
testenv: wait for config modifiers before Start() returns

### DIFF
--- a/internal/testenv/environment.go
+++ b/internal/testenv/environment.go
@@ -132,6 +132,10 @@ type Environment interface {
 	// instances are invoked in order to build the configuration, and all
 	// previously added [Task] instances are started in the background.
 	//
+	// Start() does not return until all previously added modifiers have been
+	// invoked, so that the test can read the configuration they built without
+	// racing with them.
+	//
 	// Calling Start() more than once, Calling Start() after Stop(), or calling
 	// any of the Add* functions after Start() will panic.
 	Start()
@@ -712,12 +716,14 @@ func (e *environment) Start() {
 	}
 
 	e.src = &configSource{cfg: cfg}
+
+	// Modifiers are applied from within a task, since they can block on values
+	// that are only resolved once other tasks are running (e.g. upstream server
+	// addresses).
+	modifiersApplied := make(chan struct{})
 	e.AddTask(TaskFunc(func(ctx context.Context) error {
 		fileMgr := filemgr.NewManager(filemgr.WithCacheDir(filepath.Join(e.TempDir(), "cache")))
-		for _, mod := range e.mods {
-			mod.Value.Modify(cfg)
-			require.NoError(e.t, cfg.Options.Validate(), "invoking modifier resulted in an invalid configuration:\nadded by: "+mod.Caller)
-		}
+		e.applyModifiers(cfg, modifiersApplied)
 
 		opts := []pomerium.Option{
 			pomerium.WithOverrideFileManager(fileMgr),
@@ -791,9 +797,28 @@ func (e *environment) Start() {
 		})
 	}
 
-	runtime.Gosched()
+	// Don't return until the configuration is complete, so that reads of it from
+	// the test's own goroutine don't race with the modifiers. The context is also
+	// awaited, since a modifier blocked on a value belonging to a task that
+	// failed would otherwise never finish.
+	select {
+	case <-modifiersApplied:
+	case <-e.Context().Done():
+	}
 
 	e.advanceState(Running)
+}
+
+// applyModifiers invokes all added modifiers in order to build the
+// configuration, then closes done. done is closed even if a modifier or its
+// validation fails, since require.NoError only stops this goroutine, not the
+// test, and Start() would otherwise block forever.
+func (e *environment) applyModifiers(cfg *config.Config, done chan<- struct{}) {
+	defer close(done)
+	for _, mod := range e.mods {
+		mod.Value.Modify(cfg)
+		require.NoError(e.t, cfg.Options.Validate(), "invoking modifier resulted in an invalid configuration:\nadded by: "+mod.Caller)
+	}
 }
 
 func (e *environment) NewClientCert(templateOverrides ...*x509.Certificate) *Certificate {

--- a/internal/testenv/selftests/modifiers_test.go
+++ b/internal/testenv/selftests/modifiers_test.go
@@ -1,0 +1,45 @@
+package selftests_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testenv"
+	"github.com/pomerium/pomerium/internal/testenv/snippets"
+	"github.com/pomerium/pomerium/internal/testenv/values"
+)
+
+// TestStartWaitsForModifiers asserts that Start() does not return until all
+// previously added modifiers have been applied.
+//
+// Modifiers are applied from within a task, since they can block on values that
+// are only resolved once other tasks are running. Without the barrier in
+// Start(), reading the configuration here would race with those writes, which
+// the race detector reports as a failure.
+func TestStartWaitsForModifiers(t *testing.T) {
+	env := testenv.New(t)
+
+	// resolved from within a task, so that the modifier below can only run once
+	// tasks are running
+	header := values.Deferred[string]()
+	env.AddTask(testenv.TaskFunc(func(ctx context.Context) error {
+		header.Resolve("resolved-by-task")
+		<-ctx.Done()
+		return nil
+	}))
+	env.Add(testenv.ModifierFunc(func(_ context.Context, cfg *config.Config) {
+		cfg.Options.SetResponseHeaders = map[string]string{"x-modifier": header.Value()}
+	}))
+
+	env.Start()
+
+	// asserted before waiting for startup to complete, since the guarantee under
+	// test belongs to Start() itself
+	assert.Equal(t, "resolved-by-task", env.Config().Options.SetResponseHeaders["x-modifier"])
+
+	// let startup finish, so that the environment shuts down cleanly
+	snippets.WaitStartupComplete(env)
+}


### PR DESCRIPTION
## Summary

Fixes a data race in the testenv harness: `Start()` now blocks until all previously added config modifiers have been applied, so tests reading the config they built don't race with the goroutine writing it.

## Related issues

- ENG-4270

## User Explanation

## AI disclosure

Claude Code (Opus 5) wrote the fix and verified it under `-race`; reviewed by me.

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review