### PR TITLE
Makefile: remove deps-release target 

### DIFF
--- a/.github/goreleaser-mac.yaml
+++ b/.github/goreleaser-mac.yaml
@@ -16,7 +16,7 @@ env:
 before:
   hooks:
     - go mod download
-    - make deps-build deps-release build-ui
+    - make deps-build build-ui
 
 builds:
   - id: pomerium

--- a/.github/goreleaser.yaml
+++ b/.github/goreleaser.yaml
@@ -16,7 +16,7 @@ env:
 before:
   hooks:
     - go mod download
-    - make deps-build deps-release build-ui
+    - make deps-build build-ui
 
 builds:
   - id: pomerium

--- a/Makefile
+++ b/Makefile
@@ -63,11 +63,6 @@ get-envoy: ## Fetch envoy binaries
 deps-build: get-envoy ## Install build dependencies
 	@echo "==> $@"
 
-.PHONY: deps-release
-deps-release: get-envoy ## Install release dependencies
-	@echo "==> $@"
-	@$(GO) install github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION}
-
 .PHONY: proto-before
 proto-before:
 	@echo "==> $@"
@@ -200,9 +195,9 @@ clean: ## Cleanup any build binaries or packages.
 	$(RM) -r /tmp/pomerium-protoc-3pp
 
 .PHONY: snapshot
-snapshot: deps-build deps-release ## Builds the cross-compiled binaries, naming them in such a way for release (eg. binary-GOOS-GOARCH)
+snapshot: deps-build ## Builds the cross-compiled binaries, naming them in such a way for release (eg. binary-GOOS-GOARCH)
 	@echo "==> $@"
-	@goreleaser release --clean -f .github/goreleaser.yaml --snapshot
+	@$(GO) run github.com/goreleaser/goreleaser/v2@${GORELEASER_VERSION} release --clean -f .github/goreleaser.yaml --snapshot
 
 .PHONY: npm-install
 npm-install:


### PR DESCRIPTION
## Summary

The v0.33.2 release workflow did not succeed, due to a version mismatch in the .tool-versions file. This file had `golang 1.26.8` and `goreleaser 2.18.1`. When actions/setup-go runs, it sets `GOTOOLCHAIN=local` to ensure that the specified Go version is the only one that will be used.

The GoReleaser configuration runs `make deps-release` in a `before` hook. This attempted to install GoReleaser v2.18.1, but due to the go.mod requirement for the newer Go version 1.27.1, it did not succeed.

However, this step appears to be unnecessary. Currently `make deps-release` installs GoReleaser from source. But if GoReleaser is running this hook, then GoReleaser is already present and does not need to be installed. Remove `deps-release` from this hook.

This leaves only one other usage of the `deps-release` target: the `snapshot` target. Update the `snapshot` target to use `go run` instead of a separate `go install` step. Then we can remove the `deps-release` target entirely.

I believe we'll also need to remove this target from the GoReleaser config in the mac-builds repo: https://github.com/pomerium/mac-builds/pull/20.

## Related issues

n/a

## User Explanation

## AI disclosure

none

## Checklist

- [x] reference any related issues
- [ ] updated unit tests
- [x] add appropriate label (`enhancement`, `bug`, `breaking`, `dependencies`, `ci`)
- [x] disclosed AI usage (or wrote "none") per AI_POLICY.md
- [x] ready for review
