### PR TITLE
api: add namespace_id option to GetSettingsRequest

### DIFF
--- a/internal/databroker/server_backend_config.go
+++ b/internal/databroker/server_backend_config.go
@@ -346,7 +346,7 @@ func (srv *backendConfigServer) GetSettings(
 
 	entity := new(configpb.Settings)
 	switch req.Msg.For.(type) {
-	case *configpb.GetSettingsRequest_ClusterId:
+	case *configpb.GetSettingsRequest_ClusterId, *configpb.GetSettingsRequest_NamespaceId:
 		// core only supports a single cluster, so always return not found
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("settings not found"))
 	case *configpb.GetSettingsRequest_Id:

--- a/internal/databroker/server_backend_config_test.go
+++ b/internal/databroker/server_backend_config_test.go
@@ -149,6 +149,16 @@ func TestConfigSettings(t *testing.T) {
 		}))
 		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
 	})
+	t.Run("namespace id", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := client.GetSettings(t.Context(), connect.NewRequest(&configpb.GetSettingsRequest{
+			For: &configpb.GetSettingsRequest_NamespaceId{
+				NamespaceId: "NAMESPACE_ID",
+			},
+		}))
+		assert.Equal(t, connect.CodeNotFound, connect.CodeOf(err))
+	})
 	t.Run("id", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/grpc/config/config.openapi.yaml
+++ b/pkg/grpc/config/config.openapi.yaml
@@ -2026,6 +2026,17 @@ components:
           title: id
           required:
             - id
+        - type: object
+          properties:
+            namespaceId:
+              type: string
+              title: namespace_id
+              description: |-
+                Look up Settings corresponding to this namespace ID. The Settings may
+                 belong to this namespace or to a parent namespace.
+          title: namespace_id
+          required:
+            - namespaceId
       title: GetSettingsRequest
       additionalProperties: false
     pomerium.config.GetSettingsResponse:

--- a/pkg/grpc/config/config.pb.go
+++ b/pkg/grpc/config/config.pb.go
@@ -6451,6 +6451,7 @@ type GetSettingsRequest struct {
 	//
 	//	*GetSettingsRequest_Id
 	//	*GetSettingsRequest_ClusterId
+	//	*GetSettingsRequest_NamespaceId
 	For           isGetSettingsRequest_For `protobuf_oneof:"for"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -6511,6 +6512,15 @@ func (x *GetSettingsRequest) GetClusterId() string {
 	return ""
 }
 
+func (x *GetSettingsRequest) GetNamespaceId() string {
+	if x != nil {
+		if x, ok := x.For.(*GetSettingsRequest_NamespaceId); ok {
+			return x.NamespaceId
+		}
+	}
+	return ""
+}
+
 type isGetSettingsRequest_For interface {
 	isGetSettingsRequest_For()
 }
@@ -6525,9 +6535,17 @@ type GetSettingsRequest_ClusterId struct {
 	ClusterId string `protobuf:"bytes,2,opt,name=cluster_id,json=clusterId,proto3,oneof"`
 }
 
+type GetSettingsRequest_NamespaceId struct {
+	// Look up Settings corresponding to this namespace ID. The Settings may
+	// belong to this namespace or to a parent namespace.
+	NamespaceId string `protobuf:"bytes,3,opt,name=namespace_id,json=namespaceId,proto3,oneof"`
+}
+
 func (*GetSettingsRequest_Id) isGetSettingsRequest_For() {}
 
 func (*GetSettingsRequest_ClusterId) isGetSettingsRequest_For() {}
+
+func (*GetSettingsRequest_NamespaceId) isGetSettingsRequest_For() {}
 
 type GetSettingsResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -10131,11 +10149,12 @@ const file_config_proto_rawDesc = "" +
 	"\x18GetServiceAccountRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\"e\n" +
 	"\x19GetServiceAccountResponse\x12H\n" +
-	"\x0fservice_account\x18\x02 \x01(\v2\x1f.pomerium.config.ServiceAccountR\x0eserviceAccount\"N\n" +
+	"\x0fservice_account\x18\x02 \x01(\v2\x1f.pomerium.config.ServiceAccountR\x0eserviceAccount\"s\n" +
 	"\x12GetSettingsRequest\x12\x10\n" +
 	"\x02id\x18\x01 \x01(\tH\x00R\x02id\x12\x1f\n" +
 	"\n" +
-	"cluster_id\x18\x02 \x01(\tH\x00R\tclusterIdB\x05\n" +
+	"cluster_id\x18\x02 \x01(\tH\x00R\tclusterId\x12#\n" +
+	"\fnamespace_id\x18\x03 \x01(\tH\x00R\vnamespaceIdB\x05\n" +
 	"\x03for\"L\n" +
 	"\x13GetSettingsResponse\x125\n" +
 	"\bsettings\x18\x01 \x01(\v2\x19.pomerium.config.SettingsR\bsettings\"\x1f\n" +
@@ -10864,6 +10883,7 @@ func file_config_proto_init() {
 	file_config_proto_msgTypes[50].OneofWrappers = []any{
 		(*GetSettingsRequest_Id)(nil),
 		(*GetSettingsRequest_ClusterId)(nil),
+		(*GetSettingsRequest_NamespaceId)(nil),
 	}
 	file_config_proto_msgTypes[54].OneofWrappers = []any{}
 	file_config_proto_msgTypes[56].OneofWrappers = []any{}

--- a/pkg/grpc/config/config.pb.json
+++ b/pkg/grpc/config/config.pb.json
@@ -1577,6 +1577,18 @@
               "isoneof": true,
               "oneofdecl": "for",
               "defaultValue": ""
+            },
+            {
+              "name": "namespace_id",
+              "description": "Look up Settings corresponding to this namespace ID. The Settings may\nbelong to this namespace or to a parent namespace.",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "for",
+              "defaultValue": ""
             }
           ]
         },

--- a/pkg/grpc/config/config.pb.validate.go
+++ b/pkg/grpc/config/config.pb.validate.go
@@ -8995,6 +8995,18 @@ func (m *GetSettingsRequest) validate(all bool) error {
 			errors = append(errors, err)
 		}
 		// no validation rules for ClusterId
+	case *GetSettingsRequest_NamespaceId:
+		if v == nil {
+			err := GetSettingsRequestValidationError{
+				field:  "For",
+				reason: "oneof value cannot be a typed-nil",
+			}
+			if !all {
+				return err
+			}
+			errors = append(errors, err)
+		}
+		// no validation rules for NamespaceId
 	default:
 		_ = v // ensures v is used
 	}

--- a/pkg/grpc/config/config.proto
+++ b/pkg/grpc/config/config.proto
@@ -1554,6 +1554,9 @@ message GetSettingsRequest {
     string id = 1;
     // Cluster ID whose Settings record should be returned.
     string cluster_id = 2;
+    // Look up Settings corresponding to this namespace ID. The Settings may
+    // belong to this namespace or to a parent namespace.
+    string namespace_id = 3;
   }
 }
 


### PR DESCRIPTION
## Summary

Add a third option to GetSettingsRequest, to support looking up settings for a specific namespace that may or may not be a cluster.

Core doesn't support namespaces by itself, so update the API implementation for this method to return a `not_found` error code in this case, just like it does for the `cluster_id` option.

(This is needed when ingress-controller is configured to sync to Pomerium Enterprise, in order to support arbitrary destination namespaces. The sync logic won't necessarily know the cluster ID corresponding to the namespace ID it wants to sync to.)

## Related issues

https://linear.app/pomerium/issue/ENG-4272/ingress-controller-settings-sync-to-zero-fails-with-cannot-get

## User Explanation

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
