### PR TITLE
fix(mcp): ensure mcp refresh tokens are correctly cleaned up after revocation / expiration

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pomerium/pomerium/authorize/internal/store"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/mcp"
 	"github.com/pomerium/pomerium/internal/recording"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
@@ -48,6 +49,7 @@ type Authorize struct {
 	accessTracker *AccessTracker
 	ssh           *ssh.StreamManager
 	policyIndexer ssh.PolicyIndexer
+	mcpSyncer     *mcp.StorageSyncer
 
 	tracerProvider oteltrace.TracerProvider
 	tracer         oteltrace.Tracer
@@ -135,6 +137,7 @@ func New(ctx context.Context, cfg *config.Config, opts ...Option) (*Authorize, e
 		o.cliController,
 		cfg,
 	)
+	a.mcpSyncer = mcp.NewStorageSyncer(a)
 	return a, nil
 }
 
@@ -165,6 +168,9 @@ func (a *Authorize) Run(ctx context.Context) error {
 	eg.Go(func() error {
 		a.accessTracker.Run(ctx)
 		return nil
+	})
+	eg.Go(func() error {
+		return a.mcpSyncer.Run(ctx)
 	})
 	return eg.Wait()
 }

--- a/internal/databroker/server_backend.go
+++ b/internal/databroker/server_backend.go
@@ -748,9 +748,8 @@ func (srv *backendServer) newBackendAndSetupLocked(ctx context.Context) (storage
 }
 
 func (srv *backendServer) setupRequiredIndex(ctx context.Context, backend storage.Backend) error {
-	reqCap := uint64(50000)
 	if err := backend.SetOptions(ctx, "type.googleapis.com/session.SessionBindingRequest", &databrokerpb.Options{
-		Capacity:        &reqCap,
+		Capacity:        new(uint64(50000)),
 		IndexableFields: []string{"key"},
 		Ttl:             durationpb.New(15 * time.Minute),
 	}); err != nil {
@@ -788,6 +787,12 @@ func (srv *backendServer) setupRequiredIndex(ctx context.Context, backend storag
 			"state_id",
 		},
 		Ttl: durationpb.New(15 * time.Minute),
+	}); err != nil {
+		return err
+	}
+
+	if err := backend.SetOptions(ctx, "type.googleapis.com/oauth21.MCPRefreshToken", &databrokerpb.Options{
+		Capacity: new(uint64(50000)),
 	}); err != nil {
 		return err
 	}

--- a/internal/mcp/storage_syncer.go
+++ b/internal/mcp/storage_syncer.go
@@ -1,0 +1,223 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/pomerium/pomerium/internal/log"
+	oauth21 "github.com/pomerium/pomerium/internal/oauth21/gen"
+	"github.com/pomerium/pomerium/pkg/databrokerutil"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+const (
+	defaultRefreshTokenCleanupInterval    = 5 * time.Minute
+	defaultRefreshTokenCleanupGracePeriod = time.Minute * 15
+)
+
+type RefreshTokenMd struct {
+	Revoked   bool
+	RevokedAt time.Time
+	ExpiresAt time.Time
+}
+
+type StorageSyncer struct {
+	clientB databroker.ClientGetter
+	records map[string]*RefreshTokenMd
+	StorageSyncerOptions
+
+	mu sync.RWMutex
+}
+
+type StorageSyncerOptions struct {
+	// how often to cleanup refresh tokens
+	cleanupInterval time.Duration
+	// the grace period after which to clean up a token once it has been revoked
+	cleanupGracePeriodDuration time.Duration
+	// allows for fake clock tests
+	now func() time.Time
+}
+
+func defaultStorageSyncerOptions() *StorageSyncerOptions {
+	return &StorageSyncerOptions{
+		cleanupInterval:            defaultRefreshTokenCleanupInterval,
+		cleanupGracePeriodDuration: defaultRefreshTokenCleanupGracePeriod,
+		now:                        time.Now,
+	}
+}
+
+func (o *StorageSyncerOptions) Apply(opts ...StorageSyncerOption) {
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+type StorageSyncerOption func(*StorageSyncerOptions)
+
+func WithCleanupInterval(d time.Duration) StorageSyncerOption {
+	return func(o *StorageSyncerOptions) { o.cleanupInterval = d }
+}
+
+func WithCleanupGracePeriod(d time.Duration) StorageSyncerOption {
+	return func(o *StorageSyncerOptions) { o.cleanupGracePeriodDuration = d }
+}
+
+func WithClock(now func() time.Time) StorageSyncerOption {
+	return func(o *StorageSyncerOptions) { o.now = now }
+}
+
+func NewStorageSyncer(
+	clientB databroker.ClientGetter,
+	opts ...StorageSyncerOption,
+) *StorageSyncer {
+	options := defaultStorageSyncerOptions()
+	options.Apply(opts...)
+
+	return &StorageSyncer{
+		clientB:              clientB,
+		records:              map[string]*RefreshTokenMd{},
+		StorageSyncerOptions: *options,
+	}
+}
+
+var _ databrokerutil.SyncerHandler = (*StorageSyncer)(nil)
+
+func (s *StorageSyncer) Run(ctx context.Context) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return databrokerutil.NewSyncer(
+			ctx,
+			"mcp-storage-syncer",
+			s,
+			databrokerutil.WithTypeURL("type.googleapis.com/oauth21.MCPRefreshToken"),
+			databrokerutil.WithFastForward(),
+		).Run(ctx)
+	})
+	eg.Go(func() error {
+		return s.RunCleanUp(ctx)
+	})
+
+	return eg.Wait()
+}
+
+func (s *StorageSyncer) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	return s.clientB.GetDataBrokerServiceClient()
+}
+
+func (s *StorageSyncer) ClearRecords(_ context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = map[string]*RefreshTokenMd{}
+}
+
+func (s *StorageSyncer) UpdateRecords(ctx context.Context, _ uint64, records []*databroker.Record) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	for _, rec := range records {
+		id := rec.GetId()
+		if rec.GetDeletedAt() != nil {
+			delete(s.records, id)
+			continue
+		}
+
+		refreshTokenProto := new(oauth21.MCPRefreshToken)
+		if err := rec.GetData().UnmarshalTo(refreshTokenProto); err != nil {
+			log.Ctx(ctx).Error().Err(err).
+				Str("record-id", id).
+				Msg("mcp: failed to unmarshal refresh token record")
+			continue
+		}
+
+		expiresAt := refreshTokenProto.GetExpiresAt().AsTime()
+
+		got, ok := s.records[id]
+		if !ok {
+			md := &RefreshTokenMd{
+				Revoked:   refreshTokenProto.GetRevoked(),
+				ExpiresAt: expiresAt,
+			}
+			if md.Revoked {
+				md.RevokedAt = now
+			}
+			s.records[id] = md
+			continue
+		}
+		// explicitly only handle flips from false -> true
+		if !got.Revoked && refreshTokenProto.GetRevoked() {
+			got.Revoked = true
+			got.RevokedAt = now
+		}
+		got.ExpiresAt = expiresAt
+	}
+}
+
+// RunCleanUp periodically deletes revoked and expired refresh tokens until ctx is done.
+func (s *StorageSyncer) RunCleanUp(ctx context.Context) error {
+	t := time.NewTicker(s.cleanupInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-t.C:
+			if err := s.batchCleanUp(ctx); err != nil {
+				log.Ctx(ctx).Error().Err(err).Msg("mcp: failed to clean up refresh tokens")
+			}
+		}
+	}
+}
+
+// expired reports whether the record is eligible for deletion.
+func (s *StorageSyncer) expired(md *RefreshTokenMd, now time.Time) bool {
+	if md.Revoked && md.RevokedAt.Add(s.cleanupGracePeriodDuration).Before(now) {
+		return true
+	}
+
+	return md.ExpiresAt.Add(s.cleanupGracePeriodDuration).Before(now)
+}
+
+func (s *StorageSyncer) batchCleanUp(ctx context.Context) error {
+	now := s.now()
+
+	s.mu.RLock()
+	var ids []string
+	for id, md := range s.records {
+		if s.expired(md, now) {
+			ids = append(ids, id)
+		}
+	}
+	s.mu.RUnlock()
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	data := protoutil.NewAny(new(oauth21.MCPRefreshToken))
+	deletedAt := timestamppb.New(now)
+	recs := make([]*databroker.Record, 0, len(ids))
+	for _, id := range ids {
+		recs = append(recs, &databroker.Record{
+			Id:        id,
+			Data:      data,
+			Type:      data.TypeUrl,
+			DeletedAt: deletedAt,
+		})
+	}
+
+	if _, err := s.GetDataBrokerServiceClient().Put(ctx, &databroker.PutRequest{Records: recs}); err != nil {
+		return fmt.Errorf("failed to delete expired mcp refresh tokens: %w", err)
+	}
+
+	log.Ctx(ctx).Info().
+		Int("count", len(ids)).
+		Msg("mcp: deleted expired refresh tokens")
+	return nil
+}

--- a/internal/mcp/storage_syncer_test.go
+++ b/internal/mcp/storage_syncer_test.go
@@ -1,0 +1,228 @@
+package mcp
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/pomerium/pomerium/internal/databroker"
+	oauth21 "github.com/pomerium/pomerium/internal/oauth21/gen"
+	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/databrokerutil"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+var syncerTestBase = time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+
+func TestStorageSyncerClearRecords(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.GetContext(t, time.Minute)
+	client := newTestDataBrokerClient(t)
+	s := newTestStorageSyncer(t, client, &fakeClock{t: syncerTestBase})
+	s.records["a"] = &RefreshTokenMd{}
+
+	s.ClearRecords(ctx)
+
+	assert.Empty(t, s.records)
+}
+
+func TestStorageSyncerCleanUp(t *testing.T) {
+	t.Parallel()
+
+	const grace = time.Hour
+
+	type testToken struct {
+		id string
+		// expiresIn is the token lifetime relative to the start of the test
+		expiresIn *time.Duration
+		revoked   bool
+	}
+
+	dur := func(d time.Duration) *time.Duration { return new(d) }
+
+	type testcase struct {
+		name string
+		// tokens are all created at the start of the test.
+		tokens []testToken
+		// advance is how far the clock moves before cleanup runs.
+		advance       time.Duration
+		wantRemaining []string
+	}
+
+	for _, tc := range []testcase{
+		{
+			name: "no tokens is a no-op",
+		},
+		{
+			name:          "unexpired token is kept",
+			tokens:        []testToken{{id: "a", expiresIn: dur(4 * time.Hour)}},
+			advance:       time.Hour,
+			wantRemaining: []string{"a"},
+		},
+		{
+			name:    "token without an expiry is treated as already expired",
+			tokens:  []testToken{{id: "a"}},
+			advance: time.Minute,
+		},
+		{
+			name:          "expired token within the grace period is kept",
+			tokens:        []testToken{{id: "a", expiresIn: dur(time.Hour)}},
+			advance:       time.Hour + 30*time.Minute,
+			wantRemaining: []string{"a"},
+		},
+		{
+			name:    "expired token past the grace period is deleted",
+			tokens:  []testToken{{id: "a", expiresIn: dur(time.Hour)}},
+			advance: 3 * time.Hour,
+		},
+		{
+			name:          "expired token exactly at the grace boundary is kept",
+			tokens:        []testToken{{id: "a", expiresIn: dur(time.Hour)}},
+			advance:       time.Hour + grace,
+			wantRemaining: []string{"a"},
+		},
+		{
+			name:          "revoked token within the grace period is kept",
+			tokens:        []testToken{{id: "a", expiresIn: dur(100 * time.Hour), revoked: true}},
+			advance:       30 * time.Minute,
+			wantRemaining: []string{"a"},
+		},
+		{
+			name:    "revoked token past the grace period is deleted",
+			tokens:  []testToken{{id: "a", expiresIn: dur(100 * time.Hour), revoked: true}},
+			advance: 2 * time.Hour,
+		},
+		{
+			name: "only eligible tokens are deleted",
+			tokens: []testToken{
+				{id: "revoked", expiresIn: dur(100 * time.Hour), revoked: true},
+				{id: "expired", expiresIn: dur(time.Minute)},
+				{id: "still-valid", expiresIn: dur(100 * time.Hour)},
+				{id: "no-expiry"},
+			},
+			advance:       2 * time.Hour,
+			wantRemaining: []string{"still-valid"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.GetContext(t, time.Minute)
+			client := newTestDataBrokerClient(t)
+			storage := NewStorage(client)
+			clock := &fakeClock{t: syncerTestBase}
+			s := newTestStorageSyncer(t, client, clock, WithCleanupGracePeriod(grace),
+				WithCleanupInterval(10*time.Millisecond))
+
+			tracked := func() []string {
+				s.mu.RLock()
+				defer s.mu.RUnlock()
+				return slices.Collect(maps.Keys(s.records))
+			}
+
+			var ids []string
+			for _, tok := range tc.tokens {
+				stored := &oauth21.MCPRefreshToken{Id: tok.id, Revoked: tok.revoked}
+				if tok.expiresIn != nil {
+					stored.ExpiresAt = timestamppb.New(syncerTestBase.Add(*tok.expiresIn))
+				}
+				require.NoError(t, storage.PutMCPRefreshToken(ctx, stored))
+				ids = append(ids, tok.id)
+			}
+
+			syncer := databrokerutil.NewSyncer(ctx, "mcp-refresh-token-test", s,
+				databrokerutil.WithTypeURL(protoutil.GetTypeURL(new(oauth21.MCPRefreshToken))))
+			t.Cleanup(func() { _ = syncer.Close() })
+			go func() { _ = syncer.Run(ctx) }()
+
+			// Wait for the initial sync so every token is tracked before the clock moves.
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.ElementsMatch(c, ids, tracked())
+			}, 5*time.Second, 10*time.Millisecond, "initial sync never completed")
+
+			clock.Set(syncerTestBase.Add(tc.advance))
+			go func() { _ = s.RunCleanUp(ctx) }()
+
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				var remaining []string
+				for _, tok := range tc.tokens {
+					if _, err := storage.GetMCPRefreshToken(ctx, tok.id); err == nil {
+						remaining = append(remaining, tok.id)
+					}
+				}
+				assert.ElementsMatch(c, tc.wantRemaining, remaining,
+					"unexpected set of tokens left in the databroker")
+				assert.ElementsMatch(c, tc.wantRemaining, tracked(),
+					"in-memory tracking diverged from the databroker")
+			}, 5*time.Second, 10*time.Millisecond)
+		})
+	}
+}
+
+func TestStorageSyncerRunCleanUpStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	client := newTestDataBrokerClient(t)
+	s := newTestStorageSyncer(t, client, &fakeClock{t: syncerTestBase})
+	s.cleanupInterval = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorIs(t, s.RunCleanUp(ctx), context.Canceled)
+}
+
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) Set(t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = t
+}
+
+func newTestDataBrokerClient(t *testing.T) databrokerpb.DataBrokerServiceClient {
+	t.Helper()
+
+	srv := databroker.NewBackendServer(noop.NewTracerProvider())
+	t.Cleanup(srv.Stop)
+
+	cc := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(s, srv)
+	})
+
+	return databrokerpb.NewDataBrokerServiceClient(cc)
+}
+
+func newTestStorageSyncer(
+	t *testing.T,
+	client databrokerpb.DataBrokerServiceClient,
+	clock *fakeClock,
+	opts ...StorageSyncerOption,
+) *StorageSyncer {
+	t.Helper()
+
+	return NewStorageSyncer(
+		databrokerpb.NewStaticClientGetter(client),
+		append([]StorageSyncerOption{WithClock(clock.Now)}, opts...)...,
+	)
+}


### PR DESCRIPTION
## Summary

Revoked tokens should be eventually cleaned up. We want to keep Refresh tokens around for particular authorization decisions as is recommended by the OAuth 2.1 spec & security best practices (notably RFC 9700). Although, there is no specific handling of grace periods / revoked tokens currently.

This fixes an existing storage leak, where no longer valid revoked tokens are kept

## Related issues

Issue reported in :https://github.com/pomerium/pomerium/pull/6551

## User Explanation

McpRefreshTokens are no longer durably persisted after expiration / revocation

## AI disclosure

opus 4.8 was used to help scaffhold some of the tests. 

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>