### PR TITLE
feat(databrokerutil): singleflight wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,3 +106,4 @@ gha-creds-*.json
 # tcpdump captures
 *.pcap
 *.pcapng
+*.out

--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,6 @@ gha-creds-*.json
 # tcpdump captures
 *.pcap
 *.pcapng
+# benchmark results
 *.out
+*.pprof

--- a/pkg/databrokerutil/Makefile
+++ b/pkg/databrokerutil/Makefile
@@ -1,0 +1,45 @@
+# Usage:
+#   make bench STORAGE=mem TESTCASE=concurrent_conflicting [CONC=4] [BENCHTIME=10x] [EXTRA=synchronous_commit]
+#
+# STORAGE:  mem | file | postgres
+# TESTCASE: concurrent_maybe_conflicting | concurrent_conflicting | concurrent_non-conflicting | all
+# CONC:     concurrency suffix (conc-N) | all | empty for a single combined run
+# BENCHTIME: passed to -benchtime
+# EXTRA:    optional annotation inserted in output file names
+
+STORAGE ?= mem
+TESTCASE ?= concurrent_conflicting
+CONC ?=
+BENCHTIME ?= 30s
+EXTRA ?=
+
+TESTCASES := concurrent_maybe_conflicting concurrent_conflicting concurrent_non-conflicting
+CONCS := 2 4 8
+
+NAME := $(STORAGE)$(if $(EXTRA),_$(EXTRA),)_$(TESTCASE)$(if $(CONC),_conc-$(CONC),)
+BENCH := ^BenchmarkSingleFlight$$/^$(STORAGE)$$/^conc-$(if $(CONC),$(CONC),[0-9]+)$$/^$(TESTCASE)$$
+
+.PHONY: bench
+ifeq ($(TESTCASE),all)
+bench:
+	@for tc in $(TESTCASES); do \
+		$(MAKE) --no-print-directory bench TESTCASE=$$tc CONC=$(CONC) EXTRA=$(EXTRA) || exit 1; \
+	done
+else ifeq ($(CONC),all)
+bench:
+	@for c in $(CONCS); do \
+		$(MAKE) --no-print-directory bench TESTCASE=$(TESTCASE) CONC=$$c EXTRA=$(EXTRA) || exit 1; \
+	done
+else
+bench:
+	go test -run '^$$' -bench '$(BENCH)' -benchtime=$(BENCHTIME) -benchmem \
+		-cpuprofile=$(NAME).cpu.out \
+		-memprofile=$(NAME).mem.out \
+		-trace=$(NAME).trace.out \
+		-o $(NAME).test \
+		. | tee $(NAME).out
+endif
+
+.PHONY: clean
+clean:
+	rm -f *.cpu.out *.mem.out *.trace.out *.test *.out

--- a/pkg/databrokerutil/Makefile.bench
+++ b/pkg/databrokerutil/Makefile.bench
@@ -1,5 +1,5 @@
 # Usage:
-#   make bench STORAGE=mem TESTCASE=concurrent_conflicting [CONC=4] [BENCHTIME=10x] [EXTRA=synchronous_commit]
+#   make -f Makefile.bench bench STORAGE=mem TESTCASE=concurrent_conflicting [CONC=4] [BENCHTIME=10x] [EXTRA=synchronous_commit]
 #
 # STORAGE:  mem | file | postgres
 # TESTCASE: concurrent_maybe_conflicting | concurrent_conflicting | concurrent_non-conflicting | all
@@ -33,8 +33,9 @@ bench:
 else
 bench:
 	go test -run '^$$' -bench '$(BENCH)' -benchtime=$(BENCHTIME) -benchmem \
-		-cpuprofile=$(NAME).cpu.out \
-		-memprofile=$(NAME).mem.out \
+		-cpuprofile=$(NAME).cpu.pprof \
+		-memprofile=$(NAME).mem.pprof \
+		-blockprofile=$(NAME).block.pprof \
 		-trace=$(NAME).trace.out \
 		-o $(NAME).test \
 		. | tee $(NAME).out
@@ -42,4 +43,4 @@ endif
 
 .PHONY: clean
 clean:
-	rm -f *.cpu.out *.mem.out *.trace.out *.test *.out
+	rm -f *.cpu.pprof *.mem.pprof *.block.pprof *.trace.out *.test *.out

--- a/pkg/databrokerutil/Makefile.bench
+++ b/pkg/databrokerutil/Makefile.bench
@@ -1,44 +1,66 @@
 # Usage:
-#   make -f Makefile.bench bench STORAGE=mem TESTCASE=concurrent_conflicting [CONC=4] [BENCHTIME=10x] [EXTRA=synchronous_commit]
+#   make -f Makefile.bench bench STORAGE=file TESTCASE=concurrent_conflicting [CONC=8] [TRANSPORT=tcp] [REPLICAS=3] [BENCHTIME=5s] [EXTRA=example]
 #
-# STORAGE:  mem | file | postgres
-# TESTCASE: concurrent_maybe_conflicting | concurrent_conflicting | concurrent_non-conflicting | all
-# CONC:     concurrency suffix (conc-N) | all | empty for a single combined run
+# STORAGE:   mem | file | postgres | all
+# TESTCASE:  concurrent | concurrent_conflicting | all
+# CONC:      -singleflight.concurrency, in-flight transactions per round
+# TRANSPORT: bufconn | tcp | all
+# REPLICAS:  -singleflight.replicas, servers per cluster | all
 # BENCHTIME: passed to -benchtime
-# EXTRA:    optional annotation inserted in output file names
+# EXTRA:     optional annotation inserted in output file names
 
 STORAGE ?= mem
 TESTCASE ?= concurrent_conflicting
-CONC ?=
+CONC ?= 8
+TRANSPORT ?= bufconn
+REPLICAS ?= 1
 BENCHTIME ?= 30s
 EXTRA ?=
 
-TESTCASES := concurrent_maybe_conflicting concurrent_conflicting concurrent_non-conflicting
-CONCS := 2 4 8
+STORAGES := mem file postgres
+TESTCASES := concurrent concurrent_conflicting
+TRANSPORTS := bufconn tcp
+REPLICA_COUNTS := 1 3
 
-NAME := $(STORAGE)$(if $(EXTRA),_$(EXTRA),)_$(TESTCASE)$(if $(CONC),_conc-$(CONC),)
-BENCH := ^BenchmarkSingleFlight$$/^$(STORAGE)$$/^conc-$(if $(CONC),$(CONC),[0-9]+)$$/^$(TESTCASE)$$
+BENCHFUNC_concurrent := BenchmarkSingleFlight_Concurrent
+BENCHFUNC_concurrent_conflicting := BenchmarkSingleFlight_ConcurrentConflicting
+BENCHFUNC := $(BENCHFUNC_$(TESTCASE))
+
+NAME := $(STORAGE)_$(TRANSPORT)_replicas-$(REPLICAS)_conc-$(CONC)$(if $(EXTRA),_$(EXTRA),)_$(TESTCASE)
+BENCH := ^$(BENCHFUNC)$$/^$(STORAGE)$$/^$(TRANSPORT)$$
+
+FANOUT = $(MAKE) --no-print-directory bench STORAGE=$(STORAGE) TESTCASE=$(TESTCASE) CONC=$(CONC) TRANSPORT=$(TRANSPORT) REPLICAS=$(REPLICAS) EXTRA=$(EXTRA) BENCHTIME=$(BENCHTIME)
 
 .PHONY: bench
 ifeq ($(TESTCASE),all)
 bench:
-	@for tc in $(TESTCASES); do \
-		$(MAKE) --no-print-directory bench TESTCASE=$$tc CONC=$(CONC) EXTRA=$(EXTRA) || exit 1; \
-	done
-else ifeq ($(CONC),all)
+	@for tc in $(TESTCASES); do $(FANOUT) TESTCASE=$$tc || exit 1; done
+else ifeq ($(STORAGE),all)
 bench:
-	@for c in $(CONCS); do \
-		$(MAKE) --no-print-directory bench TESTCASE=$(TESTCASE) CONC=$$c EXTRA=$(EXTRA) || exit 1; \
-	done
+	@for s in $(STORAGES); do $(FANOUT) STORAGE=$$s || exit 1; done
+else ifeq ($(TRANSPORT),all)
+bench:
+	@for tr in $(TRANSPORTS); do $(FANOUT) TRANSPORT=$$tr || exit 1; done
+else ifeq ($(REPLICAS),all)
+bench:
+	@for r in $(REPLICA_COUNTS); do $(FANOUT) REPLICAS=$$r || exit 1; done
+else
+ifeq ($(BENCHFUNC),)
+bench:
+	@echo "unknown TESTCASE=$(TESTCASE), expected one of: $(TESTCASES) all" >&2; exit 1
 else
 bench:
 	go test -run '^$$' -bench '$(BENCH)' -benchtime=$(BENCHTIME) -benchmem \
+		-singleflight.transport=$(TRANSPORT) \
+		-singleflight.replicas=$(REPLICAS) \
+		-singleflight.concurrency=$(CONC) \
 		-cpuprofile=$(NAME).cpu.pprof \
 		-memprofile=$(NAME).mem.pprof \
 		-blockprofile=$(NAME).block.pprof \
 		-trace=$(NAME).trace.out \
 		-o $(NAME).test \
 		. | tee $(NAME).out
+endif
 endif
 
 .PHONY: clean

--- a/pkg/databrokerutil/singleflight.go
+++ b/pkg/databrokerutil/singleflight.go
@@ -21,10 +21,10 @@ var (
 	}
 )
 
-// StorageOperator submits storage operations during a singleflight operation to the databroker.
+// TX submits storage operations during a singleflight operation to the databroker.
 // It is safe for concurrent use, but operations are submitted sequentially to the underlying transaction.
 // When used concurrently, there is no guarantee on operation ordering.
-type StorageOperator interface {
+type TX interface {
 	Get(ctx context.Context, req *databroker.GetRequest) (resp *databroker.GetResponse, err error)
 	Put(ctx context.Context, req *databroker.PutRequest) (resp *databroker.PutResponse, err error)
 	Patch(ctx context.Context, req *databroker.PatchRequest) (resp *databroker.PatchResponse, err error)
@@ -46,7 +46,7 @@ func Do(
 	ctx context.Context,
 	client databroker.DataBrokerServiceClient,
 	key string,
-	work func(StorageOperator) error,
+	work func(TX) error,
 ) (changed []*databroker.Record, shared bool, err error) {
 	// rollback is expressed by ending the stream without a commit, so cancelling
 	// on every exit path both rolls back and unblocks the server handler
@@ -90,7 +90,11 @@ func Do(
 	commitSeq := op.Close()
 	err = stream.Send(&databroker.TransactionStreamRequest{
 		Sequence: commitSeq,
-		Message:  &databroker.TransactionStreamRequest_Commit{Commit: new(databroker.CommitTransaction)},
+		Message: &databroker.TransactionStreamRequest_Commit{
+			Commit: &databroker.CommitTransaction{
+				Key: key,
+			},
+		},
 	})
 	if err != nil {
 		if errors.Is(err, io.EOF) {

--- a/pkg/databrokerutil/singleflight.go
+++ b/pkg/databrokerutil/singleflight.go
@@ -4,199 +4,342 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"sync"
 
-	"google.golang.org/protobuf/types/known/fieldmaskpb"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 )
 
-var ErrTransactionClosed = errors.New("databrokerutil: transaction is closed")
+var (
+	ErrTransactionClosed  = errors.New("databrokerutil: transaction is closed")
+	ErrTransactionAborted = func(err error) error {
+		return status.Error(codes.Aborted, fmt.Sprintf("databrokerutil: transaction stream closed before commit : %s", err))
+	}
+)
 
-// Transaction is not safe for concurrent use: the underlying stream is a strict
-// request/response ping-pong.
-type Transaction func(
-	*databroker.TransactionRequest,
-) (*databroker.TransactionResponse, error)
+// StorageOperator submits storage operations during a singleflight operation to the databroker.
+// It is safe for concurrent use, but operations are submitted sequentially to the underlying transaction.
+// When used concurrently, there is no guarantee on operation ordering.
+type StorageOperator interface {
+	Get(ctx context.Context, req *databroker.GetRequest) (resp *databroker.GetResponse, err error)
+	Put(ctx context.Context, req *databroker.PutRequest) (resp *databroker.PutResponse, err error)
+	Patch(ctx context.Context, req *databroker.PatchRequest) (resp *databroker.PatchResponse, err error)
+	Query(ctx context.Context, req *databroker.QueryRequest) (resp *databroker.QueryResponse, err error)
+}
 
-// Do runs work inside a databroker transaction keyed by key.
-//
-// If work returns nil the transaction is committed; if it returns an error the
-// transaction is rolled back and that error is returned.
-//
-// Transactions are singleflight by key: if another transaction for the same key
-// is already in flight, work is not called and Do reports shared=true after the
-// in-flight transaction finishes.
+type transactionClient = grpc.BidiStreamingClient[databroker.TransactionStreamRequest, databroker.TransactionStreamResponse]
+
+// Do runs a distributed singleflight callback on storage operations inside the databroker.
+// Returning an error inside the callback rollsback all submitted storage operations.
+// Storage operations are only persisted on success.
+// Error handling:
+//   - `FailedPrecondition`: protocol errors, should not be retried.
+//   - `Aborted`: connectivity errors to the databroker during the singleflight, can be retried.
+//   - `DeadlineExceeded` : transaction exceeded the alloted time set by the server, can be retried.
+//   - `Internal`: storage errors related to locking mechanisms, persistence and other internal
+//     failures that can cause the singleflight to fail.
 func Do(
 	ctx context.Context,
 	client databroker.DataBrokerServiceClient,
 	key string,
-	work func(Transaction) error,
-) (shared bool, err error) {
+	work func(StorageOperator) error,
+) (changed []*databroker.Record, shared bool, err error) {
 	// rollback is expressed by ending the stream without a commit, so cancelling
-	// on every exit path both rolls back and unblocks the server handler. A
-	// deliberate rollback therefore shows up as a cancelled RPC server-side.
+	// on every exit path both rolls back and unblocks the server handler
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	stream, err := client.Transaction(ctx)
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
 
-	var seq uint64
-	next := func() uint64 {
-		seq++
-		return seq
-	}
-
-	err = stream.Send(&databroker.TransactionStreamRequest{
-		Sequence: next(),
-		Message: &databroker.TransactionStreamRequest_Begin{
-			Begin: &databroker.BeginTransaction{Key: key},
-		},
-	})
+	seq := uint64(1)
+	res, err := initiateHandshake(stream, seq, key)
 	if err != nil {
-		return false, err
+		if _, ok := status.FromError(err); !ok {
+			return nil, false, status.Error(codes.FailedPrecondition, fmt.Sprintf("databrokerutil: failed to initiate singleflight handshake : %s", err))
+		}
+		return nil, false, err
 	}
-
-	res, err := stream.Recv()
-	if err != nil {
-		return false, err
-	}
-	// a suppressed transaction is never acked: the first and only message is the commit
+	// a shared transaction is never acked: the first and only message is the commit
 	if commit := res.GetCommit(); commit != nil {
-		return commit.GetShared(), nil
+		return res.GetCommit().GetRecords(), commit.GetShared(), nil
 	}
 	if res.GetBegin() == nil {
-		return false, fmt.Errorf("databrokerutil: expected a begin response, got %T", res.GetMessage())
+		return nil, false, status.Error(codes.FailedPrecondition, fmt.Sprintf("databrokerutil: expected a begin response, got %T", res.GetMessage()))
 	}
 
-	var mu sync.Mutex
-	var done bool
-	var submitErr error // the first transport error should be treated as the transaction failing
-	tx := func(op *databroker.TransactionRequest) (*databroker.TransactionResponse, error) {
-		mu.Lock()
-		defer mu.Unlock()
-
-		if done {
-			return nil, ErrTransactionClosed
-		}
-		if submitErr != nil {
-			return nil, submitErr
-		}
-
-		err := stream.Send(&databroker.TransactionStreamRequest{
-			Sequence: next(),
-			Message:  &databroker.TransactionStreamRequest_Operation{Operation: op},
-		})
-		if err != nil {
-			submitErr = err
-			return nil, err
-		}
-
-		res, err := stream.Recv()
-		if err != nil {
-			submitErr = err
-			return nil, err
-		}
-		if res.GetOperation() == nil {
-			submitErr = fmt.Errorf("databrokerutil: expected an operation response, got %T", res.GetMessage())
-			return nil, submitErr
-		}
-		return res.GetOperation(), nil
-	}
-	defer func() {
-		mu.Lock()
-		done = true
-		mu.Unlock()
-	}()
-
-	if err := work(tx); err != nil {
-		// the stream error after a rollback is always context.Canceled and carries
-		// no information, so the caller's error is what's worth returning
-		return false, err
-	}
-	if submitErr != nil {
-		return false, submitErr
+	op := &storageOperatorStream{
+		sequenceNum: seq + 1,
+		key:         key,
+		stream:      stream,
 	}
 
+	if err := work(op); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, false, ErrTransactionAborted(err)
+		}
+		return nil, false, err
+	}
+
+	commitSeq := op.Close()
 	err = stream.Send(&databroker.TransactionStreamRequest{
-		Sequence: next(),
+		Sequence: commitSeq,
 		Message:  &databroker.TransactionStreamRequest_Commit{Commit: new(databroker.CommitTransaction)},
 	})
 	if err != nil {
-		return false, err
+		if errors.Is(err, io.EOF) {
+			return nil, false, ErrTransactionAborted(err)
+		}
+		return nil, false, err
 	}
-
 	res, err = stream.Recv()
 	if err != nil {
-		return false, err
+		return nil, false, err
 	}
 	if res.GetCommit() == nil {
-		return false, fmt.Errorf("databrokerutil: expected a commit response, got %T", res.GetMessage())
+		return nil, false, status.Error(codes.FailedPrecondition, fmt.Sprintf("databrokerutil: expected a commit response, got %T", res.GetMessage()))
 	}
-	return res.GetCommit().GetShared(), nil
+	return res.GetCommit().GetRecords(), res.GetCommit().GetShared(), nil
 }
 
-// Get submits a get operation.
-func (tx Transaction) Get(recordType, id string) (*databroker.GetResponse, error) {
-	res, err := tx(&databroker.TransactionRequest{
-		Operation: &databroker.TransactionRequest_Get{
-			Get: &databroker.GetRequest{Type: recordType, Id: id},
+func initiateHandshake(
+	stream transactionClient,
+	sequence uint64,
+	key string,
+) (*databroker.TransactionStreamResponse, error) {
+	if err := stream.Send(&databroker.TransactionStreamRequest{
+		Sequence: sequence,
+		Message: &databroker.TransactionStreamRequest_Begin{
+			Begin: &databroker.BeginTransaction{Key: key},
 		},
-	})
-	if err != nil {
+	}); err != nil {
 		return nil, err
 	}
-	if res.GetGet() == nil {
-		return nil, fmt.Errorf("databrokerutil: expected a get response, got %T", res.GetOperation())
-	}
-	return res.GetGet(), nil
+
+	res, err := stream.Recv()
+	return res, err
 }
 
-// Put submits a put operation.
-func (tx Transaction) Put(records ...*databroker.Record) (*databroker.PutResponse, error) {
-	res, err := tx(&databroker.TransactionRequest{
-		Operation: &databroker.TransactionRequest_Put{
-			Put: &databroker.PutRequest{Records: records},
+// assumes the begin handshake succeeded and we "own" the transaction.
+type storageOperatorStream struct {
+	key    string
+	stream transactionClient
+
+	sequenceNum uint64
+	mu          sync.Mutex
+	done        bool
+}
+
+func (s *storageOperatorStream) getSequenceNumLocked() uint64 {
+	s.sequenceNum++
+	return s.sequenceNum
+}
+
+func (s *storageOperatorStream) Get(_ context.Context, req *databroker.GetRequest) (*databroker.GetResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.isClosedLocked(); err != nil {
+		return nil, err
+	}
+	sequence := s.getSequenceNumLocked()
+	sendReq := &databroker.TransactionStreamRequest{
+		Sequence: sequence,
+		Message: &databroker.TransactionStreamRequest_Operation{
+			Operation: &databroker.TransactionRequest{
+				Key: s.key,
+				Operation: &databroker.TransactionRequest_Get{
+					Get: req,
+				},
+			},
 		},
-	})
+	}
+	if err := s.stream.Send(sendReq); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.stream.Recv()
 	if err != nil {
 		return nil, err
 	}
-	if res.GetPut() == nil {
-		return nil, fmt.Errorf("databrokerutil: expected a put response, got %T", res.GetOperation())
+	if err := s.validateResponse(sendReq, resp, sequence); err != nil {
+		return nil, err
 	}
-	return res.GetPut(), nil
+
+	if rpcErr := resp.GetOperation().Err; rpcErr != nil {
+		return nil, status.Error(codes.Code(rpcErr.GetCode()), rpcErr.GetMessage())
+	}
+
+	return resp.GetOperation().GetResponse().GetGet(), nil
 }
 
-// Patch submits a patch operation.
-func (tx Transaction) Patch(mask *fieldmaskpb.FieldMask, records ...*databroker.Record) (*databroker.PatchResponse, error) {
-	res, err := tx(&databroker.TransactionRequest{
-		Operation: &databroker.TransactionRequest_Patch{
-			Patch: &databroker.PatchRequest{FieldMask: mask, Records: records},
+func (s *storageOperatorStream) Put(_ context.Context, req *databroker.PutRequest) (*databroker.PutResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.isClosedLocked(); err != nil {
+		return nil, err
+	}
+	sequence := s.getSequenceNumLocked()
+	sendReq := &databroker.TransactionStreamRequest{
+		Sequence: sequence,
+		Message: &databroker.TransactionStreamRequest_Operation{
+			Operation: &databroker.TransactionRequest{
+				Key: s.key,
+				Operation: &databroker.TransactionRequest_Put{
+					Put: req,
+				},
+			},
 		},
-	})
+	}
+	if err := s.stream.Send(sendReq); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.stream.Recv()
 	if err != nil {
 		return nil, err
 	}
-	if res.GetPatch() == nil {
-		return nil, fmt.Errorf("databrokerutil: expected a patch response, got %T", res.GetOperation())
+	if err := s.validateResponse(sendReq, resp, sequence); err != nil {
+		return nil, err
 	}
-	return res.GetPatch(), nil
+
+	if rpcErr := resp.GetOperation().Err; rpcErr != nil {
+		return nil, status.Error(codes.Code(rpcErr.GetCode()), rpcErr.GetMessage())
+	}
+
+	return resp.GetOperation().GetResponse().GetPut(), nil
 }
 
-// Query submits a query operation.
-func (tx Transaction) Query(req *databroker.QueryRequest) (*databroker.QueryResponse, error) {
-	res, err := tx(&databroker.TransactionRequest{
-		Operation: &databroker.TransactionRequest_Query{Query: req},
-	})
+func (s *storageOperatorStream) Patch(_ context.Context, req *databroker.PatchRequest) (*databroker.PatchResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.isClosedLocked(); err != nil {
+		return nil, err
+	}
+	sequence := s.getSequenceNumLocked()
+	sendReq := &databroker.TransactionStreamRequest{
+		Sequence: sequence,
+		Message: &databroker.TransactionStreamRequest_Operation{
+			Operation: &databroker.TransactionRequest{
+				Key: s.key,
+				Operation: &databroker.TransactionRequest_Patch{
+					Patch: req,
+				},
+			},
+		},
+	}
+	if err := s.stream.Send(sendReq); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.stream.Recv()
 	if err != nil {
 		return nil, err
 	}
-	if res.GetQuery() == nil {
-		return nil, fmt.Errorf("databrokerutil: expected a query response, got %T", res.GetOperation())
+	if err := s.validateResponse(sendReq, resp, sequence); err != nil {
+		return nil, err
 	}
-	return res.GetQuery(), nil
+
+	if rpcErr := resp.GetOperation().Err; rpcErr != nil {
+		return nil, status.Error(codes.Code(rpcErr.GetCode()), rpcErr.GetMessage())
+	}
+
+	return resp.GetOperation().GetResponse().GetPatch(), nil
+}
+
+func (s *storageOperatorStream) Query(_ context.Context, req *databroker.QueryRequest) (*databroker.QueryResponse, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if err := s.isClosedLocked(); err != nil {
+		return nil, err
+	}
+	sequence := s.getSequenceNumLocked()
+	sendReq := &databroker.TransactionStreamRequest{
+		Sequence: sequence,
+		Message: &databroker.TransactionStreamRequest_Operation{
+			Operation: &databroker.TransactionRequest{
+				Key: s.key,
+				Operation: &databroker.TransactionRequest_Query{
+					Query: req,
+				},
+			},
+		},
+	}
+	if err := s.stream.Send(sendReq); err != nil {
+		return nil, err
+	}
+
+	resp, err := s.stream.Recv()
+	if err != nil {
+		return nil, err
+	}
+	if err := s.validateResponse(sendReq, resp, sequence); err != nil {
+		return nil, err
+	}
+
+	if rpcErr := resp.GetOperation().Err; rpcErr != nil {
+		return nil, status.Error(codes.Code(rpcErr.GetCode()), rpcErr.GetMessage())
+	}
+
+	return resp.GetOperation().GetResponse().GetQuery(), nil
+}
+
+func (s *storageOperatorStream) isClosedLocked() error {
+	if s.done {
+		return status.Error(codes.FailedPrecondition, "calling storage operations on a transaction that has been marked done")
+	}
+	return nil
+}
+
+func (s *storageOperatorStream) Close() uint64 {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.done = true
+	return s.sequenceNum
+}
+
+func (s *storageOperatorStream) validateResponse(
+	req *databroker.TransactionStreamRequest,
+	resp *databroker.TransactionStreamResponse,
+	sequence uint64,
+) error {
+	if resp.GetOperation() == nil {
+		return status.Error(codes.FailedPrecondition, "expected response to an operation from server")
+	}
+	if resp.GetSequence() != sequence {
+		return status.Error(codes.FailedPrecondition, "unexpected sequence gap in Transaction protocol")
+	}
+	if resp.GetOperation().Err == nil {
+		if err := checkOperationTypeMatch(req.GetOperation(), resp.GetOperation().GetResponse()); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func checkOperationTypeMatch(req *databroker.TransactionRequest, resp *databroker.TransactionResponse) error {
+	var ok bool
+	switch req.GetOperation().(type) {
+	case *databroker.TransactionRequest_Get:
+		ok = resp.GetGet() != nil
+	case *databroker.TransactionRequest_Put:
+		ok = resp.GetPut() != nil
+	case *databroker.TransactionRequest_Patch:
+		ok = resp.GetPatch() != nil
+	case *databroker.TransactionRequest_Query:
+		ok = resp.GetQuery() != nil
+	}
+	if !ok {
+		return status.Errorf(
+			codes.FailedPrecondition,
+			"unexpected operation type in Transaction protocol: requested %T, got %T",
+			req.GetOperation(), resp.GetOperation(),
+		)
+	}
+	return nil
 }

--- a/pkg/databrokerutil/singleflight.go
+++ b/pkg/databrokerutil/singleflight.go
@@ -48,6 +48,7 @@ func Do(
 	key string,
 	work func(TX) error,
 ) (changed []*databroker.Record, shared bool, err error) {
+
 	// rollback is expressed by ending the stream without a commit, so cancelling
 	// on every exit path both rolls back and unblocks the server handler
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/databrokerutil/singleflight.go
+++ b/pkg/databrokerutil/singleflight.go
@@ -48,7 +48,6 @@ func Do(
 	key string,
 	work func(TX) error,
 ) (changed []*databroker.Record, shared bool, err error) {
-
 	// rollback is expressed by ending the stream without a commit, so cancelling
 	// on every exit path both rolls back and unblocks the server handler
 	ctx, cancel := context.WithCancel(ctx)

--- a/pkg/databrokerutil/singleflight.go
+++ b/pkg/databrokerutil/singleflight.go
@@ -1,0 +1,202 @@
+package databrokerutil
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"google.golang.org/protobuf/types/known/fieldmaskpb"
+
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
+)
+
+var ErrTransactionClosed = errors.New("databrokerutil: transaction is closed")
+
+// Transaction is not safe for concurrent use: the underlying stream is a strict
+// request/response ping-pong.
+type Transaction func(
+	*databroker.TransactionRequest,
+) (*databroker.TransactionResponse, error)
+
+// Do runs work inside a databroker transaction keyed by key.
+//
+// If work returns nil the transaction is committed; if it returns an error the
+// transaction is rolled back and that error is returned.
+//
+// Transactions are singleflight by key: if another transaction for the same key
+// is already in flight, work is not called and Do reports shared=true after the
+// in-flight transaction finishes.
+func Do(
+	ctx context.Context,
+	client databroker.DataBrokerServiceClient,
+	key string,
+	work func(Transaction) error,
+) (shared bool, err error) {
+	// rollback is expressed by ending the stream without a commit, so cancelling
+	// on every exit path both rolls back and unblocks the server handler. A
+	// deliberate rollback therefore shows up as a cancelled RPC server-side.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	stream, err := client.Transaction(ctx)
+	if err != nil {
+		return false, err
+	}
+
+	var seq uint64
+	next := func() uint64 {
+		seq++
+		return seq
+	}
+
+	err = stream.Send(&databroker.TransactionStreamRequest{
+		Sequence: next(),
+		Message: &databroker.TransactionStreamRequest_Begin{
+			Begin: &databroker.BeginTransaction{Key: key},
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+
+	res, err := stream.Recv()
+	if err != nil {
+		return false, err
+	}
+	// a suppressed transaction is never acked: the first and only message is the commit
+	if commit := res.GetCommit(); commit != nil {
+		return commit.GetShared(), nil
+	}
+	if res.GetBegin() == nil {
+		return false, fmt.Errorf("databrokerutil: expected a begin response, got %T", res.GetMessage())
+	}
+
+	var mu sync.Mutex
+	var done bool
+	var submitErr error // the first transport error should be treated as the transaction failing
+	tx := func(op *databroker.TransactionRequest) (*databroker.TransactionResponse, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if done {
+			return nil, ErrTransactionClosed
+		}
+		if submitErr != nil {
+			return nil, submitErr
+		}
+
+		err := stream.Send(&databroker.TransactionStreamRequest{
+			Sequence: next(),
+			Message:  &databroker.TransactionStreamRequest_Operation{Operation: op},
+		})
+		if err != nil {
+			submitErr = err
+			return nil, err
+		}
+
+		res, err := stream.Recv()
+		if err != nil {
+			submitErr = err
+			return nil, err
+		}
+		if res.GetOperation() == nil {
+			submitErr = fmt.Errorf("databrokerutil: expected an operation response, got %T", res.GetMessage())
+			return nil, submitErr
+		}
+		return res.GetOperation(), nil
+	}
+	defer func() {
+		mu.Lock()
+		done = true
+		mu.Unlock()
+	}()
+
+	if err := work(tx); err != nil {
+		// the stream error after a rollback is always context.Canceled and carries
+		// no information, so the caller's error is what's worth returning
+		return false, err
+	}
+	if submitErr != nil {
+		return false, submitErr
+	}
+
+	err = stream.Send(&databroker.TransactionStreamRequest{
+		Sequence: next(),
+		Message:  &databroker.TransactionStreamRequest_Commit{Commit: new(databroker.CommitTransaction)},
+	})
+	if err != nil {
+		return false, err
+	}
+
+	res, err = stream.Recv()
+	if err != nil {
+		return false, err
+	}
+	if res.GetCommit() == nil {
+		return false, fmt.Errorf("databrokerutil: expected a commit response, got %T", res.GetMessage())
+	}
+	return res.GetCommit().GetShared(), nil
+}
+
+// Get submits a get operation.
+func (tx Transaction) Get(recordType, id string) (*databroker.GetResponse, error) {
+	res, err := tx(&databroker.TransactionRequest{
+		Operation: &databroker.TransactionRequest_Get{
+			Get: &databroker.GetRequest{Type: recordType, Id: id},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res.GetGet() == nil {
+		return nil, fmt.Errorf("databrokerutil: expected a get response, got %T", res.GetOperation())
+	}
+	return res.GetGet(), nil
+}
+
+// Put submits a put operation.
+func (tx Transaction) Put(records ...*databroker.Record) (*databroker.PutResponse, error) {
+	res, err := tx(&databroker.TransactionRequest{
+		Operation: &databroker.TransactionRequest_Put{
+			Put: &databroker.PutRequest{Records: records},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res.GetPut() == nil {
+		return nil, fmt.Errorf("databrokerutil: expected a put response, got %T", res.GetOperation())
+	}
+	return res.GetPut(), nil
+}
+
+// Patch submits a patch operation.
+func (tx Transaction) Patch(mask *fieldmaskpb.FieldMask, records ...*databroker.Record) (*databroker.PatchResponse, error) {
+	res, err := tx(&databroker.TransactionRequest{
+		Operation: &databroker.TransactionRequest_Patch{
+			Patch: &databroker.PatchRequest{FieldMask: mask, Records: records},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res.GetPatch() == nil {
+		return nil, fmt.Errorf("databrokerutil: expected a patch response, got %T", res.GetOperation())
+	}
+	return res.GetPatch(), nil
+}
+
+// Query submits a query operation.
+func (tx Transaction) Query(req *databroker.QueryRequest) (*databroker.QueryResponse, error) {
+	res, err := tx(&databroker.TransactionRequest{
+		Operation: &databroker.TransactionRequest_Query{Query: req},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if res.GetQuery() == nil {
+		return nil, fmt.Errorf("databrokerutil: expected a query response, got %T", res.GetOperation())
+	}
+	return res.GetQuery(), nil
+}

--- a/pkg/databrokerutil/singleflight_test.go
+++ b/pkg/databrokerutil/singleflight_test.go
@@ -159,6 +159,31 @@ func TestSingleflight(t *testing.T) {
 		assertExists(t, srv, "commit-2")
 	})
 
+	t.Run("operations return their underlying storage errors", func(t *testing.T) {
+		srv, client := newSingleflightServer(t)
+		changed, shared, err := databrokerutil.Do(t.Context(), client, "absent-check", func(tx databrokerutil.TX) error {
+			_, err := tx.Get(t.Context(), &databrokerpb.GetRequest{
+				Type: singleflightRecordType(),
+				Id:   "absent",
+			})
+			assert.Error(t, err)
+			assert.Equal(t, codes.NotFound, status.Code(err))
+
+			resp, err := tx.Put(t.Context(), &databrokerpb.PutRequest{
+				Records: []*databrokerpb.Record{
+					singleflightRecord("absent"),
+				},
+			})
+			assert.NoError(t, err)
+			assert.Equal(t, len(resp.GetRecords()), 1)
+			return nil
+		})
+		assert.NoError(t, err)
+		assert.False(t, shared)
+		assert.Equal(t, len(changed), 1)
+		assertExists(t, srv, "absent")
+	})
+
 	t.Run("read your writes", func(t *testing.T) {
 		_, client := newSingleflightServer(t)
 

--- a/pkg/databrokerutil/singleflight_test.go
+++ b/pkg/databrokerutil/singleflight_test.go
@@ -3,10 +3,13 @@ package databrokerutil_test
 import (
 	"context"
 	"errors"
+	"flag"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"runtime"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -20,8 +23,10 @@ import (
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pomerium/pomerium/config"
@@ -57,7 +62,7 @@ func fileStorage(t testing.TB) config.DataBrokerOptions {
 	}
 }
 
-// postgresStorage hands every server its own database on one shared container,
+// postgresStorage hands every cluster its own database on one shared container,
 // which startPostgres starts on first use and ties to the parent benchmark.
 func postgresStorage(startPostgres func() string) func(testing.TB) config.DataBrokerOptions {
 	var databases atomic.Int64
@@ -319,9 +324,78 @@ func TestSingleflight(t *testing.T) {
 	})
 }
 
-// wireCounter tallies gRPC payload bytes on the client connection. The
-// benchmarks run over bufconn, so this is protocol traffic rather than actual
-// syscall-level IO.
+func BenchmarkSingleFlight_Concurrent(b *testing.B) {
+	restore := log.GetLevel()
+	log.SetLevel(zerolog.Disabled)
+	b.Cleanup(func() { log.SetLevel(restore) })
+
+	transport := parseTransport(b)
+	replicas := parseReplicas(b)
+	concurrency := parseConcurrency(b)
+
+	startPostgres := sync.OnceValue(func() string { return testutil.StartPostgres(b) })
+
+	stores := []struct {
+		name    string
+		options func(testing.TB) config.DataBrokerOptions
+	}{
+		{"mem", memoryStorage},
+		{"file", fileStorage},
+		{"postgres", postgresStorage(startPostgres)},
+	}
+	for _, storage := range stores {
+		b.Run(storage.name, func(b *testing.B) {
+			b.Run(transport.String(), func(b *testing.B) {
+				benchmarkConcurrent(b, func(iter, worker int) string {
+					return fmt.Sprintf("non-conflicting-%d-%d", iter, worker)
+				}, benchmarkOptions{
+					storage:     storage.options,
+					replicas:    replicas,
+					transport:   transport,
+					concurrency: concurrency,
+				})
+			})
+		})
+	}
+}
+
+func BenchmarkSingleFlight_ConcurrentConflicting(b *testing.B) {
+	restore := log.GetLevel()
+	log.SetLevel(zerolog.Disabled)
+	b.Cleanup(func() { log.SetLevel(restore) })
+
+	transport := parseTransport(b)
+	replicas := parseReplicas(b)
+	concurrency := parseConcurrency(b)
+
+	startPostgres := sync.OnceValue(func() string { return testutil.StartPostgres(b) })
+
+	stores := []struct {
+		name    string
+		options func(testing.TB) config.DataBrokerOptions
+	}{
+		{"mem", memoryStorage},
+		{"file", fileStorage},
+		{"postgres", postgresStorage(startPostgres)},
+	}
+	for _, storage := range stores {
+		b.Run(storage.name, func(b *testing.B) {
+			b.Run(transport.String(), func(b *testing.B) {
+				benchmarkConflicting(b, func(iter, _ int) string {
+					return fmt.Sprintf("conflicting-%d", iter)
+				}, benchmarkOptions{
+					storage:     storage.options,
+					replicas:    replicas,
+					transport:   transport,
+					concurrency: concurrency,
+				})
+			})
+		})
+	}
+}
+
+// wireCounter tallies gRPC payload bytes on the connections it is attached to.
+// Under bufconn this is protocol traffic rather than syscall-level IO.
 type wireCounter struct {
 	in, out atomic.Int64
 }
@@ -344,19 +418,21 @@ func (c *wireCounter) HandleConn(context.Context, stats.ConnStats) {}
 type keyFunc func() string
 
 type benchmarkOptions struct {
-	storage func(testing.TB) config.DataBrokerOptions
-	work    func(keyFunc) func(op databrokerutil.TX) error
+	storage     func(testing.TB) config.DataBrokerOptions
+	work        func(keyFunc) func(op databrokerutil.TX) error
+	replicas    int
+	concurrency int
+	transport   grpcTransport
 }
 
 type singleflightBench struct {
-	b           *testing.B
-	ctx         context.Context
-	server      databroker.Server
-	client      databrokerpb.DataBrokerServiceClient
-	wire        *wireCounter
-	concurrency int
-	key         func(iter, worker int) string
-	work        func(keyFunc) func(op databrokerutil.TX) error
+	b             *testing.B
+	ctx           context.Context
+	cluster       *cluster
+	wire, fwdWire *wireCounter
+	concurrency   int
+	key           func(iter, worker int) string
+	work          func(keyFunc) func(op databrokerutil.TX) error
 
 	wg               sync.WaitGroup
 	ran, sharedCount atomic.Int64
@@ -368,6 +444,9 @@ func newSingleflightBench(b *testing.B, concurrency int, key func(iter, worker i
 
 	if opts.storage == nil {
 		opts.storage = memoryStorage
+	}
+	if opts.replicas < 1 {
+		opts.replicas = 1
 	}
 	if opts.work == nil {
 		opts.work = func(k keyFunc) func(op databrokerutil.TX) error {
@@ -384,11 +463,12 @@ func newSingleflightBench(b *testing.B, concurrency int, key func(iter, worker i
 		b:           b,
 		ctx:         b.Context(),
 		wire:        new(wireCounter),
+		fwdWire:     new(wireCounter),
 		concurrency: concurrency,
 		key:         key,
 		work:        opts.work,
 	}
-	s.server, s.client = newSingleflightServerFor(b, opts.storage(b), grpc.WithStatsHandler(s.wire))
+	s.cluster = newCluster(b, opts.storage(b), opts.replicas, opts.transport, s.wire, s.fwdWire)
 
 	runtime.GC()
 	runtime.ReadMemStats(&s.before)
@@ -400,10 +480,11 @@ func newSingleflightBench(b *testing.B, concurrency int, key func(iter, worker i
 // start launches one worker; hold, when non-nil, blocks it inside its
 // transaction so callers can keep the flight open.
 func (s *singleflightBench) start(iter, worker int, hold func()) {
+	client := s.cluster.clients[worker%len(s.cluster.clients)]
 	s.wg.Go(func() {
 		k := s.key(iter, worker)
 		body := s.work(func() string { return k })
-		_, shared, err := databrokerutil.Do(s.ctx, s.client, k, func(op databrokerutil.TX) error {
+		_, shared, err := databrokerutil.Do(s.ctx, client, k, func(op databrokerutil.TX) error {
 			s.ran.Add(1)
 			if hold != nil {
 				hold()
@@ -426,9 +507,11 @@ func (s *singleflightBench) report() {
 
 	runtime.ReadMemStats(&s.after)
 	ops := float64(s.b.N * s.concurrency)
+	fwd := float64(s.fwdWire.in.Load() + s.fwdWire.out.Load())
 	s.b.ReportMetric(float64(s.sharedCount.Load())/ops, "shared/op")
-	s.b.ReportMetric(float64(s.wire.out.Load())/ops, "wire-out-B/op")
-	s.b.ReportMetric(float64(s.wire.in.Load())/ops, "wire-in-B/op")
+	s.b.ReportMetric(float64(s.wire.out.Load()+s.fwdWire.out.Load())/ops, "wire-out-B/op")
+	s.b.ReportMetric(float64(s.wire.in.Load()+s.fwdWire.in.Load())/ops, "wire-in-B/op")
+	s.b.ReportMetric(fwd/ops, "wire-fwd-B/op")
 	s.b.ReportMetric(float64(s.after.TotalAlloc-s.before.TotalAlloc)/ops, "heap-B/op")
 	s.b.ReportMetric(float64(s.after.HeapInuse-s.before.HeapInuse)/(1<<20), "heap-inuse-MB")
 	s.b.ReportMetric(float64(s.after.Sys)/(1<<20), "sys-MB")
@@ -436,28 +519,24 @@ func (s *singleflightBench) report() {
 
 // benchmarkConcurrent starts every worker at once and leaves whether they
 // overlap up to the scheduler.
-func benchmarkConcurrent(b *testing.B, concurrency int, key func(iter, worker int) string, opts benchmarkOptions) {
+func benchmarkConcurrent(b *testing.B, key func(iter, worker int) string, opts benchmarkOptions) {
 	b.Helper()
 
-	s := newSingleflightBench(b, concurrency, key, opts)
+	s := newSingleflightBench(b, opts.concurrency, key, opts)
 	for iter := 0; b.Loop(); iter++ {
-		for worker := range concurrency {
+		for worker := range opts.concurrency {
 			s.start(iter, worker, nil)
 		}
 		s.wg.Wait()
 	}
-	s.server.Stop()
+	s.cluster.stop()
 	s.report()
 }
 
-// benchmarkConflicting opens a transaction first and only starts the remaining
-// workers once it is in flight, so a round is one real transaction and N-1
-// sharers. A straggler that reaches the server after the holder commits starts
-// a flight of its own, so shared/op reports what was actually achieved.
-func benchmarkConflicting(b *testing.B, concurrency int, key func(iter, worker int) string, opts benchmarkOptions) {
+func benchmarkConflicting(b *testing.B, key func(iter, worker int) string, opts benchmarkOptions) {
 	b.Helper()
 
-	s := newSingleflightBench(b, concurrency, key, opts)
+	s := newSingleflightBench(b, opts.concurrency, key, opts)
 	for iter := 0; b.Loop(); iter++ {
 		held, release := make(chan struct{}), make(chan struct{})
 		s.start(iter, 0, func() {
@@ -466,7 +545,7 @@ func benchmarkConflicting(b *testing.B, concurrency int, key func(iter, worker i
 		})
 		<-held
 
-		for worker := 1; worker < concurrency; worker++ {
+		for worker := 1; worker < opts.concurrency; worker++ {
 			s.start(iter, worker, nil)
 		}
 		close(release)
@@ -476,50 +555,178 @@ func benchmarkConflicting(b *testing.B, concurrency int, key func(iter, worker i
 	s.report()
 }
 
-func BenchmarkSingleFlight(b *testing.B) {
-	restore := log.GetLevel()
-	log.SetLevel(zerolog.Disabled)
-	b.Cleanup(func() { log.SetLevel(restore) })
+var (
+	benchTransport = flag.String("singleflight.transport", "bufconn",
+		"transport to benchmark: bufconn, tcp")
+	benchReplicas = flag.Int("singleflight.replicas", 1,
+		"servers per cluster")
+	benchConcurrency = flag.Int("singleflight.concurrency", 8,
+		"max concurrent in-flight transactions")
+)
 
-	startPostgres := sync.OnceValue(func() string { return testutil.StartPostgres(b) })
+func parseTransport(b *testing.B) grpcTransport {
+	b.Helper()
 
-	stores := []struct {
-		name    string
-		options func(testing.TB) config.DataBrokerOptions
-	}{
-		{"mem", memoryStorage},
-		{"file", fileStorage},
-		{"postgres", postgresStorage(startPostgres)},
+	switch *benchTransport {
+	case "bufconn":
+		return transportBufconn
+	case "tcp":
+		return transportTCP
+	default:
+		b.Fatalf("unknown transport %q", *benchTransport)
+		return transportBufconn
 	}
-	for _, storage := range stores {
-		b.Run(storage.name, func(b *testing.B) {
-			concurrency := 1
-			for range 3 {
-				concurrency *= 2
-				b.Run(fmt.Sprintf("conc-%d", concurrency), func(b *testing.B) {
-					opts := benchmarkOptions{storage: storage.options}
+}
 
-					b.Run("concurrent maybe conflicting", func(b *testing.B) {
-						benchmarkConcurrent(b, concurrency, func(iter, _ int) string {
-							return fmt.Sprintf("conflicting-%d", iter)
-						}, opts)
-					})
+func parseReplicas(b *testing.B) int {
+	b.Helper()
 
-					// every worker contends for the same transaction, so all but one is shared
-					b.Run("concurrent conflicting", func(b *testing.B) {
-						benchmarkConflicting(b, concurrency, func(iter, _ int) string {
-							return fmt.Sprintf("conflicting-%d", iter)
-						}, opts)
-					})
+	if *benchReplicas < 1 {
+		b.Fatalf("invalid replica count %d, must be greater than 0", *benchReplicas)
+	}
+	return *benchReplicas
+}
 
-					// every worker gets its own key, so all transactions run for real
-					b.Run("concurrent non-conflicting", func(b *testing.B) {
-						benchmarkConcurrent(b, concurrency, func(iter, worker int) string {
-							return fmt.Sprintf("non-conflicting-%d-%d", iter, worker)
-						}, opts)
-					})
-				})
-			}
+func parseConcurrency(b *testing.B) int {
+	b.Helper()
+
+	if *benchConcurrency < 1 {
+		b.Fatalf("invalid concurrency %d, must be greater than 0", *benchConcurrency)
+	}
+	return *benchConcurrency
+}
+
+type grpcTransport int
+
+const (
+	transportBufconn grpcTransport = iota
+	transportTCP
+)
+
+func (tr grpcTransport) String() string {
+	if tr == transportTCP {
+		return "tcp"
+	}
+	return "bufconn"
+}
+
+type benchServer struct {
+	b      *testing.B
+	target string
+	dial   func(context.Context, string) (net.Conn, error)
+}
+
+func startBenchServer(b *testing.B, transport grpcTransport, register func(s *grpc.Server)) *benchServer {
+	b.Helper()
+
+	srv := &benchServer{b: b}
+
+	var li net.Listener
+	switch transport {
+	case transportTCP:
+		tcp, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(b, err)
+		li = tcp
+		srv.target = "passthrough:///" + tcp.Addr().String()
+	default:
+		bl := bufconn.Listen(1024 * 1024)
+		li = bl
+		srv.target = "passthrough://bufnet"
+		srv.dial = func(context.Context, string) (net.Conn, error) {
+			return bl.Dial()
+		}
+	}
+
+	s := grpc.NewServer()
+	register(s)
+	go func() {
+		err := s.Serve(li)
+		if errors.Is(err, grpc.ErrServerStopped) {
+			err = nil
+		}
+		require.NoError(b, err)
+	}()
+	b.Cleanup(s.Stop)
+
+	return srv
+}
+
+func (srv *benchServer) dialClient(dialOpts ...grpc.DialOption) *grpc.ClientConn {
+	srv.b.Helper()
+
+	opts := []grpc.DialOption{grpc.WithTransportCredentials(insecure.NewCredentials())}
+	if srv.dial != nil {
+		opts = append(opts, grpc.WithContextDialer(srv.dial))
+	}
+	opts = append(opts, dialOpts...)
+
+	cc, err := grpc.NewClient(srv.target, opts...)
+	require.NoError(srv.b, err)
+	srv.b.Cleanup(func() {
+		cc.Close()
+	})
+
+	return cc
+}
+
+func newBackend(t testing.TB, cfg *config.Config) databroker.Server {
+	t.Helper()
+
+	srv := databroker.NewBackendServer(noop.NewTracerProvider())
+	t.Cleanup(srv.Stop)
+	srv.OnConfigChange(t.Context(), cfg)
+	return srv
+}
+
+type cluster struct {
+	servers []databroker.Server
+	clients []databrokerpb.DataBrokerServiceClient
+}
+
+func newCluster(
+	b *testing.B,
+	storage config.DataBrokerOptions,
+	replicas int,
+	transport grpcTransport,
+	wire, fwdWire *wireCounter,
+) *cluster {
+	b.Helper()
+
+	cfg := config.New(&config.Options{DataBroker: storage, SharedKey: cryptutil.NewBase64Key()})
+	sharedStorage := storage.StorageType == config.StoragePostgresName
+
+	c := new(cluster)
+	add := func(srv databroker.Server) *benchServer {
+		gs := startBenchServer(b, transport, func(s *grpc.Server) {
+			databrokerpb.RegisterDataBrokerServiceServer(s, srv)
 		})
+		c.servers = append(c.servers, srv)
+		c.clients = append(c.clients,
+			databrokerpb.NewDataBrokerServiceClient(gs.dialClient(grpc.WithStatsHandler(wire))))
+		return gs
+	}
+
+	leader := add(newBackend(b, cfg))
+	if sharedStorage {
+		_, err := c.servers[0].Get(b.Context(), &databrokerpb.GetRequest{
+			Type: singleflightRecordType(),
+			Id:   "migrate",
+		})
+		require.Equal(b, codes.NotFound, status.Code(err))
+	}
+
+	for range replicas - 1 {
+		if sharedStorage {
+			add(newBackend(b, cfg))
+			continue
+		}
+		add(databroker.NewForwardingServer(leader.dialClient(grpc.WithStatsHandler(fwdWire))))
+	}
+	return c
+}
+
+func (c *cluster) stop() {
+	for _, srv := range slices.Backward(c.servers) {
+		srv.Stop()
 	}
 }

--- a/pkg/databrokerutil/singleflight_test.go
+++ b/pkg/databrokerutil/singleflight_test.go
@@ -1,0 +1,187 @@
+package databrokerutil_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/pomerium/pomerium/config"
+	"github.com/pomerium/pomerium/internal/databroker"
+	"github.com/pomerium/pomerium/internal/testutil"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+	"github.com/pomerium/pomerium/pkg/databrokerutil"
+	databrokerpb "github.com/pomerium/pomerium/pkg/grpc/databroker"
+	sessionpb "github.com/pomerium/pomerium/pkg/grpc/session"
+	"github.com/pomerium/pomerium/pkg/protoutil"
+)
+
+func newSingleflightServer(t *testing.T) (databroker.Server, databrokerpb.DataBrokerServiceClient) {
+	t.Helper()
+
+	srv := databroker.NewBackendServer(noop.NewTracerProvider())
+	t.Cleanup(srv.Stop)
+	srv.OnConfigChange(t.Context(), config.New(&config.Options{
+		DataBroker: config.DataBrokerOptions{StorageType: config.StorageInMemoryName},
+		SharedKey:  cryptutil.NewBase64Key(),
+	}))
+
+	cc := testutil.NewGRPCServer(t, func(s *grpc.Server) {
+		databrokerpb.RegisterDataBrokerServiceServer(s, srv)
+	})
+	return srv, databrokerpb.NewDataBrokerServiceClient(cc)
+}
+
+func singleflightRecordType() string {
+	return protoutil.NewAny(new(sessionpb.Session)).TypeUrl
+}
+
+func singleflightRecord(id string) *databrokerpb.Record {
+	data := protoutil.NewAny(&sessionpb.Session{Id: id})
+	return &databrokerpb.Record{Type: data.TypeUrl, Id: id, Data: data}
+}
+
+func assertExists(t *testing.T, srv databroker.Server, id string) {
+	t.Helper()
+
+	res, err := srv.Get(t.Context(), &databrokerpb.GetRequest{Type: singleflightRecordType(), Id: id})
+	assert.NoError(t, err)
+	assert.Equal(t, id, res.GetRecord().GetId())
+}
+
+func assertMissing(t *testing.T, srv databroker.Server, id string) {
+	t.Helper()
+
+	_, err := srv.Get(t.Context(), &databrokerpb.GetRequest{Type: singleflightRecordType(), Id: id})
+	assert.Equal(t, codes.NotFound, status.Code(err))
+}
+
+func TestSingleflight(t *testing.T) {
+	t.Parallel()
+
+	t.Run("commit", func(t *testing.T) {
+		srv, client := newSingleflightServer(t)
+
+		shared, err := databrokerutil.Do(t.Context(), client, "commit", func(tx databrokerutil.Transaction) error {
+			res, err := tx.Put(singleflightRecord("commit-1"), singleflightRecord("commit-2"))
+			if err != nil {
+				return err
+			}
+			assert.Len(t, res.GetRecords(), 2)
+			return nil
+		})
+		require.NoError(t, err)
+		assert.False(t, shared)
+
+		assertExists(t, srv, "commit-1")
+		assertExists(t, srv, "commit-2")
+	})
+
+	t.Run("read your writes", func(t *testing.T) {
+		_, client := newSingleflightServer(t)
+
+		shared, err := databrokerutil.Do(t.Context(), client, "ryw", func(tx databrokerutil.Transaction) error {
+			if _, err := tx.Put(singleflightRecord("ryw-1")); err != nil {
+				return err
+			}
+			res, err := tx.Get(singleflightRecordType(), "ryw-1")
+			if err != nil {
+				return err
+			}
+			assert.Equal(t, "ryw-1", res.GetRecord().GetId())
+			return nil
+		})
+		require.NoError(t, err)
+		assert.False(t, shared)
+	})
+
+	t.Run("rollback", func(t *testing.T) {
+		srv, client := newSingleflightServer(t)
+
+		rollback := errors.New("rollback")
+		shared, err := databrokerutil.Do(t.Context(), client, "rollback", func(tx databrokerutil.Transaction) error {
+			if _, err := tx.Put(singleflightRecord("rollback-1")); err != nil {
+				return err
+			}
+			return rollback
+		})
+		assert.ErrorIs(t, err, rollback)
+		assert.False(t, shared)
+
+		assertMissing(t, srv, "rollback-1")
+	})
+
+	t.Run("shared", func(t *testing.T) {
+		srv, client := newSingleflightServer(t)
+
+		held, release := make(chan struct{}), make(chan struct{})
+		holder := make(chan error, 1)
+		go func() {
+			_, err := databrokerutil.Do(t.Context(), client, "shared", func(tx databrokerutil.Transaction) error {
+				close(held)
+				<-release
+				_, err := tx.Put(singleflightRecord("holder"))
+				return err
+			})
+			holder <- err
+		}()
+		<-held
+
+		sharedC := make(chan bool, 1)
+		go func() {
+			ran := false
+			shared, err := databrokerutil.Do(t.Context(), client, "shared", func(tx databrokerutil.Transaction) error {
+				ran = true
+				_, err := tx.Put(singleflightRecord("suppressed"))
+				return err
+			})
+			assert.NoError(t, err)
+			assert.False(t, ran, "work should not run for a suppressed transaction")
+			sharedC <- shared
+		}()
+
+		close(release)
+		require.NoError(t, <-holder)
+		assert.True(t, <-sharedC)
+
+		assertExists(t, srv, "holder")
+	})
+
+	t.Run("after transaction done", func(t *testing.T) {
+		_, client := newSingleflightServer(t)
+
+		var escaped databrokerutil.Transaction
+		_, err := databrokerutil.Do(t.Context(), client, "escaped", func(tx databrokerutil.Transaction) error {
+			escaped = tx
+			return nil
+		})
+		require.NoError(t, err)
+
+		_, err = escaped.Put(singleflightRecord("escaped-1"))
+		assert.ErrorIs(t, err, databrokerutil.ErrTransactionClosed)
+	})
+
+	t.Run("operation error", func(t *testing.T) {
+		srv, client := newSingleflightServer(t)
+
+		var opErr error
+		shared, err := databrokerutil.Do(t.Context(), client, "op-error", func(tx databrokerutil.Transaction) error {
+			if _, err := tx.Put(singleflightRecord("op-error-1")); err != nil {
+				return err
+			}
+			// an empty operation is rejected by the backend, which fails the transaction
+			_, opErr = tx(new(databrokerpb.TransactionRequest))
+			return opErr
+		})
+		assert.Error(t, opErr)
+		assert.Equal(t, opErr, err)
+		assert.False(t, shared)
+
+		assertMissing(t, srv, "op-error-1")
+	})
+}

--- a/pkg/databrokerutil/singleflight_test.go
+++ b/pkg/databrokerutil/singleflight_test.go
@@ -1,18 +1,30 @@
 package databrokerutil_test
 
 import (
+	"context"
 	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/jackc/pgx/v5"
+	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace/noop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/databroker"
+	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/testutil"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/databrokerutil"
@@ -21,19 +33,74 @@ import (
 	"github.com/pomerium/pomerium/pkg/protoutil"
 )
 
-func newSingleflightServer(t *testing.T) (databroker.Server, databrokerpb.DataBrokerServiceClient) {
+func newSingleflightServer(t testing.TB, dialOpts ...grpc.DialOption) (databroker.Server, databrokerpb.DataBrokerServiceClient) {
+	t.Helper()
+
+	return newSingleflightServerFor(t, memoryStorage(t), dialOpts...)
+}
+
+func memoryStorage(testing.TB) config.DataBrokerOptions {
+	return config.DataBrokerOptions{StorageType: config.StorageInMemoryName}
+}
+
+func fileStorage(t testing.TB) config.DataBrokerOptions {
+	dir := t.TempDir()
+	t.Cleanup(func() {
+		assert.NoError(t, os.RemoveAll(dir))
+	})
+
+	return config.DataBrokerOptions{
+		StorageType:             config.StorageFileName,
+		StorageConnectionString: "file://" + dir,
+	}
+}
+
+// postgresStorage hands every server its own database on one shared container,
+// which startPostgres starts on first use and ties to the parent benchmark.
+func postgresStorage(startPostgres func() string) func(testing.TB) config.DataBrokerOptions {
+	var databases atomic.Int64
+	return func(t testing.TB) config.DataBrokerOptions {
+		return config.DataBrokerOptions{
+			StorageType:             config.StoragePostgresName,
+			StorageConnectionString: newBenchDatabase(t, startPostgres(), databases.Add(1)),
+		}
+	}
+}
+
+func newBenchDatabase(t testing.TB, dsn string, n int64) string {
+	t.Helper()
+
+	conn, err := pgx.Connect(t.Context(), dsn)
+	require.NoError(t, err)
+	defer conn.Close(t.Context())
+
+	name := fmt.Sprintf("singleflight_%d", n)
+	_, err = conn.Exec(t.Context(), `CREATE DATABASE `+name)
+	require.NoError(t, err)
+
+	u, err := url.Parse(dsn)
+	require.NoError(t, err)
+	u.Path = "/" + name
+	return u.String()
+}
+
+func newSingleflightServerFor(
+	t testing.TB,
+	storage config.DataBrokerOptions,
+	dialOpts ...grpc.DialOption,
+) (databroker.Server, databrokerpb.DataBrokerServiceClient) {
 	t.Helper()
 
 	srv := databroker.NewBackendServer(noop.NewTracerProvider())
 	t.Cleanup(srv.Stop)
 	srv.OnConfigChange(t.Context(), config.New(&config.Options{
-		DataBroker: config.DataBrokerOptions{StorageType: config.StorageInMemoryName},
+		DataBroker: storage,
 		SharedKey:  cryptutil.NewBase64Key(),
 	}))
 
 	cc := testutil.NewGRPCServer(t, func(s *grpc.Server) {
 		databrokerpb.RegisterDataBrokerServiceServer(s, srv)
-	})
+	}, dialOpts...)
 	return srv, databrokerpb.NewDataBrokerServiceClient(cc)
 }
 
@@ -152,6 +219,36 @@ func TestSingleflight(t *testing.T) {
 		assertExists(t, srv, "holder")
 	})
 
+	t.Run("shared client timeout does not cancel", func(t *testing.T) {
+		srv, client := newSingleflightServer(t)
+
+		held, release := make(chan struct{}), make(chan struct{})
+		holder := make(chan error, 1)
+		go func() {
+			_, err := databrokerutil.Do(t.Context(), client, "timeout", func(tx databrokerutil.Transaction) error {
+				close(held)
+				<-release
+				_, err := tx.Put(singleflightRecord("timeout-holder"))
+				return err
+			})
+			holder <- err
+		}()
+		<-held
+
+		waiterCtx, cancelWaiter := context.WithTimeout(t.Context(), 100*time.Millisecond)
+		defer cancelWaiter()
+		_, err := databrokerutil.Do(waiterCtx, client, "timeout", func(databrokerutil.Transaction) error {
+			assert.Fail(t, "work should not run for a shared transaction")
+			return nil
+		})
+		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
+
+		// the holder is unaffected by the suppressed client giving up
+		close(release)
+		require.NoError(t, <-holder)
+		assertExists(t, srv, "timeout-holder")
+	})
+
 	t.Run("after transaction done", func(t *testing.T) {
 		_, client := newSingleflightServer(t)
 
@@ -184,4 +281,207 @@ func TestSingleflight(t *testing.T) {
 
 		assertMissing(t, srv, "op-error-1")
 	})
+}
+
+// wireCounter tallies gRPC payload bytes on the client connection. The
+// benchmarks run over bufconn, so this is protocol traffic rather than actual
+// syscall-level IO.
+type wireCounter struct {
+	in, out atomic.Int64
+}
+
+func (c *wireCounter) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context { return ctx }
+
+func (c *wireCounter) HandleRPC(_ context.Context, rs stats.RPCStats) {
+	switch rs := rs.(type) {
+	case *stats.InPayload:
+		c.in.Add(int64(rs.WireLength))
+	case *stats.OutPayload:
+		c.out.Add(int64(rs.WireLength))
+	}
+}
+
+func (c *wireCounter) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context { return ctx }
+
+func (c *wireCounter) HandleConn(context.Context, stats.ConnStats) {}
+
+type keyFunc func() string
+
+type benchmarkOptions struct {
+	storage func(testing.TB) config.DataBrokerOptions
+	work    func(keyFunc) func(tx databrokerutil.Transaction) error
+}
+
+type singleflightBench struct {
+	b           *testing.B
+	ctx         context.Context
+	server      databroker.Server
+	client      databrokerpb.DataBrokerServiceClient
+	wire        *wireCounter
+	concurrency int
+	key         func(iter, worker int) string
+	work        func(keyFunc) func(tx databrokerutil.Transaction) error
+
+	wg               sync.WaitGroup
+	ran, sharedCount atomic.Int64
+	before, after    runtime.MemStats
+}
+
+func newSingleflightBench(b *testing.B, concurrency int, key func(iter, worker int) string, opts benchmarkOptions) *singleflightBench {
+	b.Helper()
+
+	if opts.storage == nil {
+		opts.storage = memoryStorage
+	}
+	if opts.work == nil {
+		opts.work = func(k keyFunc) func(tx databrokerutil.Transaction) error {
+			return func(tx databrokerutil.Transaction) error {
+				_, err := tx.Put(singleflightRecord(k()))
+				return err
+			}
+		}
+	}
+
+	s := &singleflightBench{
+		b:           b,
+		ctx:         b.Context(),
+		wire:        new(wireCounter),
+		concurrency: concurrency,
+		key:         key,
+		work:        opts.work,
+	}
+	s.server, s.client = newSingleflightServerFor(b, opts.storage(b), grpc.WithStatsHandler(s.wire))
+
+	runtime.GC()
+	runtime.ReadMemStats(&s.before)
+	b.ReportAllocs()
+
+	return s
+}
+
+// start launches one worker; hold, when non-nil, blocks it inside its
+// transaction so callers can keep the flight open.
+func (s *singleflightBench) start(iter, worker int, hold func()) {
+	s.wg.Go(func() {
+		k := s.key(iter, worker)
+		body := s.work(func() string { return k })
+		shared, err := databrokerutil.Do(s.ctx, s.client, k, func(tx databrokerutil.Transaction) error {
+			s.ran.Add(1)
+			if hold != nil {
+				hold()
+			}
+			return body(tx)
+		})
+		if err != nil {
+			s.b.Error(err)
+		}
+		if shared {
+			s.sharedCount.Add(1)
+		}
+	})
+}
+
+func (s *singleflightBench) report() {
+	s.b.StopTimer()
+
+	runtime.GC()
+
+	runtime.ReadMemStats(&s.after)
+	ops := float64(s.b.N * s.concurrency)
+	s.b.ReportMetric(float64(s.sharedCount.Load())/ops, "shared/op")
+	s.b.ReportMetric(float64(s.wire.out.Load())/ops, "wire-out-B/op")
+	s.b.ReportMetric(float64(s.wire.in.Load())/ops, "wire-in-B/op")
+	s.b.ReportMetric(float64(s.after.TotalAlloc-s.before.TotalAlloc)/ops, "heap-B/op")
+	s.b.ReportMetric(float64(s.after.HeapInuse-s.before.HeapInuse)/(1<<20), "heap-inuse-MB")
+	s.b.ReportMetric(float64(s.after.Sys)/(1<<20), "sys-MB")
+}
+
+// benchmarkConcurrent starts every worker at once and leaves whether they
+// overlap up to the scheduler.
+func benchmarkConcurrent(b *testing.B, concurrency int, key func(iter, worker int) string, opts benchmarkOptions) {
+	b.Helper()
+
+	s := newSingleflightBench(b, concurrency, key, opts)
+	for iter := 0; b.Loop(); iter++ {
+		for worker := range concurrency {
+			s.start(iter, worker, nil)
+		}
+		s.wg.Wait()
+	}
+	s.server.Stop()
+	s.report()
+}
+
+// benchmarkConflicting opens a transaction first and only starts the remaining
+// workers once it is in flight, so a round is one real transaction and N-1
+// sharers. A straggler that reaches the server after the holder commits starts
+// a flight of its own, so shared/op reports what was actually achieved.
+func benchmarkConflicting(b *testing.B, concurrency int, key func(iter, worker int) string, opts benchmarkOptions) {
+	b.Helper()
+
+	s := newSingleflightBench(b, concurrency, key, opts)
+	for iter := 0; b.Loop(); iter++ {
+		held, release := make(chan struct{}), make(chan struct{})
+		s.start(iter, 0, func() {
+			close(held)
+			<-release
+		})
+		<-held
+
+		for worker := 1; worker < concurrency; worker++ {
+			s.start(iter, worker, nil)
+		}
+		close(release)
+
+		s.wg.Wait()
+	}
+	s.report()
+}
+
+func BenchmarkSingleFlight(b *testing.B) {
+	restore := log.GetLevel()
+	log.SetLevel(zerolog.Disabled)
+	b.Cleanup(func() { log.SetLevel(restore) })
+
+	startPostgres := sync.OnceValue(func() string { return testutil.StartPostgres(b) })
+
+	stores := []struct {
+		name    string
+		options func(testing.TB) config.DataBrokerOptions
+	}{
+		{"mem", memoryStorage},
+		{"file", fileStorage},
+		{"postgres", postgresStorage(startPostgres)},
+	}
+	for _, storage := range stores {
+		b.Run(storage.name, func(b *testing.B) {
+			concurrency := 1
+			for range 3 {
+				concurrency *= 2
+				b.Run(fmt.Sprintf("conc-%d", concurrency), func(b *testing.B) {
+					opts := benchmarkOptions{storage: storage.options}
+
+					b.Run("concurrent maybe conflicting", func(b *testing.B) {
+						benchmarkConcurrent(b, concurrency, func(iter, _ int) string {
+							return fmt.Sprintf("conflicting-%d", iter)
+						}, opts)
+					})
+
+					// every worker contends for the same transaction, so all but one is shared
+					b.Run("concurrent conflicting", func(b *testing.B) {
+						benchmarkConflicting(b, concurrency, func(iter, _ int) string {
+							return fmt.Sprintf("conflicting-%d", iter)
+						}, opts)
+					})
+
+					// every worker gets its own key, so all transactions run for real
+					b.Run("concurrent non-conflicting", func(b *testing.B) {
+						benchmarkConcurrent(b, concurrency, func(iter, worker int) string {
+							return fmt.Sprintf("non-conflicting-%d-%d", iter, worker)
+						}, opts)
+					})
+				})
+			}
+		})
+	}
 }

--- a/pkg/databrokerutil/singleflight_test.go
+++ b/pkg/databrokerutil/singleflight_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"testing/synctest"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -21,6 +22,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/internal/databroker"
@@ -134,8 +136,10 @@ func TestSingleflight(t *testing.T) {
 	t.Run("commit", func(t *testing.T) {
 		srv, client := newSingleflightServer(t)
 
-		shared, err := databrokerutil.Do(t.Context(), client, "commit", func(tx databrokerutil.Transaction) error {
-			res, err := tx.Put(singleflightRecord("commit-1"), singleflightRecord("commit-2"))
+		changed, shared, err := databrokerutil.Do(t.Context(), client, "commit", func(op databrokerutil.StorageOperator) error {
+			res, err := op.Put(t.Context(), &databrokerpb.PutRequest{
+				Records: []*databrokerpb.Record{singleflightRecord("commit-1"), singleflightRecord("commit-2")},
+			})
 			if err != nil {
 				return err
 			}
@@ -144,6 +148,7 @@ func TestSingleflight(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.False(t, shared)
+		assert.Len(t, changed, 2)
 
 		assertExists(t, srv, "commit-1")
 		assertExists(t, srv, "commit-2")
@@ -152,11 +157,16 @@ func TestSingleflight(t *testing.T) {
 	t.Run("read your writes", func(t *testing.T) {
 		_, client := newSingleflightServer(t)
 
-		shared, err := databrokerutil.Do(t.Context(), client, "ryw", func(tx databrokerutil.Transaction) error {
-			if _, err := tx.Put(singleflightRecord("ryw-1")); err != nil {
+		_, shared, err := databrokerutil.Do(t.Context(), client, "ryw", func(op databrokerutil.StorageOperator) error {
+			if _, err := op.Put(t.Context(), &databrokerpb.PutRequest{
+				Records: []*databrokerpb.Record{singleflightRecord("ryw-1")},
+			}); err != nil {
 				return err
 			}
-			res, err := tx.Get(singleflightRecordType(), "ryw-1")
+			res, err := op.Get(t.Context(), &databrokerpb.GetRequest{
+				Type: singleflightRecordType(),
+				Id:   "ryw-1",
+			})
 			if err != nil {
 				return err
 			}
@@ -171,8 +181,10 @@ func TestSingleflight(t *testing.T) {
 		srv, client := newSingleflightServer(t)
 
 		rollback := errors.New("rollback")
-		shared, err := databrokerutil.Do(t.Context(), client, "rollback", func(tx databrokerutil.Transaction) error {
-			if _, err := tx.Put(singleflightRecord("rollback-1")); err != nil {
+		_, shared, err := databrokerutil.Do(t.Context(), client, "rollback", func(op databrokerutil.StorageOperator) error {
+			if _, err := op.Put(t.Context(), &databrokerpb.PutRequest{
+				Records: []*databrokerpb.Record{singleflightRecord("rollback-1")},
+			}); err != nil {
 				return err
 			}
 			return rollback
@@ -184,98 +196,122 @@ func TestSingleflight(t *testing.T) {
 	})
 
 	t.Run("shared", func(t *testing.T) {
-		srv, client := newSingleflightServer(t)
+		synctest.Test(t, func(t *testing.T) {
+			srv, client := newSingleflightServer(t)
 
-		held, release := make(chan struct{}), make(chan struct{})
-		holder := make(chan error, 1)
-		go func() {
-			_, err := databrokerutil.Do(t.Context(), client, "shared", func(tx databrokerutil.Transaction) error {
-				close(held)
-				<-release
-				_, err := tx.Put(singleflightRecord("holder"))
-				return err
-			})
-			holder <- err
-		}()
-		<-held
+			held, release := make(chan struct{}), make(chan struct{})
+			holder := make(chan error, 1)
+			go func() {
+				_, _, err := databrokerutil.Do(t.Context(), client, "shared", func(op databrokerutil.StorageOperator) error {
+					close(held)
+					<-release
+					_, err := op.Put(t.Context(), &databrokerpb.PutRequest{
+						Records: []*databrokerpb.Record{singleflightRecord("holder")},
+					})
+					return err
+				})
+				holder <- err
+			}()
+			<-held
 
-		sharedC := make(chan bool, 1)
-		go func() {
-			ran := false
-			shared, err := databrokerutil.Do(t.Context(), client, "shared", func(tx databrokerutil.Transaction) error {
-				ran = true
-				_, err := tx.Put(singleflightRecord("suppressed"))
-				return err
-			})
-			assert.NoError(t, err)
-			assert.False(t, ran, "work should not run for a suppressed transaction")
-			sharedC <- shared
-		}()
+			sharedC := make(chan bool, 1)
+			go func() {
+				ran := false
+				_, shared, err := databrokerutil.Do(t.Context(), client, "shared", func(op databrokerutil.StorageOperator) error {
+					ran = true
+					_, err := op.Put(t.Context(), &databrokerpb.PutRequest{
+						Records: []*databrokerpb.Record{singleflightRecord("shared")},
+					})
+					return err
+				})
+				assert.NoError(t, err)
+				assert.False(t, ran, "work should not run for a shared transaction")
+				sharedC <- shared
+			}()
+			// the waiter only shares the flight if the server sees its begin before
+			// the holder commits, so block until it is parked on the held key
+			synctest.Wait()
 
-		close(release)
-		require.NoError(t, <-holder)
-		assert.True(t, <-sharedC)
+			close(release)
+			require.NoError(t, <-holder)
+			assert.True(t, <-sharedC)
 
-		assertExists(t, srv, "holder")
+			assertExists(t, srv, "holder")
+		})
 	})
 
 	t.Run("shared client timeout does not cancel", func(t *testing.T) {
-		srv, client := newSingleflightServer(t)
+		synctest.Test(t, func(t *testing.T) {
+			srv, client := newSingleflightServer(t)
 
-		held, release := make(chan struct{}), make(chan struct{})
-		holder := make(chan error, 1)
-		go func() {
-			_, err := databrokerutil.Do(t.Context(), client, "timeout", func(tx databrokerutil.Transaction) error {
-				close(held)
-				<-release
-				_, err := tx.Put(singleflightRecord("timeout-holder"))
-				return err
+			held, release := make(chan struct{}), make(chan struct{})
+			holder := make(chan error, 1)
+			go func() {
+				_, _, err := databrokerutil.Do(t.Context(), client, "timeout", func(op databrokerutil.StorageOperator) error {
+					close(held)
+					<-release
+					_, err := op.Put(t.Context(), &databrokerpb.PutRequest{
+						Records: []*databrokerpb.Record{singleflightRecord("timeout-holder")},
+					})
+					return err
+				})
+				holder <- err
+			}()
+			<-held
+
+			// the timeout runs on synctest's fake clock, so it can only elapse once
+			// the waiter is parked on the held key
+			waiterCtx, cancelWaiter := context.WithTimeout(t.Context(), 100*time.Millisecond)
+			defer cancelWaiter()
+			_, _, err := databrokerutil.Do(waiterCtx, client, "timeout", func(databrokerutil.StorageOperator) error {
+				assert.Fail(t, "work should not run for a shared transaction")
+				return nil
 			})
-			holder <- err
-		}()
-		<-held
+			assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
 
-		waiterCtx, cancelWaiter := context.WithTimeout(t.Context(), 100*time.Millisecond)
-		defer cancelWaiter()
-		_, err := databrokerutil.Do(waiterCtx, client, "timeout", func(databrokerutil.Transaction) error {
-			assert.Fail(t, "work should not run for a shared transaction")
-			return nil
+			// the holder is unaffected by the shared client giving up
+			close(release)
+			require.NoError(t, <-holder)
+			assertExists(t, srv, "timeout-holder")
 		})
-		assert.Equal(t, codes.DeadlineExceeded, status.Code(err))
-
-		// the holder is unaffected by the suppressed client giving up
-		close(release)
-		require.NoError(t, <-holder)
-		assertExists(t, srv, "timeout-holder")
 	})
 
 	t.Run("after transaction done", func(t *testing.T) {
 		_, client := newSingleflightServer(t)
 
-		var escaped databrokerutil.Transaction
-		_, err := databrokerutil.Do(t.Context(), client, "escaped", func(tx databrokerutil.Transaction) error {
-			escaped = tx
+		var escaped databrokerutil.StorageOperator
+		_, _, err := databrokerutil.Do(t.Context(), client, "escaped", func(op databrokerutil.StorageOperator) error {
+			escaped = op
 			return nil
 		})
 		require.NoError(t, err)
 
-		_, err = escaped.Put(singleflightRecord("escaped-1"))
-		assert.ErrorIs(t, err, databrokerutil.ErrTransactionClosed)
+		_, err = escaped.Put(t.Context(), &databrokerpb.PutRequest{
+			Records: []*databrokerpb.Record{singleflightRecord("escaped-1")},
+		})
+		assert.Equal(t, codes.FailedPrecondition, status.Code(err))
 	})
 
 	t.Run("operation error", func(t *testing.T) {
 		srv, client := newSingleflightServer(t)
 
 		var opErr error
-		shared, err := databrokerutil.Do(t.Context(), client, "op-error", func(tx databrokerutil.Transaction) error {
-			if _, err := tx.Put(singleflightRecord("op-error-1")); err != nil {
+		_, shared, err := databrokerutil.Do(t.Context(), client, "op-error", func(op databrokerutil.StorageOperator) error {
+			if _, err := op.Put(t.Context(), &databrokerpb.PutRequest{
+				Records: []*databrokerpb.Record{singleflightRecord("op-error-1")},
+			}); err != nil {
 				return err
 			}
-			// an empty operation is rejected by the backend, which fails the transaction
-			_, opErr = tx(new(databrokerpb.TransactionRequest))
+			// an invalid query filter is rejected by the backend, which fails the transaction
+			_, opErr = op.Query(t.Context(), &databrokerpb.QueryRequest{
+				Type: singleflightRecordType(),
+				Filter: &structpb.Struct{Fields: map[string]*structpb.Value{
+					"$or": structpb.NewStringValue("not-an-array"),
+				}},
+			})
 			return opErr
 		})
-		assert.Error(t, opErr)
+		assert.Equal(t, codes.InvalidArgument, status.Code(opErr))
 		assert.Equal(t, opErr, err)
 		assert.False(t, shared)
 
@@ -309,7 +345,7 @@ type keyFunc func() string
 
 type benchmarkOptions struct {
 	storage func(testing.TB) config.DataBrokerOptions
-	work    func(keyFunc) func(tx databrokerutil.Transaction) error
+	work    func(keyFunc) func(op databrokerutil.StorageOperator) error
 }
 
 type singleflightBench struct {
@@ -320,7 +356,7 @@ type singleflightBench struct {
 	wire        *wireCounter
 	concurrency int
 	key         func(iter, worker int) string
-	work        func(keyFunc) func(tx databrokerutil.Transaction) error
+	work        func(keyFunc) func(op databrokerutil.StorageOperator) error
 
 	wg               sync.WaitGroup
 	ran, sharedCount atomic.Int64
@@ -334,9 +370,11 @@ func newSingleflightBench(b *testing.B, concurrency int, key func(iter, worker i
 		opts.storage = memoryStorage
 	}
 	if opts.work == nil {
-		opts.work = func(k keyFunc) func(tx databrokerutil.Transaction) error {
-			return func(tx databrokerutil.Transaction) error {
-				_, err := tx.Put(singleflightRecord(k()))
+		opts.work = func(k keyFunc) func(op databrokerutil.StorageOperator) error {
+			return func(op databrokerutil.StorageOperator) error {
+				_, err := op.Put(b.Context(), &databrokerpb.PutRequest{
+					Records: []*databrokerpb.Record{singleflightRecord(k())},
+				})
 				return err
 			}
 		}
@@ -365,12 +403,12 @@ func (s *singleflightBench) start(iter, worker int, hold func()) {
 	s.wg.Go(func() {
 		k := s.key(iter, worker)
 		body := s.work(func() string { return k })
-		shared, err := databrokerutil.Do(s.ctx, s.client, k, func(tx databrokerutil.Transaction) error {
+		_, shared, err := databrokerutil.Do(s.ctx, s.client, k, func(op databrokerutil.StorageOperator) error {
 			s.ran.Add(1)
 			if hold != nil {
 				hold()
 			}
-			return body(tx)
+			return body(op)
 		})
 		if err != nil {
 			s.b.Error(err)

--- a/pkg/databrokerutil/singleflight_test.go
+++ b/pkg/databrokerutil/singleflight_test.go
@@ -136,7 +136,7 @@ func TestSingleflight(t *testing.T) {
 	t.Run("commit", func(t *testing.T) {
 		srv, client := newSingleflightServer(t)
 
-		changed, shared, err := databrokerutil.Do(t.Context(), client, "commit", func(op databrokerutil.StorageOperator) error {
+		changed, shared, err := databrokerutil.Do(t.Context(), client, "commit", func(op databrokerutil.TX) error {
 			res, err := op.Put(t.Context(), &databrokerpb.PutRequest{
 				Records: []*databrokerpb.Record{singleflightRecord("commit-1"), singleflightRecord("commit-2")},
 			})
@@ -157,7 +157,7 @@ func TestSingleflight(t *testing.T) {
 	t.Run("read your writes", func(t *testing.T) {
 		_, client := newSingleflightServer(t)
 
-		_, shared, err := databrokerutil.Do(t.Context(), client, "ryw", func(op databrokerutil.StorageOperator) error {
+		_, shared, err := databrokerutil.Do(t.Context(), client, "ryw", func(op databrokerutil.TX) error {
 			if _, err := op.Put(t.Context(), &databrokerpb.PutRequest{
 				Records: []*databrokerpb.Record{singleflightRecord("ryw-1")},
 			}); err != nil {
@@ -181,7 +181,7 @@ func TestSingleflight(t *testing.T) {
 		srv, client := newSingleflightServer(t)
 
 		rollback := errors.New("rollback")
-		_, shared, err := databrokerutil.Do(t.Context(), client, "rollback", func(op databrokerutil.StorageOperator) error {
+		_, shared, err := databrokerutil.Do(t.Context(), client, "rollback", func(op databrokerutil.TX) error {
 			if _, err := op.Put(t.Context(), &databrokerpb.PutRequest{
 				Records: []*databrokerpb.Record{singleflightRecord("rollback-1")},
 			}); err != nil {
@@ -202,7 +202,7 @@ func TestSingleflight(t *testing.T) {
 			held, release := make(chan struct{}), make(chan struct{})
 			holder := make(chan error, 1)
 			go func() {
-				_, _, err := databrokerutil.Do(t.Context(), client, "shared", func(op databrokerutil.StorageOperator) error {
+				_, _, err := databrokerutil.Do(t.Context(), client, "shared", func(op databrokerutil.TX) error {
 					close(held)
 					<-release
 					_, err := op.Put(t.Context(), &databrokerpb.PutRequest{
@@ -217,7 +217,7 @@ func TestSingleflight(t *testing.T) {
 			sharedC := make(chan bool, 1)
 			go func() {
 				ran := false
-				_, shared, err := databrokerutil.Do(t.Context(), client, "shared", func(op databrokerutil.StorageOperator) error {
+				_, shared, err := databrokerutil.Do(t.Context(), client, "shared", func(op databrokerutil.TX) error {
 					ran = true
 					_, err := op.Put(t.Context(), &databrokerpb.PutRequest{
 						Records: []*databrokerpb.Record{singleflightRecord("shared")},
@@ -247,7 +247,7 @@ func TestSingleflight(t *testing.T) {
 			held, release := make(chan struct{}), make(chan struct{})
 			holder := make(chan error, 1)
 			go func() {
-				_, _, err := databrokerutil.Do(t.Context(), client, "timeout", func(op databrokerutil.StorageOperator) error {
+				_, _, err := databrokerutil.Do(t.Context(), client, "timeout", func(op databrokerutil.TX) error {
 					close(held)
 					<-release
 					_, err := op.Put(t.Context(), &databrokerpb.PutRequest{
@@ -263,7 +263,7 @@ func TestSingleflight(t *testing.T) {
 			// the waiter is parked on the held key
 			waiterCtx, cancelWaiter := context.WithTimeout(t.Context(), 100*time.Millisecond)
 			defer cancelWaiter()
-			_, _, err := databrokerutil.Do(waiterCtx, client, "timeout", func(databrokerutil.StorageOperator) error {
+			_, _, err := databrokerutil.Do(waiterCtx, client, "timeout", func(databrokerutil.TX) error {
 				assert.Fail(t, "work should not run for a shared transaction")
 				return nil
 			})
@@ -279,8 +279,8 @@ func TestSingleflight(t *testing.T) {
 	t.Run("after transaction done", func(t *testing.T) {
 		_, client := newSingleflightServer(t)
 
-		var escaped databrokerutil.StorageOperator
-		_, _, err := databrokerutil.Do(t.Context(), client, "escaped", func(op databrokerutil.StorageOperator) error {
+		var escaped databrokerutil.TX
+		_, _, err := databrokerutil.Do(t.Context(), client, "escaped", func(op databrokerutil.TX) error {
 			escaped = op
 			return nil
 		})
@@ -296,7 +296,7 @@ func TestSingleflight(t *testing.T) {
 		srv, client := newSingleflightServer(t)
 
 		var opErr error
-		_, shared, err := databrokerutil.Do(t.Context(), client, "op-error", func(op databrokerutil.StorageOperator) error {
+		_, shared, err := databrokerutil.Do(t.Context(), client, "op-error", func(op databrokerutil.TX) error {
 			if _, err := op.Put(t.Context(), &databrokerpb.PutRequest{
 				Records: []*databrokerpb.Record{singleflightRecord("op-error-1")},
 			}); err != nil {
@@ -345,7 +345,7 @@ type keyFunc func() string
 
 type benchmarkOptions struct {
 	storage func(testing.TB) config.DataBrokerOptions
-	work    func(keyFunc) func(op databrokerutil.StorageOperator) error
+	work    func(keyFunc) func(op databrokerutil.TX) error
 }
 
 type singleflightBench struct {
@@ -356,7 +356,7 @@ type singleflightBench struct {
 	wire        *wireCounter
 	concurrency int
 	key         func(iter, worker int) string
-	work        func(keyFunc) func(op databrokerutil.StorageOperator) error
+	work        func(keyFunc) func(op databrokerutil.TX) error
 
 	wg               sync.WaitGroup
 	ran, sharedCount atomic.Int64
@@ -370,8 +370,8 @@ func newSingleflightBench(b *testing.B, concurrency int, key func(iter, worker i
 		opts.storage = memoryStorage
 	}
 	if opts.work == nil {
-		opts.work = func(k keyFunc) func(op databrokerutil.StorageOperator) error {
-			return func(op databrokerutil.StorageOperator) error {
+		opts.work = func(k keyFunc) func(op databrokerutil.TX) error {
+			return func(op databrokerutil.TX) error {
 				_, err := op.Put(b.Context(), &databrokerpb.PutRequest{
 					Records: []*databrokerpb.Record{singleflightRecord(k())},
 				})
@@ -403,7 +403,7 @@ func (s *singleflightBench) start(iter, worker int, hold func()) {
 	s.wg.Go(func() {
 		k := s.key(iter, worker)
 		body := s.work(func() string { return k })
-		_, shared, err := databrokerutil.Do(s.ctx, s.client, k, func(op databrokerutil.StorageOperator) error {
+		_, shared, err := databrokerutil.Do(s.ctx, s.client, k, func(op databrokerutil.TX) error {
 			s.ran.Add(1)
 			if hold != nil {
 				hold()

--- a/pkg/grpc/databroker/databroker.pb.json
+++ b/pkg/grpc/databroker/databroker.pb.json
@@ -1863,7 +1863,7 @@
             },
             {
               "name": "Transaction",
-              "description": "Transaction opens a transaction.\nTransaction is used for synchronizing one-time read and update Operations\nthat require atomic updates.\nThe stream's lifetime is the transaction's lifetime.\nThe first message must be `begin`, the last must be `commit`, and a\nstream that ends any other way rolls back. Operations are atomic but not\nisolated, and there is no conflict handling for concurrent updates not wrapped\nwith the same transaction key.\nConcurrent transactions are singleflight; sharing a key waits for the first transaction\nto finish with its result, and get the same result.",
+              "description": "Transaction opens a transaction.\nTransaction is used for synchronizing one-time read and update Operations\nthat require atomic updates.\nThe stream's lifetime is the transaction's lifetime.\nThe first message must be `begin`, the last must be `commit`, and a\nstream that ends any other way rolls back. Operations are atomic but not\nisolated, and there is no conflict handling for concurrent updates not wrapped\nwith the same transaction key.\nConcurrent transactions are singleflight; sharing a key waits for the first transaction\nto finish with its result, and get the same result.\nClients requiring mutually exclusive long running transactions should prefer using databrokerutil.Do\ninstead of calling this API directly.",
               "requestType": "TransactionStreamRequest",
               "requestLongType": "TransactionStreamRequest",
               "requestFullType": "databroker.TransactionStreamRequest",

--- a/pkg/grpc/databroker/databroker.proto
+++ b/pkg/grpc/databroker/databroker.proto
@@ -231,6 +231,8 @@ service DataBrokerService {
   // with the same transaction key.
   // Concurrent transactions are singleflight; sharing a key waits for the first transaction
   // to finish with its result, and get the same result.
+  // Clients requiring mutually exclusive long running transactions should prefer using databrokerutil.Do
+  // instead of calling this API directly.
   rpc Transaction(stream TransactionStreamRequest) returns (stream TransactionStreamResponse);
 }
 

--- a/pkg/grpc/databroker/databroker_grpc.pb.go
+++ b/pkg/grpc/databroker/databroker_grpc.pb.go
@@ -81,6 +81,8 @@ type DataBrokerServiceClient interface {
 	// with the same transaction key.
 	// Concurrent transactions are singleflight; sharing a key waits for the first transaction
 	// to finish with its result, and get the same result.
+	// Clients requiring mutually exclusive long running transactions should prefer using databrokerutil.Do
+	// instead of calling this API directly.
 	Transaction(ctx context.Context, opts ...grpc.CallOption) (grpc.BidiStreamingClient[TransactionStreamRequest, TransactionStreamResponse], error)
 }
 
@@ -307,6 +309,8 @@ type DataBrokerServiceServer interface {
 	// with the same transaction key.
 	// Concurrent transactions are singleflight; sharing a key waits for the first transaction
 	// to finish with its result, and get the same result.
+	// Clients requiring mutually exclusive long running transactions should prefer using databrokerutil.Do
+	// instead of calling this API directly.
 	Transaction(grpc.BidiStreamingServer[TransactionStreamRequest, TransactionStreamResponse]) error
 }
 


### PR DESCRIPTION
## Summary

Adds a single-flight wrapper over the bidi Transactions-API.

Behaves mostly like `singleflight.Do` with some exceptions:
- returns `shared=true` only if this call waited for another to finished
- context cancellation is propagated
- storage operations inside the callback are atomic. Any errors returned from this callback rollback the inflight changes. Any internal errors (connectivity, storage) also rollback the in-flight changes and return the error to the caller. 
- returns errors:
  -  `Aborted` indicates the underlying stream ended before the storage operations in the transaction could be committed. retry-able
  - `FailedPrecondition` indicates the underlying protocol of the Transactions API was not implemented in our single-flight abstraction or an internal locking guarantee in the storage backend was not met. not typically retry-able
  - `DeadlineExceeded` when the callback runs longer than the max transaction duration (set to 6 minutes in this PR)
  - `Internal` indicates an unrecoverable storage error during the course of the Transaction. retry-able

The only mutual exclusion guarantees of the singleflight.Do is under the same key, like go's built-in singleflight.

## Related issues

[RFC-Databroker-singleflight](https://app.notion.com/p/pomerium/RFC-Databroker-singleflight-3b158e156c55802b820fffb6a3bdd39f)

## User Explanation

N/A

## AI disclosure

opus 5 was used to generate most of Makefile.bench

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>