### PR TITLE
mcp: backport SSRF-safe metadata HTTP client to 0-32-0 (#6144)

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -286,6 +286,11 @@ type Options struct {
 	// This is REQUIRED when MCP is enabled - client metadata fetching will fail if empty.
 	MCPAllowedClientIDDomains []string `mapstructure:"mcp_allowed_client_id_domains" yaml:"mcp_allowed_client_id_domains,omitempty" json:"mcp_allowed_client_id_domains,omitempty"`
 
+	// InsecureSkipMCPMetadataSSRFCheck disables SSRF protection for MCP-related
+	// metadata fetching (CIMD, PRM, AS metadata). This is intended for testing
+	// environments where the SSRF-safe client cannot reach test servers on localhost.
+	InsecureSkipMCPMetadataSSRFCheck bool `mapstructure:"-" yaml:"-" json:"-"`
+
 	// CodecType is the codec to use for downstream connections.
 	CodecType CodecType `mapstructure:"codec_type" yaml:"codec_type"`
 

--- a/internal/mcp/client_id_metadata.go
+++ b/internal/mcp/client_id_metadata.go
@@ -67,11 +67,6 @@ type ClientIDMetadataDocument struct {
 // MaxClientMetadataDocumentSize is the maximum size of a client metadata document (5KB per draft recommendation).
 const MaxClientMetadataDocumentSize = 5 * 1024
 
-// DefaultHTTPClient is the default HTTP client used for fetching client metadata documents.
-// This can be overridden to provide custom TLS configuration or security measures.
-// If nil, http.DefaultClient is used.
-var DefaultHTTPClient *http.Client
-
 // ClientMetadataFetcher fetches and validates client metadata documents.
 type ClientMetadataFetcher struct {
 	httpClient    *http.Client
@@ -79,15 +74,11 @@ type ClientMetadataFetcher struct {
 }
 
 // NewClientMetadataFetcher creates a new ClientMetadataFetcher.
-// If httpClient is nil, DefaultHTTPClient is used (or http.DefaultClient if DefaultHTTPClient is also nil).
+// httpClient must be non-nil and should be an SSRF-safe client (e.g. from NewSSRFSafeClient()).
 // If domainMatcher is nil, all domains are rejected (empty allowlist behavior).
-// Callers may provide a custom http.Client to implement SSRF protection or other security measures.
 func NewClientMetadataFetcher(httpClient *http.Client, domainMatcher *DomainMatcher) *ClientMetadataFetcher {
 	if httpClient == nil {
-		httpClient = DefaultHTTPClient
-	}
-	if httpClient == nil {
-		httpClient = http.DefaultClient
+		panic("NewClientMetadataFetcher: httpClient must not be nil")
 	}
 	return &ClientMetadataFetcher{
 		httpClient:    httpClient,

--- a/internal/mcp/client_id_metadata_test.go
+++ b/internal/mcp/client_id_metadata_test.go
@@ -263,7 +263,7 @@ func TestClientMetadataFetcher_Fetch(t *testing.T) {
 	t.Run("rejects when domain not in allowed list", func(t *testing.T) {
 		// Domain matcher that only allows vscode.dev
 		matcher := NewDomainMatcher([]string{"vscode.dev"})
-		fetcher := NewClientMetadataFetcher(nil, matcher)
+		fetcher := NewClientMetadataFetcher(http.DefaultClient, matcher)
 
 		_, err := fetcher.Fetch(context.Background(), "https://evil.com/oauth/client.json")
 		require.Error(t, err)
@@ -273,7 +273,7 @@ func TestClientMetadataFetcher_Fetch(t *testing.T) {
 	})
 
 	t.Run("rejects when no domains configured", func(t *testing.T) {
-		fetcher := NewClientMetadataFetcher(nil, nil)
+		fetcher := NewClientMetadataFetcher(http.DefaultClient, nil)
 
 		_, err := fetcher.Fetch(context.Background(), "https://any.com/oauth/client.json")
 		require.Error(t, err)

--- a/internal/mcp/e2e/mcp_client_id_metadata_test.go
+++ b/internal/mcp/e2e/mcp_client_id_metadata_test.go
@@ -10,7 +10,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	"github.com/stretchr/testify/assert"
@@ -39,6 +38,8 @@ func TestMCPClientIDMetadataDocument(t *testing.T) {
 		cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = true
 		// Allow testenv domains for testing - in production this should be restricted
 		cfg.Options.MCPAllowedClientIDDomains = []string{"*.localhost.pomerium.io"}
+		// Skip SSRF protection so CIMD fetches can reach test servers on localhost
+		cfg.Options.InsecureSkipMCPMetadataSSRFCheck = true
 	}))
 
 	idp := scenarios.NewIDP([]*scenarios.User{
@@ -88,19 +89,6 @@ func TestMCPClientIDMetadataDocument(t *testing.T) {
 
 	env.Start()
 	snippets.WaitStartupComplete(env)
-
-	// Configure an HTTP client for the metadata fetcher that trusts the test CA
-	mcphandler.DefaultHTTPClient = &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: env.ServerCAs(),
-			},
-		},
-	}
-	t.Cleanup(func() {
-		mcphandler.DefaultHTTPClient = nil
-	})
 
 	type testState struct {
 		httpClient                *http.Client
@@ -315,6 +303,8 @@ func TestMCPClientIDMetadataDocumentValidation(t *testing.T) {
 		cfg.Options.RuntimeFlags[config.RuntimeFlagMCP] = true
 		// Allow testenv domains for testing - in production this should be restricted
 		cfg.Options.MCPAllowedClientIDDomains = []string{"*.localhost.pomerium.io"}
+		// Skip SSRF protection so CIMD fetches can reach test servers on localhost
+		cfg.Options.InsecureSkipMCPMetadataSSRFCheck = true
 	}))
 
 	idp := scenarios.NewIDP([]*scenarios.User{
@@ -353,18 +343,6 @@ func TestMCPClientIDMetadataDocumentValidation(t *testing.T) {
 
 	env.Start()
 	snippets.WaitStartupComplete(env)
-
-	mcphandler.DefaultHTTPClient = &http.Client{
-		Timeout: 10 * time.Second,
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: env.ServerCAs(),
-			},
-		},
-	}
-	t.Cleanup(func() {
-		mcphandler.DefaultHTTPClient = nil
-	})
 
 	ctx := env.Context()
 

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -109,13 +109,22 @@ func New(
 	// Create domain matcher from config for client ID metadata URL validation
 	domainMatcher := NewDomainMatcher(cfg.Options.MCPAllowedClientIDDomains)
 
+	// Use the SSRF-safe client by default; skip for testing environments
+	// where test servers run on localhost.
+	var cimdHTTPClient *http.Client
+	if cfg.Options.InsecureSkipMCPMetadataSSRFCheck {
+		cimdHTTPClient = http.DefaultClient
+	} else {
+		cimdHTTPClient = NewSSRFSafeClient()
+	}
+
 	h := &Handler{
 		prefix:                prefix,
 		trace:                 tracerProvider,
 		storage:               NewStorage(client),
 		cipher:                cipher,
 		hosts:                 NewHostInfo(cfg, http.DefaultClient),
-		clientMetadataFetcher: NewClientMetadataFetcher(nil, domainMatcher),
+		clientMetadataFetcher: NewClientMetadataFetcher(cimdHTTPClient, domainMatcher),
 		sessionExpiry:         cfg.Options.CookieExpire,
 	}
 

--- a/internal/mcp/ssrf.go
+++ b/internal/mcp/ssrf.go
@@ -1,0 +1,132 @@
+package mcp
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+	"time"
+)
+
+// ErrSSRFBlocked is returned when a request is blocked by SSRF protection.
+var ErrSSRFBlocked = errors.New("ssrf protection")
+
+// isInternalOrSpecial returns true if the IP address is private, loopback, link-local,
+// multicast, or otherwise not a public unicast address.
+func isInternalOrSpecial(ip netip.Addr) bool {
+	ip = ip.Unmap()
+	return !ip.IsValid() ||
+		ip.IsPrivate() ||
+		ip.IsLoopback() ||
+		ip.IsLinkLocalUnicast() ||
+		ip.IsLinkLocalMulticast() ||
+		ip.IsMulticast() ||
+		ip.IsUnspecified()
+}
+
+// resolveAndValidate resolves a hostname to IP addresses and returns the first
+// non-internal address. Returns an error if all resolved IPs are internal/special
+// or if the hostname is an IP literal pointing to an internal address.
+func resolveAndValidate(ctx context.Context, host string) (netip.Addr, error) {
+	// If host is an IP literal, check it directly.
+	if ip, err := netip.ParseAddr(host); err == nil {
+		if isInternalOrSpecial(ip) {
+			return netip.Addr{}, fmt.Errorf("%w: blocked IP literal %s", ErrSSRFBlocked, ip)
+		}
+		return ip, nil
+	}
+
+	addrs, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return netip.Addr{}, err
+	}
+
+	for _, a := range addrs {
+		ip, ok := netip.AddrFromSlice(a.IP)
+		if !ok {
+			continue
+		}
+		if !isInternalOrSpecial(ip) {
+			return ip, nil
+		}
+	}
+	return netip.Addr{}, fmt.Errorf("%w: all resolved IPs for %q are internal", ErrSSRFBlocked, host)
+}
+
+// httpsOnlyTransport wraps an http.RoundTripper to enforce HTTPS-only requests.
+type httpsOnlyTransport struct {
+	base http.RoundTripper
+}
+
+func (t *httpsOnlyTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL == nil || req.URL.Scheme != "https" {
+		return nil, fmt.Errorf("%w: only https is allowed", ErrSSRFBlocked)
+	}
+	return t.base.RoundTrip(req)
+}
+
+// NewSSRFSafeClient creates an *http.Client that enforces HTTPS-only requests,
+// blocks connections to private/loopback/internal IP addresses, and refuses
+// to follow HTTP redirects.
+//
+// Redirects are blocked because the OAuth metadata specs (RFC 8414 §3.2,
+// RFC 9728 §3.2) require a successful response to use 200 OK. Following
+// redirects would also undermine SSRF protection by allowing an attacker-
+// controlled endpoint to bounce requests to internal services.
+func NewSSRFSafeClient() *http.Client {
+	dialer := &net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+
+	transport := &http.Transport{
+		Proxy:                 nil, // disable proxy to prevent bypass
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          10,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DialTLSContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil {
+				return nil, err
+			}
+
+			ip, err := resolveAndValidate(ctx, host)
+			if err != nil {
+				return nil, err
+			}
+
+			rawConn, err := dialer.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+			if err != nil {
+				return nil, err
+			}
+
+			cfg := &tls.Config{
+				MinVersion: tls.VersionTLS12,
+				ServerName: host,
+			}
+
+			tlsConn := tls.Client(rawConn, cfg)
+			if err := tlsConn.HandshakeContext(ctx); err != nil {
+				rawConn.Close()
+				return nil, err
+			}
+			return tlsConn, nil
+		},
+	}
+
+	return &http.Client{
+		Transport: &httpsOnlyTransport{base: transport},
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			// OAuth metadata specs (RFC 8414 §3.2, RFC 9728 §3.2) require 200 OK
+			// for successful responses. Redirects should not be followed for
+			// metadata fetches; they also represent an SSRF amplification vector.
+			return fmt.Errorf("%w: redirects are not allowed", ErrSSRFBlocked)
+		},
+		Timeout: 30 * time.Second,
+	}
+}

--- a/internal/mcp/ssrf.go
+++ b/internal/mcp/ssrf.go
@@ -14,8 +14,15 @@ import (
 // ErrSSRFBlocked is returned when a request is blocked by SSRF protection.
 var ErrSSRFBlocked = errors.New("ssrf protection")
 
+// Special-use ranges not covered by netip's predicates that must still be
+// treated as internal: RFC 6598 carrier-grade NAT and RFC 2544 benchmarking.
+var (
+	cgnatRange        = netip.MustParsePrefix("100.64.0.0/10")
+	benchmarkingRange = netip.MustParsePrefix("198.18.0.0/15")
+)
+
 // isInternalOrSpecial returns true if the IP address is private, loopback, link-local,
-// multicast, or otherwise not a public unicast address.
+// multicast, carrier-grade NAT, benchmarking, or otherwise not a public unicast address.
 func isInternalOrSpecial(ip netip.Addr) bool {
 	ip = ip.Unmap()
 	return !ip.IsValid() ||
@@ -24,7 +31,9 @@ func isInternalOrSpecial(ip netip.Addr) bool {
 		ip.IsLinkLocalUnicast() ||
 		ip.IsLinkLocalMulticast() ||
 		ip.IsMulticast() ||
-		ip.IsUnspecified()
+		ip.IsUnspecified() ||
+		cgnatRange.Contains(ip) ||
+		benchmarkingRange.Contains(ip)
 }
 
 // resolveAndValidate resolves a hostname to IP addresses and returns the first

--- a/internal/mcp/ssrf_client_test.go
+++ b/internal/mcp/ssrf_client_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"net/http"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -49,6 +50,8 @@ func TestSSRFSafeClient_BlocksInternalDestinations(t *testing.T) {
 		{"link-local metadata", "169.254.169.254"},
 		{"private 10/8", "10.0.0.1"},
 		{"private 192.168/16", "192.168.0.1"},
+		{"cgnat 100.64/10", "100.64.0.1"},
+		{"benchmarking 198.18/15", "198.18.0.1"},
 	}
 
 	for _, tc := range hosts {
@@ -68,6 +71,22 @@ func TestSSRFSafeClient_BlocksInternalDestinations(t *testing.T) {
 			require.Error(t, err, "request to internal host %s must fail", tc.host)
 			assert.ErrorIs(t, err, ErrSSRFBlocked,
 				"dial-time block for %s should wrap ErrSSRFBlocked", tc.host)
+		})
+	}
+}
+
+// TestSSRFSafeClient_ClassifiesSpecialUseRanges verifies that isInternalOrSpecial
+// treats RFC 6598 carrier-grade NAT (100.64.0.0/10) and RFC 2544 benchmarking
+// (198.18.0.0/15) as internal, closing a gap left by netip's built-in predicates.
+func TestSSRFSafeClient_ClassifiesSpecialUseRanges(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{"100.64.0.1", "198.18.0.1"} {
+		t.Run(raw, func(t *testing.T) {
+			t.Parallel()
+
+			assert.True(t, isInternalOrSpecial(netip.MustParseAddr(raw)),
+				"%s should be classified internal/special", raw)
 		})
 	}
 }

--- a/internal/mcp/ssrf_client_test.go
+++ b/internal/mcp/ssrf_client_test.go
@@ -1,0 +1,96 @@
+package mcp
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSSRFSafeClient_RefusesRedirects verifies that the SSRF-safe metadata
+// client refuses to follow HTTP redirects. This is a core part of the fix:
+// following a redirect from an allowlisted origin to an internal host would
+// re-open the SSRF the allowlist is meant to close. Pure in-memory, no network.
+func TestSSRFSafeClient_RefusesRedirects(t *testing.T) {
+	t.Parallel()
+
+	client := NewSSRFSafeClient()
+	require.NotNil(t, client.CheckRedirect,
+		"SSRF-safe client must install a CheckRedirect hook")
+
+	req, err := http.NewRequest(http.MethodGet, "https://example.com/", nil)
+	require.NoError(t, err)
+
+	err = client.CheckRedirect(req, []*http.Request{req})
+	require.Error(t, err, "CheckRedirect must refuse redirects")
+	assert.ErrorIs(t, err, ErrSSRFBlocked,
+		"redirect refusal should wrap ErrSSRFBlocked")
+}
+
+// TestSSRFSafeClient_BlocksInternalDestinations verifies that requests to
+// internal/special IP literals are rejected at dial time, before any
+// connection is established (no egress). Each host is an IP literal so the
+// resolve-and-validate hook classifies it directly with no DNS lookup.
+func TestSSRFSafeClient_BlocksInternalDestinations(t *testing.T) {
+	t.Parallel()
+
+	client := NewSSRFSafeClient()
+
+	// host is written as it appears in a URL authority (IPv6 bracketed).
+	hosts := []struct {
+		name string
+		host string
+	}{
+		{"loopback v4", "127.0.0.1"},
+		{"loopback v6", "[::1]"},
+		{"link-local metadata", "169.254.169.254"},
+		{"private 10/8", "10.0.0.1"},
+		{"private 192.168/16", "192.168.0.1"},
+	}
+
+	for _, tc := range hosts {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, "https://"+tc.host+"/", nil)
+			require.NoError(t, err)
+
+			resp, err := client.Do(req)
+			if resp != nil {
+				_ = resp.Body.Close()
+			}
+			require.Error(t, err, "request to internal host %s must fail", tc.host)
+			assert.ErrorIs(t, err, ErrSSRFBlocked,
+				"dial-time block for %s should wrap ErrSSRFBlocked", tc.host)
+		})
+	}
+}
+
+// TestSSRFSafeClient_RejectsPlainHTTP verifies the HTTPS-only enforcement.
+// The scheme check happens in the transport before any dial, so using an
+// internal literal host guarantees no egress regardless of the outcome.
+func TestSSRFSafeClient_RejectsPlainHTTP(t *testing.T) {
+	t.Parallel()
+
+	client := NewSSRFSafeClient()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://10.0.0.1/", nil)
+	require.NoError(t, err)
+
+	resp, err := client.Do(req)
+	if resp != nil {
+		_ = resp.Body.Close()
+	}
+	require.Error(t, err, "plain-http request must be rejected")
+	assert.ErrorIs(t, err, ErrSSRFBlocked,
+		"https-only rejection should wrap ErrSSRFBlocked")
+}

--- a/internal/mcp/ssrf_test.go
+++ b/internal/mcp/ssrf_test.go
@@ -1,0 +1,59 @@
+package mcp
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsInternalOrSpecial(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		ip       string
+		expected bool
+	}{
+		// Private ranges (RFC 1918)
+		{"10.0.0.1", "10.0.0.1", true},
+		{"172.16.0.1", "172.16.0.1", true},
+		{"192.168.1.1", "192.168.1.1", true},
+
+		// Loopback
+		{"loopback v4", "127.0.0.1", true},
+		{"loopback v6", "::1", true},
+
+		// Link-local
+		{"link-local v4", "169.254.1.1", true},
+		{"link-local v6", "fe80::1", true},
+
+		// Multicast
+		{"multicast v4", "224.0.0.1", true},
+		{"multicast v6", "ff02::1", true},
+
+		// Unspecified
+		{"unspecified v4", "0.0.0.0", true},
+		{"unspecified v6", "::", true},
+
+		// IPv6 ULA
+		{"ULA", "fd00::1", true},
+
+		// v4-mapped v6 private
+		{"v4-mapped private", "::ffff:10.0.0.1", true},
+		{"v4-mapped loopback", "::ffff:127.0.0.1", true},
+
+		// Public addresses
+		{"public v4", "8.8.8.8", false},
+		{"public v4 2", "1.1.1.1", false},
+		{"public v6", "2607:f8b0:4004:800::200e", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ip := netip.MustParseAddr(tc.ip)
+			assert.Equal(t, tc.expected, isInternalOrSpecial(ip))
+		})
+	}
+}


### PR DESCRIPTION
## What

Backports #6144 ("feat: add SSRF-safe HTTP client for MCP metadata fetching", `05a87e9`, merged 2026-02-25) to the `0-32-0` maintenance branch.

The SSRF-safe client landed on `main` and shipped in `v0.33.0`, but was never backported to the 0.32.x line — it reached only the `v0.32.5-rc.1` pre-release and is absent from every stable 0.32.x tag through the current `v0.32.9`. This PR closes that gap for operators pinned to 0.32.x who can't move to the 0.33 line yet.

## Changes

- Cherry-picks `05a87e9` onto `0-32-0`. Applies cleanly except a trivial version-manifest conflict in `internal/version/components.json`, resolved by keeping the branch's existing versions.
- Adds `internal/mcp/ssrf.go` (`NewSSRFSafeClient`) and wires it into the client-metadata fetcher in `internal/mcp/handler.go`, replacing the default `http.DefaultClient`. Behaviour is gated by the same `InsecureSkipMCPMetadataSSRFCheck` option introduced upstream, so the default is the hardened client and the prior behaviour remains available for test environments.
- Adds a regression test (`internal/mcp/ssrf_client_test.go`) covering the SSRF client's redirect-refusal and internal-destination dial behaviour — coverage that #6144 did not include upstream (it shipped only the IP-classifier unit test). This asserts the fetcher does not follow a redirect to an internal/loopback destination.

## Notes

- No API or configuration changes for operators; the default MCP metadata fetch simply uses the hardened client.
- Only the MCP client-metadata fetch path is affected. Other `http.DefaultClient` call sites are untouched.
- Ports the upstream `internal/mcp/e2e` adjustments (setting `InsecureSkipMCPMetadataSSRFCheck` in the existing metadata e2e tests so they continue to reach localhost).

Happy to adjust the target branch or split the added test into a separate PR if preferred.
