### PR TITLE
ci: pin goreleaser to 2.17.1 on 0-33-0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,5 @@
 golangci-lint 2.13.2
 golang 1.26.8
-goreleaser 2.18.1
+goreleaser 2.17.1
 nodejs 24.20.0
 protoc 36.1


### PR DESCRIPTION
## Summary

The v0.33.2 release job fails in the goreleaser before hook:

```
go: github.com/goreleaser/goreleaser/v2@v2.18.1: requires go >= 1.27.1
    (running go 1.26.8; GOTOOLCHAIN=local)
make: *** [Makefile:69: deps-release] Error 1
```

goreleaser raised its own Go floor to 1.27 in 2.18.0 and 1.27.1 in 2.18.1. This branch pins `golang 1.26.8` in `.tool-versions`, and the release job runs with `GOTOOLCHAIN=local`, so `make deps-release` cannot install goreleaser 2.18.1.

Revert the `goreleaser` pin to 2.17.1 — the version that built v0.33.1 — rather than moving a patch branch to Go 1.27.

The automated dependency updates will bump it again; goreleaser should be excluded from those on release branches, or this recurs on the next patch.

## Related issues

- https://github.com/pomerium/pomerium/actions/runs/34379698719

## User Explanation

None; release tooling only.

## AI disclosure

Claude Code diagnosed the failure and drafted this change.

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review