### PR TITLE
testenv: reserve allocated ports so upstreams cannot take them from envoy

### DIFF
--- a/config/envoyconfig/websocket_int_test.go
+++ b/config/envoyconfig/websocket_int_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pomerium/pomerium/internal/testenv/upstreams"
 	"github.com/pomerium/pomerium/internal/testenv/values"
 	"github.com/pomerium/pomerium/pkg/envoy"
-	"github.com/pomerium/pomerium/pkg/netutil"
 )
 
 // TestWebsocketViaMiddleEnvoy covers the topology where Pomerium runs in
@@ -233,7 +232,7 @@ func (m *middleEnvoy) Run(ctx context.Context) error {
 		return fmt.Errorf("split upstream addr: %w", err)
 	}
 
-	ports, err := netutil.AllocatePorts(1)
+	ports, err := testenv.AllocatePorts(1)
 	if err != nil {
 		return fmt.Errorf("allocate port: %w", err)
 	}

--- a/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
+++ b/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
@@ -2,7 +2,6 @@ package e2e
 
 import (
 	"context"
-	"fmt"
 	"net"
 	"net/http"
 	"sync/atomic"
@@ -165,7 +164,7 @@ func TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute(t *testing.T) {
 func startBareUpstream(t *testing.T, host string, receivedAuth *atomic.Pointer[string]) net.Listener {
 	t.Helper()
 
-	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", host))
+	listener, err := testenv.Listen(t.Context(), host)
 	require.NoError(t, err)
 
 	mux := http.NewServeMux()

--- a/internal/testenv/environment.go
+++ b/internal/testenv/environment.go
@@ -58,7 +58,6 @@ import (
 	"github.com/pomerium/pomerium/pkg/health"
 	"github.com/pomerium/pomerium/pkg/identity/manager"
 	"github.com/pomerium/pomerium/pkg/logfields"
-	"github.com/pomerium/pomerium/pkg/netutil"
 	"github.com/pomerium/pomerium/pkg/slices"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
 )
@@ -652,7 +651,7 @@ func (e *environment) Start() {
 	e.debugf("temp dir: %s", e.TempDir())
 
 	cfg := config.New(config.NewDefaultOptions())
-	ports, err := netutil.AllocatePorts(13)
+	ports, err := AllocatePorts(13)
 	require.NoError(e.t, err)
 	atoi := func(str string) int {
 		p, err := strconv.Atoi(str)

--- a/internal/testenv/ports.go
+++ b/internal/testenv/ports.go
@@ -1,0 +1,80 @@
+package testenv
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"sync"
+
+	"github.com/pomerium/pomerium/pkg/netutil"
+)
+
+// reservedPorts holds every port AllocatePorts has handed out in this process.
+//
+// netutil.AllocatePorts works by binding ephemeral ports and immediately
+// closing them, so the port numbers it returns are only reserved by convention:
+// nothing stops the kernel from handing the same port to a later bind. Pomerium
+// and envoy bind their share of those ports some time afterwards, so an
+// in-process server binding to :0 in between can take one out from under them.
+// When that happens envoy rejects the whole listener update ("failed to bind or
+// apply socket options: cannot bind ...: Address already in use") and requests
+// silently land on whichever server won the race.
+//
+// Holding the reservations open instead of tracking them is not an option:
+// envoy only enables SO_REUSEPORT on linux (see config/envoyconfig.newListener),
+// so elsewhere its bind would fail against a held-open socket, and on linux the
+// kernel would load balance connections into the placeholder.
+//
+// Ports are never released, so that an environment shutting down cannot race an
+// upstream starting up. The set stays small relative to the ephemeral port
+// range: even a binary that builds dozens of environments reserves well under
+// 1000 ports out of ~28000, so listenUnreserved rarely retries at all.
+var reservedPorts sync.Map // string (port) -> struct{}
+
+// listenMaxAttempts bounds the retry loop in listenUnreserved.
+const listenMaxAttempts = 10
+
+// AllocatePorts allocates ports for an environment's own listeners and reserves
+// them, so Listen will not hand any of them to an in-process server.
+func AllocatePorts(count int) ([]string, error) {
+	ports, err := netutil.AllocatePorts(count)
+	if err != nil {
+		return nil, err
+	}
+	for _, port := range ports {
+		reservedPorts.Store(port, struct{}{})
+	}
+	return ports, nil
+}
+
+// Listen starts a listener on an ephemeral port of host, skipping ports
+// reserved by AllocatePorts. Servers running inside a test environment should
+// use this instead of listening on :0 directly.
+func Listen(ctx context.Context, host string) (net.Listener, error) {
+	return listenUnreserved(ctx, host, func(port string) bool {
+		_, reserved := reservedPorts.Load(port)
+		return reserved
+	})
+}
+
+func listenUnreserved(ctx context.Context, host string, isReserved func(port string) bool) (net.Listener, error) {
+	var rejected []net.Listener
+	defer func() {
+		for _, li := range rejected {
+			li.Close()
+		}
+	}()
+	for range listenMaxAttempts {
+		li, err := (&net.ListenConfig{}).Listen(ctx, "tcp", net.JoinHostPort(host, "0"))
+		if err != nil {
+			return nil, err
+		}
+		_, port, _ := net.SplitHostPort(li.Addr().String())
+		if !isReserved(port) {
+			return li, nil
+		}
+		// Hold the listener open so the next attempt gets a different port.
+		rejected = append(rejected, li)
+	}
+	return nil, fmt.Errorf("no unreserved port available on %s after %d attempts", host, listenMaxAttempts)
+}

--- a/internal/testenv/ports.go
+++ b/internal/testenv/ports.go
@@ -58,12 +58,6 @@ func Listen(ctx context.Context, host string) (net.Listener, error) {
 }
 
 func listenUnreserved(ctx context.Context, host string, isReserved func(port string) bool) (net.Listener, error) {
-	var rejected []net.Listener
-	defer func() {
-		for _, li := range rejected {
-			li.Close()
-		}
-	}()
 	for range listenMaxAttempts {
 		li, err := (&net.ListenConfig{}).Listen(ctx, "tcp", net.JoinHostPort(host, "0"))
 		if err != nil {
@@ -74,7 +68,7 @@ func listenUnreserved(ctx context.Context, host string, isReserved func(port str
 			return li, nil
 		}
 		// Hold the listener open so the next attempt gets a different port.
-		rejected = append(rejected, li)
+		defer li.Close()
 	}
 	return nil, fmt.Errorf("no unreserved port available on %s after %d attempts", host, listenMaxAttempts)
 }

--- a/internal/testenv/ports_test.go
+++ b/internal/testenv/ports_test.go
@@ -1,0 +1,63 @@
+package testenv
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// listenUnreserved must keep binding until it lands on a port the predicate
+// accepts, rather than returning the first port it is given.
+func TestListenUnreservedRetriesUntilAccepted(t *testing.T) {
+	t.Parallel()
+
+	const reject = 3
+	var offered []string
+	li, err := listenUnreserved(context.Background(), "127.0.0.1", func(port string) bool {
+		if len(offered) < reject {
+			offered = append(offered, port)
+			return true
+		}
+		return false
+	})
+	require.NoError(t, err)
+	t.Cleanup(func() { li.Close() })
+
+	_, port, err := net.SplitHostPort(li.Addr().String())
+	require.NoError(t, err)
+	assert.Len(t, offered, reject, "should have kept retrying")
+	assert.NotContains(t, offered, port, "returned a port the predicate rejected")
+}
+
+func TestListenUnreservedGivesUp(t *testing.T) {
+	t.Parallel()
+
+	attempts := 0
+	li, err := listenUnreserved(context.Background(), "127.0.0.1", func(string) bool {
+		attempts++
+		return true
+	})
+	if li != nil {
+		li.Close()
+	}
+	require.Error(t, err)
+	assert.Equal(t, listenMaxAttempts, attempts)
+}
+
+// Ports handed out for an environment's own listeners must be off limits to
+// Listen, otherwise an upstream can bind one before envoy does.
+func TestAllocatePortsAreReserved(t *testing.T) {
+	t.Parallel()
+
+	ports, err := AllocatePorts(4)
+	require.NoError(t, err)
+	require.Len(t, ports, 4)
+
+	for _, port := range ports {
+		_, reserved := reservedPorts.Load(port)
+		assert.Truef(t, reserved, "port %s was not reserved", port)
+	}
+}

--- a/internal/testenv/upstreams/grpc.go
+++ b/internal/testenv/upstreams/grpc.go
@@ -128,7 +128,7 @@ func (g *grpcUpstream) Route() testenv.RouteStub {
 
 // Start implements testenv.Upstream.
 func (g *grpcUpstream) Run(ctx context.Context) error {
-	listener, err := net.Listen("tcp", fmt.Sprintf("%s:0", g.Env().Host()))
+	listener, err := testenv.Listen(ctx, g.Env().Host())
 	if err != nil {
 		return err
 	}

--- a/internal/testenv/upstreams/http.go
+++ b/internal/testenv/upstreams/http.go
@@ -291,19 +291,12 @@ func (h *httpUpstream) Route() testenv.RouteStub {
 
 // Run implements HTTPUpstream.
 func (h *httpUpstream) Run(ctx context.Context) error {
-	var listener net.Listener
+	listener, err := testenv.Listen(ctx, h.Env().Host())
+	if err != nil {
+		return err
+	}
 	if h.tlsConfig != nil {
-		var err error
-		listener, err = tls.Listen("tcp", fmt.Sprintf("%s:0", h.Env().Host()), h.tlsConfig.Value())
-		if err != nil {
-			return err
-		}
-	} else {
-		var err error
-		listener, err = net.Listen("tcp", fmt.Sprintf("%s:0", h.Env().Host()))
-		if err != nil {
-			return err
-		}
+		listener = tls.NewListener(listener, h.tlsConfig.Value())
 	}
 	h.serverPort.Resolve(listener.Addr().(*net.TCPAddr).Port)
 	if h.serverTracerProviderOverride != nil {

--- a/internal/testenv/upstreams/ssh.go
+++ b/internal/testenv/upstreams/ssh.go
@@ -157,7 +157,7 @@ func (h *sshUpstream) Route() testenv.RouteStub {
 
 // Run implements SSHUpstream.
 func (h *sshUpstream) Run(ctx context.Context) error {
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := testenv.Listen(ctx, "127.0.0.1")
 	if err != nil {
 		return err
 	}

--- a/internal/testenv/upstreams/tcp.go
+++ b/internal/testenv/upstreams/tcp.go
@@ -295,7 +295,7 @@ func (t *tcpUpstream) Route() testenv.RouteStub {
 func (t *tcpUpstream) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
-	listener, err := (&net.ListenConfig{}).Listen(ctx, "tcp", fmt.Sprintf("%s:0", t.Env().Host()))
+	listener, err := testenv.Listen(ctx, t.Env().Host())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

Fixes a CI flake in testenv-based suites where envoy comes up without its listeners.

`netutil.AllocatePorts` binds ephemeral ports and immediately closes them, so the 13 ports a test environment claims for pomerium and envoy are reserved only by convention — the kernel is free to hand the same port to a later bind. The in-process test servers bound `:0` some time after that allocation and before envoy bound its share, so they could take one. When that happened envoy rejected the whole listener update:

```
listener 'https-ingress' failed to bind or apply socket options:
  cannot bind '127.0.0.1:43125': Address already in use
→ delta config for ...v3.Listener rejected
```

and requests aimed at pomerium silently landed on whichever test server won the race, surfacing as unrelated-looking failures — most recently a TLS error in `TestSSH/#03/TestDirectTcpipSession`, where the sign-in request reached the mock IDP and failed with `x509: certificate is valid for mock-idp.localhost.pomerium.io, not authenticate.localhost.pomerium.io`.

`testenv.AllocatePorts` now records what it hands out, and `testenv.Listen` picks an ephemeral port that avoids those reservations, holding each rejected listener open so the kernel offers a different port on retry. In-process servers go through it: the four upstream types, the middle envoy in the websocket test, and the bare upstream in the MCP ext_proc test.

Reservations are never released, so an environment shutting down cannot race an upstream starting up. They are not held open as live sockets because envoy enables `SO_REUSEPORT` only on linux — elsewhere its bind would fail against a placeholder, and on linux the kernel would load balance connections into it.

Not addressed here: `databroker.New` binds `127.0.0.1:0` inside the pomerium process, which sits in the same allocate-then-bind window and affects production as well as tests. Fixing that means moving the reservation into `pkg/netutil`.

## Related issues

<!-- none -->

## User Explanation

No user-facing changes; test infrastructure only.

## AI disclosure

Claude Code diagnosed the failure from CI logs and wrote the change; reviewed and directed by me.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
