### PR TITLE
feat(databroker): APIs for singleflight transactions

### DIFF
--- a/internal/databroker/server_backend.go
+++ b/internal/databroker/server_backend.go
@@ -662,6 +662,31 @@ func (srv *backendServer) syncOptionsByType(ctx context.Context, typeURL string,
 func (srv *backendServer) Stop() {
 	srv.stop(context.Canceled)
 	srv.stopWG.Wait()
+
+	srv.mu.Lock()
+	defer srv.mu.Unlock()
+	srv.closeBackendLocked(srv.stopCtx)
+}
+
+func (srv *backendServer) closeBackendLocked(ctx context.Context) {
+	if srv.backend != nil {
+		err := srv.backend.Close()
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("databroker/backend: error closing backend")
+		}
+		srv.backend = nil
+
+		// clear the global cache
+		storage.GlobalCache.InvalidateAll()
+	}
+
+	if srv.registry != nil {
+		err := srv.registry.Close()
+		if err != nil {
+			log.Ctx(ctx).Error().Err(err).Msg("databroker/backend: error closing registry")
+		}
+		srv.registry = nil
+	}
 }
 
 func (srv *backendServer) OnConfigChange(ctx context.Context, cfg *config.Config) {
@@ -696,24 +721,7 @@ func (srv *backendServer) OnConfigChange(ctx context.Context, cfg *config.Config
 	srv.storageConnectionString = storageConnectionString
 	srv.sharedKey = sharedKey
 
-	if srv.backend != nil {
-		err := srv.backend.Close()
-		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msg("databroker/backend: error closing backend")
-		}
-		srv.backend = nil
-
-		// clear the global cache
-		storage.GlobalCache.InvalidateAll()
-	}
-
-	if srv.registry != nil {
-		err := srv.registry.Close()
-		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msg("databroker/backend: error closing registry")
-		}
-		srv.registry = nil
-	}
+	srv.closeBackendLocked(ctx)
 }
 
 func (srv *backendServer) getBackend(ctx context.Context) (backend storage.Backend, err error) {
@@ -897,7 +905,7 @@ func (srv *backendServer) Transaction(stream grpc.BidiStreamingServer[databroker
 	}
 
 	changed, shared, err := db.DoTransaction(ctx, begin.GetBegin().GetKey(), func(tx storage.Transaction) error {
-		// the ack tells the client it was not suppressed, so it knows to submit
+		// the ack tells the client it owns the transaction, so it knows to submit
 		err := stream.Send(&databrokerpb.TransactionStreamResponse{
 			Sequence: begin.GetSequence(),
 			Message: &databrokerpb.TransactionStreamResponse_Begin{

--- a/internal/databroker/server_backend.go
+++ b/internal/databroker/server_backend.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -868,4 +869,133 @@ func (srv *backendServer) buildRecordTTLs(backend storage.Backend) map[string]ti
 		}
 	}
 	return ttls
+}
+
+// TODO: this should be much longer and callers should probably set their own transaction deadlines.
+// var rather than const so tests can shorten it.
+var transactionMaxDuration = time.Minute
+
+func (srv *backendServer) Transaction(stream grpc.BidiStreamingServer[databrokerpb.TransactionStreamRequest, databrokerpb.TransactionStreamResponse]) error {
+	ctx, span := srv.tracer.Start(stream.Context(), "databroker.grpc.Transaction")
+	defer span.End()
+
+	ctx, cancel := context.WithTimeout(ctx, transactionMaxDuration)
+	defer cancel()
+
+	db, err := srv.getBackend(ctx)
+	if err != nil {
+		return err
+	}
+
+	recv := newTransactionReceiver(ctx, stream)
+	defer recv.stop()
+
+	begin, err := recv.next()
+	if err != nil {
+		return err
+	}
+	if begin.GetBegin() == nil {
+		return status.Error(codes.InvalidArgument, "the first message of a transaction must be begin")
+	}
+
+	changed, shared, err := db.DoTransaction(ctx, begin.GetBegin().GetKey(), func(tx storage.Transaction) error {
+		// the ack tells the client it was not suppressed, so it knows to submit
+		err := stream.Send(&databrokerpb.TransactionStreamResponse{
+			Sequence: begin.GetSequence(),
+			Message: &databrokerpb.TransactionStreamResponse_Begin{
+				Begin: new(databrokerpb.BeginTransactionResponse),
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		for {
+			req, err := recv.next()
+			if err != nil {
+				return err
+			}
+			switch {
+			case req.GetCommit() != nil:
+				return nil
+			case req.GetOperation() != nil:
+				res, err := tx.Submit(req.GetOperation())
+				if err != nil {
+					return err
+				}
+				err = stream.Send(&databrokerpb.TransactionStreamResponse{
+					Sequence: req.GetSequence(),
+					Message:  &databrokerpb.TransactionStreamResponse_Operation{Operation: res},
+				})
+				if err != nil {
+					return err
+				}
+			default:
+				return status.Error(codes.InvalidArgument, "expected an operation or commit message")
+			}
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	return stream.Send(&databrokerpb.TransactionStreamResponse{
+		Message: &databrokerpb.TransactionStreamResponse_Commit{
+			Commit: &databrokerpb.CommitTransactionResponse{Shared: shared, Records: changed},
+		},
+	})
+}
+
+// transactionReceiver reads from the stream on a goroutine so an idle timeout can
+// interrupt a blocking Recv, which gRPC only unblocks when the handler returns.
+type transactionReceiver struct {
+	ctx  context.Context
+	msgs chan *databrokerpb.TransactionStreamRequest
+	errs chan error
+	done chan struct{}
+}
+
+func newTransactionReceiver(
+	ctx context.Context,
+	stream grpc.BidiStreamingServer[databrokerpb.TransactionStreamRequest, databrokerpb.TransactionStreamResponse],
+) *transactionReceiver {
+	recv := &transactionReceiver{
+		ctx:  ctx,
+		msgs: make(chan *databrokerpb.TransactionStreamRequest),
+		errs: make(chan error, 1),
+		done: make(chan struct{}),
+	}
+	go func() {
+		for {
+			msg, err := stream.Recv()
+			if err != nil {
+				recv.errs <- err
+				return
+			}
+			select {
+			case recv.msgs <- msg:
+			case <-recv.done:
+				return
+			}
+		}
+	}()
+	return recv
+}
+
+func (recv *transactionReceiver) next() (*databrokerpb.TransactionStreamRequest, error) {
+	select {
+	case msg := <-recv.msgs:
+		return msg, nil
+	case err := <-recv.errs:
+		return nil, err
+	case <-recv.ctx.Done():
+		if errors.Is(recv.ctx.Err(), context.DeadlineExceeded) {
+			return nil, status.Error(codes.DeadlineExceeded, "transaction deadline exceeded")
+		}
+		return nil, context.Cause(recv.ctx)
+	}
+}
+
+func (recv *transactionReceiver) stop() {
+	close(recv.done)
 }

--- a/internal/databroker/server_backend.go
+++ b/internal/databroker/server_backend.go
@@ -871,9 +871,7 @@ func (srv *backendServer) buildRecordTTLs(backend storage.Backend) map[string]ti
 	return ttls
 }
 
-// TODO: this should be much longer and callers should probably set their own transaction deadlines.
-// var rather than const so tests can shorten it.
-var transactionMaxDuration = time.Minute
+var transactionMaxDuration = 6 * time.Minute
 
 func (srv *backendServer) Transaction(stream grpc.BidiStreamingServer[databrokerpb.TransactionStreamRequest, databrokerpb.TransactionStreamResponse]) error {
 	ctx, span := srv.tracer.Start(stream.Context(), "databroker.grpc.Transaction")
@@ -920,14 +918,9 @@ func (srv *backendServer) Transaction(stream grpc.BidiStreamingServer[databroker
 				return nil
 			case req.GetOperation() != nil:
 				res, err := tx.Submit(req.GetOperation())
-				if err != nil {
-					return err
-				}
-				err = stream.Send(&databrokerpb.TransactionStreamResponse{
-					Sequence: req.GetSequence(),
-					Message:  &databrokerpb.TransactionStreamResponse_Operation{Operation: res},
-				})
-				if err != nil {
+				if err := stream.Send(
+					constructStreamResponse(req.GetSequence(), res, err),
+				); err != nil {
 					return err
 				}
 			default:
@@ -944,6 +937,22 @@ func (srv *backendServer) Transaction(stream grpc.BidiStreamingServer[databroker
 			Commit: &databrokerpb.CommitTransactionResponse{Shared: shared, Records: changed},
 		},
 	})
+}
+
+func constructStreamResponse(sequence uint64, resp *databrokerpb.TransactionResponse, err error) *databrokerpb.TransactionStreamResponse {
+	operation := &databrokerpb.TransactionResponseWithError{Response: resp}
+	if err != nil {
+		st, _ := status.FromError(err)
+		operation.Response = nil
+		operation.Err = &databrokerpb.RPCStatus{
+			Code:    st.Proto().GetCode(),
+			Message: st.Proto().GetMessage(),
+		}
+	}
+	return &databrokerpb.TransactionStreamResponse{
+		Sequence: sequence,
+		Message:  &databrokerpb.TransactionStreamResponse_Operation{Operation: operation},
+	}
 }
 
 // transactionReceiver reads from the stream on a goroutine so an idle timeout can

--- a/internal/databroker/server_backend.go
+++ b/internal/databroker/server_backend.go
@@ -903,13 +903,16 @@ func (srv *backendServer) Transaction(stream grpc.BidiStreamingServer[databroker
 	if begin.GetBegin() == nil {
 		return status.Error(codes.InvalidArgument, "the first message of a transaction must be begin")
 	}
+	txKey := begin.GetBegin().GetKey()
 
 	changed, shared, err := db.DoTransaction(ctx, begin.GetBegin().GetKey(), func(tx storage.Transaction) error {
 		// the ack tells the client it owns the transaction, so it knows to submit
 		err := stream.Send(&databrokerpb.TransactionStreamResponse{
 			Sequence: begin.GetSequence(),
 			Message: &databrokerpb.TransactionStreamResponse_Begin{
-				Begin: new(databrokerpb.BeginTransactionResponse),
+				Begin: &databrokerpb.BeginTransactionResponse{
+					Key: txKey,
+				},
 			},
 		})
 		if err != nil {
@@ -923,8 +926,16 @@ func (srv *backendServer) Transaction(stream grpc.BidiStreamingServer[databroker
 			}
 			switch {
 			case req.GetCommit() != nil:
+				if req.GetCommit().GetKey() != txKey {
+					return status.Errorf(codes.FailedPrecondition,
+						"transaction submitted a commit for unexpected key : %s, expected : %s", req.GetCommit().GetKey(), txKey)
+				}
 				return nil
 			case req.GetOperation() != nil:
+				if req.GetOperation().GetKey() != txKey {
+					return status.Errorf(codes.FailedPrecondition,
+						"transaction submitted an operation for unexpected key : %s, expected : %s", req.GetOperation().GetKey(), txKey)
+				}
 				res, err := tx.Submit(req.GetOperation())
 				if err := stream.Send(
 					constructStreamResponse(req.GetSequence(), res, err),
@@ -942,7 +953,7 @@ func (srv *backendServer) Transaction(stream grpc.BidiStreamingServer[databroker
 
 	return stream.Send(&databrokerpb.TransactionStreamResponse{
 		Message: &databrokerpb.TransactionStreamResponse_Commit{
-			Commit: &databrokerpb.CommitTransactionResponse{Shared: shared, Records: changed},
+			Commit: &databrokerpb.CommitTransactionResponse{Key: begin.GetBegin().GetKey(), Shared: shared, Records: changed},
 		},
 	})
 }

--- a/internal/databroker/server_clustered.go
+++ b/internal/databroker/server_clustered.go
@@ -369,6 +369,13 @@ func (srv *clusteredServer) UpdateSettings(ctx context.Context, req *connect.Req
 	return current.UpdateSettings(ctx, req)
 }
 
+func (srv *clusteredServer) Transaction(stream grpc.BidiStreamingServer[databrokerpb.TransactionStreamRequest, databrokerpb.TransactionStreamResponse]) error {
+	srv.mu.RLock()
+	current := srv.currentServer
+	srv.mu.RUnlock()
+	return current.Transaction(stream)
+}
+
 func (srv *clusteredServer) Stop() {
 	srv.mu.Lock()
 	defer srv.mu.Unlock()

--- a/internal/databroker/server_clustered_follower.go
+++ b/internal/databroker/server_clustered_follower.go
@@ -395,6 +395,12 @@ func (srv *clusteredFollowerServer) UpdateSettings(ctx context.Context, req *con
 	})
 }
 
+func (srv *clusteredFollowerServer) Transaction(stream grpc.BidiStreamingServer[databrokerpb.TransactionStreamRequest, databrokerpb.TransactionStreamResponse]) error {
+	return srv.invokeReadWrite(stream.Context(), func(handler Server) error {
+		return handler.Transaction(stream)
+	})
+}
+
 func (srv *clusteredFollowerServer) Stop() {
 	srv.cancel(errClusteredFollowerServerStopped)
 	<-srv.done

--- a/internal/databroker/server_clustered_leader.go
+++ b/internal/databroker/server_clustered_leader.go
@@ -229,6 +229,10 @@ func (srv *clusteredLeaderServer) UpdateSettings(ctx context.Context, req *conne
 	return srv.local.UpdateSettings(ctx, req)
 }
 
+func (srv *clusteredLeaderServer) Transaction(stream grpc.BidiStreamingServer[databrokerpb.TransactionStreamRequest, databrokerpb.TransactionStreamResponse]) error {
+	return srv.local.Transaction(stream)
+}
+
 func (srv *clusteredLeaderServer) Stop() {
 	srv.cancel(nil)
 	<-srv.done

--- a/internal/databroker/server_erroring.go
+++ b/internal/databroker/server_erroring.go
@@ -202,5 +202,9 @@ func (srv *erroringServer) UpdateSettings(_ context.Context, _ *connect.Request[
 	return nil, srv.err
 }
 
+func (srv *erroringServer) Transaction(_ grpc.BidiStreamingServer[databrokerpb.TransactionStreamRequest, databrokerpb.TransactionStreamResponse]) error {
+	return srv.err
+}
+
 func (srv *erroringServer) Stop()                                              {}
 func (srv *erroringServer) OnConfigChange(_ context.Context, _ *config.Config) {}

--- a/internal/databroker/server_forwarding.go
+++ b/internal/databroker/server_forwarding.go
@@ -307,5 +307,9 @@ func (srv *forwardingServer) UpdateSettings(ctx context.Context, req *connect.Re
 	return connect.NewResponse(m), nil
 }
 
+func (srv *forwardingServer) Transaction(stream grpc.BidiStreamingServer[databrokerpb.TransactionStreamRequest, databrokerpb.TransactionStreamResponse]) error {
+	return grpcutil.ForwardBidiStream(srv.forwarder, stream, databrokerpb.NewDataBrokerServiceClient(srv.cc).Transaction)
+}
+
 func (srv *forwardingServer) Stop()                                              {}
 func (srv *forwardingServer) OnConfigChange(_ context.Context, _ *config.Config) {}

--- a/internal/databroker/server_secured.go
+++ b/internal/databroker/server_secured.go
@@ -336,6 +336,13 @@ func (srv *securedServer) UpdateSettings(ctx context.Context, req *connect.Reque
 	return srv.underlying.UpdateSettings(ctx, req)
 }
 
+func (srv *securedServer) Transaction(stream grpc.BidiStreamingServer[databrokerpb.TransactionStreamRequest, databrokerpb.TransactionStreamResponse]) error {
+	if err := srv.authorize(stream.Context()); err != nil {
+		return err
+	}
+	return srv.underlying.Transaction(stream)
+}
+
 func (srv *securedServer) Stop() {
 	srv.underlying.Stop()
 }

--- a/internal/databroker/transactions_test.go
+++ b/internal/databroker/transactions_test.go
@@ -78,15 +78,15 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 
 		require.NotNil(t, beginTransaction(t, stream, "operations").GetBegin())
 
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("op-1")))
-		assert.Len(t, recvOperation(t, stream).GetPut().GetRecords(), 1)
+		sendOperation(t, stream, "operations", 1, putOperation(newTransactionRecord("op-1")))
+		assert.Len(t, recvOperation(t, stream, "operations").GetPut().GetRecords(), 1)
 
-		sendOperation(t, stream, 2, getOperation("op-1"))
-		assert.Equal(t, "op-1", recvOperation(t, stream).GetGet().GetRecord().GetId())
+		sendOperation(t, stream, "operations", 2, getOperation("op-1"))
+		assert.Equal(t, "op-1", recvOperation(t, stream, "operations").GetGet().GetRecord().GetId())
 
 		patched := newTransactionRecord("op-1")
 		patched.Data = protoutil.NewAny(&sessionpb.Session{Id: "op-1", UserId: "user-1"})
-		sendOperation(t, stream, 3, &databrokerpb.TransactionRequest{
+		sendOperation(t, stream, "operations", 3, &databrokerpb.TransactionRequest{
 			Operation: &databrokerpb.TransactionRequest_Patch{
 				Patch: &databrokerpb.PatchRequest{
 					Records:   []*databrokerpb.Record{patched},
@@ -94,17 +94,17 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 				},
 			},
 		})
-		assert.Len(t, recvOperation(t, stream).GetPatch().GetRecords(), 1)
+		assert.Len(t, recvOperation(t, stream, "operations").GetPatch().GetRecords(), 1)
 
-		sendOperation(t, stream, 4, &databrokerpb.TransactionRequest{
+		sendOperation(t, stream, "operations", 4, &databrokerpb.TransactionRequest{
 			Operation: &databrokerpb.TransactionRequest_Query{
 				Query: &databrokerpb.QueryRequest{Type: recordType(), Limit: 10},
 			},
 		})
-		assert.NotNil(t, recvOperation(t, stream).GetQuery())
+		assert.NotNil(t, recvOperation(t, stream, "operations").GetQuery())
 
-		sendCommit(t, stream)
-		commit, err := recvCommit(t, stream)
+		sendCommit(t, stream, "operations")
+		commit, err := recvCommit(t, stream, "operations")
 		require.NoError(t, err)
 		assert.False(t, commit.GetShared())
 
@@ -119,7 +119,7 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 
 		require.NotNil(t, beginTransaction(t, stream, "storage-error").GetBegin())
 
-		sendOperation(t, stream, 1, getOperation("missing"))
+		sendOperation(t, stream, "storage-error", 1, getOperation("missing"))
 		res, err := stream.Recv()
 		require.NoError(t, err)
 		assert.Equal(t, uint64(1), res.GetSequence())
@@ -127,11 +127,11 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 		assert.Equal(t, int32(codes.NotFound), res.GetOperation().GetErr().GetCode())
 
 		// a failed operation does not end the transaction
-		sendOperation(t, stream, 2, putOperation(newTransactionRecord("after-error")))
-		assert.Len(t, recvOperation(t, stream).GetPut().GetRecords(), 1)
+		sendOperation(t, stream, "storage-error", 2, putOperation(newTransactionRecord("after-error")))
+		assert.Len(t, recvOperation(t, stream, "storage-error").GetPut().GetRecords(), 1)
 
-		sendCommit(t, stream)
-		_, err = recvCommit(t, stream)
+		sendCommit(t, stream, "storage-error")
+		_, err = recvCommit(t, stream, "storage-error")
 		require.NoError(t, err)
 
 		assertRecordExists(t, srv, "after-error")
@@ -144,12 +144,12 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 		require.NoError(t, err)
 
 		require.NotNil(t, beginTransaction(t, stream, "stream-closed").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("stream-closed")))
+		sendOperation(t, stream, "stream-closed", 1, putOperation(newTransactionRecord("stream-closed")))
 		_, err = stream.Recv()
 		require.NoError(t, err)
 		require.NoError(t, stream.CloseSend())
 
-		_, err = recvCommit(t, stream)
+		_, err = recvCommit(t, stream, "stream-closed")
 		assert.Error(t, err)
 		assert.NotErrorIs(t, err, io.EOF)
 
@@ -164,12 +164,12 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 			require.NoError(t, err)
 
 			require.NotNil(t, beginTransaction(t, stream, "deadline").GetBegin())
-			sendOperation(t, stream, 1, putOperation(newTransactionRecord("deadline")))
+			sendOperation(t, stream, "deadline", 1, putOperation(newTransactionRecord("deadline")))
 			_, err = stream.Recv()
 			require.NoError(t, err)
 			// the deadline runs on synctest's fake clock, so it can only elapse
 			// while every goroutine is blocked waiting for the commit
-			_, err = recvCommit(t, stream)
+			_, err = recvCommit(t, stream, "deadline")
 			assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
 
 			assertRecordMissing(t, srv, "deadline")
@@ -186,16 +186,16 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 		require.NoError(t, err)
 
 		require.NotNil(t, beginTransaction(t, stream, "commit-error").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("ok")))
+		sendOperation(t, stream, "commit-error", 1, putOperation(newTransactionRecord("ok")))
 		_, err = stream.Recv()
 		require.NoError(t, err)
 
-		sendOperation(t, stream, 2, putOperation(newTransactionRecord("error")))
+		sendOperation(t, stream, "commit-error", 2, putOperation(newTransactionRecord("error")))
 		_, err = stream.Recv()
 		require.NoError(t, err)
 
-		sendCommit(t, stream)
-		_, err = recvCommit(t, stream)
+		sendCommit(t, stream, "commit-error")
+		_, err = recvCommit(t, stream, "commit-error")
 		assert.Equal(t, codes.Internal, status.Code(err))
 		assert.ErrorContains(t, err, "error committing transaction")
 
@@ -211,12 +211,12 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 		require.NoError(t, err)
 
 		require.NotNil(t, beginTransaction(t, stream, "cancel").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("cancel-1")))
+		sendOperation(t, stream, "cancel", 1, putOperation(newTransactionRecord("cancel-1")))
 		_, err = stream.Recv()
 		require.NoError(t, err)
 		cancel()
 
-		_, err = recvCommit(t, stream)
+		_, err = recvCommit(t, stream, "cancel")
 		assert.Equal(t, codes.Canceled, status.Code(err))
 
 		assertRecordMissing(t, srv, "cancel-1")
@@ -228,9 +228,9 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 		stream, err := client.Transaction(t.Context())
 		require.NoError(t, err)
 
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("no-begin-1")))
+		sendOperation(t, stream, "no-begin", 1, putOperation(newTransactionRecord("no-begin-1")))
 
-		_, err = recvCommit(t, stream)
+		_, err = recvCommit(t, stream, "no-begin")
 		assert.Equal(t, codes.InvalidArgument, status.Code(err))
 
 		assertRecordMissing(t, srv, "no-begin-1")
@@ -243,15 +243,47 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 		require.NoError(t, err)
 
 		require.NotNil(t, beginTransaction(t, stream, "double-begin").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("double-begin-1")))
+		sendOperation(t, stream, "double-begin", 1, putOperation(newTransactionRecord("double-begin-1")))
 		_, err = stream.Recv()
 		require.NoError(t, err)
 		sendBegin(t, stream, "double-begin")
 
-		_, err = recvCommit(t, stream)
+		_, err = recvCommit(t, stream, "double-begin")
 		assert.Equal(t, codes.InvalidArgument, status.Code(err))
 
 		assertRecordMissing(t, srv, "double-begin-1")
+	})
+
+	t.Run("operation for another key is rejected", func(t *testing.T) {
+		srv, client := newServers(t)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "key-mismatch").GetBegin())
+		sendOperation(t, stream, "other-key", 1, putOperation(newTransactionRecord("key-mismatch-1")))
+
+		_, err = recvCommit(t, stream, "key-mismatch")
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+		assertRecordMissing(t, srv, "key-mismatch-1")
+	})
+
+	t.Run("messages for another key terminate the transaction", func(t *testing.T) {
+		srv, client := newServers(t)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "commit-mismatch").GetBegin())
+		sendOperation(t, stream, "commit-mismatch", 1, putOperation(newTransactionRecord("commit-mismatch")))
+		require.NotNil(t, recvOperation(t, stream, "commit-mismatch").GetPut())
+		sendCommit(t, stream, "other-key")
+
+		_, err = recvCommit(t, stream, "commit-mismatch")
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
+
+		assertRecordMissing(t, srv, "commit-mismatch")
 	})
 
 	t.Run("atomic", func(t *testing.T) {
@@ -277,7 +309,7 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 			stream, err := client.Transaction(t.Context())
 			require.NoError(t, err)
 			sendBegin(t, stream, "shared-key")
-			sendOperation(t, stream, 1, putOperation(newTransactionRecord("shared")))
+			sendOperation(t, stream, "shared-key", 1, putOperation(newTransactionRecord("shared")))
 
 			responses := make(chan *databrokerpb.TransactionStreamResponse, 1)
 			go func() {
@@ -304,6 +336,7 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 			require.True(t, ok)
 			require.Nil(t, res.GetBegin(), "a shared transaction should not be acked")
 			assert.True(t, res.GetCommit().GetShared())
+			assert.Equal(t, "shared-key", res.GetCommit().GetKey())
 
 			assertRecordExists(t, srv, "holder")
 			assertRecordMissing(t, srv, "shared")
@@ -311,14 +344,14 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 			next, err := client.Transaction(t.Context())
 			require.NoError(t, err)
 			require.NotNil(t, beginTransaction(t, next, "shared-key").GetBegin())
-			sendOperation(t, next, 1, getOperation("holder"))
-			assert.Equal(t, "holder", recvOperation(t, next).GetGet().GetRecord().GetId())
+			sendOperation(t, next, "shared-key", 1, getOperation("holder"))
+			assert.Equal(t, "holder", recvOperation(t, next, "shared-key").GetGet().GetRecord().GetId())
 
-			sendOperation(t, next, 2, putOperation(newTransactionRecord("next")))
-			recvOperation(t, next)
-			sendCommit(t, next)
+			sendOperation(t, next, "shared-key", 2, putOperation(newTransactionRecord("next")))
+			recvOperation(t, next, "shared-key")
+			sendCommit(t, next, "shared-key")
 
-			nextCommit, err := recvCommit(t, next)
+			nextCommit, err := recvCommit(t, next, "shared-key")
 			require.NoError(t, err)
 			assert.False(t, nextCommit.GetShared())
 			assertRecordExists(t, srv, "next")
@@ -335,7 +368,7 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 
 		sequences := []uint64{7, 3, 9}
 		for i, sequence := range sequences {
-			sendOperation(t, stream, sequence, putOperation(newTransactionRecord(string(rune('a'+i)))))
+			sendOperation(t, stream, "sequence", sequence, putOperation(newTransactionRecord(string(rune('a'+i)))))
 		}
 		for _, sequence := range sequences {
 			res, err := stream.Recv()
@@ -343,8 +376,8 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 			assert.Equal(t, sequence, res.GetSequence())
 		}
 
-		sendCommit(t, stream)
-		_, err = recvCommit(t, stream)
+		sendCommit(t, stream, "sequence")
+		_, err = recvCommit(t, stream, "sequence")
 		require.NoError(t, err)
 	})
 
@@ -353,8 +386,8 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 		stream, err := client.Transaction(t.Context())
 		require.NoError(t, err)
 		require.NotNil(t, beginTransaction(t, stream, "reload").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("record-1")))
-		require.NotNil(t, recvOperation(t, stream).GetPut())
+		sendOperation(t, stream, "reload", 1, putOperation(newTransactionRecord("record-1")))
+		require.NotNil(t, recvOperation(t, stream, "reload").GetPut())
 
 		// hack
 		bs := server.(*backendServer)
@@ -363,8 +396,8 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 		bs.mu.Unlock()
 		// end hack
 
-		sendCommit(t, stream)
-		_, err = recvCommit(t, stream)
+		sendCommit(t, stream, "reload")
+		_, err = recvCommit(t, stream, "reload")
 		require.Error(t, err)
 		assertRecordMissing(t, server, "record-1")
 	})
@@ -448,24 +481,31 @@ func beginTransaction(t *testing.T, stream transactionStream, key string) *datab
 	sendBegin(t, stream, key)
 	res, err := stream.Recv()
 	require.NoError(t, err)
+	if begin := res.GetBegin(); begin != nil {
+		assert.Equal(t, key, begin.GetKey())
+	}
+	if commit := res.GetCommit(); commit != nil {
+		assert.Equal(t, key, commit.GetKey())
+	}
 	return res
 }
 
-func sendOperation(t *testing.T, stream transactionStream, sequence uint64, op *databrokerpb.TransactionRequest) {
+func sendOperation(t *testing.T, stream transactionStream, key string, sequence uint64, op *databrokerpb.TransactionRequest) {
 	t.Helper()
 
+	op.Key = key
 	require.NoError(t, stream.Send(&databrokerpb.TransactionStreamRequest{
 		Sequence: sequence,
 		Message:  &databrokerpb.TransactionStreamRequest_Operation{Operation: op},
 	}))
 }
 
-func sendCommit(t *testing.T, stream transactionStream) {
+func sendCommit(t *testing.T, stream transactionStream, key string) {
 	t.Helper()
 
 	require.NoError(t, stream.Send(&databrokerpb.TransactionStreamRequest{
 		Message: &databrokerpb.TransactionStreamRequest_Commit{
-			Commit: new(databrokerpb.CommitTransaction),
+			Commit: &databrokerpb.CommitTransaction{Key: key},
 		},
 	}))
 }
@@ -487,17 +527,18 @@ func getOperation(id string) *databrokerpb.TransactionRequest {
 }
 
 // recvOperation reads an operation response and asserts the operation itself did not fail.
-func recvOperation(t *testing.T, stream transactionStream) *databrokerpb.TransactionResponse {
+func recvOperation(t *testing.T, stream transactionStream, key string) *databrokerpb.TransactionResponse {
 	t.Helper()
 
 	res, err := stream.Recv()
 	require.NoError(t, err)
 	require.Nil(t, res.GetOperation().GetErr())
+	assert.Equal(t, key, res.GetOperation().GetResponse().GetKey())
 	return res.GetOperation().GetResponse()
 }
 
 // recvCommit reads responses until the commit arm arrives, ignoring operation responses.
-func recvCommit(t *testing.T, stream transactionStream) (*databrokerpb.CommitTransactionResponse, error) {
+func recvCommit(t *testing.T, stream transactionStream, key string) (*databrokerpb.CommitTransactionResponse, error) {
 	t.Helper()
 
 	for {
@@ -506,6 +547,7 @@ func recvCommit(t *testing.T, stream transactionStream) (*databrokerpb.CommitTra
 			return nil, err
 		}
 		if commit := res.GetCommit(); commit != nil {
+			assert.Equal(t, key, commit.GetKey())
 			return commit, nil
 		}
 	}

--- a/internal/databroker/transactions_test.go
+++ b/internal/databroker/transactions_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -29,6 +30,376 @@ func newTransactionClient(t *testing.T, srv databrokerpb.DataBrokerServiceServer
 		databrokerpb.RegisterDataBrokerServiceServer(s, srv)
 	})
 	return databrokerpb.NewDataBrokerServiceClient(cc)
+}
+
+type transactionServersFunc func(t *testing.T) (Server, databrokerpb.DataBrokerServiceClient)
+
+func newBackendServers(t *testing.T) (Server, databrokerpb.DataBrokerServiceClient) {
+	srv := newServer(t)
+	t.Cleanup(func() {
+		srv.Stop()
+	})
+	return srv, newTransactionClient(t, srv)
+}
+
+func newFollowerServers(t *testing.T) (Server, databrokerpb.DataBrokerServiceClient) {
+	leader := newServer(t)
+	leaderCC := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(s, leader)
+	})
+	follower := NewClusteredFollowerServer(noop.NewTracerProvider(), newServer(t), leaderCC)
+	t.Cleanup(follower.Stop)
+	return leader, newTransactionClient(t, follower)
+}
+
+func TestDatabrokerTransactions(t *testing.T) {
+	t.Parallel()
+
+	setups := []struct {
+		name       string
+		newServers transactionServersFunc
+	}{
+		{"backend", newBackendServers},
+		{"clustered follower", newFollowerServers},
+	}
+	for _, setup := range setups {
+		t.Run(setup.name, func(t *testing.T) {
+			testTransactions(t, setup.newServers)
+		})
+	}
+}
+
+func testTransactions(t *testing.T, newServers transactionServersFunc) {
+	t.Run("get put patch query", func(t *testing.T) {
+		srv, client := newServers(t)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "operations").GetBegin())
+
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("op-1")))
+		assert.Len(t, recvOperation(t, stream).GetPut().GetRecords(), 1)
+
+		sendOperation(t, stream, 2, getOperation("op-1"))
+		assert.Equal(t, "op-1", recvOperation(t, stream).GetGet().GetRecord().GetId())
+
+		patched := newTransactionRecord("op-1")
+		patched.Data = protoutil.NewAny(&sessionpb.Session{Id: "op-1", UserId: "user-1"})
+		sendOperation(t, stream, 3, &databrokerpb.TransactionRequest{
+			Operation: &databrokerpb.TransactionRequest_Patch{
+				Patch: &databrokerpb.PatchRequest{
+					Records:   []*databrokerpb.Record{patched},
+					FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"user_id"}},
+				},
+			},
+		})
+		assert.Len(t, recvOperation(t, stream).GetPatch().GetRecords(), 1)
+
+		sendOperation(t, stream, 4, &databrokerpb.TransactionRequest{
+			Operation: &databrokerpb.TransactionRequest_Query{
+				Query: &databrokerpb.QueryRequest{Type: recordType(), Limit: 10},
+			},
+		})
+		assert.NotNil(t, recvOperation(t, stream).GetQuery())
+
+		sendCommit(t, stream)
+		commit, err := recvCommit(t, stream)
+		require.NoError(t, err)
+		assert.False(t, commit.GetShared())
+
+		assertRecordExists(t, srv, "op-1")
+	})
+
+	t.Run("returns storage errors to the caller", func(t *testing.T) {
+		srv, client := newServers(t)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "storage-error").GetBegin())
+
+		sendOperation(t, stream, 1, getOperation("missing"))
+		res, err := stream.Recv()
+		require.NoError(t, err)
+		assert.Equal(t, uint64(1), res.GetSequence())
+		assert.Nil(t, res.GetOperation().GetResponse())
+		assert.Equal(t, int32(codes.NotFound), res.GetOperation().GetErr().GetCode())
+
+		// a failed operation does not end the transaction
+		sendOperation(t, stream, 2, putOperation(newTransactionRecord("after-error")))
+		assert.Len(t, recvOperation(t, stream).GetPut().GetRecords(), 1)
+
+		sendCommit(t, stream)
+		_, err = recvCommit(t, stream)
+		require.NoError(t, err)
+
+		assertRecordExists(t, srv, "after-error")
+	})
+
+	t.Run("rollback on closed stream", func(t *testing.T) {
+		srv, client := newServers(t)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "stream-closed").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("stream-closed")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+		require.NoError(t, stream.CloseSend())
+
+		_, err = recvCommit(t, stream)
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, io.EOF)
+
+		assertRecordMissing(t, srv, "stream-closed")
+	})
+
+	t.Run("rollback on max duration exceeded", func(t *testing.T) {
+		originalMaxDuration := transactionMaxDuration
+		transactionMaxDuration = 100 * time.Millisecond
+		t.Cleanup(func() { transactionMaxDuration = originalMaxDuration })
+
+		srv, client := newServers(t)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "deadline").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("deadline")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+		assertRecordMissing(t, srv, "deadline")
+	})
+
+	t.Run("rollback on backend internal error", func(t *testing.T) {
+		srv, client := newServers(t)
+		setBackend(t, srv, func(backend storage.Backend) storage.Backend {
+			return &txErrStorageBackend{Backend: backend, failOnID: "error"}
+		})
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "commit-error").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("ok")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+
+		sendOperation(t, stream, 2, putOperation(newTransactionRecord("error")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+
+		sendCommit(t, stream)
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assert.ErrorContains(t, err, "error committing transaction")
+
+		assertRecordMissing(t, srv, "ok")
+		assertRecordMissing(t, srv, "error")
+	})
+
+	t.Run("rollback on cancel", func(t *testing.T) {
+		srv, client := newServers(t)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		stream, err := client.Transaction(ctx)
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "cancel").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("cancel-1")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+		cancel()
+
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.Canceled, status.Code(err))
+
+		assertRecordMissing(t, srv, "cancel-1")
+	})
+
+	t.Run("first message must be begin", func(t *testing.T) {
+		srv, client := newServers(t)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("no-begin-1")))
+
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+
+		assertRecordMissing(t, srv, "no-begin-1")
+	})
+
+	t.Run("second begin is rejected", func(t *testing.T) {
+		srv, client := newServers(t)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "double-begin").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("double-begin-1")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+		sendBegin(t, stream, "double-begin")
+
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+
+		assertRecordMissing(t, srv, "double-begin-1")
+	})
+
+	t.Run("atomic", func(t *testing.T) {
+		// TODO : this test is weird
+		srv, client := newServers(t)
+
+		// hold the key from the test side so the stream below is certainly suppressed
+		db, err := srv.(*backendServer).getBackend(t.Context())
+		require.NoError(t, err)
+		held, release := make(chan struct{}), make(chan struct{})
+		holder := make(chan error, 1)
+		go func() {
+			_, _, err := db.DoTransaction(t.Context(), "shared-key", func(tx storage.Transaction) error {
+				close(held)
+				<-release
+				_, err := tx.Submit(putOperation(newTransactionRecord("holder")))
+				return err
+			})
+			holder <- err
+		}()
+		<-held
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+		sendBegin(t, stream, "shared-key")
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("suppressed")))
+
+		responses := make(chan *databrokerpb.TransactionStreamResponse, 1)
+		go func() {
+			res, err := stream.Recv()
+			if err == nil {
+				responses <- res
+			}
+			close(responses)
+		}()
+
+		// while the key is held the stream is parked in singleflight, unacked
+		require.Never(t, func() bool {
+			select {
+			case <-responses:
+				return true
+			default:
+				return false
+			}
+		}, 500*time.Millisecond, 25*time.Millisecond)
+
+		close(release)
+		require.NoError(t, <-holder)
+
+		res, ok := <-responses
+		require.True(t, ok)
+		require.Nil(t, res.GetBegin(), "suppressed transaction should not be acked")
+		assert.True(t, res.GetCommit().GetShared())
+
+		assertRecordExists(t, srv, "holder")
+		assertRecordMissing(t, srv, "suppressed")
+
+		next, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, beginTransaction(t, next, "shared-key").GetBegin())
+		sendOperation(t, next, 1, getOperation("holder"))
+		assert.Equal(t, "holder", recvOperation(t, next).GetGet().GetRecord().GetId())
+
+		sendOperation(t, next, 2, putOperation(newTransactionRecord("next")))
+		recvOperation(t, next)
+		sendCommit(t, next)
+
+		nextCommit, err := recvCommit(t, next)
+		require.NoError(t, err)
+		assert.False(t, nextCommit.GetShared())
+		assertRecordExists(t, srv, "next")
+	})
+
+	t.Run("sequence echoes", func(t *testing.T) {
+		_, client := newServers(t)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "sequence").GetBegin())
+
+		sequences := []uint64{7, 3, 9}
+		for i, sequence := range sequences {
+			sendOperation(t, stream, sequence, putOperation(newTransactionRecord(string(rune('a'+i)))))
+		}
+		for _, sequence := range sequences {
+			res, err := stream.Recv()
+			require.NoError(t, err)
+			assert.Equal(t, sequence, res.GetSequence())
+		}
+
+		sendCommit(t, stream)
+		_, err = recvCommit(t, stream)
+		require.NoError(t, err)
+	})
+
+}
+
+func setBackend(t *testing.T, srv Server, wrap func(storage.Backend) storage.Backend) {
+	t.Helper()
+
+	bs, ok := srv.(*backendServer)
+	require.True(t, ok)
+
+	backend, err := bs.getBackend(t.Context())
+	require.NoError(t, err)
+
+	bs.mu.Lock()
+	bs.backend = wrap(backend)
+	bs.mu.Unlock()
+}
+
+type txErrStorageBackend struct {
+	storage.Backend
+	failOnID string
+}
+
+func (b *txErrStorageBackend) DoTransaction(ctx context.Context, key string, fn func(tx storage.Transaction) error) (
+	changed []*databrokerpb.Record,
+	shared bool,
+	err error,
+) {
+	return b.Backend.DoTransaction(ctx, key, func(tx storage.Transaction) error {
+		failing := &txErrTransaction{Transaction: tx, failOnID: b.failOnID}
+		if err := fn(failing); err != nil {
+			return err
+		}
+		if failing.doomed {
+			return status.Error(codes.Internal, "error committing transaction")
+		}
+		return nil
+	})
+}
+
+type txErrTransaction struct {
+	storage.Transaction
+	failOnID string
+	doomed   bool
+}
+
+func (tx *txErrTransaction) Submit(req *databrokerpb.TransactionRequest) (*databrokerpb.TransactionResponse, error) {
+	for _, record := range req.GetPut().GetRecords() {
+		if record.GetId() == tx.failOnID {
+			tx.doomed = true
+		}
+	}
+	return tx.Transaction.Submit(req)
 }
 
 func newTransactionRecord(id string) *databrokerpb.Record {
@@ -96,26 +467,14 @@ func getOperation(id string) *databrokerpb.TransactionRequest {
 	}
 }
 
-// putInTransaction runs a whole begin/put/commit transaction and returns the commit response.
-func putInTransaction(
-	ctx context.Context,
-	t *testing.T,
-	client databrokerpb.DataBrokerServiceClient,
-	key string,
-	records ...*databrokerpb.Record,
-) *databrokerpb.CommitTransactionResponse {
+// recvOperation reads an operation response and asserts the operation itself did not fail.
+func recvOperation(t *testing.T, stream transactionStream) *databrokerpb.TransactionResponse {
 	t.Helper()
 
-	stream, err := client.Transaction(ctx)
+	res, err := stream.Recv()
 	require.NoError(t, err)
-
-	sendBegin(t, stream, key)
-	sendOperation(t, stream, 1, putOperation(records...))
-	sendCommit(t, stream)
-
-	commit, err := recvCommit(t, stream)
-	require.NoError(t, err)
-	return commit
+	require.Nil(t, res.GetOperation().GetErr())
+	return res.GetOperation().GetResponse()
 }
 
 // recvCommit reads responses until the commit arm arrives, ignoring operation responses.
@@ -146,386 +505,4 @@ func assertRecordMissing(t *testing.T, srv Server, id string) {
 
 	_, err := srv.Get(t.Context(), &databrokerpb.GetRequest{Type: recordType(), Id: id})
 	assert.Equal(t, codes.NotFound, status.Code(err))
-}
-
-func TestDatabrokerTransactions(t *testing.T) {
-	t.Parallel()
-
-	t.Run("get put patch query", func(t *testing.T) {
-		srv := newServer(t)
-		client := newTransactionClient(t, srv)
-
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-
-		require.NotNil(t, beginTransaction(t, stream, "operations").GetBegin())
-
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("op-1")))
-		res, err := stream.Recv()
-		require.NoError(t, err)
-		assert.Len(t, res.GetOperation().GetPut().GetRecords(), 1)
-
-		sendOperation(t, stream, 2, getOperation("op-1"))
-		res, err = stream.Recv()
-		require.NoError(t, err)
-		assert.Equal(t, "op-1", res.GetOperation().GetGet().GetRecord().GetId())
-
-		patched := newTransactionRecord("op-1")
-		patched.Data = protoutil.NewAny(&sessionpb.Session{Id: "op-1", UserId: "user-1"})
-		sendOperation(t, stream, 3, &databrokerpb.TransactionRequest{
-			Operation: &databrokerpb.TransactionRequest_Patch{
-				Patch: &databrokerpb.PatchRequest{
-					Records:   []*databrokerpb.Record{patched},
-					FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"user_id"}},
-				},
-			},
-		})
-		res, err = stream.Recv()
-		require.NoError(t, err)
-		assert.Len(t, res.GetOperation().GetPatch().GetRecords(), 1)
-
-		sendOperation(t, stream, 4, &databrokerpb.TransactionRequest{
-			Operation: &databrokerpb.TransactionRequest_Query{
-				Query: &databrokerpb.QueryRequest{Type: recordType(), Limit: 10},
-			},
-		})
-		res, err = stream.Recv()
-		require.NoError(t, err)
-		assert.NotNil(t, res.GetOperation().GetQuery())
-
-		sendCommit(t, stream)
-		commit, err := recvCommit(t, stream)
-		require.NoError(t, err)
-		assert.False(t, commit.GetShared())
-
-		assertRecordExists(t, srv, "op-1")
-	})
-
-	t.Run("rollback on closed stream", func(t *testing.T) {
-		srv := newServer(t)
-		client := newTransactionClient(t, srv)
-
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-
-		require.NotNil(t, beginTransaction(t, stream, "stream-closed").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("stream-closed")))
-		_, err = stream.Recv()
-		require.NoError(t, err)
-		require.NoError(t, stream.CloseSend())
-
-		_, err = recvCommit(t, stream)
-		assert.Error(t, err)
-		assert.NotErrorIs(t, err, io.EOF)
-
-		assertRecordMissing(t, srv, "stream-closed")
-	})
-
-	t.Run("rollback on max duration exceeded", func(t *testing.T) {
-		originalMaxDuration := transactionMaxDuration
-		transactionMaxDuration = 100 * time.Millisecond
-		t.Cleanup(func() { transactionMaxDuration = originalMaxDuration })
-
-		srv := newServer(t)
-		client := newTransactionClient(t, srv)
-
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-
-		require.NotNil(t, beginTransaction(t, stream, "deadline").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("deadline")))
-		_, err = stream.Recv()
-		require.NoError(t, err)
-
-		_, err = recvCommit(t, stream)
-		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
-
-		assertRecordMissing(t, srv, "deadline")
-	})
-
-	t.Run("rollback on backend internal error", func(t *testing.T) {
-		srv := newServer(t)
-		setBackend(t, srv, func(backend storage.Backend) storage.Backend {
-			return &txErrStorageBackend{Backend: backend, failOnID: "error"}
-		})
-		client := newTransactionClient(t, srv)
-
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-
-		require.NotNil(t, beginTransaction(t, stream, "commit-error").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("ok")))
-		_, err = stream.Recv()
-		require.NoError(t, err)
-
-		sendOperation(t, stream, 2, putOperation(newTransactionRecord("error")))
-		_, err = stream.Recv()
-		require.NoError(t, err)
-
-		sendCommit(t, stream)
-		_, err = recvCommit(t, stream)
-		assert.Equal(t, codes.Internal, status.Code(err))
-		assert.ErrorContains(t, err, "error committing transaction")
-
-		assertRecordMissing(t, srv, "ok")
-		assertRecordMissing(t, srv, "error")
-	})
-
-	t.Run("rollback on cancel", func(t *testing.T) {
-		srv := newServer(t)
-		client := newTransactionClient(t, srv)
-
-		ctx, cancel := context.WithCancel(t.Context())
-		stream, err := client.Transaction(ctx)
-		require.NoError(t, err)
-
-		require.NotNil(t, beginTransaction(t, stream, "cancel").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("cancel-1")))
-		_, err = stream.Recv()
-		require.NoError(t, err)
-		cancel()
-
-		_, err = recvCommit(t, stream)
-		assert.Equal(t, codes.Canceled, status.Code(err))
-
-		assertRecordMissing(t, srv, "cancel-1")
-	})
-
-	t.Run("first message must be begin", func(t *testing.T) {
-		srv := newServer(t)
-		client := newTransactionClient(t, srv)
-
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("no-begin-1")))
-
-		_, err = recvCommit(t, stream)
-		assert.Equal(t, codes.InvalidArgument, status.Code(err))
-
-		assertRecordMissing(t, srv, "no-begin-1")
-	})
-
-	t.Run("second begin is rejected", func(t *testing.T) {
-		srv := newServer(t)
-		client := newTransactionClient(t, srv)
-
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-
-		require.NotNil(t, beginTransaction(t, stream, "double-begin").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("double-begin-1")))
-		_, err = stream.Recv()
-		require.NoError(t, err)
-		sendBegin(t, stream, "double-begin")
-
-		_, err = recvCommit(t, stream)
-		assert.Equal(t, codes.InvalidArgument, status.Code(err))
-
-		assertRecordMissing(t, srv, "double-begin-1")
-	})
-
-	t.Run("atomic", func(t *testing.T) {
-		srv := newServer(t)
-		client := newTransactionClient(t, srv)
-
-		// hold the key from the test side so the stream below is certainly suppressed
-		db, err := srv.(*backendServer).getBackend(t.Context())
-		require.NoError(t, err)
-		held, release := make(chan struct{}), make(chan struct{})
-		holder := make(chan error, 1)
-		go func() {
-			_, _, err := db.DoTransaction(t.Context(), "shared-key", func(tx storage.Transaction) error {
-				close(held)
-				<-release
-				_, err := tx.Submit(putOperation(newTransactionRecord("holder")))
-				return err
-			})
-			holder <- err
-		}()
-		<-held
-
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-		sendBegin(t, stream, "shared-key")
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("suppressed")))
-
-		responses := make(chan *databrokerpb.TransactionStreamResponse, 1)
-		go func() {
-			res, err := stream.Recv()
-			if err == nil {
-				responses <- res
-			}
-			close(responses)
-		}()
-
-		// while the key is held the stream is parked in singleflight, unacked
-		require.Never(t, func() bool {
-			select {
-			case <-responses:
-				return true
-			default:
-				return false
-			}
-		}, 500*time.Millisecond, 25*time.Millisecond)
-
-		close(release)
-		require.NoError(t, <-holder)
-
-		res, ok := <-responses
-		require.True(t, ok)
-		require.Nil(t, res.GetBegin(), "suppressed transaction should not be acked")
-		assert.True(t, res.GetCommit().GetShared())
-
-		assertRecordExists(t, srv, "holder")
-		assertRecordMissing(t, srv, "suppressed")
-
-		// suppression is concurrent-only: a later transaction on the same key runs
-		next, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-		require.NotNil(t, beginTransaction(t, next, "shared-key").GetBegin())
-		sendOperation(t, next, 1, getOperation("holder"))
-		res, err = next.Recv()
-		require.NoError(t, err)
-		assert.Equal(t, "holder", res.GetOperation().GetGet().GetRecord().GetId())
-
-		sendOperation(t, next, 2, putOperation(newTransactionRecord("next")))
-		_, err = next.Recv()
-		require.NoError(t, err)
-		sendCommit(t, next)
-
-		nextCommit, err := recvCommit(t, next)
-		require.NoError(t, err)
-		assert.False(t, nextCommit.GetShared())
-		assertRecordExists(t, srv, "next")
-	})
-
-	t.Run("sequence echoes", func(t *testing.T) {
-		srv := newServer(t)
-		client := newTransactionClient(t, srv)
-
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-
-		require.NotNil(t, beginTransaction(t, stream, "sequence").GetBegin())
-
-		sequences := []uint64{7, 3, 9}
-		for i, sequence := range sequences {
-			sendOperation(t, stream, sequence, putOperation(newTransactionRecord(string(rune('a'+i)))))
-		}
-		for _, sequence := range sequences {
-			res, err := stream.Recv()
-			require.NoError(t, err)
-			assert.Equal(t, sequence, res.GetSequence())
-		}
-
-		sendCommit(t, stream)
-		_, err = recvCommit(t, stream)
-		require.NoError(t, err)
-	})
-
-}
-
-// 	t.Run("secured", func(t *testing.T) {
-// 		underlying := newServer(t)
-// 		secured := NewSecuredServer(underlying)
-// 		sharedKey := cryptutil.NewKey()
-// 		secured.OnConfigChange(t.Context(), config.New(&config.Options{
-// 			SharedKey: base64.StdEncoding.EncodeToString(sharedKey),
-// 		}))
-// 		client := newTransactionClient(t, secured)
-
-// 		stream, err := client.Transaction(t.Context())
-// 		require.NoError(t, err)
-// 		sendBegin(t, stream, "secured")
-// 		_, err = recvCommit(t, stream)
-// 		assert.Equal(t, codes.Unauthenticated, status.Code(err))
-
-// 		ctx, err := grpcutil.WithSignedJWT(t.Context(), sharedKey)
-// 		require.NoError(t, err)
-// 		commit := putInTransaction(ctx, t, client, "secured", newTransactionRecord("secured-1"))
-// 		assert.False(t, commit.GetShared())
-// 		assertRecordExists(t, underlying, "secured-1")
-// 	})
-
-// 	t.Run("follower forwards to leader", func(t *testing.T) {
-// 		leader := newServer(t)
-// 		leaderCC := testutil.NewGRPCServer(t, func(s *grpc.Server) {
-// 			databrokerpb.RegisterDataBrokerServiceServer(s, leader)
-// 		})
-// 		local := newServer(t)
-// 		follower := NewClusteredFollowerServer(noop.NewTracerProvider(), local, leaderCC)
-// 		t.Cleanup(follower.Stop)
-// 		client := newTransactionClient(t, follower)
-
-// 		commit := putInTransaction(t.Context(), t, client, "follower", newTransactionRecord("follower-1"))
-// 		assert.False(t, commit.GetShared())
-// 		assertRecordExists(t, leader, "follower-1")
-// 		assertRecordMissing(t, local, "follower-1")
-
-// 		// a client that breaks mid-transaction rolls back on the leader
-// 		ctx, cancel := context.WithCancel(t.Context())
-// 		stream, err := client.Transaction(ctx)
-// 		require.NoError(t, err)
-// 		require.NotNil(t, beginTransaction(t, stream, "follower").GetBegin())
-// 		sendOperation(t, stream, 1, putOperation(newTransactionRecord("follower-2")))
-// 		_, err = stream.Recv()
-// 		require.NoError(t, err)
-// 		cancel()
-
-// 		_, err = recvCommit(t, stream)
-// 		assert.Error(t, err)
-// 		assertRecordMissing(t, leader, "follower-2")
-// 	})
-// }
-
-func setBackend(t *testing.T, srv Server, wrap func(storage.Backend) storage.Backend) {
-	t.Helper()
-
-	bs, ok := srv.(*backendServer)
-	require.True(t, ok)
-
-	backend, err := bs.getBackend(t.Context())
-	require.NoError(t, err)
-
-	bs.mu.Lock()
-	bs.backend = wrap(backend)
-	bs.mu.Unlock()
-}
-
-type txErrStorageBackend struct {
-	storage.Backend
-	failOnID string
-}
-
-func (b *txErrStorageBackend) DoTransaction(ctx context.Context, key string, fn func(tx storage.Transaction) error) (
-	changed []*databrokerpb.Record,
-	shared bool,
-	err error,
-) {
-	return b.Backend.DoTransaction(ctx, key, func(tx storage.Transaction) error {
-		failing := &txErrTransaction{Transaction: tx, failOnID: b.failOnID}
-		if err := fn(failing); err != nil {
-			return err
-		}
-		if failing.doomed {
-			return status.Error(codes.Internal, "error committing transaction")
-		}
-		return nil
-	})
-}
-
-type txErrTransaction struct {
-	storage.Transaction
-	failOnID string
-	doomed   bool
-}
-
-func (tx *txErrTransaction) Submit(req *databrokerpb.TransactionRequest) (*databrokerpb.TransactionResponse, error) {
-	for _, record := range req.GetPut().GetRecords() {
-		if record.GetId() == tx.failOnID {
-			tx.doomed = true
-		}
-	}
-	return tx.Transaction.Submit(req)
 }

--- a/internal/databroker/transactions_test.go
+++ b/internal/databroker/transactions_test.go
@@ -1,0 +1,455 @@
+package databroker
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	sessionpb "github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/grpcutil"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+	"github.com/pomerium/pomerium/pkg/storage"
+)
+
+type transactionStream = grpc.BidiStreamingClient[databrokerpb.TransactionStreamRequest, databrokerpb.TransactionStreamResponse]
+
+func newTransactionClient(t *testing.T, srv databrokerpb.DataBrokerServiceServer) databrokerpb.DataBrokerServiceClient {
+	t.Helper()
+
+	cc := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(s, srv)
+	})
+	return databrokerpb.NewDataBrokerServiceClient(cc)
+}
+
+func newTransactionRecord(id string) *databrokerpb.Record {
+	data := protoutil.NewAny(&sessionpb.Session{Id: id})
+	return &databrokerpb.Record{Type: data.TypeUrl, Id: id, Data: data}
+}
+
+func recordType() string {
+	return protoutil.NewAny(new(sessionpb.Session)).TypeUrl
+}
+
+func sendBegin(t *testing.T, stream transactionStream, key string) {
+	t.Helper()
+
+	require.NoError(t, stream.Send(&databrokerpb.TransactionStreamRequest{
+		Message: &databrokerpb.TransactionStreamRequest_Begin{
+			Begin: &databrokerpb.BeginTransaction{Key: key},
+		},
+	}))
+}
+
+// beginTransaction sends begin and reads the response saying whether this
+// transaction is running (begin arm) or was suppressed (commit arm).
+func beginTransaction(t *testing.T, stream transactionStream, key string) *databrokerpb.TransactionStreamResponse {
+	t.Helper()
+
+	sendBegin(t, stream, key)
+	res, err := stream.Recv()
+	require.NoError(t, err)
+	return res
+}
+
+func sendOperation(t *testing.T, stream transactionStream, sequence uint64, op *databrokerpb.TransactionRequest) {
+	t.Helper()
+
+	require.NoError(t, stream.Send(&databrokerpb.TransactionStreamRequest{
+		Sequence: sequence,
+		Message:  &databrokerpb.TransactionStreamRequest_Operation{Operation: op},
+	}))
+}
+
+func sendCommit(t *testing.T, stream transactionStream) {
+	t.Helper()
+
+	require.NoError(t, stream.Send(&databrokerpb.TransactionStreamRequest{
+		Message: &databrokerpb.TransactionStreamRequest_Commit{
+			Commit: new(databrokerpb.CommitTransaction),
+		},
+	}))
+}
+
+func putOperation(records ...*databrokerpb.Record) *databrokerpb.TransactionRequest {
+	return &databrokerpb.TransactionRequest{
+		Operation: &databrokerpb.TransactionRequest_Put{
+			Put: &databrokerpb.PutRequest{Records: records},
+		},
+	}
+}
+
+func getOperation(id string) *databrokerpb.TransactionRequest {
+	return &databrokerpb.TransactionRequest{
+		Operation: &databrokerpb.TransactionRequest_Get{
+			Get: &databrokerpb.GetRequest{Type: recordType(), Id: id},
+		},
+	}
+}
+
+// putInTransaction runs a whole begin/put/commit transaction and returns the commit response.
+func putInTransaction(
+	ctx context.Context,
+	t *testing.T,
+	client databrokerpb.DataBrokerServiceClient,
+	key string,
+	records ...*databrokerpb.Record,
+) *databrokerpb.CommitTransactionResponse {
+	t.Helper()
+
+	stream, err := client.Transaction(ctx)
+	require.NoError(t, err)
+
+	sendBegin(t, stream, key)
+	sendOperation(t, stream, 1, putOperation(records...))
+	sendCommit(t, stream)
+
+	commit, err := recvCommit(t, stream)
+	require.NoError(t, err)
+	return commit
+}
+
+// recvCommit reads responses until the commit arm arrives, ignoring operation responses.
+func recvCommit(t *testing.T, stream transactionStream) (*databrokerpb.CommitTransactionResponse, error) {
+	t.Helper()
+
+	for {
+		res, err := stream.Recv()
+		if err != nil {
+			return nil, err
+		}
+		if commit := res.GetCommit(); commit != nil {
+			return commit, nil
+		}
+	}
+}
+
+func assertRecordExists(t *testing.T, srv Server, id string) {
+	t.Helper()
+
+	res, err := srv.Get(t.Context(), &databrokerpb.GetRequest{Type: recordType(), Id: id})
+	assert.NoError(t, err)
+	assert.Equal(t, id, res.GetRecord().GetId())
+}
+
+func assertRecordMissing(t *testing.T, srv Server, id string) {
+	t.Helper()
+
+	_, err := srv.Get(t.Context(), &databrokerpb.GetRequest{Type: recordType(), Id: id})
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestDatabrokerTransactions(t *testing.T) {
+	t.Parallel()
+
+	t.Run("operations", func(t *testing.T) {
+		srv := newServer(t)
+		client := newTransactionClient(t, srv)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "operations").GetBegin())
+
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("op-1")))
+		res, err := stream.Recv()
+		require.NoError(t, err)
+		assert.Len(t, res.GetOperation().GetPut().GetRecords(), 1)
+
+		sendOperation(t, stream, 2, getOperation("op-1"))
+		res, err = stream.Recv()
+		require.NoError(t, err)
+		assert.Equal(t, "op-1", res.GetOperation().GetGet().GetRecord().GetId())
+
+		patched := newTransactionRecord("op-1")
+		patched.Data = protoutil.NewAny(&sessionpb.Session{Id: "op-1", UserId: "user-1"})
+		sendOperation(t, stream, 3, &databrokerpb.TransactionRequest{
+			Operation: &databrokerpb.TransactionRequest_Patch{
+				Patch: &databrokerpb.PatchRequest{
+					Records:   []*databrokerpb.Record{patched},
+					FieldMask: &fieldmaskpb.FieldMask{Paths: []string{"user_id"}},
+				},
+			},
+		})
+		res, err = stream.Recv()
+		require.NoError(t, err)
+		assert.Len(t, res.GetOperation().GetPatch().GetRecords(), 1)
+
+		sendOperation(t, stream, 4, &databrokerpb.TransactionRequest{
+			Operation: &databrokerpb.TransactionRequest_Query{
+				Query: &databrokerpb.QueryRequest{Type: recordType(), Limit: 10},
+			},
+		})
+		res, err = stream.Recv()
+		require.NoError(t, err)
+		assert.NotNil(t, res.GetOperation().GetQuery())
+
+		sendCommit(t, stream)
+		commit, err := recvCommit(t, stream)
+		require.NoError(t, err)
+		assert.False(t, commit.GetShared())
+
+		assertRecordExists(t, srv, "op-1")
+	})
+
+	t.Run("rollback on half-close", func(t *testing.T) {
+		srv := newServer(t)
+		client := newTransactionClient(t, srv)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "half-close").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("half-close-1")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+		require.NoError(t, stream.CloseSend())
+
+		_, err = recvCommit(t, stream)
+		assert.Error(t, err)
+		assert.NotErrorIs(t, err, io.EOF)
+
+		assertRecordMissing(t, srv, "half-close-1")
+	})
+
+	t.Run("rollback on cancel", func(t *testing.T) {
+		srv := newServer(t)
+		client := newTransactionClient(t, srv)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		stream, err := client.Transaction(ctx)
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "cancel").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("cancel-1")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+		cancel()
+
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.Canceled, status.Code(err))
+
+		assertRecordMissing(t, srv, "cancel-1")
+	})
+
+	t.Run("first message must be begin", func(t *testing.T) {
+		srv := newServer(t)
+		client := newTransactionClient(t, srv)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("no-begin-1")))
+
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+
+		assertRecordMissing(t, srv, "no-begin-1")
+	})
+
+	t.Run("second begin is rejected", func(t *testing.T) {
+		srv := newServer(t)
+		client := newTransactionClient(t, srv)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "double-begin").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("double-begin-1")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+		sendBegin(t, stream, "double-begin")
+
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.InvalidArgument, status.Code(err))
+
+		assertRecordMissing(t, srv, "double-begin-1")
+	})
+
+	t.Run("atomic", func(t *testing.T) {
+		srv := newServer(t)
+		client := newTransactionClient(t, srv)
+
+		// hold the key from the test side so the stream below is certainly suppressed
+		db, err := srv.(*backendServer).getBackend(t.Context())
+		require.NoError(t, err)
+		held, release := make(chan struct{}), make(chan struct{})
+		holder := make(chan error, 1)
+		go func() {
+			_, _, err := db.DoTransaction(t.Context(), "shared-key", func(tx storage.Transaction) error {
+				close(held)
+				<-release
+				_, err := tx.Submit(putOperation(newTransactionRecord("holder")))
+				return err
+			})
+			holder <- err
+		}()
+		<-held
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+		sendBegin(t, stream, "shared-key")
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("suppressed")))
+
+		responses := make(chan *databrokerpb.TransactionStreamResponse, 1)
+		go func() {
+			res, err := stream.Recv()
+			if err == nil {
+				responses <- res
+			}
+			close(responses)
+		}()
+
+		// while the key is held the stream is parked in singleflight, unacked
+		require.Never(t, func() bool {
+			select {
+			case <-responses:
+				return true
+			default:
+				return false
+			}
+		}, 500*time.Millisecond, 25*time.Millisecond)
+
+		close(release)
+		require.NoError(t, <-holder)
+
+		res, ok := <-responses
+		require.True(t, ok)
+		require.Nil(t, res.GetBegin(), "suppressed transaction should not be acked")
+		assert.True(t, res.GetCommit().GetShared())
+
+		assertRecordExists(t, srv, "holder")
+		assertRecordMissing(t, srv, "suppressed")
+
+		// suppression is concurrent-only: a later transaction on the same key runs
+		next, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, beginTransaction(t, next, "shared-key").GetBegin())
+		sendOperation(t, next, 1, getOperation("holder"))
+		res, err = next.Recv()
+		require.NoError(t, err)
+		assert.Equal(t, "holder", res.GetOperation().GetGet().GetRecord().GetId())
+
+		sendOperation(t, next, 2, putOperation(newTransactionRecord("next")))
+		_, err = next.Recv()
+		require.NoError(t, err)
+		sendCommit(t, next)
+
+		nextCommit, err := recvCommit(t, next)
+		require.NoError(t, err)
+		assert.False(t, nextCommit.GetShared())
+		assertRecordExists(t, srv, "next")
+	})
+
+	t.Run("max duration", func(t *testing.T) {
+		originalMaxDuration := transactionMaxDuration
+		transactionMaxDuration = 100 * time.Millisecond
+		t.Cleanup(func() { transactionMaxDuration = originalMaxDuration })
+
+		srv := newServer(t)
+		client := newTransactionClient(t, srv)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "max-duration").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("max-duration-1")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+		assertRecordMissing(t, srv, "max-duration-1")
+	})
+
+	t.Run("sequence echoes", func(t *testing.T) {
+		srv := newServer(t)
+		client := newTransactionClient(t, srv)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "sequence").GetBegin())
+
+		sequences := []uint64{7, 3, 9}
+		for i, sequence := range sequences {
+			sendOperation(t, stream, sequence, putOperation(newTransactionRecord(string(rune('a'+i)))))
+		}
+		for _, sequence := range sequences {
+			res, err := stream.Recv()
+			require.NoError(t, err)
+			assert.Equal(t, sequence, res.GetSequence())
+		}
+
+		sendCommit(t, stream)
+		_, err = recvCommit(t, stream)
+		require.NoError(t, err)
+	})
+
+	t.Run("secured", func(t *testing.T) {
+		underlying := newServer(t)
+		secured := NewSecuredServer(underlying)
+		sharedKey := cryptutil.NewKey()
+		secured.OnConfigChange(t.Context(), config.New(&config.Options{
+			SharedKey: base64.StdEncoding.EncodeToString(sharedKey),
+		}))
+		client := newTransactionClient(t, secured)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+		sendBegin(t, stream, "secured")
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+		ctx, err := grpcutil.WithSignedJWT(t.Context(), sharedKey)
+		require.NoError(t, err)
+		commit := putInTransaction(ctx, t, client, "secured", newTransactionRecord("secured-1"))
+		assert.False(t, commit.GetShared())
+		assertRecordExists(t, underlying, "secured-1")
+	})
+
+	t.Run("follower forwards to leader", func(t *testing.T) {
+		leader := newServer(t)
+		leaderCC := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+			databrokerpb.RegisterDataBrokerServiceServer(s, leader)
+		})
+		local := newServer(t)
+		follower := NewClusteredFollowerServer(noop.NewTracerProvider(), local, leaderCC)
+		t.Cleanup(follower.Stop)
+		client := newTransactionClient(t, follower)
+
+		commit := putInTransaction(t.Context(), t, client, "follower", newTransactionRecord("follower-1"))
+		assert.False(t, commit.GetShared())
+		assertRecordExists(t, leader, "follower-1")
+		assertRecordMissing(t, local, "follower-1")
+
+		// a client that breaks mid-transaction rolls back on the leader
+		ctx, cancel := context.WithCancel(t.Context())
+		stream, err := client.Transaction(ctx)
+		require.NoError(t, err)
+		require.NotNil(t, beginTransaction(t, stream, "follower").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("follower-2")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+		cancel()
+
+		_, err = recvCommit(t, stream)
+		assert.Error(t, err)
+		assertRecordMissing(t, leader, "follower-2")
+	})
+}

--- a/internal/databroker/transactions_test.go
+++ b/internal/databroker/transactions_test.go
@@ -2,25 +2,20 @@ package databroker
 
 import (
 	"context"
-	"encoding/base64"
 	"io"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/fieldmaskpb"
 
-	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/testutil"
-	"github.com/pomerium/pomerium/pkg/cryptutil"
 	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
 	sessionpb "github.com/pomerium/pomerium/pkg/grpc/session"
-	"github.com/pomerium/pomerium/pkg/grpcutil"
 	"github.com/pomerium/pomerium/pkg/protoutil"
 	"github.com/pomerium/pomerium/pkg/storage"
 )
@@ -156,7 +151,7 @@ func assertRecordMissing(t *testing.T, srv Server, id string) {
 func TestDatabrokerTransactions(t *testing.T) {
 	t.Parallel()
 
-	t.Run("operations", func(t *testing.T) {
+	t.Run("get put patch query", func(t *testing.T) {
 		srv := newServer(t)
 		client := newTransactionClient(t, srv)
 
@@ -206,15 +201,15 @@ func TestDatabrokerTransactions(t *testing.T) {
 		assertRecordExists(t, srv, "op-1")
 	})
 
-	t.Run("rollback on half-close", func(t *testing.T) {
+	t.Run("rollback on closed stream", func(t *testing.T) {
 		srv := newServer(t)
 		client := newTransactionClient(t, srv)
 
 		stream, err := client.Transaction(t.Context())
 		require.NoError(t, err)
 
-		require.NotNil(t, beginTransaction(t, stream, "half-close").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("half-close-1")))
+		require.NotNil(t, beginTransaction(t, stream, "stream-closed").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("stream-closed")))
 		_, err = stream.Recv()
 		require.NoError(t, err)
 		require.NoError(t, stream.CloseSend())
@@ -223,7 +218,57 @@ func TestDatabrokerTransactions(t *testing.T) {
 		assert.Error(t, err)
 		assert.NotErrorIs(t, err, io.EOF)
 
-		assertRecordMissing(t, srv, "half-close-1")
+		assertRecordMissing(t, srv, "stream-closed")
+	})
+
+	t.Run("rollback on max duration exceeded", func(t *testing.T) {
+		originalMaxDuration := transactionMaxDuration
+		transactionMaxDuration = 100 * time.Millisecond
+		t.Cleanup(func() { transactionMaxDuration = originalMaxDuration })
+
+		srv := newServer(t)
+		client := newTransactionClient(t, srv)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "deadline").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("deadline")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+		assertRecordMissing(t, srv, "deadline")
+	})
+
+	t.Run("rollback on backend internal error", func(t *testing.T) {
+		srv := newServer(t)
+		setBackend(t, srv, func(backend storage.Backend) storage.Backend {
+			return &txErrStorageBackend{Backend: backend, failOnID: "error"}
+		})
+		client := newTransactionClient(t, srv)
+
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+
+		require.NotNil(t, beginTransaction(t, stream, "commit-error").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("ok")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+
+		sendOperation(t, stream, 2, putOperation(newTransactionRecord("error")))
+		_, err = stream.Recv()
+		require.NoError(t, err)
+
+		sendCommit(t, stream)
+		_, err = recvCommit(t, stream)
+		assert.Equal(t, codes.Internal, status.Code(err))
+		assert.ErrorContains(t, err, "error committing transaction")
+
+		assertRecordMissing(t, srv, "ok")
+		assertRecordMissing(t, srv, "error")
 	})
 
 	t.Run("rollback on cancel", func(t *testing.T) {
@@ -355,28 +400,6 @@ func TestDatabrokerTransactions(t *testing.T) {
 		assertRecordExists(t, srv, "next")
 	})
 
-	t.Run("max duration", func(t *testing.T) {
-		originalMaxDuration := transactionMaxDuration
-		transactionMaxDuration = 100 * time.Millisecond
-		t.Cleanup(func() { transactionMaxDuration = originalMaxDuration })
-
-		srv := newServer(t)
-		client := newTransactionClient(t, srv)
-
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-
-		require.NotNil(t, beginTransaction(t, stream, "max-duration").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("max-duration-1")))
-		_, err = stream.Recv()
-		require.NoError(t, err)
-
-		_, err = recvCommit(t, stream)
-		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
-
-		assertRecordMissing(t, srv, "max-duration-1")
-	})
-
 	t.Run("sequence echoes", func(t *testing.T) {
 		srv := newServer(t)
 		client := newTransactionClient(t, srv)
@@ -401,55 +424,108 @@ func TestDatabrokerTransactions(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("secured", func(t *testing.T) {
-		underlying := newServer(t)
-		secured := NewSecuredServer(underlying)
-		sharedKey := cryptutil.NewKey()
-		secured.OnConfigChange(t.Context(), config.New(&config.Options{
-			SharedKey: base64.StdEncoding.EncodeToString(sharedKey),
-		}))
-		client := newTransactionClient(t, secured)
+}
 
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-		sendBegin(t, stream, "secured")
-		_, err = recvCommit(t, stream)
-		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+// 	t.Run("secured", func(t *testing.T) {
+// 		underlying := newServer(t)
+// 		secured := NewSecuredServer(underlying)
+// 		sharedKey := cryptutil.NewKey()
+// 		secured.OnConfigChange(t.Context(), config.New(&config.Options{
+// 			SharedKey: base64.StdEncoding.EncodeToString(sharedKey),
+// 		}))
+// 		client := newTransactionClient(t, secured)
 
-		ctx, err := grpcutil.WithSignedJWT(t.Context(), sharedKey)
-		require.NoError(t, err)
-		commit := putInTransaction(ctx, t, client, "secured", newTransactionRecord("secured-1"))
-		assert.False(t, commit.GetShared())
-		assertRecordExists(t, underlying, "secured-1")
+// 		stream, err := client.Transaction(t.Context())
+// 		require.NoError(t, err)
+// 		sendBegin(t, stream, "secured")
+// 		_, err = recvCommit(t, stream)
+// 		assert.Equal(t, codes.Unauthenticated, status.Code(err))
+
+// 		ctx, err := grpcutil.WithSignedJWT(t.Context(), sharedKey)
+// 		require.NoError(t, err)
+// 		commit := putInTransaction(ctx, t, client, "secured", newTransactionRecord("secured-1"))
+// 		assert.False(t, commit.GetShared())
+// 		assertRecordExists(t, underlying, "secured-1")
+// 	})
+
+// 	t.Run("follower forwards to leader", func(t *testing.T) {
+// 		leader := newServer(t)
+// 		leaderCC := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+// 			databrokerpb.RegisterDataBrokerServiceServer(s, leader)
+// 		})
+// 		local := newServer(t)
+// 		follower := NewClusteredFollowerServer(noop.NewTracerProvider(), local, leaderCC)
+// 		t.Cleanup(follower.Stop)
+// 		client := newTransactionClient(t, follower)
+
+// 		commit := putInTransaction(t.Context(), t, client, "follower", newTransactionRecord("follower-1"))
+// 		assert.False(t, commit.GetShared())
+// 		assertRecordExists(t, leader, "follower-1")
+// 		assertRecordMissing(t, local, "follower-1")
+
+// 		// a client that breaks mid-transaction rolls back on the leader
+// 		ctx, cancel := context.WithCancel(t.Context())
+// 		stream, err := client.Transaction(ctx)
+// 		require.NoError(t, err)
+// 		require.NotNil(t, beginTransaction(t, stream, "follower").GetBegin())
+// 		sendOperation(t, stream, 1, putOperation(newTransactionRecord("follower-2")))
+// 		_, err = stream.Recv()
+// 		require.NoError(t, err)
+// 		cancel()
+
+// 		_, err = recvCommit(t, stream)
+// 		assert.Error(t, err)
+// 		assertRecordMissing(t, leader, "follower-2")
+// 	})
+// }
+
+func setBackend(t *testing.T, srv Server, wrap func(storage.Backend) storage.Backend) {
+	t.Helper()
+
+	bs, ok := srv.(*backendServer)
+	require.True(t, ok)
+
+	backend, err := bs.getBackend(t.Context())
+	require.NoError(t, err)
+
+	bs.mu.Lock()
+	bs.backend = wrap(backend)
+	bs.mu.Unlock()
+}
+
+type txErrStorageBackend struct {
+	storage.Backend
+	failOnID string
+}
+
+func (b *txErrStorageBackend) DoTransaction(ctx context.Context, key string, fn func(tx storage.Transaction) error) (
+	changed []*databrokerpb.Record,
+	shared bool,
+	err error,
+) {
+	return b.Backend.DoTransaction(ctx, key, func(tx storage.Transaction) error {
+		failing := &txErrTransaction{Transaction: tx, failOnID: b.failOnID}
+		if err := fn(failing); err != nil {
+			return err
+		}
+		if failing.doomed {
+			return status.Error(codes.Internal, "error committing transaction")
+		}
+		return nil
 	})
+}
 
-	t.Run("follower forwards to leader", func(t *testing.T) {
-		leader := newServer(t)
-		leaderCC := testutil.NewGRPCServer(t, func(s *grpc.Server) {
-			databrokerpb.RegisterDataBrokerServiceServer(s, leader)
-		})
-		local := newServer(t)
-		follower := NewClusteredFollowerServer(noop.NewTracerProvider(), local, leaderCC)
-		t.Cleanup(follower.Stop)
-		client := newTransactionClient(t, follower)
+type txErrTransaction struct {
+	storage.Transaction
+	failOnID string
+	doomed   bool
+}
 
-		commit := putInTransaction(t.Context(), t, client, "follower", newTransactionRecord("follower-1"))
-		assert.False(t, commit.GetShared())
-		assertRecordExists(t, leader, "follower-1")
-		assertRecordMissing(t, local, "follower-1")
-
-		// a client that breaks mid-transaction rolls back on the leader
-		ctx, cancel := context.WithCancel(t.Context())
-		stream, err := client.Transaction(ctx)
-		require.NoError(t, err)
-		require.NotNil(t, beginTransaction(t, stream, "follower").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("follower-2")))
-		_, err = stream.Recv()
-		require.NoError(t, err)
-		cancel()
-
-		_, err = recvCommit(t, stream)
-		assert.Error(t, err)
-		assertRecordMissing(t, leader, "follower-2")
-	})
+func (tx *txErrTransaction) Submit(req *databrokerpb.TransactionRequest) (*databrokerpb.TransactionResponse, error) {
+	for _, record := range req.GetPut().GetRecords() {
+		if record.GetId() == tx.failOnID {
+			tx.doomed = true
+		}
+	}
+	return tx.Transaction.Submit(req)
 }

--- a/internal/databroker/transactions_test.go
+++ b/internal/databroker/transactions_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"io"
 	"testing"
-	"time"
+	"testing/synctest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -157,24 +157,23 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 	})
 
 	t.Run("rollback on max duration exceeded", func(t *testing.T) {
-		originalMaxDuration := transactionMaxDuration
-		transactionMaxDuration = 100 * time.Millisecond
-		t.Cleanup(func() { transactionMaxDuration = originalMaxDuration })
+		synctest.Test(t, func(t *testing.T) {
+			srv, client := newServers(t)
 
-		srv, client := newServers(t)
+			stream, err := client.Transaction(t.Context())
+			require.NoError(t, err)
 
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
+			require.NotNil(t, beginTransaction(t, stream, "deadline").GetBegin())
+			sendOperation(t, stream, 1, putOperation(newTransactionRecord("deadline")))
+			_, err = stream.Recv()
+			require.NoError(t, err)
+			// the deadline runs on synctest's fake clock, so it can only elapse
+			// while every goroutine is blocked waiting for the commit
+			_, err = recvCommit(t, stream)
+			assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
 
-		require.NotNil(t, beginTransaction(t, stream, "deadline").GetBegin())
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("deadline")))
-		_, err = stream.Recv()
-		require.NoError(t, err)
-
-		_, err = recvCommit(t, stream)
-		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
-
-		assertRecordMissing(t, srv, "deadline")
+			assertRecordMissing(t, srv, "deadline")
+		})
 	})
 
 	t.Run("rollback on backend internal error", func(t *testing.T) {
@@ -256,74 +255,74 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 	})
 
 	t.Run("atomic", func(t *testing.T) {
-		// TODO : this test is weird
-		srv, client := newServers(t)
+		synctest.Test(t, func(t *testing.T) {
+			srv, client := newServers(t)
 
-		// hold the key from the test side so the stream below is certainly suppressed
-		db, err := srv.(*backendServer).getBackend(t.Context())
-		require.NoError(t, err)
-		held, release := make(chan struct{}), make(chan struct{})
-		holder := make(chan error, 1)
-		go func() {
-			_, _, err := db.DoTransaction(t.Context(), "shared-key", func(tx storage.Transaction) error {
-				close(held)
-				<-release
-				_, err := tx.Submit(putOperation(newTransactionRecord("holder")))
-				return err
-			})
-			holder <- err
-		}()
-		<-held
+			// hold the key from the test side so the stream below certainly shares the result
+			db, err := srv.(*backendServer).getBackend(t.Context())
+			require.NoError(t, err)
+			held, release := make(chan struct{}), make(chan struct{})
+			holder := make(chan error, 1)
+			go func() {
+				_, _, err := db.DoTransaction(t.Context(), "shared-key", func(tx storage.Transaction) error {
+					close(held)
+					<-release
+					_, err := tx.Submit(putOperation(newTransactionRecord("holder")))
+					return err
+				})
+				holder <- err
+			}()
+			<-held
 
-		stream, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-		sendBegin(t, stream, "shared-key")
-		sendOperation(t, stream, 1, putOperation(newTransactionRecord("suppressed")))
+			stream, err := client.Transaction(t.Context())
+			require.NoError(t, err)
+			sendBegin(t, stream, "shared-key")
+			sendOperation(t, stream, 1, putOperation(newTransactionRecord("shared")))
 
-		responses := make(chan *databrokerpb.TransactionStreamResponse, 1)
-		go func() {
-			res, err := stream.Recv()
-			if err == nil {
-				responses <- res
-			}
-			close(responses)
-		}()
+			responses := make(chan *databrokerpb.TransactionStreamResponse, 1)
+			go func() {
+				res, err := stream.Recv()
+				if err == nil {
+					responses <- res
+				}
+				close(responses)
+			}()
 
-		// while the key is held the stream is parked in singleflight, unacked
-		require.Never(t, func() bool {
+			// the stream is parked in singleflight, so once everything else is
+			// blocked no response can be in flight
+			synctest.Wait()
 			select {
-			case <-responses:
-				return true
+			case res := <-responses:
+				require.FailNow(t, "the sharing stream responded while the key was held", "%v", res)
 			default:
-				return false
 			}
-		}, 500*time.Millisecond, 25*time.Millisecond)
 
-		close(release)
-		require.NoError(t, <-holder)
+			close(release)
+			require.NoError(t, <-holder)
 
-		res, ok := <-responses
-		require.True(t, ok)
-		require.Nil(t, res.GetBegin(), "suppressed transaction should not be acked")
-		assert.True(t, res.GetCommit().GetShared())
+			res, ok := <-responses
+			require.True(t, ok)
+			require.Nil(t, res.GetBegin(), "a shared transaction should not be acked")
+			assert.True(t, res.GetCommit().GetShared())
 
-		assertRecordExists(t, srv, "holder")
-		assertRecordMissing(t, srv, "suppressed")
+			assertRecordExists(t, srv, "holder")
+			assertRecordMissing(t, srv, "shared")
 
-		next, err := client.Transaction(t.Context())
-		require.NoError(t, err)
-		require.NotNil(t, beginTransaction(t, next, "shared-key").GetBegin())
-		sendOperation(t, next, 1, getOperation("holder"))
-		assert.Equal(t, "holder", recvOperation(t, next).GetGet().GetRecord().GetId())
+			next, err := client.Transaction(t.Context())
+			require.NoError(t, err)
+			require.NotNil(t, beginTransaction(t, next, "shared-key").GetBegin())
+			sendOperation(t, next, 1, getOperation("holder"))
+			assert.Equal(t, "holder", recvOperation(t, next).GetGet().GetRecord().GetId())
 
-		sendOperation(t, next, 2, putOperation(newTransactionRecord("next")))
-		recvOperation(t, next)
-		sendCommit(t, next)
+			sendOperation(t, next, 2, putOperation(newTransactionRecord("next")))
+			recvOperation(t, next)
+			sendCommit(t, next)
 
-		nextCommit, err := recvCommit(t, next)
-		require.NoError(t, err)
-		assert.False(t, nextCommit.GetShared())
-		assertRecordExists(t, srv, "next")
+			nextCommit, err := recvCommit(t, next)
+			require.NoError(t, err)
+			assert.False(t, nextCommit.GetShared())
+			assertRecordExists(t, srv, "next")
+		})
 	})
 
 	t.Run("sequence echoes", func(t *testing.T) {
@@ -349,6 +348,26 @@ func testTransactions(t *testing.T, newServers transactionServersFunc) {
 		require.NoError(t, err)
 	})
 
+	t.Run("backend closure", func(t *testing.T) {
+		server, client := newServers(t)
+		stream, err := client.Transaction(t.Context())
+		require.NoError(t, err)
+		require.NotNil(t, beginTransaction(t, stream, "reload").GetBegin())
+		sendOperation(t, stream, 1, putOperation(newTransactionRecord("record-1")))
+		require.NotNil(t, recvOperation(t, stream).GetPut())
+
+		// hack
+		bs := server.(*backendServer)
+		bs.mu.Lock()
+		bs.closeBackendLocked(t.Context())
+		bs.mu.Unlock()
+		// end hack
+
+		sendCommit(t, stream)
+		_, err = recvCommit(t, stream)
+		require.Error(t, err)
+		assertRecordMissing(t, server, "record-1")
+	})
 }
 
 func setBackend(t *testing.T, srv Server, wrap func(storage.Backend) storage.Backend) {
@@ -422,7 +441,7 @@ func sendBegin(t *testing.T, stream transactionStream, key string) {
 }
 
 // beginTransaction sends begin and reads the response saying whether this
-// transaction is running (begin arm) or was suppressed (commit arm).
+// transaction is running (begin arm) or shares another transaction's result (commit arm).
 func beginTransaction(t *testing.T, stream transactionStream, key string) *databrokerpb.TransactionStreamResponse {
 	t.Helper()
 

--- a/pkg/grpc/databroker/databroker.pb.go
+++ b/pkg/grpc/databroker/databroker.pb.go
@@ -2169,12 +2169,10 @@ func (*TransactionResponse_Query) isTransactionResponse_Operation() {}
 
 type CommitTransactionResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// shared is true when this transaction was suppressed by a concurrent one for the
-	// same key: nothing submitted after `begin` was applied.
+	// shared is true when these results come from a concurrent transaction for the
+	// same key. The transactions that were shared never ran operations themselves.
 	Shared bool `protobuf:"varint,1,opt,name=shared,proto3" json:"shared,omitempty"`
-	// records holds the records written by the committed transaction, in submission
-	// order. When shared is true these are the records written by the transaction
-	// which suppressed this one.
+	// records that were changed during this transaction.
 	Records       []*Record `protobuf:"bytes,2,rep,name=records,proto3" json:"records,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache

--- a/pkg/grpc/databroker/databroker.pb.go
+++ b/pkg/grpc/databroker/databroker.pb.go
@@ -1758,7 +1758,7 @@ func (x *TransactionStreamResponse) GetMessage() isTransactionStreamResponse_Mes
 	return nil
 }
 
-func (x *TransactionStreamResponse) GetOperation() *TransactionResponse {
+func (x *TransactionStreamResponse) GetOperation() *TransactionResponseWithError {
 	if x != nil {
 		if x, ok := x.Message.(*TransactionStreamResponse_Operation); ok {
 			return x.Operation
@@ -1790,7 +1790,7 @@ type isTransactionStreamResponse_Message interface {
 }
 
 type TransactionStreamResponse_Operation struct {
-	Operation *TransactionResponse `protobuf:"bytes,2,opt,name=operation,proto3,oneof"`
+	Operation *TransactionResponseWithError `protobuf:"bytes,2,opt,name=operation,proto3,oneof"`
 }
 
 type TransactionStreamResponse_Commit struct {
@@ -2045,6 +2045,111 @@ func (*TransactionRequest_Patch) isTransactionRequest_Operation() {}
 
 func (*TransactionRequest_Query) isTransactionRequest_Operation() {}
 
+type TransactionResponseWithError struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Response      *TransactionResponse   `protobuf:"bytes,1,opt,name=response,proto3" json:"response,omitempty"`
+	Err           *RPCStatus             `protobuf:"bytes,2,opt,name=err,proto3" json:"err,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransactionResponseWithError) Reset() {
+	*x = TransactionResponseWithError{}
+	mi := &file_databroker_proto_msgTypes[33]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransactionResponseWithError) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransactionResponseWithError) ProtoMessage() {}
+
+func (x *TransactionResponseWithError) ProtoReflect() protoreflect.Message {
+	mi := &file_databroker_proto_msgTypes[33]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransactionResponseWithError.ProtoReflect.Descriptor instead.
+func (*TransactionResponseWithError) Descriptor() ([]byte, []int) {
+	return file_databroker_proto_rawDescGZIP(), []int{33}
+}
+
+func (x *TransactionResponseWithError) GetResponse() *TransactionResponse {
+	if x != nil {
+		return x.Response
+	}
+	return nil
+}
+
+func (x *TransactionResponseWithError) GetErr() *RPCStatus {
+	if x != nil {
+		return x.Err
+	}
+	return nil
+}
+
+// mirrors "google/rpc/status.proto"'s relevant fields
+type RPCStatus struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Code          int32                  `protobuf:"varint,1,opt,name=code,proto3" json:"code,omitempty"`
+	Message       string                 `protobuf:"bytes,2,opt,name=message,proto3" json:"message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *RPCStatus) Reset() {
+	*x = RPCStatus{}
+	mi := &file_databroker_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *RPCStatus) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RPCStatus) ProtoMessage() {}
+
+func (x *RPCStatus) ProtoReflect() protoreflect.Message {
+	mi := &file_databroker_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RPCStatus.ProtoReflect.Descriptor instead.
+func (*RPCStatus) Descriptor() ([]byte, []int) {
+	return file_databroker_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *RPCStatus) GetCode() int32 {
+	if x != nil {
+		return x.Code
+	}
+	return 0
+}
+
+func (x *RPCStatus) GetMessage() string {
+	if x != nil {
+		return x.Message
+	}
+	return ""
+}
+
 type TransactionResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Key   string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
@@ -2061,7 +2166,7 @@ type TransactionResponse struct {
 
 func (x *TransactionResponse) Reset() {
 	*x = TransactionResponse{}
-	mi := &file_databroker_proto_msgTypes[33]
+	mi := &file_databroker_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2073,7 +2178,7 @@ func (x *TransactionResponse) String() string {
 func (*TransactionResponse) ProtoMessage() {}
 
 func (x *TransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[33]
+	mi := &file_databroker_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2086,7 +2191,7 @@ func (x *TransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionResponse.ProtoReflect.Descriptor instead.
 func (*TransactionResponse) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{33}
+	return file_databroker_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *TransactionResponse) GetKey() string {
@@ -2180,7 +2285,7 @@ type CommitTransactionResponse struct {
 
 func (x *CommitTransactionResponse) Reset() {
 	*x = CommitTransactionResponse{}
-	mi := &file_databroker_proto_msgTypes[34]
+	mi := &file_databroker_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2192,7 +2297,7 @@ func (x *CommitTransactionResponse) String() string {
 func (*CommitTransactionResponse) ProtoMessage() {}
 
 func (x *CommitTransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[34]
+	mi := &file_databroker_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2205,7 +2310,7 @@ func (x *CommitTransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use CommitTransactionResponse.ProtoReflect.Descriptor instead.
 func (*CommitTransactionResponse) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{34}
+	return file_databroker_proto_rawDescGZIP(), []int{36}
 }
 
 func (x *CommitTransactionResponse) GetShared() bool {
@@ -2232,7 +2337,7 @@ type Checkpoint struct {
 
 func (x *Checkpoint) Reset() {
 	*x = Checkpoint{}
-	mi := &file_databroker_proto_msgTypes[35]
+	mi := &file_databroker_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2244,7 +2349,7 @@ func (x *Checkpoint) String() string {
 func (*Checkpoint) ProtoMessage() {}
 
 func (x *Checkpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[35]
+	mi := &file_databroker_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2257,7 +2362,7 @@ func (x *Checkpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Checkpoint.ProtoReflect.Descriptor instead.
 func (*Checkpoint) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{35}
+	return file_databroker_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *Checkpoint) GetServerVersion() uint64 {
@@ -2282,7 +2387,7 @@ type GetCheckpointRequest struct {
 
 func (x *GetCheckpointRequest) Reset() {
 	*x = GetCheckpointRequest{}
-	mi := &file_databroker_proto_msgTypes[36]
+	mi := &file_databroker_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2294,7 +2399,7 @@ func (x *GetCheckpointRequest) String() string {
 func (*GetCheckpointRequest) ProtoMessage() {}
 
 func (x *GetCheckpointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[36]
+	mi := &file_databroker_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2307,7 +2412,7 @@ func (x *GetCheckpointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCheckpointRequest.ProtoReflect.Descriptor instead.
 func (*GetCheckpointRequest) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{36}
+	return file_databroker_proto_rawDescGZIP(), []int{38}
 }
 
 type GetCheckpointResponse struct {
@@ -2320,7 +2425,7 @@ type GetCheckpointResponse struct {
 
 func (x *GetCheckpointResponse) Reset() {
 	*x = GetCheckpointResponse{}
-	mi := &file_databroker_proto_msgTypes[37]
+	mi := &file_databroker_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2332,7 +2437,7 @@ func (x *GetCheckpointResponse) String() string {
 func (*GetCheckpointResponse) ProtoMessage() {}
 
 func (x *GetCheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[37]
+	mi := &file_databroker_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2345,7 +2450,7 @@ func (x *GetCheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCheckpointResponse.ProtoReflect.Descriptor instead.
 func (*GetCheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{37}
+	return file_databroker_proto_rawDescGZIP(), []int{39}
 }
 
 func (x *GetCheckpointResponse) GetCheckpoint() *Checkpoint {
@@ -2371,7 +2476,7 @@ type SetCheckpointRequest struct {
 
 func (x *SetCheckpointRequest) Reset() {
 	*x = SetCheckpointRequest{}
-	mi := &file_databroker_proto_msgTypes[38]
+	mi := &file_databroker_proto_msgTypes[40]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2383,7 +2488,7 @@ func (x *SetCheckpointRequest) String() string {
 func (*SetCheckpointRequest) ProtoMessage() {}
 
 func (x *SetCheckpointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[38]
+	mi := &file_databroker_proto_msgTypes[40]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2396,7 +2501,7 @@ func (x *SetCheckpointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCheckpointRequest.ProtoReflect.Descriptor instead.
 func (*SetCheckpointRequest) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{38}
+	return file_databroker_proto_rawDescGZIP(), []int{40}
 }
 
 func (x *SetCheckpointRequest) GetCheckpoint() *Checkpoint {
@@ -2414,7 +2519,7 @@ type SetCheckpointResponse struct {
 
 func (x *SetCheckpointResponse) Reset() {
 	*x = SetCheckpointResponse{}
-	mi := &file_databroker_proto_msgTypes[39]
+	mi := &file_databroker_proto_msgTypes[41]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2426,7 +2531,7 @@ func (x *SetCheckpointResponse) String() string {
 func (*SetCheckpointResponse) ProtoMessage() {}
 
 func (x *SetCheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[39]
+	mi := &file_databroker_proto_msgTypes[41]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2439,7 +2544,7 @@ func (x *SetCheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCheckpointResponse.ProtoReflect.Descriptor instead.
 func (*SetCheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{39}
+	return file_databroker_proto_rawDescGZIP(), []int{41}
 }
 
 var File_databroker_proto protoreflect.FileDescriptor
@@ -2556,10 +2661,10 @@ const file_databroker_proto_rawDesc = "" +
 	"\x05begin\x18\x02 \x01(\v2\x1c.databroker.BeginTransactionH\x00R\x05begin\x12>\n" +
 	"\toperation\x18\x03 \x01(\v2\x1e.databroker.TransactionRequestH\x00R\toperation\x127\n" +
 	"\x06commit\x18\x04 \x01(\v2\x1d.databroker.CommitTransactionH\x00R\x06commitB\t\n" +
-	"\amessage\"\x82\x02\n" +
+	"\amessage\"\x8b\x02\n" +
 	"\x19TransactionStreamResponse\x12\x1a\n" +
-	"\bsequence\x18\x01 \x01(\x04R\bsequence\x12?\n" +
-	"\toperation\x18\x02 \x01(\v2\x1f.databroker.TransactionResponseH\x00R\toperation\x12?\n" +
+	"\bsequence\x18\x01 \x01(\x04R\bsequence\x12H\n" +
+	"\toperation\x18\x02 \x01(\v2(.databroker.TransactionResponseWithErrorH\x00R\toperation\x12?\n" +
 	"\x06commit\x18\x03 \x01(\v2%.databroker.CommitTransactionResponseH\x00R\x06commit\x12<\n" +
 	"\x05begin\x18\x04 \x01(\v2$.databroker.BeginTransactionResponseH\x00R\x05beginB\t\n" +
 	"\amessage\"$\n" +
@@ -2573,7 +2678,13 @@ const file_databroker_proto_rawDesc = "" +
 	"\x03put\x18\x03 \x01(\v2\x16.databroker.PutRequestH\x00R\x03put\x120\n" +
 	"\x05patch\x18\x04 \x01(\v2\x18.databroker.PatchRequestH\x00R\x05patch\x120\n" +
 	"\x05query\x18\x05 \x01(\v2\x18.databroker.QueryRequestH\x00R\x05queryB\v\n" +
-	"\toperation\"\xf4\x01\n" +
+	"\toperation\"\x84\x01\n" +
+	"\x1cTransactionResponseWithError\x12;\n" +
+	"\bresponse\x18\x01 \x01(\v2\x1f.databroker.TransactionResponseR\bresponse\x12'\n" +
+	"\x03err\x18\x02 \x01(\v2\x15.databroker.RPCStatusR\x03err\"9\n" +
+	"\tRPCStatus\x12\x12\n" +
+	"\x04code\x18\x01 \x01(\x05R\x04code\x12\x18\n" +
+	"\amessage\x18\x02 \x01(\tR\amessage\"\xf4\x01\n" +
 	"\x13TransactionResponse\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12+\n" +
 	"\x03get\x18\x02 \x01(\v2\x17.databroker.GetResponseH\x00R\x03get\x12+\n" +
@@ -2636,68 +2747,70 @@ func file_databroker_proto_rawDescGZIP() []byte {
 	return file_databroker_proto_rawDescData
 }
 
-var file_databroker_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
+var file_databroker_proto_msgTypes = make([]protoimpl.MessageInfo, 42)
 var file_databroker_proto_goTypes = []any{
-	(*Record)(nil),                    // 0: databroker.Record
-	(*Versions)(nil),                  // 1: databroker.Versions
-	(*Options)(nil),                   // 2: databroker.Options
-	(*TypedOptions)(nil),              // 3: databroker.TypedOptions
-	(*ClearResponse)(nil),             // 4: databroker.ClearResponse
-	(*GetRequest)(nil),                // 5: databroker.GetRequest
-	(*GetResponse)(nil),               // 6: databroker.GetResponse
-	(*ListTypesResponse)(nil),         // 7: databroker.ListTypesResponse
-	(*QueryRequest)(nil),              // 8: databroker.QueryRequest
-	(*QueryResponse)(nil),             // 9: databroker.QueryResponse
-	(*PutRequest)(nil),                // 10: databroker.PutRequest
-	(*PutResponse)(nil),               // 11: databroker.PutResponse
-	(*PatchRequest)(nil),              // 12: databroker.PatchRequest
-	(*PatchResponse)(nil),             // 13: databroker.PatchResponse
-	(*ServerInfoResponse)(nil),        // 14: databroker.ServerInfoResponse
-	(*GetOptionsRequest)(nil),         // 15: databroker.GetOptionsRequest
-	(*GetOptionsResponse)(nil),        // 16: databroker.GetOptionsResponse
-	(*SetOptionsRequest)(nil),         // 17: databroker.SetOptionsRequest
-	(*SetOptionsResponse)(nil),        // 18: databroker.SetOptionsResponse
-	(*SyncRequest)(nil),               // 19: databroker.SyncRequest
-	(*SyncResponse)(nil),              // 20: databroker.SyncResponse
-	(*SyncLatestRequest)(nil),         // 21: databroker.SyncLatestRequest
-	(*SyncLatestResponse)(nil),        // 22: databroker.SyncLatestResponse
-	(*AcquireLeaseRequest)(nil),       // 23: databroker.AcquireLeaseRequest
-	(*AcquireLeaseResponse)(nil),      // 24: databroker.AcquireLeaseResponse
-	(*ReleaseLeaseRequest)(nil),       // 25: databroker.ReleaseLeaseRequest
-	(*RenewLeaseRequest)(nil),         // 26: databroker.RenewLeaseRequest
-	(*TransactionStreamRequest)(nil),  // 27: databroker.TransactionStreamRequest
-	(*TransactionStreamResponse)(nil), // 28: databroker.TransactionStreamResponse
-	(*BeginTransaction)(nil),          // 29: databroker.BeginTransaction
-	(*BeginTransactionResponse)(nil),  // 30: databroker.BeginTransactionResponse
-	(*CommitTransaction)(nil),         // 31: databroker.CommitTransaction
-	(*TransactionRequest)(nil),        // 32: databroker.TransactionRequest
-	(*TransactionResponse)(nil),       // 33: databroker.TransactionResponse
-	(*CommitTransactionResponse)(nil), // 34: databroker.CommitTransactionResponse
-	(*Checkpoint)(nil),                // 35: databroker.Checkpoint
-	(*GetCheckpointRequest)(nil),      // 36: databroker.GetCheckpointRequest
-	(*GetCheckpointResponse)(nil),     // 37: databroker.GetCheckpointResponse
-	(*SetCheckpointRequest)(nil),      // 38: databroker.SetCheckpointRequest
-	(*SetCheckpointResponse)(nil),     // 39: databroker.SetCheckpointResponse
-	(*anypb.Any)(nil),                 // 40: google.protobuf.Any
-	(*timestamppb.Timestamp)(nil),     // 41: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),       // 42: google.protobuf.Duration
-	(*structpb.Struct)(nil),           // 43: google.protobuf.Struct
-	(*fieldmaskpb.FieldMask)(nil),     // 44: google.protobuf.FieldMask
-	(*emptypb.Empty)(nil),             // 45: google.protobuf.Empty
+	(*Record)(nil),                       // 0: databroker.Record
+	(*Versions)(nil),                     // 1: databroker.Versions
+	(*Options)(nil),                      // 2: databroker.Options
+	(*TypedOptions)(nil),                 // 3: databroker.TypedOptions
+	(*ClearResponse)(nil),                // 4: databroker.ClearResponse
+	(*GetRequest)(nil),                   // 5: databroker.GetRequest
+	(*GetResponse)(nil),                  // 6: databroker.GetResponse
+	(*ListTypesResponse)(nil),            // 7: databroker.ListTypesResponse
+	(*QueryRequest)(nil),                 // 8: databroker.QueryRequest
+	(*QueryResponse)(nil),                // 9: databroker.QueryResponse
+	(*PutRequest)(nil),                   // 10: databroker.PutRequest
+	(*PutResponse)(nil),                  // 11: databroker.PutResponse
+	(*PatchRequest)(nil),                 // 12: databroker.PatchRequest
+	(*PatchResponse)(nil),                // 13: databroker.PatchResponse
+	(*ServerInfoResponse)(nil),           // 14: databroker.ServerInfoResponse
+	(*GetOptionsRequest)(nil),            // 15: databroker.GetOptionsRequest
+	(*GetOptionsResponse)(nil),           // 16: databroker.GetOptionsResponse
+	(*SetOptionsRequest)(nil),            // 17: databroker.SetOptionsRequest
+	(*SetOptionsResponse)(nil),           // 18: databroker.SetOptionsResponse
+	(*SyncRequest)(nil),                  // 19: databroker.SyncRequest
+	(*SyncResponse)(nil),                 // 20: databroker.SyncResponse
+	(*SyncLatestRequest)(nil),            // 21: databroker.SyncLatestRequest
+	(*SyncLatestResponse)(nil),           // 22: databroker.SyncLatestResponse
+	(*AcquireLeaseRequest)(nil),          // 23: databroker.AcquireLeaseRequest
+	(*AcquireLeaseResponse)(nil),         // 24: databroker.AcquireLeaseResponse
+	(*ReleaseLeaseRequest)(nil),          // 25: databroker.ReleaseLeaseRequest
+	(*RenewLeaseRequest)(nil),            // 26: databroker.RenewLeaseRequest
+	(*TransactionStreamRequest)(nil),     // 27: databroker.TransactionStreamRequest
+	(*TransactionStreamResponse)(nil),    // 28: databroker.TransactionStreamResponse
+	(*BeginTransaction)(nil),             // 29: databroker.BeginTransaction
+	(*BeginTransactionResponse)(nil),     // 30: databroker.BeginTransactionResponse
+	(*CommitTransaction)(nil),            // 31: databroker.CommitTransaction
+	(*TransactionRequest)(nil),           // 32: databroker.TransactionRequest
+	(*TransactionResponseWithError)(nil), // 33: databroker.TransactionResponseWithError
+	(*RPCStatus)(nil),                    // 34: databroker.RPCStatus
+	(*TransactionResponse)(nil),          // 35: databroker.TransactionResponse
+	(*CommitTransactionResponse)(nil),    // 36: databroker.CommitTransactionResponse
+	(*Checkpoint)(nil),                   // 37: databroker.Checkpoint
+	(*GetCheckpointRequest)(nil),         // 38: databroker.GetCheckpointRequest
+	(*GetCheckpointResponse)(nil),        // 39: databroker.GetCheckpointResponse
+	(*SetCheckpointRequest)(nil),         // 40: databroker.SetCheckpointRequest
+	(*SetCheckpointResponse)(nil),        // 41: databroker.SetCheckpointResponse
+	(*anypb.Any)(nil),                    // 42: google.protobuf.Any
+	(*timestamppb.Timestamp)(nil),        // 43: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),          // 44: google.protobuf.Duration
+	(*structpb.Struct)(nil),              // 45: google.protobuf.Struct
+	(*fieldmaskpb.FieldMask)(nil),        // 46: google.protobuf.FieldMask
+	(*emptypb.Empty)(nil),                // 47: google.protobuf.Empty
 }
 var file_databroker_proto_depIdxs = []int32{
-	40, // 0: databroker.Record.data:type_name -> google.protobuf.Any
-	41, // 1: databroker.Record.modified_at:type_name -> google.protobuf.Timestamp
-	41, // 2: databroker.Record.deleted_at:type_name -> google.protobuf.Timestamp
-	42, // 3: databroker.Options.ttl:type_name -> google.protobuf.Duration
+	42, // 0: databroker.Record.data:type_name -> google.protobuf.Any
+	43, // 1: databroker.Record.modified_at:type_name -> google.protobuf.Timestamp
+	43, // 2: databroker.Record.deleted_at:type_name -> google.protobuf.Timestamp
+	44, // 3: databroker.Options.ttl:type_name -> google.protobuf.Duration
 	2,  // 4: databroker.TypedOptions.options:type_name -> databroker.Options
 	0,  // 5: databroker.GetResponse.record:type_name -> databroker.Record
-	43, // 6: databroker.QueryRequest.filter:type_name -> google.protobuf.Struct
+	45, // 6: databroker.QueryRequest.filter:type_name -> google.protobuf.Struct
 	0,  // 7: databroker.QueryResponse.records:type_name -> databroker.Record
 	0,  // 8: databroker.PutRequest.records:type_name -> databroker.Record
 	0,  // 9: databroker.PutResponse.records:type_name -> databroker.Record
 	0,  // 10: databroker.PatchRequest.records:type_name -> databroker.Record
-	44, // 11: databroker.PatchRequest.field_mask:type_name -> google.protobuf.FieldMask
+	46, // 11: databroker.PatchRequest.field_mask:type_name -> google.protobuf.FieldMask
 	0,  // 12: databroker.PatchResponse.records:type_name -> databroker.Record
 	2,  // 13: databroker.GetOptionsResponse.options:type_name -> databroker.Options
 	2,  // 14: databroker.SetOptionsRequest.options:type_name -> databroker.Options
@@ -2707,64 +2820,66 @@ var file_databroker_proto_depIdxs = []int32{
 	0,  // 18: databroker.SyncLatestResponse.record:type_name -> databroker.Record
 	1,  // 19: databroker.SyncLatestResponse.versions:type_name -> databroker.Versions
 	3,  // 20: databroker.SyncLatestResponse.options:type_name -> databroker.TypedOptions
-	42, // 21: databroker.AcquireLeaseRequest.duration:type_name -> google.protobuf.Duration
-	42, // 22: databroker.RenewLeaseRequest.duration:type_name -> google.protobuf.Duration
+	44, // 21: databroker.AcquireLeaseRequest.duration:type_name -> google.protobuf.Duration
+	44, // 22: databroker.RenewLeaseRequest.duration:type_name -> google.protobuf.Duration
 	29, // 23: databroker.TransactionStreamRequest.begin:type_name -> databroker.BeginTransaction
 	32, // 24: databroker.TransactionStreamRequest.operation:type_name -> databroker.TransactionRequest
 	31, // 25: databroker.TransactionStreamRequest.commit:type_name -> databroker.CommitTransaction
-	33, // 26: databroker.TransactionStreamResponse.operation:type_name -> databroker.TransactionResponse
-	34, // 27: databroker.TransactionStreamResponse.commit:type_name -> databroker.CommitTransactionResponse
+	33, // 26: databroker.TransactionStreamResponse.operation:type_name -> databroker.TransactionResponseWithError
+	36, // 27: databroker.TransactionStreamResponse.commit:type_name -> databroker.CommitTransactionResponse
 	30, // 28: databroker.TransactionStreamResponse.begin:type_name -> databroker.BeginTransactionResponse
 	5,  // 29: databroker.TransactionRequest.get:type_name -> databroker.GetRequest
 	10, // 30: databroker.TransactionRequest.put:type_name -> databroker.PutRequest
 	12, // 31: databroker.TransactionRequest.patch:type_name -> databroker.PatchRequest
 	8,  // 32: databroker.TransactionRequest.query:type_name -> databroker.QueryRequest
-	6,  // 33: databroker.TransactionResponse.get:type_name -> databroker.GetResponse
-	11, // 34: databroker.TransactionResponse.put:type_name -> databroker.PutResponse
-	13, // 35: databroker.TransactionResponse.patch:type_name -> databroker.PatchResponse
-	9,  // 36: databroker.TransactionResponse.query:type_name -> databroker.QueryResponse
-	0,  // 37: databroker.CommitTransactionResponse.records:type_name -> databroker.Record
-	35, // 38: databroker.GetCheckpointResponse.checkpoint:type_name -> databroker.Checkpoint
-	35, // 39: databroker.SetCheckpointRequest.checkpoint:type_name -> databroker.Checkpoint
-	23, // 40: databroker.DataBrokerService.AcquireLease:input_type -> databroker.AcquireLeaseRequest
-	45, // 41: databroker.DataBrokerService.Clear:input_type -> google.protobuf.Empty
-	5,  // 42: databroker.DataBrokerService.Get:input_type -> databroker.GetRequest
-	15, // 43: databroker.DataBrokerService.GetOptions:input_type -> databroker.GetOptionsRequest
-	45, // 44: databroker.DataBrokerService.ListTypes:input_type -> google.protobuf.Empty
-	10, // 45: databroker.DataBrokerService.Put:input_type -> databroker.PutRequest
-	12, // 46: databroker.DataBrokerService.Patch:input_type -> databroker.PatchRequest
-	8,  // 47: databroker.DataBrokerService.Query:input_type -> databroker.QueryRequest
-	25, // 48: databroker.DataBrokerService.ReleaseLease:input_type -> databroker.ReleaseLeaseRequest
-	26, // 49: databroker.DataBrokerService.RenewLease:input_type -> databroker.RenewLeaseRequest
-	45, // 50: databroker.DataBrokerService.ServerInfo:input_type -> google.protobuf.Empty
-	17, // 51: databroker.DataBrokerService.SetOptions:input_type -> databroker.SetOptionsRequest
-	19, // 52: databroker.DataBrokerService.Sync:input_type -> databroker.SyncRequest
-	21, // 53: databroker.DataBrokerService.SyncLatest:input_type -> databroker.SyncLatestRequest
-	27, // 54: databroker.DataBrokerService.Transaction:input_type -> databroker.TransactionStreamRequest
-	36, // 55: databroker.CheckpointService.GetCheckpoint:input_type -> databroker.GetCheckpointRequest
-	38, // 56: databroker.CheckpointService.SetCheckpoint:input_type -> databroker.SetCheckpointRequest
-	24, // 57: databroker.DataBrokerService.AcquireLease:output_type -> databroker.AcquireLeaseResponse
-	4,  // 58: databroker.DataBrokerService.Clear:output_type -> databroker.ClearResponse
-	6,  // 59: databroker.DataBrokerService.Get:output_type -> databroker.GetResponse
-	16, // 60: databroker.DataBrokerService.GetOptions:output_type -> databroker.GetOptionsResponse
-	7,  // 61: databroker.DataBrokerService.ListTypes:output_type -> databroker.ListTypesResponse
-	11, // 62: databroker.DataBrokerService.Put:output_type -> databroker.PutResponse
-	13, // 63: databroker.DataBrokerService.Patch:output_type -> databroker.PatchResponse
-	9,  // 64: databroker.DataBrokerService.Query:output_type -> databroker.QueryResponse
-	45, // 65: databroker.DataBrokerService.ReleaseLease:output_type -> google.protobuf.Empty
-	45, // 66: databroker.DataBrokerService.RenewLease:output_type -> google.protobuf.Empty
-	14, // 67: databroker.DataBrokerService.ServerInfo:output_type -> databroker.ServerInfoResponse
-	18, // 68: databroker.DataBrokerService.SetOptions:output_type -> databroker.SetOptionsResponse
-	20, // 69: databroker.DataBrokerService.Sync:output_type -> databroker.SyncResponse
-	22, // 70: databroker.DataBrokerService.SyncLatest:output_type -> databroker.SyncLatestResponse
-	28, // 71: databroker.DataBrokerService.Transaction:output_type -> databroker.TransactionStreamResponse
-	37, // 72: databroker.CheckpointService.GetCheckpoint:output_type -> databroker.GetCheckpointResponse
-	39, // 73: databroker.CheckpointService.SetCheckpoint:output_type -> databroker.SetCheckpointResponse
-	57, // [57:74] is the sub-list for method output_type
-	40, // [40:57] is the sub-list for method input_type
-	40, // [40:40] is the sub-list for extension type_name
-	40, // [40:40] is the sub-list for extension extendee
-	0,  // [0:40] is the sub-list for field type_name
+	35, // 33: databroker.TransactionResponseWithError.response:type_name -> databroker.TransactionResponse
+	34, // 34: databroker.TransactionResponseWithError.err:type_name -> databroker.RPCStatus
+	6,  // 35: databroker.TransactionResponse.get:type_name -> databroker.GetResponse
+	11, // 36: databroker.TransactionResponse.put:type_name -> databroker.PutResponse
+	13, // 37: databroker.TransactionResponse.patch:type_name -> databroker.PatchResponse
+	9,  // 38: databroker.TransactionResponse.query:type_name -> databroker.QueryResponse
+	0,  // 39: databroker.CommitTransactionResponse.records:type_name -> databroker.Record
+	37, // 40: databroker.GetCheckpointResponse.checkpoint:type_name -> databroker.Checkpoint
+	37, // 41: databroker.SetCheckpointRequest.checkpoint:type_name -> databroker.Checkpoint
+	23, // 42: databroker.DataBrokerService.AcquireLease:input_type -> databroker.AcquireLeaseRequest
+	47, // 43: databroker.DataBrokerService.Clear:input_type -> google.protobuf.Empty
+	5,  // 44: databroker.DataBrokerService.Get:input_type -> databroker.GetRequest
+	15, // 45: databroker.DataBrokerService.GetOptions:input_type -> databroker.GetOptionsRequest
+	47, // 46: databroker.DataBrokerService.ListTypes:input_type -> google.protobuf.Empty
+	10, // 47: databroker.DataBrokerService.Put:input_type -> databroker.PutRequest
+	12, // 48: databroker.DataBrokerService.Patch:input_type -> databroker.PatchRequest
+	8,  // 49: databroker.DataBrokerService.Query:input_type -> databroker.QueryRequest
+	25, // 50: databroker.DataBrokerService.ReleaseLease:input_type -> databroker.ReleaseLeaseRequest
+	26, // 51: databroker.DataBrokerService.RenewLease:input_type -> databroker.RenewLeaseRequest
+	47, // 52: databroker.DataBrokerService.ServerInfo:input_type -> google.protobuf.Empty
+	17, // 53: databroker.DataBrokerService.SetOptions:input_type -> databroker.SetOptionsRequest
+	19, // 54: databroker.DataBrokerService.Sync:input_type -> databroker.SyncRequest
+	21, // 55: databroker.DataBrokerService.SyncLatest:input_type -> databroker.SyncLatestRequest
+	27, // 56: databroker.DataBrokerService.Transaction:input_type -> databroker.TransactionStreamRequest
+	38, // 57: databroker.CheckpointService.GetCheckpoint:input_type -> databroker.GetCheckpointRequest
+	40, // 58: databroker.CheckpointService.SetCheckpoint:input_type -> databroker.SetCheckpointRequest
+	24, // 59: databroker.DataBrokerService.AcquireLease:output_type -> databroker.AcquireLeaseResponse
+	4,  // 60: databroker.DataBrokerService.Clear:output_type -> databroker.ClearResponse
+	6,  // 61: databroker.DataBrokerService.Get:output_type -> databroker.GetResponse
+	16, // 62: databroker.DataBrokerService.GetOptions:output_type -> databroker.GetOptionsResponse
+	7,  // 63: databroker.DataBrokerService.ListTypes:output_type -> databroker.ListTypesResponse
+	11, // 64: databroker.DataBrokerService.Put:output_type -> databroker.PutResponse
+	13, // 65: databroker.DataBrokerService.Patch:output_type -> databroker.PatchResponse
+	9,  // 66: databroker.DataBrokerService.Query:output_type -> databroker.QueryResponse
+	47, // 67: databroker.DataBrokerService.ReleaseLease:output_type -> google.protobuf.Empty
+	47, // 68: databroker.DataBrokerService.RenewLease:output_type -> google.protobuf.Empty
+	14, // 69: databroker.DataBrokerService.ServerInfo:output_type -> databroker.ServerInfoResponse
+	18, // 70: databroker.DataBrokerService.SetOptions:output_type -> databroker.SetOptionsResponse
+	20, // 71: databroker.DataBrokerService.Sync:output_type -> databroker.SyncResponse
+	22, // 72: databroker.DataBrokerService.SyncLatest:output_type -> databroker.SyncLatestResponse
+	28, // 73: databroker.DataBrokerService.Transaction:output_type -> databroker.TransactionStreamResponse
+	39, // 74: databroker.CheckpointService.GetCheckpoint:output_type -> databroker.GetCheckpointResponse
+	41, // 75: databroker.CheckpointService.SetCheckpoint:output_type -> databroker.SetCheckpointResponse
+	59, // [59:76] is the sub-list for method output_type
+	42, // [42:59] is the sub-list for method input_type
+	42, // [42:42] is the sub-list for extension type_name
+	42, // [42:42] is the sub-list for extension extendee
+	0,  // [0:42] is the sub-list for field type_name
 }
 
 func init() { file_databroker_proto_init() }
@@ -2800,7 +2915,7 @@ func file_databroker_proto_init() {
 		(*TransactionRequest_Patch)(nil),
 		(*TransactionRequest_Query)(nil),
 	}
-	file_databroker_proto_msgTypes[33].OneofWrappers = []any{
+	file_databroker_proto_msgTypes[35].OneofWrappers = []any{
 		(*TransactionResponse_Get)(nil),
 		(*TransactionResponse_Put)(nil),
 		(*TransactionResponse_Patch)(nil),
@@ -2812,7 +2927,7 @@ func file_databroker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_databroker_proto_rawDesc), len(file_databroker_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   40,
+			NumMessages:   42,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/grpc/databroker/databroker.pb.go
+++ b/pkg/grpc/databroker/databroker.pb.go
@@ -1594,6 +1594,335 @@ func (x *RenewLeaseRequest) GetDuration() *durationpb.Duration {
 	return nil
 }
 
+type TransactionStreamRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// sequence is echoed on the matching response.
+	Sequence uint64 `protobuf:"varint,1,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	// Types that are valid to be assigned to Message:
+	//
+	//	*TransactionStreamRequest_Begin
+	//	*TransactionStreamRequest_Operation
+	//	*TransactionStreamRequest_Commit
+	Message       isTransactionStreamRequest_Message `protobuf_oneof:"message"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransactionStreamRequest) Reset() {
+	*x = TransactionStreamRequest{}
+	mi := &file_databroker_proto_msgTypes[27]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransactionStreamRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransactionStreamRequest) ProtoMessage() {}
+
+func (x *TransactionStreamRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_databroker_proto_msgTypes[27]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransactionStreamRequest.ProtoReflect.Descriptor instead.
+func (*TransactionStreamRequest) Descriptor() ([]byte, []int) {
+	return file_databroker_proto_rawDescGZIP(), []int{27}
+}
+
+func (x *TransactionStreamRequest) GetSequence() uint64 {
+	if x != nil {
+		return x.Sequence
+	}
+	return 0
+}
+
+func (x *TransactionStreamRequest) GetMessage() isTransactionStreamRequest_Message {
+	if x != nil {
+		return x.Message
+	}
+	return nil
+}
+
+func (x *TransactionStreamRequest) GetBegin() *BeginTransaction {
+	if x != nil {
+		if x, ok := x.Message.(*TransactionStreamRequest_Begin); ok {
+			return x.Begin
+		}
+	}
+	return nil
+}
+
+func (x *TransactionStreamRequest) GetOperation() *TransactionRequest {
+	if x != nil {
+		if x, ok := x.Message.(*TransactionStreamRequest_Operation); ok {
+			return x.Operation
+		}
+	}
+	return nil
+}
+
+func (x *TransactionStreamRequest) GetCommit() *CommitTransaction {
+	if x != nil {
+		if x, ok := x.Message.(*TransactionStreamRequest_Commit); ok {
+			return x.Commit
+		}
+	}
+	return nil
+}
+
+type isTransactionStreamRequest_Message interface {
+	isTransactionStreamRequest_Message()
+}
+
+type TransactionStreamRequest_Begin struct {
+	Begin *BeginTransaction `protobuf:"bytes,2,opt,name=begin,proto3,oneof"`
+}
+
+type TransactionStreamRequest_Operation struct {
+	Operation *TransactionRequest `protobuf:"bytes,3,opt,name=operation,proto3,oneof"`
+}
+
+type TransactionStreamRequest_Commit struct {
+	Commit *CommitTransaction `protobuf:"bytes,4,opt,name=commit,proto3,oneof"`
+}
+
+func (*TransactionStreamRequest_Begin) isTransactionStreamRequest_Message() {}
+
+func (*TransactionStreamRequest_Operation) isTransactionStreamRequest_Message() {}
+
+func (*TransactionStreamRequest_Commit) isTransactionStreamRequest_Message() {}
+
+type TransactionStreamResponse struct {
+	state    protoimpl.MessageState `protogen:"open.v1"`
+	Sequence uint64                 `protobuf:"varint,1,opt,name=sequence,proto3" json:"sequence,omitempty"`
+	// Types that are valid to be assigned to Message:
+	//
+	//	*TransactionStreamResponse_Operation
+	//	*TransactionStreamResponse_Commit
+	//	*TransactionStreamResponse_Begin
+	Message       isTransactionStreamResponse_Message `protobuf_oneof:"message"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *TransactionStreamResponse) Reset() {
+	*x = TransactionStreamResponse{}
+	mi := &file_databroker_proto_msgTypes[28]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *TransactionStreamResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*TransactionStreamResponse) ProtoMessage() {}
+
+func (x *TransactionStreamResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_databroker_proto_msgTypes[28]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use TransactionStreamResponse.ProtoReflect.Descriptor instead.
+func (*TransactionStreamResponse) Descriptor() ([]byte, []int) {
+	return file_databroker_proto_rawDescGZIP(), []int{28}
+}
+
+func (x *TransactionStreamResponse) GetSequence() uint64 {
+	if x != nil {
+		return x.Sequence
+	}
+	return 0
+}
+
+func (x *TransactionStreamResponse) GetMessage() isTransactionStreamResponse_Message {
+	if x != nil {
+		return x.Message
+	}
+	return nil
+}
+
+func (x *TransactionStreamResponse) GetOperation() *TransactionResponse {
+	if x != nil {
+		if x, ok := x.Message.(*TransactionStreamResponse_Operation); ok {
+			return x.Operation
+		}
+	}
+	return nil
+}
+
+func (x *TransactionStreamResponse) GetCommit() *CommitTransactionResponse {
+	if x != nil {
+		if x, ok := x.Message.(*TransactionStreamResponse_Commit); ok {
+			return x.Commit
+		}
+	}
+	return nil
+}
+
+func (x *TransactionStreamResponse) GetBegin() *BeginTransactionResponse {
+	if x != nil {
+		if x, ok := x.Message.(*TransactionStreamResponse_Begin); ok {
+			return x.Begin
+		}
+	}
+	return nil
+}
+
+type isTransactionStreamResponse_Message interface {
+	isTransactionStreamResponse_Message()
+}
+
+type TransactionStreamResponse_Operation struct {
+	Operation *TransactionResponse `protobuf:"bytes,2,opt,name=operation,proto3,oneof"`
+}
+
+type TransactionStreamResponse_Commit struct {
+	Commit *CommitTransactionResponse `protobuf:"bytes,3,opt,name=commit,proto3,oneof"`
+}
+
+type TransactionStreamResponse_Begin struct {
+	Begin *BeginTransactionResponse `protobuf:"bytes,4,opt,name=begin,proto3,oneof"`
+}
+
+func (*TransactionStreamResponse_Operation) isTransactionStreamResponse_Message() {}
+
+func (*TransactionStreamResponse_Commit) isTransactionStreamResponse_Message() {}
+
+func (*TransactionStreamResponse_Begin) isTransactionStreamResponse_Message() {}
+
+type BeginTransaction struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BeginTransaction) Reset() {
+	*x = BeginTransaction{}
+	mi := &file_databroker_proto_msgTypes[29]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BeginTransaction) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BeginTransaction) ProtoMessage() {}
+
+func (x *BeginTransaction) ProtoReflect() protoreflect.Message {
+	mi := &file_databroker_proto_msgTypes[29]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BeginTransaction.ProtoReflect.Descriptor instead.
+func (*BeginTransaction) Descriptor() ([]byte, []int) {
+	return file_databroker_proto_rawDescGZIP(), []int{29}
+}
+
+func (x *BeginTransaction) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
+type BeginTransactionResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BeginTransactionResponse) Reset() {
+	*x = BeginTransactionResponse{}
+	mi := &file_databroker_proto_msgTypes[30]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BeginTransactionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BeginTransactionResponse) ProtoMessage() {}
+
+func (x *BeginTransactionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_databroker_proto_msgTypes[30]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BeginTransactionResponse.ProtoReflect.Descriptor instead.
+func (*BeginTransactionResponse) Descriptor() ([]byte, []int) {
+	return file_databroker_proto_rawDescGZIP(), []int{30}
+}
+
+type CommitTransaction struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CommitTransaction) Reset() {
+	*x = CommitTransaction{}
+	mi := &file_databroker_proto_msgTypes[31]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CommitTransaction) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CommitTransaction) ProtoMessage() {}
+
+func (x *CommitTransaction) ProtoReflect() protoreflect.Message {
+	mi := &file_databroker_proto_msgTypes[31]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CommitTransaction.ProtoReflect.Descriptor instead.
+func (*CommitTransaction) Descriptor() ([]byte, []int) {
+	return file_databroker_proto_rawDescGZIP(), []int{31}
+}
+
 type TransactionRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	Key   string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
@@ -1610,7 +1939,7 @@ type TransactionRequest struct {
 
 func (x *TransactionRequest) Reset() {
 	*x = TransactionRequest{}
-	mi := &file_databroker_proto_msgTypes[27]
+	mi := &file_databroker_proto_msgTypes[32]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1622,7 +1951,7 @@ func (x *TransactionRequest) String() string {
 func (*TransactionRequest) ProtoMessage() {}
 
 func (x *TransactionRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[27]
+	mi := &file_databroker_proto_msgTypes[32]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1635,7 +1964,7 @@ func (x *TransactionRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionRequest.ProtoReflect.Descriptor instead.
 func (*TransactionRequest) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{27}
+	return file_databroker_proto_rawDescGZIP(), []int{32}
 }
 
 func (x *TransactionRequest) GetKey() string {
@@ -1732,7 +2061,7 @@ type TransactionResponse struct {
 
 func (x *TransactionResponse) Reset() {
 	*x = TransactionResponse{}
-	mi := &file_databroker_proto_msgTypes[28]
+	mi := &file_databroker_proto_msgTypes[33]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1744,7 +2073,7 @@ func (x *TransactionResponse) String() string {
 func (*TransactionResponse) ProtoMessage() {}
 
 func (x *TransactionResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[28]
+	mi := &file_databroker_proto_msgTypes[33]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1757,7 +2086,7 @@ func (x *TransactionResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use TransactionResponse.ProtoReflect.Descriptor instead.
 func (*TransactionResponse) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{28}
+	return file_databroker_proto_rawDescGZIP(), []int{33}
 }
 
 func (x *TransactionResponse) GetKey() string {
@@ -1838,6 +2167,63 @@ func (*TransactionResponse_Patch) isTransactionResponse_Operation() {}
 
 func (*TransactionResponse_Query) isTransactionResponse_Operation() {}
 
+type CommitTransactionResponse struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// shared is true when this transaction was suppressed by a concurrent one for the
+	// same key: nothing submitted after `begin` was applied.
+	Shared bool `protobuf:"varint,1,opt,name=shared,proto3" json:"shared,omitempty"`
+	// records holds the records written by the committed transaction, in submission
+	// order. When shared is true these are the records written by the transaction
+	// which suppressed this one.
+	Records       []*Record `protobuf:"bytes,2,rep,name=records,proto3" json:"records,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CommitTransactionResponse) Reset() {
+	*x = CommitTransactionResponse{}
+	mi := &file_databroker_proto_msgTypes[34]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CommitTransactionResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CommitTransactionResponse) ProtoMessage() {}
+
+func (x *CommitTransactionResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_databroker_proto_msgTypes[34]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CommitTransactionResponse.ProtoReflect.Descriptor instead.
+func (*CommitTransactionResponse) Descriptor() ([]byte, []int) {
+	return file_databroker_proto_rawDescGZIP(), []int{34}
+}
+
+func (x *CommitTransactionResponse) GetShared() bool {
+	if x != nil {
+		return x.Shared
+	}
+	return false
+}
+
+func (x *CommitTransactionResponse) GetRecords() []*Record {
+	if x != nil {
+		return x.Records
+	}
+	return nil
+}
+
 type Checkpoint struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
 	ServerVersion uint64                 `protobuf:"varint,1,opt,name=server_version,json=serverVersion,proto3" json:"server_version,omitempty"`
@@ -1848,7 +2234,7 @@ type Checkpoint struct {
 
 func (x *Checkpoint) Reset() {
 	*x = Checkpoint{}
-	mi := &file_databroker_proto_msgTypes[29]
+	mi := &file_databroker_proto_msgTypes[35]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1860,7 +2246,7 @@ func (x *Checkpoint) String() string {
 func (*Checkpoint) ProtoMessage() {}
 
 func (x *Checkpoint) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[29]
+	mi := &file_databroker_proto_msgTypes[35]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1873,7 +2259,7 @@ func (x *Checkpoint) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use Checkpoint.ProtoReflect.Descriptor instead.
 func (*Checkpoint) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{29}
+	return file_databroker_proto_rawDescGZIP(), []int{35}
 }
 
 func (x *Checkpoint) GetServerVersion() uint64 {
@@ -1898,7 +2284,7 @@ type GetCheckpointRequest struct {
 
 func (x *GetCheckpointRequest) Reset() {
 	*x = GetCheckpointRequest{}
-	mi := &file_databroker_proto_msgTypes[30]
+	mi := &file_databroker_proto_msgTypes[36]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1910,7 +2296,7 @@ func (x *GetCheckpointRequest) String() string {
 func (*GetCheckpointRequest) ProtoMessage() {}
 
 func (x *GetCheckpointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[30]
+	mi := &file_databroker_proto_msgTypes[36]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1923,7 +2309,7 @@ func (x *GetCheckpointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCheckpointRequest.ProtoReflect.Descriptor instead.
 func (*GetCheckpointRequest) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{30}
+	return file_databroker_proto_rawDescGZIP(), []int{36}
 }
 
 type GetCheckpointResponse struct {
@@ -1936,7 +2322,7 @@ type GetCheckpointResponse struct {
 
 func (x *GetCheckpointResponse) Reset() {
 	*x = GetCheckpointResponse{}
-	mi := &file_databroker_proto_msgTypes[31]
+	mi := &file_databroker_proto_msgTypes[37]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1948,7 +2334,7 @@ func (x *GetCheckpointResponse) String() string {
 func (*GetCheckpointResponse) ProtoMessage() {}
 
 func (x *GetCheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[31]
+	mi := &file_databroker_proto_msgTypes[37]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1961,7 +2347,7 @@ func (x *GetCheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use GetCheckpointResponse.ProtoReflect.Descriptor instead.
 func (*GetCheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{31}
+	return file_databroker_proto_rawDescGZIP(), []int{37}
 }
 
 func (x *GetCheckpointResponse) GetCheckpoint() *Checkpoint {
@@ -1987,7 +2373,7 @@ type SetCheckpointRequest struct {
 
 func (x *SetCheckpointRequest) Reset() {
 	*x = SetCheckpointRequest{}
-	mi := &file_databroker_proto_msgTypes[32]
+	mi := &file_databroker_proto_msgTypes[38]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1999,7 +2385,7 @@ func (x *SetCheckpointRequest) String() string {
 func (*SetCheckpointRequest) ProtoMessage() {}
 
 func (x *SetCheckpointRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[32]
+	mi := &file_databroker_proto_msgTypes[38]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2012,7 +2398,7 @@ func (x *SetCheckpointRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCheckpointRequest.ProtoReflect.Descriptor instead.
 func (*SetCheckpointRequest) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{32}
+	return file_databroker_proto_rawDescGZIP(), []int{38}
 }
 
 func (x *SetCheckpointRequest) GetCheckpoint() *Checkpoint {
@@ -2030,7 +2416,7 @@ type SetCheckpointResponse struct {
 
 func (x *SetCheckpointResponse) Reset() {
 	*x = SetCheckpointResponse{}
-	mi := &file_databroker_proto_msgTypes[33]
+	mi := &file_databroker_proto_msgTypes[39]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -2042,7 +2428,7 @@ func (x *SetCheckpointResponse) String() string {
 func (*SetCheckpointResponse) ProtoMessage() {}
 
 func (x *SetCheckpointResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_databroker_proto_msgTypes[33]
+	mi := &file_databroker_proto_msgTypes[39]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -2055,7 +2441,7 @@ func (x *SetCheckpointResponse) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use SetCheckpointResponse.ProtoReflect.Descriptor instead.
 func (*SetCheckpointResponse) Descriptor() ([]byte, []int) {
-	return file_databroker_proto_rawDescGZIP(), []int{33}
+	return file_databroker_proto_rawDescGZIP(), []int{39}
 }
 
 var File_databroker_proto protoreflect.FileDescriptor
@@ -2166,7 +2552,23 @@ const file_databroker_proto_rawDesc = "" +
 	"\x11RenewLeaseRequest\x12\x12\n" +
 	"\x04name\x18\x01 \x01(\tR\x04name\x12\x0e\n" +
 	"\x02id\x18\x02 \x01(\tR\x02id\x125\n" +
-	"\bduration\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\bduration\"\xef\x01\n" +
+	"\bduration\x18\x03 \x01(\v2\x19.google.protobuf.DurationR\bduration\"\xf0\x01\n" +
+	"\x18TransactionStreamRequest\x12\x1a\n" +
+	"\bsequence\x18\x01 \x01(\x04R\bsequence\x124\n" +
+	"\x05begin\x18\x02 \x01(\v2\x1c.databroker.BeginTransactionH\x00R\x05begin\x12>\n" +
+	"\toperation\x18\x03 \x01(\v2\x1e.databroker.TransactionRequestH\x00R\toperation\x127\n" +
+	"\x06commit\x18\x04 \x01(\v2\x1d.databroker.CommitTransactionH\x00R\x06commitB\t\n" +
+	"\amessage\"\x82\x02\n" +
+	"\x19TransactionStreamResponse\x12\x1a\n" +
+	"\bsequence\x18\x01 \x01(\x04R\bsequence\x12?\n" +
+	"\toperation\x18\x02 \x01(\v2\x1f.databroker.TransactionResponseH\x00R\toperation\x12?\n" +
+	"\x06commit\x18\x03 \x01(\v2%.databroker.CommitTransactionResponseH\x00R\x06commit\x12<\n" +
+	"\x05begin\x18\x04 \x01(\v2$.databroker.BeginTransactionResponseH\x00R\x05beginB\t\n" +
+	"\amessage\"$\n" +
+	"\x10BeginTransaction\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"\x1a\n" +
+	"\x18BeginTransactionResponse\"\x13\n" +
+	"\x11CommitTransaction\"\xef\x01\n" +
 	"\x12TransactionRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12*\n" +
 	"\x03get\x18\x02 \x01(\v2\x16.databroker.GetRequestH\x00R\x03get\x12*\n" +
@@ -2180,7 +2582,10 @@ const file_databroker_proto_rawDesc = "" +
 	"\x03put\x18\x03 \x01(\v2\x17.databroker.PutResponseH\x00R\x03put\x121\n" +
 	"\x05patch\x18\x04 \x01(\v2\x19.databroker.PatchResponseH\x00R\x05patch\x121\n" +
 	"\x05query\x18\x05 \x01(\v2\x19.databroker.QueryResponseH\x00R\x05queryB\v\n" +
-	"\toperation\"Z\n" +
+	"\toperation\"a\n" +
+	"\x19CommitTransactionResponse\x12\x16\n" +
+	"\x06shared\x18\x01 \x01(\bR\x06shared\x12,\n" +
+	"\arecords\x18\x02 \x03(\v2\x12.databroker.RecordR\arecords\"Z\n" +
 	"\n" +
 	"Checkpoint\x12%\n" +
 	"\x0eserver_version\x18\x01 \x01(\x04R\rserverVersion\x12%\n" +
@@ -2195,7 +2600,7 @@ const file_databroker_proto_rawDesc = "" +
 	"\n" +
 	"checkpoint\x18\x01 \x01(\v2\x16.databroker.CheckpointR\n" +
 	"checkpoint\"\x17\n" +
-	"\x15SetCheckpointResponse2\xcc\a\n" +
+	"\x15SetCheckpointResponse2\xac\b\n" +
 	"\x11DataBrokerService\x12Q\n" +
 	"\fAcquireLease\x12\x1f.databroker.AcquireLeaseRequest\x1a .databroker.AcquireLeaseResponse\x12:\n" +
 	"\x05Clear\x12\x16.google.protobuf.Empty\x1a\x19.databroker.ClearResponse\x126\n" +
@@ -2215,7 +2620,8 @@ const file_databroker_proto_rawDesc = "" +
 	"SetOptions\x12\x1d.databroker.SetOptionsRequest\x1a\x1e.databroker.SetOptionsResponse\x12;\n" +
 	"\x04Sync\x12\x17.databroker.SyncRequest\x1a\x18.databroker.SyncResponse0\x01\x12M\n" +
 	"\n" +
-	"SyncLatest\x12\x1d.databroker.SyncLatestRequest\x1a\x1e.databroker.SyncLatestResponse0\x012\xbf\x01\n" +
+	"SyncLatest\x12\x1d.databroker.SyncLatestRequest\x1a\x1e.databroker.SyncLatestResponse0\x01\x12^\n" +
+	"\vTransaction\x12$.databroker.TransactionStreamRequest\x1a%.databroker.TransactionStreamResponse(\x010\x012\xbf\x01\n" +
 	"\x11CheckpointService\x12T\n" +
 	"\rGetCheckpoint\x12 .databroker.GetCheckpointRequest\x1a!.databroker.GetCheckpointResponse\x12T\n" +
 	"\rSetCheckpoint\x12 .databroker.SetCheckpointRequest\x1a!.databroker.SetCheckpointResponseB2Z0github.com/pomerium/pomerium/pkg/grpc/databrokerb\x06proto3"
@@ -2232,62 +2638,68 @@ func file_databroker_proto_rawDescGZIP() []byte {
 	return file_databroker_proto_rawDescData
 }
 
-var file_databroker_proto_msgTypes = make([]protoimpl.MessageInfo, 34)
+var file_databroker_proto_msgTypes = make([]protoimpl.MessageInfo, 40)
 var file_databroker_proto_goTypes = []any{
-	(*Record)(nil),                // 0: databroker.Record
-	(*Versions)(nil),              // 1: databroker.Versions
-	(*Options)(nil),               // 2: databroker.Options
-	(*TypedOptions)(nil),          // 3: databroker.TypedOptions
-	(*ClearResponse)(nil),         // 4: databroker.ClearResponse
-	(*GetRequest)(nil),            // 5: databroker.GetRequest
-	(*GetResponse)(nil),           // 6: databroker.GetResponse
-	(*ListTypesResponse)(nil),     // 7: databroker.ListTypesResponse
-	(*QueryRequest)(nil),          // 8: databroker.QueryRequest
-	(*QueryResponse)(nil),         // 9: databroker.QueryResponse
-	(*PutRequest)(nil),            // 10: databroker.PutRequest
-	(*PutResponse)(nil),           // 11: databroker.PutResponse
-	(*PatchRequest)(nil),          // 12: databroker.PatchRequest
-	(*PatchResponse)(nil),         // 13: databroker.PatchResponse
-	(*ServerInfoResponse)(nil),    // 14: databroker.ServerInfoResponse
-	(*GetOptionsRequest)(nil),     // 15: databroker.GetOptionsRequest
-	(*GetOptionsResponse)(nil),    // 16: databroker.GetOptionsResponse
-	(*SetOptionsRequest)(nil),     // 17: databroker.SetOptionsRequest
-	(*SetOptionsResponse)(nil),    // 18: databroker.SetOptionsResponse
-	(*SyncRequest)(nil),           // 19: databroker.SyncRequest
-	(*SyncResponse)(nil),          // 20: databroker.SyncResponse
-	(*SyncLatestRequest)(nil),     // 21: databroker.SyncLatestRequest
-	(*SyncLatestResponse)(nil),    // 22: databroker.SyncLatestResponse
-	(*AcquireLeaseRequest)(nil),   // 23: databroker.AcquireLeaseRequest
-	(*AcquireLeaseResponse)(nil),  // 24: databroker.AcquireLeaseResponse
-	(*ReleaseLeaseRequest)(nil),   // 25: databroker.ReleaseLeaseRequest
-	(*RenewLeaseRequest)(nil),     // 26: databroker.RenewLeaseRequest
-	(*TransactionRequest)(nil),    // 27: databroker.TransactionRequest
-	(*TransactionResponse)(nil),   // 28: databroker.TransactionResponse
-	(*Checkpoint)(nil),            // 29: databroker.Checkpoint
-	(*GetCheckpointRequest)(nil),  // 30: databroker.GetCheckpointRequest
-	(*GetCheckpointResponse)(nil), // 31: databroker.GetCheckpointResponse
-	(*SetCheckpointRequest)(nil),  // 32: databroker.SetCheckpointRequest
-	(*SetCheckpointResponse)(nil), // 33: databroker.SetCheckpointResponse
-	(*anypb.Any)(nil),             // 34: google.protobuf.Any
-	(*timestamppb.Timestamp)(nil), // 35: google.protobuf.Timestamp
-	(*durationpb.Duration)(nil),   // 36: google.protobuf.Duration
-	(*structpb.Struct)(nil),       // 37: google.protobuf.Struct
-	(*fieldmaskpb.FieldMask)(nil), // 38: google.protobuf.FieldMask
-	(*emptypb.Empty)(nil),         // 39: google.protobuf.Empty
+	(*Record)(nil),                    // 0: databroker.Record
+	(*Versions)(nil),                  // 1: databroker.Versions
+	(*Options)(nil),                   // 2: databroker.Options
+	(*TypedOptions)(nil),              // 3: databroker.TypedOptions
+	(*ClearResponse)(nil),             // 4: databroker.ClearResponse
+	(*GetRequest)(nil),                // 5: databroker.GetRequest
+	(*GetResponse)(nil),               // 6: databroker.GetResponse
+	(*ListTypesResponse)(nil),         // 7: databroker.ListTypesResponse
+	(*QueryRequest)(nil),              // 8: databroker.QueryRequest
+	(*QueryResponse)(nil),             // 9: databroker.QueryResponse
+	(*PutRequest)(nil),                // 10: databroker.PutRequest
+	(*PutResponse)(nil),               // 11: databroker.PutResponse
+	(*PatchRequest)(nil),              // 12: databroker.PatchRequest
+	(*PatchResponse)(nil),             // 13: databroker.PatchResponse
+	(*ServerInfoResponse)(nil),        // 14: databroker.ServerInfoResponse
+	(*GetOptionsRequest)(nil),         // 15: databroker.GetOptionsRequest
+	(*GetOptionsResponse)(nil),        // 16: databroker.GetOptionsResponse
+	(*SetOptionsRequest)(nil),         // 17: databroker.SetOptionsRequest
+	(*SetOptionsResponse)(nil),        // 18: databroker.SetOptionsResponse
+	(*SyncRequest)(nil),               // 19: databroker.SyncRequest
+	(*SyncResponse)(nil),              // 20: databroker.SyncResponse
+	(*SyncLatestRequest)(nil),         // 21: databroker.SyncLatestRequest
+	(*SyncLatestResponse)(nil),        // 22: databroker.SyncLatestResponse
+	(*AcquireLeaseRequest)(nil),       // 23: databroker.AcquireLeaseRequest
+	(*AcquireLeaseResponse)(nil),      // 24: databroker.AcquireLeaseResponse
+	(*ReleaseLeaseRequest)(nil),       // 25: databroker.ReleaseLeaseRequest
+	(*RenewLeaseRequest)(nil),         // 26: databroker.RenewLeaseRequest
+	(*TransactionStreamRequest)(nil),  // 27: databroker.TransactionStreamRequest
+	(*TransactionStreamResponse)(nil), // 28: databroker.TransactionStreamResponse
+	(*BeginTransaction)(nil),          // 29: databroker.BeginTransaction
+	(*BeginTransactionResponse)(nil),  // 30: databroker.BeginTransactionResponse
+	(*CommitTransaction)(nil),         // 31: databroker.CommitTransaction
+	(*TransactionRequest)(nil),        // 32: databroker.TransactionRequest
+	(*TransactionResponse)(nil),       // 33: databroker.TransactionResponse
+	(*CommitTransactionResponse)(nil), // 34: databroker.CommitTransactionResponse
+	(*Checkpoint)(nil),                // 35: databroker.Checkpoint
+	(*GetCheckpointRequest)(nil),      // 36: databroker.GetCheckpointRequest
+	(*GetCheckpointResponse)(nil),     // 37: databroker.GetCheckpointResponse
+	(*SetCheckpointRequest)(nil),      // 38: databroker.SetCheckpointRequest
+	(*SetCheckpointResponse)(nil),     // 39: databroker.SetCheckpointResponse
+	(*anypb.Any)(nil),                 // 40: google.protobuf.Any
+	(*timestamppb.Timestamp)(nil),     // 41: google.protobuf.Timestamp
+	(*durationpb.Duration)(nil),       // 42: google.protobuf.Duration
+	(*structpb.Struct)(nil),           // 43: google.protobuf.Struct
+	(*fieldmaskpb.FieldMask)(nil),     // 44: google.protobuf.FieldMask
+	(*emptypb.Empty)(nil),             // 45: google.protobuf.Empty
 }
 var file_databroker_proto_depIdxs = []int32{
-	34, // 0: databroker.Record.data:type_name -> google.protobuf.Any
-	35, // 1: databroker.Record.modified_at:type_name -> google.protobuf.Timestamp
-	35, // 2: databroker.Record.deleted_at:type_name -> google.protobuf.Timestamp
-	36, // 3: databroker.Options.ttl:type_name -> google.protobuf.Duration
+	40, // 0: databroker.Record.data:type_name -> google.protobuf.Any
+	41, // 1: databroker.Record.modified_at:type_name -> google.protobuf.Timestamp
+	41, // 2: databroker.Record.deleted_at:type_name -> google.protobuf.Timestamp
+	42, // 3: databroker.Options.ttl:type_name -> google.protobuf.Duration
 	2,  // 4: databroker.TypedOptions.options:type_name -> databroker.Options
 	0,  // 5: databroker.GetResponse.record:type_name -> databroker.Record
-	37, // 6: databroker.QueryRequest.filter:type_name -> google.protobuf.Struct
+	43, // 6: databroker.QueryRequest.filter:type_name -> google.protobuf.Struct
 	0,  // 7: databroker.QueryResponse.records:type_name -> databroker.Record
 	0,  // 8: databroker.PutRequest.records:type_name -> databroker.Record
 	0,  // 9: databroker.PutResponse.records:type_name -> databroker.Record
 	0,  // 10: databroker.PatchRequest.records:type_name -> databroker.Record
-	38, // 11: databroker.PatchRequest.field_mask:type_name -> google.protobuf.FieldMask
+	44, // 11: databroker.PatchRequest.field_mask:type_name -> google.protobuf.FieldMask
 	0,  // 12: databroker.PatchResponse.records:type_name -> databroker.Record
 	2,  // 13: databroker.GetOptionsResponse.options:type_name -> databroker.Options
 	2,  // 14: databroker.SetOptionsRequest.options:type_name -> databroker.Options
@@ -2297,55 +2709,64 @@ var file_databroker_proto_depIdxs = []int32{
 	0,  // 18: databroker.SyncLatestResponse.record:type_name -> databroker.Record
 	1,  // 19: databroker.SyncLatestResponse.versions:type_name -> databroker.Versions
 	3,  // 20: databroker.SyncLatestResponse.options:type_name -> databroker.TypedOptions
-	36, // 21: databroker.AcquireLeaseRequest.duration:type_name -> google.protobuf.Duration
-	36, // 22: databroker.RenewLeaseRequest.duration:type_name -> google.protobuf.Duration
-	5,  // 23: databroker.TransactionRequest.get:type_name -> databroker.GetRequest
-	10, // 24: databroker.TransactionRequest.put:type_name -> databroker.PutRequest
-	12, // 25: databroker.TransactionRequest.patch:type_name -> databroker.PatchRequest
-	8,  // 26: databroker.TransactionRequest.query:type_name -> databroker.QueryRequest
-	6,  // 27: databroker.TransactionResponse.get:type_name -> databroker.GetResponse
-	11, // 28: databroker.TransactionResponse.put:type_name -> databroker.PutResponse
-	13, // 29: databroker.TransactionResponse.patch:type_name -> databroker.PatchResponse
-	9,  // 30: databroker.TransactionResponse.query:type_name -> databroker.QueryResponse
-	29, // 31: databroker.GetCheckpointResponse.checkpoint:type_name -> databroker.Checkpoint
-	29, // 32: databroker.SetCheckpointRequest.checkpoint:type_name -> databroker.Checkpoint
-	23, // 33: databroker.DataBrokerService.AcquireLease:input_type -> databroker.AcquireLeaseRequest
-	39, // 34: databroker.DataBrokerService.Clear:input_type -> google.protobuf.Empty
-	5,  // 35: databroker.DataBrokerService.Get:input_type -> databroker.GetRequest
-	15, // 36: databroker.DataBrokerService.GetOptions:input_type -> databroker.GetOptionsRequest
-	39, // 37: databroker.DataBrokerService.ListTypes:input_type -> google.protobuf.Empty
-	10, // 38: databroker.DataBrokerService.Put:input_type -> databroker.PutRequest
-	12, // 39: databroker.DataBrokerService.Patch:input_type -> databroker.PatchRequest
-	8,  // 40: databroker.DataBrokerService.Query:input_type -> databroker.QueryRequest
-	25, // 41: databroker.DataBrokerService.ReleaseLease:input_type -> databroker.ReleaseLeaseRequest
-	26, // 42: databroker.DataBrokerService.RenewLease:input_type -> databroker.RenewLeaseRequest
-	39, // 43: databroker.DataBrokerService.ServerInfo:input_type -> google.protobuf.Empty
-	17, // 44: databroker.DataBrokerService.SetOptions:input_type -> databroker.SetOptionsRequest
-	19, // 45: databroker.DataBrokerService.Sync:input_type -> databroker.SyncRequest
-	21, // 46: databroker.DataBrokerService.SyncLatest:input_type -> databroker.SyncLatestRequest
-	30, // 47: databroker.CheckpointService.GetCheckpoint:input_type -> databroker.GetCheckpointRequest
-	32, // 48: databroker.CheckpointService.SetCheckpoint:input_type -> databroker.SetCheckpointRequest
-	24, // 49: databroker.DataBrokerService.AcquireLease:output_type -> databroker.AcquireLeaseResponse
-	4,  // 50: databroker.DataBrokerService.Clear:output_type -> databroker.ClearResponse
-	6,  // 51: databroker.DataBrokerService.Get:output_type -> databroker.GetResponse
-	16, // 52: databroker.DataBrokerService.GetOptions:output_type -> databroker.GetOptionsResponse
-	7,  // 53: databroker.DataBrokerService.ListTypes:output_type -> databroker.ListTypesResponse
-	11, // 54: databroker.DataBrokerService.Put:output_type -> databroker.PutResponse
-	13, // 55: databroker.DataBrokerService.Patch:output_type -> databroker.PatchResponse
-	9,  // 56: databroker.DataBrokerService.Query:output_type -> databroker.QueryResponse
-	39, // 57: databroker.DataBrokerService.ReleaseLease:output_type -> google.protobuf.Empty
-	39, // 58: databroker.DataBrokerService.RenewLease:output_type -> google.protobuf.Empty
-	14, // 59: databroker.DataBrokerService.ServerInfo:output_type -> databroker.ServerInfoResponse
-	18, // 60: databroker.DataBrokerService.SetOptions:output_type -> databroker.SetOptionsResponse
-	20, // 61: databroker.DataBrokerService.Sync:output_type -> databroker.SyncResponse
-	22, // 62: databroker.DataBrokerService.SyncLatest:output_type -> databroker.SyncLatestResponse
-	31, // 63: databroker.CheckpointService.GetCheckpoint:output_type -> databroker.GetCheckpointResponse
-	33, // 64: databroker.CheckpointService.SetCheckpoint:output_type -> databroker.SetCheckpointResponse
-	49, // [49:65] is the sub-list for method output_type
-	33, // [33:49] is the sub-list for method input_type
-	33, // [33:33] is the sub-list for extension type_name
-	33, // [33:33] is the sub-list for extension extendee
-	0,  // [0:33] is the sub-list for field type_name
+	42, // 21: databroker.AcquireLeaseRequest.duration:type_name -> google.protobuf.Duration
+	42, // 22: databroker.RenewLeaseRequest.duration:type_name -> google.protobuf.Duration
+	29, // 23: databroker.TransactionStreamRequest.begin:type_name -> databroker.BeginTransaction
+	32, // 24: databroker.TransactionStreamRequest.operation:type_name -> databroker.TransactionRequest
+	31, // 25: databroker.TransactionStreamRequest.commit:type_name -> databroker.CommitTransaction
+	33, // 26: databroker.TransactionStreamResponse.operation:type_name -> databroker.TransactionResponse
+	34, // 27: databroker.TransactionStreamResponse.commit:type_name -> databroker.CommitTransactionResponse
+	30, // 28: databroker.TransactionStreamResponse.begin:type_name -> databroker.BeginTransactionResponse
+	5,  // 29: databroker.TransactionRequest.get:type_name -> databroker.GetRequest
+	10, // 30: databroker.TransactionRequest.put:type_name -> databroker.PutRequest
+	12, // 31: databroker.TransactionRequest.patch:type_name -> databroker.PatchRequest
+	8,  // 32: databroker.TransactionRequest.query:type_name -> databroker.QueryRequest
+	6,  // 33: databroker.TransactionResponse.get:type_name -> databroker.GetResponse
+	11, // 34: databroker.TransactionResponse.put:type_name -> databroker.PutResponse
+	13, // 35: databroker.TransactionResponse.patch:type_name -> databroker.PatchResponse
+	9,  // 36: databroker.TransactionResponse.query:type_name -> databroker.QueryResponse
+	0,  // 37: databroker.CommitTransactionResponse.records:type_name -> databroker.Record
+	35, // 38: databroker.GetCheckpointResponse.checkpoint:type_name -> databroker.Checkpoint
+	35, // 39: databroker.SetCheckpointRequest.checkpoint:type_name -> databroker.Checkpoint
+	23, // 40: databroker.DataBrokerService.AcquireLease:input_type -> databroker.AcquireLeaseRequest
+	45, // 41: databroker.DataBrokerService.Clear:input_type -> google.protobuf.Empty
+	5,  // 42: databroker.DataBrokerService.Get:input_type -> databroker.GetRequest
+	15, // 43: databroker.DataBrokerService.GetOptions:input_type -> databroker.GetOptionsRequest
+	45, // 44: databroker.DataBrokerService.ListTypes:input_type -> google.protobuf.Empty
+	10, // 45: databroker.DataBrokerService.Put:input_type -> databroker.PutRequest
+	12, // 46: databroker.DataBrokerService.Patch:input_type -> databroker.PatchRequest
+	8,  // 47: databroker.DataBrokerService.Query:input_type -> databroker.QueryRequest
+	25, // 48: databroker.DataBrokerService.ReleaseLease:input_type -> databroker.ReleaseLeaseRequest
+	26, // 49: databroker.DataBrokerService.RenewLease:input_type -> databroker.RenewLeaseRequest
+	45, // 50: databroker.DataBrokerService.ServerInfo:input_type -> google.protobuf.Empty
+	17, // 51: databroker.DataBrokerService.SetOptions:input_type -> databroker.SetOptionsRequest
+	19, // 52: databroker.DataBrokerService.Sync:input_type -> databroker.SyncRequest
+	21, // 53: databroker.DataBrokerService.SyncLatest:input_type -> databroker.SyncLatestRequest
+	27, // 54: databroker.DataBrokerService.Transaction:input_type -> databroker.TransactionStreamRequest
+	36, // 55: databroker.CheckpointService.GetCheckpoint:input_type -> databroker.GetCheckpointRequest
+	38, // 56: databroker.CheckpointService.SetCheckpoint:input_type -> databroker.SetCheckpointRequest
+	24, // 57: databroker.DataBrokerService.AcquireLease:output_type -> databroker.AcquireLeaseResponse
+	4,  // 58: databroker.DataBrokerService.Clear:output_type -> databroker.ClearResponse
+	6,  // 59: databroker.DataBrokerService.Get:output_type -> databroker.GetResponse
+	16, // 60: databroker.DataBrokerService.GetOptions:output_type -> databroker.GetOptionsResponse
+	7,  // 61: databroker.DataBrokerService.ListTypes:output_type -> databroker.ListTypesResponse
+	11, // 62: databroker.DataBrokerService.Put:output_type -> databroker.PutResponse
+	13, // 63: databroker.DataBrokerService.Patch:output_type -> databroker.PatchResponse
+	9,  // 64: databroker.DataBrokerService.Query:output_type -> databroker.QueryResponse
+	45, // 65: databroker.DataBrokerService.ReleaseLease:output_type -> google.protobuf.Empty
+	45, // 66: databroker.DataBrokerService.RenewLease:output_type -> google.protobuf.Empty
+	14, // 67: databroker.DataBrokerService.ServerInfo:output_type -> databroker.ServerInfoResponse
+	18, // 68: databroker.DataBrokerService.SetOptions:output_type -> databroker.SetOptionsResponse
+	20, // 69: databroker.DataBrokerService.Sync:output_type -> databroker.SyncResponse
+	22, // 70: databroker.DataBrokerService.SyncLatest:output_type -> databroker.SyncLatestResponse
+	28, // 71: databroker.DataBrokerService.Transaction:output_type -> databroker.TransactionStreamResponse
+	37, // 72: databroker.CheckpointService.GetCheckpoint:output_type -> databroker.GetCheckpointResponse
+	39, // 73: databroker.CheckpointService.SetCheckpoint:output_type -> databroker.SetCheckpointResponse
+	57, // [57:74] is the sub-list for method output_type
+	40, // [40:57] is the sub-list for method input_type
+	40, // [40:40] is the sub-list for extension type_name
+	40, // [40:40] is the sub-list for extension extendee
+	0,  // [0:40] is the sub-list for field type_name
 }
 
 func init() { file_databroker_proto_init() }
@@ -2366,12 +2787,22 @@ func file_databroker_proto_init() {
 		(*SyncLatestResponse_Options)(nil),
 	}
 	file_databroker_proto_msgTypes[27].OneofWrappers = []any{
+		(*TransactionStreamRequest_Begin)(nil),
+		(*TransactionStreamRequest_Operation)(nil),
+		(*TransactionStreamRequest_Commit)(nil),
+	}
+	file_databroker_proto_msgTypes[28].OneofWrappers = []any{
+		(*TransactionStreamResponse_Operation)(nil),
+		(*TransactionStreamResponse_Commit)(nil),
+		(*TransactionStreamResponse_Begin)(nil),
+	}
+	file_databroker_proto_msgTypes[32].OneofWrappers = []any{
 		(*TransactionRequest_Get)(nil),
 		(*TransactionRequest_Put)(nil),
 		(*TransactionRequest_Patch)(nil),
 		(*TransactionRequest_Query)(nil),
 	}
-	file_databroker_proto_msgTypes[28].OneofWrappers = []any{
+	file_databroker_proto_msgTypes[33].OneofWrappers = []any{
 		(*TransactionResponse_Get)(nil),
 		(*TransactionResponse_Put)(nil),
 		(*TransactionResponse_Patch)(nil),
@@ -2383,7 +2814,7 @@ func file_databroker_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_databroker_proto_rawDesc), len(file_databroker_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   34,
+			NumMessages:   40,
 			NumExtensions: 0,
 			NumServices:   2,
 		},

--- a/pkg/grpc/databroker/databroker.pb.go
+++ b/pkg/grpc/databroker/databroker.pb.go
@@ -1853,6 +1853,7 @@ func (x *BeginTransaction) GetKey() string {
 
 type BeginTransactionResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1887,8 +1888,16 @@ func (*BeginTransactionResponse) Descriptor() ([]byte, []int) {
 	return file_databroker_proto_rawDescGZIP(), []int{30}
 }
 
+func (x *BeginTransactionResponse) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
+}
+
 type CommitTransaction struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
+	Key           string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1921,6 +1930,13 @@ func (x *CommitTransaction) ProtoReflect() protoreflect.Message {
 // Deprecated: Use CommitTransaction.ProtoReflect.Descriptor instead.
 func (*CommitTransaction) Descriptor() ([]byte, []int) {
 	return file_databroker_proto_rawDescGZIP(), []int{31}
+}
+
+func (x *CommitTransaction) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
 }
 
 type TransactionRequest struct {
@@ -2274,11 +2290,13 @@ func (*TransactionResponse_Query) isTransactionResponse_Operation() {}
 
 type CommitTransactionResponse struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
+	Key   string                 `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// shared is true when these results come from a concurrent transaction for the
-	// same key. The transactions that were shared never ran operations themselves.
-	Shared bool `protobuf:"varint,1,opt,name=shared,proto3" json:"shared,omitempty"`
+	// same key that shares results, like singleflight transactions.
+	// The transactions that were shared never ran operations themselves.
+	Shared bool `protobuf:"varint,2,opt,name=shared,proto3" json:"shared,omitempty"`
 	// records that were changed during this transaction.
-	Records       []*Record `protobuf:"bytes,2,rep,name=records,proto3" json:"records,omitempty"`
+	Records       []*Record `protobuf:"bytes,3,rep,name=records,proto3" json:"records,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2311,6 +2329,13 @@ func (x *CommitTransactionResponse) ProtoReflect() protoreflect.Message {
 // Deprecated: Use CommitTransactionResponse.ProtoReflect.Descriptor instead.
 func (*CommitTransactionResponse) Descriptor() ([]byte, []int) {
 	return file_databroker_proto_rawDescGZIP(), []int{36}
+}
+
+func (x *CommitTransactionResponse) GetKey() string {
+	if x != nil {
+		return x.Key
+	}
+	return ""
 }
 
 func (x *CommitTransactionResponse) GetShared() bool {
@@ -2669,9 +2694,11 @@ const file_databroker_proto_rawDesc = "" +
 	"\x05begin\x18\x04 \x01(\v2$.databroker.BeginTransactionResponseH\x00R\x05beginB\t\n" +
 	"\amessage\"$\n" +
 	"\x10BeginTransaction\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\"\x1a\n" +
-	"\x18BeginTransactionResponse\"\x13\n" +
-	"\x11CommitTransaction\"\xef\x01\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\",\n" +
+	"\x18BeginTransactionResponse\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"%\n" +
+	"\x11CommitTransaction\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\"\xef\x01\n" +
 	"\x12TransactionRequest\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12*\n" +
 	"\x03get\x18\x02 \x01(\v2\x16.databroker.GetRequestH\x00R\x03get\x12*\n" +
@@ -2691,10 +2718,11 @@ const file_databroker_proto_rawDesc = "" +
 	"\x03put\x18\x03 \x01(\v2\x17.databroker.PutResponseH\x00R\x03put\x121\n" +
 	"\x05patch\x18\x04 \x01(\v2\x19.databroker.PatchResponseH\x00R\x05patch\x121\n" +
 	"\x05query\x18\x05 \x01(\v2\x19.databroker.QueryResponseH\x00R\x05queryB\v\n" +
-	"\toperation\"a\n" +
-	"\x19CommitTransactionResponse\x12\x16\n" +
-	"\x06shared\x18\x01 \x01(\bR\x06shared\x12,\n" +
-	"\arecords\x18\x02 \x03(\v2\x12.databroker.RecordR\arecords\"Z\n" +
+	"\toperation\"s\n" +
+	"\x19CommitTransactionResponse\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x16\n" +
+	"\x06shared\x18\x02 \x01(\bR\x06shared\x12,\n" +
+	"\arecords\x18\x03 \x03(\v2\x12.databroker.RecordR\arecords\"Z\n" +
 	"\n" +
 	"Checkpoint\x12%\n" +
 	"\x0eserver_version\x18\x01 \x01(\x04R\rserverVersion\x12%\n" +

--- a/pkg/grpc/databroker/databroker.pb.json
+++ b/pkg/grpc/databroker/databroker.pb.json
@@ -729,6 +729,42 @@
           ]
         },
         {
+          "name": "RPCStatus",
+          "longName": "RPCStatus",
+          "fullName": "databroker.RPCStatus",
+          "description": "mirrors \"google/rpc/status.proto\"'s relevant fields",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "code",
+              "description": "",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "message",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
           "name": "Record",
           "longName": "Record",
           "fullName": "databroker.Record",
@@ -1352,6 +1388,42 @@
           ]
         },
         {
+          "name": "TransactionResponseWithError",
+          "longName": "TransactionResponseWithError",
+          "fullName": "databroker.TransactionResponseWithError",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "response",
+              "description": "",
+              "label": "",
+              "type": "TransactionResponse",
+              "longType": "TransactionResponse",
+              "fullType": "databroker.TransactionResponse",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "err",
+              "description": "",
+              "label": "",
+              "type": "RPCStatus",
+              "longType": "RPCStatus",
+              "fullType": "databroker.RPCStatus",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
           "name": "TransactionStreamRequest",
           "longName": "TransactionStreamRequest",
           "fullName": "databroker.TransactionStreamRequest",
@@ -1437,9 +1509,9 @@
               "name": "operation",
               "description": "",
               "label": "",
-              "type": "TransactionResponse",
-              "longType": "TransactionResponse",
-              "fullType": "databroker.TransactionResponse",
+              "type": "TransactionResponseWithError",
+              "longType": "TransactionResponseWithError",
+              "fullType": "databroker.TransactionResponseWithError",
               "ismap": false,
               "isoneof": true,
               "oneofdecl": "message",

--- a/pkg/grpc/databroker/databroker.pb.json
+++ b/pkg/grpc/databroker/databroker.pb.json
@@ -72,6 +72,41 @@
           ]
         },
         {
+          "name": "BeginTransaction",
+          "longName": "BeginTransaction",
+          "fullName": "databroker.BeginTransaction",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "BeginTransactionResponse",
+          "longName": "BeginTransactionResponse",
+          "fullName": "databroker.BeginTransactionResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
           "name": "Checkpoint",
           "longName": "Checkpoint",
           "fullName": "databroker.Checkpoint",
@@ -136,6 +171,53 @@
               "type": "uint64",
               "longType": "uint64",
               "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "CommitTransaction",
+          "longName": "CommitTransaction",
+          "fullName": "databroker.CommitTransaction",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": false,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": []
+        },
+        {
+          "name": "CommitTransactionResponse",
+          "longName": "CommitTransactionResponse",
+          "fullName": "databroker.CommitTransactionResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "shared",
+              "description": "shared is true when this transaction was suppressed by a concurrent one for the\nsame key: nothing submitted after `begin` was applied.",
+              "label": "",
+              "type": "bool",
+              "longType": "bool",
+              "fullType": "bool",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "records",
+              "description": "records holds the records written by the committed transaction, in submission\norder. When shared is true these are the records written by the transaction\nwhich suppressed this one.",
+              "label": "repeated",
+              "type": "Record",
+              "longType": "Record",
+              "fullType": "databroker.Record",
               "ismap": false,
               "isoneof": false,
               "oneofdecl": "",
@@ -1270,6 +1352,126 @@
           ]
         },
         {
+          "name": "TransactionStreamRequest",
+          "longName": "TransactionStreamRequest",
+          "fullName": "databroker.TransactionStreamRequest",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "sequence",
+              "description": "sequence is echoed on the matching response.",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "begin",
+              "description": "",
+              "label": "",
+              "type": "BeginTransaction",
+              "longType": "BeginTransaction",
+              "fullType": "databroker.BeginTransaction",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "message",
+              "defaultValue": ""
+            },
+            {
+              "name": "operation",
+              "description": "",
+              "label": "",
+              "type": "TransactionRequest",
+              "longType": "TransactionRequest",
+              "fullType": "databroker.TransactionRequest",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "message",
+              "defaultValue": ""
+            },
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "CommitTransaction",
+              "longType": "CommitTransaction",
+              "fullType": "databroker.CommitTransaction",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "message",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
+          "name": "TransactionStreamResponse",
+          "longName": "TransactionStreamResponse",
+          "fullName": "databroker.TransactionStreamResponse",
+          "description": "",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "sequence",
+              "description": "",
+              "label": "",
+              "type": "uint64",
+              "longType": "uint64",
+              "fullType": "uint64",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "operation",
+              "description": "",
+              "label": "",
+              "type": "TransactionResponse",
+              "longType": "TransactionResponse",
+              "fullType": "databroker.TransactionResponse",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "message",
+              "defaultValue": ""
+            },
+            {
+              "name": "commit",
+              "description": "",
+              "label": "",
+              "type": "CommitTransactionResponse",
+              "longType": "CommitTransactionResponse",
+              "fullType": "databroker.CommitTransactionResponse",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "message",
+              "defaultValue": ""
+            },
+            {
+              "name": "begin",
+              "description": "",
+              "label": "",
+              "type": "BeginTransactionResponse",
+              "longType": "BeginTransactionResponse",
+              "fullType": "databroker.BeginTransactionResponse",
+              "ismap": false,
+              "isoneof": true,
+              "oneofdecl": "message",
+              "defaultValue": ""
+            }
+          ]
+        },
+        {
           "name": "TypedOptions",
           "longName": "TypedOptions",
           "fullName": "databroker.TypedOptions",
@@ -1547,6 +1749,18 @@
               "responseType": "SyncLatestResponse",
               "responseLongType": "SyncLatestResponse",
               "responseFullType": "databroker.SyncLatestResponse",
+              "responseStreaming": true
+            },
+            {
+              "name": "Transaction",
+              "description": "Transaction opens a transaction. \nTransaction is used for synchronizing one-time read and update Operations\nthat require atomic updates.\nThe stream's lifetime is the transaction's lifetime.\nThe first message must be `begin`, the last must be `commit`, and a\nstream that ends any other way rolls back. Operations are atomic but not\nisolated, and there is no conflict handling for concurrent updates not wrapped\nwith the same transaction key. \nConcurrent transactions are singleflight; sharing a key waits for the first transaction\nto finish with its result, and get the same result.",
+              "requestType": "TransactionStreamRequest",
+              "requestLongType": "TransactionStreamRequest",
+              "requestFullType": "databroker.TransactionStreamRequest",
+              "requestStreaming": true,
+              "responseType": "TransactionStreamResponse",
+              "responseLongType": "TransactionStreamResponse",
+              "responseFullType": "databroker.TransactionStreamResponse",
               "responseStreaming": true
             }
           ]

--- a/pkg/grpc/databroker/databroker.pb.json
+++ b/pkg/grpc/databroker/databroker.pb.json
@@ -101,10 +101,23 @@
           "fullName": "databroker.BeginTransactionResponse",
           "description": "",
           "hasExtensions": false,
-          "hasFields": false,
+          "hasFields": true,
           "hasOneofs": false,
           "extensions": [],
-          "fields": []
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
         },
         {
           "name": "Checkpoint",
@@ -184,10 +197,23 @@
           "fullName": "databroker.CommitTransaction",
           "description": "",
           "hasExtensions": false,
-          "hasFields": false,
+          "hasFields": true,
           "hasOneofs": false,
           "extensions": [],
-          "fields": []
+          "fields": [
+            {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
         },
         {
           "name": "CommitTransactionResponse",
@@ -200,8 +226,20 @@
           "extensions": [],
           "fields": [
             {
+              "name": "key",
+              "description": "",
+              "label": "",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
               "name": "shared",
-              "description": "shared is true when these results come from a concurrent transaction for the\nsame key. The transactions that were shared never ran operations themselves.",
+              "description": "shared is true when these results come from a concurrent transaction for the\nsame key that shares results, like singleflight transactions.\nThe transactions that were shared never ran operations themselves.",
               "label": "",
               "type": "bool",
               "longType": "bool",

--- a/pkg/grpc/databroker/databroker.pb.json
+++ b/pkg/grpc/databroker/databroker.pb.json
@@ -201,7 +201,7 @@
           "fields": [
             {
               "name": "shared",
-              "description": "shared is true when this transaction was suppressed by a concurrent one for the\nsame key: nothing submitted after `begin` was applied.",
+              "description": "shared is true when these results come from a concurrent transaction for the\nsame key. The transactions that were shared never ran operations themselves.",
               "label": "",
               "type": "bool",
               "longType": "bool",
@@ -213,7 +213,7 @@
             },
             {
               "name": "records",
-              "description": "records holds the records written by the committed transaction, in submission\norder. When shared is true these are the records written by the transaction\nwhich suppressed this one.",
+              "description": "records that were changed during this transaction.",
               "label": "repeated",
               "type": "Record",
               "longType": "Record",
@@ -1753,7 +1753,7 @@
             },
             {
               "name": "Transaction",
-              "description": "Transaction opens a transaction. \nTransaction is used for synchronizing one-time read and update Operations\nthat require atomic updates.\nThe stream's lifetime is the transaction's lifetime.\nThe first message must be `begin`, the last must be `commit`, and a\nstream that ends any other way rolls back. Operations are atomic but not\nisolated, and there is no conflict handling for concurrent updates not wrapped\nwith the same transaction key. \nConcurrent transactions are singleflight; sharing a key waits for the first transaction\nto finish with its result, and get the same result.",
+              "description": "Transaction opens a transaction.\nTransaction is used for synchronizing one-time read and update Operations\nthat require atomic updates.\nThe stream's lifetime is the transaction's lifetime.\nThe first message must be `begin`, the last must be `commit`, and a\nstream that ends any other way rolls back. Operations are atomic but not\nisolated, and there is no conflict handling for concurrent updates not wrapped\nwith the same transaction key.\nConcurrent transactions are singleflight; sharing a key waits for the first transaction\nto finish with its result, and get the same result.",
               "requestType": "TransactionStreamRequest",
               "requestLongType": "TransactionStreamRequest",
               "requestFullType": "databroker.TransactionStreamRequest",

--- a/pkg/grpc/databroker/databroker.proto
+++ b/pkg/grpc/databroker/databroker.proto
@@ -257,9 +257,13 @@ message BeginTransaction {
   string key = 1;
 }
 
-message BeginTransactionResponse {}
+message BeginTransactionResponse {
+  string key = 1;
+}
 
-message CommitTransaction {}
+message CommitTransaction {
+  string key = 1;
+}
 
 message TransactionRequest {
   string key = 1;
@@ -293,11 +297,13 @@ message TransactionResponse {
 }
 
 message CommitTransactionResponse {
+  string key = 1;
   // shared is true when these results come from a concurrent transaction for the
-  // same key. The transactions that were shared never ran operations themselves.
-  bool shared = 1;
+  // same key that shares results, like singleflight transactions.
+  // The transactions that were shared never ran operations themselves.
+  bool shared = 2;
   // records that were changed during this transaction.
-  repeated Record records = 2;
+  repeated Record records = 3;
 }
 
 

--- a/pkg/grpc/databroker/databroker.proto
+++ b/pkg/grpc/databroker/databroker.proto
@@ -221,7 +221,45 @@ service DataBrokerService {
   rpc Sync(SyncRequest) returns (stream SyncResponse);
   // SyncLatest streams the latest version of every record.
   rpc SyncLatest(SyncLatestRequest) returns (stream SyncLatestResponse);
+  // Transaction opens a transaction. 
+  // Transaction is used for synchronizing one-time read and update Operations
+  // that require atomic updates.
+  // The stream's lifetime is the transaction's lifetime.
+  // The first message must be `begin`, the last must be `commit`, and a
+  // stream that ends any other way rolls back. Operations are atomic but not
+  // isolated, and there is no conflict handling for concurrent updates not wrapped
+  // with the same transaction key. 
+  // Concurrent transactions are singleflight; sharing a key waits for the first transaction
+  // to finish with its result, and get the same result.
+  rpc Transaction(stream TransactionStreamRequest) returns (stream TransactionStreamResponse);
 }
+
+message TransactionStreamRequest {
+  // sequence is echoed on the matching response.
+  uint64 sequence = 1;
+  oneof message {
+    BeginTransaction   begin     = 2;
+    TransactionRequest operation = 3;
+    CommitTransaction  commit    = 4;
+  }
+}
+
+message TransactionStreamResponse {
+  uint64 sequence = 1;
+  oneof message {
+    TransactionResponse       operation = 2;
+    CommitTransactionResponse commit    = 3;
+    BeginTransactionResponse  begin     = 4;
+  }
+}
+
+message BeginTransaction {
+  string key = 1;
+}
+
+message BeginTransactionResponse {}
+
+message CommitTransaction {}
 
 message TransactionRequest {
   string key = 1;
@@ -242,6 +280,15 @@ message TransactionResponse {
     QueryResponse query = 5;
   }
 }
+
+message CommitTransactionResponse {
+  // shared is true when these results come from a concurrent transaction for the
+  // same key. The transactions that were shared never ran operations themselves.
+  bool shared = 1;
+  // records that were changed during this transaction.
+  repeated Record records = 2;
+}
+
 
 message Checkpoint {
   uint64 server_version = 1;

--- a/pkg/grpc/databroker/databroker.proto
+++ b/pkg/grpc/databroker/databroker.proto
@@ -221,14 +221,14 @@ service DataBrokerService {
   rpc Sync(SyncRequest) returns (stream SyncResponse);
   // SyncLatest streams the latest version of every record.
   rpc SyncLatest(SyncLatestRequest) returns (stream SyncLatestResponse);
-  // Transaction opens a transaction. 
+  // Transaction opens a transaction.
   // Transaction is used for synchronizing one-time read and update Operations
   // that require atomic updates.
   // The stream's lifetime is the transaction's lifetime.
   // The first message must be `begin`, the last must be `commit`, and a
   // stream that ends any other way rolls back. Operations are atomic but not
   // isolated, and there is no conflict handling for concurrent updates not wrapped
-  // with the same transaction key. 
+  // with the same transaction key.
   // Concurrent transactions are singleflight; sharing a key waits for the first transaction
   // to finish with its result, and get the same result.
   rpc Transaction(stream TransactionStreamRequest) returns (stream TransactionStreamResponse);

--- a/pkg/grpc/databroker/databroker.proto
+++ b/pkg/grpc/databroker/databroker.proto
@@ -247,9 +247,9 @@ message TransactionStreamRequest {
 message TransactionStreamResponse {
   uint64 sequence = 1;
   oneof message {
-    TransactionResponse       operation = 2;
-    CommitTransactionResponse commit    = 3;
-    BeginTransactionResponse  begin     = 4;
+    TransactionResponseWithError  operation = 2;
+    CommitTransactionResponse     commit    = 3;
+    BeginTransactionResponse      begin     = 4;
   }
 }
 
@@ -269,6 +269,17 @@ message TransactionRequest {
     PatchRequest patch = 4;
     QueryRequest query = 5;
   }
+}
+
+message TransactionResponseWithError {
+  TransactionResponse response   = 1;
+  RPCStatus err = 2;
+}
+
+// mirrors "google/rpc/status.proto"'s relevant fields
+message RPCStatus {
+  int32 code = 1;
+  string message = 2;
 }
 
 message TransactionResponse {

--- a/pkg/grpc/databroker/databroker_grpc.pb.go
+++ b/pkg/grpc/databroker/databroker_grpc.pb.go
@@ -34,6 +34,7 @@ const (
 	DataBrokerService_SetOptions_FullMethodName   = "/databroker.DataBrokerService/SetOptions"
 	DataBrokerService_Sync_FullMethodName         = "/databroker.DataBrokerService/Sync"
 	DataBrokerService_SyncLatest_FullMethodName   = "/databroker.DataBrokerService/SyncLatest"
+	DataBrokerService_Transaction_FullMethodName  = "/databroker.DataBrokerService/Transaction"
 )
 
 // DataBrokerServiceClient is the client API for DataBrokerService service.
@@ -70,6 +71,17 @@ type DataBrokerServiceClient interface {
 	Sync(ctx context.Context, in *SyncRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SyncResponse], error)
 	// SyncLatest streams the latest version of every record.
 	SyncLatest(ctx context.Context, in *SyncLatestRequest, opts ...grpc.CallOption) (grpc.ServerStreamingClient[SyncLatestResponse], error)
+	// Transaction opens a transaction.
+	// Transaction is used for synchronizing one-time read and update Operations
+	// that require atomic updates.
+	// The stream's lifetime is the transaction's lifetime.
+	// The first message must be `begin`, the last must be `commit`, and a
+	// stream that ends any other way rolls back. Operations are atomic but not
+	// isolated, and there is no conflict handling for concurrent updates not wrapped
+	// with the same transaction key.
+	// Concurrent transactions are singleflight; sharing a key waits for the first transaction
+	// to finish with its result, and get the same result.
+	Transaction(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TransactionStreamRequest, TransactionStreamResponse], error)
 }
 
 type dataBrokerServiceClient struct {
@@ -238,6 +250,19 @@ func (c *dataBrokerServiceClient) SyncLatest(ctx context.Context, in *SyncLatest
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type DataBrokerService_SyncLatestClient = grpc.ServerStreamingClient[SyncLatestResponse]
 
+func (c *dataBrokerServiceClient) Transaction(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TransactionStreamRequest, TransactionStreamResponse], error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	stream, err := c.cc.NewStream(ctx, &DataBrokerService_ServiceDesc.Streams[2], DataBrokerService_Transaction_FullMethodName, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	x := &grpc.GenericClientStream[TransactionStreamRequest, TransactionStreamResponse]{ClientStream: stream}
+	return x, nil
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DataBrokerService_TransactionClient = grpc.BidiStreamingClient[TransactionStreamRequest, TransactionStreamResponse]
+
 // DataBrokerServiceServer is the server API for DataBrokerService service.
 // All implementations should embed UnimplementedDataBrokerServiceServer
 // for forward compatibility.
@@ -272,6 +297,17 @@ type DataBrokerServiceServer interface {
 	Sync(*SyncRequest, grpc.ServerStreamingServer[SyncResponse]) error
 	// SyncLatest streams the latest version of every record.
 	SyncLatest(*SyncLatestRequest, grpc.ServerStreamingServer[SyncLatestResponse]) error
+	// Transaction opens a transaction.
+	// Transaction is used for synchronizing one-time read and update Operations
+	// that require atomic updates.
+	// The stream's lifetime is the transaction's lifetime.
+	// The first message must be `begin`, the last must be `commit`, and a
+	// stream that ends any other way rolls back. Operations are atomic but not
+	// isolated, and there is no conflict handling for concurrent updates not wrapped
+	// with the same transaction key.
+	// Concurrent transactions are singleflight; sharing a key waits for the first transaction
+	// to finish with its result, and get the same result.
+	Transaction(grpc.BidiStreamingServer[TransactionStreamRequest, TransactionStreamResponse]) error
 }
 
 // UnimplementedDataBrokerServiceServer should be embedded to have
@@ -322,6 +358,9 @@ func (UnimplementedDataBrokerServiceServer) Sync(*SyncRequest, grpc.ServerStream
 }
 func (UnimplementedDataBrokerServiceServer) SyncLatest(*SyncLatestRequest, grpc.ServerStreamingServer[SyncLatestResponse]) error {
 	return status.Error(codes.Unimplemented, "method SyncLatest not implemented")
+}
+func (UnimplementedDataBrokerServiceServer) Transaction(grpc.BidiStreamingServer[TransactionStreamRequest, TransactionStreamResponse]) error {
+	return status.Error(codes.Unimplemented, "method Transaction not implemented")
 }
 func (UnimplementedDataBrokerServiceServer) testEmbeddedByValue() {}
 
@@ -581,6 +620,13 @@ func _DataBrokerService_SyncLatest_Handler(srv interface{}, stream grpc.ServerSt
 // This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
 type DataBrokerService_SyncLatestServer = grpc.ServerStreamingServer[SyncLatestResponse]
 
+func _DataBrokerService_Transaction_Handler(srv interface{}, stream grpc.ServerStream) error {
+	return srv.(DataBrokerServiceServer).Transaction(&grpc.GenericServerStream[TransactionStreamRequest, TransactionStreamResponse]{ServerStream: stream})
+}
+
+// This type alias is provided for backwards compatibility with existing code that references the prior non-generic stream type by name.
+type DataBrokerService_TransactionServer = grpc.BidiStreamingServer[TransactionStreamRequest, TransactionStreamResponse]
+
 // DataBrokerService_ServiceDesc is the grpc.ServiceDesc for DataBrokerService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -647,6 +693,12 @@ var DataBrokerService_ServiceDesc = grpc.ServiceDesc{
 			StreamName:    "SyncLatest",
 			Handler:       _DataBrokerService_SyncLatest_Handler,
 			ServerStreams: true,
+		},
+		{
+			StreamName:    "Transaction",
+			Handler:       _DataBrokerService_Transaction_Handler,
+			ServerStreams: true,
+			ClientStreams: true,
 		},
 	},
 	Metadata: "databroker.proto",

--- a/pkg/grpc/databroker/mock_databroker/databroker.pb.go
+++ b/pkg/grpc/databroker/mock_databroker/databroker.pb.go
@@ -323,6 +323,26 @@ func (mr *MockDataBrokerServiceClientMockRecorder) SyncLatest(ctx, in any, opts 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncLatest", reflect.TypeOf((*MockDataBrokerServiceClient)(nil).SyncLatest), varargs...)
 }
 
+// Transaction mocks base method.
+func (m *MockDataBrokerServiceClient) Transaction(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[databroker.TransactionStreamRequest, databroker.TransactionStreamResponse], error) {
+	m.ctrl.T.Helper()
+	varargs := []any{ctx}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Transaction", varargs...)
+	ret0, _ := ret[0].(grpc.BidiStreamingClient[databroker.TransactionStreamRequest, databroker.TransactionStreamResponse])
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Transaction indicates an expected call of Transaction.
+func (mr *MockDataBrokerServiceClientMockRecorder) Transaction(ctx any, opts ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{ctx}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transaction", reflect.TypeOf((*MockDataBrokerServiceClient)(nil).Transaction), varargs...)
+}
+
 // MockDataBrokerServiceServer is a mock of DataBrokerServiceServer interface.
 type MockDataBrokerServiceServer struct {
 	ctrl     *gomock.Controller
@@ -553,6 +573,20 @@ func (m *MockDataBrokerServiceServer) SyncLatest(arg0 *databroker.SyncLatestRequ
 func (mr *MockDataBrokerServiceServerMockRecorder) SyncLatest(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SyncLatest", reflect.TypeOf((*MockDataBrokerServiceServer)(nil).SyncLatest), arg0, arg1)
+}
+
+// Transaction mocks base method.
+func (m *MockDataBrokerServiceServer) Transaction(arg0 grpc.BidiStreamingServer[databroker.TransactionStreamRequest, databroker.TransactionStreamResponse]) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Transaction", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Transaction indicates an expected call of Transaction.
+func (mr *MockDataBrokerServiceServerMockRecorder) Transaction(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Transaction", reflect.TypeOf((*MockDataBrokerServiceServer)(nil).Transaction), arg0)
 }
 
 // MockUnsafeDataBrokerServiceServer is a mock of UnsafeDataBrokerServiceServer interface.

--- a/pkg/grpcutil/forward.go
+++ b/pkg/grpcutil/forward.go
@@ -107,6 +107,62 @@ func ForwardStream[Res any, Req any](
 	})
 }
 
+// ForwardBidiStream takes a bidirectional server stream and copies it to a
+// bidirectional client stream.
+func ForwardBidiStream[Req any, Res any](
+	forwarder Forwarder,
+	serverStream grpc.BidiStreamingServer[Req, Res],
+	getClientStream func(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[Req, Res], error),
+	opts ...grpc.CallOption,
+) error {
+	return forwarder.Forward(serverStream.Context(), func(ctx context.Context) error {
+		ctx, cancel := context.WithCancelCause(ctx)
+		defer cancel(nil)
+
+		clientStream, err := getClientStream(ctx, opts...)
+		if err != nil {
+			return err
+		}
+
+		// copy requests from the server stream to the client stream
+		go func() {
+			for {
+				msg, err := serverStream.Recv()
+				if errors.Is(err, io.EOF) {
+					if err := clientStream.CloseSend(); err != nil {
+						cancel(err)
+					}
+					return
+				} else if err != nil {
+					cancel(err)
+					return
+				}
+
+				err = clientStream.Send(msg)
+				if err != nil {
+					cancel(err)
+					return
+				}
+			}
+		}()
+
+		// copy responses from the client stream to the server stream
+		for {
+			msg, err := clientStream.Recv()
+			if errors.Is(err, io.EOF) {
+				return nil
+			} else if err != nil {
+				return errors.Join(err, context.Cause(ctx))
+			}
+
+			err = serverStream.Send(msg)
+			if err != nil {
+				return err
+			}
+		}
+	})
+}
+
 // ForwardUnary forwards a unary request to a gRPC client.
 func ForwardUnary[Res any, Req any](
 	ctx context.Context,


### PR DESCRIPTION
## Summary

Bi-directional stream abstraction over a storage backend's DoTransaction callback.

The protocol accepts requests from the client of 3 types:
- begin : initiate the singleflight request. 
  - If this stream owns the callback, the server responds with a begin message. 
  - Otherwise the server is expected to respond with the commit message with the (changed records, error).
- operation : a storage operation to be run in the singleflight callback. They are atomic with respect to the transaction callback. One of `get`, `put`, `patch`, `query` operations.
- commit : ends this transaction. no more operations can be submitted.

The server expects a begin message to be sent first and a commit message to be sent last.

## Related issues

[RFC-Databroker-singleflight](https://app.notion.com/p/pomerium/RFC-Databroker-singleflight-3b158e156c55802b820fffb6a3bdd39f)

## User Explanation

N/A

## AI disclosure

opus 5 was used to refactor  `TestDatabrokerTransactions` into a shape that could accept a forwarded client.

```go
func TestDatabrokerTransactions(t *testing.T) {
	t.Parallel()

	setups := []struct {
		name       string
		newServers transactionServersFunc
	}{
		{"backend", newBackendServers},
		{"clustered follower", newFollowerServers},
	}
	for _, setup := range setups {
		t.Run(setup.name, func(t *testing.T) {
			testTransactions(t, setup.newServers)
		})
	}
}
```

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>