### PR TITLE
fix(portal): derive proxied TCP/UDP route names from target domain

### DIFF
--- a/pkg/zero/importutil/namegen.go
+++ b/pkg/zero/importutil/namegen.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"github.com/zeebo/xxh3"
+
+	"github.com/pomerium/pomerium/internal/urlutil"
 )
 
 func GenerateCertName(cert *x509.Certificate) *string {
@@ -314,7 +316,15 @@ func (t *domainTrie[T]) Insert(route T) {
 		// ignore invalid urls, they will be assigned generic fallback names
 		return
 	}
-	parts := strings.Split(u.Hostname(), ".")
+
+	hostname := u.Hostname()
+	if strings.HasPrefix(u.Scheme, "tcp+") || strings.HasPrefix(u.Scheme, "udp+") {
+		if domains := urlutil.GetDomainsForURL(u, false); len(domains) > 0 {
+			hostname = urlutil.StripPort(domains[0])
+		}
+	}
+
+	parts := strings.Split(hostname, ".")
 	slices.Reverse(parts)
 	cur := t.root
 	for _, part := range parts[:len(parts)-1] {

--- a/pkg/zero/importutil/namegen_test.go
+++ b/pkg/zero/importutil/namegen_test.go
@@ -131,6 +131,33 @@ func TestGenerateRouteNames(t *testing.T) {
 			expected: []string{"foo", "bar", "baz"},
 		},
 		{
+			name: "tcp routes through proxy",
+			input: []*configpb.Route{
+				{
+					From: "tcp+https://auth.example.com:4443/ssh-db1-live.example.com:22",
+				},
+				{
+					From: "tcp+https://auth.example.com:4443/ssh-db2-live.example.com:22",
+				},
+				{
+					From: "tcp+https://auth.example.com:4443/ssh-db3-live.example.com:22",
+				},
+			},
+			expected: []string{"ssh-db1-live", "ssh-db2-live", "ssh-db3-live"},
+		},
+		{
+			name: "udp routes through proxy",
+			input: []*configpb.Route{
+				{
+					From: "udp+https://auth.example.com:4443/dns1.example.com:53",
+				},
+				{
+					From: "udp+https://auth.example.com:4443/dns2.example.com:53",
+				},
+			},
+			expected: []string{"dns1", "dns2"},
+		},
+		{
 			name: "multiple domain names, unique subdomains",
 			input: []*configpb.Route{
 				{From: "https://a.domain1.example.com"},

--- a/proxy/portal/portal_test.go
+++ b/proxy/portal/portal_test.go
@@ -50,6 +50,13 @@ func TestRouteFromConfigRoute(t *testing.T) {
 			ConnectCommand: "pomerium-cli udp dns.example.com:53",
 		},
 		{
+			ID:             "7b2efd6bc00173d7",
+			Name:           "production-database",
+			Type:           portal.RouteTypeTCP,
+			From:           "tcp+https://proxy.corp.example.com:8443/postgres.internal.example.com:5432",
+			ConnectCommand: "pomerium-cli tcp tcp+https://proxy.corp.example.com:8443/postgres.internal.example.com:5432",
+		},
+		{
 			ID:             "8544b096d71c5dfe",
 			Name:           "redis",
 			Type:           portal.RouteTypeTCP,
@@ -83,7 +90,11 @@ func TestRouteFromConfigRoute(t *testing.T) {
 			To:   to2,
 		},
 		{
-			Name: "redis",
+			Name: "production-database",
+			From: "tcp+https://proxy.corp.example.com:8443/postgres.internal.example.com:5432",
+			To:   to3,
+		},
+		{
 			From: "tcp+https://proxy.corp.example.com:8443/redis.internal.example.com:6379",
 			To:   to3,
 		},


### PR DESCRIPTION
## Summary

<!--  For example...
The existing implementation has poor numerical properties for
large arguments, so use the McGillicutty algorithm to improve
accuracy above 1e10.

The algorithm is described at https://wikipedia.org/wiki/McGillicutty_Algorithm
-->

Fix route name generation for proxied TCP and UDP routes.

For extended route URLs, use the target domain in the URL path instead of the Pomerium proxy hostname when generating route names. This prevents multiple routes from being displayed as `auth`, `auth (2)`, etc.

## Related issues

<!-- For example...
- #159
-->

- Closes: https://github.com/pomerium/pomerium/issues/5555

## User Explanation

<!-- How would you explain this change to the user? If this
change doesn't create any user-facing changes, you can leave
this blank. If filled out, add the `docs` label -->

TCP and UDP routes using a Pomerium proxy on a non-standard port now get names derived from their target domain, making them easier to distinguish in the Routes Portal and Pomerium Desktop.

## AI disclosure

<!-- If this PR was assisted by AI (Claude, Copilot, Cursor, Amp, etc.),
state which tool and roughly how much of the work was AI-assisted (e.g.
"Cursor autocomplete only", "Claude Code drafted scaffolding, I rewrote
the auth path"). If no AI was used, write "none". See AI_POLICY.md. -->

I used ChatGPT to investigate the issue, discuss possible implementation approaches, and help draft this PR description.
I wrote and reviewed the implementation myself.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label ( `bug`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
