### PR TITLE
feat(mcp): add mcp_client_id_metadata runtime flag

### DIFF
--- a/config/options.go
+++ b/config/options.go
@@ -1687,7 +1687,7 @@ func (o *Options) ApplySettings(ctx context.Context, certsIndex *cryptutil.Certi
 	if settings.HasBrandingOptions() {
 		o.BrandingOptions = settings
 	}
-	copyMap(&o.RuntimeFlags, settings.RuntimeFlags, func(k string, v bool) (RuntimeFlag, bool) {
+	mergeMap(&o.RuntimeFlags, settings.RuntimeFlags, func(k string, v bool) (RuntimeFlag, bool) {
 		return RuntimeFlag(k), v
 	})
 	if settings.Http3AdvertisePort != nil {
@@ -2105,6 +2105,26 @@ func copyMap[T1Key comparable, T1Value any, T2Key comparable, T2Value any, TMap1
 		k1, v1 := convert(k, v)
 		(*dst)[k1] = v1
 	}
+}
+
+// mergeMap overlays src onto dst, leaving keys absent from src untouched, so an
+// overlay only overrides what it carries. dst is replaced rather than mutated in
+// place because the map may be shared with the config being overlaid.
+func mergeMap[T1Key comparable, T1Value any, T2Key comparable, T2Value any, TMap1 ~map[T1Key]T1Value, TMap2 ~map[T2Key]T2Value](
+	dst *TMap1,
+	src TMap2,
+	convert func(T2Key, T2Value) (T1Key, T1Value),
+) {
+	if len(src) == 0 {
+		return
+	}
+	merged := make(TMap1, len(*dst)+len(src))
+	maps.Copy(merged, *dst)
+	for k, v := range src {
+		k1, v1 := convert(k, v)
+		merged[k1] = v1
+	}
+	*dst = merged
 }
 
 func setCertificate(

--- a/config/options.go
+++ b/config/options.go
@@ -360,7 +360,12 @@ var defaultOptions = Options{
 
 // IsRuntimeFlagSet returns true if the runtime flag is sets
 func (o *Options) IsRuntimeFlagSet(flag RuntimeFlag) bool {
-	return o.RuntimeFlags[flag]
+	// a flag absent from the map falls back to its default: a persisted config written
+	// before the flag existed must not silently turn a default-enabled feature off
+	if v, ok := o.RuntimeFlags[flag]; ok {
+		return v
+	}
+	return defaultRuntimeFlags[flag]
 }
 
 var defaultSetResponseHeaders = map[string]string{

--- a/config/options_test.go
+++ b/config/options_test.go
@@ -1137,6 +1137,22 @@ func TestOptions_ApplySettings(t *testing.T) {
 		assert.Equal(t, "SSH_USER_CA_KEY", options.SSHUserCAKey)
 	})
 
+	t.Run("runtime flags", func(t *testing.T) {
+		opts := NewDefaultOptions()
+		opts.RuntimeFlags[RuntimeFlagMCPClientIDMetadata] = false
+		shared := opts.RuntimeFlags
+
+		opts.ApplySettings(t.Context(), nil, &configpb.Settings{
+			RuntimeFlags: map[string]bool{string(RuntimeFlagMCPDynamicClientRegistration): true},
+		})
+
+		// settings only override the flags they carry
+		assert.False(t, opts.IsRuntimeFlagSet(RuntimeFlagMCPClientIDMetadata))
+		assert.True(t, opts.IsRuntimeFlagSet(RuntimeFlagMCPDynamicClientRegistration))
+		// the original map is shared with the config being overlaid, so it must not be modified
+		assert.False(t, shared[RuntimeFlagMCPDynamicClientRegistration])
+	})
+
 	t.Run("empty", func(t *testing.T) {
 		opts := NewDefaultOptions()
 		// set a few non-default options too

--- a/config/runtime_flags.go
+++ b/config/runtime_flags.go
@@ -33,6 +33,11 @@ var (
 	// RuntimeFlagMCP enables the MCP services for the authorize service
 	RuntimeFlagMCP = runtimeFlag("mcp", true)
 
+	// RuntimeFlagMCPClientIDMetadata advertises support for Client ID Metadata Documents in the
+	// MCP authorization server metadata. Disable it to present Pomerium as DCR-only: clients that
+	// prefer CIMD whenever it is advertised will then register dynamically instead.
+	RuntimeFlagMCPClientIDMetadata = runtimeFlag("mcp_client_id_metadata", true)
+
 	// RuntimeFlagMCPDynamicClientRegistration enables Dynamic Client Registration as an authorization
 	// method for upstream MCP servers
 	RuntimeFlagMCPDynamicClientRegistration = runtimeFlag("mcp_dynamic_client_registration", false)

--- a/internal/controlplane/http.go
+++ b/internal/controlplane/http.go
@@ -80,14 +80,17 @@ func (srv *Server) mountCommonEndpoints(root *mux.Router, cfg *config.Config) er
 	root.Handle(endpoints.PathWellKnownPomerium+"/", traceHandler(handlers.WellKnownPomerium(authenticateURL)))
 	root.Path(endpoints.PathJWKS).Methods(http.MethodGet).Handler(traceHandler(handlers.JWKSHandler(signingKey)))
 	root.Path(endpoints.PathHPKEPublicKey).Methods(http.MethodGet).Handler(traceHandler(hpke_handlers.HPKEPublicKeyHandler(hpkePublicKey)))
-	dcrEnabled := cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCPDynamicClientRegistration)
+	metadataOptions := mcp.MetadataOptions{
+		DCREnabled:  cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCPDynamicClientRegistration),
+		CIMDEnabled: cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCPClientIDMetadata),
+	}
 	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
 		root.Path(mcp.WellKnownAuthorizationServerEndpoint).
 			Methods(http.MethodGet, http.MethodOptions).
-			Handler(mcp.AuthorizationServerMetadataHandler(mcp.DefaultPrefix, dcrEnabled))
+			Handler(mcp.AuthorizationServerMetadataHandler(mcp.DefaultPrefix, metadataOptions))
 		root.PathPrefix(mcp.WellKnownProtectedResourceEndpoint).
 			Methods(http.MethodGet, http.MethodOptions).
-			Handler(mcp.ProtectedResourceMetadataHandler(mcp.DefaultPrefix, dcrEnabled))
+			Handler(mcp.ProtectedResourceMetadataHandler(mcp.DefaultPrefix, metadataOptions))
 	}
 
 	return nil

--- a/internal/mcp/handler_metadata.go
+++ b/internal/mcp/handler_metadata.go
@@ -136,15 +136,24 @@ type ProtectedResourceMetadata struct {
 	DPoPBoundAccessTokensRequired bool `json:"dpop_bound_access_tokens_required,omitempty"`
 }
 
-func AuthorizationServerMetadataHandler(prefix string, dcrEnabled bool) http.HandlerFunc {
-	return getMetadataHandler(getAuthorizationServerMetadata, prefix, dcrEnabled)
+// MetadataOptions controls which optional capabilities are advertised in the MCP metadata
+// documents.
+type MetadataOptions struct {
+	// DCREnabled advertises the dynamic client registration endpoint.
+	DCREnabled bool
+	// CIMDEnabled advertises support for Client ID Metadata Documents.
+	CIMDEnabled bool
 }
 
-func ProtectedResourceMetadataHandler(prefix string, dcrEnabled bool) http.HandlerFunc {
-	return getMetadataHandler(getProtectedResourceMetadata, prefix, dcrEnabled)
+func AuthorizationServerMetadataHandler(prefix string, opts MetadataOptions) http.HandlerFunc {
+	return getMetadataHandler(getAuthorizationServerMetadata, prefix, opts)
 }
 
-func getAuthorizationServerMetadata(r *http.Request, prefix string, dcrEnabled bool) AuthorizationServerMetadata {
+func ProtectedResourceMetadataHandler(prefix string, opts MetadataOptions) http.HandlerFunc {
+	return getMetadataHandler(getProtectedResourceMetadata, prefix, opts)
+}
+
+func getAuthorizationServerMetadata(r *http.Request, prefix string, opts MetadataOptions) AuthorizationServerMetadata {
 	baseURL := url.URL{
 		Scheme: "https",
 		Host:   r.Host,
@@ -168,16 +177,16 @@ func getAuthorizationServerMetadata(r *http.Request, prefix string, dcrEnabled b
 		GrantTypesSupported:                        []string{"authorization_code", "refresh_token"},
 		RevocationEndpoint:                         P(path.Join(prefix, revocationEndpoint)),
 		RevocationEndpointAuthMethodsSupported:     []string{"client_secret_post"},
-		ClientIDMetadataDocumentSupported:          true,
+		ClientIDMetadataDocumentSupported:          opts.CIMDEnabled,
 		AuthorizationResponseISSParameterSupported: true,
 	}
-	if dcrEnabled {
+	if opts.DCREnabled {
 		md.RegistrationEndpoint = P(path.Join(prefix, registerEndpoint))
 	}
 	return md
 }
 
-func getProtectedResourceMetadata(r *http.Request, _ string, _ bool) ProtectedResourceMetadata {
+func getProtectedResourceMetadata(r *http.Request, _ string, _ MetadataOptions) ProtectedResourceMetadata {
 	return ProtectedResourceMetadata{
 		Resource: (&url.URL{
 			Scheme: "https",
@@ -193,7 +202,7 @@ func getProtectedResourceMetadata(r *http.Request, _ string, _ bool) ProtectedRe
 	}
 }
 
-func getMetadataHandler[T any](fn func(r *http.Request, prefix string, dcrEnabled bool) T, prefix string, dcrEnabled bool) http.HandlerFunc {
+func getMetadataHandler[T any](fn func(r *http.Request, prefix string, opts MetadataOptions) T, prefix string, opts MetadataOptions) http.HandlerFunc {
 	c := cors.New(cors.Options{
 		AllowedMethods: []string{http.MethodGet, http.MethodOptions},
 		AllowedOrigins: []string{"*"},
@@ -205,7 +214,7 @@ func getMetadataHandler[T any](fn func(r *http.Request, prefix string, dcrEnable
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 
-		meta := fn(r, prefix, dcrEnabled)
+		meta := fn(r, prefix, opts)
 		_ = json.NewEncoder(w).Encode(meta)
 	})
 	r.Methods(http.MethodOptions).HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/mcp/handler_metadata_test.go
+++ b/internal/mcp/handler_metadata_test.go
@@ -1,7 +1,9 @@
 package mcp_test
 
 import (
+	"encoding/json"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -54,6 +56,63 @@ func TestWWWAuthenticate(t *testing.T) {
 			require.Empty(t, cmp.Diff(hdr, http.Header{
 				"Www-Authenticate": []string{tc.expected},
 			}))
+		})
+	}
+}
+
+func TestAuthorizationServerMetadataCapabilities(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		opts             mcp.MetadataOptions
+		wantCIMD         bool
+		wantRegistration string
+	}{
+		{
+			name:             "defaults advertise cimd only",
+			opts:             mcp.MetadataOptions{CIMDEnabled: true},
+			wantCIMD:         true,
+			wantRegistration: "",
+		},
+		{
+			name:             "both advertised",
+			opts:             mcp.MetadataOptions{CIMDEnabled: true, DCREnabled: true},
+			wantCIMD:         true,
+			wantRegistration: "https://example.com/.pomerium/mcp/register",
+		},
+		{
+			// Clients that prefer CIMD whenever it is advertised only fall back to
+			// DCR when the field is absent entirely.
+			name:             "dcr only omits cimd",
+			opts:             mcp.MetadataOptions{DCREnabled: true},
+			wantCIMD:         false,
+			wantRegistration: "https://example.com/.pomerium/mcp/register",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			req := httptest.NewRequest(http.MethodGet, "https://example.com"+mcp.WellKnownAuthorizationServerEndpoint, nil)
+			req.Host = "example.com"
+			w := httptest.NewRecorder()
+
+			mcp.AuthorizationServerMetadataHandler(mcp.DefaultPrefix, tc.opts).ServeHTTP(w, req)
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var got mcp.AuthorizationServerMetadata
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+			require.Equal(t, tc.wantCIMD, got.ClientIDMetadataDocumentSupported)
+			require.Equal(t, tc.wantRegistration, got.RegistrationEndpoint)
+
+			// omitempty: the field must be absent, not false, so clients cannot
+			// read it as an explicit capability declaration.
+			var raw map[string]any
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &raw))
+			_, present := raw["client_id_metadata_document_supported"]
+			require.Equal(t, tc.wantCIMD, present)
 		})
 	}
 }


### PR DESCRIPTION
## Summary 

Adds an opt-out runtime flag `mcp_client_id_metadata` (default `true`) controlling whether `client_id_metadata_document_supported` is advertised in the MCP authorization-server metadata. Disabling it presents Pomerium as DCR-only.

## Details

DCR is already gated behind `mcp_dynamic_client_registration`, but CIMD was hardcoded on, so there was no configuration in which Pomerium advertises DCR without also advertising CIMD. Clients whose acquisition order prefers CIMD therefore never exercise DCR — claude.ai's documented order is pre-registered client ID, then CIMD, then DCR. Unsetting `mcp_allowed_client_id_domains` is not a workaround: such a client still attempts CIMD and receives a 401 instead of falling back.

The field carries `omitempty`, so disabling the flag removes it from the document rather than emitting `false`. That distinction is load-bearing: clients read an absent field differently from an explicit `false`.

The metadata handlers took a bare `dcrEnabled bool`; they now take a `MetadataOptions` struct, so the two capabilities do not become an unlabelled pair of booleans at every call site.

Scope: this changes what is advertised only. Disabling the flag does not make Pomerium reject a client that presents a CIMD client ID anyway — `mcp_allowed_client_id_domains` already governs that, and denies all when unset.

Note the flag is named for the capability rather than `mcp_disable_client_id_metadata` as suggested in the issue, to match the existing `mcp` and `mcp_dynamic_client_registration` flags.

Fixes #6675

## AI disclosure

Fully Claude Code written, tested against my own setup using this feature.