### PR TITLE
fix(mcp/CIMD): negotiate supported token auth endpoint methods based on Oauth2 server metadata

### DIFF
--- a/internal/mcp/client_id_metadata.go
+++ b/internal/mcp/client_id_metadata.go
@@ -43,6 +43,12 @@ type ClientIDMetadataDocument struct {
 	// Per draft, MUST NOT be client_secret_basic, client_secret_post, client_secret_jwt.
 	TokenEndpointAuthMethod string `json:"token_endpoint_auth_method,omitempty"`
 
+	// RFC8414 Oauth 2.0 Server Metadata
+	// OPTIONAL. JSON array containing a list of client authentication
+	// methods supported by this token endpoint.  Client authentication
+	// method values are used in the "token_endpoint_auth_method". See above.
+	TokendEndpointAuthMethodsSupported []string `json:"token_endpoint_auth_methods_supported,omitempty"`
+
 	// Scope is OPTIONAL.
 	Scope string `json:"scope,omitempty"`
 

--- a/internal/mcp/handler_authorization.go
+++ b/internal/mcp/handler_authorization.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"slices"
 	"time"
 
 	"buf.build/go/protovalidate"
@@ -19,6 +20,10 @@ import (
 	oauth21proto "github.com/pomerium/pomerium/internal/oauth21/gen"
 	rfc7591v1 "github.com/pomerium/pomerium/internal/rfc7591"
 )
+
+var supportedTokenAuthMethodsForCIMD = []string{
+	rfc7591v1.TokenEndpointAuthMethodNone,
+}
 
 // Authorize handles the /authorize endpoint.
 func (srv *Handler) Authorize(w http.ResponseWriter, r *http.Request) {
@@ -354,8 +359,58 @@ func (srv *Handler) getOrFetchClient(ctx context.Context, clientID string) (*rfc
 		if err != nil {
 			return nil, err
 		}
+
+		if err := srv.negotiateTokenEndpointAuthMethod(ctx, doc); err != nil {
+			return nil, err
+		}
+
 		return doc.ToClientRegistration(), nil
 	}
 
 	return srv.storage.GetClient(ctx, clientID)
+}
+
+func (srv *Handler) negotiateTokenEndpointAuthMethod(ctx context.Context, doc *ClientIDMetadataDocument) error {
+	if doc.TokenEndpointAuthMethod == "" {
+		log.Ctx(ctx).Info().
+			Str("client-id", doc.ClientID).
+			Msg("mcp/authorize: client did not specify a token endpoint auth method, defaulting to none")
+		doc.TokenEndpointAuthMethod = rfc7591v1.TokenEndpointAuthMethodClientSecretBasic
+	}
+
+	if !slices.Contains(supportedTokenAuthMethodsForCIMD, doc.TokenEndpointAuthMethod) {
+		log.Ctx(ctx).Info().
+			Str("client-id", doc.ClientID).
+			Str("preferred-auth-method", doc.TokenEndpointAuthMethod).
+			Strs("client-supported-auth-methods", doc.TokendEndpointAuthMethodsSupported).
+			Strs("pomerium-supported-auth-methods", supportedTokenAuthMethodsForCIMD).
+			Msg("mcp/authorize: client prefers a token endpoint auth method not supported by Pomerium, checking additional auth methods")
+
+		for _, method := range supportedTokenAuthMethodsForCIMD {
+			if slices.Contains(doc.TokendEndpointAuthMethodsSupported, method) {
+				log.Ctx(ctx).Info().
+					Str("client-id", doc.ClientID).
+					Str("auth-method", method).
+					Msg("mcp/authorize: negotiated token endpoint auth method")
+				doc.TokenEndpointAuthMethod = method
+				return nil
+			}
+		}
+
+		log.Ctx(ctx).Error().
+			Str("client-id", doc.ClientID).
+			Str("preferred-auth-method", doc.TokenEndpointAuthMethod).
+			Strs("client-supported-auth-methods", doc.TokendEndpointAuthMethodsSupported).
+			Strs("pomerium-supported-auth-methods", supportedTokenAuthMethodsForCIMD).
+			Msg("mcp/authorize: failed to negotiate a token endpoint auth method")
+
+		return fmt.Errorf("%w: no mutually suported token endpoint auth method", ErrClientMetadataValidation)
+	}
+
+	log.Ctx(ctx).Debug().
+		Str("client-id", doc.ClientID).
+		Str("auth-method", doc.TokenEndpointAuthMethod).
+		Msg("mcp/authorize: using client's preferred token endpoint auth method")
+
+	return nil
 }

--- a/internal/mcp/handler_authorization_test.go
+++ b/internal/mcp/handler_authorization_test.go
@@ -465,3 +465,68 @@ func TestAuthorize_ExpiredTokenWithRefreshToken_RefreshesSilently(t *testing.T) 
 		"should redirect to client redirect_uri after silent refresh, got %q", loc)
 	assert.Contains(t, loc, "code=", "redirect should carry the authorization code")
 }
+
+func TestNegotiateTokenEndpointAuthMethod(t *testing.T) {
+	srv := &Handler{}
+
+	cases := []struct {
+		name      string
+		preferred string
+		supported []string
+		expect    string
+		expectErr bool
+	}{
+		{
+			name:      "preferred_supported",
+			preferred: rfc7591v1.TokenEndpointAuthMethodNone,
+			supported: []string{"private_key_jwt", rfc7591v1.TokenEndpointAuthMethodNone},
+			expect:    rfc7591v1.TokenEndpointAuthMethodNone,
+		},
+		{
+			name:      "negotiated",
+			preferred: "private_key_jwt",
+			supported: []string{"private_key_jwt", rfc7591v1.TokenEndpointAuthMethodNone},
+			expect:    rfc7591v1.TokenEndpointAuthMethodNone,
+		},
+		{
+			name:      "no_overlap",
+			preferred: "private_key_jwt",
+			supported: []string{"private_key_jwt", "tls_client_auth"},
+			expectErr: true,
+			expect:    "private_key_jwt",
+		},
+		{
+			name:      "empty_supported",
+			expect:    "private_key_jwt",
+			preferred: "private_key_jwt",
+			supported: nil,
+			expectErr: true,
+		},
+		{
+			name:      "no preferred",
+			expect:    "client_secret_basic",
+			preferred: "",
+			supported: nil,
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := &ClientIDMetadataDocument{
+				ClientID:                           "https://example.com/oauth/client.json",
+				RedirectURIs:                       []string{"https://client.example.com/callback"},
+				TokenEndpointAuthMethod:            tc.preferred,
+				TokendEndpointAuthMethodsSupported: tc.supported,
+			}
+
+			err := srv.negotiateTokenEndpointAuthMethod(context.Background(), doc)
+			if tc.expectErr {
+				assert.ErrorIs(t, err, ErrClientMetadataValidation)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tc.expect, doc.TokenEndpointAuthMethod)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Our CIMD flow fetches client side metadata and was using the default advertised `token_endpoint_auth_method` metadata.

As per RFC 8414, Oauth 2 may also include an optional list of `token_endpoint_auth_methods_supported`, which include a list of supported methods.

ChatGPT exposes `private_key_jwt` as the default token endpoint auth method, which Pomerium currently does not support. It also allows for the `none` method which Pomerium does support (It's actually the only method we currently support for this downstream CIMD flow).

This PR adds a negotiation layer for supported auth methods, to future proof this downstream client flow, and returns a bad request error with relevant information about the mismatch between auth methods, so that the failure is clear.

I plan to look into the `private_key_jwt` mechanism in more detail and see if we can implement it in Pomerium.

## Related issues

Addresses: https://github.com/pomerium/pomerium/issues/6692

## User Explanation

MCP Clients could break if they advertised default token auth methods like `private_key_jwt` that Pomerium doesn't support in its flow.

## AI disclosure

I used claude Opus 5 to draft the log messages to fit the existing log messages in `internal/mcp`. The fix, approach to the problem and code is my own.

## Checklist

- [X] reference any related issues
- [X] updated unit tests
- [X] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [X] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [X] ready for review
