### PR TITLE
mcp: keep ext_proc databroker access working across outbound connection reloads (#6740)

### DIFF
--- a/authorize/authorize.go
+++ b/authorize/authorize.go
@@ -117,7 +117,7 @@ func New(ctx context.Context, cfg *config.Config, opts ...Option) (*Authorize, e
 		outboundGrpcConn: grpc.CachedOutboundGRPClientConn{Name: "authorize"},
 	}
 	a.currentConfig.Store(cfg)
-	state, err := newAuthorizeStateFromConfig(ctx, nil, tracerProvider, cfg, a.store, &a.outboundGrpcConn)
+	state, err := newAuthorizeStateFromConfig(ctx, nil, tracerProvider, cfg, a.store, &a.outboundGrpcConn, a)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +250,7 @@ func newPolicyEvaluator(
 func (a *Authorize) OnConfigChange(ctx context.Context, cfg *config.Config) {
 	currentState := a.state.Load()
 	a.currentConfig.Store(cfg)
-	if newState, err := newAuthorizeStateFromConfig(ctx, currentState, a.tracerProvider, cfg, a.store, &a.outboundGrpcConn); err != nil {
+	if newState, err := newAuthorizeStateFromConfig(ctx, currentState, a.tracerProvider, cfg, a.store, &a.outboundGrpcConn, a); err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("authorize: error updating state")
 	} else {
 		a.state.Store(newState)

--- a/authorize/state.go
+++ b/authorize/state.go
@@ -47,6 +47,7 @@ func newAuthorizeStateFromConfig(
 	cfg *config.Config,
 	store *store.Store,
 	outboundGrpcConn *grpc.CachedOutboundGRPClientConn,
+	dataBrokerClient databroker.ClientGetter,
 ) (*authorizeState, error) {
 	if err := validateOptions(cfg.Options); err != nil {
 		return nil, fmt.Errorf("authorize: bad options: %w", err)
@@ -90,7 +91,7 @@ func newAuthorizeStateFromConfig(
 
 	var evaluatorOptions []evaluator.Option
 	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
-		mcp, err := mcp.New(ctx, mcp.DefaultPrefix, cfg, outboundGrpcConn)
+		mcp, err := mcp.New(ctx, mcp.DefaultPrefix, cfg, dataBrokerClient)
 		if err != nil {
 			return nil, fmt.Errorf("authorize: failed to create mcp handler: %w", err)
 		}

--- a/internal/controlplane/server.go
+++ b/internal/controlplane/server.go
@@ -250,12 +250,11 @@ func NewServer(
 	// handler is safe to install even when no MCP routes exist yet.
 	extProcHandler := options.extProcHandler
 	if extProcHandler == nil {
-		mcpHandler, handlerErr := mcp.NewUpstreamAuthHandlerFromConfig(ctx, cfg, &srv.outboundGRPCConnection)
-		if handlerErr != nil {
-			return nil, fmt.Errorf("mcp upstream auth handler: %w", handlerErr)
+		srv.mcpExtProcHandler, err = mcp.NewUpstreamAuthHandler(ctx, cfg)
+		if err != nil {
+			return nil, fmt.Errorf("mcp upstream auth handler: %w", err)
 		}
-		extProcHandler = mcpHandler
-		srv.mcpExtProcHandler = mcpHandler
+		extProcHandler = srv.mcpExtProcHandler
 	}
 	extproc.NewServer(extProcHandler, options.extProcCallback).Register(srv.GRPCServer)
 
@@ -486,7 +485,7 @@ func (srv *Server) update(ctx context.Context, cfg *config.Config) error {
 	// are resolvable by the time Envoy begins routing to them. nil when a
 	// test injects its own handler via WithExtProcHandler.
 	if srv.mcpExtProcHandler != nil {
-		srv.mcpExtProcHandler.OnConfigChange(cfg)
+		srv.mcpExtProcHandler.OnConfigChange(ctx, cfg)
 	}
 
 	res, err := srv.buildDiscoveryResources(ctx)

--- a/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
+++ b/internal/mcp/e2e/ext_proc_databroker_config_update_test.go
@@ -101,7 +101,7 @@ func TestExtProcUsesUpdatedDatabrokerConfigForLateMCPRoute(t *testing.T) {
 
 	// Seed the upstream MCP token under the same composite key ext_proc will
 	// derive from (user_id, route_id, upstream_server).
-	storage := mcp.NewStorage(dbClient)
+	storage := mcp.NewStorage(databrokerpb.NewStaticClientGetter(dbClient))
 	require.NoError(t, storage.PutUpstreamMCPToken(ctx, &oauth21proto.UpstreamMCPToken{
 		UserId:         sa.UserId,
 		RouteId:        seededRouteID,

--- a/internal/mcp/handler.go
+++ b/internal/mcp/handler.go
@@ -10,14 +10,11 @@ import (
 
 	"github.com/gorilla/mux"
 	"github.com/rs/cors"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/singleflight"
-	googlegrpc "google.golang.org/grpc"
 
 	"github.com/pomerium/pomerium/config"
 	"github.com/pomerium/pomerium/pkg/endpoints"
-	"github.com/pomerium/pomerium/pkg/grpc"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/identity"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
@@ -106,15 +103,10 @@ func New(
 	ctx context.Context,
 	prefix string,
 	cfg *config.Config,
-	outboundGrpcConn *grpc.CachedOutboundGRPClientConn,
+	client databroker.ClientGetter,
 	opts ...HandlerOption,
 ) (*Handler, error) {
 	tracerProvider := trace.NewTracerProvider(ctx, "MCP")
-
-	client, err := getDatabrokerServiceClient(ctx, cfg, tracerProvider, outboundGrpcConn)
-	if err != nil {
-		return nil, fmt.Errorf("databroker client: %w", err)
-	}
 
 	cipher, err := getCipher(cfg)
 	if err != nil {
@@ -181,27 +173,4 @@ func (srv *Handler) HandlerFunc() http.HandlerFunc {
 	r.Path(path.Join(srv.prefix, disconnectEndpoint)).Methods(http.MethodPost).HandlerFunc(srv.DisconnectRoutes)
 
 	return r.ServeHTTP
-}
-
-func getDatabrokerServiceClient(
-	ctx context.Context,
-	cfg *config.Config,
-	tracerProvider oteltrace.TracerProvider,
-	outboundGrpcConn *grpc.CachedOutboundGRPClientConn,
-) (databroker.DataBrokerServiceClient, error) {
-	sharedKey, err := cfg.Options.GetSharedKey()
-	if err != nil {
-		return nil, fmt.Errorf("shared key: %w", err)
-	}
-
-	dataBrokerConn, err := outboundGrpcConn.Get(ctx, &grpc.OutboundOptions{
-		OutboundPort:   cfg.OutboundPort,
-		InstallationID: cfg.Options.InstallationID,
-		ServiceName:    cfg.Options.Services,
-		SignedJWTKey:   sharedKey,
-	}, googlegrpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(tracerProvider))))
-	if err != nil {
-		return nil, fmt.Errorf("databroker connection: %w", err)
-	}
-	return databroker.NewDataBrokerServiceClient(dataBrokerConn), nil
 }

--- a/internal/mcp/handler_token_test.go
+++ b/internal/mcp/handler_token_test.go
@@ -209,7 +209,7 @@ func setupTestDatabroker(ctx context.Context, t *testing.T) *Storage {
 	require.NoError(t, err)
 
 	client := databroker_grpc.NewDataBrokerServiceClient(conn)
-	return NewStorage(client)
+	return NewStorage(databroker_grpc.NewStaticClientGetter(client))
 }
 
 func TestTokenHandler_StoresRefreshToken(t *testing.T) {

--- a/internal/mcp/storage.go
+++ b/internal/mcp/storage.go
@@ -45,16 +45,16 @@ type HandlerStorage interface {
 
 // Storage implements HandlerStorage using a databroker client.
 type Storage struct {
-	client databroker.DataBrokerServiceClient
+	clientGetter databroker.ClientGetter
 }
 
 // NewStorage creates a new Storage instance.
-func NewStorage(
-	client databroker.DataBrokerServiceClient,
-) *Storage {
-	return &Storage{
-		client: client,
-	}
+func NewStorage(client databroker.ClientGetter) *Storage {
+	return &Storage{clientGetter: client}
+}
+
+func (storage *Storage) client() databroker.DataBrokerServiceClient {
+	return storage.clientGetter.GetDataBrokerServiceClient()
 }
 
 func (storage *Storage) RegisterClient(
@@ -63,7 +63,7 @@ func (storage *Storage) RegisterClient(
 ) (string, error) {
 	data := protoutil.NewAny(req)
 	id := uuid.NewString()
-	_, err := storage.client.Put(ctx, &databroker.PutRequest{
+	_, err := storage.client().Put(ctx, &databroker.PutRequest{
 		Records: []*databroker.Record{{
 			Id:   id,
 			Data: data,
@@ -81,7 +81,7 @@ func (storage *Storage) GetClient(
 	id string,
 ) (*rfc7591v1.ClientRegistration, error) {
 	v := new(rfc7591v1.ClientRegistration)
-	rec, err := storage.client.Get(ctx, &databroker.GetRequest{
+	rec, err := storage.client().Get(ctx, &databroker.GetRequest{
 		Type: protoutil.GetTypeURL(v),
 		Id:   id,
 	})
@@ -103,7 +103,7 @@ func (storage *Storage) CreateAuthorizationRequest(
 ) (string, error) {
 	data := protoutil.NewAny(req)
 	id := uuid.NewString()
-	_, err := storage.client.Put(ctx, &databroker.PutRequest{
+	_, err := storage.client().Put(ctx, &databroker.PutRequest{
 		Records: []*databroker.Record{{
 			Id:   id,
 			Data: data,
@@ -121,7 +121,7 @@ func (storage *Storage) GetAuthorizationRequest(
 	id string,
 ) (*oauth21proto.AuthorizationRequest, error) {
 	v := new(oauth21proto.AuthorizationRequest)
-	rec, err := storage.client.Get(ctx, &databroker.GetRequest{
+	rec, err := storage.client().Get(ctx, &databroker.GetRequest{
 		Type: protoutil.GetTypeURL(v),
 		Id:   id,
 	})
@@ -142,7 +142,7 @@ func (storage *Storage) DeleteAuthorizationRequest(
 	id string,
 ) error {
 	data := protoutil.NewAny(&oauth21proto.AuthorizationRequest{})
-	_, err := storage.client.Put(ctx, &databroker.PutRequest{
+	_, err := storage.client().Put(ctx, &databroker.PutRequest{
 		Records: []*databroker.Record{{
 			Id:        id,
 			Data:      data,
@@ -158,7 +158,7 @@ func (storage *Storage) DeleteAuthorizationRequest(
 
 func (storage *Storage) GetSession(ctx context.Context, id string) (*session.Session, uint64, error) {
 	v := new(session.Session)
-	rec, err := storage.client.Get(ctx, &databroker.GetRequest{
+	rec, err := storage.client().Get(ctx, &databroker.GetRequest{
 		Type: protoutil.GetTypeURL(v),
 		Id:   id,
 	})
@@ -180,7 +180,7 @@ func (storage *Storage) PutMCPRefreshToken(
 	token *oauth21proto.MCPRefreshToken,
 ) error {
 	data := protoutil.NewAny(token)
-	_, err := storage.client.Put(ctx, &databroker.PutRequest{
+	_, err := storage.client().Put(ctx, &databroker.PutRequest{
 		Records: []*databroker.Record{{
 			Id:   token.Id,
 			Data: data,
@@ -213,7 +213,7 @@ func (storage *Storage) GetMCPRefreshToken(
 	id string,
 ) (*oauth21proto.MCPRefreshToken, error) {
 	v := new(oauth21proto.MCPRefreshToken)
-	rec, err := storage.client.Get(ctx, &databroker.GetRequest{
+	rec, err := storage.client().Get(ctx, &databroker.GetRequest{
 		Type: protoutil.GetTypeURL(v),
 		Id:   id,
 	})
@@ -235,7 +235,7 @@ func (storage *Storage) DeleteMCPRefreshToken(
 	id string,
 ) error {
 	data := protoutil.NewAny(&oauth21proto.MCPRefreshToken{})
-	_, err := storage.client.Put(ctx, &databroker.PutRequest{
+	_, err := storage.client().Put(ctx, &databroker.PutRequest{
 		Records: []*databroker.Record{{
 			Id:        id,
 			Data:      data,
@@ -272,7 +272,7 @@ func (storage *Storage) PutUpstreamMCPToken(
 		return err
 	}
 	data := protoutil.NewAny(token)
-	_, err = storage.client.Put(ctx, &databroker.PutRequest{
+	_, err = storage.client().Put(ctx, &databroker.PutRequest{
 		Records: []*databroker.Record{{
 			Id:   id,
 			Data: data,
@@ -302,7 +302,7 @@ func (storage *Storage) GetUpstreamMCPToken(
 		return nil, err
 	}
 	v := new(oauth21proto.UpstreamMCPToken)
-	rec, err := storage.client.Get(ctx, &databroker.GetRequest{
+	rec, err := storage.client().Get(ctx, &databroker.GetRequest{
 		Type: protoutil.GetTypeURL(v),
 		Id:   id,
 	})
@@ -328,7 +328,7 @@ func (storage *Storage) DeleteUpstreamMCPToken(
 		return err
 	}
 	data := protoutil.NewAny(&oauth21proto.UpstreamMCPToken{})
-	_, err = storage.client.Put(ctx, &databroker.PutRequest{
+	_, err = storage.client().Put(ctx, &databroker.PutRequest{
 		Records: []*databroker.Record{{
 			Id:        id,
 			Data:      data,
@@ -349,7 +349,7 @@ func (storage *Storage) DeleteUpstreamMCPToken(
 
 // PutSession stores a session in the databroker.
 func (storage *Storage) PutSession(ctx context.Context, s *session.Session) (uint64, error) {
-	res, err := session.Put(ctx, storage.client, s)
+	res, err := session.Put(ctx, storage.client(), s)
 	if err != nil {
 		return 0, err
 	}
@@ -373,7 +373,7 @@ func (storage *Storage) PutPendingUpstreamAuth(
 		return fmt.Errorf("pending upstream auth requires non-empty user_id and downstream_host")
 	}
 	data := protoutil.NewAny(pending)
-	_, err := storage.client.Put(ctx, &databroker.PutRequest{
+	_, err := storage.client().Put(ctx, &databroker.PutRequest{
 		Records: []*databroker.Record{{
 			Id:   id,
 			Data: data,
@@ -392,7 +392,7 @@ func (storage *Storage) GetPendingUpstreamAuth(
 	userID, host string,
 ) (*oauth21proto.PendingUpstreamAuth, error) {
 	v := new(oauth21proto.PendingUpstreamAuth)
-	rec, err := storage.client.Get(ctx, &databroker.GetRequest{
+	rec, err := storage.client().Get(ctx, &databroker.GetRequest{
 		Type: protoutil.GetTypeURL(v),
 		Id:   pendingUpstreamAuthID(userID, host),
 	})
@@ -413,7 +413,7 @@ func (storage *Storage) DeletePendingUpstreamAuth(
 	userID, host string,
 ) error {
 	data := protoutil.NewAny(&oauth21proto.PendingUpstreamAuth{})
-	_, err := storage.client.Put(ctx, &databroker.PutRequest{
+	_, err := storage.client().Put(ctx, &databroker.PutRequest{
 		Records: []*databroker.Record{{
 			Id:        pendingUpstreamAuthID(userID, host),
 			Data:      data,
@@ -434,7 +434,7 @@ func (storage *Storage) GetPendingUpstreamAuthByState(
 	stateID string,
 ) (*oauth21proto.PendingUpstreamAuth, error) {
 	v := new(oauth21proto.PendingUpstreamAuth)
-	res, err := storage.client.Query(ctx, &databroker.QueryRequest{
+	res, err := storage.client().Query(ctx, &databroker.QueryRequest{
 		Type:  protoutil.GetTypeURL(v),
 		Limit: 1,
 		Filter: &structpb.Struct{Fields: map[string]*structpb.Value{
@@ -467,7 +467,7 @@ func (storage *Storage) GetUpstreamOAuthClient(
 	issuer, downstreamHost string,
 ) (*oauth21proto.UpstreamOAuthClient, error) {
 	v := new(oauth21proto.UpstreamOAuthClient)
-	rec, err := storage.client.Get(ctx, &databroker.GetRequest{
+	rec, err := storage.client().Get(ctx, &databroker.GetRequest{
 		Type: protoutil.GetTypeURL(v),
 		Id:   upstreamOAuthClientID(issuer, downstreamHost),
 	})
@@ -495,7 +495,7 @@ func (storage *Storage) PutUpstreamOAuthClient(
 	}
 	id := upstreamOAuthClientID(client.Issuer, client.DownstreamHost)
 	data := protoutil.NewAny(client)
-	_, err := storage.client.Put(ctx, &databroker.PutRequest{
+	_, err := storage.client().Put(ctx, &databroker.PutRequest{
 		Records: []*databroker.Record{{
 			Id:   id,
 			Data: data,

--- a/internal/mcp/storage_test.go
+++ b/internal/mcp/storage_test.go
@@ -59,7 +59,7 @@ func TestStorage(t *testing.T) {
 	require.NoError(t, err)
 
 	client := databroker_grpc.NewDataBrokerServiceClient(conn)
-	storage := mcp.NewStorage(client)
+	storage := mcp.NewStorage(databroker_grpc.NewStaticClientGetter(client))
 
 	t.Run("client registration", func(t *testing.T) {
 		t.Parallel()

--- a/internal/mcp/upstream_auth.go
+++ b/internal/mcp/upstream_auth.go
@@ -2,7 +2,6 @@ package mcp
 
 import (
 	"context"
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -12,6 +11,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/singleflight"
 	googlegrpc "google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -22,7 +22,6 @@ import (
 	"github.com/pomerium/pomerium/internal/log"
 	"github.com/pomerium/pomerium/internal/mcp/extproc"
 	oauth21proto "github.com/pomerium/pomerium/internal/oauth21/gen"
-	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc"
 	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
@@ -78,89 +77,117 @@ func newPendingUpstreamAuth(p newPendingUpstreamAuthParams, setup *upstreamOAuth
 // All upstream auth modes (auto-discovery, pre-registered, fully static) use a unified
 // UpstreamMCPToken storage path.
 //
-// hosts and asMetadataDomainMatcher refresh via OnConfigChange; both are held
-// behind atomic pointers so request-path readers stay lock-free.
+// The handler lives for the whole process. hosts, asMetadataDomainMatcher and
+// dataBrokerClient refresh via OnConfigChange and are held behind atomic
+// pointers so request-path readers stay lock-free.
 type UpstreamAuthHandler struct {
 	storage                 HandlerStorage
 	hosts                   *HostInfo
 	httpClient              *http.Client
 	asMetadataDomainMatcher atomic.Pointer[DomainMatcher]
 	singleFlight            singleflight.Group
+
+	tracerProvider         oteltrace.TracerProvider
+	outboundGRPCConnection grpc.CachedOutboundGRPClientConn
+	dataBrokerClient       atomic.Pointer[databroker.DataBrokerServiceClient]
 }
 
-// NewUpstreamAuthHandler creates a new UpstreamAuthHandler.
+// UpstreamAuthHandlerOption configures an UpstreamAuthHandler.
+type UpstreamAuthHandlerOption func(*UpstreamAuthHandler)
+
+// WithUpstreamHTTPClient sets the HTTP client used for upstream discovery and
+// token refresh. By default a client trusting the configured CA is used.
+func WithUpstreamHTTPClient(client *http.Client) UpstreamAuthHandlerOption {
+	return func(h *UpstreamAuthHandler) {
+		h.httpClient = client
+	}
+}
+
+// WithStorage replaces the handler's storage (for tests)
+func WithStorage(storage HandlerStorage) UpstreamAuthHandlerOption {
+	return func(h *UpstreamAuthHandler) {
+		h.storage = storage
+	}
+}
+
+// NewUpstreamAuthHandler creates an UpstreamAuthHandler for cfg.
 func NewUpstreamAuthHandler(
-	storage HandlerStorage,
-	hosts *HostInfo,
-	httpClient *http.Client,
-	asMetadataDomainMatcher *DomainMatcher,
-) *UpstreamAuthHandler {
-	h := &UpstreamAuthHandler{
-		storage:    storage,
-		hosts:      hosts,
-		httpClient: httpClient,
-	}
-	h.asMetadataDomainMatcher.Store(asMetadataDomainMatcher)
-	return h
-}
-
-// OnConfigChange refreshes the handler's host index and AS-metadata domain allowlist
-// so that config updates delivered after the handler was constructed become visible
-// to ext_proc lookups.
-func (h *UpstreamAuthHandler) OnConfigChange(cfg *config.Config) {
-	h.hosts.OnConfigChange(cfg)
-	var allowed []string
-	if cfg != nil {
-		allowed = cfg.Options.GetMCPAllowedAsMetadataDomains()
-	}
-	h.asMetadataDomainMatcher.Store(NewDomainMatcher(allowed))
-}
-
-// NewUpstreamAuthHandlerFromConfig creates an UpstreamAuthHandler using the provided config
-// and outbound gRPC connection. This is the primary factory used by the controlplane server.
-func NewUpstreamAuthHandlerFromConfig(
 	ctx context.Context,
 	cfg *config.Config,
-	outboundGrpcConn *grpc.CachedOutboundGRPClientConn,
+	opts ...UpstreamAuthHandlerOption,
 ) (*UpstreamAuthHandler, error) {
-	tracerProvider := trace.NewTracerProvider(ctx, "MCP-ExtProc")
+	h := &UpstreamAuthHandler{
+		tracerProvider:         trace.NewTracerProvider(ctx, "MCP-ExtProc"),
+		outboundGRPCConnection: grpc.CachedOutboundGRPClientConn{Name: "mcp-extproc"},
+	}
+	for _, opt := range opts {
+		opt(h)
+	}
+	if h.httpClient == nil {
+		h.httpClient = newUpstreamHTTPClient(ctx, cfg)
+	}
+	if h.storage == nil {
+		h.storage = NewStorage(h) // the handler resolves its own client per use
+	}
+	if err := h.updateDataBrokerClient(ctx, cfg); err != nil {
+		return nil, err
+	}
+	h.hosts = NewHostInfo(cfg, h.httpClient)
+	h.asMetadataDomainMatcher.Store(NewDomainMatcher(cfg.Options.GetMCPAllowedAsMetadataDomains()))
+	return h, nil
+}
 
+// GetDataBrokerServiceClient returns the current DataBrokerServiceClient.
+func (h *UpstreamAuthHandler) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	return *h.dataBrokerClient.Load()
+}
+
+// OnConfigChange refreshes the handler's databroker client, host index and
+// AS-metadata domain allowlist so that config updates delivered after the
+// handler was constructed become visible to ext_proc lookups.
+func (h *UpstreamAuthHandler) OnConfigChange(ctx context.Context, cfg *config.Config) {
+	// On failure the previous client stays referenced until the next config
+	// change. An invalid shared key fails before the cached connection is
+	// touched; a failed re-dial leaves the cache empty, so the next change
+	// dials afresh.
+	if err := h.updateDataBrokerClient(ctx, cfg); err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("mcp_upstream_auth: error updating databroker client")
+	}
+	h.hosts.OnConfigChange(cfg)
+	h.asMetadataDomainMatcher.Store(NewDomainMatcher(cfg.Options.GetMCPAllowedAsMetadataDomains()))
+}
+
+// updateDataBrokerClient builds the databroker client for cfg
+func (h *UpstreamAuthHandler) updateDataBrokerClient(ctx context.Context, cfg *config.Config) error {
 	sharedKey, err := cfg.Options.GetSharedKey()
 	if err != nil {
-		return nil, fmt.Errorf("shared key: %w", err)
+		return fmt.Errorf("mcp_upstream_auth: shared key: %w", err)
 	}
-
-	dataBrokerConn, err := outboundGrpcConn.Get(ctx, &grpc.OutboundOptions{
+	cc, err := h.outboundGRPCConnection.Get(ctx, &grpc.OutboundOptions{
 		OutboundPort:   cfg.OutboundPort,
 		InstallationID: cfg.Options.InstallationID,
 		ServiceName:    cfg.Options.Services,
 		SignedJWTKey:   sharedKey,
-	}, googlegrpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(tracerProvider))))
+	}, googlegrpc.WithStatsHandler(otelgrpc.NewClientHandler(otelgrpc.WithTracerProvider(h.tracerProvider))))
 	if err != nil {
-		return nil, fmt.Errorf("databroker connection: %w", err)
+		return fmt.Errorf("mcp_upstream_auth: databroker connection: %w", err)
 	}
+	client := databroker.NewDataBrokerServiceClient(cc)
+	h.dataBrokerClient.Store(&client)
+	return nil
+}
 
-	storage := NewStorage(databroker.NewDataBrokerServiceClient(dataBrokerConn))
-
-	httpClient := http.DefaultClient
-	if cfg.Options.CA != "" || cfg.Options.CAFile != "" {
-		rootCAs, caErr := cryptutil.GetCertPool(cfg.Options.CA, cfg.Options.CAFile)
-		if caErr != nil {
-			log.Ctx(ctx).Warn().Err(caErr).Msg("mcp_upstream_auth: error loading custom CA, using system defaults")
-		} else {
-			transport := http.DefaultTransport.(*http.Transport).Clone()
-			transport.TLSClientConfig = &tls.Config{
-				RootCAs:    rootCAs,
-				MinVersion: tls.VersionTLS12,
-			}
-			httpClient = &http.Client{Transport: transport}
-		}
+// newUpstreamHTTPClient returns an HTTP client trusting the configured CAs, or
+// the default client when they cannot be loaded.
+func newUpstreamHTTPClient(ctx context.Context, cfg *config.Config) *http.Client {
+	tlsConfig, err := cfg.GetTLSClientConfig()
+	if err != nil {
+		log.Ctx(ctx).Warn().Err(err).Msg("mcp_upstream_auth: error loading custom CA, using system defaults")
+		return http.DefaultClient
 	}
-
-	hosts := NewHostInfo(cfg, httpClient)
-	asDomainMatcher := NewDomainMatcher(cfg.Options.GetMCPAllowedAsMetadataDomains())
-
-	return NewUpstreamAuthHandler(storage, hosts, httpClient, asDomainMatcher), nil
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.TLSClientConfig = tlsConfig
+	return &http.Client{Transport: transport}
 }
 
 // GetUpstreamToken looks up a cached upstream token for the given route context and host.

--- a/internal/mcp/upstream_auth_onconfigchange_test.go
+++ b/internal/mcp/upstream_auth_onconfigchange_test.go
@@ -16,19 +16,15 @@ func TestUpstreamAuthHandler_OnConfigChange_RefreshesDomainMatcher(t *testing.T)
 	old := config.New(config.NewDefaultOptions())
 	old.Options.MCPAllowedASMetadataDomains = []string{"old.example.com"}
 
-	h := NewUpstreamAuthHandler(
-		nil,
-		NewHostInfo(old, nil),
-		nil,
-		NewDomainMatcher(old.Options.GetMCPAllowedAsMetadataDomains()),
-	)
+	h, err := NewUpstreamAuthHandler(t.Context(), old)
+	require.NoError(t, err)
 
 	require.NoError(t, h.asMetadataDomainMatcher.Load().ValidateURLDomain(
 		mustParseURL(t, "https://old.example.com/.well-known/oauth-authorization-server")))
 
 	updated := config.New(config.NewDefaultOptions())
 	updated.Options.MCPAllowedASMetadataDomains = []string{"new.example.com"}
-	h.OnConfigChange(updated)
+	h.OnConfigChange(t.Context(), updated)
 
 	matcher := h.asMetadataDomainMatcher.Load()
 	assert.NoError(t, matcher.ValidateURLDomain(mustParseURL(t, "https://new.example.com/foo")))

--- a/internal/mcp/upstream_auth_prm_resource_test.go
+++ b/internal/mcp/upstream_auth_prm_resource_test.go
@@ -98,7 +98,7 @@ func TestHandleUpstreamResponse_ConfiguredUpstreamBasePath(t *testing.T) {
 		},
 	}
 
-	handler := NewUpstreamAuthHandler(store, hosts, upstreamSrv.Client(), allowLocalhost())
+	handler := newTestUpstreamAuthHandler(t, cfg, store, upstreamSrv.Client())
 
 	routeCtx := &extproc.RouteContext{
 		RouteID: "route-123",

--- a/internal/mcp/upstream_auth_test.go
+++ b/internal/mcp/upstream_auth_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pomerium/pomerium/internal/mcp/extproc"
 	oauth21proto "github.com/pomerium/pomerium/internal/oauth21/gen"
 	rfc7591v1 "github.com/pomerium/pomerium/internal/rfc7591"
+	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc/session"
 )
 
@@ -93,7 +94,7 @@ func TestHandleUpstreamResponse_DownstreamHostRouting(t *testing.T) {
 			},
 		}
 
-		handler := NewUpstreamAuthHandler(store, hosts, upstreamSrv.Client(), allowLocalhost())
+		handler := newTestUpstreamAuthHandler(t, cfg, store, upstreamSrv.Client())
 
 		routeCtx := &extproc.RouteContext{
 			RouteID: "route-123",
@@ -627,7 +628,6 @@ func TestHandle401_ResourceParamStoredInPending(t *testing.T) {
 				},
 			},
 		})
-		hosts := NewHostInfo(cfg, nil)
 
 		var capturedPending *oauth21proto.PendingUpstreamAuth
 		store := &testUpstreamAuthStorage{
@@ -637,7 +637,7 @@ func TestHandle401_ResourceParamStoredInPending(t *testing.T) {
 			},
 		}
 
-		handler := NewUpstreamAuthHandler(store, hosts, srv.Client(), allowLocalhost())
+		handler := newTestUpstreamAuthHandler(t, cfg, store, srv.Client())
 
 		routeCtx := &extproc.RouteContext{
 			RouteID: "route-123",
@@ -1228,4 +1228,15 @@ func (s *autoDiscoveryTestStorage) PutUpstreamMCPToken(ctx context.Context, toke
 		return s.putUpstreamMCPTokenFunc(ctx, token)
 	}
 	return nil
+}
+
+// newTestUpstreamAuthHandler builds a handler for cfg that talks to the
+// loopback servers tests run and keeps its state in store.
+func newTestUpstreamAuthHandler(t *testing.T, cfg *config.Config, store HandlerStorage, httpClient *http.Client) *UpstreamAuthHandler {
+	t.Helper()
+	cfg.Options.MCPAllowedASMetadataDomains = []string{"127.0.0.1"}
+	cfg.Options.SharedKey = cryptutil.NewBase64Key()
+	h, err := NewUpstreamAuthHandler(t.Context(), cfg, WithStorage(store), WithUpstreamHTTPClient(httpClient))
+	require.NoError(t, err)
+	return h
 }

--- a/proxy/proxy.go
+++ b/proxy/proxy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pomerium/pomerium/internal/telemetry/metrics"
 	"github.com/pomerium/pomerium/pkg/cryptutil"
 	"github.com/pomerium/pomerium/pkg/grpc"
+	"github.com/pomerium/pomerium/pkg/grpc/databroker"
 	"github.com/pomerium/pomerium/pkg/identity"
 	"github.com/pomerium/pomerium/pkg/storage"
 	"github.com/pomerium/pomerium/pkg/telemetry/trace"
@@ -82,7 +83,7 @@ func New(ctx context.Context, cfg *config.Config) (*Proxy, error) {
 	p.currentConfig.Store(config.New(config.NewDefaultOptions()))
 	p.currentRouter.Store(httputil.NewRouter())
 	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
-		mcpHandler, err := mcp.New(ctx, mcp.DefaultPrefix, cfg, outboundGrpcConn,
+		mcpHandler, err := mcp.New(ctx, mcp.DefaultPrefix, cfg, p,
 			mcp.WithAuthenticatorGetter(func(ctx context.Context, idpID string) (identity.Authenticator, error) {
 				return cfg.Options.GetAuthenticator(ctx, tracerProvider, idpID)
 			}),
@@ -102,6 +103,11 @@ func New(ctx context.Context, cfg *config.Config) (*Proxy, error) {
 	return p, nil
 }
 
+// GetDataBrokerServiceClient implements databroker.ClientGetter
+func (p *Proxy) GetDataBrokerServiceClient() databroker.DataBrokerServiceClient {
+	return p.state.Load().dataBrokerClient
+}
+
 // Mount mounts the http handler to a mux router.
 func (p *Proxy) Mount(r *mux.Router) {
 	r.PathPrefix("/").Handler(p)
@@ -113,27 +119,28 @@ func (p *Proxy) OnConfigChange(ctx context.Context, cfg *config.Config) {
 		return
 	}
 
+	p.currentConfig.Store(cfg)
+	if err := p.setHandlers(ctx, cfg.Options); err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("proxy: failed to update proxy handlers from configuration settings")
+	}
+	state, err := newProxyStateFromConfig(ctx, p.tracerProvider, cfg, p.outboundGrpcConn)
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("proxy: failed to update proxy state from configuration settings")
+		return
+	}
+	p.state.Store(state)
+
 	if cfg.Options.IsRuntimeFlagSet(config.RuntimeFlagMCP) {
-		mcpHandler, err := mcp.New(ctx, mcp.DefaultPrefix, cfg, p.outboundGrpcConn,
+		mcpHandler, err := mcp.New(ctx, mcp.DefaultPrefix, cfg, p,
 			mcp.WithAuthenticatorGetter(func(ctx context.Context, idpID string) (identity.Authenticator, error) {
 				return cfg.Options.GetAuthenticator(ctx, p.tracerProvider, idpID)
 			}),
 		)
 		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Msg("proxy: failed to update proxy state from configuration settings")
+			log.Ctx(ctx).Error().Err(err).Msg("proxy: failed to update mcp handler from configuration settings")
 		} else {
 			p.mcp.Store(mcpHandler)
 		}
-	}
-
-	p.currentConfig.Store(cfg)
-	if err := p.setHandlers(ctx, cfg.Options); err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("proxy: failed to update proxy handlers from configuration settings")
-	}
-	if state, err := newProxyStateFromConfig(ctx, p.tracerProvider, cfg, p.outboundGrpcConn); err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("proxy: failed to update proxy state from configuration settings")
-	} else {
-		p.state.Store(state)
 	}
 }
 


### PR DESCRIPTION
Backport of #6740 to `0-33-0`, stacked on #6743 (the backport of #6739) so the end-to-end test in that branch goes green here.

## Summary

The MCP ext_proc handler captured a databroker connection from the controlplane's shared outbound connection cache once at startup. Any later reload of that cache, triggered by the first stored identity-manager error after the config gained databroker-delivered settings, closed the captured connection and every upstream-token lookup failed with `Canceled`, so the handler answered 502 until restart.

The handler now owns its outbound connection and rebuilds its databroker client from every config change, and its storage resolves the client on each use. `mcp.New` and the ext_proc constructor take a client getter; proxy and authorize supply one backed by their current state, and the ext_proc handler is built through a single constructor.

Conflicts resolved for `0-33-0`: `proxy.OnConfigChange` keeps this branch's `newProxyStateFromConfig` signature, which has no previous-state argument, and `authorize/state_test.go` does not exist on this branch, so its change was dropped.

## Related issues

- #6730
- #6740

## AI disclosure

Claude Code performed the cherry-pick and conflict resolution under the maintainer's direction.
