### PR TITLE
grpc: identify owner and changed options when the outbound connection reloads (#6738)

### DIFF
--- a/authenticate/authenticate.go
+++ b/authenticate/authenticate.go
@@ -68,7 +68,8 @@ func New(ctx context.Context, cfg *config.Config, options ...Option) (*Authentic
 	tracer := tracerProvider.Tracer(trace.PomeriumCoreTracer)
 
 	a := &Authenticate{
-		backgroundCtx: ctx,
+		backgroundCtx:    ctx,
+		outboundGrpcConn: grpc.CachedOutboundGRPClientConn{Name: "authenticate"},
 
 		accessTokenVerificationCount: metrics.Int64Counter("authenticate.idp_access_token.verifications",
 			metric.WithDescription("Number of IDP access token verifications."),

--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -113,6 +113,8 @@ func New(ctx context.Context, cfg *config.Config, opts ...Option) (*Authorize, e
 		tracerProvider:  tracerProvider,
 		tracer:          tracer,
 		recordingServer: atomic.Pointer[recording.Server]{},
+
+		outboundGrpcConn: grpc.CachedOutboundGRPClientConn{Name: "authorize"},
 	}
 	a.currentConfig.Store(cfg)
 	state, err := newAuthorizeStateFromConfig(ctx, nil, tracerProvider, cfg, a.store, &a.outboundGrpcConn)

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -177,6 +177,8 @@ func NewServer(
 		updateConfig:    make(chan *config.Config, 1),
 		healthMetrics:   metrics,
 		options:         options,
+
+		outboundGRPCConnection: pom_grpc.CachedOutboundGRPClientConn{Name: "controlplane"},
 	}
 	srv.currentConfig.Store(cfg)
 	srv.httpRouter.Store(mux.NewRouter())

--- a/internal/databroker/config_source.go
+++ b/internal/databroker/config_source.go
@@ -80,7 +80,7 @@ func NewConfigSource(
 		dbConfigs:              map[string]dbConfig{},
 		dbVersionedConfigs:     map[string]dbConfig{},
 		bundle:                 NewConfigBundle(),
-		outboundGRPCConnection: new(grpc.CachedOutboundGRPClientConn),
+		outboundGRPCConnection: &grpc.CachedOutboundGRPClientConn{Name: "databroker-config"},
 	}
 	for _, li := range listeners {
 		src.OnConfigChange(ctx, li)

--- a/internal/registry/reporter.go
+++ b/internal/registry/reporter.go
@@ -34,7 +34,7 @@ type Reporter struct {
 // NewReporter creates a new Reporter.
 func NewReporter(tracerProvider oteltrace.TracerProvider) *Reporter {
 	return &Reporter{
-		outboundGRPCConnection: new(grpc.CachedOutboundGRPClientConn),
+		outboundGRPCConnection: &grpc.CachedOutboundGRPClientConn{Name: "registry"},
 		tracerProvider:         tracerProvider,
 	}
 }

--- a/pkg/grpc/client.go
+++ b/pkg/grpc/client.go
@@ -1,7 +1,9 @@
 package grpc
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 	"net"
 	"sync"
 	"time"
@@ -91,6 +93,9 @@ func newOutboundGRPCClientConn(ctx context.Context, opts *OutboundOptions, other
 
 // CachedOutboundGRPClientConn keeps a cached outbound gRPC client connection open based on options.
 type CachedOutboundGRPClientConn struct {
+	// Name identifies the owner of the connection in logs.
+	Name string
+
 	mu          sync.Mutex
 	opts        *OutboundOptions
 	current     *grpc.ClientConn
@@ -106,8 +111,13 @@ func (cache *CachedOutboundGRPClientConn) Get(ctx context.Context, opts *Outboun
 	if cache.current != nil && cmp.Equal(cache.opts, opts) {
 		return cache.current, nil
 	}
-	log.Ctx(ctx).Info().Msg("outbound client connection has changed meaningfully, reloading")
-	if cache.current != nil {
+	if cache.current == nil {
+		log.Ctx(ctx).Info().Str("owner", cache.Name).Msg("creating outbound client connection")
+	} else {
+		log.Ctx(ctx).Info().
+			Str("owner", cache.Name).
+			Strs("changed", changedOutboundOptions(cache.opts, opts)).
+			Msg("outbound client connection has changed meaningfully, reloading")
 		if cache.stopCleanup() {
 			// We prevented the AfterFunc from running; close the connection ourselves.
 			cache.current.Close()
@@ -130,11 +140,29 @@ func (cache *CachedOutboundGRPClientConn) Get(ctx context.Context, opts *Outboun
 
 	cache.stopCleanup = context.AfterFunc(ctx, func() {
 		defer close(done)
-		log.Ctx(ctx).Info().Msg("stopping outbound client connection")
+		log.Ctx(ctx).Info().Str("owner", cache.Name).Msg("stopping outbound client connection")
 		if err := cc.Close(); err != nil {
-			log.Ctx(ctx).Err(err).Msg("failed to stop outbound client connection")
+			log.Ctx(ctx).Err(err).Str("owner", cache.Name).Msg("failed to stop outbound client connection")
 		}
-		log.Ctx(ctx).Info().Msg("ready to create new outbound client connection")
+		log.Ctx(ctx).Info().Str("owner", cache.Name).Msg("ready to create new outbound client connection")
 	})
 	return cache.current, nil
+}
+
+// changedOutboundOptions names the fields that differ between two sets of options,
+// with their before and after values. The signed JWT key is never rendered.
+func changedOutboundOptions(prev, next *OutboundOptions) []string {
+	var changed []string
+	diff := func(name, before, after string) {
+		if before != after {
+			changed = append(changed, fmt.Sprintf("%s: %q -> %q", name, before, after))
+		}
+	}
+	diff("outbound_port", prev.OutboundPort, next.OutboundPort)
+	diff("installation_id", prev.InstallationID, next.InstallationID)
+	diff("service_name", prev.ServiceName, next.ServiceName)
+	if !bytes.Equal(prev.SignedJWTKey, next.SignedJWTKey) {
+		changed = append(changed, "signed_jwt_key: changed")
+	}
+	return changed
 }

--- a/pkg/grpc/client_test.go
+++ b/pkg/grpc/client_test.go
@@ -128,3 +128,18 @@ func TestCachedOutboundGRPClientConn_GetSameOptions(t *testing.T) {
 
 	assert.Same(t, cc1, cc2, "same options should return the cached connection")
 }
+
+func TestChangedOutboundOptions(t *testing.T) {
+	t.Parallel()
+
+	prev := &OutboundOptions{OutboundPort: "1", InstallationID: "", ServiceName: "all", SignedJWTKey: []byte("k1")}
+	assert.Empty(t, changedOutboundOptions(prev, prev))
+	assert.Equal(t, []string{`installation_id: "" -> "b"`},
+		changedOutboundOptions(prev, &OutboundOptions{OutboundPort: "1", InstallationID: "b", ServiceName: "all", SignedJWTKey: []byte("k1")}))
+	assert.Equal(t, []string{
+		`outbound_port: "1" -> "2"`,
+		`installation_id: "" -> "b"`,
+		`service_name: "all" -> "proxy"`,
+		"signed_jwt_key: changed",
+	}, changedOutboundOptions(prev, &OutboundOptions{OutboundPort: "2", InstallationID: "b", ServiceName: "proxy", SignedJWTKey: []byte("k2")}))
+}

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -67,7 +67,7 @@ type Proxy struct {
 // Function returns an error if options fail to validate.
 func New(ctx context.Context, cfg *config.Config) (*Proxy, error) {
 	tracerProvider := trace.NewTracerProvider(ctx, "Proxy")
-	outboundGrpcConn := &grpc.CachedOutboundGRPClientConn{}
+	outboundGrpcConn := &grpc.CachedOutboundGRPClientConn{Name: "proxy"}
 	state, err := newProxyStateFromConfig(ctx, tracerProvider, cfg, outboundGrpcConn)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Backport of #6738 to `0-33-0`.

## Summary

The outbound gRPC connection cache logged "outbound client connection has changed meaningfully, reloading" without saying which service's connection reloaded or what changed, and logged the same message for the very first dial. Each cache now carries an owner name (controlplane, proxy, authorize, authenticate, databroker-config, registry), the first dial logs "creating outbound client connection", and a reload lists each changed option with its before and after value. The signed JWT key is reported by name only.

The only conflict was `proxy.New`, where `0-33-0` does not yet pass a previous state into `newProxyStateFromConfig`; the release-branch call is kept.

## Related issues

- #6730
- #6738

## AI disclosure

Claude Code performed the cherry-pick and conflict resolution under the maintainer's direction.
