### PR TITLE
feat(file): singleflight 

### DIFF
--- a/pkg/grpc/databroker/databroker.pb.go
+++ b/pkg/grpc/databroker/databroker.pb.go
@@ -1594,6 +1594,250 @@ func (x *RenewLeaseRequest) GetDuration() *durationpb.Duration {
 	return nil
 }
 
+type TransactionRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Key   string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Types that are valid to be assigned to Operation:
+	//
+	//	*TransactionRequest_Get
+	//	*TransactionRequest_Put
+	//	*TransactionRequest_Patch
+	//	*TransactionRequest_Query
+	Operation     isTransactionRequest_Operation `protobuf_oneof:"operation"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransactionRequest) Reset() {
+	*x = TransactionRequest{}
+	mi := &file_databroker_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransactionRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransactionRequest) ProtoMessage() {}
+
+func (x *TransactionRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_databroker_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransactionRequest.ProtoReflect.Descriptor instead.
+func (*TransactionRequest) Descriptor() ([]byte, []int) {
+	return file_databroker_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *TransactionRequest) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *TransactionRequest) GetOperation() isTransactionRequest_Operation {
+	if x != nil {
+		return x.Operation
+	}
+	return nil
+}
+
+func (x *TransactionRequest) GetGet() *GetRequest {
+	if x != nil {
+		if x, ok := x.Operation.(*TransactionRequest_Get); ok {
+			return x.Get
+		}
+	}
+	return nil
+}
+
+func (x *TransactionRequest) GetPut() *PutRequest {
+	if x != nil {
+		if x, ok := x.Operation.(*TransactionRequest_Put); ok {
+			return x.Put
+		}
+	}
+	return nil
+}
+
+func (x *TransactionRequest) GetPatch() *PatchRequest {
+	if x != nil {
+		if x, ok := x.Operation.(*TransactionRequest_Patch); ok {
+			return x.Patch
+		}
+	}
+	return nil
+}
+
+func (x *TransactionRequest) GetQuery() *QueryRequest {
+	if x != nil {
+		if x, ok := x.Operation.(*TransactionRequest_Query); ok {
+			return x.Query
+		}
+	}
+	return nil
+}
+
+type isTransactionRequest_Operation interface {
+	isTransactionRequest_Operation()
+}
+
+type TransactionRequest_Get struct {
+	Get *GetRequest `protobuf:"bytes,2,opt,name=get,proto3,oneof"`
+}
+
+type TransactionRequest_Put struct {
+	Put *PutRequest `protobuf:"bytes,3,opt,name=put,proto3,oneof"`
+}
+
+type TransactionRequest_Patch struct {
+	Patch *PatchRequest `protobuf:"bytes,4,opt,name=patch,proto3,oneof"`
+}
+
+type TransactionRequest_Query struct {
+	Query *QueryRequest `protobuf:"bytes,5,opt,name=query,proto3,oneof"`
+}
+
+func (*TransactionRequest_Get) isTransactionRequest_Operation() {}
+
+func (*TransactionRequest_Put) isTransactionRequest_Operation() {}
+
+func (*TransactionRequest_Patch) isTransactionRequest_Operation() {}
+
+func (*TransactionRequest_Query) isTransactionRequest_Operation() {}
+
+type TransactionResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Key   string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	// Types that are valid to be assigned to Operation:
+	//
+	//	*TransactionResponse_Get
+	//	*TransactionResponse_Put
+	//	*TransactionResponse_Patch
+	//	*TransactionResponse_Query
+	Operation     isTransactionResponse_Operation `protobuf_oneof:"operation"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransactionResponse) Reset() {
+	*x = TransactionResponse{}
+	mi := &file_databroker_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransactionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransactionResponse) ProtoMessage() {}
+
+func (x *TransactionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_databroker_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransactionResponse.ProtoReflect.Descriptor instead.
+func (*TransactionResponse) Descriptor() ([]byte, []int) {
+	return file_databroker_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *TransactionResponse) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+func (x *TransactionResponse) GetOperation() isTransactionResponse_Operation {
+	if x != nil {
+		return x.Operation
+	}
+	return nil
+}
+
+func (x *TransactionResponse) GetGet() *GetResponse {
+	if x != nil {
+		if x, ok := x.Operation.(*TransactionResponse_Get); ok {
+			return x.Get
+		}
+	}
+	return nil
+}
+
+func (x *TransactionResponse) GetPut() *PutResponse {
+	if x != nil {
+		if x, ok := x.Operation.(*TransactionResponse_Put); ok {
+			return x.Put
+		}
+	}
+	return nil
+}
+
+func (x *TransactionResponse) GetPatch() *PatchResponse {
+	if x != nil {
+		if x, ok := x.Operation.(*TransactionResponse_Patch); ok {
+			return x.Patch
+		}
+	}
+	return nil
+}
+
+func (x *TransactionResponse) GetQuery() *QueryResponse {
+	if x != nil {
+		if x, ok := x.Operation.(*TransactionResponse_Query); ok {
+			return x.Query
+		}
+	}
+	return nil
+}
+
+type isTransactionResponse_Operation interface {
+	isTransactionResponse_Operation()
+}
+
+type TransactionResponse_Get struct {
+	Get *GetResponse `protobuf:"bytes,2,opt,name=get,proto3,oneof"`
+}
+
+type TransactionResponse_Put struct {
+	Put *PutResponse `protobuf:"bytes,3,opt,name=put,proto3,oneof"`
+}
+
+type TransactionResponse_Patch struct {
+	Patch *PatchResponse `protobuf:"bytes,4,opt,name=patch,proto3,oneof"`
+}
+
+type TransactionResponse_Query struct {
+	Query *QueryResponse `protobuf:"bytes,5,opt,name=query,proto3,oneof"`
+}
+
+func (*TransactionResponse_Get) isTransactionResponse_Operation() {}
+
+func (*TransactionResponse_Put) isTransactionResponse_Operation() {}
+
+func (*TransactionResponse_Patch) isTransactionResponse_Operation() {}
+
+func (*TransactionResponse_Query) isTransactionResponse_Operation() {}
+
 type Checkpoint struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ServerVersion uint64                 `protobuf:"varint,1,opt,name=server_version,json=serverVersion,proto3" json:"server_version,omitempty"`
@@ -1604,7 +1848,7 @@ type Checkpoint struct {
 
 func (x *Checkpoint) Reset() {
 	*x = Checkpoint{}
-	mi := &file_databroker_proto_msgTypes[27]
+	mi := &file_databroker_proto_msgTypes[29]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1616,7 +1860,7 @@ func (x *Checkpoint) String() string {
 func (*Checkpoint) ProtoMessage() {}
 
 func (x *Checkpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[27]
+	mi := &file_databroker_proto_msgTypes[29]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1629,7 +1873,7 @@ func (x *Checkpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Checkpoint.ProtoReflect.Descriptor instead.
 func (*Checkpoint) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{27}
+	return file_databroker_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *Checkpoint) GetServerVersion() uint64 {
@@ -1654,7 +1898,7 @@ type GetCheckpointRequest struct {
 
 func (x *GetCheckpointRequest) Reset() {
 	*x = GetCheckpointRequest{}
-	mi := &file_databroker_proto_msgTypes[28]
+	mi := &file_databroker_proto_msgTypes[30]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1666,7 +1910,7 @@ func (x *GetCheckpointRequest) String() string {
 func (*GetCheckpointRequest) ProtoMessage() {}
 
 func (x *GetCheckpointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[28]
+	mi := &file_databroker_proto_msgTypes[30]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1679,7 +1923,7 @@ func (x *GetCheckpointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCheckpointRequest.ProtoReflect.Descriptor instead.
 func (*GetCheckpointRequest) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{28}
+	return file_databroker_proto_rawDescGZIP(), []int{30}
 }
 
 type GetCheckpointResponse struct {
@@ -1692,7 +1936,7 @@ type GetCheckpointResponse struct {
 
 func (x *GetCheckpointResponse) Reset() {
 	*x = GetCheckpointResponse{}
-	mi := &file_databroker_proto_msgTypes[29]
+	mi := &file_databroker_proto_msgTypes[31]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1704,7 +1948,7 @@ func (x *GetCheckpointResponse) String() string {
 func (*GetCheckpointResponse) ProtoMessage() {}
 
 func (x *GetCheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[29]
+	mi := &file_databroker_proto_msgTypes[31]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1717,7 +1961,7 @@ func (x *GetCheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCheckpointResponse.ProtoReflect.Descriptor instead.
 func (*GetCheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{29}
+	return file_databroker_proto_rawDescGZIP(), []int{31}
 }
 
 func (x *GetCheckpointResponse) GetCheckpoint() *Checkpoint {
@@ -1743,7 +1987,7 @@ type SetCheckpointRequest struct {
 
 func (x *SetCheckpointRequest) Reset() {
 	*x = SetCheckpointRequest{}
-	mi := &file_databroker_proto_msgTypes[30]
+	mi := &file_databroker_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1755,7 +1999,7 @@ func (x *SetCheckpointRequest) String() string {
 func (*SetCheckpointRequest) ProtoMessage() {}
 
 func (x *SetCheckpointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[30]
+	mi := &file_databroker_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1768,7 +2012,7 @@ func (x *SetCheckpointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCheckpointRequest.ProtoReflect.Descriptor instead.
 func (*SetCheckpointRequest) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{30}
+	return file_databroker_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *SetCheckpointRequest) GetCheckpoint() *Checkpoint {
@@ -1786,7 +2030,7 @@ type SetCheckpointResponse struct {
 
 func (x *SetCheckpointResponse) Reset() {
 	*x = SetCheckpointResponse{}
-	mi := &file_databroker_proto_msgTypes[31]
+	mi := &file_databroker_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1798,7 +2042,7 @@ func (x *SetCheckpointResponse) String() string {
 func (*SetCheckpointResponse) ProtoMessage() {}
 
 func (x *SetCheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[31]
+	mi := &file_databroker_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1811,7 +2055,7 @@ func (x *SetCheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCheckpointResponse.ProtoReflect.Descriptor instead.
 func (*SetCheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{31}
+	return file_databroker_proto_rawDescGZIP(), []int{33}
 }
 
 var File_databroker_proto protoreflect.FileDescriptor
@@ -1922,7 +2166,21 @@ const file_databroker_proto_rawDesc = "" +
 	"\x11RenewLeaseRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x125\n" +
-	"\bduration\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\bduration\"Z\n" +
+	"\bduration\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\bduration\"\xef\x01\n" +
+	"\x12TransactionRequest\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12*\n" +
+	"\x03get\x18\x02 \x01(\v2\x16.databroker.GetRequestH\x00R\x03get\x12*\n" +
+	"\x03put\x18\x03 \x01(\v2\x16.databroker.PutRequestH\x00R\x03put\x120\n" +
+	"\x05patch\x18\x04 \x01(\v2\x18.databroker.PatchRequestH\x00R\x05patch\x120\n" +
+	"\x05query\x18\x05 \x01(\v2\x18.databroker.QueryRequestH\x00R\x05queryB\v\n" +
+	"\toperation\"\xf4\x01\n" +
+	"\x13TransactionResponse\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12+\n" +
+	"\x03get\x18\x02 \x01(\v2\x17.databroker.GetResponseH\x00R\x03get\x12+\n" +
+	"\x03put\x18\x03 \x01(\v2\x17.databroker.PutResponseH\x00R\x03put\x121\n" +
+	"\x05patch\x18\x04 \x01(\v2\x19.databroker.PatchResponseH\x00R\x05patch\x121\n" +
+	"\x05query\x18\x05 \x01(\v2\x19.databroker.QueryResponseH\x00R\x05queryB\v\n" +
+	"\toperation\"Z\n" +
 	"\n" +
 	"Checkpoint\x12%\n" +
 	"\x0eserver_version\x18\x01 \x01(\x04R\rserverVersion\x12%\n" +
@@ -1974,7 +2232,7 @@ func file_databroker_proto_rawDescGZIP() []byte {
 	return file_databroker_proto_rawDescData
 }
 
-var file_databroker_proto_msgTypes = make([]protoimpl.MessageInfo, 32)
+var file_databroker_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
 var file_databroker_proto_goTypes = []any{
 	(*Record)(nil),                // 0: databroker.Record
 	(*Versions)(nil),              // 1: databroker.Versions
@@ -2003,31 +2261,33 @@ var file_databroker_proto_goTypes = []any{
 	(*AcquireLeaseResponse)(nil),  // 24: databroker.AcquireLeaseResponse
 	(*ReleaseLeaseRequest)(nil),   // 25: databroker.ReleaseLeaseRequest
 	(*RenewLeaseRequest)(nil),     // 26: databroker.RenewLeaseRequest
-	(*Checkpoint)(nil),            // 27: databroker.Checkpoint
-	(*GetCheckpointRequest)(nil),  // 28: databroker.GetCheckpointRequest
-	(*GetCheckpointResponse)(nil), // 29: databroker.GetCheckpointResponse
-	(*SetCheckpointRequest)(nil),  // 30: databroker.SetCheckpointRequest
-	(*SetCheckpointResponse)(nil), // 31: databroker.SetCheckpointResponse
-	(*anypb.Any)(nil),             // 32: google.protobuf.Any
-	(*timestamppb.Timestamp)(nil), // 33: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),   // 34: google.protobuf.Duration
-	(*structpb.Struct)(nil),       // 35: google.protobuf.Struct
-	(*fieldmaskpb.FieldMask)(nil), // 36: google.protobuf.FieldMask
-	(*emptypb.Empty)(nil),         // 37: google.protobuf.Empty
+	(*TransactionRequest)(nil),    // 27: databroker.TransactionRequest
+	(*TransactionResponse)(nil),   // 28: databroker.TransactionResponse
+	(*Checkpoint)(nil),            // 29: databroker.Checkpoint
+	(*GetCheckpointRequest)(nil),  // 30: databroker.GetCheckpointRequest
+	(*GetCheckpointResponse)(nil), // 31: databroker.GetCheckpointResponse
+	(*SetCheckpointRequest)(nil),  // 32: databroker.SetCheckpointRequest
+	(*SetCheckpointResponse)(nil), // 33: databroker.SetCheckpointResponse
+	(*anypb.Any)(nil),             // 34: google.protobuf.Any
+	(*timestamppb.Timestamp)(nil), // 35: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),   // 36: google.protobuf.Duration
+	(*structpb.Struct)(nil),       // 37: google.protobuf.Struct
+	(*fieldmaskpb.FieldMask)(nil), // 38: google.protobuf.FieldMask
+	(*emptypb.Empty)(nil),         // 39: google.protobuf.Empty
 }
 var file_databroker_proto_depIdxs = []int32{
-	32, // 0: databroker.Record.data:type_name -> google.protobuf.Any
-	33, // 1: databroker.Record.modified_at:type_name -> google.protobuf.Timestamp
-	33, // 2: databroker.Record.deleted_at:type_name -> google.protobuf.Timestamp
-	34, // 3: databroker.Options.ttl:type_name -> google.protobuf.Duration
+	34, // 0: databroker.Record.data:type_name -> google.protobuf.Any
+	35, // 1: databroker.Record.modified_at:type_name -> google.protobuf.Timestamp
+	35, // 2: databroker.Record.deleted_at:type_name -> google.protobuf.Timestamp
+	36, // 3: databroker.Options.ttl:type_name -> google.protobuf.Duration
 	2,  // 4: databroker.TypedOptions.options:type_name -> databroker.Options
 	0,  // 5: databroker.GetResponse.record:type_name -> databroker.Record
-	35, // 6: databroker.QueryRequest.filter:type_name -> google.protobuf.Struct
+	37, // 6: databroker.QueryRequest.filter:type_name -> google.protobuf.Struct
 	0,  // 7: databroker.QueryResponse.records:type_name -> databroker.Record
 	0,  // 8: databroker.PutRequest.records:type_name -> databroker.Record
 	0,  // 9: databroker.PutResponse.records:type_name -> databroker.Record
 	0,  // 10: databroker.PatchRequest.records:type_name -> databroker.Record
-	36, // 11: databroker.PatchRequest.field_mask:type_name -> google.protobuf.FieldMask
+	38, // 11: databroker.PatchRequest.field_mask:type_name -> google.protobuf.FieldMask
 	0,  // 12: databroker.PatchResponse.records:type_name -> databroker.Record
 	2,  // 13: databroker.GetOptionsResponse.options:type_name -> databroker.Options
 	2,  // 14: databroker.SetOptionsRequest.options:type_name -> databroker.Options
@@ -2037,47 +2297,55 @@ var file_databroker_proto_depIdxs = []int32{
 	0,  // 18: databroker.SyncLatestResponse.record:type_name -> databroker.Record
 	1,  // 19: databroker.SyncLatestResponse.versions:type_name -> databroker.Versions
 	3,  // 20: databroker.SyncLatestResponse.options:type_name -> databroker.TypedOptions
-	34, // 21: databroker.AcquireLeaseRequest.duration:type_name -> google.protobuf.Duration
-	34, // 22: databroker.RenewLeaseRequest.duration:type_name -> google.protobuf.Duration
-	27, // 23: databroker.GetCheckpointResponse.checkpoint:type_name -> databroker.Checkpoint
-	27, // 24: databroker.SetCheckpointRequest.checkpoint:type_name -> databroker.Checkpoint
-	23, // 25: databroker.DataBrokerService.AcquireLease:input_type -> databroker.AcquireLeaseRequest
-	37, // 26: databroker.DataBrokerService.Clear:input_type -> google.protobuf.Empty
-	5,  // 27: databroker.DataBrokerService.Get:input_type -> databroker.GetRequest
-	15, // 28: databroker.DataBrokerService.GetOptions:input_type -> databroker.GetOptionsRequest
-	37, // 29: databroker.DataBrokerService.ListTypes:input_type -> google.protobuf.Empty
-	10, // 30: databroker.DataBrokerService.Put:input_type -> databroker.PutRequest
-	12, // 31: databroker.DataBrokerService.Patch:input_type -> databroker.PatchRequest
-	8,  // 32: databroker.DataBrokerService.Query:input_type -> databroker.QueryRequest
-	25, // 33: databroker.DataBrokerService.ReleaseLease:input_type -> databroker.ReleaseLeaseRequest
-	26, // 34: databroker.DataBrokerService.RenewLease:input_type -> databroker.RenewLeaseRequest
-	37, // 35: databroker.DataBrokerService.ServerInfo:input_type -> google.protobuf.Empty
-	17, // 36: databroker.DataBrokerService.SetOptions:input_type -> databroker.SetOptionsRequest
-	19, // 37: databroker.DataBrokerService.Sync:input_type -> databroker.SyncRequest
-	21, // 38: databroker.DataBrokerService.SyncLatest:input_type -> databroker.SyncLatestRequest
-	28, // 39: databroker.CheckpointService.GetCheckpoint:input_type -> databroker.GetCheckpointRequest
-	30, // 40: databroker.CheckpointService.SetCheckpoint:input_type -> databroker.SetCheckpointRequest
-	24, // 41: databroker.DataBrokerService.AcquireLease:output_type -> databroker.AcquireLeaseResponse
-	4,  // 42: databroker.DataBrokerService.Clear:output_type -> databroker.ClearResponse
-	6,  // 43: databroker.DataBrokerService.Get:output_type -> databroker.GetResponse
-	16, // 44: databroker.DataBrokerService.GetOptions:output_type -> databroker.GetOptionsResponse
-	7,  // 45: databroker.DataBrokerService.ListTypes:output_type -> databroker.ListTypesResponse
-	11, // 46: databroker.DataBrokerService.Put:output_type -> databroker.PutResponse
-	13, // 47: databroker.DataBrokerService.Patch:output_type -> databroker.PatchResponse
-	9,  // 48: databroker.DataBrokerService.Query:output_type -> databroker.QueryResponse
-	37, // 49: databroker.DataBrokerService.ReleaseLease:output_type -> google.protobuf.Empty
-	37, // 50: databroker.DataBrokerService.RenewLease:output_type -> google.protobuf.Empty
-	14, // 51: databroker.DataBrokerService.ServerInfo:output_type -> databroker.ServerInfoResponse
-	18, // 52: databroker.DataBrokerService.SetOptions:output_type -> databroker.SetOptionsResponse
-	20, // 53: databroker.DataBrokerService.Sync:output_type -> databroker.SyncResponse
-	22, // 54: databroker.DataBrokerService.SyncLatest:output_type -> databroker.SyncLatestResponse
-	29, // 55: databroker.CheckpointService.GetCheckpoint:output_type -> databroker.GetCheckpointResponse
-	31, // 56: databroker.CheckpointService.SetCheckpoint:output_type -> databroker.SetCheckpointResponse
-	41, // [41:57] is the sub-list for method output_type
-	25, // [25:41] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	36, // 21: databroker.AcquireLeaseRequest.duration:type_name -> google.protobuf.Duration
+	36, // 22: databroker.RenewLeaseRequest.duration:type_name -> google.protobuf.Duration
+	5,  // 23: databroker.TransactionRequest.get:type_name -> databroker.GetRequest
+	10, // 24: databroker.TransactionRequest.put:type_name -> databroker.PutRequest
+	12, // 25: databroker.TransactionRequest.patch:type_name -> databroker.PatchRequest
+	8,  // 26: databroker.TransactionRequest.query:type_name -> databroker.QueryRequest
+	6,  // 27: databroker.TransactionResponse.get:type_name -> databroker.GetResponse
+	11, // 28: databroker.TransactionResponse.put:type_name -> databroker.PutResponse
+	13, // 29: databroker.TransactionResponse.patch:type_name -> databroker.PatchResponse
+	9,  // 30: databroker.TransactionResponse.query:type_name -> databroker.QueryResponse
+	29, // 31: databroker.GetCheckpointResponse.checkpoint:type_name -> databroker.Checkpoint
+	29, // 32: databroker.SetCheckpointRequest.checkpoint:type_name -> databroker.Checkpoint
+	23, // 33: databroker.DataBrokerService.AcquireLease:input_type -> databroker.AcquireLeaseRequest
+	39, // 34: databroker.DataBrokerService.Clear:input_type -> google.protobuf.Empty
+	5,  // 35: databroker.DataBrokerService.Get:input_type -> databroker.GetRequest
+	15, // 36: databroker.DataBrokerService.GetOptions:input_type -> databroker.GetOptionsRequest
+	39, // 37: databroker.DataBrokerService.ListTypes:input_type -> google.protobuf.Empty
+	10, // 38: databroker.DataBrokerService.Put:input_type -> databroker.PutRequest
+	12, // 39: databroker.DataBrokerService.Patch:input_type -> databroker.PatchRequest
+	8,  // 40: databroker.DataBrokerService.Query:input_type -> databroker.QueryRequest
+	25, // 41: databroker.DataBrokerService.ReleaseLease:input_type -> databroker.ReleaseLeaseRequest
+	26, // 42: databroker.DataBrokerService.RenewLease:input_type -> databroker.RenewLeaseRequest
+	39, // 43: databroker.DataBrokerService.ServerInfo:input_type -> google.protobuf.Empty
+	17, // 44: databroker.DataBrokerService.SetOptions:input_type -> databroker.SetOptionsRequest
+	19, // 45: databroker.DataBrokerService.Sync:input_type -> databroker.SyncRequest
+	21, // 46: databroker.DataBrokerService.SyncLatest:input_type -> databroker.SyncLatestRequest
+	30, // 47: databroker.CheckpointService.GetCheckpoint:input_type -> databroker.GetCheckpointRequest
+	32, // 48: databroker.CheckpointService.SetCheckpoint:input_type -> databroker.SetCheckpointRequest
+	24, // 49: databroker.DataBrokerService.AcquireLease:output_type -> databroker.AcquireLeaseResponse
+	4,  // 50: databroker.DataBrokerService.Clear:output_type -> databroker.ClearResponse
+	6,  // 51: databroker.DataBrokerService.Get:output_type -> databroker.GetResponse
+	16, // 52: databroker.DataBrokerService.GetOptions:output_type -> databroker.GetOptionsResponse
+	7,  // 53: databroker.DataBrokerService.ListTypes:output_type -> databroker.ListTypesResponse
+	11, // 54: databroker.DataBrokerService.Put:output_type -> databroker.PutResponse
+	13, // 55: databroker.DataBrokerService.Patch:output_type -> databroker.PatchResponse
+	9,  // 56: databroker.DataBrokerService.Query:output_type -> databroker.QueryResponse
+	39, // 57: databroker.DataBrokerService.ReleaseLease:output_type -> google.protobuf.Empty
+	39, // 58: databroker.DataBrokerService.RenewLease:output_type -> google.protobuf.Empty
+	14, // 59: databroker.DataBrokerService.ServerInfo:output_type -> databroker.ServerInfoResponse
+	18, // 60: databroker.DataBrokerService.SetOptions:output_type -> databroker.SetOptionsResponse
+	20, // 61: databroker.DataBrokerService.Sync:output_type -> databroker.SyncResponse
+	22, // 62: databroker.DataBrokerService.SyncLatest:output_type -> databroker.SyncLatestResponse
+	31, // 63: databroker.CheckpointService.GetCheckpoint:output_type -> databroker.GetCheckpointResponse
+	33, // 64: databroker.CheckpointService.SetCheckpoint:output_type -> databroker.SetCheckpointResponse
+	49, // [49:65] is the sub-list for method output_type
+	33, // [33:49] is the sub-list for method input_type
+	33, // [33:33] is the sub-list for extension type_name
+	33, // [33:33] is the sub-list for extension extendee
+	0,  // [0:33] is the sub-list for field type_name
 }
 
 func init() { file_databroker_proto_init() }
@@ -2097,13 +2365,25 @@ func file_databroker_proto_init() {
 		(*SyncLatestResponse_Versions)(nil),
 		(*SyncLatestResponse_Options)(nil),
 	}
+	file_databroker_proto_msgTypes[27].OneofWrappers = []any{
+		(*TransactionRequest_Get)(nil),
+		(*TransactionRequest_Put)(nil),
+		(*TransactionRequest_Patch)(nil),
+		(*TransactionRequest_Query)(nil),
+	}
+	file_databroker_proto_msgTypes[28].OneofWrappers = []any{
+		(*TransactionResponse_Get)(nil),
+		(*TransactionResponse_Put)(nil),
+		(*TransactionResponse_Patch)(nil),
+		(*TransactionResponse_Query)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_databroker_proto_rawDesc), len(file_databroker_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   32,
+			NumMessages:   34,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/grpc/databroker/databroker.pb.json
+++ b/pkg/grpc/databroker/databroker.pb.json
@@ -1126,6 +1126,150 @@
           ]
         },
         {
+          "name": "TransactionRequest",
+          "longName": "TransactionRequest",
+          "fullName": "databroker.TransactionRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "get",
+              "description": "",
+              "label": "",
+              "type": "GetRequest",
+              "longType": "GetRequest",
+              "fullType": "databroker.GetRequest",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "operation",
+              "defaultValue": ""
+            },
+            {
+              "name": "put",
+              "description": "",
+              "label": "",
+              "type": "PutRequest",
+              "longType": "PutRequest",
+              "fullType": "databroker.PutRequest",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "operation",
+              "defaultValue": ""
+            },
+            {
+              "name": "patch",
+              "description": "",
+              "label": "",
+              "type": "PatchRequest",
+              "longType": "PatchRequest",
+              "fullType": "databroker.PatchRequest",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "operation",
+              "defaultValue": ""
+            },
+            {
+              "name": "query",
+              "description": "",
+              "label": "",
+              "type": "QueryRequest",
+              "longType": "QueryRequest",
+              "fullType": "databroker.QueryRequest",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "operation",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransactionResponse",
+          "longName": "TransactionResponse",
+          "fullName": "databroker.TransactionResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "get",
+              "description": "",
+              "label": "",
+              "type": "GetResponse",
+              "longType": "GetResponse",
+              "fullType": "databroker.GetResponse",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "operation",
+              "defaultValue": ""
+            },
+            {
+              "name": "put",
+              "description": "",
+              "label": "",
+              "type": "PutResponse",
+              "longType": "PutResponse",
+              "fullType": "databroker.PutResponse",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "operation",
+              "defaultValue": ""
+            },
+            {
+              "name": "patch",
+              "description": "",
+              "label": "",
+              "type": "PatchResponse",
+              "longType": "PatchResponse",
+              "fullType": "databroker.PatchResponse",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "operation",
+              "defaultValue": ""
+            },
+            {
+              "name": "query",
+              "description": "",
+              "label": "",
+              "type": "QueryResponse",
+              "longType": "QueryResponse",
+              "fullType": "databroker.QueryResponse",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "operation",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
           "name": "TypedOptions",
           "longName": "TypedOptions",
           "fullName": "databroker.TypedOptions",

--- a/pkg/grpc/databroker/databroker.proto
+++ b/pkg/grpc/databroker/databroker.proto
@@ -243,8 +243,6 @@ message TransactionResponse {
   }
 }
 
-
-
 message Checkpoint {
   uint64 server_version = 1;
   uint64 record_version = 2;

--- a/pkg/grpc/databroker/databroker.proto
+++ b/pkg/grpc/databroker/databroker.proto
@@ -223,6 +223,28 @@ service DataBrokerService {
   rpc SyncLatest(SyncLatestRequest) returns (stream SyncLatestResponse);
 }
 
+message TransactionRequest {
+  string key = 1;
+  oneof operation {
+    GetRequest get = 2;
+    PutRequest put = 3;
+    PatchRequest patch = 4;
+    QueryRequest query = 5;
+  }
+}
+
+message TransactionResponse {
+  string key = 1;
+  oneof operation {
+    GetResponse get = 2;
+    PutResponse put = 3;
+    PatchResponse patch = 4;
+    QueryResponse query = 5;
+  }
+}
+
+
+
 message Checkpoint {
   uint64 server_version = 1;
   uint64 record_version = 2;

--- a/pkg/storage/file/backend.go
+++ b/pkg/storage/file/backend.go
@@ -398,8 +398,7 @@ func (backend *Backend) Versions(
 func (backend *Backend) DoTransaction(
 	ctx context.Context,
 	key string,
-	fn func(tx storage.Transaction,
-	) error,
+	fn func(tx storage.Transaction) error,
 ) (changed []*databrokerpb.Record, shared bool, err error) {
 	if err := backend.init(); err != nil {
 		return nil, false, fmt.Errorf("pebble : error initializing : %w", err)

--- a/pkg/storage/file/backend.go
+++ b/pkg/storage/file/backend.go
@@ -15,6 +15,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 	oteltrace "go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -59,6 +60,9 @@ type Backend struct {
 	closeErr  error
 	closeCtx  context.Context
 	close     context.CancelFunc
+
+	// primitives used for tracking transactions
+	txGroup singleflight.Group
 }
 
 // Option configures the backend instance.
@@ -101,13 +105,11 @@ func (backend *Backend) Close() error {
 	if err != nil {
 		return fmt.Errorf("pebble: error initializing: %w", err)
 	}
-
 	backend.mu.Lock()
 	defer backend.mu.Unlock()
 
 	backend.closeOnce.Do(func() {
 		backend.close()
-
 		if backend.metricRegistration != nil {
 			err := backend.metricRegistration.Unregister()
 			if err != nil {
@@ -391,6 +393,39 @@ func (backend *Backend) Versions(
 	}
 
 	return serverVersion, earliestRecordVersion, latestRecordVersion, nil
+}
+
+func (backend *Backend) DoTransaction(
+	ctx context.Context,
+	key string,
+	fn func(tx storage.Transaction,
+	) error,
+) (changed []*databrokerpb.Record, shared bool, err error) {
+	if err := backend.init(); err != nil {
+		return nil, false, fmt.Errorf("pebble : error initializing : %w", err)
+	}
+
+	// singleflight reports shared to the owner of a flight too
+	var ran bool
+	res, err, _ := backend.txGroup.Do(key, func() (any, error) {
+		ran = true
+
+		tx := &transaction{
+			backend: backend,
+			ctx:     ctx,
+			batch:   backend.db.NewIndexedBatch(),
+		}
+		if err := fn(tx); err != nil {
+			tx.rollback()
+			return nil, err
+		}
+		if err := tx.Commit(); err != nil {
+			return nil, err
+		}
+		return tx.changed, nil
+	})
+	changed, _ = res.([]*databrokerpb.Record)
+	return changed, !ran, err
 }
 
 func (backend *Backend) cleanLocked(

--- a/pkg/storage/file/transaction.go
+++ b/pkg/storage/file/transaction.go
@@ -1,0 +1,181 @@
+package file
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/cockroachdb/pebble/v2"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+type transaction struct {
+	backend *Backend
+	ctx     context.Context
+
+	batch             *pebble.Batch
+	onCommitCallbacks []func()
+	responses         []*databrokerpb.TransactionResponse
+	changed           []*databrokerpb.Record
+}
+
+func (tx *transaction) onCommit(callback func()) {
+	tx.onCommitCallbacks = append(tx.onCommitCallbacks, callback)
+}
+
+// Submit applies a single operation to the transaction's batch. The operation is
+// not durable until the transaction commits.
+func (tx *transaction) Submit(req *databrokerpb.TransactionRequest) (*databrokerpb.TransactionResponse, error) {
+	if tx.ctx.Err() != nil {
+		return nil, context.Cause(tx.ctx)
+	}
+
+	tx.backend.mu.Lock()
+	defer tx.backend.mu.Unlock()
+
+	if err := tx.checkClosedLocked(); err != nil {
+		return nil, err
+	}
+
+	var res *databrokerpb.TransactionResponse
+	var err error
+	switch op := req.GetOperation().(type) {
+	case *databrokerpb.TransactionRequest_Get:
+		res, err = tx.submitGetLocked(op.Get)
+	case *databrokerpb.TransactionRequest_Put:
+		res, err = tx.submitPutLocked(op.Put)
+	case *databrokerpb.TransactionRequest_Patch:
+		res, err = tx.submitPatchLocked(op.Patch)
+	case *databrokerpb.TransactionRequest_Query:
+		res, err = tx.submitQueryLocked(op.Query)
+	default:
+		err = status.Errorf(codes.InvalidArgument, "unsupported transaction operation: %T", req.GetOperation())
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	res.Key = req.GetKey()
+	tx.responses = append(tx.responses, res)
+	return res, nil
+}
+
+func (tx *transaction) submitGetLocked(req *databrokerpb.GetRequest) (*databrokerpb.TransactionResponse, error) {
+	record, err := tx.backend.getRecordLocked(tx.batch, req.GetType(), req.GetId())
+	if err != nil {
+		return nil, err
+	}
+	return &databrokerpb.TransactionResponse{
+		Operation: &databrokerpb.TransactionResponse_Get{Get: &databrokerpb.GetResponse{Record: record}},
+	}, nil
+}
+
+func (tx *transaction) submitPutLocked(req *databrokerpb.PutRequest) (*databrokerpb.TransactionResponse, error) {
+	records := slices.Clone(req.GetRecords())
+	serverVersion := tx.backend.serverVersion
+	if err := tx.backend.putRecordsLocked(tx.batch, records); err != nil {
+		return nil, err
+	}
+	tx.onCommit(func() { tx.backend.onRecordChange.Broadcast(tx.ctx) })
+	tx.changed = append(tx.changed, records...)
+	return &databrokerpb.TransactionResponse{
+		Operation: &databrokerpb.TransactionResponse_Put{Put: &databrokerpb.PutResponse{
+			ServerVersion: serverVersion,
+			Records:       records,
+		}},
+	}, nil
+}
+
+func (tx *transaction) submitPatchLocked(req *databrokerpb.PatchRequest) (*databrokerpb.TransactionResponse, error) {
+	serverVersion := tx.backend.serverVersion
+	patched, err := tx.backend.patchRecordsLocked(tx.batch, req.GetRecords(), req.GetFieldMask())
+	if err != nil {
+		return nil, err
+	}
+	tx.onCommit(func() { tx.backend.onRecordChange.Broadcast(tx.ctx) })
+	tx.changed = append(tx.changed, patched...)
+	return &databrokerpb.TransactionResponse{
+		Operation: &databrokerpb.TransactionResponse_Patch{Patch: &databrokerpb.PatchResponse{
+			ServerVersion: serverVersion,
+			Records:       patched,
+		}},
+	}, nil
+}
+
+func (tx *transaction) submitQueryLocked(req *databrokerpb.QueryRequest) (*databrokerpb.TransactionResponse, error) {
+	expr, err := storage.FilterExpressionFromStruct(req.GetFilter())
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "invalid query filter: %v", err)
+	}
+
+	all, err := tx.backend.listLatestRecordsLocked(tx.batch, req.GetType(), expr)
+	if err != nil {
+		return nil, err
+	}
+
+	query := strings.ToLower(req.GetQuery())
+	filtered := make([]*databrokerpb.Record, 0, len(all))
+	for _, record := range all {
+		if query != "" && !storage.MatchAny(record.GetData(), query) {
+			continue
+		}
+		filtered = append(filtered, record)
+	}
+
+	records, totalCount := databrokerpb.ApplyOffsetAndLimit(filtered, int(req.GetOffset()), int(req.GetLimit()))
+	return &databrokerpb.TransactionResponse{
+		Operation: &databrokerpb.TransactionResponse_Query{Query: &databrokerpb.QueryResponse{
+			Records:       records,
+			TotalCount:    int64(totalCount),
+			ServerVersion: tx.backend.serverVersion,
+			RecordVersion: tx.backend.latestRecordVersion,
+		}},
+	}, nil
+}
+
+func (tx *transaction) checkClosedLocked() error {
+	select {
+	case <-tx.backend.closeCtx.Done():
+		return context.Cause(tx.backend.closeCtx)
+	default:
+	}
+	return nil
+}
+
+func (tx *transaction) rollback() {
+	tx.backend.mu.Lock()
+	defer tx.backend.mu.Unlock()
+	if err := tx.checkClosedLocked(); err != nil {
+		return
+	}
+
+	_ = tx.batch.Close()
+}
+
+// Commit writes the transaction's batch to the database. It deliberately does not
+// check closeCtx: a transaction which has finished its callback runs to completion.
+func (tx *transaction) Commit() error {
+	tx.backend.mu.Lock()
+	defer tx.backend.mu.Unlock()
+
+	if err := tx.checkClosedLocked(); err != nil {
+		return err
+	}
+
+	err := tx.batch.Commit(nil)
+	_ = tx.batch.Close()
+	if err != nil {
+		return fmt.Errorf("pebble: error committing transaction: %w", err)
+	}
+
+	for _, f := range slices.Backward(tx.onCommitCallbacks) {
+		f()
+	}
+
+	return nil
+}

--- a/pkg/storage/file/transactions_test.go
+++ b/pkg/storage/file/transactions_test.go
@@ -1,0 +1,22 @@
+package file_test
+
+import (
+	"testing"
+
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/pomerium/pomerium/pkg/storage"
+	"github.com/pomerium/pomerium/pkg/storage/file"
+	"github.com/pomerium/pomerium/pkg/storage/storagetest"
+)
+
+func newTransactionBackend(t *testing.T) storage.Backend {
+	t.Helper()
+	backend := file.New(noop.NewTracerProvider(), "memory://")
+	t.Cleanup(func() { _ = backend.Close() })
+	return backend
+}
+
+func TestTransactions(t *testing.T) {
+	storagetest.TestTransaction(t, newTransactionBackend)
+}

--- a/pkg/storage/postgres/backend.go
+++ b/pkg/storage/postgres/backend.go
@@ -404,6 +404,12 @@ func (backend *Backend) SyncLatest(
 	return serverVersion, recordVersion, backend.iterateLatestRecords(ctx, expr), nil
 }
 
+func (backend *Backend) DoTransaction(
+	context.Context, string, func(tx storage.Transaction) error,
+) (changed []*databroker.Record, shared bool, err error) {
+	panic("implement me")
+}
+
 // Versions returns the versions of the storage backend.
 func (backend *Backend) Versions(ctx context.Context) (serverVersion, earliestRecordVersion, latestRecordVersion uint64, err error) {
 	serverVersion, pool, err := backend.init(ctx)

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -66,6 +66,7 @@ type Backend interface {
 	// and rolling it back otherwise. A concurrent call for an in-flight key does
 	// not run its callback and returns the in-flight call's error when it finishes.
 	// A shared caller receives the in-flight call's changed records.
+	// Callers of this method should not call tx.Commit()
 	DoTransaction(ctx context.Context, key string, cb func(tx Transaction) error) (
 		changed []*databroker.Record,
 		shared bool,
@@ -81,7 +82,7 @@ type Transaction interface {
 	// Submit adds an operation to the transaction. Intermediary responses from operations
 	// return information.
 	Submit(*databroker.TransactionRequest) (*databroker.TransactionResponse, error)
-	// commit applies the submitted operations. Concurrent calls for the same key
+	// Commit applies the submitted operations. Concurrent calls for the same key
 	// block until the in-flight commit completes.
 	Commit() error
 }

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -62,6 +62,28 @@ type Backend interface {
 	SyncLatest(ctx context.Context, recordType string, filter FilterExpression) (serverVersion, recordVersion uint64, seq RecordIterator, err error)
 	// Versions returns versions from the storage backend.
 	Versions(ctx context.Context) (serverVersion, earliestRecordVersion, latestRecordVersion uint64, err error)
+	// DoTransaction runs cb against a transaction, committing it if cb returns nil
+	// and rolling it back otherwise. A concurrent call for an in-flight key does
+	// not run its callback and returns the in-flight call's error when it finishes.
+	// A shared caller receives the in-flight call's changed records.
+	DoTransaction(ctx context.Context, key string, cb func(tx Transaction) error) (
+		changed []*databroker.Record,
+		shared bool,
+		err error,
+	)
+}
+
+// A Transaction applies its submitted operations atomically on Commit.
+//
+// Only persistent indices are updated, so do not submit operations on records
+// that should update an in-memory index.
+type Transaction interface {
+	// Submit adds an operation to the transaction. Intermediary responses from operations
+	// return information.
+	Submit(*databroker.TransactionRequest) (*databroker.TransactionResponse, error)
+	// commit applies the submitted operations. Concurrent calls for the same key
+	// block until the in-flight commit completes.
+	Commit() error
 }
 
 // CleanOptions are the options used for cleaning the storage backend.

--- a/pkg/storage/storagetest/storagetest.go
+++ b/pkg/storage/storagetest/storagetest.go
@@ -1556,7 +1556,6 @@ func TestTransaction(t *testing.T, backendFactory func(t *testing.T) storage.Bac
 
 			const waiters = 7
 			var callbacks atomic.Int64
-			started := make(chan struct{})
 			release := make(chan struct{})
 
 			var wg sync.WaitGroup
@@ -1564,14 +1563,14 @@ func TestTransaction(t *testing.T, backendFactory func(t *testing.T) storage.Bac
 			wg.Go(func() {
 				results[0].changed, results[0].shared, results[0].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
 					callbacks.Add(1)
-					close(started)
 					<-release
 					_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
 					return err
 				})
 			})
 
-			requireReceive(t, started, "first transaction did not start")
+			synctest.Wait()
+
 			for i := 1; i <= waiters; i++ {
 				wg.Go(func() {
 					results[i].changed, results[i].shared, results[i].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
@@ -1622,7 +1621,6 @@ func TestTransaction(t *testing.T, backendFactory func(t *testing.T) storage.Bac
 			const waiters = 3
 			errFail := errors.New("fail")
 			var callbacks atomic.Int64
-			started := make(chan struct{})
 			release := make(chan struct{})
 
 			var wg sync.WaitGroup
@@ -1630,7 +1628,6 @@ func TestTransaction(t *testing.T, backendFactory func(t *testing.T) storage.Bac
 			wg.Go(func() {
 				results[0].changed, results[0].shared, results[0].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
 					callbacks.Add(1)
-					close(started)
 					<-release
 					_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
 					require.NoError(t, err)
@@ -1638,7 +1635,8 @@ func TestTransaction(t *testing.T, backendFactory func(t *testing.T) storage.Bac
 				})
 			})
 
-			requireReceive(t, started, "first transaction did not start")
+			synctest.Wait()
+
 			for i := 1; i <= waiters; i++ {
 				wg.Go(func() {
 					results[i].changed, results[i].shared, results[i].err = backend.DoTransaction(context.Background(), "k", func(_ storage.Transaction) error {

--- a/pkg/storage/storagetest/storagetest.go
+++ b/pkg/storage/storagetest/storagetest.go
@@ -9,6 +9,7 @@ import (
 	"iter"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -34,6 +35,7 @@ import (
 	"github.com/pomerium/pomerium/pkg/grpcutil"
 	"github.com/pomerium/pomerium/pkg/iterutil"
 	"github.com/pomerium/pomerium/pkg/protoutil"
+	"github.com/pomerium/pomerium/pkg/slices"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
 
@@ -1400,5 +1402,548 @@ func TestClear(t *testing.T, backend storage.Backend) {
 func truncateTimestamps(ts ...*timestamppb.Timestamp) {
 	for _, t := range ts {
 		t.Nanos = (t.Nanos / 1000) * 1000
+	}
+}
+
+const transactionTestTimeout = 10 * time.Second
+
+func TestTransaction(t *testing.T, backendFactory func(t *testing.T) storage.Backend) {
+	t.Parallel()
+	t.Run("transactions", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		r1 := newTestRecord(t, "r1", map[string]any{"name": "alice"})
+		r2 := newTestRecord(t, "r2", map[string]any{"name": "bob"})
+
+		changed, shared, err := backend.DoTransaction(t.Context(), "k", func(tx storage.Transaction) error {
+			res, err := tx.Submit(putRequest(r1, r2))
+			require.NoError(t, err)
+			assert.Equal(t, "put", res.GetKey())
+			assert.Len(t, res.GetPut().GetRecords(), 2)
+			assert.NotZero(t, res.GetPut().GetServerVersion())
+
+			res, err = tx.Submit(getRequest("r1"))
+			require.NoError(t, err)
+			assert.Equal(t, "get", res.GetKey())
+			assert.Equal(t, "r1", res.GetGet().GetRecord().GetId())
+
+			res, err = tx.Submit(patchRequest(
+				&fieldmaskpb.FieldMask{Paths: []string{"fields"}},
+				newTestRecord(t, "r2", map[string]any{"name": "carol"}),
+			))
+			require.NoError(t, err)
+			assert.Equal(t, "patch", res.GetKey())
+			assert.Len(t, res.GetPatch().GetRecords(), 1)
+
+			res, err = tx.Submit(queryRequest(""))
+			require.NoError(t, err)
+			assert.Equal(t, "query", res.GetKey())
+			assert.ElementsMatch(t, []string{"r1", "r2"}, recordIDs(res.GetQuery().GetRecords()))
+			assert.Equal(t, int64(2), res.GetQuery().GetTotalCount())
+
+			res, err = tx.Submit(queryRequest("carol"))
+			require.NoError(t, err)
+			assert.Equal(t, []string{"r2"}, recordIDs(res.GetQuery().GetRecords()))
+
+			return nil
+		})
+		require.NoError(t, err)
+		require.False(t, shared)
+		assert.Equal(t, []string{"r1", "r2", "r2"}, recordIDs(changed))
+		assertChangedPersisted(t, backend, changed)
+		record, err := backend.Get(t.Context(), "example", "r2")
+		require.NoError(t, err)
+		assert.Contains(t, record.GetData().String(), "carol")
+	})
+
+	t.Run("unsupported operation", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		_, _, err := backend.DoTransaction(t.Context(), "k", func(tx storage.Transaction) error {
+			_, err := tx.Submit(&databroker.TransactionRequest{Key: "bad"})
+			return err
+		})
+		assert.Error(t, err)
+	})
+
+	t.Run("atomic", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		errRollback := errors.New("rollback")
+		changed, shared, err := backend.DoTransaction(t.Context(), "k", func(tx storage.Transaction) error {
+			_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
+			require.NoError(t, err)
+			_, err = tx.Submit(putRequest(newTestRecord(t, "r2", nil)))
+			require.NoError(t, err)
+			return errRollback
+		})
+		assert.ErrorIs(t, err, errRollback)
+		assert.Empty(t, changed)
+		assert.False(t, shared)
+
+		for _, id := range []string{"r1", "r2"} {
+			_, err := backend.Get(t.Context(), "example", id)
+			assert.ErrorIs(t, err, storage.ErrNotFound)
+		}
+	})
+
+	// TODO : this may be specific to file/memory backend
+	t.Run("read your writes", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		submitted := make(chan struct{})
+		checked := make(chan struct{})
+		go func() {
+			defer close(checked)
+			<-submitted
+			_, err := backend.Get(context.Background(), "example", "r1")
+			assert.ErrorIs(t, err, storage.ErrNotFound)
+		}()
+
+		changed, _, err := backend.DoTransaction(t.Context(), "k", func(tx storage.Transaction) error {
+			_, err := tx.Submit(putRequest(newTestRecord(t, "r1", map[string]any{"name": "alice"})))
+			require.NoError(t, err)
+
+			close(submitted)
+			requireReceive(t, checked, "concurrent Get did not complete")
+
+			res, err := tx.Submit(getRequest("r1"))
+			require.NoError(t, err)
+			assert.Equal(t, "r1", res.GetGet().GetRecord().GetId())
+			return nil
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"r1"}, recordIDs(changed))
+		assertChangedPersisted(t, backend, changed)
+	})
+
+	// do not holdup other backup operations across an open transaction
+	t.Run("backend not blocked during callback", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		parked := make(chan struct{})
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			<-parked
+			_, err := backend.Put(context.Background(), []*databroker.Record{newTestRecord(t, "other", nil)})
+			assert.NoError(t, err)
+		}()
+
+		_, _, err := backend.DoTransaction(t.Context(), "k", func(tx storage.Transaction) error {
+			_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
+			require.NoError(t, err)
+			close(parked)
+			requireReceive(t, done, "backend.Put blocked while a transaction callback was running")
+			return nil
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("singleflight dedup", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		const waiters = 7
+		var entered, callbacks atomic.Int64
+		started := make(chan struct{})
+		release := make(chan struct{})
+
+		var wg sync.WaitGroup
+		results := make([]flightResult, waiters+1)
+		wg.Go(func() {
+			results[0].changed, results[0].shared, results[0].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
+				callbacks.Add(1)
+				close(started)
+				<-release
+				_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
+				return err
+			})
+		})
+
+		requireReceive(t, started, "first transaction did not start")
+		for i := 1; i <= waiters; i++ {
+			wg.Go(func() {
+				entered.Add(1)
+				results[i].changed, results[i].shared, results[i].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
+					callbacks.Add(1)
+					_, err := tx.Submit(putRequest(newTestRecord(t, fmt.Sprintf("w%d", i), nil)))
+					return err
+				})
+			})
+		}
+
+		requireEnteredFlight(t, &entered, waiters)
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, ranCallbacks(results), callbacks.Load(),
+			"a deduped callback ran, or an owned one did not")
+
+		allChanged := slices.Map(results, func(r flightResult) []*databroker.Record {
+			return r.changed
+		})
+
+		// TODO : this is flaky
+		assertEveryRecordSetEqual(t, allChanged...)
+
+		for i, r := range results {
+			assert.NoError(t, r.err)
+			assertChangedPersisted(t, backend, r.changed)
+
+			own := "r1"
+			if i > 0 {
+				own = fmt.Sprintf("w%d", i)
+			}
+			_, err := backend.Get(t.Context(), "example", own)
+			if r.shared {
+				assert.NotContains(t, recordIDs(r.changed), own)
+				assert.ErrorIs(t, err, storage.ErrNotFound)
+			} else {
+				assert.Equal(t, []string{own}, recordIDs(r.changed))
+				assert.NoError(t, err)
+			}
+		}
+	})
+
+	t.Run("error sharing", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		const waiters = 3
+		errFail := errors.New("fail")
+		var entered, callbacks atomic.Int64
+		started := make(chan struct{})
+		release := make(chan struct{})
+
+		var wg sync.WaitGroup
+		results := make([]flightResult, waiters+1)
+		wg.Go(func() {
+			results[0].changed, results[0].shared, results[0].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
+				callbacks.Add(1)
+				close(started)
+				<-release
+				_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
+				require.NoError(t, err)
+				return errFail
+			})
+		})
+
+		requireReceive(t, started, "first transaction did not start")
+		for i := 1; i <= waiters; i++ {
+			wg.Go(func() {
+				entered.Add(1)
+				// a straggler that misses the flight leads one of its own, so it
+				// must fail the same way
+				results[i].changed, results[i].shared, results[i].err = backend.DoTransaction(context.Background(), "k", func(_ storage.Transaction) error {
+					callbacks.Add(1)
+					return errFail
+				})
+			})
+		}
+
+		requireEnteredFlight(t, &entered, waiters)
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, ranCallbacks(results), callbacks.Load(), "a deduped callback ran")
+		for _, r := range results {
+			assert.ErrorIs(t, r.err, errFail)
+			assert.Empty(t, r.changed, "a rolled back transaction reported changed records")
+		}
+		_, err := backend.Get(t.Context(), "example", "r1")
+		assert.ErrorIs(t, err, storage.ErrNotFound)
+	})
+
+	t.Run("distinct keys run concurrently", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		inA := make(chan struct{})
+		inB := make(chan struct{})
+
+		var wg sync.WaitGroup
+		wg.Go(func() {
+			assert.NoError(t, txErr(backend.DoTransaction(context.Background(), "a", func(_ storage.Transaction) error {
+				close(inA)
+				requireReceive(t, inB, "transaction b did not start concurrently")
+				return nil
+			})))
+		})
+		wg.Go(func() {
+			assert.NoError(t, txErr(backend.DoTransaction(context.Background(), "b", func(_ storage.Transaction) error {
+				close(inB)
+				requireReceive(t, inA, "transaction a did not start concurrently")
+				return nil
+			})))
+		})
+		wg.Wait()
+	})
+
+	t.Run("sequential calls are not deduped", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		changed, _, err := backend.DoTransaction(t.Context(), "k", func(tx storage.Transaction) error {
+			_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
+			return err
+		})
+		require.NoError(t, err)
+		assert.Equal(t, []string{"r1"}, recordIDs(changed))
+		assertChangedPersisted(t, backend, changed)
+
+		var ran bool
+		require.NoError(t, txErr(backend.DoTransaction(t.Context(), "k", func(tx storage.Transaction) error {
+			ran = true
+			res, err := tx.Submit(getRequest("r1"))
+			require.NoError(t, err)
+			assert.Equal(t, "r1", res.GetGet().GetRecord().GetId())
+			return nil
+		})))
+		assert.True(t, ran)
+	})
+
+	t.Run("empty callback", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		assert.NoError(t, txErr(backend.DoTransaction(t.Context(), "k", func(_ storage.Transaction) error {
+			return nil
+		})))
+	})
+	t.Run("backend close errors transaction", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+
+		parked := make(chan struct{})
+		release := make(chan struct{})
+		go func() {
+			assert.Error(t, txErr(backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
+				close(parked)
+				<-release
+				_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
+				return err
+			})))
+		}()
+		requireReceive(t, parked, "transaction did not start")
+		assert.NoError(t, backend.Close())
+		_, err := backend.Get(t.Context(), "foo", "foo")
+		assert.Error(t, err)
+		close(release)
+	})
+
+	t.Run("transaction after close", func(t *testing.T) {
+		t.Parallel()
+		backend := backendFactory(t)
+		require.NoError(t, backend.Close())
+
+		_, _, err := backend.DoTransaction(t.Context(), "k", func(_ storage.Transaction) error {
+			return nil
+		})
+		assert.Error(t, err)
+	})
+}
+
+// TestTransactionsClustered tests
+func TestTransactionsClustered(t *testing.T, clusterFactory func(t *testing.T) (leader storage.Backend, followers []storage.Backend)) {
+	t.Parallel()
+	t.Run("singleflight dedup", func(t *testing.T) {
+		t.Parallel()
+		leader, followers := clusterFactory(t)
+		require.NotEqual(t, 0, len(followers), "clustered transaction tests require followers")
+
+		var entered, callbacks atomic.Int64
+		started := make(chan struct{})
+		release := make(chan struct{})
+
+		var wg sync.WaitGroup
+		results := make([]flightResult, len(followers)+1)
+		wg.Go(func() {
+			results[0].changed, results[0].shared, results[0].err = leader.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
+				callbacks.Add(1)
+				close(started)
+				<-release
+				// FIXME: I'm not sure there is a way to ensure followers have joined at this point,
+				// other than implementing a field to read directly in the respective backends.
+				time.Sleep(time.Second)
+				_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
+				return err
+			})
+		})
+
+		requireReceive(t, started, "first transaction did not start")
+		for i, follower := range followers {
+			wg.Go(func() {
+				entered.Add(1)
+				results[i+1].changed, results[i+1].shared, results[i+1].err = follower.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
+					callbacks.Add(1)
+					_, err := tx.Submit(putRequest(newTestRecord(t, fmt.Sprintf("w%d", i), nil)))
+					return err
+				})
+			})
+		}
+
+		requireEnteredFlight(t, &entered, int64(len(followers)))
+		close(release)
+		wg.Wait()
+
+		assert.Equal(t, ranCallbacks(results), callbacks.Load(),
+			"a deduped callback ran, or an owned one did not")
+
+		allChanged := slices.Map(results, func(r flightResult) []*databroker.Record {
+			return r.changed
+		})
+
+		// TODO : this is flaky
+		assertEveryRecordSetEqual(t, allChanged...)
+
+		for i, r := range results {
+			assert.NoError(t, r.err)
+			assertChangedPersisted(t, leader, r.changed)
+
+			own := "r1"
+			if i > 0 {
+				own = fmt.Sprintf("w%d", i)
+			}
+			_, err := leader.Get(t.Context(), "example", own)
+			if r.shared {
+				assert.NotContains(t, recordIDs(r.changed), own)
+				assert.ErrorIs(t, err, storage.ErrNotFound)
+			} else {
+				assert.Equal(t, []string{own}, recordIDs(r.changed))
+				assert.NoError(t, err)
+			}
+		}
+	})
+}
+
+func newTestRecord(t *testing.T, id string, fields map[string]any) *databroker.Record {
+	t.Helper()
+	s, err := structpb.NewStruct(fields)
+	require.NoError(t, err)
+	return &databroker.Record{Type: "example", Id: id, Data: protoutil.NewAny(s)}
+}
+
+// assertChangedPersisted checks that the last change reported for each record is
+// what the backend now returns. Earlier entries for a record are superseded by a
+// later operation in the same transaction, so only the last one can still match.
+func assertChangedPersisted(t *testing.T, backend storage.Backend, changed []*databroker.Record) {
+	t.Helper()
+	latest := map[string]*databroker.Record{}
+	for _, record := range changed {
+		latest[record.GetType()+"/"+record.GetId()] = record
+	}
+	for _, want := range latest {
+		got, err := backend.Get(context.Background(), want.GetType(), want.GetId())
+		if !assert.NoError(t, err) {
+			continue
+		}
+		testutil.AssertProtoEqual(t, maskModifiedAt(want), maskModifiedAt(got))
+	}
+}
+
+func maskModifiedAt(record *databroker.Record) *databroker.Record {
+	masked := proto.CloneOf(record)
+	masked.ModifiedAt = nil
+	return masked
+}
+
+func requireReceive[T any](t *testing.T, ch <-chan T, msg string) T {
+	t.Helper()
+	select {
+	case v := <-ch:
+		return v
+	case <-time.After(transactionTestTimeout):
+		require.FailNow(t, "timed out", msg)
+		var zero T
+		return zero
+	}
+}
+
+type flightResult struct {
+	changed []*databroker.Record
+	shared  bool
+	err     error
+}
+
+func ranCallbacks(results []flightResult) int64 {
+	var cnt int64
+	for _, r := range results {
+		if !r.shared {
+			cnt++
+		}
+	}
+	return cnt
+}
+
+// requireEnteredFlight only makes dedup likely: a goroutine may still be short
+// of the singleflight group, so assertions are written against shared.
+// TODO : this is flaky.
+func requireEnteredFlight(t *testing.T, entered *atomic.Int64, cnt int64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		return entered.Load() == cnt
+	}, transactionTestTimeout, 10*time.Millisecond)
+}
+
+func txErr(_ []*databroker.Record, _ bool, err error) error {
+	return err
+}
+
+func putRequest(records ...*databroker.Record) *databroker.TransactionRequest {
+	return &databroker.TransactionRequest{
+		Key:       "put",
+		Operation: &databroker.TransactionRequest_Put{Put: &databroker.PutRequest{Records: records}},
+	}
+}
+
+func getRequest(id string) *databroker.TransactionRequest {
+	return &databroker.TransactionRequest{
+		Key:       "get",
+		Operation: &databroker.TransactionRequest_Get{Get: &databroker.GetRequest{Type: "example", Id: id}},
+	}
+}
+
+func patchRequest(fields *fieldmaskpb.FieldMask, records ...*databroker.Record) *databroker.TransactionRequest {
+	return &databroker.TransactionRequest{
+		Key: "patch",
+		Operation: &databroker.TransactionRequest_Patch{Patch: &databroker.PatchRequest{
+			Records:   records,
+			FieldMask: fields,
+		}},
+	}
+}
+
+func queryRequest(query string) *databroker.TransactionRequest {
+	return &databroker.TransactionRequest{
+		Key: "query",
+		Operation: &databroker.TransactionRequest_Query{Query: &databroker.QueryRequest{
+			Type:  "example",
+			Query: query,
+			Limit: 100,
+		}},
+	}
+}
+
+func recordIDs(records []*databroker.Record) []string {
+	ids := make([]string, 0, len(records))
+	for _, record := range records {
+		ids = append(ids, record.GetId())
+	}
+	return ids
+}
+
+func assertEveryRecordSetEqual(t *testing.T, recordSets ...[]*databroker.Record) {
+	t.Helper()
+	require.Greater(t, len(recordSets), 1, "more than one record set needs to be compared for equality")
+
+	expected := recordSets[0]
+	for _, actual := range recordSets[1:] {
+		assert.Empty(t, cmp.Diff(expected, actual, protocmp.Transform()))
 	}
 }

--- a/pkg/storage/storagetest/storagetest.go
+++ b/pkg/storage/storagetest/storagetest.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
@@ -1490,7 +1491,6 @@ func TestTransaction(t *testing.T, backendFactory func(t *testing.T) storage.Bac
 		}
 	})
 
-	// TODO : this may be specific to file/memory backend
 	t.Run("read your writes", func(t *testing.T) {
 		t.Parallel()
 		backend := backendFactory(t)
@@ -1545,119 +1545,121 @@ func TestTransaction(t *testing.T, backendFactory func(t *testing.T) storage.Bac
 		require.NoError(t, err)
 	})
 
+	// the singleflight tests run in a synctest bubble: synctest.Wait returns
+	// once every other goroutine is durably blocked, and with the owner parked
+	// on release the waiters can only be parked inside the flight. This
+	// requires a backend that blocks on in-process primitives only.
 	t.Run("singleflight dedup", func(t *testing.T) {
 		t.Parallel()
-		backend := backendFactory(t)
+		synctest.Test(t, func(t *testing.T) {
+			backend := backendFactory(t)
 
-		const waiters = 7
-		var entered, callbacks atomic.Int64
-		started := make(chan struct{})
-		release := make(chan struct{})
+			const waiters = 7
+			var callbacks atomic.Int64
+			started := make(chan struct{})
+			release := make(chan struct{})
 
-		var wg sync.WaitGroup
-		results := make([]flightResult, waiters+1)
-		wg.Go(func() {
-			results[0].changed, results[0].shared, results[0].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
-				callbacks.Add(1)
-				close(started)
-				<-release
-				_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
-				return err
-			})
-		})
-
-		requireReceive(t, started, "first transaction did not start")
-		for i := 1; i <= waiters; i++ {
+			var wg sync.WaitGroup
+			results := make([]flightResult, waiters+1)
 			wg.Go(func() {
-				entered.Add(1)
-				results[i].changed, results[i].shared, results[i].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
+				results[0].changed, results[0].shared, results[0].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
 					callbacks.Add(1)
-					_, err := tx.Submit(putRequest(newTestRecord(t, fmt.Sprintf("w%d", i), nil)))
+					close(started)
+					<-release
+					_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
 					return err
 				})
 			})
-		}
 
-		requireEnteredFlight(t, &entered, waiters)
-		close(release)
-		wg.Wait()
+			requireReceive(t, started, "first transaction did not start")
+			for i := 1; i <= waiters; i++ {
+				wg.Go(func() {
+					results[i].changed, results[i].shared, results[i].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
+						callbacks.Add(1)
+						_, err := tx.Submit(putRequest(newTestRecord(t, fmt.Sprintf("w%d", i), nil)))
+						return err
+					})
+				})
+			}
 
-		assert.Equal(t, ranCallbacks(results), callbacks.Load(),
-			"a deduped callback ran, or an owned one did not")
+			synctest.Wait()
+			close(release)
+			wg.Wait()
 
-		allChanged := slices.Map(results, func(r flightResult) []*databroker.Record {
-			return r.changed
+			assert.Equal(t, int64(1), callbacks.Load(),
+				"a deduped callback ran, or an owned one did not")
+
+			allChanged := slices.Map(results, func(r flightResult) []*databroker.Record {
+				return r.changed
+			})
+			assertEveryRecordSetEqual(t, allChanged...)
+
+			for i, r := range results {
+				assert.NoError(t, r.err)
+				assertChangedPersisted(t, backend, r.changed)
+
+				own := "r1"
+				if i > 0 {
+					own = fmt.Sprintf("w%d", i)
+				}
+				_, err := backend.Get(t.Context(), "example", own)
+				if r.shared {
+					assert.NotContains(t, recordIDs(r.changed), own)
+					assert.ErrorIs(t, err, storage.ErrNotFound)
+				} else {
+					assert.Equal(t, []string{own}, recordIDs(r.changed))
+					assert.NoError(t, err)
+				}
+			}
 		})
-
-		// TODO : this is flaky
-		assertEveryRecordSetEqual(t, allChanged...)
-
-		for i, r := range results {
-			assert.NoError(t, r.err)
-			assertChangedPersisted(t, backend, r.changed)
-
-			own := "r1"
-			if i > 0 {
-				own = fmt.Sprintf("w%d", i)
-			}
-			_, err := backend.Get(t.Context(), "example", own)
-			if r.shared {
-				assert.NotContains(t, recordIDs(r.changed), own)
-				assert.ErrorIs(t, err, storage.ErrNotFound)
-			} else {
-				assert.Equal(t, []string{own}, recordIDs(r.changed))
-				assert.NoError(t, err)
-			}
-		}
 	})
 
 	t.Run("error sharing", func(t *testing.T) {
 		t.Parallel()
-		backend := backendFactory(t)
+		synctest.Test(t, func(t *testing.T) {
+			backend := backendFactory(t)
 
-		const waiters = 3
-		errFail := errors.New("fail")
-		var entered, callbacks atomic.Int64
-		started := make(chan struct{})
-		release := make(chan struct{})
+			const waiters = 3
+			errFail := errors.New("fail")
+			var callbacks atomic.Int64
+			started := make(chan struct{})
+			release := make(chan struct{})
 
-		var wg sync.WaitGroup
-		results := make([]flightResult, waiters+1)
-		wg.Go(func() {
-			results[0].changed, results[0].shared, results[0].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
-				callbacks.Add(1)
-				close(started)
-				<-release
-				_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
-				require.NoError(t, err)
-				return errFail
-			})
-		})
-
-		requireReceive(t, started, "first transaction did not start")
-		for i := 1; i <= waiters; i++ {
+			var wg sync.WaitGroup
+			results := make([]flightResult, waiters+1)
 			wg.Go(func() {
-				entered.Add(1)
-				// a straggler that misses the flight leads one of its own, so it
-				// must fail the same way
-				results[i].changed, results[i].shared, results[i].err = backend.DoTransaction(context.Background(), "k", func(_ storage.Transaction) error {
+				results[0].changed, results[0].shared, results[0].err = backend.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
 					callbacks.Add(1)
+					close(started)
+					<-release
+					_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
+					require.NoError(t, err)
 					return errFail
 				})
 			})
-		}
 
-		requireEnteredFlight(t, &entered, waiters)
-		close(release)
-		wg.Wait()
+			requireReceive(t, started, "first transaction did not start")
+			for i := 1; i <= waiters; i++ {
+				wg.Go(func() {
+					results[i].changed, results[i].shared, results[i].err = backend.DoTransaction(context.Background(), "k", func(_ storage.Transaction) error {
+						callbacks.Add(1)
+						return errFail
+					})
+				})
+			}
 
-		assert.Equal(t, ranCallbacks(results), callbacks.Load(), "a deduped callback ran")
-		for _, r := range results {
-			assert.ErrorIs(t, r.err, errFail)
-			assert.Empty(t, r.changed, "a rolled back transaction reported changed records")
-		}
-		_, err := backend.Get(t.Context(), "example", "r1")
-		assert.ErrorIs(t, err, storage.ErrNotFound)
+			synctest.Wait()
+			close(release)
+			wg.Wait()
+
+			assert.Equal(t, int64(1), callbacks.Load(), "a deduped callback ran")
+			for _, r := range results {
+				assert.ErrorIs(t, r.err, errFail)
+				assert.Empty(t, r.changed, "a rolled back transaction reported changed records")
+			}
+			_, err := backend.Get(t.Context(), "example", "r1")
+			assert.ErrorIs(t, err, storage.ErrNotFound)
+		})
 	})
 
 	t.Run("distinct keys run concurrently", func(t *testing.T) {
@@ -1754,71 +1756,72 @@ func TestTransactionsClustered(t *testing.T, clusterFactory func(t *testing.T) (
 	t.Parallel()
 	t.Run("singleflight dedup", func(t *testing.T) {
 		t.Parallel()
-		leader, followers := clusterFactory(t)
-		require.NotEqual(t, 0, len(followers), "clustered transaction tests require followers")
+		synctest.Test(t, func(t *testing.T) {
+			leader, followers := clusterFactory(t)
+			require.NotEqual(t, 0, len(followers), "clustered transaction tests require followers")
 
-		var entered, callbacks atomic.Int64
-		started := make(chan struct{})
-		release := make(chan struct{})
+			var entered, callbacks atomic.Int64
+			started := make(chan struct{})
+			release := make(chan struct{})
 
-		var wg sync.WaitGroup
-		results := make([]flightResult, len(followers)+1)
-		wg.Go(func() {
-			results[0].changed, results[0].shared, results[0].err = leader.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
-				callbacks.Add(1)
-				close(started)
-				<-release
-				// FIXME: I'm not sure there is a way to ensure followers have joined at this point,
-				// other than implementing a field to read directly in the respective backends.
-				time.Sleep(time.Second)
-				_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
-				return err
-			})
-		})
-
-		requireReceive(t, started, "first transaction did not start")
-		for i, follower := range followers {
+			var wg sync.WaitGroup
+			results := make([]flightResult, len(followers)+1)
 			wg.Go(func() {
-				entered.Add(1)
-				results[i+1].changed, results[i+1].shared, results[i+1].err = follower.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
+				results[0].changed, results[0].shared, results[0].err = leader.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
 					callbacks.Add(1)
-					_, err := tx.Submit(putRequest(newTestRecord(t, fmt.Sprintf("w%d", i), nil)))
+					close(started)
+					<-release
+					// FIXME: I'm not sure there is a way to ensure followers have joined at this point,
+					// other than implementing a field to read directly in the respective backends.
+					time.Sleep(time.Second)
+					_, err := tx.Submit(putRequest(newTestRecord(t, "r1", nil)))
 					return err
 				})
 			})
-		}
 
-		requireEnteredFlight(t, &entered, int64(len(followers)))
-		close(release)
-		wg.Wait()
+			requireReceive(t, started, "first transaction did not start")
+			for i, follower := range followers {
+				wg.Go(func() {
+					entered.Add(1)
+					results[i+1].changed, results[i+1].shared, results[i+1].err = follower.DoTransaction(context.Background(), "k", func(tx storage.Transaction) error {
+						callbacks.Add(1)
+						_, err := tx.Submit(putRequest(newTestRecord(t, fmt.Sprintf("w%d", i), nil)))
+						return err
+					})
+				})
+			}
 
-		assert.Equal(t, ranCallbacks(results), callbacks.Load(),
-			"a deduped callback ran, or an owned one did not")
+			synctest.Wait()
+			close(release)
+			wg.Wait()
 
-		allChanged := slices.Map(results, func(r flightResult) []*databroker.Record {
-			return r.changed
+			assert.Equal(t, 1, callbacks.Load(),
+				"a deduped callback ran, or an owned one did not")
+
+			allChanged := slices.Map(results, func(r flightResult) []*databroker.Record {
+				return r.changed
+			})
+
+			assertEveryRecordSetEqual(t, allChanged...)
+
+			for i, r := range results {
+				assert.NoError(t, r.err)
+				assertChangedPersisted(t, leader, r.changed)
+
+				own := "r1"
+				if i > 0 {
+					own = fmt.Sprintf("w%d", i)
+				}
+				_, err := leader.Get(t.Context(), "example", own)
+				if r.shared {
+					assert.NotContains(t, recordIDs(r.changed), own)
+					assert.ErrorIs(t, err, storage.ErrNotFound)
+				} else {
+					assert.Equal(t, []string{own}, recordIDs(r.changed))
+					assert.NoError(t, err)
+				}
+			}
 		})
-
-		// TODO : this is flaky
-		assertEveryRecordSetEqual(t, allChanged...)
-
-		for i, r := range results {
-			assert.NoError(t, r.err)
-			assertChangedPersisted(t, leader, r.changed)
-
-			own := "r1"
-			if i > 0 {
-				own = fmt.Sprintf("w%d", i)
-			}
-			_, err := leader.Get(t.Context(), "example", own)
-			if r.shared {
-				assert.NotContains(t, recordIDs(r.changed), own)
-				assert.ErrorIs(t, err, storage.ErrNotFound)
-			} else {
-				assert.Equal(t, []string{own}, recordIDs(r.changed))
-				assert.NoError(t, err)
-			}
-		}
 	})
 }
 
@@ -1869,26 +1872,6 @@ type flightResult struct {
 	changed []*databroker.Record
 	shared  bool
 	err     error
-}
-
-func ranCallbacks(results []flightResult) int64 {
-	var cnt int64
-	for _, r := range results {
-		if !r.shared {
-			cnt++
-		}
-	}
-	return cnt
-}
-
-// requireEnteredFlight only makes dedup likely: a goroutine may still be short
-// of the singleflight group, so assertions are written against shared.
-// TODO : this is flaky.
-func requireEnteredFlight(t *testing.T, entered *atomic.Int64, cnt int64) {
-	t.Helper()
-	require.Eventually(t, func() bool {
-		return entered.Load() == cnt
-	}, transactionTestTimeout, 10*time.Millisecond)
 }
 
 func txErr(_ []*databroker.Record, _ bool, err error) error {


### PR DESCRIPTION
## Summary

Adds a file based implementation of a `DoTransaction` callback that implements a single-flight like mechanism for the storage layer.

The callback to `storage.DoTransaction` is a function that itself is allowed to do storage operations like `Get`, `Put`, `Patch`, `Query`.

## Related issues

[RFC-Databroker-singleflight](https://app.notion.com/p/pomerium/RFC-Databroker-singleflight-3b158e156c55802b820fffb6a3bdd39f?d=3b858e156c5580faa38a001c7f8c206e#3b258e156c55806e9142ea92c8822e34)

## User Explanation

N/A

## AI disclosure

none

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>