### PR TITLE
chore: upgrade to go 1.27

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golangci-lint 2.13.1
-golang 1.26.7
-goreleaser 2.17.1
+golang 1.27.0
+goreleaser 2.18.0
 nodejs 24.19.0
 protoc 36.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN make npm-install
 COPY ./ui/ ./ui/
 RUN make build-ui
 
-FROM golang:1.26.7-bookworm@sha256:6ef6e30f0ea5c384f6d111cf856e024e3086bbdcb1779da3f3b3fbba0aea53d2 AS build
+FROM golang:1.27.0-bookworm@sha256:484ef6066fa69acb059fdfeda7ba2b8f7391f2ef6abc6f9b8411e669ebd56466 AS build
 WORKDIR /go/src/github.com/pomerium/pomerium
 
 RUN apt-get update \

--- a/authorize/access_tracker.go
+++ b/authorize/access_tracker.go
@@ -37,7 +37,7 @@ type AccessTracker struct {
 	maxSize                int
 	debouncePeriod         time.Duration
 
-	droppedAccesses int64
+	droppedAccesses atomic.Int64
 }
 
 // NewAccessTracker creates a new SessionAccessTracker.
@@ -69,7 +69,7 @@ func (tracker *AccessTracker) Run(ctx context.Context) {
 		serviceAccountAccesses.Insert(serviceAccountID)
 	}
 	runSubmit := func() {
-		if dropped := atomic.SwapInt64(&tracker.droppedAccesses, 0); dropped > 0 {
+		if dropped := tracker.droppedAccesses.Swap(0); dropped > 0 {
 			log.Ctx(ctx).Error().
 				Int64("dropped", dropped).
 				Msg("authorize: failed to track all session accesses")
@@ -116,7 +116,7 @@ func (tracker *AccessTracker) TrackServiceAccountAccess(serviceAccountID string)
 	select {
 	case tracker.serviceAccountAccesses <- serviceAccountID:
 	default:
-		atomic.AddInt64(&tracker.droppedAccesses, 1)
+		tracker.droppedAccesses.Add(1)
 	}
 }
 
@@ -125,7 +125,7 @@ func (tracker *AccessTracker) TrackSessionAccess(sessionID string) {
 	select {
 	case tracker.sessionAccesses <- sessionID:
 	default:
-		atomic.AddInt64(&tracker.droppedAccesses, 1)
+		tracker.droppedAccesses.Add(1)
 	}
 }
 

--- a/examples/mutual-tls/Dockerfile
+++ b/examples/mutual-tls/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.7-bookworm@sha256:6ef6e30f0ea5c384f6d111cf856e024e3086bbdcb1779da3f3b3fbba0aea53d2 AS build-env
+FROM golang:1.27.0-bookworm@sha256:484ef6066fa69acb059fdfeda7ba2b8f7391f2ef6abc6f9b8411e669ebd56466 AS build-env
 
 WORKDIR /go/src/app
 ADD . /go/src/app

--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ require (
 	github.com/cockroachdb/errors v1.11.3 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
-	github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b // indirect
+	github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258 // indirect
 	github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 // indirect
 	github.com/containerd/errdefs v1.0.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -326,8 +326,8 @@ github.com/cockroachdb/pebble/v2 v2.1.6 h1:GDo7Z2+LgFZ7LJLdLmBXhDeTVIwgSPGxIT15h
 github.com/cockroachdb/pebble/v2 v2.1.6/go.mod h1:Reo1RTniv1UjVTAu/Fv74y5i3kJ5gmVrPhO9UtFiKn8=
 github.com/cockroachdb/redact v1.1.5 h1:u1PMllDkdFfPWaNGMyLD1+so+aq3uUItthCFqzwPJ30=
 github.com/cockroachdb/redact v1.1.5/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZZ2lK+dpvRg=
-github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b h1:VXvSNzmr8hMj8XTuY0PT9Ane9qZGul/p67vGYwl9BFI=
-github.com/cockroachdb/swiss v0.0.0-20251224182025-b0f6560f979b/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
+github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258 h1:IJ+uNItEm0qx9FE2AgIc1PMsCUtk8nbSIzhQE1t5GWw=
+github.com/cockroachdb/swiss v0.0.0-20260820225851-333444432258/go.mod h1:yBRu/cnL4ks9bgy4vAASdjIW+/xMlFwuHKqtmh3GZQg=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/containerd/errdefs v1.0.0 h1:tg5yIfIlQIrxYtu9ajqY42W3lpS19XqdxRQeEwYG8PI=

--- a/internal/httputil/errors_test.go
+++ b/internal/httputil/errors_test.go
@@ -29,8 +29,7 @@ func TestHTTPError_ErrorResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			fn := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				err := NewError(tt.Status, tt.Err)
-				var e *HTTPError
-				if errors.As(err, &e) {
+				if e, ok := errors.AsType[*HTTPError](err); ok {
 					e.ErrorResponse(r.Context(), w, r)
 				} else {
 					http.Error(w, "coulnd't convert error type", http.StatusTeapot)

--- a/internal/mcp/handler_authorization.go
+++ b/internal/mcp/handler_authorization.go
@@ -144,8 +144,7 @@ func (srv *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 	if err := oauth21.ValidateAuthorizationRequest(client.ResponseMetadata, v); err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("mcp/authorize: failed to validate authorization request for client")
 		description := "The authorization request is not valid for this client."
-		var oauthErr oauth21.Error
-		if errors.As(err, &oauthErr) {
+		if oauthErr, ok := errors.AsType[oauth21.Error](err); ok {
 			description = oauthErr.Description
 		}
 		httputil.NewError(http.StatusBadRequest, err).
@@ -219,8 +218,7 @@ func (srv *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
 			// Discovery errors are non-fatal — upstream may not need OAuth.
 			// Fall through to issue the auth code; ext_proc will catch if
 			// upstream actually returns 401 later.
-			var discoveryErr *DiscoveryError
-			if errors.As(resolveErr, &discoveryErr) {
+			if _, ok := errors.AsType[*DiscoveryError](resolveErr); ok {
 				log.Ctx(ctx).Warn().Err(resolveErr).
 					Str("host", r.Host).
 					Str("upstream_url", info.UpstreamURL).

--- a/internal/mcp/handler_authorization_test.go
+++ b/internal/mcp/handler_authorization_test.go
@@ -383,9 +383,9 @@ func TestAuthorize_ExpiredTokenWithRefreshToken_RefreshesSilently(t *testing.T) 
 		testUserID      = "test-user"
 	)
 
-	var tokenEndpointHits int32
+	var tokenEndpointHits atomic.Int32
 	tokenSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&tokenEndpointHits, 1)
+		tokenEndpointHits.Add(1)
 		require.NoError(t, r.ParseForm())
 		assert.Equal(t, "refresh_token", r.FormValue("grant_type"))
 		assert.Equal(t, "valid-refresh-token", r.FormValue("refresh_token"))
@@ -451,7 +451,7 @@ func TestAuthorize_ExpiredTokenWithRefreshToken_RefreshesSilently(t *testing.T) 
 	srv.Authorize(w, r)
 
 	// Primary assertion: refresh MUST happen rather than falling into resolveAutoDiscoveryAuth.
-	assert.Equal(t, int32(1), atomic.LoadInt32(&tokenEndpointHits),
+	assert.Equal(t, int32(1), tokenEndpointHits.Load(),
 		"expired token with refresh_token should trigger silent refresh against token_endpoint")
 	require.NotNil(t, storedToken, "refreshed token should be written back to storage")
 	assert.Equal(t, "new-access", storedToken.AccessToken)

--- a/internal/mcp/handler_connect.go
+++ b/internal/mcp/handler_connect.go
@@ -180,8 +180,7 @@ func (srv *Handler) ConnectGet(w http.ResponseWriter, r *http.Request) {
 
 			// Discovery errors are non-fatal but should be surfaced to the user
 			// by appending error info to the redirect URL.
-			var discoveryErr *DiscoveryError
-			if errors.As(resolveErr, &discoveryErr) {
+			if _, ok := errors.AsType[*DiscoveryError](resolveErr); ok {
 				reqID := requestid.FromContext(ctx)
 				log.Ctx(ctx).Warn().Err(resolveErr).
 					Str("redirect-url", redirectURL).

--- a/internal/mcp/handler_connect_test.go
+++ b/internal/mcp/handler_connect_test.go
@@ -354,9 +354,9 @@ func TestConnect_ExpiredTokenWithRefreshToken_RefreshesSilently(t *testing.T) {
 		testUserID      = "test-user"
 	)
 
-	var tokenEndpointHits int32
+	var tokenEndpointHits atomic.Int32
 	tokenSrv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		atomic.AddInt32(&tokenEndpointHits, 1)
+		tokenEndpointHits.Add(1)
 		require.NoError(t, r.ParseForm())
 		assert.Equal(t, "refresh_token", r.FormValue("grant_type"))
 		assert.Equal(t, "valid-refresh-token", r.FormValue("refresh_token"))
@@ -407,7 +407,7 @@ func TestConnect_ExpiredTokenWithRefreshToken_RefreshesSilently(t *testing.T) {
 	w := httptest.NewRecorder()
 	srv.ConnectGet(w, r)
 
-	assert.Equal(t, int32(1), atomic.LoadInt32(&tokenEndpointHits),
+	assert.Equal(t, int32(1), tokenEndpointHits.Load(),
 		"expired token with refresh_token should trigger silent refresh")
 	require.NotNil(t, storedToken, "refreshed token should be written back to storage")
 	assert.Equal(t, "new-access", storedToken.AccessToken)

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -571,8 +571,7 @@ func isNotFound(err error) bool {
 // HTTP 4xx responses from the token endpoint are permanent: the AS is rejecting the request.
 // Everything else (network errors, 5xx, parse errors) is transient.
 func isTokenRefreshPermanent(err error) bool {
-	var tokenErr *tokenEndpointError
-	if errors.As(err, &tokenErr) {
+	if tokenErr, ok := errors.AsType[*tokenEndpointError](err); ok {
 		return tokenErr.StatusCode >= 400 && tokenErr.StatusCode < 500
 	}
 	return false

--- a/internal/version/components.json
+++ b/internal/version/components.json
@@ -1,6 +1,6 @@
 {
   "config": "v0.38.0",
   "hosted-authenticate-oidc": "v0.1.0",
-  "mcp": "v0.32.0",
+  "mcp": "v0.33.0",
   "ssh": "v0.21.0"
 }

--- a/pkg/storage/postgres/postgres_test.go
+++ b/pkg/storage/postgres/postgres_test.go
@@ -49,12 +49,12 @@ func TestDeleteDeadlock(t *testing.T) {
 			_, err := migrate(ctx, tx)
 			return err
 		}))
-	var version uint64
+	var version atomic.Uint64
 
 	for range 10 {
 		require.NoError(t, putRecordAndChange(ctx, conn1, &databroker.Record{
 			Type:       "example",
-			Version:    atomic.AddUint64(&version, 1),
+			Version:    version.Add(1),
 			Id:         uuid.NewString(),
 			Data:       protoutil.NewAnyString("example"),
 			ModifiedAt: timestamppb.New(tm1),

--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -75,8 +75,8 @@ update-tools() {
 
 	require-command asdf
 
-	asdf install golang latest:1.26
-	asdf set golang latest:1.26
+	asdf install golang latest:1.27
+	asdf set golang latest:1.27
 	asdf install golangci-lint latest:2
 	asdf set golangci-lint latest:2
 	asdf install nodejs latest:24


### PR DESCRIPTION
## Summary
Upgrade to go 1.27. Also run `go fix`.

## Related issues
- [ENG-4338](https://linear.app/pomerium/issue/ENG-4338/various-upgrade-go-to-127)

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] ready for review
