### PR TITLE
mcp: prefix opaque access/refresh tokens (pom_mat_/pom_mrt_)

### DIFF
--- a/internal/mcp/token.go
+++ b/internal/mcp/token.go
@@ -2,10 +2,19 @@ package mcp
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/pomerium/pomerium/internal/oauth21"
 	oauth21proto "github.com/pomerium/pomerium/internal/oauth21/gen"
+)
+
+// Type prefixes for the opaque tokens this package mints. The '_' is disjoint
+// from the standard-base64 token body, so trimming an absent prefix is
+// unambiguous, and bare tokens issued before prefixing still parse.
+const (
+	accessTokenPrefix  = "pom_mat_"
+	refreshTokenPrefix = "pom_mrt_"
 )
 
 func CheckPKCE(
@@ -38,17 +47,25 @@ func (srv *Handler) GetAccessTokenForSession(sessionID string, sessionExpiresAt 
 // the session's databroker record version, so the authorize service can read
 // the session with a read-your-writes (minimum-version) guarantee.
 func (srv *Handler) GetAccessTokenForSessionWithVersion(sessionID string, sessionRecordVersion uint64, sessionExpiresAt time.Time) (string, error) {
-	return CreateCodeWithRecordVersion(CodeTypeAccess, sessionID, sessionExpiresAt, "", srv.cipher, sessionRecordVersion)
+	code, err := CreateCodeWithRecordVersion(CodeTypeAccess, sessionID, sessionExpiresAt, "", srv.cipher, sessionRecordVersion)
+	if err != nil {
+		return "", err
+	}
+	return accessTokenPrefix + code, nil
 }
 
 // CreateRefreshToken creates a refresh token for a given session and client.
 func (srv *Handler) CreateRefreshToken(sessionID string, clientID string, expiresAt time.Time) (string, error) {
-	return CreateCode(CodeTypeRefresh, sessionID, expiresAt, clientID, srv.cipher)
+	code, err := CreateCode(CodeTypeRefresh, sessionID, expiresAt, clientID, srv.cipher)
+	if err != nil {
+		return "", err
+	}
+	return refreshTokenPrefix + code, nil
 }
 
 // DecryptRefreshToken decrypts and validates a refresh token.
 func (srv *Handler) DecryptRefreshToken(refreshToken string, clientID string) (*oauth21proto.Code, error) {
-	return DecryptCode(CodeTypeRefresh, refreshToken, srv.cipher, clientID, time.Now())
+	return DecryptCode(CodeTypeRefresh, strings.TrimPrefix(refreshToken, refreshTokenPrefix), srv.cipher, clientID, time.Now())
 }
 
 // GetSessionIDFromAccessToken decrypts the access token and returns the
@@ -62,7 +79,7 @@ func (srv *Handler) GetSessionIDFromAccessToken(accessToken string) (string, err
 // underlying session ID together with the databroker record version recorded at
 // issuance time (zero if none).
 func (srv *Handler) GetSessionAndVersionFromAccessToken(accessToken string) (string, uint64, error) {
-	code, err := DecryptCode(CodeTypeAccess, accessToken, srv.cipher, "", time.Now())
+	code, err := DecryptCode(CodeTypeAccess, strings.TrimPrefix(accessToken, accessTokenPrefix), srv.cipher, "", time.Now())
 	if err != nil {
 		return "", 0, err
 	}

--- a/internal/mcp/token_test.go
+++ b/internal/mcp/token_test.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pomerium/pomerium/pkg/cryptutil"
+)
+
+func newTokenTestHandler(t *testing.T) *Handler {
+	t.Helper()
+	testCipher, err := cryptutil.NewAEADCipher(cryptutil.NewKey())
+	require.NoError(t, err)
+	return &Handler{cipher: testCipher}
+}
+
+func TestAccessTokenPrefix(t *testing.T) {
+	srv := newTokenTestHandler(t)
+	expires := time.Now().Add(time.Hour)
+
+	t.Run("prefixed", func(t *testing.T) {
+		tok, err := srv.GetAccessTokenForSessionWithVersion("session-1", 42, expires)
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(tok, "pom_mat_"), "got %q", tok)
+
+		id, version, err := srv.GetSessionAndVersionFromAccessToken(tok)
+		require.NoError(t, err)
+		assert.Equal(t, "session-1", id)
+		assert.Equal(t, uint64(42), version)
+	})
+
+	t.Run("bare", func(t *testing.T) {
+		bare, err := CreateCodeWithRecordVersion(CodeTypeAccess, "session-2", expires, "", srv.cipher, 7)
+		require.NoError(t, err)
+		require.False(t, strings.HasPrefix(bare, accessTokenPrefix))
+
+		id, version, err := srv.GetSessionAndVersionFromAccessToken(bare)
+		require.NoError(t, err)
+		assert.Equal(t, "session-2", id)
+		assert.Equal(t, uint64(7), version)
+	})
+}
+
+func TestRefreshTokenPrefix(t *testing.T) {
+	srv := newTokenTestHandler(t)
+	expires := time.Now().Add(time.Hour)
+
+	t.Run("prefixed", func(t *testing.T) {
+		tok, err := srv.CreateRefreshToken("session-3", "client-a", expires)
+		require.NoError(t, err)
+		require.True(t, strings.HasPrefix(tok, "pom_mrt_"), "got %q", tok)
+
+		code, err := srv.DecryptRefreshToken(tok, "client-a")
+		require.NoError(t, err)
+		assert.Equal(t, "session-3", code.GetId())
+	})
+
+	t.Run("bare", func(t *testing.T) {
+		bare, err := CreateCode(CodeTypeRefresh, "session-4", expires, "client-b", srv.cipher)
+		require.NoError(t, err)
+		require.False(t, strings.HasPrefix(bare, refreshTokenPrefix))
+
+		code, err := srv.DecryptRefreshToken(bare, "client-b")
+		require.NoError(t, err)
+		assert.Equal(t, "session-4", code.GetId())
+	})
+}


### PR DESCRIPTION
## Summary

Opaque MCP tokens minted by Pomerium are now self-describing: access tokens are prefixed `pom_mat_` and refresh tokens `pom_mrt_`. Previously both were bare base64 blobs, indistinguishable from each other and from any other opaque credential in a log, a config file, or a bug report.

Parsing dual-accepts prefixed and unprefixed tokens, so tokens issued before this change keep working until they expire. `_` does not appear in the standard-base64 token body, so trimming an absent prefix cannot corrupt a bare token.

This is in anticipation of being able to distinguish two different sources of tokens arriving to MCP routes - issued to interactive users and to workloads executing on behalf of the users. 

## Related

- https://github.blog/engineering/platform-security/behind-githubs-new-authentication-token-formats/

## User Explanation

MCP access and refresh tokens issued by Pomerium now start with `pom_mat_` and `pom_mrt_` respectively. This makes the token type obvious on sight and lets secret scanners recognize a leaked Pomerium MCP token. Existing tokens continue to be accepted, so no client needs to re-authenticate.

## AI disclosure

Claude Code: extracted the change from a larger branch, wrote the tests, and drafted this description; reviewed by me.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
