### PR TITLE
fix(mcp) : concurrent token refresh with session identity manager

### DIFF
--- a/internal/databroker/server_backend.go
+++ b/internal/databroker/server_backend.go
@@ -793,6 +793,9 @@ func (srv *backendServer) setupRequiredIndex(ctx context.Context, backend storag
 
 	if err := backend.SetOptions(ctx, "type.googleapis.com/oauth21.MCPRefreshToken", &databrokerpb.Options{
 		Capacity: new(uint64(50000)),
+		IndexableFields: []string{
+			"initiating_session_id",
+		},
 	}); err != nil {
 		return err
 	}

--- a/internal/mcp/handler_token.go
+++ b/internal/mcp/handler_token.go
@@ -24,9 +24,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/storage"
 )
 
-var (
-	ErrTokenNoInitiatingSession = errors.New("mcp upstream refresh token does not have an initiating session")
-)
+var ErrTokenNoInitiatingSession = errors.New("mcp upstream refresh token does not have an initiating session")
 
 const (
 	// RefreshTokenTTL is the lifetime for MCP refresh tokens.
@@ -460,8 +458,7 @@ func (srv *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 		IssuedAt:             timestamppb.Now(),
 		ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
 		Scopes:               refreshTokenRecord.Scopes,
-		// keep the initating session
-		InitiatingSessionId: newSession.GetId(),
+		InitiatingSessionId:  newSession.GetId(),
 	}
 
 	log.Ctx(ctx).Debug().
@@ -533,13 +530,14 @@ func (srv *Handler) getOrRecreateSession(
 	upstreamRefreshToken := refreshTokenRecord.UpstreamRefreshToken
 	initiatingSession, existingRecordVersion, err := srv.getRecordSession(ctx, refreshTokenRecord)
 	if storage.IsNotFound(err) || errors.Is(err, ErrTokenNoInitiatingSession) {
-		// TODO : this needs to have the latest refresh token from the previously delete session
+		// the upstream token should carry the most recently seen refresh token from the expired session
+		// if it is available
 		return srv.recreateSession(ctx, refreshTokenRecord, refreshTokenRecord.UpstreamRefreshToken)
 	} else if err != nil {
 		return nil, 0, err
 	}
 
-	if sessionUsable(initiatingSession) {
+	if sessionUsableForRefresh(initiatingSession) {
 		log.Ctx(ctx).Debug().
 			Str("session-id", initiatingSession.Id).
 			Time("expires-at", initiatingSession.ExpiresAt.AsTime()).
@@ -549,7 +547,8 @@ func (srv *Handler) getOrRecreateSession(
 	// Prefer the refresh token stored on the session: the identity manager may have rotated it
 	// after this record was written, in which case the record's copy is no longer valid upstream.
 
-	// The session stil exists, but is no longer usable. In what scenarios could this happen?
+	// As far as I can tell this scenario happens when an expired session hasn't been deleted yet,
+	// or it has been created from incomingIDPTokenSessionCreator
 	if t := initiatingSession.GetOauthToken().GetRefreshToken(); t != "" {
 		upstreamRefreshToken = t
 	}
@@ -575,6 +574,9 @@ func (srv *Handler) recreateSession(
 		Str("idp-id", newSession.IdpId).
 		Time("expires-at", newSession.ExpiresAt.AsTime()).
 		Msg("mcp/session: created new session")
+
+	// the authenticator should get a new token only when the session is no longer valid and
+	// fetch a new token for use
 
 	// Refresh the upstream token to get a fresh access token and populate claims.
 	// We use NewSessionUnmarshaler to capture ID token claims from the upstream IdP.
@@ -666,10 +668,10 @@ func (srv *Handler) getRecordSession(
 	return s, recordVersion, nil
 }
 
-// sessionUsable reports whether a session can be handed back to the client as-is, without
+// sessionUsableForRefresh reports whether a session can be handed back to the client as-is, without
 // exchanging the upstream refresh token.
-func sessionUsable(s *session.Session) bool {
-	if s.GetOauthToken().GetAccessToken() == "" {
+func sessionUsableForRefresh(s *session.Session) bool {
+	if s.GetOauthToken().GetAccessToken() == "" || s.GetRefreshDisabled() {
 		return false
 	}
 	return s.Validate() == nil

--- a/internal/mcp/handler_token.go
+++ b/internal/mcp/handler_token.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -20,6 +21,11 @@ import (
 	rfc7591v1 "github.com/pomerium/pomerium/internal/rfc7591"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/identity/manager"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+var (
+	ErrTokenNoInitiatingSession = errors.New("mcp upstream refresh token does not have an initiating session")
 )
 
 const (
@@ -218,6 +224,7 @@ func (srv *Handler) handleAuthorizationCodeToken(w http.ResponseWriter, r *http.
 		IssuedAt:             timestamppb.Now(),
 		ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
 		Scopes:               authReq.GetScopes(),
+		InitiatingSessionId:  session.GetId(),
 	}
 
 	log.Ctx(ctx).Debug().
@@ -453,6 +460,8 @@ func (srv *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 		IssuedAt:             timestamppb.Now(),
 		ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
 		Scopes:               refreshTokenRecord.Scopes,
+		// keep the initating session
+		InitiatingSessionId: newSession.GetId(),
 	}
 
 	log.Ctx(ctx).Debug().
@@ -517,13 +526,42 @@ func (srv *Handler) getOrRecreateSession(
 	log.Ctx(ctx).Debug().
 		Str("user-id", refreshTokenRecord.UserId).
 		Str("idp-id", refreshTokenRecord.IdpId).
+		Str("initating-session-id", refreshTokenRecord.InitiatingSessionId).
 		Bool("has-upstream-refresh-token", refreshTokenRecord.UpstreamRefreshToken != "").
-		Msg("mcp/session: recreating session from refresh token")
+		Msg("mcp/session: getting session for refresh token")
 
-	// For now, we need to create a new session since we don't track the original session ID
-	// The session will be created using the upstream refresh token
+	upstreamRefreshToken := refreshTokenRecord.UpstreamRefreshToken
+	initiatingSession, existingRecordVersion, err := srv.getRecordSession(ctx, refreshTokenRecord)
+	if storage.IsNotFound(err) || errors.Is(err, ErrTokenNoInitiatingSession) {
+		// TODO : this needs to have the latest refresh token from the previously delete session
+		return srv.recreateSession(ctx, refreshTokenRecord, refreshTokenRecord.UpstreamRefreshToken)
+	} else if err != nil {
+		return nil, 0, err
+	}
 
-	if refreshTokenRecord.UpstreamRefreshToken == "" {
+	if sessionUsable(initiatingSession) {
+		log.Ctx(ctx).Debug().
+			Str("session-id", initiatingSession.Id).
+			Time("expires-at", initiatingSession.ExpiresAt.AsTime()).
+			Msg("mcp/session: reusing existing session, skipping upstream token exchange")
+		return initiatingSession, existingRecordVersion, nil
+	}
+	// Prefer the refresh token stored on the session: the identity manager may have rotated it
+	// after this record was written, in which case the record's copy is no longer valid upstream.
+
+	// The session stil exists, but is no longer usable. In what scenarios could this happen?
+	if t := initiatingSession.GetOauthToken().GetRefreshToken(); t != "" {
+		upstreamRefreshToken = t
+	}
+	return srv.recreateSession(ctx, refreshTokenRecord, upstreamRefreshToken)
+}
+
+func (srv *Handler) recreateSession(
+	ctx context.Context,
+	refreshTokenRecord *oauth21proto.MCPRefreshToken,
+	curUpstreamRefreshToken string,
+) (*session.Session, uint64, error) {
+	if curUpstreamRefreshToken == "" {
 		log.Ctx(ctx).Error().Msg("mcp/session: no upstream refresh token available")
 		return nil, 0, fmt.Errorf("no upstream refresh token available")
 	}
@@ -531,7 +569,6 @@ func (srv *Handler) getOrRecreateSession(
 	// Create a new session first so we can populate it with claims from the upstream IdP
 	newSessionID := uuid.NewString()
 	newSession := session.Create(refreshTokenRecord.IdpId, newSessionID, refreshTokenRecord.UserId, time.Now(), srv.sessionExpiry)
-
 	log.Ctx(ctx).Debug().
 		Str("session-id", newSession.Id).
 		Str("user-id", newSession.UserId).
@@ -569,7 +606,7 @@ func (srv *Handler) getOrRecreateSession(
 
 	log.Ctx(ctx).Debug().Msg("mcp/session: refreshing upstream OAuth token")
 	oldToken := &oauth2.Token{
-		RefreshToken: refreshTokenRecord.UpstreamRefreshToken,
+		RefreshToken: curUpstreamRefreshToken,
 	}
 	// Use NewSessionUnmarshaler to capture ID token claims from the upstream IdP.
 	// This ensures the recreated session has the same claims as a fresh session.
@@ -612,6 +649,30 @@ func (srv *Handler) getOrRecreateSession(
 		Msg("mcp/session: session stored successfully")
 
 	return newSession, sessionRecordVersion, nil
+}
+
+func (srv *Handler) getRecordSession(
+	ctx context.Context,
+	refreshTokenRecord *oauth21proto.MCPRefreshToken,
+) (*session.Session, uint64, error) {
+	if refreshTokenRecord.GetInitiatingSessionId() == "" {
+		return nil, 0, ErrTokenNoInitiatingSession
+	}
+
+	s, recordVersion, err := srv.storage.GetSession(ctx, refreshTokenRecord.GetInitiatingSessionId())
+	if err != nil {
+		return nil, 0, err
+	}
+	return s, recordVersion, nil
+}
+
+// sessionUsable reports whether a session can be handed back to the client as-is, without
+// exchanging the upstream refresh token.
+func sessionUsable(s *session.Session) bool {
+	if s.GetOauthToken().GetAccessToken() == "" {
+		return false
+	}
+	return s.Validate() == nil
 }
 
 // createTokenResponse generates access and refresh tokens for a session.

--- a/internal/mcp/handler_token.go
+++ b/internal/mcp/handler_token.go
@@ -442,60 +442,17 @@ func (srv *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 		Bool("has-upstream-refresh-token", newSession.GetOauthToken().GetRefreshToken() != "").
 		Msg("mcp/token/refresh: session obtained, proceeding with token rotation")
 
-	// Update the refresh token record with the new session's upstream token (if rotated)
-	if newSession.GetOauthToken().GetRefreshToken() != "" {
-		log.Ctx(ctx).Debug().Msg("mcp/token/refresh: updating upstream refresh token from new session")
-		refreshTokenRecord.UpstreamRefreshToken = newSession.GetOauthToken().GetRefreshToken()
-	}
-
-	// Create new refresh token record (rotation)
-	newRefreshTokenRecord := &oauth21proto.MCPRefreshToken{
-		Id:                   uuid.NewString(),
-		UserId:               refreshTokenRecord.UserId,
-		ClientId:             refreshTokenRecord.ClientId,
-		IdpId:                refreshTokenRecord.IdpId,
-		UpstreamRefreshToken: refreshTokenRecord.UpstreamRefreshToken,
-		IssuedAt:             timestamppb.Now(),
-		ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
-		Scopes:               refreshTokenRecord.Scopes,
-		InitiatingSessionId:  newSession.GetId(),
-	}
-
-	log.Ctx(ctx).Debug().
-		Str("old-refresh-token-id", refreshTokenRecord.Id).
-		Str("new-refresh-token-id", newRefreshTokenRecord.Id).
-		Time("new-expires-at", newRefreshTokenRecord.ExpiresAt.AsTime()).
-		Msg("mcp/token/refresh: rotating refresh token (creating new, then revoking old)")
-
-	// Store new refresh token first, then revoke old one.
-	// This order ensures that if revoking fails, the user still has a valid token.
-	if err := srv.storage.PutMCPRefreshToken(ctx, newRefreshTokenRecord); err != nil {
+	issuedRecord, err := srv.issueRefreshTokenIfChanged(ctx, refreshTokenRecord, newSession)
+	if err != nil {
 		log.Ctx(ctx).Error().Err(err).
-			Str("refresh-token-id", newRefreshTokenRecord.Id).
-			Msg("mcp/token/refresh: failed to store new refresh token")
+			Str("refresh-token-id", refreshTokenRecord.Id).
+			Msg("mcp/token/refresh: failed to store refresh token")
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
-	log.Ctx(ctx).Debug().
-		Str("refresh-token-id", newRefreshTokenRecord.Id).
-		Msg("mcp/token/refresh: new refresh token stored")
-
-	refreshTokenRecord.Revoked = true
-	if err := srv.storage.PutMCPRefreshToken(ctx, refreshTokenRecord); err != nil {
-		// Log the error but don't fail the request - the new token is already stored
-		// and the user can continue. The old token will eventually expire.
-		log.Ctx(ctx).Warn().Err(err).
-			Str("refresh-token-id", refreshTokenRecord.Id).
-			Msg("mcp/token/refresh: failed to revoke old refresh token (new token already issued)")
-	} else {
-		log.Ctx(ctx).Debug().
-			Str("refresh-token-id", refreshTokenRecord.Id).
-			Msg("mcp/token/refresh: old refresh token revoked")
-	}
-
 	sessionExpiresAt := newSession.ExpiresAt.AsTime()
-	resp, err := srv.createTokenResponse(newSession.Id, newSessionRecordVersion, sessionExpiresAt, newRefreshTokenRecord, refreshTokenRecord.Scopes)
+	resp, err := srv.createTokenResponse(newSession.Id, newSessionRecordVersion, sessionExpiresAt, issuedRecord, refreshTokenRecord.Scopes)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("mcp/token/refresh: failed to create token response")
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -507,12 +464,69 @@ func (srv *Handler) handleRefreshTokenGrant(w http.ResponseWriter, r *http.Reque
 		Str("user-id", refreshTokenRecord.UserId).
 		Str("session-id", newSession.Id).
 		Str("old-refresh-token-id", refreshTokenRecord.Id).
-		Str("new-refresh-token-id", newRefreshTokenRecord.Id).
+		Str("new-refresh-token-id", issuedRecord.Id).
+		Bool("rotated", issuedRecord != refreshTokenRecord).
 		Int64("expires-in", resp.GetExpiresIn()).
 		Str("scope", resp.GetScope()).
 		Msg("mcp/token/refresh: token refreshed successfully")
 
 	writeTokenResponse(w, resp)
+}
+
+// issueRefreshTokenIfChanged returns the record to hand back to the client, rotating it only when
+// the session carries a newer upstream token.
+func (srv *Handler) issueRefreshTokenIfChanged(
+	ctx context.Context,
+	current *oauth21proto.MCPRefreshToken,
+	newSession *session.Session,
+) (*oauth21proto.MCPRefreshToken, error) {
+	upstreamRefreshToken := newSession.GetOauthToken().GetRefreshToken()
+	upstreamRotated := upstreamRefreshToken != "" && upstreamRefreshToken != current.UpstreamRefreshToken
+	sessionChanged := current.InitiatingSessionId != newSession.GetId()
+
+	switch {
+	case !upstreamRotated && !sessionChanged:
+		return current, nil
+	case !upstreamRotated:
+		// this happens when the identity manager is not refreshing the token, but the
+		// session has been recreated
+		current.InitiatingSessionId = newSession.GetId()
+		return current, srv.storage.PutMCPRefreshToken(ctx, current)
+	}
+
+	rotated := &oauth21proto.MCPRefreshToken{
+		Id:                   uuid.NewString(),
+		UserId:               current.UserId,
+		ClientId:             current.ClientId,
+		IdpId:                current.IdpId,
+		UpstreamRefreshToken: upstreamRefreshToken,
+		IssuedAt:             timestamppb.Now(),
+		ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
+		Scopes:               current.Scopes,
+		InitiatingSessionId:  newSession.GetId(),
+	}
+
+	log.Ctx(ctx).Debug().
+		Str("old-refresh-token-id", current.Id).
+		Str("new-refresh-token-id", rotated.Id).
+		Time("new-expires-at", rotated.ExpiresAt.AsTime()).
+		Msg("mcp/token/refresh: rotating refresh token (creating new, then revoking old)")
+
+	// Store the new token before revoking the old one, so a failure here leaves the client with a
+	// token it can still use.
+	if err := srv.storage.PutMCPRefreshToken(ctx, rotated); err != nil {
+		return nil, err
+	}
+
+	current.Revoked = true
+	if err := srv.storage.PutMCPRefreshToken(ctx, current); err != nil {
+		// Not fatal: the new token is already issued and the old one expires on its own.
+		log.Ctx(ctx).Warn().Err(err).
+			Str("refresh-token-id", current.Id).
+			Msg("mcp/token/refresh: failed to revoke old refresh token")
+	}
+
+	return rotated, nil
 }
 
 // getOrRecreateSession tries to get an existing valid session, or recreates it using the upstream refresh token.
@@ -544,17 +558,15 @@ func (srv *Handler) getOrRecreateSession(
 			Msg("mcp/session: reusing existing session, skipping upstream token exchange")
 		return initiatingSession, existingRecordVersion, nil
 	}
-	// Prefer the refresh token stored on the session: the identity manager may have rotated it
-	// after this record was written, in which case the record's copy is no longer valid upstream.
-
-	// As far as I can tell this scenario happens when an expired session hasn't been deleted yet,
-	// or it has been created from incomingIDPTokenSessionCreator
+	// Prefer the refresh token stored on the session, even if the session is not usable
 	if t := initiatingSession.GetOauthToken().GetRefreshToken(); t != "" {
 		upstreamRefreshToken = t
 	}
 	return srv.recreateSession(ctx, refreshTokenRecord, upstreamRefreshToken)
 }
 
+// recreateSession assumes that the previous session is no longer active.
+// there can be no token rotation in the identity manager concurrently running.
 func (srv *Handler) recreateSession(
 	ctx context.Context,
 	refreshTokenRecord *oauth21proto.MCPRefreshToken,

--- a/internal/mcp/handler_token_test.go
+++ b/internal/mcp/handler_token_test.go
@@ -701,141 +701,120 @@ func TestRefreshTokenGrant(t *testing.T) {
 		assert.False(t, oldRecord.Revoked, "old refresh token should NOT be revoked when new token storage fails")
 	})
 
-	t.Run("session token rotation", func(t *testing.T) {
-		// A user logs in with a refreshable session (refresh_disabled = false). The
-		// identity manager independently refreshes that session, rotating the upstream
-		// refresh token held by the IdP. The upstream token recorded on the MCP refresh
-		// token at authorization time is now stale, so the MCP refresh grant must pick
-		// up the rotated token off the initiating session rather than replaying the
-		// stale one.
+	// The identity manager refreshes the session on its own schedule, rotating the upstream token
+	// and leaving the copy on the MCP record stale. The grant must exchange the session's copy.
+	t.Run("expired session's rotated upstream token wins over the record's", func(t *testing.T) {
 		const (
-			idpID          = "session-rotation-idp"
-			userID         = "session-rotation-user-id"
-			loginToken     = "upstream-refresh-token-at-login"
-			managerToken   = "upstream-refresh-token-after-manager-refresh"
-			mcpGrantToken  = "upstream-refresh-token-after-mcp-grant"
-			loginSessionID = "session-rotation-session-id"
+			staleToken   = "upstream-token-at-login"
+			rotatedToken = "upstream-token-after-manager-refresh"
+			grantToken   = "upstream-token-after-mcp-grant"
+			sessionID    = "session-rotation-session-id"
 		)
 
-		loginSession := session.Create(idpID, loginSessionID, userID, time.Now(), 14*time.Hour)
-		loginSession.RefreshDisabled = false
-		loginSession.OauthToken = &session.OAuthToken{
-			AccessToken:  "upstream-access-token-at-login",
+		sess := session.Create("test-idp", sessionID, "session-rotation-user-id", time.Now(), 14*time.Hour)
+		sess.ExpiresAt = timestamppb.New(time.Now().Add(-time.Minute))
+		sess.OauthToken = &session.OAuthToken{
+			AccessToken:  "upstream-access-token",
 			TokenType:    "Bearer",
-			RefreshToken: loginToken,
+			RefreshToken: rotatedToken,
 			ExpiresAt:    timestamppb.New(time.Now().Add(time.Hour)),
 		}
-		_, err := storage.PutSession(ctx, loginSession)
+		_, err := storage.PutSession(ctx, sess)
 		require.NoError(t, err)
 
-		refreshTokenRecord := &oauth21proto.MCPRefreshToken{
+		record := &oauth21proto.MCPRefreshToken{
 			Id:                   "session-rotation-refresh-token-id",
-			UserId:               userID,
+			UserId:               "session-rotation-user-id",
 			ClientId:             clientID,
-			IdpId:                idpID,
-			UpstreamRefreshToken: loginToken,
-			InitiatingSessionId:  loginSessionID,
+			IdpId:                "test-idp",
+			UpstreamRefreshToken: staleToken,
+			InitiatingSessionId:  sessionID,
 			IssuedAt:             timestamppb.Now(),
 			ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
-			Scopes:               []string{"openid"},
 		}
-		require.NoError(t, storage.PutMCPRefreshToken(ctx, refreshTokenRecord))
+		require.NoError(t, storage.PutMCPRefreshToken(ctx, record))
 
-		// Mirror what (*manager.Manager in `pkg/identity/manager`).refreshSession does to a refreshable session:
-		// exchange the session's upstream refresh token, write the rotated token back onto the session, and persist it.
-		var tokenSeenByManager string
-		managerAuth := &mockAuthenticator{
-			refreshFunc: func(_ context.Context, t *oauth2.Token, v identitystate.State) (*oauth2.Token, error) {
-				tokenSeenByManager = t.RefreshToken
-				v.SetRawIDToken("manager-id-token")
-				return &oauth2.Token{
-					AccessToken:  "upstream-access-token-after-manager-refresh",
-					RefreshToken: managerToken,
-					TokenType:    "Bearer",
-					// Already expired, so the grant below cannot reuse the session as-is and must
-					// exchange an upstream token. That is what puts the stale-vs-rotated choice
-					// under test; a session with a live access token is reused instead, which
-					// TestRefreshGrantSessionOwnership covers.
-					Expiry: time.Now().Add(-time.Minute),
-				}, nil
-			},
-		}
-		require.False(t, loginSession.GetRefreshDisabled(), "session must be refreshable")
-		newToken, err := managerAuth.Refresh(ctx,
-			manager.FromOAuthToken(loginSession.OauthToken),
-			manager.NewSessionUnmarshaler(loginSession))
-		require.NoError(t, err)
-		loginSession.OauthToken = manager.ToOAuthToken(newToken)
-		_, err = storage.PutSession(ctx, loginSession)
-		require.NoError(t, err)
-		assert.Equal(t, loginToken, tokenSeenByManager,
-			"identity manager should refresh using the session's login token")
-
-		// Now perform the MCP refresh grant. It must present the rotated token.
-		var tokenSeenByGrant string
-		mockAuth := &mockAuthenticator{
-			refreshFunc: func(_ context.Context, t *oauth2.Token, v identitystate.State) (*oauth2.Token, error) {
-				tokenSeenByGrant = t.RefreshToken
-				if t.RefreshToken != managerToken {
-					return nil, errors.New("stale upstream refresh token presented to IdP")
-				}
-				v.SetRawIDToken("mcp-id-token")
-				return &oauth2.Token{
-					AccessToken:  "upstream-access-token-after-mcp-grant",
-					RefreshToken: mcpGrantToken,
-					TokenType:    "Bearer",
-					Expiry:       time.Now().Add(time.Hour),
-				}, nil
-			},
-		}
-
+		var presented string
 		srv := &Handler{
 			cipher:        testCipher,
 			storage:       storage,
 			sessionExpiry: 14 * time.Hour,
 			getAuthenticator: func(_ context.Context, _ string) (identity.Authenticator, error) {
-				return mockAuth, nil
+				return &mockAuthenticator{
+					refreshFunc: func(_ context.Context, tok *oauth2.Token, _ identitystate.State) (*oauth2.Token, error) {
+						presented = tok.RefreshToken
+						return &oauth2.Token{
+							AccessToken:  "fresh-access-token",
+							RefreshToken: grantToken,
+							TokenType:    "Bearer",
+							Expiry:       time.Now().Add(time.Hour),
+						}, nil
+					},
+				}, nil
 			},
 		}
 
-		refreshToken, err := srv.CreateRefreshToken(refreshTokenRecord.Id, clientID, refreshTokenRecord.ExpiresAt.AsTime())
+		refreshToken, err := srv.CreateRefreshToken(record.Id, clientID, record.ExpiresAt.AsTime())
 		require.NoError(t, err)
 
-		form := url.Values{
-			"grant_type":    {"refresh_token"},
-			"refresh_token": {refreshToken},
-			"client_id":     {clientID},
-		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/token", strings.NewReader(form.Encode()))
+		w := postTokenRefresh(ctx, t, srv, clientID, refreshToken)
+		require.Equal(t, http.StatusOK, w.Code, "response body: %s", w.Body.String())
+		assert.Equal(t, rotatedToken, presented, "grant must exchange the session's token, not the record's")
+
+		// The rotated MCP record must carry the newest upstream token forward.
+		newRecord := rotatedRecord(ctx, t, srv, storage, clientID, w)
+		assert.Equal(t, grantToken, newRecord.UpstreamRefreshToken)
+
+		oldRecord, err := storage.GetMCPRefreshToken(ctx, record.Id)
 		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-		w := httptest.NewRecorder()
-		srv.Token(w, req)
-
-		require.Equal(t, http.StatusOK, w.Code, "grant should succeed after external session refresh: %s", w.Body.String())
-		assert.Equal(t, managerToken, tokenSeenByGrant,
-			"grant should use the upstream token rotated onto the session by the identity manager")
-
-		var tokenResp map[string]any
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &tokenResp))
-		newRefreshToken, ok := tokenResp["refresh_token"].(string)
-		require.True(t, ok, "expected refresh_token in response")
-
-		// The rotated MCP refresh token must carry the newest upstream token forward.
-		code, err := srv.DecryptRefreshToken(newRefreshToken, clientID)
-		require.NoError(t, err)
-		newRecord, err := storage.GetMCPRefreshToken(ctx, code.Id)
-		require.NoError(t, err)
-		assert.Equal(t, mcpGrantToken, newRecord.UpstreamRefreshToken)
-		assert.Equal(t, loginSessionID, newRecord.InitiatingSessionId,
-			"rotation keeps pointing at the initiating login session")
-
-		oldRecord, err := storage.GetMCPRefreshToken(ctx, refreshTokenRecord.Id)
-		require.NoError(t, err)
-		assert.True(t, oldRecord.Revoked, "old refresh token should be revoked")
-
+		assert.True(t, oldRecord.Revoked)
 	})
+}
+
+func postTokenRefresh(
+	ctx context.Context,
+	t *testing.T,
+	srv *Handler,
+	clientID, refreshToken string,
+) *httptest.ResponseRecorder {
+	t.Helper()
+
+	form := url.Values{
+		"grant_type":    {"refresh_token"},
+		"refresh_token": {refreshToken},
+		"client_id":     {clientID},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/token", strings.NewReader(form.Encode()))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	w := httptest.NewRecorder()
+	srv.Token(w, req)
+	return w
+}
+
+// rotatedRecord resolves the refresh token in a grant response back to its stored record.
+func rotatedRecord(
+	ctx context.Context,
+	t *testing.T,
+	srv *Handler,
+	storage *Storage,
+	clientID string,
+	w *httptest.ResponseRecorder,
+) *oauth21proto.MCPRefreshToken {
+	t.Helper()
+
+	var resp struct {
+		RefreshToken string `json:"refresh_token"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.NotEmpty(t, resp.RefreshToken)
+
+	code, err := srv.DecryptRefreshToken(resp.RefreshToken, clientID)
+	require.NoError(t, err)
+	record, err := storage.GetMCPRefreshToken(ctx, code.Id)
+	require.NoError(t, err)
+	return record
 }
 
 // mockAuthenticator implements identity.Authenticator for testing
@@ -1196,7 +1175,7 @@ func TestSessionUnmarshalerInRefresh(t *testing.T) {
 }
 
 // TestRefreshGrantSessionOwnership covers who owns the upstream refresh token chain for a
-// session created by the MCP token endpoint. With upstream refresh token rotation (e.g. Auth0),
+// session created by the MCP token endpoint. With upstream refresh token rotation (e.g. Okta, Auth0),
 // exchanging the same upstream token twice invalidates the whole token family, so the endpoint
 // must be the only component that exchanges it, and must exchange the newest one exactly once.
 func TestRefreshGrantSessionOwnership(t *testing.T) {
@@ -1238,32 +1217,8 @@ func TestRefreshGrantSessionOwnership(t *testing.T) {
 		}
 	}
 
-	t.Run("recreated session is not refreshable by the identity manager", func(t *testing.T) {
-		srv := newHandler(store, freshToken("rotated-upstream-token"))
-
-		newSession, _, err := srv.getOrRecreateSession(ctx, &oauth21proto.MCPRefreshToken{
-			Id:                   "ownership-refresh-disabled",
-			UserId:               "test-user-id",
-			ClientId:             clientID,
-			IdpId:                "test-idp",
-			UpstreamRefreshToken: "upstream-refresh-token",
-			IssuedAt:             timestamppb.Now(),
-			ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
-		})
-		require.NoError(t, err)
-
-		assert.True(t, newSession.RefreshDisabled,
-			"the identity manager must not refresh an MCP-owned session; it would rotate the upstream "+
-				"refresh token behind the MCP record's back and delete the session when that fails")
-
-		stored, _, err := store.GetSession(ctx, newSession.Id)
-		require.NoError(t, err)
-		assert.True(t, stored.RefreshDisabled, "RefreshDisabled must survive the round trip to the databroker")
-	})
-
 	t.Run("reuses the session referenced by the refresh token record", func(t *testing.T) {
 		liveSession := session.Create("test-idp", "ownership-live-session", "test-user-id", time.Now(), 14*time.Hour)
-		liveSession.RefreshDisabled = true
 		liveSession.OauthToken = &session.OAuthToken{
 			AccessToken:  "live-access-token",
 			RefreshToken: "live-upstream-token",
@@ -1298,11 +1253,9 @@ func TestRefreshGrantSessionOwnership(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Equal(t, liveSession.Id, got.Id,
-			"a grant against a still-valid session must reuse it rather than mint a new one")
-		assert.Zero(t, refreshCalls,
-			"reusing a valid session must not exchange the upstream refresh token; with rotation enabled "+
-				"every extra exchange invalidates the previous token for any concurrent grant")
+		assert.Equal(t, liveSession.Id, got.Id, "a valid session must be reused, not replaced")
+		// Every extra exchange invalidates the previous token for any concurrent grant.
+		assert.Zero(t, refreshCalls, "reusing a valid session must not exchange the upstream token")
 	})
 
 	t.Run("rotated refresh token record retains the session id", func(t *testing.T) {
@@ -1331,32 +1284,13 @@ func TestRefreshGrantSessionOwnership(t *testing.T) {
 		refreshToken, err := srv.CreateRefreshToken(record.Id, clientID, record.ExpiresAt.AsTime())
 		require.NoError(t, err)
 
-		form := url.Values{
-			"grant_type":    {"refresh_token"},
-			"refresh_token": {refreshToken},
-			"client_id":     {clientID},
-		}
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/token", strings.NewReader(form.Encode()))
-		require.NoError(t, err)
-		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-
-		w := httptest.NewRecorder()
-		srv.Token(w, req)
+		w := postTokenRefresh(ctx, t, srv, clientID, refreshToken)
 		require.Equal(t, http.StatusOK, w.Code, "response body: %s", w.Body.String())
 
-		var tokenResp struct {
-			RefreshToken string `json:"refresh_token"`
-		}
-		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &tokenResp))
-
-		rotatedCode, err := srv.DecryptRefreshToken(tokenResp.RefreshToken, clientID)
-		require.NoError(t, err)
-		rotated, err := store.GetMCPRefreshToken(ctx, rotatedCode.Id)
-		require.NoError(t, err)
-
-		assert.NotEmpty(t, rotated.InitiatingSessionId,
-			"rotation must carry SessionId forward; dropping it permanently disables the session lookup "+
-				"and pins every later grant to the stale upstream token stored on the record")
+		// Dropping the session id disables the session lookup for good, pinning every later
+		// grant to the upstream token stored on the record.
+		rotated := rotatedRecord(ctx, t, srv, store, clientID, w)
+		assert.NotEmpty(t, rotated.InitiatingSessionId, "rotation must carry the session id forward")
 	})
 
 	t.Run("transient databroker error does not fall back to a stale upstream token", func(t *testing.T) {
@@ -1391,10 +1325,9 @@ func TestRefreshGrantSessionOwnership(t *testing.T) {
 			ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
 		})
 
-		require.Error(t, err,
-			"a transient databroker error is not evidence that the record's upstream token is live; "+
-				"masking it and exchanging the stale token burns the token family")
-		assert.NotContains(t, presented, "stale-upstream-token",
-			"the stale token must not be presented upstream when the session lookup failed for an unknown reason")
+		// A lookup failure is not evidence that the record's token is still live; exchanging it
+		// on a guess burns the token family.
+		require.Error(t, err, "an unexpected databroker error must not be masked")
+		assert.NotContains(t, presented, "stale-upstream-token")
 	})
 }

--- a/internal/mcp/handler_token_test.go
+++ b/internal/mcp/handler_token_test.go
@@ -700,6 +700,142 @@ func TestRefreshTokenGrant(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, oldRecord.Revoked, "old refresh token should NOT be revoked when new token storage fails")
 	})
+
+	t.Run("session token rotation", func(t *testing.T) {
+		// A user logs in with a refreshable session (refresh_disabled = false). The
+		// identity manager independently refreshes that session, rotating the upstream
+		// refresh token held by the IdP. The upstream token recorded on the MCP refresh
+		// token at authorization time is now stale, so the MCP refresh grant must pick
+		// up the rotated token off the initiating session rather than replaying the
+		// stale one.
+		const (
+			idpID          = "session-rotation-idp"
+			userID         = "session-rotation-user-id"
+			loginToken     = "upstream-refresh-token-at-login"
+			managerToken   = "upstream-refresh-token-after-manager-refresh"
+			mcpGrantToken  = "upstream-refresh-token-after-mcp-grant"
+			loginSessionID = "session-rotation-session-id"
+		)
+
+		loginSession := session.Create(idpID, loginSessionID, userID, time.Now(), 14*time.Hour)
+		loginSession.RefreshDisabled = false
+		loginSession.OauthToken = &session.OAuthToken{
+			AccessToken:  "upstream-access-token-at-login",
+			TokenType:    "Bearer",
+			RefreshToken: loginToken,
+			ExpiresAt:    timestamppb.New(time.Now().Add(time.Hour)),
+		}
+		_, err := storage.PutSession(ctx, loginSession)
+		require.NoError(t, err)
+
+		refreshTokenRecord := &oauth21proto.MCPRefreshToken{
+			Id:                   "session-rotation-refresh-token-id",
+			UserId:               userID,
+			ClientId:             clientID,
+			IdpId:                idpID,
+			UpstreamRefreshToken: loginToken,
+			InitiatingSessionId:  loginSessionID,
+			IssuedAt:             timestamppb.Now(),
+			ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
+			Scopes:               []string{"openid"},
+		}
+		require.NoError(t, storage.PutMCPRefreshToken(ctx, refreshTokenRecord))
+
+		// Mirror what (*manager.Manager in `pkg/identity/manager`).refreshSession does to a refreshable session:
+		// exchange the session's upstream refresh token, write the rotated token back onto the session, and persist it.
+		var tokenSeenByManager string
+		managerAuth := &mockAuthenticator{
+			refreshFunc: func(_ context.Context, t *oauth2.Token, v identitystate.State) (*oauth2.Token, error) {
+				tokenSeenByManager = t.RefreshToken
+				v.SetRawIDToken("manager-id-token")
+				return &oauth2.Token{
+					AccessToken:  "upstream-access-token-after-manager-refresh",
+					RefreshToken: managerToken,
+					TokenType:    "Bearer",
+					// Already expired, so the grant below cannot reuse the session as-is and must
+					// exchange an upstream token. That is what puts the stale-vs-rotated choice
+					// under test; a session with a live access token is reused instead, which
+					// TestRefreshGrantSessionOwnership covers.
+					Expiry: time.Now().Add(-time.Minute),
+				}, nil
+			},
+		}
+		require.False(t, loginSession.GetRefreshDisabled(), "session must be refreshable")
+		newToken, err := managerAuth.Refresh(ctx,
+			manager.FromOAuthToken(loginSession.OauthToken),
+			manager.NewSessionUnmarshaler(loginSession))
+		require.NoError(t, err)
+		loginSession.OauthToken = manager.ToOAuthToken(newToken)
+		_, err = storage.PutSession(ctx, loginSession)
+		require.NoError(t, err)
+		assert.Equal(t, loginToken, tokenSeenByManager,
+			"identity manager should refresh using the session's login token")
+
+		// Now perform the MCP refresh grant. It must present the rotated token.
+		var tokenSeenByGrant string
+		mockAuth := &mockAuthenticator{
+			refreshFunc: func(_ context.Context, t *oauth2.Token, v identitystate.State) (*oauth2.Token, error) {
+				tokenSeenByGrant = t.RefreshToken
+				if t.RefreshToken != managerToken {
+					return nil, errors.New("stale upstream refresh token presented to IdP")
+				}
+				v.SetRawIDToken("mcp-id-token")
+				return &oauth2.Token{
+					AccessToken:  "upstream-access-token-after-mcp-grant",
+					RefreshToken: mcpGrantToken,
+					TokenType:    "Bearer",
+					Expiry:       time.Now().Add(time.Hour),
+				}, nil
+			},
+		}
+
+		srv := &Handler{
+			cipher:        testCipher,
+			storage:       storage,
+			sessionExpiry: 14 * time.Hour,
+			getAuthenticator: func(_ context.Context, _ string) (identity.Authenticator, error) {
+				return mockAuth, nil
+			},
+		}
+
+		refreshToken, err := srv.CreateRefreshToken(refreshTokenRecord.Id, clientID, refreshTokenRecord.ExpiresAt.AsTime())
+		require.NoError(t, err)
+
+		form := url.Values{
+			"grant_type":    {"refresh_token"},
+			"refresh_token": {refreshToken},
+			"client_id":     {clientID},
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/token", strings.NewReader(form.Encode()))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		w := httptest.NewRecorder()
+		srv.Token(w, req)
+
+		require.Equal(t, http.StatusOK, w.Code, "grant should succeed after external session refresh: %s", w.Body.String())
+		assert.Equal(t, managerToken, tokenSeenByGrant,
+			"grant should use the upstream token rotated onto the session by the identity manager")
+
+		var tokenResp map[string]any
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &tokenResp))
+		newRefreshToken, ok := tokenResp["refresh_token"].(string)
+		require.True(t, ok, "expected refresh_token in response")
+
+		// The rotated MCP refresh token must carry the newest upstream token forward.
+		code, err := srv.DecryptRefreshToken(newRefreshToken, clientID)
+		require.NoError(t, err)
+		newRecord, err := storage.GetMCPRefreshToken(ctx, code.Id)
+		require.NoError(t, err)
+		assert.Equal(t, mcpGrantToken, newRecord.UpstreamRefreshToken)
+		assert.Equal(t, loginSessionID, newRecord.InitiatingSessionId,
+			"rotation keeps pointing at the initiating login session")
+
+		oldRecord, err := storage.GetMCPRefreshToken(ctx, refreshTokenRecord.Id)
+		require.NoError(t, err)
+		assert.True(t, oldRecord.Revoked, "old refresh token should be revoked")
+
+	})
 }
 
 // mockAuthenticator implements identity.Authenticator for testing
@@ -760,6 +896,7 @@ var _ identity.Authenticator = (*mockAuthenticator)(nil)
 type mockStorage struct {
 	*Storage
 	putMCPRefreshTokenFunc func(ctx context.Context, token *oauth21proto.MCPRefreshToken) error
+	getSessionFunc         func(ctx context.Context, id string) (*session.Session, uint64, error)
 }
 
 func (m *mockStorage) PutMCPRefreshToken(ctx context.Context, token *oauth21proto.MCPRefreshToken) error {
@@ -767,6 +904,13 @@ func (m *mockStorage) PutMCPRefreshToken(ctx context.Context, token *oauth21prot
 		return m.putMCPRefreshTokenFunc(ctx, token)
 	}
 	return m.Storage.PutMCPRefreshToken(ctx, token)
+}
+
+func (m *mockStorage) GetSession(ctx context.Context, id string) (*session.Session, uint64, error) {
+	if m.getSessionFunc != nil {
+		return m.getSessionFunc(ctx, id)
+	}
+	return m.Storage.GetSession(ctx, id)
 }
 
 func TestGetOrRecreateSession(t *testing.T) {
@@ -1049,4 +1193,208 @@ func TestSessionUnmarshalerInRefresh(t *testing.T) {
 
 	// Note: With a valid JWT, the ID token would be parsed and set on the session.
 	// See pkg/identity/manager/data_test.go TestSession_RefreshUpdate for an example with a valid JWT.
+}
+
+// TestRefreshGrantSessionOwnership covers who owns the upstream refresh token chain for a
+// session created by the MCP token endpoint. With upstream refresh token rotation (e.g. Auth0),
+// exchanging the same upstream token twice invalidates the whole token family, so the endpoint
+// must be the only component that exchanges it, and must exchange the newest one exactly once.
+func TestRefreshGrantSessionOwnership(t *testing.T) {
+	ctx := context.Background()
+	store := setupTestDatabroker(ctx, t)
+
+	key := cryptutil.NewKey()
+	testCipher, err := cryptutil.NewAEADCipher(key)
+	require.NoError(t, err)
+
+	clientID, err := store.RegisterClient(ctx, &rfc7591v1.ClientRegistration{
+		ResponseMetadata: &rfc7591v1.Metadata{
+			TokenEndpointAuthMethod: new("none"),
+		},
+	})
+	require.NoError(t, err)
+
+	newHandler := func(s HandlerStorage, auth identity.Authenticator) *Handler {
+		return &Handler{
+			cipher:        testCipher,
+			storage:       s,
+			sessionExpiry: 14 * time.Hour,
+			getAuthenticator: func(_ context.Context, _ string) (identity.Authenticator, error) {
+				return auth, nil
+			},
+		}
+	}
+
+	freshToken := func(refresh string) *mockAuthenticator {
+		return &mockAuthenticator{
+			refreshFunc: func(_ context.Context, _ *oauth2.Token, _ identitystate.State) (*oauth2.Token, error) {
+				return &oauth2.Token{
+					AccessToken:  "fresh-access-token",
+					RefreshToken: refresh,
+					TokenType:    "Bearer",
+					Expiry:       time.Now().Add(time.Hour),
+				}, nil
+			},
+		}
+	}
+
+	t.Run("recreated session is not refreshable by the identity manager", func(t *testing.T) {
+		srv := newHandler(store, freshToken("rotated-upstream-token"))
+
+		newSession, _, err := srv.getOrRecreateSession(ctx, &oauth21proto.MCPRefreshToken{
+			Id:                   "ownership-refresh-disabled",
+			UserId:               "test-user-id",
+			ClientId:             clientID,
+			IdpId:                "test-idp",
+			UpstreamRefreshToken: "upstream-refresh-token",
+			IssuedAt:             timestamppb.Now(),
+			ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
+		})
+		require.NoError(t, err)
+
+		assert.True(t, newSession.RefreshDisabled,
+			"the identity manager must not refresh an MCP-owned session; it would rotate the upstream "+
+				"refresh token behind the MCP record's back and delete the session when that fails")
+
+		stored, _, err := store.GetSession(ctx, newSession.Id)
+		require.NoError(t, err)
+		assert.True(t, stored.RefreshDisabled, "RefreshDisabled must survive the round trip to the databroker")
+	})
+
+	t.Run("reuses the session referenced by the refresh token record", func(t *testing.T) {
+		liveSession := session.Create("test-idp", "ownership-live-session", "test-user-id", time.Now(), 14*time.Hour)
+		liveSession.RefreshDisabled = true
+		liveSession.OauthToken = &session.OAuthToken{
+			AccessToken:  "live-access-token",
+			RefreshToken: "live-upstream-token",
+			ExpiresAt:    timestamppb.New(time.Now().Add(time.Hour)),
+		}
+		_, err := store.PutSession(ctx, liveSession)
+		require.NoError(t, err)
+
+		refreshCalls := 0
+		auth := &mockAuthenticator{
+			refreshFunc: func(_ context.Context, _ *oauth2.Token, _ identitystate.State) (*oauth2.Token, error) {
+				refreshCalls++
+				return &oauth2.Token{
+					AccessToken:  "fresh-access-token",
+					RefreshToken: "rotated-upstream-token",
+					TokenType:    "Bearer",
+					Expiry:       time.Now().Add(time.Hour),
+				}, nil
+			},
+		}
+		srv := newHandler(store, auth)
+
+		got, _, err := srv.getOrRecreateSession(ctx, &oauth21proto.MCPRefreshToken{
+			Id:                   "ownership-reuse",
+			UserId:               "test-user-id",
+			ClientId:             clientID,
+			IdpId:                "test-idp",
+			UpstreamRefreshToken: "live-upstream-token",
+			InitiatingSessionId:  liveSession.Id,
+			IssuedAt:             timestamppb.Now(),
+			ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, liveSession.Id, got.Id,
+			"a grant against a still-valid session must reuse it rather than mint a new one")
+		assert.Zero(t, refreshCalls,
+			"reusing a valid session must not exchange the upstream refresh token; with rotation enabled "+
+				"every extra exchange invalidates the previous token for any concurrent grant")
+	})
+
+	t.Run("rotated refresh token record retains the session id", func(t *testing.T) {
+		sess := session.Create("test-idp", "ownership-rotation-session", "test-user-id", time.Now(), 14*time.Hour)
+		sess.OauthToken = &session.OAuthToken{
+			AccessToken:  "access-token",
+			RefreshToken: "upstream-token-v1",
+			ExpiresAt:    timestamppb.New(time.Now().Add(-time.Minute)),
+		}
+		_, err := store.PutSession(ctx, sess)
+		require.NoError(t, err)
+
+		record := &oauth21proto.MCPRefreshToken{
+			Id:                   "ownership-rotation",
+			UserId:               "test-user-id",
+			ClientId:             clientID,
+			IdpId:                "test-idp",
+			UpstreamRefreshToken: "upstream-token-v1",
+			InitiatingSessionId:  sess.Id,
+			IssuedAt:             timestamppb.Now(),
+			ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
+		}
+		require.NoError(t, store.PutMCPRefreshToken(ctx, record))
+
+		srv := newHandler(store, freshToken("upstream-token-v2"))
+		refreshToken, err := srv.CreateRefreshToken(record.Id, clientID, record.ExpiresAt.AsTime())
+		require.NoError(t, err)
+
+		form := url.Values{
+			"grant_type":    {"refresh_token"},
+			"refresh_token": {refreshToken},
+			"client_id":     {clientID},
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/token", strings.NewReader(form.Encode()))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+		w := httptest.NewRecorder()
+		srv.Token(w, req)
+		require.Equal(t, http.StatusOK, w.Code, "response body: %s", w.Body.String())
+
+		var tokenResp struct {
+			RefreshToken string `json:"refresh_token"`
+		}
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &tokenResp))
+
+		rotatedCode, err := srv.DecryptRefreshToken(tokenResp.RefreshToken, clientID)
+		require.NoError(t, err)
+		rotated, err := store.GetMCPRefreshToken(ctx, rotatedCode.Id)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, rotated.InitiatingSessionId,
+			"rotation must carry SessionId forward; dropping it permanently disables the session lookup "+
+				"and pins every later grant to the stale upstream token stored on the record")
+	})
+
+	t.Run("transient databroker error does not fall back to a stale upstream token", func(t *testing.T) {
+		var presented []string
+		auth := &mockAuthenticator{
+			refreshFunc: func(_ context.Context, tok *oauth2.Token, _ identitystate.State) (*oauth2.Token, error) {
+				presented = append(presented, tok.RefreshToken)
+				return &oauth2.Token{
+					AccessToken:  "fresh-access-token",
+					RefreshToken: "rotated-upstream-token",
+					TokenType:    "Bearer",
+					Expiry:       time.Now().Add(time.Hour),
+				}, nil
+			},
+		}
+		mockStore := &mockStorage{
+			Storage: store,
+			getSessionFunc: func(_ context.Context, _ string) (*session.Session, uint64, error) {
+				return nil, 0, errors.New("databroker unavailable")
+			},
+		}
+		srv := newHandler(mockStore, auth)
+
+		_, _, err := srv.getOrRecreateSession(ctx, &oauth21proto.MCPRefreshToken{
+			Id:                   "ownership-transient",
+			UserId:               "test-user-id",
+			ClientId:             clientID,
+			IdpId:                "test-idp",
+			UpstreamRefreshToken: "stale-upstream-token",
+			InitiatingSessionId:  "ownership-unreachable-session",
+			IssuedAt:             timestamppb.Now(),
+			ExpiresAt:            timestamppb.New(time.Now().Add(RefreshTokenTTL)),
+		})
+
+		require.Error(t, err,
+			"a transient databroker error is not evidence that the record's upstream token is live; "+
+				"masking it and exchanging the stale token burns the token family")
+		assert.NotContains(t, presented, "stale-upstream-token",
+			"the stale token must not be presented upstream when the session lookup failed for an unknown reason")
+	})
 }

--- a/internal/mcp/storage_syncer.go
+++ b/internal/mcp/storage_syncer.go
@@ -2,18 +2,23 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/structpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	"github.com/pomerium/pomerium/internal/log"
 	oauth21 "github.com/pomerium/pomerium/internal/oauth21/gen"
 	"github.com/pomerium/pomerium/pkg/databrokerutil"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/protoutil"
+	"github.com/pomerium/pomerium/pkg/slices"
 )
 
 const (
@@ -21,35 +26,16 @@ const (
 	defaultRefreshTokenCleanupGracePeriod = time.Minute * 15
 )
 
+var ErrNoMCPToken = errors.New("session has no matching mcp token")
+
 type RefreshTokenMd struct {
 	Revoked   bool
 	RevokedAt time.Time
 	ExpiresAt time.Time
 }
 
-type StorageSyncer struct {
-	clientB databroker.ClientGetter
-	records map[string]*RefreshTokenMd
-	StorageSyncerOptions
-
-	mu sync.RWMutex
-}
-
 type StorageSyncerOptions struct {
-	// how often to cleanup refresh tokens
-	cleanupInterval time.Duration
-	// the grace period after which to clean up a token once it has been revoked
-	cleanupGracePeriodDuration time.Duration
-	// allows for fake clock tests
-	now func() time.Time
-}
-
-func defaultStorageSyncerOptions() *StorageSyncerOptions {
-	return &StorageSyncerOptions{
-		cleanupInterval:            defaultRefreshTokenCleanupInterval,
-		cleanupGracePeriodDuration: defaultRefreshTokenCleanupGracePeriod,
-		now:                        time.Now,
-	}
+	tokenOpts []TokenExpirationSyncerOption
 }
 
 func (o *StorageSyncerOptions) Apply(opts ...StorageSyncerOption) {
@@ -58,37 +44,107 @@ func (o *StorageSyncerOptions) Apply(opts ...StorageSyncerOption) {
 	}
 }
 
-type StorageSyncerOption func(*StorageSyncerOptions)
+type StorageSyncerOption func(o *StorageSyncerOptions)
 
-func WithCleanupInterval(d time.Duration) StorageSyncerOption {
-	return func(o *StorageSyncerOptions) { o.cleanupInterval = d }
+func WithTokenExpirationSyncerOption(opt TokenExpirationSyncerOption) StorageSyncerOption {
+	return func(o *StorageSyncerOptions) {
+		o.tokenOpts = append(o.tokenOpts, opt)
+	}
 }
 
-func WithCleanupGracePeriod(d time.Duration) StorageSyncerOption {
-	return func(o *StorageSyncerOptions) { o.cleanupGracePeriodDuration = d }
-}
-
-func WithClock(now func() time.Time) StorageSyncerOption {
-	return func(o *StorageSyncerOptions) { o.now = now }
+type StorageSyncer struct {
+	tokenExpiration    *tokenExpirationSyncer
+	sessionTokenSyncer *sessionTokenSyncer
 }
 
 func NewStorageSyncer(
 	clientB databroker.ClientGetter,
 	opts ...StorageSyncerOption,
 ) *StorageSyncer {
-	options := defaultStorageSyncerOptions()
+	options := &StorageSyncerOptions{
+		tokenOpts: []TokenExpirationSyncerOption{},
+	}
 	options.Apply(opts...)
-
 	return &StorageSyncer{
-		clientB:              clientB,
-		records:              map[string]*RefreshTokenMd{},
-		StorageSyncerOptions: *options,
+		tokenExpiration:    newTokenExpirationSyncer(clientB, options.tokenOpts...),
+		sessionTokenSyncer: newSessionTokenSyncer(clientB),
 	}
 }
 
-var _ databrokerutil.SyncerHandler = (*StorageSyncer)(nil)
-
 func (s *StorageSyncer) Run(ctx context.Context) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return s.tokenExpiration.Run(ctx)
+	})
+	eg.Go(func() error {
+		return s.sessionTokenSyncer.Run(ctx)
+	})
+
+	return eg.Wait()
+}
+
+func newTokenExpirationSyncer(
+	clientB databroker.ClientGetter,
+	opts ...TokenExpirationSyncerOption,
+) *tokenExpirationSyncer {
+	options := defaultTokenExpirationSyncerOptions()
+	options.Apply(opts...)
+	return &tokenExpirationSyncer{
+		clientB:                      clientB,
+		records:                      map[string]*RefreshTokenMd{},
+		mu:                           sync.RWMutex{},
+		TokenExpirationSyncerOptions: *options,
+	}
+}
+
+type tokenExpirationSyncer struct {
+	clientB databroker.ClientGetter
+	records map[string]*RefreshTokenMd
+	TokenExpirationSyncerOptions
+
+	mu sync.RWMutex
+}
+
+type TokenExpirationSyncerOptions struct {
+	// how often to cleanup refresh tokens
+	cleanupInterval time.Duration
+	// the grace period after which to clean up a token once it has been revoked
+	cleanupGracePeriodDuration time.Duration
+	// allows for fake clock tests
+	now func() time.Time
+}
+
+func defaultTokenExpirationSyncerOptions() *TokenExpirationSyncerOptions {
+	return &TokenExpirationSyncerOptions{
+		cleanupInterval:            defaultRefreshTokenCleanupInterval,
+		cleanupGracePeriodDuration: defaultRefreshTokenCleanupGracePeriod,
+		now:                        time.Now,
+	}
+}
+
+func (o *TokenExpirationSyncerOptions) Apply(opts ...TokenExpirationSyncerOption) {
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+type TokenExpirationSyncerOption func(*TokenExpirationSyncerOptions)
+
+func WithCleanupInterval(d time.Duration) TokenExpirationSyncerOption {
+	return func(o *TokenExpirationSyncerOptions) { o.cleanupInterval = d }
+}
+
+func WithCleanupGracePeriod(d time.Duration) TokenExpirationSyncerOption {
+	return func(o *TokenExpirationSyncerOptions) { o.cleanupGracePeriodDuration = d }
+}
+
+func WithClock(now func() time.Time) TokenExpirationSyncerOption {
+	return func(o *TokenExpirationSyncerOptions) { o.now = now }
+}
+
+var _ databrokerutil.SyncerHandler = (*tokenExpirationSyncer)(nil)
+
+func (s *tokenExpirationSyncer) Run(ctx context.Context) error {
 	eg, ctx := errgroup.WithContext(ctx)
 	eg.Go(func() error {
 		return databrokerutil.NewSyncer(
@@ -106,17 +162,17 @@ func (s *StorageSyncer) Run(ctx context.Context) error {
 	return eg.Wait()
 }
 
-func (s *StorageSyncer) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+func (s *tokenExpirationSyncer) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
 	return s.clientB.GetDataBrokerServiceClient()
 }
 
-func (s *StorageSyncer) ClearRecords(_ context.Context) {
+func (s *tokenExpirationSyncer) ClearRecords(_ context.Context) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.records = map[string]*RefreshTokenMd{}
 }
 
-func (s *StorageSyncer) UpdateRecords(ctx context.Context, _ uint64, records []*databroker.Record) {
+func (s *tokenExpirationSyncer) UpdateRecords(ctx context.Context, _ uint64, records []*databroker.Record) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -160,7 +216,7 @@ func (s *StorageSyncer) UpdateRecords(ctx context.Context, _ uint64, records []*
 }
 
 // RunCleanUp periodically deletes revoked and expired refresh tokens until ctx is done.
-func (s *StorageSyncer) RunCleanUp(ctx context.Context) error {
+func (s *tokenExpirationSyncer) RunCleanUp(ctx context.Context) error {
 	t := time.NewTicker(s.cleanupInterval)
 	defer t.Stop()
 	for {
@@ -176,7 +232,7 @@ func (s *StorageSyncer) RunCleanUp(ctx context.Context) error {
 }
 
 // expired reports whether the record is eligible for deletion.
-func (s *StorageSyncer) expired(md *RefreshTokenMd, now time.Time) bool {
+func (s *tokenExpirationSyncer) expired(md *RefreshTokenMd, now time.Time) bool {
 	if md.Revoked && md.RevokedAt.Add(s.cleanupGracePeriodDuration).Before(now) {
 		return true
 	}
@@ -184,7 +240,7 @@ func (s *StorageSyncer) expired(md *RefreshTokenMd, now time.Time) bool {
 	return md.ExpiresAt.Add(s.cleanupGracePeriodDuration).Before(now)
 }
 
-func (s *StorageSyncer) batchCleanUp(ctx context.Context) error {
+func (s *tokenExpirationSyncer) batchCleanUp(ctx context.Context) error {
 	now := s.now()
 
 	s.mu.RLock()
@@ -220,4 +276,150 @@ func (s *StorageSyncer) batchCleanUp(ctx context.Context) error {
 		Int("count", len(ids)).
 		Msg("mcp: deleted expired refresh tokens")
 	return nil
+}
+
+type sessionTokenSyncer struct {
+	clientB databroker.ClientGetter
+}
+
+func newSessionTokenSyncer(clientB databroker.ClientGetter) *sessionTokenSyncer {
+	return &sessionTokenSyncer{
+		clientB: clientB,
+	}
+}
+
+var _ databrokerutil.SyncerHandler = (*sessionTokenSyncer)(nil)
+
+func (s *sessionTokenSyncer) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	return s.clientB.GetDataBrokerServiceClient()
+}
+func (s *sessionTokenSyncer) ClearRecords(_ context.Context) {}
+
+func (s *sessionTokenSyncer) queryMcpRefreshTokens(ctx context.Context, sessionID string) (*oauth21.MCPRefreshToken, error) {
+	b := backoff.NewConstantBackOff(time.Second)
+	mostRecent, err := backoff.RetryWithData(func() (*oauth21.MCPRefreshToken, error) {
+		mcpRefreshTokens, err := s.clientB.GetDataBrokerServiceClient().
+			Query(ctx, &databroker.QueryRequest{
+				Type:   "type.googleapis.com/oauth21.MCPRefreshToken",
+				Filter: indexedFieldFilter("initiating_session_id", sessionID),
+				Limit:  50,
+			})
+		if err != nil {
+			return nil, err
+		}
+		return mostRecentUsableRefreshToken(ctx, mcpRefreshTokens.GetRecords(), time.Now())
+	}, backoff.WithMaxRetries(backoff.WithContext(b, ctx), 3))
+	return mostRecent, err
+}
+
+func (s *sessionTokenSyncer) UpdateRecords(ctx context.Context, _ uint64, records []*databroker.Record) {
+	for _, rec := range records {
+		sessionID := rec.GetId()
+		if rec.GetDeletedAt() != nil {
+			continue
+		}
+		sessionProto := new(session.Session)
+		if err := rec.GetData().UnmarshalTo(sessionProto); err != nil {
+			log.Ctx(ctx).Error().Err(err).
+				Str("record-id", sessionID).
+				Msg("mcp: failed to unmarshal session record")
+			continue
+		}
+		if sessionProto.GetOauthToken().GetRefreshToken() == "" {
+			continue
+		}
+		mostRecent, err := s.queryMcpRefreshTokens(ctx, sessionID)
+		if err != nil {
+			if errors.Is(err, ErrNoMCPToken) {
+				log.Ctx(ctx).Debug().Str("session-id", sessionID).Msg("mcp : session does not have a matching mcp refresh token")
+			} else {
+				log.Ctx(ctx).Err(err).Str("session-id", sessionID).Msg("mcp: failed to fetch matching mcp upstream records for session")
+			}
+		}
+		if errors.Is(err, ErrNoMCPToken) {
+			continue
+		} else if err != nil {
+			continue
+		}
+		// TODO : are there some cases here where this is undesirable?
+		if mostRecent.UpstreamRefreshToken != sessionProto.GetOauthToken().RefreshToken {
+			mostRecent.UpstreamRefreshToken = sessionProto.GetOauthToken().RefreshToken
+			_, err := s.clientB.GetDataBrokerServiceClient().Put(
+				ctx,
+				&databroker.PutRequest{
+					Records: []*databroker.Record{
+						databroker.NewRecord(mostRecent),
+					},
+				},
+			)
+			if err != nil {
+				log.Ctx(ctx).Err(err).Msg("failed to refresh mcp refresh token from session")
+			}
+		}
+	}
+}
+
+// falls back to the most recently modified token when none are usable.
+// assumes len(records) > 0.
+func mostRecentUsableRefreshToken(
+	ctx context.Context,
+	records []*databroker.Record,
+	now time.Time,
+) (*oauth21.MCPRefreshToken, error) {
+	records = slices.Filter(records, func(d *databroker.Record) bool {
+		return d.GetDeletedAt() == nil
+	})
+
+	if len(records) == 0 {
+		return nil, backoff.Permanent(ErrNoMCPToken)
+	}
+
+	var bestValid, bestAny *oauth21.MCPRefreshToken
+	var bestValidAt, bestAnyAt time.Time
+
+	for _, rec := range records {
+		token := new(oauth21.MCPRefreshToken)
+		if err := rec.GetData().UnmarshalTo(token); err != nil {
+			log.Ctx(ctx).Error().Err(err).
+				Str("record-id", rec.GetId()).
+				Msg("mcp: failed to unmarshal refresh token record")
+			continue
+		}
+
+		modifiedAt := rec.GetModifiedAt().AsTime()
+		if bestAny == nil || modifiedAt.After(bestAnyAt) {
+			bestAny, bestAnyAt = token, modifiedAt
+		}
+		if token.GetRevoked() || !token.GetExpiresAt().AsTime().After(now) {
+			continue
+		}
+		if bestValid == nil || modifiedAt.After(bestValidAt) {
+			bestValid, bestValidAt = token, modifiedAt
+		}
+	}
+
+	if bestValid != nil {
+		return bestValid, nil
+	}
+	return bestAny, nil
+}
+
+func indexedFieldFilter(field, value string) (filter *structpb.Struct) {
+	filter, _ = structpb.NewStruct(map[string]any{
+		field: map[string]any{
+			"$eq": value,
+		},
+	})
+	return
+}
+
+func (s *sessionTokenSyncer) Run(ctx context.Context) error {
+	syncer := databrokerutil.NewSyncer(
+		ctx,
+		"mcp-session-token-syncer",
+		s,
+		databrokerutil.WithTypeURL("type.googleapis.com/session.Session"),
+		databrokerutil.WithFastForward(),
+	)
+	return syncer.Run(ctx)
 }

--- a/internal/mcp/storage_syncer_test.go
+++ b/internal/mcp/storage_syncer_test.go
@@ -19,17 +19,18 @@ import (
 	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/pkg/databrokerutil"
 	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
 var syncerTestBase = time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
 
-func TestStorageSyncerClearRecords(t *testing.T) {
+func TestTokenExpirationSyncerClearRecords(t *testing.T) {
 	t.Parallel()
 
 	ctx := testutil.GetContext(t, time.Minute)
 	client := newTestDataBrokerClient(t)
-	s := newTestStorageSyncer(t, client, &fakeClock{t: syncerTestBase})
+	s := newTestTokenExpirationSyncer(t, client, &fakeClock{t: syncerTestBase})
 	s.records["a"] = &RefreshTokenMd{}
 
 	s.ClearRecords(ctx)
@@ -37,7 +38,7 @@ func TestStorageSyncerClearRecords(t *testing.T) {
 	assert.Empty(t, s.records)
 }
 
-func TestStorageSyncerCleanUp(t *testing.T) {
+func TestTokenExpirationSyncerCleanUp(t *testing.T) {
 	t.Parallel()
 
 	const grace = time.Hour
@@ -122,7 +123,7 @@ func TestStorageSyncerCleanUp(t *testing.T) {
 			client := newTestDataBrokerClient(t)
 			storage := NewStorage(client)
 			clock := &fakeClock{t: syncerTestBase}
-			s := newTestStorageSyncer(t, client, clock, WithCleanupGracePeriod(grace),
+			s := newTestTokenExpirationSyncer(t, client, clock, WithCleanupGracePeriod(grace),
 				WithCleanupInterval(10*time.Millisecond))
 
 			tracked := func() []string {
@@ -170,17 +171,358 @@ func TestStorageSyncerCleanUp(t *testing.T) {
 	}
 }
 
-func TestStorageSyncerRunCleanUpStopsOnContextCancel(t *testing.T) {
+func TestTokenExpirationSyncerRunCleanUpStopsOnContextCancel(t *testing.T) {
 	t.Parallel()
 
 	client := newTestDataBrokerClient(t)
-	s := newTestStorageSyncer(t, client, &fakeClock{t: syncerTestBase})
+	s := newTestTokenExpirationSyncer(t, client, &fakeClock{t: syncerTestBase})
 	s.cleanupInterval = time.Hour
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
 	require.ErrorIs(t, s.RunCleanUp(ctx), context.Canceled)
+}
+
+func TestMostRecentUsableRefreshToken(t *testing.T) {
+	t.Parallel()
+
+	type testRecord struct {
+		id string
+		// modifiedIn is the record's modification time relative to the start of the test
+		modifiedIn time.Duration
+		// expiresIn is the token lifetime relative to the start of the test
+		expiresIn *time.Duration
+		revoked   bool
+		deleted   bool
+	}
+
+	dur := func(d time.Duration) *time.Duration { return &d }
+
+	type testcase struct {
+		name    string
+		records []testRecord
+		// wantID is the id of the expected token, empty means nil.
+		wantID  string
+		wantErr error
+	}
+
+	for _, tc := range []testcase{
+		{
+			name:    "single valid token",
+			records: []testRecord{{id: "a", expiresIn: dur(time.Hour)}},
+			wantID:  "a",
+		},
+		{
+			name: "most recently modified valid token wins",
+			records: []testRecord{
+				{id: "old", modifiedIn: -2 * time.Hour, expiresIn: dur(time.Hour)},
+				{id: "new", modifiedIn: -time.Minute, expiresIn: dur(time.Hour)},
+				{id: "middle", modifiedIn: -time.Hour, expiresIn: dur(time.Hour)},
+			},
+			wantID: "new",
+		},
+		{
+			name: "a newer unusable token does not beat an older valid one",
+			records: []testRecord{
+				{id: "valid", modifiedIn: -time.Hour, expiresIn: dur(time.Hour)},
+				{id: "revoked", modifiedIn: -time.Minute, expiresIn: dur(time.Hour), revoked: true},
+				{id: "expired", modifiedIn: -time.Second, expiresIn: dur(-time.Minute)},
+			},
+			wantID: "valid",
+		},
+		{
+			name: "falls back to the most recently modified when none are usable",
+			records: []testRecord{
+				{id: "revoked", modifiedIn: -time.Hour, expiresIn: dur(time.Hour), revoked: true},
+				{id: "expired", modifiedIn: -time.Minute, expiresIn: dur(-time.Minute)},
+			},
+			wantID: "expired",
+		},
+		{
+			name:    "token without an expiry is not usable",
+			records: []testRecord{{id: "a"}},
+			wantID:  "a",
+		},
+		{
+			name: "deleted records are ignored",
+			records: []testRecord{
+				{id: "deleted", modifiedIn: -time.Minute, expiresIn: dur(time.Hour), deleted: true},
+				{id: "a", modifiedIn: -time.Hour, expiresIn: dur(time.Hour)},
+			},
+			wantID: "a",
+		},
+		{
+			name:    "all records deleted",
+			records: []testRecord{{id: "a", expiresIn: dur(time.Hour), deleted: true}},
+			wantErr: ErrNoMCPToken,
+		},
+		{
+			name: "token expiring exactly now is not usable",
+			records: []testRecord{
+				{id: "boundary", modifiedIn: -time.Minute, expiresIn: dur(0)},
+				{id: "valid", modifiedIn: -time.Hour, expiresIn: dur(time.Hour)},
+			},
+			wantID: "valid",
+		},
+		{
+			name: "all tokens revoked or expired falls back to the newest",
+			records: []testRecord{
+				{id: "revoked-old", modifiedIn: -3 * time.Hour, expiresIn: dur(time.Hour), revoked: true},
+				{id: "expired-newest", modifiedIn: -time.Minute, expiresIn: dur(-time.Hour)},
+				{id: "no-expiry", modifiedIn: -2 * time.Hour},
+				{id: "revoked-and-expired", modifiedIn: -time.Hour, expiresIn: dur(-time.Minute), revoked: true},
+			},
+			wantID: "expired-newest",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.GetContext(t, time.Minute)
+
+			var records []*databrokerpb.Record
+			for _, r := range tc.records {
+				token := &oauth21.MCPRefreshToken{Id: r.id, Revoked: r.revoked}
+				if r.expiresIn != nil {
+					token.ExpiresAt = timestamppb.New(syncerTestBase.Add(*r.expiresIn))
+				}
+				rec := &databrokerpb.Record{
+					Id:         r.id,
+					Data:       protoutil.NewAny(token),
+					ModifiedAt: timestamppb.New(syncerTestBase.Add(r.modifiedIn)),
+				}
+				if r.deleted {
+					rec.DeletedAt = timestamppb.New(syncerTestBase)
+				}
+				records = append(records, rec)
+			}
+
+			got, err := mostRecentUsableRefreshToken(ctx, records, syncerTestBase)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr, tc.name)
+				assert.Nil(t, got, tc.name)
+				return
+			}
+			require.NoError(t, err, tc.name)
+			require.NotNil(t, got, tc.name)
+			assert.Equal(t, tc.wantID, got.GetId(), tc.name)
+		})
+	}
+}
+
+func TestSessionTokenSyncer(t *testing.T) {
+	t.Parallel()
+
+	type testSession struct {
+		id              string
+		accessToken     string
+		refreshToken    string
+		expiresIn       *time.Duration
+		refreshDisabled bool
+		deleted         bool
+	}
+
+	type testToken struct {
+		id                   string
+		initiatingSessionID  string
+		upstreamRefreshToken string
+		// expiresIn is the token lifetime relative to now
+		expiresIn *time.Duration
+		revoked   bool
+	}
+
+	dur := func(d time.Duration) *time.Duration { return &d }
+
+	type testcase struct {
+		name     string
+		sessions []testSession
+		tokens   []testToken
+		// wantUpstream maps a token id to the upstream refresh token it should end up with.
+		wantUpstream map[string]string
+	}
+
+	for _, tc := range []testcase{
+		{
+			name: "stale upstream refresh token is updated from the session",
+			sessions: []testSession{
+				{id: "s1", accessToken: "at", refreshToken: "new-upstream", expiresIn: dur(time.Hour)},
+			},
+			tokens: []testToken{
+				{id: "t1", initiatingSessionID: "s1", upstreamRefreshToken: "old-upstream", expiresIn: dur(time.Hour)},
+			},
+			wantUpstream: map[string]string{"t1": "new-upstream"},
+		},
+		{
+			name: "only the token for the matching session is updated",
+			sessions: []testSession{
+				{id: "s1", accessToken: "at", refreshToken: "new-upstream", expiresIn: dur(time.Hour)},
+			},
+			tokens: []testToken{
+				{id: "t1", initiatingSessionID: "s1", upstreamRefreshToken: "old-upstream", expiresIn: dur(time.Hour)},
+				{id: "t2", initiatingSessionID: "other", upstreamRefreshToken: "untouched", expiresIn: dur(time.Hour)},
+			},
+			wantUpstream: map[string]string{"t1": "new-upstream", "t2": "untouched"},
+		},
+		{
+			name: "the most recently written usable token for the session is updated",
+			sessions: []testSession{
+				{id: "s1", accessToken: "at", refreshToken: "new-upstream", expiresIn: dur(time.Hour)},
+			},
+			tokens: []testToken{
+				{id: "expired", initiatingSessionID: "s1", upstreamRefreshToken: "stale-expired", expiresIn: dur(-time.Hour)},
+				{id: "revoked", initiatingSessionID: "s1", upstreamRefreshToken: "stale-revoked", expiresIn: dur(time.Hour), revoked: true},
+				{id: "valid", initiatingSessionID: "s1", upstreamRefreshToken: "old-upstream", expiresIn: dur(time.Hour)},
+			},
+			wantUpstream: map[string]string{
+				"expired": "stale-expired",
+				"revoked": "stale-revoked",
+				"valid":   "new-upstream",
+			},
+		},
+		{
+			// The identity manager's last refresh lands after the session has expired, and it is
+			// the one that rotates the upstream token at the IdP, so it must still propagate.
+			name: "expired session still propagates its upstream refresh token",
+			sessions: []testSession{
+				{id: "s1", accessToken: "at", refreshToken: "new-upstream", expiresIn: dur(-time.Hour)},
+			},
+			tokens: []testToken{
+				{id: "t1", initiatingSessionID: "s1", upstreamRefreshToken: "old-upstream", expiresIn: dur(time.Hour)},
+			},
+			wantUpstream: map[string]string{"t1": "new-upstream"},
+		},
+		{
+			name: "session with refresh disabled still propagates its upstream refresh token",
+			sessions: []testSession{
+				{id: "s1", accessToken: "at", refreshToken: "new-upstream", expiresIn: dur(time.Hour), refreshDisabled: true},
+			},
+			tokens: []testToken{
+				{id: "t1", initiatingSessionID: "s1", upstreamRefreshToken: "old-upstream", expiresIn: dur(time.Hour)},
+			},
+			wantUpstream: map[string]string{"t1": "new-upstream"},
+		},
+		{
+			name: "session without an upstream refresh token is skipped",
+			sessions: []testSession{
+				{id: "s1", accessToken: "at", expiresIn: dur(time.Hour)},
+			},
+			tokens: []testToken{
+				{id: "t1", initiatingSessionID: "s1", upstreamRefreshToken: "old-upstream", expiresIn: dur(time.Hour)},
+			},
+			wantUpstream: map[string]string{"t1": "old-upstream"},
+		},
+		{
+			name: "a deleted session does not blank the stored upstream refresh token",
+			sessions: []testSession{
+				{id: "s1", accessToken: "at", refreshToken: "new-upstream", expiresIn: dur(time.Hour), deleted: true},
+			},
+			tokens: []testToken{
+				{id: "t1", initiatingSessionID: "s1", upstreamRefreshToken: "old-upstream", expiresIn: dur(time.Hour)},
+			},
+			wantUpstream: map[string]string{"t1": "old-upstream"},
+		},
+		{
+			name: "session without a matching token is a no-op",
+			sessions: []testSession{
+				{id: "s1", accessToken: "at", refreshToken: "new-upstream", expiresIn: dur(time.Hour)},
+			},
+			tokens: []testToken{
+				{id: "t1", initiatingSessionID: "other", upstreamRefreshToken: "untouched", expiresIn: dur(time.Hour)},
+			},
+			wantUpstream: map[string]string{"t1": "untouched"},
+		},
+		{
+			name: "an already matching token is left alone",
+			sessions: []testSession{
+				{id: "s1", accessToken: "at", refreshToken: "same-upstream", expiresIn: dur(time.Hour)},
+			},
+			tokens: []testToken{
+				{id: "t1", initiatingSessionID: "s1", upstreamRefreshToken: "same-upstream", expiresIn: dur(time.Hour)},
+			},
+			wantUpstream: map[string]string{"t1": "same-upstream"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.GetContext(t, time.Minute)
+			client := newTestDataBrokerClient(t)
+			storage := NewStorage(client)
+			now := time.Now()
+
+			for _, tok := range tc.tokens {
+				stored := &oauth21.MCPRefreshToken{
+					Id:                   tok.id,
+					InitiatingSessionId:  tok.initiatingSessionID,
+					UpstreamRefreshToken: tok.upstreamRefreshToken,
+					Revoked:              tok.revoked,
+				}
+				if tok.expiresIn != nil {
+					stored.ExpiresAt = timestamppb.New(now.Add(*tok.expiresIn))
+				}
+				require.NoError(t, storage.PutMCPRefreshToken(ctx, stored))
+			}
+
+			for _, sess := range tc.sessions {
+				stored := &session.Session{
+					Id:              sess.id,
+					UserId:          "user-" + sess.id,
+					RefreshDisabled: sess.refreshDisabled,
+					OauthToken: &session.OAuthToken{
+						AccessToken:  sess.accessToken,
+						RefreshToken: sess.refreshToken,
+					},
+				}
+				if sess.expiresIn != nil {
+					stored.ExpiresAt = timestamppb.New(now.Add(*sess.expiresIn))
+				}
+				rec := databrokerpb.NewRecord(stored)
+				if sess.deleted {
+					rec.DeletedAt = timestamppb.New(now)
+				}
+				_, err := client.Put(ctx, &databrokerpb.PutRequest{Records: []*databrokerpb.Record{rec}})
+				require.NoError(t, err)
+			}
+
+			s := newSessionTokenSyncer(databrokerpb.NewStaticClientGetter(client))
+			syncer := databrokerutil.NewSyncer(ctx, "mcp-session-token-test", s,
+				databrokerutil.WithTypeURL(protoutil.GetTypeURL(new(session.Session))))
+			t.Cleanup(func() { _ = syncer.Close() })
+			go func() { _ = syncer.Run(ctx) }()
+
+			upstream := func() map[string]string {
+				got := map[string]string{}
+				for _, tok := range tc.tokens {
+					stored, err := storage.GetMCPRefreshToken(ctx, tok.id)
+					if err != nil {
+						continue
+					}
+					got[tok.id] = stored.GetUpstreamRefreshToken()
+				}
+				return got
+			}
+
+			initial := map[string]string{}
+			for _, tok := range tc.tokens {
+				initial[tok.id] = tok.upstreamRefreshToken
+			}
+
+			// When the syncer is expected to leave everything as stored, waiting for the
+			// expectation to hold proves nothing: assert it never stops holding instead.
+			if assert.ObjectsAreEqual(tc.wantUpstream, initial) {
+				assert.Never(t, func() bool {
+					return !assert.ObjectsAreEqual(tc.wantUpstream, upstream())
+				}, time.Second, 50*time.Millisecond,
+					"the syncer modified a token it should have left alone")
+				return
+			}
+
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.Equal(c, tc.wantUpstream, upstream())
+			}, 5*time.Second, 10*time.Millisecond)
+		})
+	}
 }
 
 type fakeClock struct {
@@ -213,16 +555,16 @@ func newTestDataBrokerClient(t *testing.T) databrokerpb.DataBrokerServiceClient 
 	return databrokerpb.NewDataBrokerServiceClient(cc)
 }
 
-func newTestStorageSyncer(
+func newTestTokenExpirationSyncer(
 	t *testing.T,
 	client databrokerpb.DataBrokerServiceClient,
 	clock *fakeClock,
-	opts ...StorageSyncerOption,
-) *StorageSyncer {
+	opts ...TokenExpirationSyncerOption,
+) *tokenExpirationSyncer {
 	t.Helper()
 
-	return NewStorageSyncer(
+	return newTokenExpirationSyncer(
 		databrokerpb.NewStaticClientGetter(client),
-		append([]StorageSyncerOption{WithClock(clock.Now)}, opts...)...,
+		append([]TokenExpirationSyncerOption{WithClock(clock.Now)}, opts...)...,
 	)
 }

--- a/internal/oauth21/gen/mcp_refresh_token.pb.go
+++ b/internal/oauth21/gen/mcp_refresh_token.pb.go
@@ -44,9 +44,12 @@ type MCPRefreshToken struct {
 	// Scopes granted with this refresh token
 	Scopes []string `protobuf:"bytes,8,rep,name=scopes,proto3" json:"scopes,omitempty"`
 	// Whether this refresh token has been revoked
-	Revoked       bool `protobuf:"varint,9,opt,name=revoked,proto3" json:"revoked,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Revoked bool `protobuf:"varint,9,opt,name=revoked,proto3" json:"revoked,omitempty"`
+	// Reference to the user's session that initated the original
+	// mcp refresh token
+	InitiatingSessionId string `protobuf:"bytes,10,opt,name=initiating_session_id,json=initiatingSessionId,proto3" json:"initiating_session_id,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *MCPRefreshToken) Reset() {
@@ -142,11 +145,18 @@ func (x *MCPRefreshToken) GetRevoked() bool {
 	return false
 }
 
+func (x *MCPRefreshToken) GetInitiatingSessionId() string {
+	if x != nil {
+		return x.InitiatingSessionId
+	}
+	return ""
+}
+
 var File_mcp_refresh_token_proto protoreflect.FileDescriptor
 
 const file_mcp_refresh_token_proto_rawDesc = "" +
 	"\n" +
-	"\x17mcp_refresh_token.proto\x12\aoauth21\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xee\x02\n" +
+	"\x17mcp_refresh_token.proto\x12\aoauth21\x1a\x1bbuf/validate/validate.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa2\x03\n" +
 	"\x0fMCPRefreshToken\x12\x1a\n" +
 	"\x02id\x18\x01 \x01(\tB\n" +
 	"\xbaH\a\xc8\x01\x01r\x02\x10\x01R\x02id\x12#\n" +
@@ -160,7 +170,9 @@ const file_mcp_refresh_token_proto_rawDesc = "" +
 	"\n" +
 	"expires_at\x18\a \x01(\v2\x1a.google.protobuf.TimestampR\texpiresAt\x12\x16\n" +
 	"\x06scopes\x18\b \x03(\tR\x06scopes\x12\x18\n" +
-	"\arevoked\x18\t \x01(\bR\arevokedB\x92\x01\n" +
+	"\arevoked\x18\t \x01(\bR\arevoked\x122\n" +
+	"\x15initiating_session_id\x18\n" +
+	" \x01(\tR\x13initiatingSessionIdB\x92\x01\n" +
 	"\vcom.oauth21B\x14McpRefreshTokenProtoP\x01Z1github.com/pomerium/pomerium/internal/oauth21/gen\xa2\x02\x03OXX\xaa\x02\aOauth21\xca\x02\aOauth21\xe2\x02\x13Oauth21\\GPBMetadata\xea\x02\aOauth21b\x06proto3"
 
 var (

--- a/internal/oauth21/proto/mcp_refresh_token.proto
+++ b/internal/oauth21/proto/mcp_refresh_token.proto
@@ -45,4 +45,8 @@ message MCPRefreshToken {
 
   // Whether this refresh token has been revoked
   bool revoked = 9;
+
+  // Reference to the user's session that initated the original
+  // mcp refresh token
+  string initiating_session_id = 10;
 }


### PR DESCRIPTION
## Summary

TODO

## Related issues

https://github.com/pomerium/pomerium/issues/6530

## User Explanation

Users whose IDP allows token rotation (consume on use), will no longer get kicked out early from their mcp sessions. MCP sessions will continously refresh until the IDP no longer allows it.

## AI disclosure

opus 4.8 was used to scaffhold the tests in token_handler_test.go and storage_syncer_test.go.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>