### PR TITLE
feat: expose GCP serverless token as set_request_headers template var…

### DIFF
--- a/authorize/evaluator/headers_evaluator_evaluation.go
+++ b/authorize/evaluator/headers_evaluator_evaluation.go
@@ -164,6 +164,30 @@ func (e *headersEvaluatorEvaluation) fillGoogleCloudServerlessHeaders(ctx contex
 	}
 }
 
+func (e *headersEvaluatorEvaluation) getGCPServerlessToken(ctx context.Context) string {
+	if e.request.Policy == nil || !e.request.Policy.EnableGoogleCloudServerlessAuthentication {
+		return ""
+	}
+
+	var toAudience string
+	for _, wu := range e.request.Policy.To {
+		toAudience = "https://" + wu.URL.Hostname()
+	}
+
+	src, err := getGoogleCloudServerlessTokenSource(e.evaluator.store.GetGoogleCloudServerlessAuthenticationServiceAccount(), toAudience)
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("authorize/header-evaluator: error retrieving google cloud serverless token source")
+		return ""
+	}
+
+	tok, err := src.Token()
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("authorize/header-evaluator: error retrieving google cloud serverless token")
+		return ""
+	}
+	return tok.AccessToken
+}
+
 func (e *headersEvaluatorEvaluation) fillRoutingKeyHeaders() {
 	if e.request.Policy == nil {
 		return
@@ -197,6 +221,8 @@ func (e *headersEvaluatorEvaluation) fillSetRequestHeaders(ctx context.Context) 
 				return s.GetIdToken().GetRaw()
 			case slices.Equal(ref, []string{"pomerium", "jwt"}):
 				return e.getSignedJWT(ctx)
+			case slices.Equal(ref, []string{"pomerium", "google_cloud_serverless_token"}):
+				return e.getGCPServerlessToken(ctx)
 			case len(ref) > 3 && ref[0] == "pomerium" && ref[1] == "request" && ref[2] == "headers":
 				return e.request.HTTP.Headers[httputil.CanonicalHeaderKey(ref[3])]
 			}

--- a/authorize/evaluator/headers_evaluator_test.go
+++ b/authorize/evaluator/headers_evaluator_test.go
@@ -919,3 +919,66 @@ func (m *mockMCPAccessTokenProvider) GetAccessTokenForSession(_ string, _ time.T
 	}
 	return m.sessionToken, nil
 }
+
+func TestHeadersEvaluator_GoogleCloudServerlessToken(t *testing.T) {
+	// Not parallel: withMockGCP mutates package-level globals.
+
+	privateJWK, _ := newJWK(t)
+	iat := time.Unix(1686870680, 0)
+
+	t.Run("resolves token when serverless auth enabled", func(t *testing.T) {
+		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJleGFtcGxlIn0.signature"))
+		})
+
+		ctx := t.Context()
+		ctx = storage.WithQuerier(ctx, storage.NewStaticQuerier(
+			&session.Session{Id: "s1"},
+		))
+		s := store.New()
+		s.UpdateSigningKey(privateJWK)
+		e := NewHeadersEvaluator(s)
+
+		output, err := e.Evaluate(ctx, &Request{
+			Policy: &config.Policy{
+				EnableGoogleCloudServerlessAuthentication: true,
+				To: config.WeightedURLs{
+					{URL: *mustParseURL("https://my-service.a.run.app")},
+				},
+				SetRequestHeaders: map[string]string{
+					"X-Custom-Auth": "Bearer ${pomerium.google_cloud_serverless_token}",
+				},
+			},
+			Session: RequestSession{ID: "s1"},
+		}, rego.EvalTime(iat))
+		require.NoError(t, err)
+		assert.Equal(t, "Bearer eyJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJleGFtcGxlIn0.signature",
+			output.Headers.Get("X-Custom-Auth"))
+	})
+
+	t.Run("resolves to empty when serverless auth disabled", func(t *testing.T) {
+		withMockGCP(t, func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("should-not-be-called"))
+		})
+
+		ctx := t.Context()
+		ctx = storage.WithQuerier(ctx, storage.NewStaticQuerier(
+			&session.Session{Id: "s1"},
+		))
+		s := store.New()
+		s.UpdateSigningKey(privateJWK)
+		e := NewHeadersEvaluator(s)
+
+		output, err := e.Evaluate(ctx, &Request{
+			Policy: &config.Policy{
+				EnableGoogleCloudServerlessAuthentication: false,
+				SetRequestHeaders: map[string]string{
+					"X-Custom-Auth": "Token ${pomerium.google_cloud_serverless_token}",
+				},
+			},
+			Session: RequestSession{ID: "s1"},
+		}, rego.EvalTime(iat))
+		require.NoError(t, err)
+		assert.Equal(t, "Token ", output.Headers.Get("X-Custom-Auth"))
+	})
+}


### PR DESCRIPTION
## Summary

Since v0.33 ([#6268](https://github.com/pomerium/pomerium/pull/6268)), Pomerium sends the GCP identity token via `X-Serverless-Authorization` instead of `Authorization`. Cloud Run strips the signature from this header before forwarding to the container (`SIGNATURE_REMOVED_BY_GOOGLE`), making it impossible for dual-path services (reachable both through Pomerium and a public load balancer) to verify that a request originated from Pomerium.

This adds a new `${pomerium.google_cloud_serverless_token}` template variable for use in `set_request_headers`, allowing users to place the raw GCP identity token (with signature intact) in any header of their choice.

## Related issues

- #6677

## User Explanation

A new template variable `${pomerium.google_cloud_serverless_token}` is available in `set_request_headers`. It resolves to the raw GCP identity token for the route's upstream audience when `enable_google_cloud_serverless_authentication` is enabled, or to an empty string otherwise.

Example usage:

```yaml
- from: https://service.example.com
  to: https://my-service.a.run.app
  enable_google_cloud_serverless_authentication: true
  set_request_headers:
    Authorization: "Bearer ${pomerium.google_cloud_serverless_token}"
```

This restores the ability for applications to verify the Pomerium-originated token signature, which was lost when the token moved to `X-Serverless-Authorization` in v0.33.

## AI disclosure

Claude Code drafted the implementation and tests. I manually tested the functionality via a deployed fork.

## Checklist

- [x] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
