### PR TITLE
mcp: drop client_secret_basic method

### DIFF
--- a/internal/mcp/handler_metadata.go
+++ b/internal/mcp/handler_metadata.go
@@ -164,7 +164,7 @@ func getAuthorizationServerMetadata(r *http.Request, prefix string, dcrEnabled b
 		ResponseTypesSupported:                     []string{"code"},
 		CodeChallengeMethodsSupported:              []string{"S256"},
 		TokenEndpoint:                              P(path.Join(prefix, tokenEndpoint)),
-		TokenEndpointAuthMethodsSupported:          []string{"client_secret_basic", "none"},
+		TokenEndpointAuthMethodsSupported:          []string{"none"},
 		GrantTypesSupported:                        []string{"authorization_code", "refresh_token"},
 		RevocationEndpoint:                         P(path.Join(prefix, revocationEndpoint)),
 		RevocationEndpointAuthMethodsSupported:     []string{"client_secret_post"},
@@ -173,6 +173,7 @@ func getAuthorizationServerMetadata(r *http.Request, prefix string, dcrEnabled b
 	}
 	if dcrEnabled {
 		md.RegistrationEndpoint = P(path.Join(prefix, registerEndpoint))
+		md.TokenEndpointAuthMethodsSupported = []string{"client_secret_basic", "none"}
 	}
 	return md
 }

--- a/internal/mcp/handler_metadata_test.go
+++ b/internal/mcp/handler_metadata_test.go
@@ -1,10 +1,13 @@
 package mcp_test
 
 import (
+	"io"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/pomerium/pomerium/internal/mcp"
@@ -56,4 +59,58 @@ func TestWWWAuthenticate(t *testing.T) {
 			}))
 		})
 	}
+}
+
+func TestAuthorizationServerMetadataHandler(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "/.well-known/oauth-protected-resource", nil)
+	r.Host = "my-domain.internal"
+
+	t.Run("DCR disabled", func(t *testing.T) {
+		h := mcp.AuthorizationServerMetadataHandler("/prefix", false)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		res := w.Result()
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		b, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"authorization_endpoint": "https://my-domain.internal/prefix/authorize",
+			"authorization_response_iss_parameter_supported": true,
+			"client_id_metadata_document_supported": true,
+			"code_challenge_methods_supported": [ "S256" ],
+			"grant_types_supported": [ "authorization_code", "refresh_token" ],
+			"issuer": "https://my-domain.internal",
+			"response_types_supported": [ "code" ],
+			"revocation_endpoint": "https://my-domain.internal/prefix/revoke",
+			"revocation_endpoint_auth_methods_supported": [ "client_secret_post" ],
+			"service_documentation": "https://pomerium.com/docs",
+			"token_endpoint": "https://my-domain.internal/prefix/token",
+			"token_endpoint_auth_methods_supported": [ "none" ]
+		}`, string(b))
+	})
+
+	t.Run("DCR enabled", func(t *testing.T) {
+		h := mcp.AuthorizationServerMetadataHandler("/prefix", true)
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, r)
+		res := w.Result()
+		assert.Equal(t, http.StatusOK, res.StatusCode)
+		b, err := io.ReadAll(res.Body)
+		require.NoError(t, err)
+		assert.JSONEq(t, `{
+			"authorization_endpoint": "https://my-domain.internal/prefix/authorize",
+			"authorization_response_iss_parameter_supported": true,
+			"client_id_metadata_document_supported": true,
+			"code_challenge_methods_supported": [ "S256" ],
+			"grant_types_supported": [ "authorization_code", "refresh_token" ],
+			"issuer": "https://my-domain.internal",
+			"registration_endpoint": "https://my-domain.internal/prefix/register",
+			"response_types_supported": [ "code" ],
+			"revocation_endpoint": "https://my-domain.internal/prefix/revoke",
+			"revocation_endpoint_auth_methods_supported": [ "client_secret_post" ],
+			"service_documentation": "https://pomerium.com/docs",
+			"token_endpoint": "https://my-domain.internal/prefix/token",
+			"token_endpoint_auth_methods_supported": [ "client_secret_basic", "none" ]
+		}`, string(b))
+	})
 }


### PR DESCRIPTION
## Summary

MCP OAuth clients cannot use the client_secret_basic token endpoint auth method except with dynamic client registration (DCR). So, if DCR is not enabled, do not advertise support for this method.

## Related issues

n/a (small cleanup)

## User Explanation

## AI disclosure

none

## Checklist

- [ ] reference any related issues
- [x] updated unit tests
- [ ] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [ ] ready for review
