### PR TITLE
feat/idp atomic token refresh

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pomerium/pomerium/authorize/internal/store"
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/mcp"
 	"github.com/pomerium/pomerium/internal/recording"
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
@@ -48,6 +49,7 @@ type Authorize struct {
 	accessTracker *AccessTracker
 	ssh           *ssh.StreamManager
 	policyIndexer ssh.PolicyIndexer
+	mcpSyncer     *mcp.StorageSyncer
 
 	tracerProvider oteltrace.TracerProvider
 	tracer         oteltrace.Tracer
@@ -135,6 +137,7 @@ func New(ctx context.Context, cfg *config.Config, opts ...Option) (*Authorize, e
 		o.cliController,
 		cfg,
 	)
+	a.mcpSyncer = mcp.NewStorageSyncer(a)
 	return a, nil
 }
 
@@ -165,6 +168,9 @@ func (a *Authorize) Run(ctx context.Context) error {
 	eg.Go(func() error {
 		a.accessTracker.Run(ctx)
 		return nil
+	})
+	eg.Go(func() error {
+		return a.mcpSyncer.Run(ctx)
 	})
 	return eg.Wait()
 }

--- a/internal/databroker/server_backend.go
+++ b/internal/databroker/server_backend.go
@@ -748,9 +748,8 @@ func (srv *backendServer) newBackendAndSetupLocked(ctx context.Context) (storage
 }
 
 func (srv *backendServer) setupRequiredIndex(ctx context.Context, backend storage.Backend) error {
-	reqCap := uint64(50000)
 	if err := backend.SetOptions(ctx, "type.googleapis.com/session.SessionBindingRequest", &databrokerpb.Options{
-		Capacity:        &reqCap,
+		Capacity:        new(uint64(50000)),
 		IndexableFields: []string{"key"},
 		Ttl:             durationpb.New(15 * time.Minute),
 	}); err != nil {
@@ -788,6 +787,12 @@ func (srv *backendServer) setupRequiredIndex(ctx context.Context, backend storag
 			"state_id",
 		},
 		Ttl: durationpb.New(15 * time.Minute),
+	}); err != nil {
+		return err
+	}
+
+	if err := backend.SetOptions(ctx, "type.googleapis.com/oauth21.MCPRefreshToken", &databrokerpb.Options{
+		Capacity: new(uint64(50000)),
 	}); err != nil {
 		return err
 	}

--- a/internal/mcp/storage_syncer.go
+++ b/internal/mcp/storage_syncer.go
@@ -1,0 +1,223 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/pomerium/pomerium/internal/log"
+	oauth21 "github.com/pomerium/pomerium/internal/oauth21/gen"
+	"github.com/pomerium/pomerium/pkg/databrokerutil"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+const (
+	defaultRefreshTokenCleanupInterval    = 5 * time.Minute
+	defaultRefreshTokenCleanupGracePeriod = time.Minute * 15
+)
+
+type RefreshTokenMd struct {
+	Revoked   bool
+	RevokedAt time.Time
+	ExpiresAt time.Time
+}
+
+type StorageSyncer struct {
+	clientB databroker.ClientGetter
+	records map[string]*RefreshTokenMd
+	StorageSyncerOptions
+
+	mu sync.RWMutex
+}
+
+type StorageSyncerOptions struct {
+	// how often to cleanup refresh tokens
+	cleanupInterval time.Duration
+	// the grace period after which to clean up a token once it has been revoked
+	cleanupGracePeriodDuration time.Duration
+	// allows for fake clock tests
+	now func() time.Time
+}
+
+func defaultStorageSyncerOptions() *StorageSyncerOptions {
+	return &StorageSyncerOptions{
+		cleanupInterval:            defaultRefreshTokenCleanupInterval,
+		cleanupGracePeriodDuration: defaultRefreshTokenCleanupGracePeriod,
+		now:                        time.Now,
+	}
+}
+
+func (o *StorageSyncerOptions) Apply(opts ...StorageSyncerOption) {
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+type StorageSyncerOption func(*StorageSyncerOptions)
+
+func WithCleanupInterval(d time.Duration) StorageSyncerOption {
+	return func(o *StorageSyncerOptions) { o.cleanupInterval = d }
+}
+
+func WithCleanupGracePeriod(d time.Duration) StorageSyncerOption {
+	return func(o *StorageSyncerOptions) { o.cleanupGracePeriodDuration = d }
+}
+
+func WithClock(now func() time.Time) StorageSyncerOption {
+	return func(o *StorageSyncerOptions) { o.now = now }
+}
+
+func NewStorageSyncer(
+	clientB databroker.ClientGetter,
+	opts ...StorageSyncerOption,
+) *StorageSyncer {
+	options := defaultStorageSyncerOptions()
+	options.Apply(opts...)
+
+	return &StorageSyncer{
+		clientB:              clientB,
+		records:              map[string]*RefreshTokenMd{},
+		StorageSyncerOptions: *options,
+	}
+}
+
+var _ databrokerutil.SyncerHandler = (*StorageSyncer)(nil)
+
+func (s *StorageSyncer) Run(ctx context.Context) error {
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return databrokerutil.NewSyncer(
+			ctx,
+			"mcp-storage-syncer",
+			s,
+			databrokerutil.WithTypeURL("type.googleapis.com/oauth21.MCPRefreshToken"),
+			databrokerutil.WithFastForward(),
+		).Run(ctx)
+	})
+	eg.Go(func() error {
+		return s.RunCleanUp(ctx)
+	})
+
+	return eg.Wait()
+}
+
+func (s *StorageSyncer) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	return s.clientB.GetDataBrokerServiceClient()
+}
+
+func (s *StorageSyncer) ClearRecords(_ context.Context) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.records = map[string]*RefreshTokenMd{}
+}
+
+func (s *StorageSyncer) UpdateRecords(ctx context.Context, _ uint64, records []*databroker.Record) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	for _, rec := range records {
+		id := rec.GetId()
+		if rec.GetDeletedAt() != nil {
+			delete(s.records, id)
+			continue
+		}
+
+		refreshTokenProto := new(oauth21.MCPRefreshToken)
+		if err := rec.GetData().UnmarshalTo(refreshTokenProto); err != nil {
+			log.Ctx(ctx).Error().Err(err).
+				Str("record-id", id).
+				Msg("mcp: failed to unmarshal refresh token record")
+			continue
+		}
+
+		expiresAt := refreshTokenProto.GetExpiresAt().AsTime()
+
+		got, ok := s.records[id]
+		if !ok {
+			md := &RefreshTokenMd{
+				Revoked:   refreshTokenProto.GetRevoked(),
+				ExpiresAt: expiresAt,
+			}
+			if md.Revoked {
+				md.RevokedAt = now
+			}
+			s.records[id] = md
+			continue
+		}
+		// explicitly only handle flips from false -> true
+		if !got.Revoked && refreshTokenProto.GetRevoked() {
+			got.Revoked = true
+			got.RevokedAt = now
+		}
+		got.ExpiresAt = expiresAt
+	}
+}
+
+// RunCleanUp periodically deletes revoked and expired refresh tokens until ctx is done.
+func (s *StorageSyncer) RunCleanUp(ctx context.Context) error {
+	t := time.NewTicker(s.cleanupInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return context.Cause(ctx)
+		case <-t.C:
+			if err := s.batchCleanUp(ctx); err != nil {
+				log.Ctx(ctx).Error().Err(err).Msg("mcp: failed to clean up refresh tokens")
+			}
+		}
+	}
+}
+
+// expired reports whether the record is eligible for deletion.
+func (s *StorageSyncer) expired(md *RefreshTokenMd, now time.Time) bool {
+	if md.Revoked && md.RevokedAt.Add(s.cleanupGracePeriodDuration).Before(now) {
+		return true
+	}
+
+	return md.ExpiresAt.Add(s.cleanupGracePeriodDuration).Before(now)
+}
+
+func (s *StorageSyncer) batchCleanUp(ctx context.Context) error {
+	now := s.now()
+
+	s.mu.RLock()
+	var ids []string
+	for id, md := range s.records {
+		if s.expired(md, now) {
+			ids = append(ids, id)
+		}
+	}
+	s.mu.RUnlock()
+
+	if len(ids) == 0 {
+		return nil
+	}
+
+	data := protoutil.NewAny(new(oauth21.MCPRefreshToken))
+	deletedAt := timestamppb.New(now)
+	recs := make([]*databroker.Record, 0, len(ids))
+	for _, id := range ids {
+		recs = append(recs, &databroker.Record{
+			Id:        id,
+			Data:      data,
+			Type:      data.TypeUrl,
+			DeletedAt: deletedAt,
+		})
+	}
+
+	if _, err := s.GetDataBrokerServiceClient().Put(ctx, &databroker.PutRequest{Records: recs}); err != nil {
+		return fmt.Errorf("failed to delete expired mcp refresh tokens: %w", err)
+	}
+
+	log.Ctx(ctx).Info().
+		Int("count", len(ids)).
+		Msg("mcp: deleted expired refresh tokens")
+	return nil
+}

--- a/internal/mcp/storage_syncer_test.go
+++ b/internal/mcp/storage_syncer_test.go
@@ -1,0 +1,228 @@
+package mcp
+
+import (
+	"context"
+	"maps"
+	"slices"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/pomerium/pomerium/internal/databroker"
+	oauth21 "github.com/pomerium/pomerium/internal/oauth21/gen"
+	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/databrokerutil"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+var syncerTestBase = time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+
+func TestStorageSyncerClearRecords(t *testing.T) {
+	t.Parallel()
+
+	ctx := testutil.GetContext(t, time.Minute)
+	client := newTestDataBrokerClient(t)
+	s := newTestStorageSyncer(t, client, &fakeClock{t: syncerTestBase})
+	s.records["a"] = &RefreshTokenMd{}
+
+	s.ClearRecords(ctx)
+
+	assert.Empty(t, s.records)
+}
+
+func TestStorageSyncerCleanUp(t *testing.T) {
+	t.Parallel()
+
+	const grace = time.Hour
+
+	type testToken struct {
+		id string
+		// expiresIn is the token lifetime relative to the start of the test
+		expiresIn *time.Duration
+		revoked   bool
+	}
+
+	dur := func(d time.Duration) *time.Duration { return new(d) }
+
+	type testcase struct {
+		name string
+		// tokens are all created at the start of the test.
+		tokens []testToken
+		// advance is how far the clock moves before cleanup runs.
+		advance       time.Duration
+		wantRemaining []string
+	}
+
+	for _, tc := range []testcase{
+		{
+			name: "no tokens is a no-op",
+		},
+		{
+			name:          "unexpired token is kept",
+			tokens:        []testToken{{id: "a", expiresIn: dur(4 * time.Hour)}},
+			advance:       time.Hour,
+			wantRemaining: []string{"a"},
+		},
+		{
+			name:    "token without an expiry is treated as already expired",
+			tokens:  []testToken{{id: "a"}},
+			advance: time.Minute,
+		},
+		{
+			name:          "expired token within the grace period is kept",
+			tokens:        []testToken{{id: "a", expiresIn: dur(time.Hour)}},
+			advance:       time.Hour + 30*time.Minute,
+			wantRemaining: []string{"a"},
+		},
+		{
+			name:    "expired token past the grace period is deleted",
+			tokens:  []testToken{{id: "a", expiresIn: dur(time.Hour)}},
+			advance: 3 * time.Hour,
+		},
+		{
+			name:          "expired token exactly at the grace boundary is kept",
+			tokens:        []testToken{{id: "a", expiresIn: dur(time.Hour)}},
+			advance:       time.Hour + grace,
+			wantRemaining: []string{"a"},
+		},
+		{
+			name:          "revoked token within the grace period is kept",
+			tokens:        []testToken{{id: "a", expiresIn: dur(100 * time.Hour), revoked: true}},
+			advance:       30 * time.Minute,
+			wantRemaining: []string{"a"},
+		},
+		{
+			name:    "revoked token past the grace period is deleted",
+			tokens:  []testToken{{id: "a", expiresIn: dur(100 * time.Hour), revoked: true}},
+			advance: 2 * time.Hour,
+		},
+		{
+			name: "only eligible tokens are deleted",
+			tokens: []testToken{
+				{id: "revoked", expiresIn: dur(100 * time.Hour), revoked: true},
+				{id: "expired", expiresIn: dur(time.Minute)},
+				{id: "still-valid", expiresIn: dur(100 * time.Hour)},
+				{id: "no-expiry"},
+			},
+			advance:       2 * time.Hour,
+			wantRemaining: []string{"still-valid"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := testutil.GetContext(t, time.Minute)
+			client := newTestDataBrokerClient(t)
+			storage := NewStorage(client)
+			clock := &fakeClock{t: syncerTestBase}
+			s := newTestStorageSyncer(t, client, clock, WithCleanupGracePeriod(grace),
+				WithCleanupInterval(10*time.Millisecond))
+
+			tracked := func() []string {
+				s.mu.RLock()
+				defer s.mu.RUnlock()
+				return slices.Collect(maps.Keys(s.records))
+			}
+
+			var ids []string
+			for _, tok := range tc.tokens {
+				stored := &oauth21.MCPRefreshToken{Id: tok.id, Revoked: tok.revoked}
+				if tok.expiresIn != nil {
+					stored.ExpiresAt = timestamppb.New(syncerTestBase.Add(*tok.expiresIn))
+				}
+				require.NoError(t, storage.PutMCPRefreshToken(ctx, stored))
+				ids = append(ids, tok.id)
+			}
+
+			syncer := databrokerutil.NewSyncer(ctx, "mcp-refresh-token-test", s,
+				databrokerutil.WithTypeURL(protoutil.GetTypeURL(new(oauth21.MCPRefreshToken))))
+			t.Cleanup(func() { _ = syncer.Close() })
+			go func() { _ = syncer.Run(ctx) }()
+
+			// Wait for the initial sync so every token is tracked before the clock moves.
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.ElementsMatch(c, ids, tracked())
+			}, 5*time.Second, 10*time.Millisecond, "initial sync never completed")
+
+			clock.Set(syncerTestBase.Add(tc.advance))
+			go func() { _ = s.RunCleanUp(ctx) }()
+
+			assert.EventuallyWithT(t, func(c *assert.CollectT) {
+				var remaining []string
+				for _, tok := range tc.tokens {
+					if _, err := storage.GetMCPRefreshToken(ctx, tok.id); err == nil {
+						remaining = append(remaining, tok.id)
+					}
+				}
+				assert.ElementsMatch(c, tc.wantRemaining, remaining,
+					"unexpected set of tokens left in the databroker")
+				assert.ElementsMatch(c, tc.wantRemaining, tracked(),
+					"in-memory tracking diverged from the databroker")
+			}, 5*time.Second, 10*time.Millisecond)
+		})
+	}
+}
+
+func TestStorageSyncerRunCleanUpStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	client := newTestDataBrokerClient(t)
+	s := newTestStorageSyncer(t, client, &fakeClock{t: syncerTestBase})
+	s.cleanupInterval = time.Hour
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	require.ErrorIs(t, s.RunCleanUp(ctx), context.Canceled)
+}
+
+type fakeClock struct {
+	mu sync.Mutex
+	t  time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.t
+}
+
+func (c *fakeClock) Set(t time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.t = t
+}
+
+func newTestDataBrokerClient(t *testing.T) databrokerpb.DataBrokerServiceClient {
+	t.Helper()
+
+	srv := databroker.NewBackendServer(noop.NewTracerProvider())
+	t.Cleanup(srv.Stop)
+
+	cc := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(s, srv)
+	})
+
+	return databrokerpb.NewDataBrokerServiceClient(cc)
+}
+
+func newTestStorageSyncer(
+	t *testing.T,
+	client databrokerpb.DataBrokerServiceClient,
+	clock *fakeClock,
+	opts ...StorageSyncerOption,
+) *StorageSyncer {
+	t.Helper()
+
+	return NewStorageSyncer(
+		databrokerpb.NewStaticClientGetter(client),
+		append([]StorageSyncerOption{WithClock(clock.Now)}, opts...)...,
+	)
+}

--- a/pkg/identity/manager/manager.go
+++ b/pkg/identity/manager/manager.go
@@ -3,6 +3,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -22,6 +23,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpc/user"
 	"github.com/pomerium/pomerium/pkg/grpcutil"
 	"github.com/pomerium/pomerium/pkg/identity/identity"
+	"github.com/pomerium/pomerium/pkg/identity/token"
 	metrics_ids "github.com/pomerium/pomerium/pkg/metrics"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
@@ -54,6 +56,11 @@ func New(
 	}
 	mgr.UpdateConfig(options...)
 	return mgr
+}
+
+// GetEventDispatcher gets the event manager used to report errors.
+func (mgr *Manager) GetEventDispatcher() *events.Manager {
+	return mgr.cfg.Load().eventMgr
 }
 
 // UpdateConfig updates the manager with the new options.
@@ -207,71 +214,58 @@ func (mgr *Manager) refreshSession(ctx context.Context, sessionID string) {
 		return
 	}
 
-	expiry := s.GetExpiresAt().AsTime()
-	if !expiry.After(mgr.cfg.Load().now()) {
+	// TODO : define this is a field on the struct itself.
+	rotator := token.NewAtomicTokenRotator(
+		token.NewStaticAuthenticatorGetter(authenticator),
+		mgr,
+		token.WithClock(mgr.cfg.Load().now),
+		token.WithEventDispatcher(mgr),
+	)
+
+	res, err := rotator.RotateSessionToken(ctx, s, u)
+	switch {
+	case err == nil:
+	case errors.Is(err, token.ErrDoNotRefresh):
+		return
+	case errors.Is(err, token.ErrExpiredSession):
 		log.Ctx(ctx).Info().
 			Str("user-id", s.GetUserId()).
 			Str("session-id", s.GetId()).
 			Msg("deleting expired session")
 		mgr.deleteSession(ctx, sessionID)
 		return
-	}
-
-	if s.GetRefreshDisabled() {
-		// refresh was explicitly disabled
-		return
-	}
-
-	if s.GetOauthToken() == nil {
-		log.Ctx(ctx).Info().
-			Str("user-id", s.GetUserId()).
-			Str("session-id", s.GetId()).
-			Msg("no session oauth2 token found for refresh")
-		return
-	}
-	// TODO: short term lease
-	newToken, err := authenticator.Refresh(ctx, FromOAuthToken(s.OauthToken), NewSessionUnmarshaler(s))
-	metrics.RecordIdentityManagerSessionRefresh(ctx, err)
-	mgr.recordLastError(metrics_ids.IdentityManagerLastSessionRefreshError, err)
-	if isTemporaryError(err) {
+	case errors.Is(err, token.ErrStorageLease), errors.Is(err, token.ErrTokenNotRotated), isTemporaryError(err):
+		// failed to determine if the lease is held, or the failure was transient,
+		// so keep the session and let the scheduler try again
 		log.Ctx(ctx).Error().Err(err).
 			Str("user-id", s.GetUserId()).
 			Str("session-id", s.GetId()).
-			Msg("failed to refresh oauth2 token")
+			Msg("failed to rotate session token")
 		return
-	} else if err != nil {
+	default:
 		log.Ctx(ctx).Error().Err(err).
 			Str("user-id", s.GetUserId()).
 			Str("session-id", s.GetId()).
-			Msg("failed to refresh oauth2 token, deleting session")
+			Msg("failed to rotate session token, deleting session")
 		mgr.deleteSession(ctx, sessionID)
 		return
 	}
-	s.OauthToken = ToOAuthToken(newToken)
-
-	err = authenticator.UpdateUserInfo(ctx, FromOAuthToken(s.OauthToken), newMultiUnmarshaler(newUserUnmarshaler(u), NewSessionUnmarshaler(s)))
-	metrics.RecordIdentityManagerUserRefresh(ctx, err)
-	mgr.recordLastError(metrics_ids.IdentityManagerLastUserRefreshError, err)
-	if isTemporaryError(err) {
-		log.Ctx(ctx).Error().Err(err).
-			Str("user-id", s.GetUserId()).
-			Str("session-id", s.GetId()).
-			Msg("failed to update user info")
-		return
-	} else if err != nil {
-		log.Ctx(ctx).Error().Err(err).
-			Str("user-id", s.GetUserId()).
-			Str("session-id", s.GetId()).
-			Msg("failed to update user info, deleting session")
-		mgr.deleteSession(ctx, sessionID)
-		return
+	// the rotator already persisted the records, so only the local data store and
+	// the schedulers need to catch up
+	mgr.mu.Lock()
+	if newSession := res.Session; newSession != nil {
+		mgr.dataStore.putSession(newSession)
+		if rss, ok := mgr.refreshSessionSchedulers[newSession.GetId()]; ok {
+			rss.Update(newSession)
+		}
 	}
-
-	mgr.updateSession(ctx, s)
-	if u != nil {
-		mgr.updateUser(ctx, u)
+	if newUser := res.User; newUser != nil {
+		mgr.dataStore.putUser(newUser)
+		if uuis, ok := mgr.updateUserInfoSchedulers[newUser.GetId()]; ok {
+			uuis.Reset()
+		}
 	}
-	// TODO : end todo
+	mgr.mu.Unlock()
 }
 
 func (mgr *Manager) updateUserInfo(ctx context.Context, userID string) {

--- a/pkg/identity/manager/manager.go
+++ b/pkg/identity/manager/manager.go
@@ -229,7 +229,7 @@ func (mgr *Manager) refreshSession(ctx context.Context, sessionID string) {
 			Msg("no session oauth2 token found for refresh")
 		return
 	}
-
+	// TODO: short term lease
 	newToken, err := authenticator.Refresh(ctx, FromOAuthToken(s.OauthToken), NewSessionUnmarshaler(s))
 	metrics.RecordIdentityManagerSessionRefresh(ctx, err)
 	mgr.recordLastError(metrics_ids.IdentityManagerLastSessionRefreshError, err)
@@ -271,6 +271,7 @@ func (mgr *Manager) refreshSession(ctx context.Context, sessionID string) {
 	if u != nil {
 		mgr.updateUser(ctx, u)
 	}
+	// TODO : end todo
 }
 
 func (mgr *Manager) updateUserInfo(ctx context.Context, userID string) {

--- a/pkg/identity/token/atomic_rotator.go
+++ b/pkg/identity/token/atomic_rotator.go
@@ -1,0 +1,295 @@
+package token
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pomerium/pomerium/pkg/grpc/user"
+
+	"github.com/pomerium/pomerium/internal/events"
+	"github.com/pomerium/pomerium/internal/log"
+	"github.com/pomerium/pomerium/internal/telemetry/metrics"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/identity"
+	metrics_ids "github.com/pomerium/pomerium/pkg/metrics"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+var (
+	ErrStorageLease    = errors.New("storage error from lease")
+	ErrExpiredSession  = errors.New("expired session")
+	ErrDoNotRefresh    = errors.New("refresh disabled")
+	ErrTokenNotRotated = errors.New("token not rotated")
+)
+
+type AuthenticatorGetter interface {
+	GetAuthenticator() identity.Authenticator
+}
+
+func NewStaticAuthenticatorGetter(a identity.Authenticator) AuthenticatorGetter {
+	return staticAuthenticatorGetter{a: a}
+}
+
+type staticAuthenticatorGetter struct {
+	a identity.Authenticator
+}
+
+func (s staticAuthenticatorGetter) GetAuthenticator() identity.Authenticator {
+	return s.a
+}
+
+type EventDispatcherGetter interface {
+	GetEventDispatcher() *events.Manager
+}
+
+type TokenRotatorOptions struct {
+	now        func() time.Time
+	dispatcher EventDispatcherGetter
+}
+
+func (o *TokenRotatorOptions) Apply(opts ...TokenRotatorOption) {
+	for _, opt := range opts {
+		opt(o)
+	}
+}
+
+type TokenRotatorOption func(o *TokenRotatorOptions)
+
+func WithClock(now func() time.Time) TokenRotatorOption {
+	return func(o *TokenRotatorOptions) {
+		o.now = now
+	}
+}
+
+func WithEventDispatcher(dispatcher EventDispatcherGetter) TokenRotatorOption {
+	return func(o *TokenRotatorOptions) {
+		o.dispatcher = dispatcher
+	}
+}
+
+type AtomicTokenRotator struct {
+	authenticator AuthenticatorGetter
+	clientB       databroker.ClientGetter
+	TokenRotatorOptions
+}
+
+func NewAtomicTokenRotator(
+	authenticator AuthenticatorGetter,
+	clientB databroker.ClientGetter,
+	opts ...TokenRotatorOption,
+) *AtomicTokenRotator {
+	options := &TokenRotatorOptions{
+		now: time.Now,
+	}
+	options.Apply(opts...)
+
+	return &AtomicTokenRotator{
+		authenticator:       authenticator,
+		clientB:             clientB,
+		TokenRotatorOptions: *options,
+	}
+}
+
+type RotateTokenSuccess struct {
+	Session *session.Session
+	User    *user.User
+	Token   *oauth2.Token
+}
+
+func (r *AtomicTokenRotator) RotateSessionToken(
+	ctx context.Context,
+	s *session.Session,
+	u *user.User,
+) (
+	*RotateTokenSuccess,
+	error,
+) {
+	expiry := s.GetExpiresAt().AsTime()
+	if expiry.Before(r.now()) {
+		return nil, ErrExpiredSession
+	}
+
+	if s.GetRefreshDisabled() {
+		// refresh was explicitly disabled
+		return nil, ErrDoNotRefresh
+	}
+
+	if s.GetOauthToken() == nil {
+		return nil, ErrDoNotRefresh
+	}
+	authenticator := r.authenticator.GetAuthenticator()
+	if authenticator == nil {
+		return nil, ErrDoNotRefresh
+	}
+
+	leaseDur := 30 * time.Second
+	_, err := r.clientB.GetDataBrokerServiceClient().
+		AcquireLease(ctx, &databroker.AcquireLeaseRequest{
+			Name:     s.GetId(),
+			Duration: durationpb.New(leaseDur),
+		})
+
+	if err == nil {
+		// intentionally do not rotate lease to prevent clients reading back
+		// new sessions that may race against newly acquired leases
+		return r.runRotateLeased(ctx, authenticator, s, u)
+	}
+	if status.Code(err) == codes.AlreadyExists {
+		leaseCtx, leaseCa := context.WithTimeout(ctx, 30*time.Second)
+		defer leaseCa()
+		b := backoff.NewExponentialBackOff()
+		s, err := backoff.RetryWithData(func() (*session.Session, error) {
+			newSession, err := session.Get(ctx, r.clientB.GetDataBrokerServiceClient(), s.GetId())
+			if err != nil {
+				return nil, err
+			}
+			if newSession.GetOauthToken().GetRefreshToken() != s.GetOauthToken().GetRefreshToken() {
+				return newSession, nil
+			}
+			return nil, ErrTokenNotRotated
+		}, backoff.WithContext(b, leaseCtx))
+		if err != nil {
+			return nil, fmt.Errorf("%w : %w", ErrTokenNotRotated, err)
+		}
+
+		if u != nil {
+			// get user
+			newU, err := user.Get(ctx, r.clientB.GetDataBrokerServiceClient(), u.GetId())
+			if err != nil {
+				panic(err) // TODO:
+			}
+			u = newU
+		}
+		return &RotateTokenSuccess{
+			Session: s,
+			User:    u,
+			Token:   FromOAuthToken(s.GetOauthToken()),
+		}, nil
+	}
+
+	return nil, fmt.Errorf("%w : %w", ErrStorageLease, err)
+}
+
+func (r *AtomicTokenRotator) runRotateLeased(
+	ctx context.Context,
+	authenticator identity.Authenticator,
+	s *session.Session,
+	u *user.User,
+) (*RotateTokenSuccess, error) {
+	leaseCtx, leaseCa := context.WithTimeout(ctx, 30*time.Second)
+	defer leaseCa()
+	newToken, err := authenticator.Refresh(leaseCtx, FromOAuthToken(s.GetOauthToken()), NewSessionUnmarshaler(s))
+	metrics.RecordIdentityManagerSessionRefresh(ctx, err)
+	r.recordLastError(metrics_ids.IdentityManagerLastSessionRefreshError, err)
+	if err != nil {
+		return nil, err
+	}
+
+	s.OauthToken = ToOAuthToken(newToken)
+	err = authenticator.UpdateUserInfo(ctx, FromOAuthToken(s.OauthToken), newMultiUnmarshaler(newUserUnmarshaler(u), NewSessionUnmarshaler(s)))
+	metrics.RecordIdentityManagerUserRefresh(ctx, err)
+	r.recordLastError(metrics_ids.IdentityManagerLastUserRefreshError, err)
+	if err != nil {
+		return nil, err
+	}
+	// TODO : renew lease in the background, while we update session, user info?
+	if err := r.updateSession(ctx, s); err != nil {
+		return nil, err
+	}
+	if u != nil {
+		if err := r.updateUser(ctx, u); err != nil {
+			return nil, err
+		}
+	}
+
+	return &RotateTokenSuccess{
+		Session: s,
+		User:    u,
+		Token:   newToken,
+	}, nil
+}
+
+func (r *AtomicTokenRotator) recordLastError(id string, err error) {
+	if err == nil || r.dispatcher == nil {
+		return
+	}
+	evtMgr := r.dispatcher.GetEventDispatcher()
+	if evtMgr == nil {
+		return
+	}
+	evtMgr.Dispatch(&events.LastError{
+		Time:    timestamppb.Now(),
+		Message: err.Error(),
+		Id:      id,
+	})
+}
+
+func (r *AtomicTokenRotator) updateSession(ctx context.Context, s *session.Session) error {
+	log.Ctx(ctx).Debug().
+		Str("user-id", s.GetUserId()).
+		Str("session-id", s.GetId()).
+		Msg("updating session")
+
+	fm, err := fieldmaskpb.New(s, "oauth_token", "id_token", "claims")
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).
+			Str("user-id", s.GetUserId()).
+			Str("session-id", s.GetId()).
+			Msg("failed to create fieldmask for session")
+		return err
+	}
+
+	_, err = session.Patch(ctx, r.clientB.GetDataBrokerServiceClient(), s, fm)
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).
+			Str("user-id", s.GetUserId()).
+			Str("session-id", s.GetId()).
+			Msg("failed to patch updated session record")
+		return err
+	}
+	return nil
+}
+
+func (r *AtomicTokenRotator) updateUser(ctx context.Context, u *user.User) error {
+	_, err := databroker.Put(ctx, r.clientB.GetDataBrokerServiceClient(), u)
+	if err != nil {
+		log.Ctx(ctx).Error().
+			Str("user-id", u.GetId()).
+			Err(err).
+			Msg("failed to store updated user record")
+		return err
+	}
+	return nil
+}
+
+// TODO : duplicated
+// FromOAuthToken converts a session oauth token to oauth2.Token.
+func FromOAuthToken(token *session.OAuthToken) *oauth2.Token {
+	return &oauth2.Token{
+		AccessToken:  token.GetAccessToken(),
+		TokenType:    token.GetTokenType(),
+		RefreshToken: token.GetRefreshToken(),
+		Expiry:       token.GetExpiresAt().AsTime(),
+	}
+}
+
+// TODO : duplicated
+// ToOAuthToken converts an oauth2.Token to a session oauth token.
+func ToOAuthToken(token *oauth2.Token) *session.OAuthToken {
+	expiry := timestamppb.New(token.Expiry)
+	return &session.OAuthToken{
+		AccessToken:  token.AccessToken,
+		TokenType:    token.TokenType,
+		RefreshToken: token.RefreshToken,
+		ExpiresAt:    expiry,
+	}
+}

--- a/pkg/identity/token/atomic_rotator_test.go
+++ b/pkg/identity/token/atomic_rotator_test.go
@@ -1,0 +1,337 @@
+package token
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pomerium/pomerium/internal/databroker"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+
+	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/grpc/user"
+	"github.com/pomerium/pomerium/pkg/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"golang.org/x/oauth2"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type mockAuthenticator struct {
+	identity.Authenticator
+
+	refreshResult       *oauth2.Token
+	refreshError        error
+	updateUserInfoError error
+}
+
+func (mock *mockAuthenticator) Refresh(_ context.Context, _ *oauth2.Token, _ identity.State) (*oauth2.Token, error) {
+	return mock.refreshResult, mock.refreshError
+}
+
+func (mock *mockAuthenticator) UpdateUserInfo(_ context.Context, _ *oauth2.Token, _ any) error {
+	return mock.updateUserInfoError
+}
+
+func TestRotateTokenSingle(t *testing.T) {
+	validSession := func() *session.Session {
+		iat := time.Now()
+		return &session.Session{
+			Id:        "session-1",
+			UserId:    "user-1",
+			IssuedAt:  timestamppb.New(iat),
+			ExpiresAt: timestamppb.New(iat.Add(24 * time.Hour)),
+			OauthToken: &session.OAuthToken{
+				AccessToken:  "fake-access-token",
+				RefreshToken: "fake-refresh-token",
+			},
+		}
+	}
+
+	newRotator := func(t *testing.T, authenticator identity.Authenticator) (*AtomicTokenRotator, databrokerpb.DataBrokerServiceClient) {
+		t.Helper()
+		client := newTestDataBrokerClient(t)
+		return NewAtomicTokenRotator(NewStaticAuthenticatorGetter(authenticator), databrokerpb.NewStaticClientGetter(client)), client
+	}
+
+	// not ported: the rotator is handed a session by the caller, it never looks one up by id.
+	// not ported ("no authenticator"): the authenticator is a constructor dependency, there is no
+	// per-session authenticator lookup that can fail.
+
+	t.Run("session expired", func(t *testing.T) {
+		r, _ := newRotator(t, &mockAuthenticator{})
+
+		sess := validSession()
+		sess.ExpiresAt = timestamppb.New(time.Now().Add(-1 * time.Hour))
+
+		res, err := r.RotateSessionToken(t.Context(), sess, nil)
+		assert.Nil(t, res)
+		assert.ErrorIs(t, err, ErrExpiredSession)
+	})
+	t.Run("refresh disabled", func(t *testing.T) {
+		r, _ := newRotator(t, &mockAuthenticator{})
+
+		sess := validSession()
+		sess.RefreshDisabled = true
+
+		res, err := r.RotateSessionToken(t.Context(), sess, nil)
+		assert.Nil(t, res)
+		assert.ErrorIs(t, err, ErrDoNotRefresh)
+	})
+	t.Run("missing token", func(t *testing.T) {
+		r, _ := newRotator(t, &mockAuthenticator{})
+
+		sess := validSession()
+		sess.OauthToken = nil
+
+		res, err := r.RotateSessionToken(t.Context(), sess, nil)
+		assert.Nil(t, res)
+		assert.ErrorIs(t, err, ErrDoNotRefresh)
+	})
+	t.Run("refresh temporary error", func(t *testing.T) {
+		// TODO: the rotator does not yet distinguish temporary from fatal refresh errors,
+		// see the TODO in runRotateLeased and the unused isTemporaryError.
+	})
+	t.Run("refresh fatal error", func(t *testing.T) {
+		refreshError := errors.New("failed to refresh")
+		r, _ := newRotator(t, &mockAuthenticator{refreshError: refreshError})
+
+		sess := validSession()
+
+		res, err := r.RotateSessionToken(t.Context(), sess, nil)
+		assert.Nil(t, res)
+		// the rotator only surfaces the error, deleting the session is the caller's decision.
+		assert.ErrorIs(t, err, refreshError)
+	})
+	t.Run("user info temporary error", func(t *testing.T) {
+		// TODO: the rotator does not yet distinguish temporary from fatal user info errors.
+	})
+	t.Run("user info fatal error", func(t *testing.T) {
+		updateUserInfoError := errors.New("failed to get user info")
+		r, _ := newRotator(t, &mockAuthenticator{
+			refreshResult: &oauth2.Token{
+				AccessToken:  "new-access-token",
+				RefreshToken: "new-refresh-token",
+				Expiry:       time.Now().Add(1 * time.Hour),
+			},
+			updateUserInfoError: updateUserInfoError,
+		})
+
+		sess := validSession()
+
+		res, err := r.RotateSessionToken(t.Context(), sess, nil)
+		assert.Nil(t, res)
+		assert.ErrorIs(t, err, updateUserInfoError)
+	})
+	t.Run("ok", func(t *testing.T) {
+		newToken := &oauth2.Token{
+			AccessToken:  "new-access-token",
+			RefreshToken: "new-refresh-token",
+			Expiry:       time.Now().Add(1 * time.Hour),
+		}
+		r, client := newRotator(t, &mockAuthenticator{refreshResult: newToken})
+
+		sess := validSession()
+		u := &user.User{Id: "user-1"}
+		_, err := databrokerpb.Put(t.Context(), client, sess)
+		require.NoError(t, err)
+		_, err = databrokerpb.Put(t.Context(), client, u)
+		require.NoError(t, err)
+
+		res, err := r.RotateSessionToken(t.Context(), sess, u)
+		require.NoError(t, err)
+		assert.Equal(t, newToken, res.Token)
+		assert.Equal(t, u, res.User)
+		testutil.AssertProtoEqual(t, &session.OAuthToken{
+			AccessToken:  "new-access-token",
+			RefreshToken: "new-refresh-token",
+			ExpiresAt:    timestamppb.New(newToken.Expiry),
+		}, res.Session.GetOauthToken())
+
+		stored, err := session.Get(t.Context(), client, sess.GetId())
+		require.NoError(t, err)
+		testutil.AssertProtoEqual(t, res.Session.GetOauthToken(), stored.GetOauthToken())
+	})
+}
+
+func TestRotateTokenConcurrent(t *testing.T) {
+	t.Run("client waits until existing token is refreshed", func(t *testing.T) {
+		newToken := &oauth2.Token{
+			AccessToken:  "new-access-token",
+			RefreshToken: "new-refresh-token",
+			Expiry:       time.Now().Add(1 * time.Hour),
+		}
+		authenticator := &blockingAuthenticator{
+			mockAuthenticator: mockAuthenticator{refreshResult: newToken},
+			started:           make(chan struct{}),
+			release:           make(chan struct{}),
+		}
+
+		client := newTestDataBrokerClient(t)
+		r := NewAtomicTokenRotator(NewStaticAuthenticatorGetter(authenticator), databrokerpb.NewStaticClientGetter(client))
+
+		iat := time.Now()
+		sess := &session.Session{
+			Id:        "session-1",
+			UserId:    "user-1",
+			IssuedAt:  timestamppb.New(iat),
+			ExpiresAt: timestamppb.New(iat.Add(24 * time.Hour)),
+			OauthToken: &session.OAuthToken{
+				AccessToken:  "fake-access-token",
+				RefreshToken: "fake-refresh-token",
+			},
+		}
+		_, err := databrokerpb.Put(t.Context(), client, sess)
+		require.NoError(t, err)
+
+		type result struct {
+			res *RotateTokenSuccess
+			err error
+		}
+		rotate := func() <-chan result {
+			done := make(chan result, 1)
+			go func() {
+				res, err := r.RotateSessionToken(t.Context(), proto.Clone(sess).(*session.Session), nil)
+				done <- result{res: res, err: err}
+			}()
+			return done
+		}
+
+		// the first caller acquires the lease and blocks inside Refresh
+		leader := rotate()
+		select {
+		case <-authenticator.started:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for the first refresh to start")
+		}
+
+		// the second caller finds the lease already held, so it must wait rather than
+		// refresh a second time or return the stale token
+		waiter := rotate()
+		select {
+		case got := <-waiter:
+			t.Fatalf("second caller returned while the refresh was still in flight: %+v", got)
+		case <-time.After(time.Second):
+		}
+
+		close(authenticator.release)
+
+		leaderResult := <-leader
+		require.NoError(t, leaderResult.err)
+		assert.Equal(t, newToken, leaderResult.res.Token)
+
+		waiterResult := <-waiter
+		require.NoError(t, waiterResult.err)
+		assert.Equal(t, newToken.AccessToken, waiterResult.res.Token.AccessToken)
+		assert.Equal(t, newToken.RefreshToken, waiterResult.res.Token.RefreshToken)
+		assert.Equal(t, int32(1), authenticator.refreshCount.Load())
+	})
+
+	t.Run("failed leased rotation", func(t *testing.T) {
+		refreshError := errors.New("failed to refresh")
+		authenticator := &blockingAuthenticator{
+			mockAuthenticator: mockAuthenticator{refreshError: refreshError},
+			started:           make(chan struct{}),
+			release:           make(chan struct{}),
+		}
+
+		client := newTestDataBrokerClient(t)
+		r := NewAtomicTokenRotator(NewStaticAuthenticatorGetter(authenticator), databrokerpb.NewStaticClientGetter(client))
+
+		iat := time.Now()
+		sess := &session.Session{
+			Id:        "session-1",
+			UserId:    "user-1",
+			IssuedAt:  timestamppb.New(iat),
+			ExpiresAt: timestamppb.New(iat.Add(24 * time.Hour)),
+			OauthToken: &session.OAuthToken{
+				AccessToken:  "fake-access-token",
+				RefreshToken: "fake-refresh-token",
+			},
+		}
+		_, err := databrokerpb.Put(t.Context(), client, sess)
+		require.NoError(t, err)
+
+		type result struct {
+			res *RotateTokenSuccess
+			err error
+		}
+		rotate := func(ctx context.Context) <-chan result {
+			done := make(chan result, 1)
+			go func() {
+				res, err := r.RotateSessionToken(ctx, proto.Clone(sess).(*session.Session), nil)
+				done <- result{res: res, err: err}
+			}()
+			return done
+		}
+
+		// the first caller acquires the lease and blocks inside Refresh
+		leader := rotate(t.Context())
+		select {
+		case <-authenticator.started:
+		case <-time.After(10 * time.Second):
+			t.Fatal("timed out waiting for the first refresh to start")
+		}
+
+		// the lease holder's refresh fails, so the session is never rotated and the
+		// waiting caller gives up once its own context expires
+		waiterCtx, waiterCancel := context.WithTimeout(t.Context(), 2*time.Second)
+		defer waiterCancel()
+		waiter := rotate(waiterCtx)
+
+		close(authenticator.release)
+
+		leaderResult := <-leader
+		assert.Nil(t, leaderResult.res)
+		assert.ErrorIs(t, leaderResult.err, refreshError)
+
+		waiterResult := <-waiter
+		assert.Nil(t, waiterResult.res)
+		assert.ErrorIs(t, waiterResult.err, ErrTokenNotRotated)
+
+		// the waiter never refreshes on its own, even after the lease holder fails
+		assert.Equal(t, int32(1), authenticator.refreshCount.Load())
+
+		stored, err := session.Get(t.Context(), client, sess.GetId())
+		require.NoError(t, err)
+		testutil.AssertProtoEqual(t, sess.GetOauthToken(), stored.GetOauthToken())
+	})
+}
+
+type blockingAuthenticator struct {
+	mockAuthenticator
+
+	started      chan struct{}
+	release      chan struct{}
+	refreshCount atomic.Int32
+}
+
+func (mock *blockingAuthenticator) Refresh(ctx context.Context, t *oauth2.Token, s identity.State) (*oauth2.Token, error) {
+	mock.refreshCount.Add(1)
+	close(mock.started)
+	select {
+	case <-mock.release:
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+	return mock.mockAuthenticator.Refresh(ctx, t, s)
+}
+
+func newTestDataBrokerClient(t *testing.T) databrokerpb.DataBrokerServiceClient {
+	t.Helper()
+
+	srv := databroker.NewBackendServer(noop.NewTracerProvider())
+	t.Cleanup(srv.Stop)
+
+	cc := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(s, srv)
+	})
+
+	return databrokerpb.NewDataBrokerServiceClient(cc)
+}

--- a/pkg/identity/token/unmarshaller.go
+++ b/pkg/identity/token/unmarshaller.go
@@ -1,0 +1,97 @@
+package token
+
+import (
+	"encoding/json"
+	"errors"
+
+	"github.com/pomerium/pomerium/pkg/grpc/user"
+
+	"github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/identity"
+)
+
+// TODO :duplicated
+
+// a multiUnmarshaler is used as the target of the json Unmarshal function to
+// unmarshal a single JSON value into multiple destinations.
+type multiUnmarshaler []any
+
+func newMultiUnmarshaler(args ...any) *multiUnmarshaler {
+	return (*multiUnmarshaler)(&args)
+}
+
+func (dst *multiUnmarshaler) UnmarshalJSON(data []byte) error {
+	var err error
+	for _, o := range *dst {
+		if o != nil {
+			err = errors.Join(err, json.Unmarshal(data, o))
+		}
+	}
+	return err
+}
+
+// SessionUnmarshaler wraps a session and implements json.Unmarshaler
+// to populate the session with claims from an ID token.
+type SessionUnmarshaler struct {
+	*session.Session
+}
+
+// NewSessionUnmarshaler creates a new SessionUnmarshaler for the given session.
+func NewSessionUnmarshaler(s *session.Session) *SessionUnmarshaler {
+	return &SessionUnmarshaler{Session: s}
+}
+
+func (dst *SessionUnmarshaler) UnmarshalJSON(data []byte) error {
+	if dst.Session == nil {
+		return nil
+	}
+
+	var raw map[string]json.RawMessage
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return err
+	}
+
+	// To preserve existing behavior: filter out claims not related to user info.
+	delete(raw, "iss")
+	delete(raw, "sub")
+	delete(raw, "exp")
+	delete(raw, "iat")
+
+	dst.Session.AddClaims(identity.NewClaimsFromRaw(raw).Flatten())
+
+	return nil
+}
+
+type userUnmarshaler struct {
+	*user.User
+}
+
+func newUserUnmarshaler(u *user.User) *userUnmarshaler {
+	return &userUnmarshaler{User: u}
+}
+
+func (dst *userUnmarshaler) UnmarshalJSON(data []byte) error {
+	if dst.User == nil {
+		return nil
+	}
+
+	var raw map[string]json.RawMessage
+	err := json.Unmarshal(data, &raw)
+	if err != nil {
+		return err
+	}
+
+	if name, ok := raw["name"]; ok {
+		_ = json.Unmarshal(name, &dst.User.Name)
+		delete(raw, "name")
+	}
+	if email, ok := raw["email"]; ok {
+		_ = json.Unmarshal(email, &dst.User.Email)
+		delete(raw, "email")
+	}
+
+	dst.User.AddClaims(identity.NewClaimsFromRaw(raw).Flatten())
+
+	return nil
+}


### PR DESCRIPTION
## Summary

With the introduction of MCP, and later on agentic identities, we need to atomically refresh tokens when multiple internal pomerium resources may be interested in the same oauth refresh token.

For instance, the MCP refresh token must refresh the token every type the token grant is requested from MCP clients, but it is also refreshed in the background on the IDP session manager.
In addition, the MCP refresh token outlives sessions, so we need a way to keep track of the last known token in the case where the Pomerium session expires. This is done in a follow PR, that uses a databroker syncer to update the latest MCP refresh token with the current session.Session token.


## Related issues

Related to https://github.com/pomerium/pomerium/issues/6530

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

## AI disclosure

<!-- If this PR was assisted by AI (Claude, Copilot, Cursor, Amp, etc.),
state which tool and roughly how much of the work was AI-assisted (e.g.
"Cursor autocomplete only", "Claude Code drafted scaffolding, I rewrote
the auth path"). If no AI was used, write "none". See AI_PO
LICY.md. -->

## Checklist

- [ ] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [ ] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>