### PR TITLE
test(acceptance): hosted authenticate e2e suite (hosted IdP flow + legacy stateless flow)

### DIFF
--- a/internal/acceptance/.gitignore
+++ b/internal/acceptance/.gitignore
@@ -17,3 +17,6 @@ test-results/
 
 # Debug/temporary files
 *.log
+
+# hosted-IdP test account for the hosted e2e suite (never commit)
+browser/.env.hosted

--- a/internal/acceptance/Makefile
+++ b/internal/acceptance/Makefile
@@ -1,6 +1,6 @@
 # E2E Acceptance Testing Makefile
 
-.PHONY: help deps up down test test-mode-headed test-mode-debug test-suite-authn test-suite-authz test-suite-headers test-headed test-debug test-authn test-authz test-headers test-go logs status report artifacts clean deps-mcp test-mcp test-mcp-headed deps-downstream-mtls test-downstream-mtls test-downstream-mtls-headed deps-upstream-tls test-upstream-tls test-upstream-tls-headed
+.PHONY: help deps up down test test-mode-headed test-mode-debug test-suite-authn test-suite-authz test-suite-headers up-hosted test-suite-hosted test-hosted test-headed test-debug test-authn test-authz test-headers test-go logs status report artifacts clean deps-mcp test-mcp test-mcp-headed deps-downstream-mtls test-downstream-mtls test-downstream-mtls-headed deps-upstream-tls test-upstream-tls test-upstream-tls-headed
 
 COMPOSE_PROJECT ?= acceptance
 COMPOSE_FILE ?= docker-compose.yml
@@ -24,6 +24,9 @@ help:
 	@echo "  make test-suite-authn  - Run authn tests"
 	@echo "  make test-suite-authz  - Run authz tests"
 	@echo "  make test-suite-headers  - Run headers tests"
+	@echo "  make test-suite-hosted   - Run hosted-authenticate tests (real cloud;"
+	@echo "                             needs internet + optional HOSTED_TEST_EMAIL/PASSWORD)"
+	@echo "  make up-hosted    - Start the stack incl. hosted-authenticate instances"
 	@echo "  make down         - Stop the stack"
 	@echo "  make logs         - Tail container logs"
 	@echo "  make status       - Show container and health status"
@@ -57,9 +60,9 @@ deps:
 up:
 	$(COMPOSE) up -d --build --wait
 
-# Stop the test stack
+# Stop the test stack (includes the "hosted" profile services, if started)
 down:
-	$(COMPOSE) down -v
+	$(COMPOSE) --profile hosted down -v
 
 # Run all tests (headless)
 test: up
@@ -83,12 +86,24 @@ test-suite-authz: up
 test-suite-headers: up
 	cd $(BROWSER_DIR) && npm run test:headers
 
+# Start the test stack INCLUDING the hosted-authenticate instances
+up-hosted:
+	$(COMPOSE) --profile hosted up -d --build --wait
+
+# Hosted-authenticate suite: talks to the REAL https://authenticate.pomerium.app
+# (requires outbound internet). Positive login/logout/timeout tests additionally
+# need HOSTED_TEST_EMAIL and HOSTED_TEST_PASSWORD (a real hosted-IdP account)
+# exported in the environment; without them those tests are skipped.
+test-suite-hosted: up-hosted
+	cd $(BROWSER_DIR) && HOSTED_E2E=1 npm run test:hosted
+
 # Backward-compatible aliases
 test-headed: test-mode-headed
 test-debug: test-mode-debug
 test-authn: test-suite-authn
 test-authz: test-suite-authz
 test-headers: test-suite-headers
+test-hosted: test-suite-hosted
 
 # Run tests via Go test wrapper
 test-go: up

--- a/internal/acceptance/README.md
+++ b/internal/acceptance/README.md
@@ -85,6 +85,45 @@ make status
 - Update Keycloak token lifetimes or mappers in `internal/acceptance/keycloak/realm.json`.
 - Update URLs and timeouts in `internal/acceptance/browser/fixtures/test-data.ts`.
 
+## Hosted authenticate suite (`browser/tests/hosted/`)
+
+Automates the QA test plan cases for both hosted-authenticate flavors against
+the REAL cloud service `https://authenticate.pomerium.app`:
+
+- **New HA** (`idp_provider: hosted` + local authenticate) - `pomerium-hosted-new`
+  (`:8444`, `pomerium/config-hosted-new.yaml`)
+- **Old HA** (stateless flow, `authenticate_service_url: https://authenticate.pomerium.app`) -
+  `pomerium-hosted-old` (`:8445`, `cookie_expire: 90s` for the session-timeout test)
+- **Priority** (hosted URL + a full Keycloak IdP block; hosted must win) -
+  `pomerium-hosted-priority` (`:8446`)
+
+These services sit behind the `hosted` compose profile and the specs are gated
+on `HOSTED_E2E=1`, so the default `make test` / PR CI never starts them and
+reports every hosted test as skipped.
+
+```bash
+# everything that needs no account (redirect shapes, invalid/empty creds, priority):
+make test-suite-hosted
+
+# full suite - positive login/logout/timeout tests need a real hosted-IdP account:
+HOSTED_TEST_EMAIL='qa@example.com' HOSTED_TEST_PASSWORD='...' make test-suite-hosted
+```
+
+Notes:
+
+- Requires outbound internet; `global-setup.ts` fails fast with a named check
+  when the cloud service is unreachable.
+- Tests that log in are serialized (`--workers=1`) and only ever use the real
+  account for positive paths; invalid-credential tests use random fake emails,
+  so the account cannot be locked out.
+- `HA.Google single-sign.positive` from the QA plan is intentionally NOT
+  automated (real Google login cannot be driven by automation) - manual only.
+- All selectors, copy strings, and captured live-UI facts for the cloud
+  sign-in and sign-out UI live in `browser/helpers/hosted.ts` only (see its
+  module header). If the hosted UI changes, re-capture with
+  `cd browser && npx playwright codegen --ignore-https-errors
+  https://verify-hosted.localhost.pomerium.io:8444` and update that one file.
+
 ## CI
 
 Workflow lives in `.github/workflows/acceptance.yaml` and installs Node, Go, and Playwright dependencies. Artifacts are collected under `internal/acceptance/artifacts/`.

--- a/internal/acceptance/browser/fixtures/feature-map.json
+++ b/internal/acceptance/browser/fixtures/feature-map.json
@@ -69,6 +69,36 @@
           "Preserve Host"
         ]
       }
+    },
+    "Hosted Authenticate": {
+      "description": "Hosted authenticate service (authenticate.pomerium.app): new hosted-IdP flow and legacy stateless flow",
+      "files": {
+        "hosted/new-ha-login.spec.ts": [
+          "Hosted IdP Flow",
+          "Signed Request Object",
+          "Login Negative"
+        ],
+        "hosted/new-ha-logout.spec.ts": [
+          "Hosted Sign-Out Confirm",
+          "Session Termination"
+        ],
+        "hosted/old-ha-login.spec.ts": [
+          "Stateless Sign-In",
+          "HPKE Redirect",
+          "Login Negative"
+        ],
+        "hosted/old-ha-logout.spec.ts": [
+          "Hosted Sign-Out Confirm",
+          "Sign-Out Cancel"
+        ],
+        "hosted/old-ha-session-timeout.spec.ts": [
+          "Cookie Expiry",
+          "Forced Re-Auth"
+        ],
+        "hosted/old-ha-priority.spec.ts": [
+          "Hosted URL Precedence"
+        ]
+      }
     }
   }
 }

--- a/internal/acceptance/browser/fixtures/test-data.ts
+++ b/internal/acceptance/browser/fixtures/test-data.ts
@@ -25,6 +25,27 @@ export const urls = {
 
   /** Cross-origin base used for CORS browser-context tests */
   corsOrigin: process.env.CORS_ORIGIN || "http://localhost:8081",
+
+  /** New-HA route URL (idp_provider: hosted; started via `make up-hosted`) */
+  verifyHostedNew:
+    process.env.VERIFY_HOSTED_NEW_URL || "https://verify-hosted.localhost.pomerium.io:8444",
+
+  /** New-HA local authenticate service URL (= the derived OIDC client_id) */
+  authenticateHostedNew:
+    process.env.AUTHENTICATE_HOSTED_NEW_URL ||
+    "https://authenticate-hosted.localhost.pomerium.io:8444",
+
+  /** Old-HA (stateless flow) route URL */
+  verifyHostedOld:
+    process.env.VERIFY_HOSTED_OLD_URL || "https://verify-hosted-old.localhost.pomerium.io:8445",
+
+  /** Old-HA route URL on the instance that ALSO has a Keycloak IdP block (priority test) */
+  verifyHostedPriority:
+    process.env.VERIFY_HOSTED_PRIORITY_URL ||
+    "https://verify-hosted-priority.localhost.pomerium.io:8446",
+
+  /** The real hosted authenticate service (cloud) */
+  hostedAuthenticate: process.env.HOSTED_AUTHENTICATE_URL || "https://authenticate.pomerium.app",
 };
 
 /**
@@ -218,6 +239,9 @@ export const timeouts = {
 
   /** Poll interval for waiting operations */
   pollInterval: 500,
+
+  /** cookie_expire on the old-HA instance (pomerium/config-hosted-old.yaml) */
+  hostedCookieExpire: 90000,
 };
 
 /**

--- a/internal/acceptance/browser/global-setup.ts
+++ b/internal/acceptance/browser/global-setup.ts
@@ -1,6 +1,7 @@
 import { FullConfig } from "@playwright/test";
 import https from "https";
 import http from "http";
+import { urls, paths } from "./fixtures/test-data.js";
 
 /**
  * Global setup for Pomerium E2E acceptance tests.
@@ -39,20 +40,46 @@ async function globalSetup(_config: FullConfig): Promise<void> {
     },
   ];
 
+  // Hosted-authenticate suite checks (make up-hosted). The three local
+  // instances only exist when the "hosted" compose profile is active, and the
+  // cloud check fails fast on missing internet / a hosted-service outage.
+  if (process.env.HOSTED_E2E) {
+    checks.push(
+      { name: "Pomerium hosted-new healthz", url: `${urls.authenticateHostedNew}/healthz` },
+      { name: "Pomerium hosted-old healthz", url: `${urls.verifyHostedOld}/healthz` },
+      {
+        name: "Pomerium hosted-priority healthz",
+        url: `${urls.verifyHostedPriority}/healthz`,
+      },
+      {
+        name: "Hosted authenticate (cloud) reachability",
+        url: `${urls.hostedAuthenticate}${paths.hpkePublicKey}`,
+      },
+    );
+  }
+
   console.log("Verifying service availability:");
 
-  for (const check of checks) {
-    try {
-      await checkUrl(check.url, check.name);
+  const results = await Promise.allSettled(
+    checks.map((check) => checkUrl(check.url, check.name))
+  );
+  let failedCheck: string | undefined;
+  results.forEach((result, i) => {
+    const check = checks[i];
+    if (result.status === "fulfilled") {
       console.log(`  ✓ ${check.name}: OK`);
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+    } else {
+      const message =
+        result.reason instanceof Error ? result.reason.message : String(result.reason);
       console.log(`  ✗ ${check.name}: ${message}`);
-      throw new Error(
-        `Service check failed for ${check.name}. ` +
-        `Ensure all services are running with 'make up' or 'docker compose up -d --wait'.`
-      );
+      failedCheck ??= check.name;
     }
+  });
+  if (failedCheck) {
+    throw new Error(
+      `Service check failed for ${failedCheck}. ` +
+      `Ensure all services are running with 'make up' or 'docker compose up -d --wait'.`
+    );
   }
 
   console.log("");

--- a/internal/acceptance/browser/helpers/hosted.ts
+++ b/internal/acceptance/browser/helpers/hosted.ts
@@ -1,0 +1,381 @@
+/**
+ * Hosted-authenticate (https://authenticate.pomerium.app) helpers for the
+ * `tests/hosted/` suite.
+ *
+ * Every selector and copy string for the REAL cloud sign-in / sign-out UI
+ * lives ONLY in this module, so a hosted UI redesign is a one-file fix (see
+ * the "Hosted authenticate suite" section of internal/acceptance/README.md
+ * for the re-capture procedure).
+ *
+ * Live-UI facts (captured 2026-08-21): the sign-in page is a JS-rendered app
+ * whose inputs carry no labels, names, or placeholders - only type attributes;
+ * the submit button is "Login" and stays DISABLED while either field is empty
+ * (so empty submissions are impossible and no native validation message ever
+ * appears); rejected credentials render a role="alert" MUI element reading
+ * "The supplied auth credential is malformed or has expired."
+ *
+ * Env contract:
+ *   HOSTED_E2E=1            - enables the suite (services: `make up-hosted`)
+ *   HOSTED_TEST_EMAIL       - real hosted-IdP account (positive-path tests)
+ *   HOSTED_TEST_PASSWORD    - its password
+ */
+
+import { APIResponse, Page, Locator, test, expect } from "@playwright/test";
+import { urls, paths, timeouts, headerNames, cookieNames } from "../fixtures/test-data.js";
+
+export interface HostedUser {
+  email: string;
+  password: string;
+}
+
+/** Hostname of the hosted authenticate service (env-overridable via urls). */
+export const HOSTED_HOSTNAME = new URL(urls.hostedAuthenticate).hostname;
+
+// ---------------------------------------------------------------------------
+// Env gating
+// ---------------------------------------------------------------------------
+
+/**
+ * Skip the enclosing scope unless the hosted e2e suite is enabled
+ * (`make test-suite-hosted` sets HOSTED_E2E=1). Call once per describe.
+ */
+export function skipUnlessHostedE2E(): void {
+  test.skip(
+    !process.env.HOSTED_E2E,
+    "hosted e2e disabled - run via `make test-suite-hosted` (HOSTED_E2E=1)"
+  );
+}
+
+/**
+ * Hosted-IdP account for positive-path tests: skips the test when the
+ * credentials env vars are unset, and returns a non-null user otherwise.
+ * Never hardcode credentials.
+ */
+export function requireHostedUser(): HostedUser {
+  const email = process.env.HOSTED_TEST_EMAIL;
+  const password = process.env.HOSTED_TEST_PASSWORD;
+  test.skip(!email || !password, "HOSTED_TEST_EMAIL / HOSTED_TEST_PASSWORD not set");
+  return { email: email!, password: password! };
+}
+
+/**
+ * A clearly-fake unique address for invalid-credential tests. Never uses the
+ * real account, so repeated failures cannot lock it out.
+ */
+export function randomInvalidEmail(): string {
+  const rand = Math.random().toString(36).slice(2, 10);
+  return `e2e-invalid-${Date.now()}-${rand}@invalid.pomerium.test`;
+}
+
+// ---------------------------------------------------------------------------
+// Sign-in form (JS-rendered app - always wait for the rendered inputs, never
+// for page text; the inputs are only reachable by their type attributes).
+// ---------------------------------------------------------------------------
+
+function emailInput(page: Page): Locator {
+  return page.locator('input[type="email"]').first();
+}
+
+function passwordInput(page: Page): Locator {
+  return page.locator('input[type="password"]').first();
+}
+
+function signInButton(page: Page): Locator {
+  return page.getByRole("button", { name: /log ?in/i }).first();
+}
+
+/** Wait until the redirect chain lands on the hosted sign-in form. */
+export async function waitForHostedSignInPage(page: Page): Promise<void> {
+  await page.waitForURL((url) => url.hostname === HOSTED_HOSTNAME, {
+    timeout: timeouts.long,
+  });
+  await expect(
+    passwordInput(page),
+    "hosted sign-in form should render (JS app)"
+  ).toBeVisible({ timeout: timeouts.long });
+}
+
+/** Fill and submit the hosted email/password form. */
+export async function submitHostedLoginForm(page: Page, user: HostedUser): Promise<void> {
+  await emailInput(page).fill(user.email);
+  await passwordInput(page).fill(user.password);
+  await signInButton(page).click();
+}
+
+/**
+ * Full positive login round trip: open the protected target, sign in at the
+ * hosted service, and wait until the browser is back on the target's host.
+ *
+ * Requires a fresh browser context (no hosted SSO cookie): the form MUST
+ * appear. For navigation that may silently SSO instead, use
+ * completeHostedLoginIfFormShown.
+ */
+export async function loginViaHosted(
+  page: Page,
+  opts: { targetUrl: string; user: HostedUser }
+): Promise<void> {
+  const targetHost = new URL(opts.targetUrl).hostname;
+  await page.goto(opts.targetUrl, { waitUntil: "domcontentloaded" });
+  await waitForHostedSignInPage(page);
+  await submitHostedLoginForm(page, opts.user);
+  await page.waitForURL((url) => url.hostname === targetHost, {
+    timeout: timeouts.long,
+  });
+}
+
+/**
+ * Silent-SSO-tolerant login completion: after a navigation that may either
+ * show the hosted credentials form or complete silently (the hosted session
+ * is still alive), submit the form only if it renders, then wait until back
+ * on the target host.
+ */
+export async function completeHostedLoginIfFormShown(
+  page: Page,
+  targetHost: string,
+  user: HostedUser
+): Promise<void> {
+  try {
+    await passwordInput(page).waitFor({ state: "visible", timeout: timeouts.medium });
+    await submitHostedLoginForm(page, user);
+  } catch {
+    // form never rendered: silent SSO is completing the round trip
+  }
+  await page.waitForURL((url) => url.hostname === targetHost, {
+    timeout: timeouts.long,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Negative-path assertions
+// ---------------------------------------------------------------------------
+
+/**
+ * Copy shown by the hosted UI when credentials are rejected (see the live-UI
+ * facts in the module header). `invalid credential` is kept as a tolerant
+ * alternate because Firebase's copy varies slightly per rejection cause.
+ */
+const INVALID_CREDENTIALS_COPY =
+  /supplied auth credential is malformed or has expired|invalid credential/i;
+
+/**
+ * Assert the hosted service rejected the credentials: an alert with the
+ * rejection copy is visible and the browser is still on the hosted service.
+ */
+export async function expectInvalidCredentialsError(page: Page): Promise<void> {
+  const alert = page.getByRole("alert").filter({ hasText: INVALID_CREDENTIALS_COPY }).first();
+  await expect(
+    alert,
+    "hosted service should show the invalid-credentials alert"
+  ).toBeVisible({ timeout: timeouts.long });
+  expect(new URL(page.url()).hostname, "should still be on the hosted service").toBe(
+    HOSTED_HOSTNAME
+  );
+}
+
+/**
+ * Assert the hosted sign-in form blocks submission while fields are empty:
+ * the live UI disables the submit button (there is no native `required`
+ * validation), so a user cannot submit empty or partial credentials at all.
+ */
+export async function expectEmptyFieldsBlocked(page: Page): Promise<void> {
+  const button = signInButton(page);
+
+  await expect(
+    button,
+    "submit should be disabled while both fields are empty"
+  ).toBeDisabled();
+
+  // Partial input (email only) must not enable submission either.
+  await emailInput(page).fill("someone@example.com");
+  await expect(
+    button,
+    "submit should stay disabled while the password is empty"
+  ).toBeDisabled();
+}
+
+/**
+ * Assert the route holds no session: a protected internal endpoint must
+ * answer with a sign-in redirect, whose target URL is returned for further
+ * assertions.
+ */
+export async function expectSignInRedirect(page: Page, routeUrl: string): Promise<URL> {
+  const response = await page.request.get(`${routeUrl}${paths.user}`, {
+    ignoreHTTPSErrors: true,
+    maxRedirects: 0,
+  });
+  expect(
+    response.status(),
+    `unauthenticated ${paths.user} must redirect to sign-in`
+  ).toBe(302);
+  return new URL(response.headers()["location"] || "");
+}
+
+// ---------------------------------------------------------------------------
+// Positive-path assertions
+// ---------------------------------------------------------------------------
+
+/** Parse the pomerium/verify /json echo into a lowercase-keyed header map. */
+async function readEchoedHeaders(response: APIResponse): Promise<Record<string, string>> {
+  const body = (await response.json()) as { headers?: Record<string, unknown> };
+  const headers: Record<string, string> = {};
+  for (const [key, value] of Object.entries(body.headers ?? {})) {
+    headers[key.toLowerCase()] = Array.isArray(value) ? value.join(", ") : String(value);
+  }
+  return headers;
+}
+
+/**
+ * Assert the route serves the authenticated user: the verify upstream's /json
+ * echo must be reachable (200) and carry the user's email identity header.
+ */
+export async function expectUpstreamSeesUser(
+  page: Page,
+  routeUrl: string,
+  email: string
+): Promise<void> {
+  const response = await page.request.get(`${routeUrl}/json`, {
+    ignoreHTTPSErrors: true,
+  });
+  expect(response.status(), "authenticated request must reach the upstream").toBe(200);
+  const headers = await readEchoedHeaders(response);
+  expect(headers[headerNames.claimEmail]).toContain(email);
+}
+
+/** Assert a Pomerium session cookie exists for the given route URL. */
+export async function expectSessionCookie(page: Page, routeUrl: string): Promise<void> {
+  const cookies = await page.context().cookies(routeUrl);
+  expect(
+    cookies.some((cookie) => cookie.name === cookieNames.session),
+    `${cookieNames.session} session cookie should be set`
+  ).toBe(true);
+}
+
+// ---------------------------------------------------------------------------
+// Sign-out confirmation page (rendered by the hosted service in BOTH flows -
+// verified manually: old and new HA show the same confirmation window).
+// ---------------------------------------------------------------------------
+
+function signOutConfirmButton(page: Page): Locator {
+  return page.getByRole("button", { name: /^(ok|log ?out|sign ?out|yes)/i }).first();
+}
+
+function signOutCancelButton(page: Page): Locator {
+  return page.getByRole("button", { name: /cancel|no/i }).first();
+}
+
+/** Wait for the hosted sign-out confirmation page (confirm + cancel visible). */
+export async function waitForHostedSignOutConfirm(page: Page): Promise<void> {
+  await page.waitForURL((url) => url.hostname === HOSTED_HOSTNAME, {
+    timeout: timeouts.long,
+  });
+  await expect(
+    signOutConfirmButton(page),
+    "hosted sign-out confirm button should be visible"
+  ).toBeVisible({ timeout: timeouts.long });
+  await expect(
+    signOutCancelButton(page),
+    "hosted sign-out cancel button should be visible"
+  ).toBeVisible();
+}
+
+/**
+ * Click confirm or cancel on the hosted sign-out page and let it settle.
+ *
+ * NOTE for callers: the resulting signed-out page can still hold pending
+ * activity (a late redirect) - make the NEXT navigation with
+ * {@link gotoStable}, or a plain page.goto may abort with net::ERR_ABORTED.
+ */
+export async function confirmHostedSignOut(
+  page: Page,
+  action: "confirm" | "cancel"
+): Promise<void> {
+  const button = action === "confirm" ? signOutConfirmButton(page) : signOutCancelButton(page);
+  await button.click();
+  await page.waitForLoadState("domcontentloaded");
+  if (action === "confirm") {
+    // The hosted SPA renders "User has been logged out." optimistically while
+    // its revocation request may still be in flight; navigating away inside
+    // that window can silently re-authenticate (the session isn't dead yet).
+    // Wait for the page's network to settle plus a small propagation buffer
+    // (measured: settles in ~1-2s against the live service).
+    await page.waitForLoadState("networkidle", { timeout: 15_000 }).catch(() => {});
+    await page.waitForTimeout(1_000);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Plumbing
+// ---------------------------------------------------------------------------
+
+/**
+ * page.goto that retries transient navigation aborts. The hosted signed-out
+ * page can still hold a pending redirect when a test navigates away from it,
+ * which Chromium surfaces as net::ERR_ABORTED on our navigation; container
+ * churn can likewise surface ERR_NETWORK_CHANGED. Retrying only the
+ * navigation lets the pending activity settle (mirrors
+ * suites/upstream-tls/helpers/nav.ts).
+ */
+export async function gotoStable(
+  page: Page,
+  url: string,
+  attempts = 4
+): Promise<void> {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      await page.goto(url, { waitUntil: "domcontentloaded" });
+      return;
+    } catch (err) {
+      if (attempt < attempts && /ERR_ABORTED|ERR_NETWORK_CHANGED/.test(String(err))) {
+        await page.waitForTimeout(500);
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+export interface RequestTracker {
+  /** URLs of all matching requests seen so far. */
+  urls: () => string[];
+  /** Stop recording. */
+  dispose: () => void;
+}
+
+/**
+ * Record every request whose URL matches the predicate. Use for NEGATIVE
+ * assertions ("this host was never contacted"); for positive "the round trip
+ * happened" checks prefer the one-shot page.waitForRequest.
+ */
+export function trackRequests(page: Page, predicate: (url: URL) => boolean): RequestTracker {
+  const seen: string[] = [];
+  const listener = (request: { url: () => string }) => {
+    try {
+      const url = new URL(request.url());
+      if (predicate(url)) {
+        seen.push(url.toString());
+      }
+    } catch {
+      // ignore non-parseable URLs (data:, about:)
+    }
+  };
+  page.on("request", listener);
+  return {
+    urls: () => [...seen],
+    dispose: () => page.off("request", listener),
+  };
+}
+
+/**
+ * Decode a compact JWS (header.payload.signature) without verifying the
+ * signature - structural assertions only.
+ */
+export function decodeCompactJws(jws: string): {
+  header: Record<string, unknown>;
+  payload: Record<string, unknown>;
+} {
+  const parts = jws.split(".");
+  expect(parts, "a compact JWS has exactly 3 dot-separated segments").toHaveLength(3);
+  const decode = (segment: string) =>
+    JSON.parse(Buffer.from(segment, "base64url").toString("utf8"));
+  return { header: decode(parts[0]), payload: decode(parts[1]) };
+}

--- a/internal/acceptance/browser/helpers/keycloak.ts
+++ b/internal/acceptance/browser/helpers/keycloak.ts
@@ -4,7 +4,9 @@
  */
 
 import { urls, keycloakPaths } from "../fixtures/test-data.js";
-import { getRunId } from "../fixtures/users.js";
+
+/** Unique per-process run id used to prefix ephemeral test usernames. */
+const runId = Date.now().toString(36);
 
 /**
  * Keycloak admin client for test operations.
@@ -174,7 +176,7 @@ export class KeycloakAdmin {
    * Username should be without the run prefix.
    */
   async removeTestUserFromGroup(username: string, groupName: string): Promise<void> {
-    const prefixedUsername = `test-user-${getRunId()}-${username}`;
+    const prefixedUsername = `test-user-${runId}-${username}`;
 
     const user = await this.getUserByUsername(prefixedUsername);
     if (!user) {
@@ -194,7 +196,7 @@ export class KeycloakAdmin {
    * Username should be without the run prefix.
    */
   async addTestUserToGroup(username: string, groupName: string): Promise<void> {
-    const prefixedUsername = `test-user-${getRunId()}-${username}`;
+    const prefixedUsername = `test-user-${runId}-${username}`;
 
     const user = await this.getUserByUsername(prefixedUsername);
     if (!user) {

--- a/internal/acceptance/browser/package.json
+++ b/internal/acceptance/browser/package.json
@@ -11,6 +11,7 @@
     "test:authn": "playwright test tests/authn/",
     "test:authz": "playwright test tests/authz/",
     "test:headers": "playwright test tests/headers/",
+    "test:hosted": "playwright test tests/hosted/ --workers=1",
     "report": "playwright show-report ../artifacts/playwright/report",
     "install:browsers": "playwright install chromium",
     "typecheck": "tsc --noEmit"

--- a/internal/acceptance/browser/tests/headers/forwarded-host.spec.ts
+++ b/internal/acceptance/browser/tests/headers/forwarded-host.spec.ts
@@ -9,7 +9,7 @@
  * | Headers | preserve host header | preserve_host_header: true | Upstream host remains original |
  */
 
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 import { login, clearAuthState } from "../../helpers/authn-flow.js";
 import { testUsers } from "../../fixtures/users.js";
 import { urls, testRoutes } from "../../fixtures/test-data.js";
@@ -19,7 +19,7 @@ const expectedOriginalHost = new URL(urls.app).host;
 const autoRewrittenHost = "websocket-server:8080";
 const rewrittenHost = "rewritten.example.internal";
 
-async function getRequestInfo(page, route: string) {
+async function getRequestInfo(page: Page, route: string) {
   const response = await page.request.get(`${urls.app}${route}`, {
     ignoreHTTPSErrors: true,
     headers: {

--- a/internal/acceptance/browser/tests/hosted/new-ha-login.spec.ts
+++ b/internal/acceptance/browser/tests/hosted/new-ha-login.spec.ts
@@ -1,0 +1,151 @@
+/**
+ * New Hosted Authenticate (Hosted IdP) - Login Tests
+ *
+ * Notion: QA -> Test Plans -> Core Test Plan -> Authentication ->
+ *         New Hosted Authenticate (Hosted IdP) -> "New HA.Log in. positive" /
+ *         "New HA.Log in.negative".
+ *
+ * Flow under test: idp_provider "hosted" - the LOCAL authenticate service uses
+ * https://authenticate.pomerium.app as its OIDC identity provider with DERIVED
+ * client credentials (client_id = authenticate_service_url, EdDSA signing key
+ * = HKDF(shared_secret); no idp_client_id/secret configured).
+ *
+ * Gated on HOSTED_E2E=1 (`make test-suite-hosted`) - talks to the REAL cloud
+ * service. Positive tests additionally need HOSTED_TEST_EMAIL/PASSWORD.
+ * The live UI diverges from the QA plan's expected wording - see the live-UI
+ * facts in helpers/hosted.ts.
+ */
+
+import { test, expect } from "@playwright/test";
+import { urls, paths, timeouts } from "../../fixtures/test-data.js";
+import {
+  decodeCompactJws,
+  expectEmptyFieldsBlocked,
+  expectInvalidCredentialsError,
+  expectSessionCookie,
+  expectSignInRedirect,
+  expectUpstreamSeesUser,
+  loginViaHosted,
+  randomInvalidEmail,
+  requireHostedUser,
+  skipUnlessHostedE2E,
+  submitHostedLoginForm,
+  waitForHostedSignInPage,
+} from "../../helpers/hosted.js";
+
+test.describe("New Hosted Authenticate: login", () => {
+  skipUnlessHostedE2E();
+
+  test("sign-in redirects to the hosted authorization endpoint with a signed request object", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted.localhost.pomerium.io:8444 -> http://upstream:8000
+    // Config: authenticate_service_url = local :8444, idp_provider: hosted,
+    //         idp_provider_url: https://authenticate.pomerium.app (config-hosted-new.yaml)
+
+    const authorizeRequest = await test.step("unauthenticated visit is redirected to the hosted /oidc/auth", async () => {
+      const captured = page.waitForRequest(
+        (req) => req.url().startsWith(`${urls.hostedAuthenticate}/oidc/auth`),
+        { timeout: timeouts.long }
+      );
+      // paths.user requires login, so it triggers the whole redirect chain
+      // without touching the upstream.
+      await page.goto(`${urls.verifyHostedNew}${paths.user}`, {
+        waitUntil: "domcontentloaded",
+      });
+      return new URL((await captured).url());
+    });
+
+    await test.step("authorization request carries exactly one query param: request", () => {
+      expect([...authorizeRequest.searchParams.keys()]).toEqual(["request"]);
+    });
+
+    const payload = await test.step("request param is a compact EdDSA JWS with an embedded Ed25519 JWK", () => {
+      const decoded = decodeCompactJws(authorizeRequest.searchParams.get("request")!);
+      expect(decoded.header.alg, "request object must be EdDSA-signed").toBe("EdDSA");
+      expect(decoded.header.typ).toBe("JWT");
+      const jwk = decoded.header.jwk as Record<string, unknown>;
+      expect(jwk.kty, "embedded JWK must be an Ed25519 key").toBe("OKP");
+      expect(jwk.crv).toBe("Ed25519");
+      return decoded.payload;
+    });
+
+    await test.step("JWS claims identify this Pomerium via its derived client credentials", () => {
+      expect(payload.response_type).toBe("code");
+      expect(payload.client_id, "client_id is the authenticate service URL").toBe(
+        urls.authenticateHostedNew
+      );
+      expect(payload.redirect_uri).toBe(`${urls.authenticateHostedNew}${paths.oauth2Callback}`);
+      expect(payload.scope).toBe("openid profile email offline_access");
+      expect(payload.iss, "iss equals the derived client_id").toBe(payload.client_id);
+      expect(payload.aud, "aud is the hosted provider URL").toBe(urls.hostedAuthenticate);
+      expect(payload.state, "an opaque state must be present").toBeTruthy();
+      expect(String(payload.pomerium_version).trim().length).toBeGreaterThan(0);
+      expect(Number(payload.exp)).toBeGreaterThan(Number(payload.iat));
+      // The live hosted discovery does not advertise PKCE.
+      expect(payload).not.toHaveProperty("code_challenge");
+    });
+  });
+
+  test("N1: valid hosted-IdP credentials grant access to the route", async ({ page }) => {
+    // Route: https://verify-hosted.localhost.pomerium.io:8444 -> http://upstream:8000 (pomerium/verify)
+    // Config: config-hosted-new.yaml (idp_provider: hosted, pass_identity_headers,
+    //         jwt_claims_headers X-Pomerium-Claim-Email)
+    const user = requireHostedUser();
+
+    await test.step("open the protected route and sign in at the hosted IdP", async () => {
+      await loginViaHosted(page, { targetUrl: urls.verifyHostedNew, user });
+    });
+
+    await test.step("a Pomerium session cookie was issued for the route domain", async () => {
+      await expectSessionCookie(page, urls.verifyHostedNew);
+    });
+
+    await test.step("the upstream receives the authenticated identity header", async () => {
+      await expectUpstreamSeesUser(page, urls.verifyHostedNew, user.email);
+    });
+  });
+
+  test("N2: invalid credentials show a rejection error and grant no access", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted.localhost.pomerium.io:8444 -> http://upstream:8000
+    // Config: config-hosted-new.yaml (idp_provider: hosted)
+    // Uses a random fake account - never the real one (no lockout risk).
+
+    await test.step("reach the hosted sign-in form from the protected route", async () => {
+      await page.goto(urls.verifyHostedNew, { waitUntil: "domcontentloaded" });
+      await waitForHostedSignInPage(page);
+    });
+
+    await test.step("bogus credentials are rejected with a visible error", async () => {
+      await submitHostedLoginForm(page, {
+        email: randomInvalidEmail(),
+        password: "wrong-password-12345",
+      });
+      await expectInvalidCredentialsError(page);
+    });
+
+    await test.step("no session was granted on the route", async () => {
+      await expectSignInRedirect(page, urls.verifyHostedNew);
+    });
+  });
+
+  test("N2: empty credentials cannot be submitted and grant no access", async ({ page }) => {
+    // Route: https://verify-hosted.localhost.pomerium.io:8444 -> http://upstream:8000
+    // Config: config-hosted-new.yaml (idp_provider: hosted)
+
+    await test.step("reach the hosted sign-in form from the protected route", async () => {
+      await page.goto(urls.verifyHostedNew, { waitUntil: "domcontentloaded" });
+      await waitForHostedSignInPage(page);
+    });
+
+    await test.step("submission is blocked while fields are empty or partial", async () => {
+      await expectEmptyFieldsBlocked(page);
+    });
+
+    await test.step("no session was granted on the route", async () => {
+      await expectSignInRedirect(page, urls.verifyHostedNew);
+    });
+  });
+});

--- a/internal/acceptance/browser/tests/hosted/new-ha-logout.spec.ts
+++ b/internal/acceptance/browser/tests/hosted/new-ha-logout.spec.ts
@@ -1,0 +1,136 @@
+/**
+ * New Hosted Authenticate (Hosted IdP) - Logout Tests
+ *
+ * Mirrors the old-HA Notion cases "HA.Log out.positive" / "HA.Log out.negative"
+ * on the NEW flow (no dedicated Notion page yet): manual QA verified that both
+ * flows show the SAME logout confirmation window, rendered by the hosted
+ * service at authenticate.pomerium.app.
+ *
+ * Mechanics (code-verified):
+ * - proxy/handlers_sign_out.go clears the route-domain session cookie BEFORE
+ *   redirecting, and with idp_provider "hosted" the local authenticate skips
+ *   its own SignOutConfirm page and revokes the local session before
+ *   redirecting to the hosted end-session endpoint
+ *   (authenticate/handlers_sign_out.go).
+ * - Therefore after "Cancel" only the HOSTED session survives; route access is
+ *   re-established via a silent SSO round trip. The invariant is "access
+ *   without re-entering credentials", never "cookie survived".
+ *
+ * Gated on HOSTED_E2E=1 + HOSTED_TEST_EMAIL/PASSWORD (real hosted account).
+ */
+
+import { test, expect } from "@playwright/test";
+import { urls, paths, timeouts } from "../../fixtures/test-data.js";
+import {
+  confirmHostedSignOut,
+  expectSignInRedirect,
+  expectUpstreamSeesUser,
+  gotoStable,
+  loginViaHosted,
+  requireHostedUser,
+  skipUnlessHostedE2E,
+  waitForHostedSignInPage,
+  waitForHostedSignOutConfirm,
+} from "../../helpers/hosted.js";
+
+const LOCAL_AUTHENTICATE_HOSTNAME = new URL(urls.authenticateHostedNew).hostname;
+const ROUTE_HOSTNAME = new URL(urls.verifyHostedNew).hostname;
+
+test.describe("New Hosted Authenticate: logout", () => {
+  skipUnlessHostedE2E();
+
+  test("N3: sign-out confirmed at the hosted service clears the session and forces re-authentication", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted.localhost.pomerium.io:8444 -> http://upstream:8000
+    // Config: config-hosted-new.yaml (local authenticate + idp_provider: hosted)
+    const user = requireHostedUser();
+
+    await test.step("log in via the hosted IdP", async () => {
+      await loginViaHosted(page, { targetUrl: urls.verifyHostedNew, user });
+    });
+
+    await test.step("route sign-out leads to the confirmation page RENDERED BY the hosted service", async () => {
+      // The local authenticate must only ever answer with redirects during
+      // this chain - the confirm UI is the hosted service's, not a local
+      // SignOutConfirm page (the observable new-HA delta).
+      const localResponses: Array<{ url: string; status: number }> = [];
+      const listener = (response: { url: () => string; status: () => number }) => {
+        if (new URL(response.url()).hostname === LOCAL_AUTHENTICATE_HOSTNAME) {
+          localResponses.push({ url: response.url(), status: response.status() });
+        }
+      };
+      page.on("response", listener);
+      await page.goto(`${urls.verifyHostedNew}${paths.signOut}`, {
+        waitUntil: "domcontentloaded",
+      });
+      await waitForHostedSignOutConfirm(page);
+      page.off("response", listener);
+
+      expect(
+        localResponses.length,
+        "the chain must pass through the local authenticate service"
+      ).toBeGreaterThan(0);
+      for (const entry of localResponses) {
+        expect(
+          entry.status,
+          `local authenticate must only redirect, never render (${entry.url})`
+        ).toBeGreaterThanOrEqual(300);
+        expect(entry.status).toBeLessThan(400);
+      }
+    });
+
+    await test.step("confirm the sign-out on the hosted page", async () => {
+      await confirmHostedSignOut(page, "confirm");
+    });
+
+    await test.step("the route session is gone", async () => {
+      await expectSignInRedirect(page, urls.verifyHostedNew);
+    });
+
+    await test.step("revisiting the route forces a full re-authentication", async () => {
+      // The confirm also ended the hosted session, so the credentials form
+      // must appear on the hosted host (not a silent SSO) - which itself
+      // proves the re-auth round trip.
+      await gotoStable(page, urls.verifyHostedNew);
+      await waitForHostedSignInPage(page);
+    });
+  });
+
+  test("N4: sign-out cancelled at the hosted service keeps route access without re-entering credentials", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted.localhost.pomerium.io:8444 -> http://upstream:8000
+    // Config: config-hosted-new.yaml (local authenticate + idp_provider: hosted)
+    const user = requireHostedUser();
+
+    await test.step("log in via the hosted IdP", async () => {
+      await loginViaHosted(page, { targetUrl: urls.verifyHostedNew, user });
+    });
+
+    await test.step("start sign-out and reach the hosted confirmation page", async () => {
+      await page.goto(`${urls.verifyHostedNew}${paths.signOut}`, {
+        waitUntil: "domcontentloaded",
+      });
+      await waitForHostedSignOutConfirm(page);
+    });
+
+    await test.step("cancel the sign-out", async () => {
+      await confirmHostedSignOut(page, "cancel");
+    });
+
+    await test.step("the route is accessible again WITHOUT a credentials prompt", async () => {
+      // The route cookie was already cleared when sign-out started, so a
+      // silent SSO round trip through the hosted service is EXPECTED here -
+      // the invariant is that no credentials form blocks the navigation.
+      await gotoStable(page, urls.verifyHostedNew);
+      await page.waitForURL((url) => url.hostname === ROUTE_HOSTNAME, {
+        timeout: timeouts.long,
+      });
+    });
+
+    await test.step("the same user's identity still reaches the upstream", async () => {
+      await expectUpstreamSeesUser(page, urls.verifyHostedNew, user.email);
+    });
+  });
+});

--- a/internal/acceptance/browser/tests/hosted/old-ha-login.spec.ts
+++ b/internal/acceptance/browser/tests/hosted/old-ha-login.spec.ts
@@ -1,0 +1,142 @@
+/**
+ * Old Hosted Authenticate (stateless flow) - Login Tests
+ *
+ * Notion: QA -> Test Plans -> Core Test Plan -> Authentication -> Hosted
+ *         Authenticate -> "HA.Email-password.positive" /
+ *         "HA.Email-password.negative".
+ *
+ * Flow under test: authenticate_service_url: https://authenticate.pomerium.app
+ * switches Pomerium to the STATELESS authenticate flow - no local authenticate
+ * service; the sign-in UI lives at the hosted service and the whole exchange
+ * travels via browser redirects with HPKE-sealed query params (k & q).
+ *
+ * "HA.Google single-sign.positive" is intentionally NOT automated: a real
+ * Google login cannot be driven by automation (bot detection, 2FA, ToS) - it
+ * stays a manual test case.
+ *
+ * Gated on HOSTED_E2E=1 (`make test-suite-hosted`). The positive test
+ * additionally needs HOSTED_TEST_EMAIL/PASSWORD. The live UI diverges from the
+ * QA plan's expected wording - see the live-UI facts in helpers/hosted.ts.
+ */
+
+import { test, expect } from "@playwright/test";
+import { urls, paths, timeouts } from "../../fixtures/test-data.js";
+import {
+  expectEmptyFieldsBlocked,
+  expectInvalidCredentialsError,
+  expectSessionCookie,
+  expectSignInRedirect,
+  expectUpstreamSeesUser,
+  loginViaHosted,
+  randomInvalidEmail,
+  requireHostedUser,
+  skipUnlessHostedE2E,
+  submitHostedLoginForm,
+  waitForHostedSignInPage,
+} from "../../helpers/hosted.js";
+
+test.describe("Old Hosted Authenticate: login (stateless flow)", () => {
+  skipUnlessHostedE2E();
+
+  test("sign-in redirect goes to the hosted /.pomerium/sign_in with exactly the HPKE pair k & q", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted-old.localhost.pomerium.io:8445 -> http://upstream:8000
+    // Config: authenticate_service_url: https://authenticate.pomerium.app,
+    //         no idp_* settings, cookie_expire: 90s (config-hosted-old.yaml)
+
+    const location = await test.step("unauthenticated request is redirected to the hosted sign-in", async () => {
+      return expectSignInRedirect(page, urls.verifyHostedOld);
+    });
+
+    await test.step("redirect target is the cloud authenticate service", () => {
+      expect(location.origin).toBe(urls.hostedAuthenticate);
+      expect(location.pathname).toBe(paths.signIn);
+    });
+
+    await test.step("query carries exactly the HPKE pair: k (sender key) and q (sealed params)", () => {
+      expect([...location.searchParams.keys()].sort()).toEqual(["k", "q"]);
+      expect(
+        location.searchParams.get("k"),
+        "k is a 32-byte X25519 public key, base64url"
+      ).toMatch(/^[A-Za-z0-9_-]{43}$/);
+      expect(
+        location.searchParams.get("q"),
+        "q is the HPKE-sealed query string"
+      ).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+  });
+
+  test("O1: valid credentials at the hosted authenticate grant access to the route", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted-old.localhost.pomerium.io:8445 -> http://upstream:8000 (pomerium/verify)
+    // Config: config-hosted-old.yaml (stateless flow, pass_identity_headers,
+    //         jwt_claims_headers X-Pomerium-Claim-Email)
+    const user = requireHostedUser();
+
+    const callback = page.waitForRequest(
+      (req) => req.url().startsWith(`${urls.verifyHostedOld}/.pomerium/callback`),
+      { timeout: timeouts.long }
+    );
+
+    await test.step("open the protected route and sign in at the hosted authenticate", async () => {
+      await loginViaHosted(page, { targetUrl: urls.verifyHostedOld, user });
+    });
+
+    await test.step("the stateless flow returned through /.pomerium/callback/ on the route domain", async () => {
+      await callback;
+    });
+
+    await test.step("a Pomerium session cookie was issued for the route domain", async () => {
+      await expectSessionCookie(page, urls.verifyHostedOld);
+    });
+
+    await test.step("the upstream receives the authenticated identity header", async () => {
+      await expectUpstreamSeesUser(page, urls.verifyHostedOld, user.email);
+    });
+  });
+
+  test("O2: invalid credentials show a rejection error and grant no access", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted-old.localhost.pomerium.io:8445 -> http://upstream:8000
+    // Config: config-hosted-old.yaml (stateless flow)
+    // Uses a random fake account - never the real one (no lockout risk).
+
+    await test.step("reach the hosted sign-in form from the protected route", async () => {
+      await page.goto(urls.verifyHostedOld, { waitUntil: "domcontentloaded" });
+      await waitForHostedSignInPage(page);
+    });
+
+    await test.step("bogus credentials are rejected with a visible error", async () => {
+      await submitHostedLoginForm(page, {
+        email: randomInvalidEmail(),
+        password: "wrong-password-12345",
+      });
+      await expectInvalidCredentialsError(page);
+    });
+
+    await test.step("no session was granted on the route", async () => {
+      await expectSignInRedirect(page, urls.verifyHostedOld);
+    });
+  });
+
+  test("O2: empty credentials cannot be submitted and grant no access", async ({ page }) => {
+    // Route: https://verify-hosted-old.localhost.pomerium.io:8445 -> http://upstream:8000
+    // Config: config-hosted-old.yaml (stateless flow)
+
+    await test.step("reach the hosted sign-in form from the protected route", async () => {
+      await page.goto(urls.verifyHostedOld, { waitUntil: "domcontentloaded" });
+      await waitForHostedSignInPage(page);
+    });
+
+    await test.step("submission is blocked while fields are empty or partial", async () => {
+      await expectEmptyFieldsBlocked(page);
+    });
+
+    await test.step("no session was granted on the route", async () => {
+      await expectSignInRedirect(page, urls.verifyHostedOld);
+    });
+  });
+});

--- a/internal/acceptance/browser/tests/hosted/old-ha-logout.spec.ts
+++ b/internal/acceptance/browser/tests/hosted/old-ha-logout.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Old Hosted Authenticate (stateless flow) - Logout Tests
+ *
+ * Notion: QA -> Test Plans -> Core Test Plan -> Authentication -> Hosted
+ *         Authenticate -> "HA.Log out.positive" / "HA.Log out.negative".
+ *
+ * Mechanics (code-verified): the proxy's /.pomerium/sign_out clears the
+ * route-domain session cookie FIRST, then redirects to the hosted service's
+ * signed sign-out URL, which renders the confirmation window. After "Cancel"
+ * only the HOSTED session survives, so route access is re-established via a
+ * silent SSO round trip - the invariant is "access without re-entering
+ * credentials", never "cookie survived".
+ *
+ * Gated on HOSTED_E2E=1 + HOSTED_TEST_EMAIL/PASSWORD (real hosted account).
+ */
+
+import { test, expect } from "@playwright/test";
+import { urls, paths, timeouts } from "../../fixtures/test-data.js";
+import {
+  confirmHostedSignOut,
+  expectSignInRedirect,
+  expectUpstreamSeesUser,
+  gotoStable,
+  loginViaHosted,
+  requireHostedUser,
+  skipUnlessHostedE2E,
+  waitForHostedSignInPage,
+  waitForHostedSignOutConfirm,
+} from "../../helpers/hosted.js";
+
+const ROUTE_HOSTNAME = new URL(urls.verifyHostedOld).hostname;
+
+test.describe("Old Hosted Authenticate: logout", () => {
+  skipUnlessHostedE2E();
+
+  test("O3: sign-out confirmed at the hosted page clears the session and forces re-authentication", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted-old.localhost.pomerium.io:8445 -> http://upstream:8000
+    // Config: config-hosted-old.yaml (stateless flow; sign-out UI lives at the
+    //         hosted service)
+    const user = requireHostedUser();
+
+    await test.step("log in via the hosted authenticate", async () => {
+      await loginViaHosted(page, { targetUrl: urls.verifyHostedOld, user });
+    });
+
+    await test.step("route sign-out redirects to the hosted service's SIGNED sign-out URL", async () => {
+      // NOTE: browser navigation, never page.request - the API context shares
+      // the cookie jar and a request-context GET would clear the session
+      // out-of-band before the browser flow runs.
+      const signOutHop = page.waitForRequest(
+        (req) => req.url().startsWith(`${urls.hostedAuthenticate}${paths.signOut}`),
+        { timeout: timeouts.long }
+      );
+      await page.goto(`${urls.verifyHostedOld}${paths.signOut}`, {
+        waitUntil: "domcontentloaded",
+      });
+      await waitForHostedSignOutConfirm(page);
+
+      const hop = new URL((await signOutHop).url());
+      expect(hop.searchParams.get("pomerium_issued"), "signed URL: issued ts").toBeTruthy();
+      expect(hop.searchParams.get("pomerium_expiry"), "signed URL: expiry ts").toBeTruthy();
+      expect(hop.searchParams.get("pomerium_signature"), "signed URL: HMAC").toBeTruthy();
+    });
+
+    await test.step("confirm the sign-out on the hosted page", async () => {
+      await confirmHostedSignOut(page, "confirm");
+    });
+
+    await test.step("the route session is gone", async () => {
+      await expectSignInRedirect(page, urls.verifyHostedOld);
+    });
+
+    await test.step("revisiting the route forces a full re-authentication", async () => {
+      // Confirming also ended the hosted session, so the credentials form
+      // must appear on the hosted host (not a silent SSO) - which itself
+      // proves the re-auth round trip.
+      await gotoStable(page, urls.verifyHostedOld);
+      await waitForHostedSignInPage(page);
+    });
+  });
+
+  test("O4: sign-out cancelled at the hosted page keeps route access without re-entering credentials", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted-old.localhost.pomerium.io:8445 -> http://upstream:8000
+    // Config: config-hosted-old.yaml (stateless flow)
+    const user = requireHostedUser();
+
+    await test.step("log in via the hosted authenticate", async () => {
+      await loginViaHosted(page, { targetUrl: urls.verifyHostedOld, user });
+    });
+
+    await test.step("start sign-out and reach the hosted confirmation page", async () => {
+      await page.goto(`${urls.verifyHostedOld}${paths.signOut}`, {
+        waitUntil: "domcontentloaded",
+      });
+      await waitForHostedSignOutConfirm(page);
+    });
+
+    await test.step("cancel the sign-out", async () => {
+      await confirmHostedSignOut(page, "cancel");
+    });
+
+    await test.step("the route is accessible again WITHOUT a credentials prompt", async () => {
+      // The route cookie was already cleared when sign-out started
+      // (proxy/handlers_sign_out.go), so a silent SSO round trip through the
+      // still-alive hosted session is EXPECTED - asserting cookie persistence
+      // would be wrong. The invariant: no credentials form blocks navigation.
+      await gotoStable(page, urls.verifyHostedOld);
+      await page.waitForURL((url) => url.hostname === ROUTE_HOSTNAME, {
+        timeout: timeouts.long,
+      });
+    });
+
+    await test.step("the same user's identity still reaches the upstream", async () => {
+      await expectUpstreamSeesUser(page, urls.verifyHostedOld, user.email);
+    });
+  });
+});

--- a/internal/acceptance/browser/tests/hosted/old-ha-priority.spec.ts
+++ b/internal/acceptance/browser/tests/hosted/old-ha-priority.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Hosted Authenticate priority over configured IdP settings
+ *
+ * Notion: QA -> Test Plans -> Core Test Plan -> Authentication -> Hosted
+ *         Authenticate -> "HA.HA priority over IdP".
+ *
+ * The instance under test has BOTH a hosted authenticate_service_url AND a
+ * full idp_provider block for the local compose Keycloak. Flow selection keys
+ * purely off the authenticate hostname (config/options.go
+ * UseStatelessAuthenticateFlow), so sign-in must go to
+ * authenticate.pomerium.app and the browser must never touch Keycloak.
+ *
+ * This test deliberately never completes a login: the first redirect is a
+ * purely local decision, so the hosted service's handling of the (unknown)
+ * sealed pomerium_idp_id cannot fail it.
+ *
+ * Gated on HOSTED_E2E=1 only - no account needed.
+ */
+
+import { test, expect } from "@playwright/test";
+import { urls, paths } from "../../fixtures/test-data.js";
+import {
+  expectSignInRedirect,
+  skipUnlessHostedE2E,
+  trackRequests,
+  waitForHostedSignInPage,
+} from "../../helpers/hosted.js";
+
+const KEYCLOAK_HOSTNAME = new URL(urls.keycloak).hostname;
+
+test.describe("Hosted authenticate takes priority over configured IdP", () => {
+  skipUnlessHostedE2E();
+
+  test("O6: with both hosted authenticate URL and Keycloak idp_* configured, sign-in goes to the hosted service", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted-priority.localhost.pomerium.io:8446 -> http://upstream:8000
+    // Config: authenticate_service_url: https://authenticate.pomerium.app PLUS a
+    //         full idp_provider: oidc block for the compose Keycloak
+    //         (config-hosted-priority.yaml)
+
+    await test.step("the first redirect targets the hosted service, not Keycloak", async () => {
+      const location = await expectSignInRedirect(page, urls.verifyHostedPriority);
+      expect(location.origin, "sign-in must go to the hosted service").toBe(
+        urls.hostedAuthenticate
+      );
+      expect(location.pathname).toBe(paths.signIn);
+      expect(
+        [...location.searchParams.keys()].sort(),
+        "stateless flow: HPKE pair only"
+      ).toEqual(["k", "q"]);
+    });
+
+    await test.step("browser navigation lands on the hosted sign-in and never touches Keycloak", async () => {
+      const keycloakRequests = trackRequests(
+        page,
+        (url) => url.hostname === KEYCLOAK_HOSTNAME
+      );
+      await page.goto(urls.verifyHostedPriority, { waitUntil: "domcontentloaded" });
+      await waitForHostedSignInPage(page);
+      keycloakRequests.dispose();
+      expect(
+        keycloakRequests.urls(),
+        "the configured Keycloak IdP must never be contacted"
+      ).toEqual([]);
+    });
+  });
+});

--- a/internal/acceptance/browser/tests/hosted/old-ha-session-timeout.spec.ts
+++ b/internal/acceptance/browser/tests/hosted/old-ha-session-timeout.spec.ts
@@ -1,0 +1,102 @@
+/**
+ * Old Hosted Authenticate (stateless flow) - Session Timeout Test
+ *
+ * Notion: QA -> Test Plans -> Core Test Plan -> Authentication -> Hosted
+ *         Authenticate -> "HA.Session Timeout".
+ *
+ * In the stateless flow session refresh is DISABLED, so cookie_expire is a
+ * hard deadline. The instance under test shortens it to 90s (the QA plan uses
+ * 2m; the behavior is identical) so this test completes in ~2 minutes.
+ *
+ * Silent-SSO caveat: after expiry the HOSTED session may still be alive, so
+ * the next request may re-authenticate without showing the credentials form.
+ * The hard assertion is therefore the forced re-auth ROUND TRIP through the
+ * hosted /.pomerium/sign_in - form visibility is handled either way.
+ *
+ * Gated on HOSTED_E2E=1 + HOSTED_TEST_EMAIL/PASSWORD (real hosted account).
+ */
+
+import { test, expect } from "@playwright/test";
+import { urls, paths, timeouts } from "../../fixtures/test-data.js";
+import { sleep } from "../../helpers/wait.js";
+import {
+  HOSTED_HOSTNAME,
+  completeHostedLoginIfFormShown,
+  expectUpstreamSeesUser,
+  loginViaHosted,
+  requireHostedUser,
+  skipUnlessHostedE2E,
+  trackRequests,
+} from "../../helpers/hosted.js";
+
+const ROUTE_HOSTNAME = new URL(urls.verifyHostedOld).hostname;
+
+test.describe("Old Hosted Authenticate: session timeout", () => {
+  skipUnlessHostedE2E();
+
+  test("O5: after cookie_expire elapses the next request forces a re-auth round trip", async ({
+    page,
+  }) => {
+    // Route: https://verify-hosted-old.localhost.pomerium.io:8445 -> http://upstream:8000
+    // Config: config-hosted-old.yaml (stateless flow, cookie_expire: 90s -
+    //         hard deadline, no session refresh in stateless mode)
+    test.setTimeout(240_000); // login + 90s cookie_expire + re-auth round trip
+    const user = requireHostedUser();
+
+    const loginAt = await test.step("log in via the hosted authenticate", async () => {
+      await loginViaHosted(page, { targetUrl: urls.verifyHostedOld, user });
+      return Date.now();
+    });
+
+    await test.step("immediately after login the route is served WITHOUT a hosted round trip", async () => {
+      const hostedRequests = trackRequests(page, (url) => url.hostname === HOSTED_HOSTNAME);
+      const response = await page.goto(`${urls.verifyHostedOld}/json`, {
+        waitUntil: "domcontentloaded",
+      });
+      hostedRequests.dispose();
+      expect(response, "navigation should produce a response").not.toBeNull();
+      expect(response!.status()).toBe(200);
+      expect(
+        hostedRequests.urls(),
+        "a fresh session must not round-trip through the hosted service"
+      ).toEqual([]);
+    });
+
+    await test.step("wait until the session cookie has expired", async () => {
+      // Sleep out the configured lifetime, then poll for the observable
+      // signal (the sign-in redirect) instead of guessing a fixed buffer.
+      // Safe in stateless mode: no refresh, so polling cannot extend the
+      // session; this is the same check the next step relies on.
+      const elapsed = Date.now() - loginAt;
+      await sleep(Math.max(timeouts.hostedCookieExpire - elapsed, 0));
+      await expect
+        .poll(
+          async () => {
+            const response = await page.request.get(`${urls.verifyHostedOld}${paths.user}`, {
+              ignoreHTTPSErrors: true,
+              maxRedirects: 0,
+            });
+            return response.status();
+          },
+          { timeout: 30_000, message: "session should expire into a sign-in redirect" }
+        )
+        .toBe(302);
+    });
+
+    await test.step("the next request is forced back through the hosted sign-in", async () => {
+      const signInHop = page.waitForRequest(
+        (req) => req.url().startsWith(`${urls.hostedAuthenticate}${paths.signIn}`),
+        { timeout: timeouts.long }
+      );
+      await page.goto(urls.verifyHostedOld, { waitUntil: "domcontentloaded" });
+      // Tolerates both outcomes: credentials form shown (hosted session also
+      // expired) or silent SSO completion (hosted session still alive).
+      await completeHostedLoginIfFormShown(page, ROUTE_HOSTNAME, user);
+      await signInHop;
+    });
+
+    await test.step("access after re-authentication is intact", async () => {
+      await expectUpstreamSeesUser(page, urls.verifyHostedOld, user.email);
+    });
+  });
+});

--- a/internal/acceptance/browser/tsconfig.json
+++ b/internal/acceptance/browser/tsconfig.json
@@ -13,7 +13,6 @@
     "sourceMap": true,
     "outDir": "./dist",
     "rootDir": ".",
-    "baseUrl": ".",
     "paths": {
       "@fixtures/*": ["./fixtures/*"],
       "@helpers/*": ["./helpers/*"]

--- a/internal/acceptance/docker-compose.yml
+++ b/internal/acceptance/docker-compose.yml
@@ -1,3 +1,16 @@
+# Shared build definition for all Pomerium instances. Every service reuses the
+# single built-from-source image (same tag), so extra instances cost ~nothing
+# (the repeated build is a full cache hit). NOTE: `<<:` merge is shallow -
+# volumes/ports/networks/healthcheck/depends_on stay per-service.
+x-pomerium: &pomerium-base
+  build:
+    context: ../..
+    dockerfile: Dockerfile
+  image: pomerium-acceptance:local
+  environment:
+    CERTIFICATE_FILE: /certs/pomerium.crt
+    CERTIFICATE_KEY_FILE: /certs/pomerium.key
+
 services:
   # Certificate generation - runs once before other services
   certs-init:
@@ -39,10 +52,7 @@ services:
 
   # Pomerium proxy (built from source)
   pomerium:
-    build:
-      context: ../..
-      dockerfile: Dockerfile
-    image: pomerium-acceptance:local
+    <<: *pomerium-base
     volumes:
       - ./certs:/certs:ro
       - ./pomerium/config.yaml:/pomerium/config.yaml:ro
@@ -55,9 +65,6 @@ services:
           - app.localhost.pomerium.io
           - admin.localhost.pomerium.io
           - mtls.localhost.pomerium.io
-    environment:
-      CERTIFICATE_FILE: /certs/pomerium.crt
-      CERTIFICATE_KEY_FILE: /certs/pomerium.key
     depends_on:
       certs-init:
         condition: service_completed_successfully
@@ -97,6 +104,92 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+      start_period: 10s
+
+
+  # ===========================================================================
+  # Hosted-authenticate instances (real cloud: authenticate.pomerium.app)
+  # Started only with the "hosted" compose profile (make up-hosted /
+  # COMPOSE_PROFILES=hosted). Require outbound internet access. Each instance
+  # listens on the SAME port inside and outside the container so browser-facing
+  # and in-network URLs are identical.
+  # ===========================================================================
+
+  # NEW hosted-authenticate flow: local authenticate service, hosted service
+  # as its OIDC identity provider (idp_provider: hosted).
+  pomerium-hosted-new:
+    <<: *pomerium-base
+    profiles: ["hosted"]
+    volumes:
+      - ./certs:/certs:ro
+      - ./pomerium/config-hosted-new.yaml:/pomerium/config.yaml:ro
+    ports:
+      - "8444:8444"
+    networks:
+      default:
+        aliases:
+          - authenticate-hosted.localhost.pomerium.io
+          - verify-hosted.localhost.pomerium.io
+    depends_on:
+      certs-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "--no-check-certificate", "https://localhost:8444/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  # OLD hosted-authenticate flow (stateless): the authenticate service IS the
+  # cloud service. cookie_expire is shortened to 90s for the session-timeout
+  # test - see pomerium/config-hosted-old.yaml.
+  pomerium-hosted-old:
+    <<: *pomerium-base
+    profiles: ["hosted"]
+    volumes:
+      - ./certs:/certs:ro
+      - ./pomerium/config-hosted-old.yaml:/pomerium/config.yaml:ro
+    ports:
+      - "8445:8445"
+    networks:
+      default:
+        aliases:
+          - verify-hosted-old.localhost.pomerium.io
+    depends_on:
+      certs-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "--no-check-certificate", "https://localhost:8445/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 10s
+
+  # OLD flow with a full Keycloak IdP block present: proves the hosted
+  # authenticate URL takes priority over configured IdP settings.
+  pomerium-hosted-priority:
+    <<: *pomerium-base
+    profiles: ["hosted"]
+    volumes:
+      - ./certs:/certs:ro
+      - ./pomerium/config-hosted-priority.yaml:/pomerium/config.yaml:ro
+    ports:
+      - "8446:8446"
+    networks:
+      default:
+        aliases:
+          - verify-hosted-priority.localhost.pomerium.io
+    # No keycloak dependency: in stateless mode this instance never contacts
+    # Keycloak (the IdP block is hashed into config, not dialed) - and the
+    # priority test asserts exactly that.
+    depends_on:
+      certs-init:
+        condition: service_completed_successfully
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "--no-check-certificate", "https://localhost:8446/healthz"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
       start_period: 10s
 
 volumes:

--- a/internal/acceptance/pomerium/config-hosted-new.yaml
+++ b/internal/acceptance/pomerium/config-hosted-new.yaml
@@ -1,0 +1,40 @@
+# Pomerium configuration for the NEW Hosted Authenticate flow e2e tests.
+#
+# The LOCAL authenticate service runs on this instance and uses Pomerium's
+# hosted service (https://authenticate.pomerium.app) as its identity provider.
+# idp_client_id / idp_client_secret are intentionally absent: with
+# idp_provider "hosted" they are derived automatically (client_id = the
+# authenticate_service_url, request/assertion signing key = HKDF(shared_secret);
+# see pkg/identity/oidc/hosted/derived.go).
+#
+# Started only with the "hosted" compose profile (make up-hosted). Requires
+# outbound internet access to reach authenticate.pomerium.app.
+
+address: :8444
+authenticate_service_url: https://authenticate-hosted.localhost.pomerium.io:8444
+
+idp_provider: hosted
+idp_provider_url: https://authenticate.pomerium.app
+
+# TLS Configuration
+certificate_file: /certs/pomerium.crt
+certificate_key_file: /certs/pomerium.key
+
+# Secrets shared with pomerium/config.yaml.
+# These are test-only values - NEVER use in production
+cookie_secret: dj5y7E03ULP9YebCgHNIXmxWnWfYlVXCgwbm9IEdysI=
+shared_secret: 0CdEkgO02jgxmgSC2AdkqIbFELAN4CGw0v0RY85xNr4=
+
+# Logging
+log_level: debug
+
+# Pass the email claim as an HTTP header so the verify upstream can echo it
+jwt_claims_headers:
+  X-Pomerium-Claim-Email: email
+
+routes:
+  # Test route: any user authenticated via the hosted IdP may access
+  - from: https://verify-hosted.localhost.pomerium.io:8444
+    to: http://upstream:8000
+    pass_identity_headers: true
+    allow_any_authenticated_user: true

--- a/internal/acceptance/pomerium/config-hosted-old.yaml
+++ b/internal/acceptance/pomerium/config-hosted-old.yaml
@@ -1,0 +1,43 @@
+# Pomerium configuration for the OLD Hosted Authenticate flow e2e tests.
+#
+# authenticate_service_url points at the real cloud service, which switches
+# this instance to the STATELESS authenticate flow (config/options.go
+# UseStatelessAuthenticateFlow): no local authenticate service, the whole
+# sign-in/sign-out UI lives at https://authenticate.pomerium.app. No idp_*
+# settings locally - the IdP is managed by the hosted service.
+#
+# Session refresh is disabled in stateless mode, so cookie_expire is a hard
+# deadline. It is shortened to 90s (Notion test case says 2m) so the
+# session-timeout test completes in ~2 minutes; every test against this
+# instance logs in fresh and finishes its assertions well inside 90s.
+#
+# Started only with the "hosted" compose profile (make up-hosted). Requires
+# outbound internet access to reach authenticate.pomerium.app.
+
+address: :8445
+authenticate_service_url: https://authenticate.pomerium.app
+
+# TLS Configuration
+certificate_file: /certs/pomerium.crt
+certificate_key_file: /certs/pomerium.key
+
+# Secrets shared with pomerium/config.yaml.
+# These are test-only values - NEVER use in production
+cookie_secret: dj5y7E03ULP9YebCgHNIXmxWnWfYlVXCgwbm9IEdysI=
+shared_secret: 0CdEkgO02jgxmgSC2AdkqIbFELAN4CGw0v0RY85xNr4=
+
+cookie_expire: 90s
+
+# Logging
+log_level: debug
+
+# Pass the email claim as an HTTP header so the verify upstream can echo it
+jwt_claims_headers:
+  X-Pomerium-Claim-Email: email
+
+routes:
+  # Test route: any user authenticated via the hosted authenticate may access
+  - from: https://verify-hosted-old.localhost.pomerium.io:8445
+    to: http://upstream:8000
+    pass_identity_headers: true
+    allow_any_authenticated_user: true

--- a/internal/acceptance/pomerium/config-hosted-priority.yaml
+++ b/internal/acceptance/pomerium/config-hosted-priority.yaml
@@ -1,0 +1,44 @@
+# Pomerium configuration for the Hosted Authenticate PRIORITY e2e test.
+#
+# BOTH a hosted authenticate_service_url AND a full idp_provider block are
+# configured. Expected behavior: sign-in still goes to
+# https://authenticate.pomerium.app - the hosted authenticate URL takes
+# priority over the configured IdP settings. Flow selection keys purely off
+# the authenticate hostname (config/options.go UseStatelessAuthenticateFlow),
+# so the browser must never be sent to the Keycloak IdP configured below.
+#
+# Started only with the "hosted" compose profile (make up-hosted). Requires
+# outbound internet access to reach authenticate.pomerium.app.
+
+address: :8446
+authenticate_service_url: https://authenticate.pomerium.app
+
+# Identity Provider (Keycloak) - present but expected to be superseded by the
+# hosted authenticate service above.
+idp_provider: oidc
+idp_provider_url: http://keycloak.localhost.pomerium.io:8080/realms/pomerium-e2e
+idp_client_id: pomerium
+idp_client_secret: pomerium-e2e-secret
+
+# TLS Configuration
+certificate_file: /certs/pomerium.crt
+certificate_key_file: /certs/pomerium.key
+
+# Secrets shared with pomerium/config.yaml.
+# These are test-only values - NEVER use in production
+cookie_secret: dj5y7E03ULP9YebCgHNIXmxWnWfYlVXCgwbm9IEdysI=
+shared_secret: 0CdEkgO02jgxmgSC2AdkqIbFELAN4CGw0v0RY85xNr4=
+
+# Logging
+log_level: debug
+
+# Pass the email claim as an HTTP header so the verify upstream can echo it
+jwt_claims_headers:
+  X-Pomerium-Claim-Email: email
+
+routes:
+  # Test route: any user authenticated via the hosted authenticate may access
+  - from: https://verify-hosted-priority.localhost.pomerium.io:8446
+    to: http://upstream:8000
+    pass_identity_headers: true
+    allow_any_authenticated_user: true

--- a/internal/acceptance/scripts/collect-artifacts.sh
+++ b/internal/acceptance/scripts/collect-artifacts.sh
@@ -18,7 +18,7 @@ mkdir -p "$ARTIFACTS_DIR/docker-logs" \
   "$ARTIFACTS_DIR/diagnostics" \
   "$ARTIFACTS_DIR/playwright"
 
-services=(keycloak pomerium upstream websocket-server)
+services=(keycloak pomerium upstream websocket-server pomerium-hosted-new pomerium-hosted-old pomerium-hosted-priority)
 
 for svc in "${services[@]}"; do
   "${COMPOSE[@]}" logs --no-color "$svc" > "$ARTIFACTS_DIR/docker-logs/${svc}.log" 2>&1 || true
@@ -39,16 +39,20 @@ done
 } > "$ARTIFACTS_DIR/diagnostics/network.txt"
 
 {
-  echo "=== Pomerium Config (Sanitized) ==="
-  if [ -f "${ROOT_DIR}/pomerium/config.yaml" ]; then
+  echo "=== Pomerium Configs (Sanitized) ==="
+  found=0
+  for config in "${ROOT_DIR}"/pomerium/*.yaml; do
+    [ -f "$config" ] || continue
+    found=1
+    echo "--- ${config##*/} ---"
     sed -e 's/\(secret:\s*\).*/\1[REDACTED]/' \
         -e 's/\(cookie_secret:\s*\).*/\1[REDACTED]/' \
         -e 's/\(shared_secret:\s*\).*/\1[REDACTED]/' \
         -e 's/\(idp_client_secret:\s*\).*/\1[REDACTED]/' \
-        "${ROOT_DIR}/pomerium/config.yaml"
-  else
-    echo "Config file not found"
-  fi
+        "$config"
+    echo ""
+  done
+  [ "$found" = 1 ] || echo "No config files found"
 } > "$ARTIFACTS_DIR/config/pomerium-config.txt"
 
 {


### PR DESCRIPTION
## Summary

Adds Playwright e2e coverage for both Hosted Authenticate flavors to `internal/acceptance/browser`, automating the QA test plan (Notion → QA → Test Plans → Core Test Plan → Authentication) against the **real** cloud service `https://authenticate.pomerium.app`. Neither flow had any e2e coverage before — the acceptance harness only exercised the stateful flow against local Keycloak.

- **New HA** (`idp_provider: hosted` + local `authenticate_service_url`): the local authenticate service uses the hosted service as its OIDC IdP with derived client credentials (client_id = authenticate URL, EdDSA signing key = HKDF(shared_secret) — no `idp_client_id`/`idp_client_secret`).
- **Old HA** (`authenticate_service_url: https://authenticate.pomerium.app`): the stateless flow — no local authenticate service; sign-in/sign-out UI lives at the hosted service, exchange travels via HPKE-sealed browser redirects (`k`/`q`). This is the default flow for an unconfigured Pomerium Core.

## Test matrix (14 tests, `browser/tests/hosted/`)

| QA case | Spec | Asserts |
|---|---|---|
| New HA config/redirect shape | `new-ha-login.spec.ts` | 302 → `/oidc/auth` with exactly one `request` param; decoded EdDSA JWS header (`alg`, embedded Ed25519 JWK) and claims (derived `client_id`, `redirect_uri`, scope, `iss`/`aud`, no PKCE) |
| New HA.Log in. positive (N1) | `new-ha-login.spec.ts` | full login via hosted IdP; `_pomerium` cookie; `X-Pomerium-Claim-Email` reaches upstream |
| New HA.Log in.negative (N2 ×2) | `new-ha-login.spec.ts` | invalid creds → rejection alert, no session; empty fields → submit blocked, no session |
| New HA logout confirm/cancel (N3/N4)* | `new-ha-logout.spec.ts` | confirm page is rendered by the **hosted** service (local authenticate only ever 302s); confirm → session gone, re-auth form required; cancel → access retained without credentials prompt |
| Old HA sign-in shape | `old-ha-login.spec.ts` | 302 → hosted `/.pomerium/sign_in` with exactly the HPKE pair `k` (43-char base64url) & `q` |
| HA.Email-password.positive (O1) | `old-ha-login.spec.ts` | login + return via route `/.pomerium/callback/`; cookie; identity header |
| HA.Email-password.negative (O2 ×2) | `old-ha-login.spec.ts` | same negative assertions as N2 |
| HA.Log out.positive/negative (O3/O4) | `old-ha-logout.spec.ts` | signed sign-out URL (`pomerium_issued`/`expiry`/`signature`); confirm → re-auth required; cancel → access retained |
| HA.Session Timeout (O5) | `old-ha-session-timeout.spec.ts` | fresh session serves without hosted round trip; after `cookie_expire` (90s, refresh disabled in stateless mode) the next request is forced through hosted `/.pomerium/sign_in` |
| HA.HA priority over IdP (O6) | `old-ha-priority.spec.ts` | with a full Keycloak `idp_*` block also configured, sign-in still goes to the hosted service and Keycloak is never contacted |

\* N3/N4 mirror the old-HA logout cases per manual QA finding that both flows show the same hosted-rendered confirmation window (no dedicated Notion page yet).

**Excluded:** `HA.Google single-sign.positive` — real Google login is not automatable (bot detection, 2FA); stays manual. Documented in the spec header.

## Gating — PR CI is unaffected

The suite talks to the live cloud service, so it is opt-in end to end:

- The 3 new Pomerium instances sit behind compose profile `hosted` — default `make up`/`make test` never starts them.
- Specs skip unless `HOSTED_E2E=1`; positive-path tests additionally skip unless `HOSTED_TEST_EMAIL`/`HOSTED_TEST_PASSWORD` (a real hosted-IdP QA account) are set. Negative tests use random fake emails, so the real account can never be locked out.
- Default runs report all 14 as **skipped** in the existing summary's new "Hosted Authenticate" category. `.github/workflows/acceptance.yaml` is untouched.

```bash
make test-suite-hosted                                   # shape + negative + priority tests (no account)
HOSTED_TEST_EMAIL=… HOSTED_TEST_PASSWORD=… make test-suite-hosted   # all 14
```

## Infrastructure

- `docker-compose.yml`: `x-pomerium` anchor dedupes build/image/env across all Pomerium services; 3 new profile-gated instances (`pomerium-hosted-new` :8444, `pomerium-hosted-old` :8445 with `cookie_expire: 90s`, `pomerium-hosted-priority` :8446) reusing the built-from-source image (cache-hit builds). Container port == host port so browser-facing and in-network URLs are identical; wildcard cert + public `*.localhost.pomerium.io` DNS cover the new subdomains with zero cert/DNS work.
- `pomerium/config-hosted-{new,old,priority}.yaml`: one config per flavor.
- `browser/helpers/hosted.ts`: single home for every cloud-UI selector/copy string (with captured live-UI facts and a codegen re-capture procedure in the README), env gating, login/sign-out flows, and shared assertions.
- Makefile `up-hosted` / `test-suite-hosted` targets; `down` is profile-aware; artifacts collection includes the new services and all sanitized configs.

## Notable findings from running against the live service

- The derived client_id with a **nonstandard port** (`https://…:8444`) is accepted by the hosted AS through the full authorize → token → sign-out cycle.
- Two QA-plan expected results don't match the live (Firebase-backed) UI — specs assert reality and the Notion pages should be updated: invalid creds show *"The supplied auth credential is malformed or has expired."*, and empty fields can't be submitted at all (Login button disabled; no native "Please fill in this field" validation).
- The hosted sign-out confirm page renders "User has been logged out." while its revocation request can still be in flight; navigating away inside that window silently re-authenticates. The sign-out helper settles on network-idle, and post-sign-out navigations use a retrying `gotoStable` (the signed-out page's pending redirect otherwise aborts the next navigation with `net::ERR_ABORTED`).
- Sign-out cancel semantics: the proxy clears the route cookie *before* the confirm page, so "cancel keeps the session" is observable only as "route re-accessible without a credentials prompt" (silent SSO via the surviving hosted session), never as cookie persistence. The tests assert accordingly.

## Also included (pre-existing breakage, needed for `tsc --noEmit` to pass)

- `browser/tsconfig.json`: drop `baseUrl` (hard error on the pinned TS 6; `paths` aliases keep working — verified with Playwright's resolver at runtime).
- `browser/helpers/keycloak.ts`: restore compilation after a `getRunId` import that never existed in `fixtures/users.ts` (module-local run id).
- `browser/tests/headers/forwarded-host.spec.ts`: type the untyped `page` param (TS7006 under `strict`).

## Verification

- `HOSTED_E2E=1` + creds: **14/14 pass** against the live cloud service (multiple consecutive full runs, ~2.4 min).
- Without creds: 7 shape/negative/priority tests pass, 7 positive-path tests skip.
- Default hermetic run: all 14 skip; no hosted containers start; existing authn suite (19 tests incl. the `@helpers`-alias pkce specs) passes; `npm run typecheck` clean; summary generator unit tests pass and render the new category with no unmapped-file warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
